### PR TITLE
[App Search] Add small engine breadcrumb utility helper

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/__mocks__/engine_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/__mocks__/engine_logic.mock.ts
@@ -6,6 +6,7 @@
  */
 
 import { EngineDetails } from '../components/engine/types';
+import { ENGINES_TITLE } from '../components/engines';
 import { generateEncodedPath } from '../utils/encode_path_params';
 
 export const mockEngineValues = {
@@ -20,6 +21,11 @@ export const mockEngineActions = {
 export const mockGenerateEnginePath = jest.fn((path, pathParams = {}) =>
   generateEncodedPath(path, { engineName: mockEngineValues.engineName, ...pathParams })
 );
+export const mockGetEngineBreadcrumbs = jest.fn((breadcrumbs = []) => [
+  ENGINES_TITLE,
+  mockEngineValues.engineName,
+  ...breadcrumbs,
+]);
 
 jest.mock('../components/engine', () => ({
   EngineLogic: {
@@ -27,4 +33,5 @@ jest.mock('../components/engine', () => ({
     actions: mockEngineActions,
   },
   generateEnginePath: mockGenerateEnginePath,
+  getEngineBreadcrumbs: mockGetEngineBreadcrumbs,
 }));

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_router.test.tsx
@@ -18,7 +18,7 @@ import { AnalyticsRouter } from './';
 describe('AnalyticsRouter', () => {
   // Detailed route testing is better done via E2E tests
   it('renders', () => {
-    const wrapper = shallow(<AnalyticsRouter engineBreadcrumb={['Engines', 'some-engine']} />);
+    const wrapper = shallow(<AnalyticsRouter />);
 
     expect(wrapper.find(Switch)).toHaveLength(1);
     expect(wrapper.find(Route)).toHaveLength(9);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_router.tsx
@@ -10,7 +10,6 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 
 import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { BreadcrumbTrail } from '../../../shared/kibana_chrome/generate_breadcrumbs';
 import { NotFound } from '../../../shared/not_found';
 import {
   ENGINE_ANALYTICS_PATH,
@@ -22,7 +21,7 @@ import {
   ENGINE_ANALYTICS_QUERY_DETAILS_PATH,
   ENGINE_ANALYTICS_QUERY_DETAIL_PATH,
 } from '../../routes';
-import { generateEnginePath } from '../engine';
+import { generateEnginePath, getEngineBreadcrumbs } from '../engine';
 
 import {
   ANALYTICS_TITLE,
@@ -42,11 +41,8 @@ import {
   QueryDetail,
 } from './views';
 
-interface Props {
-  engineBreadcrumb: BreadcrumbTrail;
-}
-export const AnalyticsRouter: React.FC<Props> = ({ engineBreadcrumb }) => {
-  const ANALYTICS_BREADCRUMB = [...engineBreadcrumb, ANALYTICS_TITLE];
+export const AnalyticsRouter: React.FC = () => {
+  const ANALYTICS_BREADCRUMB = getEngineBreadcrumbs([ANALYTICS_TITLE]);
 
   return (
     <Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.test.tsx
@@ -7,10 +7,11 @@
 
 import { setMockValues, setMockActions, rerender } from '../../../__mocks__';
 import '../../../__mocks__/shallow_useeffect.mock';
+import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { EuiPageHeader } from '@elastic/eui';
 
@@ -32,16 +33,14 @@ describe('ApiLogs', () => {
     pollForApiLogs: jest.fn(),
   };
 
-  let wrapper: ShallowWrapper;
-
   beforeEach(() => {
     jest.clearAllMocks();
     setMockValues(values);
     setMockActions(actions);
-    wrapper = shallow(<ApiLogs engineBreadcrumb={['some engine']} />);
   });
 
   it('renders', () => {
+    const wrapper = shallow(<ApiLogs />);
     expect(wrapper.find(EuiPageHeader).prop('pageTitle')).toEqual('API Logs');
     expect(wrapper.find(ApiLogsTable)).toHaveLength(1);
     expect(wrapper.find(NewApiEventsPrompt)).toHaveLength(1);
@@ -52,13 +51,14 @@ describe('ApiLogs', () => {
 
   it('renders a loading screen', () => {
     setMockValues({ ...values, dataLoading: true, apiLogs: [] });
-    rerender(wrapper);
+    const wrapper = shallow(<ApiLogs />);
 
     expect(wrapper.find(Loading)).toHaveLength(1);
   });
 
   describe('effects', () => {
     it('calls a manual fetchApiLogs on page load and pagination', () => {
+      const wrapper = shallow(<ApiLogs />);
       expect(actions.fetchApiLogs).toHaveBeenCalledTimes(1);
 
       setMockValues({ ...values, meta: { page: { current: 2 } } });
@@ -68,6 +68,7 @@ describe('ApiLogs', () => {
     });
 
     it('starts pollForApiLogs on page load', () => {
+      shallow(<ApiLogs />);
       expect(actions.pollForApiLogs).toHaveBeenCalledTimes(1);
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.tsx
@@ -21,9 +21,9 @@ import {
 
 import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { BreadcrumbTrail } from '../../../shared/kibana_chrome/generate_breadcrumbs';
 import { Loading } from '../../../shared/loading';
 
+import { getEngineBreadcrumbs } from '../engine';
 import { LogRetentionCallout, LogRetentionTooltip, LogRetentionOptions } from '../log_retention';
 
 import { ApiLogFlyout } from './api_log';
@@ -32,10 +32,7 @@ import { API_LOGS_TITLE, RECENT_API_EVENTS } from './constants';
 
 import { ApiLogsLogic } from './';
 
-interface Props {
-  engineBreadcrumb: BreadcrumbTrail;
-}
-export const ApiLogs: React.FC<Props> = ({ engineBreadcrumb }) => {
+export const ApiLogs: React.FC = () => {
   const { dataLoading, apiLogs, meta } = useValues(ApiLogsLogic);
   const { fetchApiLogs, pollForApiLogs } = useActions(ApiLogsLogic);
 
@@ -51,7 +48,7 @@ export const ApiLogs: React.FC<Props> = ({ engineBreadcrumb }) => {
 
   return (
     <>
-      <SetPageChrome trail={[...engineBreadcrumb, API_LOGS_TITLE]} />
+      <SetPageChrome trail={getEngineBreadcrumbs([API_LOGS_TITLE])} />
       <EuiPageHeader pageTitle={API_LOGS_TITLE} />
 
       <FlashMessages />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import '../../__mocks__/engine_logic.mock';
+
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
@@ -14,7 +16,7 @@ import { CurationsRouter } from './';
 
 describe('CurationsRouter', () => {
   it('renders', () => {
-    const wrapper = shallow(<CurationsRouter engineBreadcrumb={['Engines', 'some-engine']} />);
+    const wrapper = shallow(<CurationsRouter />);
 
     expect(wrapper.find(Switch)).toHaveLength(1);
     expect(wrapper.find(Route)).toHaveLength(4);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.tsx
@@ -10,23 +10,20 @@ import { Route, Switch } from 'react-router-dom';
 
 import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { BreadcrumbTrail } from '../../../shared/kibana_chrome/generate_breadcrumbs';
 import { NotFound } from '../../../shared/not_found';
 import {
   ENGINE_CURATIONS_PATH,
   ENGINE_CURATIONS_NEW_PATH,
   ENGINE_CURATION_PATH,
 } from '../../routes';
+import { getEngineBreadcrumbs } from '../engine';
 
 import { CURATIONS_TITLE, CREATE_NEW_CURATION_TITLE } from './constants';
 import { Curation } from './curation';
 import { Curations, CurationCreation } from './views';
 
-interface Props {
-  engineBreadcrumb: BreadcrumbTrail;
-}
-export const CurationsRouter: React.FC<Props> = ({ engineBreadcrumb }) => {
-  const CURATIONS_BREADCRUMB = [...engineBreadcrumb, CURATIONS_TITLE];
+export const CurationsRouter: React.FC = () => {
+  const CURATIONS_BREADCRUMB = getEngineBreadcrumbs([CURATIONS_TITLE]);
 
   return (
     <Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.test.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import '../../../__mocks__/react_router_history.mock';
 import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
 import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
+import '../../../__mocks__/react_router_history.mock';
+import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 import { useParams } from 'react-router-dom';
@@ -44,17 +45,17 @@ describe('DocumentDetail', () => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<DocumentDetail engineBreadcrumb={['test']} />);
+    const wrapper = shallow(<DocumentDetail />);
     expect(wrapper.find(EuiPageContent).length).toBe(1);
   });
 
   it('initializes data on mount', () => {
-    shallow(<DocumentDetail engineBreadcrumb={['test']} />);
+    shallow(<DocumentDetail />);
     expect(actions.getDocumentDetails).toHaveBeenCalledWith('1');
   });
 
   it('calls setFields on unmount', () => {
-    shallow(<DocumentDetail engineBreadcrumb={['test']} />);
+    shallow(<DocumentDetail />);
     unmountHandler();
     expect(actions.setFields).toHaveBeenCalledWith([]);
   });
@@ -65,7 +66,7 @@ describe('DocumentDetail', () => {
       dataLoading: true,
     });
 
-    const wrapper = shallow(<DocumentDetail engineBreadcrumb={['test']} />);
+    const wrapper = shallow(<DocumentDetail />);
 
     expect(wrapper.find(Loading).length).toBe(1);
   });
@@ -80,7 +81,7 @@ describe('DocumentDetail', () => {
     };
 
     beforeEach(() => {
-      const wrapper = shallow(<DocumentDetail engineBreadcrumb={['test']} />);
+      const wrapper = shallow(<DocumentDetail />);
       columns = wrapper.find(EuiBasicTable).props().columns;
     });
 
@@ -101,7 +102,7 @@ describe('DocumentDetail', () => {
   });
 
   it('will delete the document when the delete button is pressed', () => {
-    const wrapper = shallow(<DocumentDetail engineBreadcrumb={['test']} />);
+    const wrapper = shallow(<DocumentDetail />);
     const header = wrapper.find(EuiPageHeader).dive().children().dive();
     const button = header.find('[data-test-subj="DeleteDocumentButton"]');
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.tsx
@@ -25,6 +25,7 @@ import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { Loading } from '../../../shared/loading';
 import { useDecodedParams } from '../../utils/encode_path_params';
+import { getEngineBreadcrumbs } from '../engine';
 import { ResultFieldValue } from '../result';
 
 import { DOCUMENTS_TITLE } from './constants';
@@ -36,11 +37,8 @@ const DOCUMENT_DETAIL_TITLE = (documentId: string) =>
     defaultMessage: 'Document: {documentId}',
     values: { documentId },
   });
-interface Props {
-  engineBreadcrumb: string[];
-}
 
-export const DocumentDetail: React.FC<Props> = ({ engineBreadcrumb }) => {
+export const DocumentDetail: React.FC = () => {
   const { dataLoading, fields } = useValues(DocumentDetailLogic);
   const { deleteDocument, getDocumentDetails, setFields } = useActions(DocumentDetailLogic);
 
@@ -77,7 +75,7 @@ export const DocumentDetail: React.FC<Props> = ({ engineBreadcrumb }) => {
 
   return (
     <>
-      <SetPageChrome trail={[...engineBreadcrumb, DOCUMENTS_TITLE, documentTitle]} />
+      <SetPageChrome trail={getEngineBreadcrumbs([DOCUMENTS_TITLE, documentTitle])} />
       <EuiPageHeader
         pageTitle={DOCUMENT_DETAIL_TITLE(documentTitle)}
         rightSideItems={[

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { setMockValues } from '../../../__mocks__/kea.mock';
+import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
@@ -30,7 +31,7 @@ describe('Documents', () => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<Documents engineBreadcrumb={['test']} />);
+    const wrapper = shallow(<Documents />);
     expect(wrapper.find(SearchExperience).exists()).toBe(true);
   });
 
@@ -44,7 +45,7 @@ describe('Documents', () => {
         myRole: { canManageEngineDocuments: true },
       });
 
-      const wrapper = shallow(<Documents engineBreadcrumb={['test']} />);
+      const wrapper = shallow(<Documents />);
       expect(getHeader(wrapper).find(DocumentCreationButton).exists()).toBe(true);
     });
 
@@ -54,7 +55,7 @@ describe('Documents', () => {
         myRole: { canManageEngineDocuments: false },
       });
 
-      const wrapper = shallow(<Documents engineBreadcrumb={['test']} />);
+      const wrapper = shallow(<Documents />);
       expect(getHeader(wrapper).find(DocumentCreationButton).exists()).toBe(false);
     });
 
@@ -65,7 +66,7 @@ describe('Documents', () => {
         isMetaEngine: true,
       });
 
-      const wrapper = shallow(<Documents engineBreadcrumb={['test']} />);
+      const wrapper = shallow(<Documents />);
       expect(getHeader(wrapper).find(DocumentCreationButton).exists()).toBe(false);
     });
   });
@@ -77,7 +78,7 @@ describe('Documents', () => {
         isMetaEngine: true,
       });
 
-      const wrapper = shallow(<Documents engineBreadcrumb={['test']} />);
+      const wrapper = shallow(<Documents />);
       expect(wrapper.find('[data-test-subj="MetaEnginesCallout"]').exists()).toBe(true);
     });
 
@@ -87,7 +88,7 @@ describe('Documents', () => {
         isMetaEngine: false,
       });
 
-      const wrapper = shallow(<Documents engineBreadcrumb={['test']} />);
+      const wrapper = shallow(<Documents />);
       expect(wrapper.find('[data-test-subj="MetaEnginesCallout"]').exists()).toBe(false);
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
@@ -16,23 +16,19 @@ import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 
 import { AppLogic } from '../../app_logic';
-import { EngineLogic } from '../engine';
+import { EngineLogic, getEngineBreadcrumbs } from '../engine';
 
 import { DOCUMENTS_TITLE } from './constants';
 import { DocumentCreationButton } from './document_creation_button';
 import { SearchExperience } from './search_experience';
 
-interface Props {
-  engineBreadcrumb: string[];
-}
-
-export const Documents: React.FC<Props> = ({ engineBreadcrumb }) => {
+export const Documents: React.FC = () => {
   const { isMetaEngine } = useValues(EngineLogic);
   const { myRole } = useValues(AppLogic);
 
   return (
     <>
-      <SetPageChrome trail={[...engineBreadcrumb, DOCUMENTS_TITLE]} />
+      <SetPageChrome trail={getEngineBreadcrumbs([DOCUMENTS_TITLE])} />
       <EuiPageHeader
         pageTitle={DOCUMENTS_TITLE}
         rightSideItems={

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -38,12 +38,11 @@ import { ApiLogs } from '../api_logs';
 import { CurationsRouter } from '../curations';
 import { DocumentDetail, Documents } from '../documents';
 import { EngineOverview } from '../engine_overview';
-import { ENGINES_TITLE } from '../engines';
 import { RelevanceTuning } from '../relevance_tuning';
 
 import { ResultSettings } from '../result_settings';
 
-import { EngineLogic } from './';
+import { EngineLogic, getEngineBreadcrumbs } from './';
 
 export const EngineRouter: React.FC = () => {
   const {
@@ -85,43 +84,41 @@ export const EngineRouter: React.FC = () => {
   const isLoadingNewEngine = engineName !== engineNameFromUrl;
   if (isLoadingNewEngine || dataLoading) return <Loading />;
 
-  const engineBreadcrumb = [ENGINES_TITLE, engineName];
-
   return (
     <Switch>
       {canViewEngineAnalytics && (
         <Route path={ENGINE_ANALYTICS_PATH}>
-          <AnalyticsRouter engineBreadcrumb={engineBreadcrumb} />
+          <AnalyticsRouter />
         </Route>
       )}
       <Route path={ENGINE_DOCUMENT_DETAIL_PATH}>
-        <DocumentDetail engineBreadcrumb={engineBreadcrumb} />
+        <DocumentDetail />
       </Route>
       <Route path={ENGINE_DOCUMENTS_PATH}>
-        <Documents engineBreadcrumb={engineBreadcrumb} />
+        <Documents />
       </Route>
       {canManageEngineCurations && (
         <Route path={ENGINE_CURATIONS_PATH}>
-          <CurationsRouter engineBreadcrumb={engineBreadcrumb} />
+          <CurationsRouter />
         </Route>
       )}
       {canManageEngineRelevanceTuning && (
         <Route path={ENGINE_RELEVANCE_TUNING_PATH}>
-          <RelevanceTuning engineBreadcrumb={engineBreadcrumb} />
+          <RelevanceTuning />
         </Route>
       )}
       {canManageEngineResultSettings && (
         <Route path={ENGINE_RESULT_SETTINGS_PATH}>
-          <ResultSettings engineBreadcrumb={engineBreadcrumb} />
+          <ResultSettings />
         </Route>
       )}
       {canViewEngineApiLogs && (
         <Route path={ENGINE_API_LOGS_PATH}>
-          <ApiLogs engineBreadcrumb={engineBreadcrumb} />
+          <ApiLogs />
         </Route>
       )}
       <Route>
-        <SetPageChrome trail={[...engineBreadcrumb]} />
+        <SetPageChrome trail={getEngineBreadcrumbs()} />
         <EngineOverview />
       </Route>
     </Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/index.ts
@@ -8,4 +8,4 @@
 export { EngineRouter } from './engine_router';
 export { EngineNav } from './engine_nav';
 export { EngineLogic } from './engine_logic';
-export { generateEnginePath } from './utils';
+export { generateEnginePath, getEngineBreadcrumbs } from './utils';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/utils.test.ts
@@ -7,10 +7,12 @@
 
 import { mockEngineValues } from '../../__mocks__';
 
-import { generateEnginePath } from './utils';
+import { generateEnginePath, getEngineBreadcrumbs } from './utils';
 
 describe('generateEnginePath', () => {
-  mockEngineValues.engineName = 'hello-world';
+  beforeEach(() => {
+    mockEngineValues.engineName = 'hello-world';
+  });
 
   it('generates paths with engineName filled from state', () => {
     expect(generateEnginePath('/engines/:engineName/example')).toEqual(
@@ -25,5 +27,17 @@ describe('generateEnginePath', () => {
         bar: 'baz',
       })
     ).toEqual('/engines/override/foo/baz');
+  });
+});
+
+describe('getEngineBreadcrumbs', () => {
+  beforeEach(() => {
+    mockEngineValues.engineName = 'foo';
+  });
+
+  it('generates breadcrumbs with engineName filled from state', () => {
+    expect(getEngineBreadcrumbs(['bar', 'baz'])).toEqual(['Engines', 'foo', 'bar', 'baz']);
+    expect(getEngineBreadcrumbs(['bar'])).toEqual(['Engines', 'foo', 'bar']);
+    expect(getEngineBreadcrumbs()).toEqual(['Engines', 'foo']);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/utils.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
+import { BreadcrumbTrail } from '../../../shared/kibana_chrome/generate_breadcrumbs';
 import { generateEncodedPath } from '../../utils/encode_path_params';
+
+import { ENGINES_TITLE } from '../engines';
 
 import { EngineLogic } from './';
 
@@ -15,4 +18,12 @@ import { EngineLogic } from './';
 export const generateEnginePath = (path: string, pathParams: object = {}) => {
   const { engineName } = EngineLogic.values;
   return generateEncodedPath(path, { engineName, ...pathParams });
+};
+
+/**
+ * Generate a breadcrumb trail with engineName automatically filled from EngineLogic state
+ */
+export const getEngineBreadcrumbs = (breadcrumbs: BreadcrumbTrail = []) => {
+  const { engineName } = EngineLogic.values;
+  return [ENGINES_TITLE, engineName, ...breadcrumbs];
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning.test.tsx
@@ -4,8 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import '../../../__mocks__/shallow_useeffect.mock';
+
 import { setMockActions, setMockValues } from '../../../__mocks__/kea.mock';
+import '../../../__mocks__/shallow_useeffect.mock';
+import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
@@ -37,7 +39,7 @@ describe('RelevanceTuning', () => {
     resetSearchSettings: jest.fn(),
   };
 
-  const subject = () => shallow(<RelevanceTuning engineBreadcrumb={['test']} />);
+  const subject = () => shallow(<RelevanceTuning />);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning.tsx
@@ -23,10 +23,6 @@ import { RelevanceTuningPreview } from './relevance_tuning_preview';
 
 import { RelevanceTuningLogic } from '.';
 
-interface Props {
-  engineBreadcrumb: string[];
-}
-
 const EmptyCallout: React.FC = () => {
   return (
     <EuiEmptyPrompt
@@ -65,7 +61,7 @@ const EmptyCallout: React.FC = () => {
   );
 };
 
-export const RelevanceTuning: React.FC<Props> = ({ engineBreadcrumb }) => {
+export const RelevanceTuning: React.FC = () => {
   const { dataLoading, engineHasSchemaFields, unsavedChanges } = useValues(RelevanceTuningLogic);
   const { initializeRelevanceTuning } = useActions(RelevanceTuningLogic);
 
@@ -95,7 +91,7 @@ export const RelevanceTuning: React.FC<Props> = ({ engineBreadcrumb }) => {
   };
 
   return (
-    <RelevanceTuningLayout engineBreadcrumb={engineBreadcrumb}>
+    <RelevanceTuningLayout>
       <UnsavedChangesPrompt hasUnsavedChanges={unsavedChanges} />
       {body()}
     </RelevanceTuningLayout>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_layout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_layout.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { setMockActions, setMockValues } from '../../../__mocks__/kea.mock';
+import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
@@ -32,7 +33,7 @@ describe('RelevanceTuningLayout', () => {
     setMockActions(actions);
   });
 
-  const subject = () => shallow(<RelevanceTuningLayout engineBreadcrumb={['test']} />);
+  const subject = () => shallow(<RelevanceTuningLayout />);
   const findButtons = (wrapper: ShallowWrapper) =>
     wrapper.find(EuiPageHeader).prop('rightSideItems') as React.ReactElement[];
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_layout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_layout.tsx
@@ -17,16 +17,13 @@ import { SAVE_BUTTON_LABEL } from '../../../shared/constants';
 import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { RESTORE_DEFAULTS_BUTTON_LABEL } from '../../constants';
+import { getEngineBreadcrumbs } from '../engine';
 
 import { RELEVANCE_TUNING_TITLE } from './constants';
 import { RelevanceTuningCallouts } from './relevance_tuning_callouts';
 import { RelevanceTuningLogic } from './relevance_tuning_logic';
 
-interface Props {
-  engineBreadcrumb: string[];
-}
-
-export const RelevanceTuningLayout: React.FC<Props> = ({ engineBreadcrumb, children }) => {
+export const RelevanceTuningLayout: React.FC = ({ children }) => {
   const { resetSearchSettings, updateSearchSettings } = useActions(RelevanceTuningLogic);
   const { engineHasSchemaFields } = useValues(RelevanceTuningLogic);
 
@@ -66,7 +63,7 @@ export const RelevanceTuningLayout: React.FC<Props> = ({ engineBreadcrumb, child
 
   return (
     <>
-      <SetPageChrome trail={[...engineBreadcrumb, RELEVANCE_TUNING_TITLE]} />
+      <SetPageChrome trail={getEngineBreadcrumbs([RELEVANCE_TUNING_TITLE])} />
       {pageHeader()}
       <FlashMessages />
       <RelevanceTuningCallouts />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import '../../../__mocks__/shallow_useeffect.mock';
-
 import { setMockValues, setMockActions } from '../../../__mocks__';
+import '../../../__mocks__/shallow_useeffect.mock';
+import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
@@ -37,7 +37,7 @@ describe('RelevanceTuning', () => {
     jest.clearAllMocks();
   });
 
-  const subject = () => shallow(<ResultSettings engineBreadcrumb={['test']} />);
+  const subject = () => shallow(<ResultSettings />);
   const findButtons = (wrapper: ShallowWrapper) =>
     wrapper.find(EuiPageHeader).prop('rightSideItems') as React.ReactElement[];
 
@@ -48,7 +48,7 @@ describe('RelevanceTuning', () => {
   });
 
   it('initializes result settings data when mounted', () => {
-    shallow(<ResultSettings engineBreadcrumb={['test']} />);
+    shallow(<ResultSettings />);
     expect(actions.initializeResultSettingsData).toHaveBeenCalled();
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
@@ -18,10 +18,10 @@ import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { Loading } from '../../../shared/loading';
 import { RESTORE_DEFAULTS_BUTTON_LABEL } from '../../constants';
+import { getEngineBreadcrumbs } from '../engine';
 
 import { RESULT_SETTINGS_TITLE } from './constants';
 import { ResultSettingsTable } from './result_settings_table';
-
 import { SampleResponse } from './sample_response';
 
 import { ResultSettingsLogic } from '.';
@@ -31,11 +31,7 @@ const CLEAR_BUTTON_LABEL = i18n.translate(
   { defaultMessage: 'Clear all values' }
 );
 
-interface Props {
-  engineBreadcrumb: string[];
-}
-
-export const ResultSettings: React.FC<Props> = ({ engineBreadcrumb }) => {
+export const ResultSettings: React.FC = () => {
   const { dataLoading } = useValues(ResultSettingsLogic);
   const {
     initializeResultSettingsData,
@@ -52,7 +48,7 @@ export const ResultSettings: React.FC<Props> = ({ engineBreadcrumb }) => {
 
   return (
     <>
-      <SetPageChrome trail={[...engineBreadcrumb, RESULT_SETTINGS_TITLE]} />
+      <SetPageChrome trail={getEngineBreadcrumbs([RESULT_SETTINGS_TITLE])} />
       <EuiPageHeader
         pageTitle={RESULT_SETTINGS_TITLE}
         description={i18n.translate(


### PR DESCRIPTION
## Summary

Adds a super small `getEngineBreadcrumbs()` utility that populates an engine breadcrumb trail from the currently loaded engine. This DRY's out having to repeatedly pass `engineBreadcrumb` as a prop to multiple components.

### Before:

```tsx
<SomeView engineBreadcrumb={engineBreadcrumb} />

export const SomeView: React.FC<Props> = ({ engineBreadcrumb }) => (
  <SetPageChrome trail={[...engineBreadcrumb, 'Some parent view', 'Some child view']} />
);
```

### After

```tsx
import { getEngineBreadcrumbs } from '../engine';

export const SomeView: React.FC = () => (
  <SetPageChrome trail={getEngineBreadcrumbs(['Some parent view', 'Some child view'])} />
);
```

## QA

- [x] All engine breadcrumbs function as before

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios