### PR TITLE
[Lens] respect custom labels for fields in time series visualizations

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -70,7 +70,10 @@ const fieldsOne = [
     aggregatable: true,
     searchable: true,
   },
-  documentField,
+  {
+    ...documentField,
+    displayName: 'Records label',
+  },
 ];
 
 const fieldsTwo = [
@@ -2230,7 +2233,7 @@ describe('IndexPattern Data Source suggestions', () => {
                   operation: {
                     dataType: 'number',
                     isBucketed: false,
-                    label: 'Cumulative sum of Records',
+                    label: 'Cumulative sum of Records label',
                     scale: undefined,
                   },
                 },

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions.test.ts
@@ -134,6 +134,40 @@ const layer: IndexPatternLayer = {
   },
 };
 
+describe('labels', () => {
+  const calcColumnArgs = {
+    ...baseColumnArgs,
+    referenceIds: ['metric'],
+    layer,
+    previousColumn: layer.columns.metric,
+  };
+  it('should use label of referenced operation to create label for derivative and moving average', () => {
+    expect(derivativeOperation.buildColumn(calcColumnArgs)).toEqual(
+      expect.objectContaining({
+        label: 'Differences of metricLabel',
+      })
+    );
+    expect(movingAverageOperation.buildColumn(calcColumnArgs)).toEqual(
+      expect.objectContaining({
+        label: 'Moving average of metricLabel',
+      })
+    );
+  });
+
+  it('should use displayName of a field for a label for counter rate and cumulative sum', () => {
+    expect(counterRateOperation.buildColumn(calcColumnArgs)).toEqual(
+      expect.objectContaining({
+        label: 'Counter rate of bytesLabel per second',
+      })
+    );
+    expect(cumulativeSumOperation.buildColumn(calcColumnArgs)).toEqual(
+      expect.objectContaining({
+        label: 'Cumulative sum of bytesLabel',
+      })
+    );
+  });
+});
+
 describe('time scale transition', () => {
   it('should carry over time scale and adjust label on operation from count to sum', () => {
     expect(
@@ -158,60 +192,6 @@ describe('time scale transition', () => {
         expect(result.timeScale).toEqual('h');
         expect(result.label).toContain('per hour');
       }
-    );
-  });
-
-  it('should use label of referenced operation to create label for derivative and moving average', () => {
-    expect(
-      derivativeOperation.buildColumn({
-        ...baseColumnArgs,
-        referenceIds: ['metric'],
-        layer,
-        previousColumn: layer.columns.metric,
-      })
-    ).toEqual(
-      expect.objectContaining({
-        label: 'Differences of metricLabel',
-      })
-    );
-    expect(
-      movingAverageOperation.buildColumn({
-        ...baseColumnArgs,
-        referenceIds: ['metric'],
-        layer,
-        previousColumn: layer.columns.metric,
-      })
-    ).toEqual(
-      expect.objectContaining({
-        label: 'Moving average of metricLabel',
-      })
-    );
-  });
-
-  it('should use displayName of a field for a label for counter rate and cumulative sum', () => {
-    expect(
-      counterRateOperation.buildColumn({
-        ...baseColumnArgs,
-        referenceIds: ['metric'],
-        layer,
-        previousColumn: layer.columns.metric,
-      })
-    ).toEqual(
-      expect.objectContaining({
-        label: 'Counter rate of bytesLabel per second',
-      })
-    );
-    expect(
-      cumulativeSumOperation.buildColumn({
-        ...baseColumnArgs,
-        referenceIds: ['metric'],
-        layer,
-        previousColumn: layer.columns.metric,
-      })
-    ).toEqual(
-      expect.objectContaining({
-        label: 'Cumulative sum of bytesLabel',
-      })
     );
   });
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
@@ -75,11 +75,16 @@ export const counterRateOperation: OperationDefinition<
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'lens_counter_rate');
   },
-  buildColumn: ({ referenceIds, previousColumn, layer }) => {
+  buildColumn: ({ referenceIds, previousColumn, layer, indexPattern }) => {
     const metric = layer.columns[referenceIds[0]];
     const timeScale = previousColumn?.timeScale || DEFAULT_TIME_SCALE;
     return {
-      label: ofName(metric && 'label' in metric ? metric.label : undefined, timeScale),
+      label: ofName(
+        metric && 'sourceField' in metric
+          ? indexPattern.getFieldByName(metric.sourceField)?.displayName
+          : undefined,
+        timeScale
+      ),
       dataType: 'number',
       operationType: 'counter_rate',
       isBucketed: false,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
@@ -65,7 +65,12 @@ export const counterRateOperation: OperationDefinition<
     }
   },
   getDefaultLabel: (column, indexPattern, columns) => {
-    return ofName(columns[column.references[0]]?.label, column.timeScale);
+    const ref = columns[column.references[0]];
+    return ofName(
+      ref && 'sourceField' in ref
+        ? indexPattern.getFieldByName(ref.sourceField)?.displayName
+        : undefined
+    );
   },
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'lens_counter_rate');

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
@@ -65,8 +65,7 @@ export const counterRateOperation: OperationDefinition<
     }
   },
   getDefaultLabel: (column, indexPattern, columns) => {
-    const ref = columns[column.references[0]];
-    return ofName(ref && 'sourceField' in ref ? ref.sourceField : undefined, column.timeScale);
+    return ofName(columns[column.references[0]]?.label, column.timeScale);
   },
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'lens_counter_rate');
@@ -75,7 +74,7 @@ export const counterRateOperation: OperationDefinition<
     const metric = layer.columns[referenceIds[0]];
     const timeScale = previousColumn?.timeScale || DEFAULT_TIME_SCALE;
     return {
-      label: ofName(metric && 'sourceField' in metric ? metric.sourceField : undefined, timeScale),
+      label: ofName(metric && 'label' in metric ? metric.label : undefined, timeScale),
       dataType: 'number',
       operationType: 'counter_rate',
       isBucketed: false,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
@@ -69,7 +69,8 @@ export const counterRateOperation: OperationDefinition<
     return ofName(
       ref && 'sourceField' in ref
         ? indexPattern.getFieldByName(ref.sourceField)?.displayName
-        : undefined
+        : undefined,
+      column.timeScale
     );
   },
   toExpression: (layer, columnId) => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
@@ -63,8 +63,7 @@ export const cumulativeSumOperation: OperationDefinition<
     }
   },
   getDefaultLabel: (column, indexPattern, columns) => {
-    const ref = columns[column.references[0]];
-    return ofName(ref && 'sourceField' in ref ? ref.sourceField : undefined);
+    return ofName(columns[column.references[0]]?.label);
   },
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'cumulative_sum');
@@ -72,7 +71,7 @@ export const cumulativeSumOperation: OperationDefinition<
   buildColumn: ({ referenceIds, previousColumn, layer }) => {
     const ref = layer.columns[referenceIds[0]];
     return {
-      label: ofName(ref && 'sourceField' in ref ? ref.sourceField : undefined),
+      label: ofName(ref && 'label' in ref ? ref.label : undefined),
       dataType: 'number',
       operationType: 'cumulative_sum',
       isBucketed: false,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
@@ -73,11 +73,14 @@ export const cumulativeSumOperation: OperationDefinition<
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'cumulative_sum');
   },
-  buildColumn: ({ referenceIds, previousColumn, layer }) => {
+  buildColumn: ({ referenceIds, previousColumn, layer, indexPattern }) => {
     const ref = layer.columns[referenceIds[0]];
-
     return {
-      label: ofName(ref && 'label' in ref ? ref.label : undefined),
+      label: ofName(
+        ref && 'sourceField' in ref
+          ? indexPattern.getFieldByName(ref.sourceField)?.displayName
+          : undefined
+      ),
       dataType: 'number',
       operationType: 'cumulative_sum',
       isBucketed: false,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
@@ -63,13 +63,19 @@ export const cumulativeSumOperation: OperationDefinition<
     }
   },
   getDefaultLabel: (column, indexPattern, columns) => {
-    return ofName(columns[column.references[0]]?.label);
+    const ref = columns[column.references[0]];
+    return ofName(
+      ref && 'sourceField' in ref
+        ? indexPattern.getFieldByName(ref.sourceField)?.displayName
+        : undefined
+    );
   },
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'cumulative_sum');
   },
   buildColumn: ({ referenceIds, previousColumn, layer }) => {
     const ref = layer.columns[referenceIds[0]];
+
     return {
       label: ofName(ref && 'label' in ref ? ref.label : undefined),
       dataType: 'number',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/differences.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/differences.tsx
@@ -74,7 +74,7 @@ export const derivativeOperation: OperationDefinition<
   buildColumn: ({ referenceIds, previousColumn, layer }) => {
     const ref = layer.columns[referenceIds[0]];
     return {
-      label: ofName(ref && 'label' in ref ? ref.label : undefined, previousColumn?.timeScale),
+      label: ofName(ref?.label, previousColumn?.timeScale),
       dataType: 'number',
       operationType: OPERATION_NAME,
       isBucketed: false,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/differences.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/differences.tsx
@@ -66,8 +66,7 @@ export const derivativeOperation: OperationDefinition<
     }
   },
   getDefaultLabel: (column, indexPattern, columns) => {
-    const ref = columns[column.references[0]];
-    return ofName(ref && 'sourceField' in ref ? ref.sourceField : undefined, column.timeScale);
+    return ofName(columns[column.references[0]]?.label, column.timeScale);
   },
   toExpression: (layer, columnId) => {
     return dateBasedOperationToExpression(layer, columnId, 'derivative');
@@ -75,10 +74,7 @@ export const derivativeOperation: OperationDefinition<
   buildColumn: ({ referenceIds, previousColumn, layer }) => {
     const ref = layer.columns[referenceIds[0]];
     return {
-      label: ofName(
-        ref && 'sourceField' in ref ? ref.sourceField : undefined,
-        previousColumn?.timeScale
-      ),
+      label: ofName(ref && 'label' in ref ? ref.label : undefined, previousColumn?.timeScale),
       dataType: 'number',
       operationType: OPERATION_NAME,
       isBucketed: false,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/93574

For moving average and differences, I've decided to pass the name of the inner operation too:

<img width="185" alt="Screenshot 2021-04-13 at 14 47 04" src="https://user-images.githubusercontent.com/4283304/114554530-1dc5d100-9c67-11eb-8af1-150e8f4638cc.png">
<img width="242" alt="Screenshot 2021-04-13 at 14 47 22" src="https://user-images.githubusercontent.com/4283304/114554571-2918fc80-9c67-11eb-8fba-b66cfc2653a5.png">


For counter_rate and cumulative sum, only the field:

<img width="234" alt="Screenshot 2021-04-13 at 14 47 41" src="https://user-images.githubusercontent.com/4283304/114554602-346c2800-9c67-11eb-864d-afeb5e419130.png">
<img width="240" alt="Screenshot 2021-04-13 at 14 47 49" src="https://user-images.githubusercontent.com/4283304/114554619-3930dc00-9c67-11eb-9b1b-411da9924c9f.png">
