### PR TITLE
[Lens] Give test more time

### DIFF
--- a/x-pack/plugins/lens/public/debounced_component/debounced_component.test.tsx
+++ b/x-pack/plugins/lens/public/debounced_component/debounced_component.test.tsx
@@ -26,7 +26,7 @@ describe('debouncedComponent', () => {
     component.setProps({ title: 'yall' });
     expect(component.text()).toEqual('there');
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 1));
+      await new Promise((r) => setTimeout(r, 10));
     });
     expect(component.text()).toEqual('yall');
   });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/96697

We were debouncing by 1ms and also waiting for 1ms which is a bit tight. I tried to resolve this properly by forwarding the timers using jest, but it didn't place nicely with the lodash debounce function, that's why I resorted to this fix