### PR TITLE
[Workplace Search] Hide Kibana chrome on 3rd party connector redirects

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
@@ -7,7 +7,7 @@
 
 import '../../../../__mocks__/shallow_useeffect.mock';
 
-import { setMockActions } from '../../../../__mocks__';
+import { setMockActions, setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
 import { useLocation } from 'react-router-dom';
@@ -20,9 +20,11 @@ import { SourceAdded } from './source_added';
 
 describe('SourceAdded', () => {
   const saveSourceParams = jest.fn();
+  const setChromeIsVisible = jest.fn();
 
   beforeEach(() => {
     setMockActions({ saveSourceParams });
+    setMockValues({ setChromeIsVisible });
   });
 
   it('renders', () => {
@@ -32,5 +34,6 @@ describe('SourceAdded', () => {
 
     expect(wrapper.find(Loading)).toHaveLength(1);
     expect(saveSourceParams).toHaveBeenCalled();
+    expect(setChromeIsVisible).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -9,10 +9,11 @@ import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { Location } from 'history';
-import { useActions } from 'kea';
+import { useActions, useValues } from 'kea';
 
 import { EuiPage, EuiPageBody } from '@elastic/eui';
 
+import { KibanaLogic } from '../../../../shared/kibana';
 import { Loading } from '../../../../shared/loading';
 
 import { AddSourceLogic } from './add_source/add_source_logic';
@@ -24,7 +25,11 @@ import { AddSourceLogic } from './add_source/add_source_logic';
  */
 export const SourceAdded: React.FC = () => {
   const { search } = useLocation() as Location;
+  const { setChromeIsVisible } = useValues(KibanaLogic);
   const { saveSourceParams } = useActions(AddSourceLogic);
+
+  // We don't want the personal dashboard to flash the Kibana chrome, so we hide it.
+  setChromeIsVisible(false);
 
   useEffect(() => {
     saveSourceParams(search);


### PR DESCRIPTION
### closes https://github.com/elastic/workplace-search-team/issues/1642

## Summary

When adding a personal source, the 3rd party app redirects to our app. When this happens, the UI shows a flash of full chrome, which is not desired in the Personal dashboard. The workaround is to hide the chrome on the catchall component that renders the loading spinner before redirecting.

**Before**
![before](https://user-images.githubusercontent.com/1869731/114605327-96c12a80-9c5f-11eb-88f4-a1bc4b4a21be.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/114605364-a04a9280-9c5f-11eb-9cb5-1498c7ecee41.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
