### PR TITLE
[TSVB] Fix per-request caching of index patterns

### DIFF
--- a/src/plugins/vis_type_timeseries/common/__mocks__/index_patterns_utils.ts
+++ b/src/plugins/vis_type_timeseries/common/__mocks__/index_patterns_utils.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const mock = jest.requireActual('../index_patterns_utils');
+
+jest.spyOn(mock, 'fetchIndexPattern');
+
+export const {
+  isStringTypeIndexPattern,
+  getIndexPatternKey,
+  extractIndexPatternValues,
+  fetchIndexPattern,
+} = mock;

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/lib/cached_index_pattern_fetcher.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/lib/cached_index_pattern_fetcher.test.ts
@@ -7,10 +7,13 @@
  */
 
 import { IndexPattern, IndexPatternsService } from 'src/plugins/data/server';
+import { fetchIndexPattern } from '../../../../common/index_patterns_utils';
 import {
   getCachedIndexPatternFetcher,
   CachedIndexPatternFetcher,
 } from './cached_index_pattern_fetcher';
+
+jest.mock('../../../../common/index_patterns_utils');
 
 describe('CachedIndexPatternFetcher', () => {
   let mockedIndices: IndexPattern[] | [];
@@ -24,6 +27,8 @@ describe('CachedIndexPatternFetcher', () => {
       get: jest.fn(() => Promise.resolve(mockedIndices[0])),
       find: jest.fn(() => Promise.resolve(mockedIndices || [])),
     } as unknown) as IndexPatternsService;
+
+    (fetchIndexPattern as jest.Mock).mockClear();
 
     cachedIndexPatternFetcher = getCachedIndexPatternFetcher(indexPatternsService);
   });
@@ -51,6 +56,14 @@ describe('CachedIndexPatternFetcher', () => {
           "indexPatternString": "indexTitle",
         }
       `);
+    });
+
+    test('should cache once', async () => {
+      await cachedIndexPatternFetcher('indexTitle');
+      await cachedIndexPatternFetcher('indexTitle');
+      await cachedIndexPatternFetcher('indexTitle');
+
+      expect(fetchIndexPattern as jest.Mock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -85,6 +98,21 @@ describe('CachedIndexPatternFetcher', () => {
           "indexPatternString": "",
         }
       `);
+    });
+
+    test('should cache once', async () => {
+      mockedIndices = [
+        {
+          id: 'indexId',
+          title: 'indexTitle',
+        },
+      ] as IndexPattern[];
+
+      await cachedIndexPatternFetcher({ id: 'indexId' });
+      await cachedIndexPatternFetcher({ id: 'indexId' });
+      await cachedIndexPatternFetcher({ id: 'indexId' });
+
+      expect(fetchIndexPattern as jest.Mock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/lib/cached_index_pattern_fetcher.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/lib/cached_index_pattern_fetcher.ts
@@ -23,7 +23,7 @@ export const getCachedIndexPatternFetcher = (indexPatternsService: IndexPatterns
 
     const fetchedIndex = fetchIndexPattern(indexPatternValue, indexPatternsService);
 
-    cache.set(indexPatternValue, fetchedIndex);
+    cache.set(key, fetchedIndex);
 
     return fetchedIndex;
   };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/96901 by updating the cache key

Fixes a cache key issue introduced in https://github.com/elastic/kibana/pull/92812/

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
