### PR TITLE
[7.x] [Security Solution] Fixes `Exit full screen` and `Copy to cliboard` styling issues (#96676)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/lib/clipboard/with_copy_to_clipboard.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/clipboard/with_copy_to_clipboard.tsx
@@ -7,21 +7,11 @@
 
 import { EuiToolTip } from '@elastic/eui';
 import React from 'react';
-import styled from 'styled-components';
 
 import { TooltipWithKeyboardShortcut } from '../../components/accessibility/tooltip_with_keyboard_shortcut';
 import * as i18n from '../../components/drag_and_drop/translations';
 
 import { Clipboard } from './clipboard';
-
-const WithCopyToClipboardContainer = styled.div`
-  align-items: center;
-  display: flex;
-  flex-direction: row;
-  user-select: text;
-`;
-
-WithCopyToClipboardContainer.displayName = 'WithCopyToClipboardContainer';
 
 /**
  * Renders `children` with an adjacent icon that when clicked, copies `text` to
@@ -31,7 +21,7 @@ export const WithCopyToClipboard = React.memo<{
   keyboardShortcut?: string;
   text: string;
   titleSummary?: string;
-}>(({ keyboardShortcut = '', text, titleSummary, children }) => (
+}>(({ keyboardShortcut = '', text, titleSummary }) => (
   <EuiToolTip
     content={
       <TooltipWithKeyboardShortcut
@@ -42,10 +32,7 @@ export const WithCopyToClipboard = React.memo<{
       />
     }
   >
-    <WithCopyToClipboardContainer>
-      <>{children}</>
-      <Clipboard content={text} titleSummary={titleSummary} toastLifeTimeMs={800} />
-    </WithCopyToClipboardContainer>
+    <Clipboard content={text} titleSummary={titleSummary} toastLifeTimeMs={800} />
   </EuiToolTip>
 ));
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/pinned_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/pinned_tab_content/index.tsx
@@ -62,11 +62,7 @@ const StyledEuiFlyoutFooter = styled(EuiFlyoutFooter)`
   }
 `;
 
-const ExitFullScreenFlexItem = styled(EuiFlexItem)`
-  &.euiFlexItem {
-    ${({ theme }) => `margin: ${theme.eui.euiSizeS} 0 0 ${theme.eui.euiSizeS};`}
-  }
-
+const ExitFullScreenContainer = styled.div`
   width: 180px;
 `;
 
@@ -205,13 +201,15 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   return (
     <>
       <FullWidthFlexGroup data-test-subj={`${TimelineTabs.pinned}-tab`}>
-        {timelineFullScreen && setTimelineFullScreen != null && (
-          <ExitFullScreenFlexItem grow={false}>
-            <ExitFullScreen fullScreen={timelineFullScreen} setFullScreen={setTimelineFullScreen} />
-          </ExitFullScreenFlexItem>
-        )}
-
         <ScrollableFlexItem grow={2}>
+          {timelineFullScreen && setTimelineFullScreen != null && (
+            <ExitFullScreenContainer>
+              <ExitFullScreen
+                fullScreen={timelineFullScreen}
+                setFullScreen={setTimelineFullScreen}
+              />
+            </ExitFullScreenContainer>
+          )}
           <EventDetailsWidthProvider>
             <StyledEuiFlyoutBody
               data-test-subj={`${TimelineTabs.pinned}-tab-flyout-body`}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ## [Security Solution] Fixes `Exit full screen` and `Copy to cliboard` styling issues (#96676)