### PR TITLE
[Workplace Search] Add breadcrumbs to Role mappings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/constants.ts
@@ -18,15 +18,6 @@ export const UPDATE_ROLE_MAPPING = i18n.translate(
   { defaultMessage: 'Update role mapping' }
 );
 
-export const ADD_ROLE_MAPPING_TITLE = i18n.translate(
-  'xpack.enterpriseSearch.appSearch.roleMapping.newRoleMappingTitle',
-  { defaultMessage: 'Add role mapping' }
-);
-export const MANAGE_ROLE_MAPPING_TITLE = i18n.translate(
-  'xpack.enterpriseSearch.appSearch.roleMapping.manageRoleMappingTitle',
-  { defaultMessage: 'Manage role mapping' }
-);
-
 export const EMPTY_ROLE_MAPPINGS_BODY = i18n.translate(
   'xpack.enterpriseSearch.appSearch.roleMapping.emptyRoleMappingsBody',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mapping.tsx
@@ -33,7 +33,11 @@ import {
   DeleteMappingCallout,
   RoleSelector,
 } from '../../../shared/role_mapping';
-import { ROLE_MAPPINGS_TITLE } from '../../../shared/role_mapping/constants';
+import {
+  ROLE_MAPPINGS_TITLE,
+  ADD_ROLE_MAPPING_TITLE,
+  MANAGE_ROLE_MAPPING_TITLE,
+} from '../../../shared/role_mapping/constants';
 import { AppLogic } from '../../app_logic';
 
 import { roleHasScopedEngines } from '../../utils/role/has_scoped_engines';
@@ -42,8 +46,6 @@ import { Engine } from '../engine/types';
 import {
   SAVE_ROLE_MAPPING,
   UPDATE_ROLE_MAPPING,
-  ADD_ROLE_MAPPING_TITLE,
-  MANAGE_ROLE_MAPPING_TITLE,
   ADVANCED_ROLE_TYPES,
   STANDARD_ROLE_TYPES,
   ADVANCED_ROLE_SELECTORS_TITLE,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -108,6 +108,16 @@ export const ROLE_MAPPINGS_TITLE = i18n.translate(
   }
 );
 
+export const ADD_ROLE_MAPPING_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.newRoleMappingTitle',
+  { defaultMessage: 'Add role mapping' }
+);
+
+export const MANAGE_ROLE_MAPPING_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.manageRoleMappingTitle',
+  { defaultMessage: 'Manage role mapping' }
+);
+
 export const EMPTY_ROLE_MAPPINGS_TITLE = i18n.translate(
   'xpack.enterpriseSearch.roleMapping.emptyRoleMappingsTitle',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
@@ -42,7 +42,9 @@ export const WorkplaceSearchNav: React.FC<Props> = ({
     <SideNavLink to={GROUPS_PATH} subNav={groupsSubNav}>
       {NAV.GROUPS}
     </SideNavLink>
-    <SideNavLink to={ROLE_MAPPINGS_PATH}>{NAV.ROLE_MAPPINGS}</SideNavLink>
+    <SideNavLink shouldShowActiveForSubroutes to={ROLE_MAPPINGS_PATH}>
+      {NAV.ROLE_MAPPINGS}
+    </SideNavLink>
     <SideNavLink to={SECURITY_PATH}>{NAV.SECURITY}</SideNavLink>
     <SideNavLink subNav={settingsSubNav} to={ORG_SETTINGS_PATH}>
       {NAV.SETTINGS}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -40,7 +40,7 @@ export const NAV = {
     defaultMessage: 'Content',
   }),
   ROLE_MAPPINGS: i18n.translate('xpack.enterpriseSearch.workplaceSearch.nav.roleMappings', {
-    defaultMessage: 'Role Mappings',
+    defaultMessage: 'Users & roles',
   }),
   SECURITY: i18n.translate('xpack.enterpriseSearch.workplaceSearch.nav.security', {
     defaultMessage: 'Security',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
@@ -24,13 +24,19 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { FlashMessages } from '../../../shared/flash_messages';
+import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { Loading } from '../../../shared/loading';
 import {
   AttributeSelector,
   DeleteMappingCallout,
   RoleSelector,
 } from '../../../shared/role_mapping';
-import { ROLE_LABEL } from '../../../shared/role_mapping/constants';
+import {
+  ROLE_LABEL,
+  ROLE_MAPPINGS_TITLE,
+  ADD_ROLE_MAPPING_TITLE,
+  MANAGE_ROLE_MAPPING_TITLE,
+} from '../../../shared/role_mapping/constants';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
 import { Role } from '../../types';
 
@@ -105,6 +111,7 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
 
   const hasGroupAssignment = selectedGroups.size > 0 || includeInAllGroups;
 
+  const TITLE = isNew ? ADD_ROLE_MAPPING_TITLE : MANAGE_ROLE_MAPPING_TITLE;
   const SAVE_ROLE_MAPPING_LABEL = i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.roleMapping.saveRoleMappingButtonMessage',
     {
@@ -121,6 +128,7 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
 
   return (
     <>
+      <SetPageChrome trail={[ROLE_MAPPINGS_TITLE, TITLE]} />
       <ViewContentHeader title={SAVE_ROLE_MAPPING_LABEL} action={saveRoleMappingButton} />
       <EuiSpacer size="l" />
       <div>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
@@ -12,6 +12,7 @@ import { useActions, useValues } from 'kea';
 import { EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
 
 import { FlashMessages } from '../../../shared/flash_messages';
+import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { Loading } from '../../../shared/loading';
 import { AddRoleMappingButton, RoleMappingsTable } from '../../../shared/role_mapping';
 import {
@@ -61,6 +62,7 @@ export const RoleMappings: React.FC = () => {
 
   return (
     <>
+      <SetPageChrome trail={[ROLE_MAPPINGS_TITLE]} />
       <ViewContentHeader title={ROLE_MAPPINGS_TITLE} description={ROLE_MAPPINGS_DESCRIPTION} />
       <div>
         <FlashMessages />


### PR DESCRIPTION
## Summary

This PR adds breadcrumbs to Workplace Search Role mappings. It also moves the constants from App Search to `shared` for use in both apps.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
