### PR TITLE
[Workplace Search] Remove shadows from Source overview panels

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -230,7 +230,12 @@ export const Overview: React.FC = () => {
       <EuiFlexGroup direction="column" gutterSize="s" data-test-subj="GroupsSummary">
         {groups.map((group, index) => (
           <EuiFlexItem key={index}>
-            <EuiPanelTo to={getGroupPath(group.id)} data-test-subj="SourceGroupLink">
+            <EuiPanelTo
+              hasShadow={false}
+              color="subdued"
+              to={getGroupPath(group.id)}
+              data-test-subj="SourceGroupLink"
+            >
               <EuiText size="s" className="eui-textTruncate">
                 <strong>{group.name}</strong>
               </EuiText>
@@ -248,7 +253,7 @@ export const Overview: React.FC = () => {
         <h4>{CONFIGURATION_TITLE}</h4>
       </EuiText>
       <EuiSpacer size="s" />
-      <EuiPanel>
+      <EuiPanel hasShadow={false} color="subdued">
         <EuiText size="s">
           {details.map((detail, index) => (
             <EuiFlexGroup
@@ -276,7 +281,7 @@ export const Overview: React.FC = () => {
         <h4>{DOCUMENT_PERMISSIONS_TITLE}</h4>
       </EuiTitle>
       <EuiSpacer size="m" />
-      <EuiPanel>
+      <EuiPanel hasShadow={false} color="subdued">
         <EuiFlexGroup gutterSize="m" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiIcon type={aclImage} size="l" color="primary" />
@@ -298,7 +303,7 @@ export const Overview: React.FC = () => {
         <h4>{DOCUMENT_PERMISSIONS_TITLE}</h4>
       </EuiTitle>
       <EuiSpacer size="m" />
-      <EuiPanel data-test-subj="DocumentPermissionsDisabled">
+      <EuiPanel hasShadow={false} color="subdued" data-test-subj="DocumentPermissionsDisabled">
         <EuiText size="s">
           <EuiFlexGroup wrap gutterSize="m" alignItems="center" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
@@ -329,7 +334,7 @@ export const Overview: React.FC = () => {
   );
 
   const sourceStatus = (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <EuiText size="s">
         <h6>
           <EuiTextColor color="subdued">{STATUS_HEADER}</EuiTextColor>
@@ -353,7 +358,7 @@ export const Overview: React.FC = () => {
   );
 
   const permissionsStatus = (
-    <EuiPanel data-test-subj="PermissionsStatus">
+    <EuiPanel hasShadow={false} color="subdued" data-test-subj="PermissionsStatus">
       <EuiText size="s">
         <h6>
           <EuiTextColor color="subdued">{STATUS_HEADING}</EuiTextColor>
@@ -389,7 +394,7 @@ export const Overview: React.FC = () => {
   );
 
   const credentials = (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <EuiText size="s">
         <h6>
           <EuiTextColor color="subdued">{CREDENTIALS_TITLE}</EuiTextColor>
@@ -409,7 +414,7 @@ export const Overview: React.FC = () => {
     title: string;
     children: React.ReactNode;
   }) => (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <EuiText size="s">
         <h6>
           <EuiTextColor color="subdued">{DOCUMENTATION_LINK_TITLE}</EuiTextColor>
@@ -424,7 +429,7 @@ export const Overview: React.FC = () => {
   );
 
   const documentPermssionsLicenseLocked = (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <LicenseBadge />
       <EuiSpacer size="s" />
       <EuiTitle size="xs">


### PR DESCRIPTION
## Summary

Remove shadows from Source overview panels

**Before**
![before](https://user-images.githubusercontent.com/1869731/114625822-6df95f00-9c78-11eb-8c7c-1b193993d7ac.png)

**After**
![after](https://user-images.githubusercontent.com/1869731/114625823-6fc32280-9c78-11eb-8de5-c2adba41c926.png)
