### PR TITLE
[TSVB][performance] remove visPayloadSchema.validate

### DIFF
--- a/src/plugins/vis_type_timeseries/server/routes/vis.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/vis.ts
@@ -34,14 +34,6 @@ export const visDataRoutes = (router: VisTypeTimeseriesRouter, framework: Framew
         });
       }
 
-      try {
-        visPayloadSchema.validate(request.body);
-      } catch (error) {
-        framework.logger.debug(
-          `Request validation error: ${error.message}. This most likely means your TSVB visualization contains outdated configuration. You can report this problem under https://github.com/elastic/kibana/issues/new?template=Bug_report.md`
-        );
-      }
-
       const results = await getVisData(requestContext, request, framework);
       return response.ok({ body: results });
     }

--- a/src/plugins/vis_type_timeseries/server/routes/vis.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/vis.ts
@@ -9,7 +9,6 @@
 import { schema } from '@kbn/config-schema';
 import { ensureNoUnsafeProperties } from '@kbn/std';
 import { getVisData } from '../lib/get_vis_data';
-import { visPayloadSchema } from '../../common/vis_schema';
 import { ROUTES } from '../../common/constants';
 import { Framework } from '../plugin';
 import type { VisTypeTimeseriesRouter } from '../types';


### PR DESCRIPTION
Part of: #97061

## Summary

First step of work on #97061 ([TSVB] Improve schema validation performance). For current release we remove `visPayloadSchema.validate` method execution to fix the performance issues related with calling this method. 
Next step will be using TS types instead of `visPayloadSchema` in TSVB.
