### PR TITLE
Update VisualizationNoResults component

### DIFF
--- a/src/plugins/visualizations/public/components/__snapshots__/visualization_noresults.test.js.snap
+++ b/src/plugins/visualizations/public/components/__snapshots__/visualization_noresults.test.js.snap
@@ -6,32 +6,27 @@ exports[`VisualizationNoResults should render according to snapshot 1`] = `
   data-test-subj="visNoResult"
 >
   <div
-    class="item top"
-  />
-  <div
-    class="item"
+    class="euiEmptyPrompt"
+    data-test-subj="visualization-error"
   >
+    <span
+      color="default"
+      data-euiicon-type="visualizeApp"
+    />
     <div
-      class="euiText euiText--extraSmall"
+      class="euiSpacer euiSpacer--s"
+    />
+    <span
+      class="euiTextColor euiTextColor--subdued"
     >
       <div
-        class="euiTextColor euiTextColor--subdued"
+        class="euiText euiText--medium"
       >
-        <span
-          color="subdued"
-          data-euiicon-type="visualizeApp"
-        />
-        <div
-          class="euiSpacer euiSpacer--s"
-        />
         <p>
           No results found
         </p>
       </div>
-    </div>
+    </span>
   </div>
-  <div
-    class="item bottom"
-  />
 </div>
 `;

--- a/src/plugins/visualizations/public/components/__snapshots__/visualization_noresults.test.js.snap
+++ b/src/plugins/visualizations/public/components/__snapshots__/visualization_noresults.test.js.snap
@@ -22,9 +22,11 @@ exports[`VisualizationNoResults should render according to snapshot 1`] = `
       <div
         class="euiText euiText--medium"
       >
-        <p>
+        <div
+          class="euiText euiText--extraSmall"
+        >
           No results found
-        </p>
+        </div>
       </div>
     </span>
   </div>

--- a/src/plugins/visualizations/public/components/visualization_error.tsx
+++ b/src/plugins/visualizations/public/components/visualization_error.tsx
@@ -6,12 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { EuiEmptyPrompt } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import React from 'react';
 
 interface VisualizationNoResultsProps {
   onInit?: () => void;
-  error: string;
+  error: string | Error;
 }
 
 export class VisualizationError extends React.Component<VisualizationNoResultsProps> {
@@ -21,7 +21,11 @@ export class VisualizationError extends React.Component<VisualizationNoResultsPr
         iconType="alert"
         iconColor="danger"
         data-test-subj="visualization-error"
-        body={<p>{this.props.error}</p>}
+        body={
+          <EuiText size="xs">
+            {typeof this.props.error === 'string' ? this.props.error : this.props.error.message}
+          </EuiText>
+        }
       />
     );
   }

--- a/src/plugins/visualizations/public/components/visualization_noresults.tsx
+++ b/src/plugins/visualizations/public/components/visualization_noresults.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { EuiEmptyPrompt } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 
@@ -23,11 +23,11 @@ export class VisualizationNoResults extends React.Component<VisualizationNoResul
           iconColor="default"
           data-test-subj="visualization-error"
           body={
-            <p>
+            <EuiText size="xs">
               {i18n.translate('visualizations.noResultsFoundTitle', {
                 defaultMessage: 'No results found',
               })}
-            </p>
+            </EuiText>
           }
         />
       </div>

--- a/src/plugins/visualizations/public/components/visualization_noresults.tsx
+++ b/src/plugins/visualizations/public/components/visualization_noresults.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 
@@ -15,26 +15,21 @@ interface VisualizationNoResultsProps {
 }
 
 export class VisualizationNoResults extends React.Component<VisualizationNoResultsProps> {
-  private containerDiv = React.createRef<HTMLDivElement>();
-
   public render() {
     return (
-      <div data-test-subj="visNoResult" className="visError" ref={this.containerDiv}>
-        <div className="item top" />
-        <div className="item">
-          <EuiText size="xs" color="subdued">
-            <EuiIcon type="visualizeApp" size="m" color="subdued" />
-
-            <EuiSpacer size="s" />
-
+      <div data-test-subj="visNoResult" className="visError">
+        <EuiEmptyPrompt
+          iconType="visualizeApp"
+          iconColor="default"
+          data-test-subj="visualization-error"
+          body={
             <p>
               {i18n.translate('visualizations.noResultsFoundTitle', {
                 defaultMessage: 'No results found',
               })}
             </p>
-          </EuiText>
-        </div>
-        <div className="item bottom" />
+          }
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

@cchaos @chandlerprall  I found that `VisualizationNoResults` is slightly different from other warnings / errors in visualizations. I don't know whether this was done on purpose or not, but it might make sense to use one style for that. 

I recommend to use `EuiEmptyPrompt` for all similar places. 

## Screens
#### Before: 
![image](https://user-images.githubusercontent.com/20072247/114696549-752a7680-9d25-11eb-98d1-997fc707bdb8.png)


#### After: 
![image](https://user-images.githubusercontent.com/20072247/114696487-6217a680-9d25-11eb-8546-c8346e7291af.png)
