### PR TITLE
[ML] security_network module - fix type of defaultIndexPattern

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/manifest.json
@@ -4,11 +4,7 @@
   "description": "Detect anomalous network activity in your ECS-compatible network logs.",
   "type": "network data",
   "logoFile": "logo.json",
-  "defaultIndexPattern": [
-    "logs-*",
-    "filebeat-*",
-    "packetbeat-*"
-  ],
+  "defaultIndexPattern": "logs-*,filebeat-*,packetbeat-*",
   "query": {
     "bool": {
       "filter": [

--- a/x-pack/test/api_integration/apis/ml/modules/get_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/get_module.ts
@@ -11,6 +11,8 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 import { USER } from '../../../../functional/services/ml/security_common';
 import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
 
+import { isPopulatedObject } from '../../../../../plugins/ml/common/util/object_utils';
+
 const moduleIds = [
   'apache_ecs',
   'apm_jsbase',
@@ -69,6 +71,32 @@ export default ({ getService }: FtrProviderContext) => {
       it(`loads module ${moduleId}`, async () => {
         const rspBody = await executeGetModuleRequest(moduleId, USER.ML_POWERUSER, 200);
         expect(rspBody).to.be.an(Object);
+
+        expect(rspBody).to.have.property('id').a('string');
+        expect(rspBody).to.have.property('title').a('string');
+        expect(rspBody).to.have.property('description').a('string');
+        expect(rspBody).to.have.property('type').a('string');
+        if (isPopulatedObject(rspBody, ['logoFile'])) {
+          expect(rspBody).to.have.property('logoFile').a('string');
+        }
+        if (isPopulatedObject(rspBody, ['logo'])) {
+          expect(rspBody).to.have.property('logo').an(Object);
+        }
+        if (isPopulatedObject(rspBody, ['defaultIndexPattern'])) {
+          expect(rspBody).to.have.property('defaultIndexPattern').a('string');
+        }
+        if (isPopulatedObject(rspBody, ['query'])) {
+          expect(rspBody).to.have.property('query').an(Object);
+        }
+        if (isPopulatedObject(rspBody, ['jobs'])) {
+          expect(rspBody).to.have.property('jobs').an(Object);
+        }
+        if (isPopulatedObject(rspBody, ['datafeeds'])) {
+          expect(rspBody).to.have.property('datafeeds').an(Object);
+        }
+        if (isPopulatedObject(rspBody, ['kibana'])) {
+          expect(rspBody).to.have.property('kibana').an(Object);
+        }
 
         expect(rspBody.id).to.eql(moduleId);
       });


### PR DESCRIPTION
## Summary

This PR fixes the `defaultIndexPattern` type in the `security_network` module definition.

### Details / additional information

- `security_network` module has been introduced in #96480
- The `defaultIndexPattern` should be a string (and if more than one index is needed, a string of comma separated patterns, see e.g. the [definition](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json#L7) of the `security_windows` module))
- I've added some response body type checks to the `get_module` API test, that brought up the following failure:
  ```
  Error: expected [ 'logs-*', 'filebeat-*', 'packetbeat-*' ] to be a string
  ```
- Then I've converted the array of patterns into a comma separated string of patterns, which fixed the failing test.
