### PR TITLE
[Workplace Search] Source row and Group Manager Modal bugfixes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+.source-row--error,
+.source-row--error:hover {
+  color: $euiColorDanger;
+  background: rgba($euiColorDanger, .1);
+
+  .euiLink {
+    color: $euiColorDanger;
+  }
+}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 
+import classNames from 'classnames';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -29,6 +31,8 @@ import {
 } from '../../../routes';
 import { ContentSourceDetails } from '../../../types';
 import { SourceIcon } from '../source_icon';
+
+import './source_row.scss';
 
 const CREDENTIALS_INVALID_ERROR_REASON = 'credentials_invalid';
 
@@ -65,6 +69,8 @@ export const SourceRow: React.FC<SourceRowProps> = ({
   const showFix =
     isOrganization && hasError && allowsReauth && errorReason === CREDENTIALS_INVALID_ERROR_REASON;
 
+  const rowClass = classNames({ 'source-row--error': hasError });
+
   const fixLink = (
     <EuiLinkTo
       to={getSourcesPath(
@@ -89,7 +95,7 @@ export const SourceRow: React.FC<SourceRowProps> = ({
   );
 
   return (
-    <EuiTableRow data-test-subj="GroupsRow">
+    <EuiTableRow data-test-subj="GroupsRow" className={rowClass}>
       <EuiTableRowCell>
         <EuiFlexGroup
           justifyContent="flexStart"

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.tsx
@@ -135,7 +135,7 @@ export const GroupManagerModal: React.FC<GroupManagerModalProps> = ({
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="none">
+            <EuiFlexGroup gutterSize="m">
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty data-test-subj="CloseGroupsModal" onClick={handleClose}>
                   {CANCEL_BUTTON}


### PR DESCRIPTION
## Summary

This PR fixes two items from [this bugfix task](https://github.com/elastic/workplace-search-team/issues/1578):

1. Source row error state
![source-row-error](https://user-images.githubusercontent.com/1869731/114759766-32b46a00-9d24-11eb-9fe4-034b248cb172.png)
2. Button spacing on Group Manager Modal
**Before**
![before](https://user-images.githubusercontent.com/1869731/114759699-203a3080-9d24-11eb-8e4a-5e6d6511c8f7.png)
**After**
![after](https://user-images.githubusercontent.com/1869731/114759709-2203f400-9d24-11eb-8593-a132f5e524b9.png)

