### PR TITLE
[App Search] Fixed relevance tuning

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/types.ts
@@ -69,4 +69,5 @@ export interface SearchSettings {
   boosts: Record<string, Boost[]>;
   search_fields: Record<string, SearchField>;
   result_fields?: object;
+  precision?: number;
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.test.ts
@@ -53,6 +53,7 @@ describe('search settings routes', () => {
     boosts,
     result_fields: resultFields,
     search_fields: searchFields,
+    precision: 2,
   };
 
   beforeEach(() => {

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.ts
@@ -22,6 +22,7 @@ const searchSettingsSchema = schema.object({
   boosts,
   result_fields: resultFields,
   search_fields: searchFields,
+  precision: schema.number(),
 });
 
 export function registerSearchSettingsRoutes({


### PR DESCRIPTION
## Summary

The ent-search API introduced a new attribute on SearchSettings: `precision`.

It is seamlessly passed through from our initial GET request and persisted in the Relevance Tuning logic.

```
GET api/app_search/engines/national-parks-demo/search_settings/details
{
    "searchSettings": {
        "search_fields": {
          ...
        },
        "result_fields": {
            ...
        },
        "boosts": {
           ...
        },
        "precision": 2 // New attribute
    },
    "schema": {
      ...
    }
}
```

We then post that back to the server after a user makes changes:

```
PUT api/app_search/engines/national-parks-demo/search_settings
{
    "searchSettings": {
        "search_fields": {
          ...
        },
        "result_fields": {
            ...
        },
        "boosts": {
           ...
        },
        "precision": 2 // New attribute
    },
    "schema": {
      ...
    }
}
```

There were a few options for dealing with this:
1. We could filter out unknown attributes like `precision` on the incoming data, hence preventing it from being passed back out.
2. We could loosen our server validations to allow for unknowns, to let this flow seamlessly out just as it flowed in.
3. We could update our server validation schema to allow `precision`.

I chose 3, for simplicity, and it solves the immediate issue.

However, something to consider is that *this could happen again*, and there are *no automated tests that will catch this sort of error*. We need to rely on manual testing to catch this at the moment.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
