### PR TITLE
[ML] Data Frame Analytics: Adds hyperparameter importance chart.

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -224,6 +224,7 @@ export class DocLinksService {
           customUrls: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-configuring-url.html`,
           dataFrameAnalytics: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-dfanalytics.html`,
           featureImportance: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-feature-importance.html`,
+          hyperparameters: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/hyperparameters.html`,
           outlierDetectionRoc: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-dfanalytics-evaluate.html#ml-dfanalytics-roc`,
           regressionEvaluation: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-dfanalytics-evaluate.html#ml-dfanalytics-regression-evaluation`,
           classificationAucRoc: `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc`,

--- a/x-pack/plugins/ml/common/types/ml_url_generator.ts
+++ b/x-pack/plugins/ml/common/types/ml_url_generator.ts
@@ -247,6 +247,7 @@ export type ExpandablePanels =
   | 'analysis'
   | 'evaluation'
   | 'feature_importance'
+  | 'hyperparameter_importance'
   | 'results'
   | 'splom';
 

--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -45,6 +45,14 @@ export interface TrainedModelStat {
   };
 }
 
+export interface Hyperparameter {
+  name: string;
+  value: number;
+  absolute_importance: number;
+  relative_importance: number;
+  supplied: boolean;
+}
+
 export interface TrainedModelConfigResponse {
   description: string;
   created_by: string;
@@ -59,6 +67,7 @@ export interface TrainedModelConfigResponse {
         input: any;
         total_feature_importance?: TotalFeatureImportance[];
         feature_importance_baseline?: FeatureImportanceBaseline;
+        hyperparameters?: Hyperparameter[];
       }
     | Record<string, any>;
   model_id: string;

--- a/x-pack/plugins/ml/public/application/components/data_grid/types.ts
+++ b/x-pack/plugins/ml/public/application/components/data_grid/types.ts
@@ -21,6 +21,7 @@ import { ChartData } from '../../../../common/types/field_histograms';
 import { INDEX_STATUS } from '../../data_frame_analytics/common/analytics';
 
 import { FeatureImportanceBaseline } from '../../../../common/types/feature_importance';
+import { Hyperparameter } from '../../../../common/types/trained_models';
 
 export type ColumnId = string;
 export type DataGridItem = Record<string, any>;
@@ -78,6 +79,7 @@ export interface UseIndexDataReturnType
     | 'toggleChartVisibility'
     | 'visibleColumns'
     | 'baseline'
+    | 'hyperparameters'
     | 'predictionFieldName'
     | 'resultsField'
   > {
@@ -116,6 +118,7 @@ export interface UseDataGridReturnType {
   toggleChartVisibility: () => void;
   visibleColumns: ColumnId[];
   baseline?: FeatureImportanceBaseline;
+  hyperparameters?: Hyperparameter[];
   predictionFieldName?: string;
   resultsField?: string;
 }

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/exploration_results_table/exploration_results_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/exploration_results_table/exploration_results_table.tsx
@@ -9,8 +9,7 @@ import React, { FC } from 'react';
 
 import { IndexPattern } from '../../../../../../../../../../src/plugins/data/public';
 
-import { getToastNotifications } from '../../../../../util/dependency_cache';
-import { useMlKibana } from '../../../../../contexts/kibana';
+import { UseIndexDataReturnType } from '../../../../../components/data_grid';
 
 import { DataFrameAnalyticsConfig } from '../../../../common';
 import { ResultsSearchQuery } from '../../../../common/analytics';
@@ -19,40 +18,25 @@ import { DataFrameTaskStateType } from '../../../analytics_management/components
 
 import { ExpandableSectionResults } from '../expandable_section';
 
-import { useExplorationResults } from './use_exploration_results';
-
 interface Props {
   indexPattern: IndexPattern;
   jobConfig: DataFrameAnalyticsConfig;
   jobStatus?: DataFrameTaskStateType;
   needsDestIndexPattern: boolean;
+  resultsTableData: UseIndexDataReturnType;
   searchQuery: ResultsSearchQuery;
 }
 
 export const ExplorationResultsTable: FC<Props> = React.memo(
-  ({ indexPattern, jobConfig, needsDestIndexPattern, searchQuery }) => {
-    const {
-      services: {
-        mlServices: { mlApiServices },
-      },
-    } = useMlKibana();
-
-    const classificationData = useExplorationResults(
-      indexPattern,
-      jobConfig,
-      searchQuery,
-      getToastNotifications(),
-      mlApiServices
-    );
-
-    if (jobConfig === undefined || classificationData === undefined) {
+  ({ resultsTableData, indexPattern, jobConfig, needsDestIndexPattern, searchQuery }) => {
+    if (jobConfig === undefined || resultsTableData === undefined) {
       return null;
     }
 
     return (
       <div data-test-subj="mlDFAnalyticsExplorationTablePanel">
         <ExpandableSectionResults
-          indexData={classificationData}
+          indexData={resultsTableData}
           indexPattern={indexPattern}
           jobConfig={jobConfig}
           needsDestIndexPattern={needsDestIndexPattern}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/exploration_results_table/use_exploration_results.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/exploration_results_table/use_exploration_results.ts
@@ -38,6 +38,7 @@ import { isRegressionAnalysis } from '../../../../common/analytics';
 import { extractErrorMessage } from '../../../../../../../common/util/errors';
 import { useTrainedModelsApiService } from '../../../../../services/ml_api_service/trained_models';
 import { FeatureImportanceBaseline } from '../../../../../../../common/types/feature_importance';
+import { Hyperparameter } from '../../../../../../../common/types/trained_models';
 import { useExplorationDataGrid } from './use_exploration_data_grid';
 
 export const useExplorationResults = (
@@ -48,6 +49,7 @@ export const useExplorationResults = (
   mlApiServices: MlApiServices
 ): UseIndexDataReturnType => {
   const [baseline, setBaseLine] = useState<FeatureImportanceBaseline | undefined>();
+  const [hyperparameters, setHyperparameters] = useState<Hyperparameter[] | undefined>();
 
   const trainedModelsApiService = useTrainedModelsApiService();
 
@@ -140,7 +142,7 @@ export const useExplorationResults = (
       ) {
         const jobId = jobConfig.id;
         const inferenceModels = await trainedModelsApiService.getTrainedModels(`${jobId}*`, {
-          include: 'feature_importance_baseline',
+          include: 'feature_importance_baseline,hyperparameters',
         });
         const inferenceModel = inferenceModels.find(
           (model) => model.metadata?.analytics_config?.id === jobId
@@ -148,6 +150,9 @@ export const useExplorationResults = (
 
         if (inferenceModel?.metadata?.feature_importance_baseline !== undefined) {
           setBaseLine(inferenceModel?.metadata?.feature_importance_baseline);
+        }
+        if (inferenceModel?.metadata?.hyperparameters !== undefined) {
+          setHyperparameters(inferenceModel?.metadata?.hyperparameters);
         }
       }
     } catch (e) {
@@ -181,6 +186,7 @@ export const useExplorationResults = (
     ...dataGrid,
     renderCellValue,
     baseline,
+    hyperparameters,
     predictionFieldName,
     resultsField,
   };

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/hyperparameters/hyperparameters_summary.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/hyperparameters/hyperparameters_summary.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC, useCallback, useMemo } from 'react';
+import { EuiButtonEmpty, EuiSpacer, EuiCallOut } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import {
+  Chart,
+  Settings,
+  Axis,
+  ScaleType,
+  Position,
+  BarSeries,
+  RecursivePartial,
+  AxisStyle,
+  PartialTheme,
+  BarSeriesSpec,
+} from '@elastic/charts';
+import { i18n } from '@kbn/i18n';
+import euiVars from '@elastic/eui/dist/eui_theme_light.json';
+
+import { Hyperparameter } from '../../../../../../../common/types/trained_models';
+
+import { useMlKibana } from '../../../../../contexts/kibana';
+
+import { ExpandableSection } from '../expandable_section';
+
+const { euiColorMediumShade } = euiVars;
+const axisColor = euiColorMediumShade;
+
+const axes: RecursivePartial<AxisStyle> = {
+  axisLine: {
+    stroke: axisColor,
+  },
+  tickLabel: {
+    fontSize: 12,
+    fill: axisColor,
+  },
+  tickLine: {
+    stroke: axisColor,
+  },
+  gridLine: {
+    horizontal: {
+      dash: [1, 2],
+    },
+    vertical: {
+      strokeWidth: 0,
+    },
+  },
+};
+const theme: PartialTheme = {
+  axes,
+  legend: {
+    /**
+     * Added buffer between label and value.
+     * Smaller values render a more compact legend
+     */
+    spacingBuffer: 100,
+  },
+};
+
+export interface HyperparametersSummaryPanelProps {
+  hyperparameters: Hyperparameter[];
+}
+
+const tooltipContent = i18n.translate(
+  'xpack.ml.dataframe.analytics.exploration.hyperparametersSummaryTooltipContent',
+  {
+    defaultMessage:
+      'Hyperparameter importance values indicate how significantly a hyperparameter affects the predictions across all the training data.',
+  }
+);
+
+export const HyperparametersSummaryPanel: FC<HyperparametersSummaryPanelProps> = ({
+  hyperparameters,
+}) => {
+  const {
+    services: { docLinks },
+  } = useMlKibana();
+
+  const [plotData, barSeriesSpec, chartHeight] = useMemo(() => {
+    let sortedData: Array<{
+      name: string;
+      importance: number;
+    }> = [];
+    const _barSeriesSpec: Partial<BarSeriesSpec> = {
+      xAccessor: 'name',
+      yAccessors: ['importance'],
+      name: i18n.translate('xpack.ml.dataframe.analytics.exploration.hyperparametersYSeriesName', {
+        defaultMessage: 'importance',
+      }) as string,
+    };
+    if (hyperparameters.length < 1) {
+      return [sortedData, _barSeriesSpec];
+    }
+
+    sortedData = hyperparameters
+      .map((d) => {
+        return {
+          name: d.name,
+          importance: d.absolute_importance,
+        };
+      })
+      .sort((a, b) => b.importance - a.importance);
+
+    const _chartHeight = hyperparameters.length * (hyperparameters.length < 5 ? 40 : 20) + 50;
+    return [sortedData, _barSeriesSpec, _chartHeight];
+  }, [hyperparameters]);
+
+  const docLink = docLinks.links.ml.hyperparameters;
+  const tickFormatter = useCallback((d) => Number(d.toPrecision(3)).toString(), []);
+
+  // do not expand by default if no hyperparameters importance data
+  const noDataCallOut = useMemo(() => {
+    // if no total hyperparameters importance data
+    if (hyperparameters.every((d) => d.absolute_importance === 0)) {
+      return (
+        <EuiCallOut
+          data-test-subj="mlNoHyperparametersImportanceCallout"
+          size="s"
+          title={
+            <FormattedMessage
+              id="xpack.ml.dataframe.analytics.exploration.noHyperparametersCalloutMessage"
+              defaultMessage="Hyperparameters data is not available; the data set is uniform and the importance has no significant impact on the prediction."
+            />
+          }
+        />
+      );
+    }
+  }, [hyperparameters]);
+
+  return (
+    <>
+      <ExpandableSection
+        urlStateKey={'hyperparameter_importance'}
+        isExpanded={noDataCallOut === undefined}
+        dataTestId="HyperparametersSummary"
+        title={
+          <FormattedMessage
+            id="xpack.ml.dataframe.analytics.exploration.hyperparametersSummaryTitle"
+            defaultMessage="Hyperparameters importance"
+          />
+        }
+        docsLink={
+          <EuiButtonEmpty
+            target="_blank"
+            iconType="help"
+            iconSide="left"
+            color="primary"
+            href={docLink}
+          >
+            <FormattedMessage
+              id="xpack.ml.dataframe.analytics.exploration.hyperparametersDocsLink"
+              defaultMessage="Hyperparameters docs"
+            />
+          </EuiButtonEmpty>
+        }
+        headerItems={[
+          {
+            id: 'HyperparametersSummary',
+            value: tooltipContent,
+          },
+        ]}
+        content={
+          noDataCallOut ? (
+            noDataCallOut
+          ) : (
+            <div data-test-subj="mlHyperparametersImportanceChart">
+              <Chart
+                size={{
+                  width: '100%',
+                  height: chartHeight,
+                }}
+              >
+                <Settings rotation={90} theme={theme} showLegend={false} />
+
+                <Axis
+                  id="x-axis"
+                  title={i18n.translate(
+                    'xpack.ml.dataframe.analytics.exploration.hyperparametersXAxisTitle',
+                    {
+                      defaultMessage: 'Hyperparameter importance',
+                    }
+                  )}
+                  position={Position.Bottom}
+                  tickFormat={tickFormatter}
+                />
+                <Axis id="y-axis" title="" position={Position.Left} />
+                <BarSeries
+                  id="importance"
+                  xScaleType={ScaleType.Ordinal}
+                  yScaleType={ScaleType.Linear}
+                  data={plotData}
+                  {...barSeriesSpec}
+                />
+              </Chart>
+            </div>
+          )
+        }
+      />
+      <EuiSpacer size="m" />
+    </>
+  );
+};

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/hooks/use_exploration_url_state.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/hooks/use_exploration_url_state.ts
@@ -22,6 +22,7 @@ export function getDefaultExplorationPageUrlState(
     analysis: false,
     evaluation: true,
     feature_importance: true,
+    hyperparameter_importance: true,
     results: true,
     splom: true,
     ...(isPopulatedObject(overrides) ? overrides : {}),


### PR DESCRIPTION
## Summary

Fixes #87863.
Depends on https://github.com/elastic/ml-cpp/issues/1859.

Adds hyperparameters importance chart.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
