### PR TITLE
[core.logging] Remove logging config validation that requires default appender to be present.

### DIFF
--- a/docs/developer/architecture/core/logging-configuration-migration.asciidoc
+++ b/docs/developer/architecture/core/logging-configuration-migration.asciidoc
@@ -3,11 +3,19 @@
 
 Compatibility with the legacy logging system is assured until the end of the `v7` version. 
 All log messages handled by `root` context are forwarded to the legacy logging service. If you re-write
-root appenders, make sure that it contains `default` appender to provide backward compatibility.
+root appenders, make sure that it contains `default` appender if you wish
+to provide backward compatibility with `v7`.
 
-NOTE: When you switch to the new logging configuration, you will start seeing duplicate log entries in both formats. 
-These will be removed when the `default` appender is no longer required. If you define an appender for a logger, 
-the log messages aren't handled by the `root` logger anymore and are not forwarded to the legacy logging service.
+WARNING: When you switch to the new logging configuration, you will start seeing duplicate log entries in both formats
+if you still have the `default` appender set in the `root` context.
+Removing the `default` will get rid of the duplicate entries, however,
+it means you will no longer be receiving logs in the legacy format.
+This may break your existing integrations if you are ingesting the Kibana
+logs somewhere and relying on the legacy format. In particular, if you use
+the https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-module-kibana.html[Filebeat Kibana module]
+to ingest your Kibana logs, it is recommended that you do *not* remove
+the `default` appender before `v8`, as logs will no longer be indexed
+with the same fields.
 
 [[logging-pattern-format-old-and-new-example]]
 [options="header"]

--- a/docs/settings/logging-settings.asciidoc
+++ b/docs/settings/logging-settings.asciidoc
@@ -5,12 +5,20 @@
 ++++
 
 Compatibility with the legacy logging system is assured until the end of the `v7` version.
-All log messages handled by `root` context (default) are forwarded to the legacy logging service.
+All log messages handled by the `root` context's `default` appender are forwarded to the legacy logging service.
 The logging configuration is validated against the predefined schema and if there are
 any issues with it, {kib} will fail to start with the detailed error message.
 
-NOTE: When you switch to the new logging configuration, you will start seeing duplicate log entries in both formats. 
-These will be removed when the `default` appender is no longer required.
+WARNING: When you switch to the new logging configuration, you will start seeing duplicate log entries in both formats
+if you still have the `default` appender set in the `root` context.
+Removing the `default` will get rid of the duplicate entries, however,
+it means you will no longer be receiving logs in the legacy format.
+This may break your existing integrations if you are ingesting the Kibana
+logs somewhere and relying on the legacy format. In particular, if you use
+the https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-module-kibana.html[Filebeat Kibana module]
+to ingest your Kibana logs, it is recommended that you do *not* remove
+the `default` appender before `v8`, as logs will no longer be indexed
+with the same fields.
 
 Here are some configuration examples for the most common logging use cases:
 
@@ -36,7 +44,7 @@ logging:
 ==== Log in json format
 
 Log the default log format to json layout instead of pattern (the default).
-With `json` layout log messages will be formatted as JSON strings in https://www.elastic.co/guide/en/ecs/current/ecs-reference.html[ECS format] that includes a timestamp, log level, logger, message text and any other metadata that may be associated with the log message itself
+With `json` layout log messages will be formatted as JSON strings in https://www.elastic.co/guide/en/ecs/1.9/ecs-reference.html[ECS format] that includes a timestamp, log level, logger, message text and any other metadata that may be associated with the log message itself
 
 [source,yaml]
 ----

--- a/src/core/server/logging/logging_config.test.ts
+++ b/src/core/server/logging/logging_config.test.ts
@@ -52,18 +52,6 @@ test('`schema` throws if `root` logger does not have appenders configured.', () 
   );
 });
 
-test('`schema` throws if `root` logger does not have "default" appender configured.', () => {
-  expect(() =>
-    config.schema.validate({
-      root: {
-        appenders: ['console'],
-      },
-    })
-  ).toThrowErrorMatchingInlineSnapshot(
-    `"[root]: \\"default\\" appender required for migration period till the next major release"`
-  );
-});
-
 test('`getParentLoggerContext()` returns correct parent context name.', () => {
   expect(LoggingConfig.getParentLoggerContext('a.b.c')).toEqual('a.b');
   expect(LoggingConfig.getParentLoggerContext('a.b')).toEqual('a');

--- a/src/core/server/logging/logging_config.ts
+++ b/src/core/server/logging/logging_config.ts
@@ -67,22 +67,13 @@ export const config = {
     loggers: schema.arrayOf(loggerSchema, {
       defaultValue: [],
     }),
-    root: schema.object(
-      {
-        appenders: schema.arrayOf(schema.string(), {
-          defaultValue: [DEFAULT_APPENDER_NAME],
-          minSize: 1,
-        }),
-        level: levelSchema,
-      },
-      {
-        validate(rawConfig) {
-          if (!rawConfig.appenders.includes(DEFAULT_APPENDER_NAME)) {
-            return `"${DEFAULT_APPENDER_NAME}" appender required for migration period till the next major release`;
-          }
-        },
-      }
-    ),
+    root: schema.object({
+      appenders: schema.arrayOf(schema.string(), {
+        defaultValue: [DEFAULT_APPENDER_NAME],
+        minSize: 1,
+      }),
+      level: levelSchema,
+    }),
   }),
 };
 


### PR DESCRIPTION
cc @mshustov @TinaHeiligers @joshdover As discussed offline, let's use this PR to discuss whether we want to get this change into 7.13, or wait.

---

Updates the logging config to remove the validation which requires that users of the KP logging system specify a `default` appender for the `root` context.

The `default` appender is responsible for forwarding all logs to the legacy logging system to preserve BWC with legacy log formats. The original rationale for enforcing the `default` appender is present was to ensure that folks don't accidentally break legacy logs when using the new system. The downside of the `default` appender, however, is that it creates duplicate log entries for every record: one in the legacy format, one in the new format.

Now that all of the legacy logging features are available in the new system, we think it would be okay to lift this requirement. Folks who want to opt-in to the new logging system may also opt-out of the legacy one by excluding the `default` appender. And those who need to preserve the legacy formats can keep it in place.

One important thing to note here is that filebeat's `kibana` module __still relies on the legacy logging format__, and __will break__ if users relying on it remove the `default` appender. The impact here is that the new log format uses different field names, so for filebeat users who have set up dashboards/filters/etc based on these fields, those will no longer work if `default` is removed. This situation also applies to anyone who isn't using filebeat but is still relying on the legacy log format for ingesting Kibana logs. I've updated the docs to reflect this.

Here's a screengrab showing an example of how the fields differ (These are two different log entries, but you get the idea. Legacy format on the left, new format on the right.)

<img width="1344" alt="Screen Shot 2021-04-14 at 4 09 47 PM" src="https://user-images.githubusercontent.com/1608770/114938484-64006900-9dfc-11eb-922e-c7b4acee6bb3.png">


### Plugin API Changes
Kibana's core logging service maintains a `default` logging appender to provide backwards compatibility with our legacy logging format, which will be removed in `8.0`. Previously, including the `default` appender in your `root` context was a requirement:
```yaml
logging:
  root:
    appenders: [default, console] # previously `default` was required
    level: info
```

The downside of this approach was that you would get duplicate entries in your Kibana logs: one in legacy format (via `default` appender), and one in the new format.

We have now lifted this requirement for folks who want to fully opt-in to the new system.
```yaml
logging:
  root:
    appenders: [console] # no `default` necessary
    level: info
```

**Please note**, however, that removing the `default` appender may break existing logging integrations you have which rely on the legacy Kibana logging format. In particular, if you use the [Filebeat Kibana module](https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-module-kibana.html), we do not recommend removing this setting as it will cause your Kibana logs to be indexed under different field names. The same recommendation applies for folks who have set up other custom integrations with the Kibana logs: keeping the `default` in place ensures that your logs will not break in `7.x`.
