### PR TITLE
[7.11] [ci] ship Jest unit test junit with runbld in jest worker (#97197)

### DIFF
--- a/vars/kibanaPipeline.groovy
+++ b/vars/kibanaPipeline.groovy
@@ -450,7 +450,13 @@ def allCiTasks() {
     },
     jest: {
       workers.ci(name: 'jest', size: 'c2-8', ramDisk: true) {
-        scriptTask('Jest Unit Tests', 'test/scripts/test/jest_unit.sh')()
+        catchErrors {
+          scriptTask('Jest Unit Tests', 'test/scripts/test/jest_unit.sh')()
+        }
+
+        catchErrors {
+          runbld.junit()
+        }
       }
     },
     xpackJest: {


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [ci] ship Jest unit test junit with runbld in jest worker (#97197)