### PR TITLE
[7.x] [Security Solution] Breaks very long hostnames so they are readable (#97253)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_details.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_details.tsx
@@ -245,7 +245,7 @@ export const EndpointDetails = memo(
           title: i18n.translate('xpack.securitySolution.endpoint.details.hostname', {
             defaultMessage: 'Hostname',
           }),
-          description: <EuiText>{details.host.hostname}</EuiText>,
+          description: <EuiText className="eui-textBreakAll">{details.host.hostname}</EuiText>,
         },
         {
           title: i18n.translate('xpack.securitySolution.endpoint.details.endpointVersion', {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution] Breaks very long hostnames so they are readable (#97253)