### PR TITLE
[TSVB] Fix validation for Data time range mode combo-box

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
@@ -18,7 +18,6 @@ import {
   EuiComboBox,
   EuiRange,
   EuiIconTip,
-  EuiText,
   EuiFormLabel,
 } from '@elastic/eui';
 import { FieldSelect } from './aggs/field_select';
@@ -126,6 +125,9 @@ export const IndexPattern = ({
     ({ value }) => model[TIME_RANGE_MODE_KEY] === value
   );
   const isTimeSeries = model.type === PANEL_TYPES.TIMESERIES;
+  const isDataTimerangeModeInvalid =
+    selectedTimeRangeOption &&
+    !isTimerangeModeEnabled(selectedTimeRangeOption.value, uiRestrictions);
 
   useEffect(() => {
     updateControlValidity(intervalName, intervalValidation.isValid);
@@ -143,13 +145,38 @@ export const IndexPattern = ({
           <EuiFlexItem>
             <EuiFormRow
               id={htmlId('timeRange')}
-              label={i18n.translate('visTypeTimeseries.indexPattern.timeRange.label', {
-                defaultMessage: 'Data timerange mode',
+              label={
+                <>
+                  <FormattedMessage
+                    id="visTypeTimeseries.indexPattern.timeRange.label"
+                    defaultMessage="Data timerange mode"
+                  />{' '}
+                  <EuiIconTip
+                    position="right"
+                    content={
+                      <FormattedMessage
+                        id="visTypeTimeseries.indexPattern.timeRange.hint"
+                        defaultMessage='This setting controls the timespan used for matching documents.
+                        "Entire timerange" will match all the documents selected in the timepicker.
+                        "Last value" will match only the documents for the specified interval from the end of the timerange.'
+                      />
+                    }
+                    type="questionInCircle"
+                  />
+                </>
+              }
+              isInvalid={isDataTimerangeModeInvalid}
+              error={i18n.translate('visTypeTimeseries.indexPattern.timeRange.error', {
+                defaultMessage: 'You cannot use "{mode}" with the current index type.',
+                values: {
+                  mode: selectedTimeRangeOption?.label,
+                },
               })}
             >
               <EuiComboBox
                 data-test-subj="dataTimeRangeMode"
                 isClearable={false}
+                isInvalid={isDataTimerangeModeInvalid}
                 placeholder={i18n.translate(
                   'visTypeTimeseries.indexPattern.timeRange.selectTimeRange',
                   {
@@ -157,6 +184,9 @@ export const IndexPattern = ({
                   }
                 )}
                 options={timeRangeOptions}
+                error={i18n.translate('visTypeTimeseries.indexPattern.timeRange.entireTimeRange', {
+                  defaultMessage: 'Entire time range',
+                })}
                 selectedOptions={selectedTimeRangeOption ? [selectedTimeRangeOption] : []}
                 onChange={handleSelectChange(TIME_RANGE_MODE_KEY)}
                 singleSelection={{ asPlainText: true }}
@@ -171,13 +201,6 @@ export const IndexPattern = ({
                 })}
               />
             </EuiFormRow>
-            <EuiText size="xs" style={{ margin: 0 }}>
-              {i18n.translate('visTypeTimeseries.indexPattern.timeRange.hint', {
-                defaultMessage: `This setting controls the timespan used for matching documents.
-                "Entire timerange" will match all the documents selected in the timepicker.
-                "Last value" will match only the documents for the specified interval from the end of the timerange.`,
-              })}
-            </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       )}

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_series_data.ts
@@ -105,5 +105,6 @@ export async function getSeriesData(
         ...handleErrorResponse(panel)(err),
       };
     }
+    return meta;
   }
 }

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.ts
@@ -115,5 +115,6 @@ export async function getTableData(
         ...handleErrorResponse(panel)(err),
       };
     }
+    return meta;
   }
 }


### PR DESCRIPTION
## Summary

Regression of #93608

"Entire Timerange mode" is not supported for rollup indexes.  After selecting that type of indexes user should see a validation error.

In current implementation we disable unsupported mode without showing without showing a form validation error. In can confuse users  if that mode was already selected. 

**Before:** 
![image](https://user-images.githubusercontent.com/20072247/115257291-9ed60a00-a138-11eb-86d2-e16c6787622b.png)


**After:** 
![image](https://user-images.githubusercontent.com/20072247/115256672-1c4d4a80-a138-11eb-8ba7-68e85e7b2a44.png)




