### PR TITLE
[Workplace Search] Fix doc link, remove shadows on panels and fix source id bug

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -19,9 +19,10 @@ export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
 export const DOCS_PREFIX = docLinks.workplaceSearchBase;
+export const PERMISSIONS_DOCS_URL = `${DOCS_PREFIX}/workplace-search-permissions.html`;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = `${DOCS_PREFIX}/workplace-search-sources-document-permissions.html`;
 export const DOCUMENT_PERMISSIONS_SYNC_DOCS_URL = `${DOCUMENT_PERMISSIONS_DOCS_URL}#sources-permissions-synchronizing`;
-export const PRIVATE_SOURCES_DOCS_URL = `${DOCUMENT_PERMISSIONS_DOCS_URL}#sources-permissions-org-private`;
+export const PRIVATE_SOURCES_DOCS_URL = `${PERMISSIONS_DOCS_URL}#organizational-sources-private-sources`;
 export const EXTERNAL_IDENTITIES_DOCS_URL = `${DOCS_PREFIX}/workplace-search-external-identities-api.html`;
 export const SECURITY_DOCS_URL = `${DOCS_PREFIX}/workplace-search-security.html`;
 export const SMTP_DOCS_URL = `${DOCS_PREFIX}/workplace-search-smtp-mailer.html`;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
@@ -126,7 +126,7 @@ export const AddSourceList: React.FC = () => {
           <EuiFlexGroup justifyContent="center" alignItems="stretch">
             <EuiFlexItem>
               <EuiSpacer size="xl" />
-              <EuiPanel>
+              <EuiPanel hasShadow={false} color="subdued">
                 <EuiSpacer size="s" />
                 <EuiSpacer size="xxl" />
                 <EuiEmptyPrompt

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings.tsx
@@ -113,7 +113,7 @@ export const DisplaySettings: React.FC<DisplaySettingsProps> = ({ tabId }) => {
             onTabClick={onSelectedTabChanged}
           />
         ) : (
-          <EuiPanel>
+          <EuiPanel hasShadow={false} color="subdued">
             <EuiEmptyPrompt
               iconType="indexRollupApp"
               title={<h2>{DISPLAY_SETTINGS_EMPTY_TITLE}</h2>}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -116,7 +116,12 @@ export const Overview: React.FC = () => {
     const emptyState = (
       <>
         <EuiSpacer size="s" />
-        <EuiPanel paddingSize="l" data-test-subj="EmptyDocumentSummary">
+        <EuiPanel
+          hasShadow={false}
+          color="subdued"
+          paddingSize="l"
+          data-test-subj="EmptyDocumentSummary"
+        >
           <EuiEmptyPrompt
             title={<h2>{SOURCES_NO_CONTENT_TITLE}</h2>}
             iconType="documents"
@@ -163,7 +168,12 @@ export const Overview: React.FC = () => {
     const emptyState = (
       <>
         <EuiSpacer size="s" />
-        <EuiPanel paddingSize="l" data-test-subj="EmptyActivitySummary">
+        <EuiPanel
+          paddingSize="l"
+          hasShadow={false}
+          color="subdued"
+          data-test-subj="EmptyActivitySummary"
+        >
           <EuiEmptyPrompt
             title={<h2>{EMPTY_ACTIVITY_TITLE}</h2>}
             iconType="clock"

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -140,7 +140,7 @@ export const Schema: React.FC = () => {
             <SchemaFieldsTable />
           </>
         ) : (
-          <EuiPanel>
+          <EuiPanel hasShadow={false} color="subdued">
             <EuiEmptyPrompt
               iconType="managementApp"
               title={<h2>{SCHEMA_EMPTY_SCHEMA_TITLE}</h2>}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.test.tsx
@@ -34,7 +34,6 @@ import { SourceContent } from './source_content';
 describe('SourceContent', () => {
   const setActivePage = jest.fn();
   const searchContentSourceDocuments = jest.fn();
-  const resetSourceState = jest.fn();
   const setContentFilterValue = jest.fn();
 
   const mockValues = {
@@ -51,7 +50,6 @@ describe('SourceContent', () => {
     setMockActions({
       setActivePage,
       searchContentSourceDocuments,
-      resetSourceState,
       setContentFilterValue,
     });
     setMockValues({ ...mockValues });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
@@ -106,7 +106,7 @@ export const SourceContent: React.FC = () => {
   const isCustomSource = serviceType === CUSTOM_SERVICE_TYPE;
 
   const emptyState = (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <EuiEmptyPrompt
         title={<h2>{emptyMessage}</h2>}
         iconType="documents"

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
@@ -56,12 +56,9 @@ const MAX_LENGTH = 28;
 export const SourceContent: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
 
-  const {
-    setActivePage,
-    searchContentSourceDocuments,
-    resetSourceState,
-    setContentFilterValue,
-  } = useActions(SourceLogic);
+  const { setActivePage, searchContentSourceDocuments, setContentFilterValue } = useActions(
+    SourceLogic
+  );
 
   const {
     contentSource: { id, serviceType, urlField, titleField, urlFieldIsLinkable, isFederatedSource },
@@ -73,10 +70,6 @@ export const SourceContent: React.FC = () => {
     dataLoading,
     sectionLoading,
   } = useValues(SourceLogic);
-
-  useEffect(() => {
-    return resetSourceState;
-  }, []);
 
   useEffect(() => {
     searchContentSourceDocuments(id);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
@@ -23,7 +23,6 @@ import { SourceSettings } from './source_settings';
 describe('SourceSettings', () => {
   const updateContentSource = jest.fn();
   const removeContentSource = jest.fn();
-  const resetSourceState = jest.fn();
   const getSourceConfigData = jest.fn();
   const contentSource = fullContentSources[0];
   const buttonLoading = false;
@@ -41,7 +40,6 @@ describe('SourceSettings', () => {
     setMockActions({
       updateContentSource,
       removeContentSource,
-      resetSourceState,
       getSourceConfigData,
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -52,7 +52,7 @@ import { staticSourceData } from '../source_data';
 import { SourceLogic } from '../source_logic';
 
 export const SourceSettings: React.FC = () => {
-  const { updateContentSource, removeContentSource, resetSourceState } = useActions(SourceLogic);
+  const { updateContentSource, removeContentSource } = useActions(SourceLogic);
   const { getSourceConfigData } = useActions(AddSourceLogic);
 
   const {
@@ -68,7 +68,6 @@ export const SourceSettings: React.FC = () => {
 
   useEffect(() => {
     getSourceConfigData(serviceType);
-    return resetSourceState;
   }, []);
 
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/private_sources.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/private_sources.tsx
@@ -81,7 +81,7 @@ export const PrivateSources: React.FC = () => {
   );
 
   const privateSourcesEmptyState = (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <EuiSpacer size="xxl" />
       <EuiEmptyPrompt iconType="lock" title={<h2>{PRIVATE_EMPTY_TITLE}</h2>} />
       <EuiSpacer size="xxl" />
@@ -107,7 +107,7 @@ export const PrivateSources: React.FC = () => {
   );
 
   const sharedSourcesEmptyState = (
-    <EuiPanel>
+    <EuiPanel hasShadow={false} color="subdued">
       <EuiSpacer size="xxl" />
       <EuiEmptyPrompt
         iconType={noSharedSourcesIcon}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -88,13 +88,14 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
           ...contentSource,
           summary,
         }),
+        resetSourceState: () => ({} as ContentSourceFullData),
       },
     ],
     dataLoading: [
       true,
       {
         onInitializeSource: () => false,
-        resetSourceState: () => false,
+        resetSourceState: () => true,
       },
     ],
     buttonLoading: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.tsx
@@ -47,12 +47,13 @@ import { SourceLogic } from './source_logic';
 
 export const SourceRouter: React.FC = () => {
   const { sourceId } = useParams() as { sourceId: string };
-  const { initializeSource } = useActions(SourceLogic);
+  const { initializeSource, resetSourceState } = useActions(SourceLogic);
   const { contentSource, dataLoading } = useValues(SourceLogic);
   const { isOrganization } = useValues(AppLogic);
 
   useEffect(() => {
     initializeSource(sourceId);
+    return resetSourceState;
   }, []);
 
   if (dataLoading) return <Loading />;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/constants.ts
@@ -15,6 +15,27 @@ export const DELETE_ROLE_MAPPING_MESSAGE = i18n.translate(
   }
 );
 
+export const ROLE_MAPPING_DELETED_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.roleMappingDeletedMessage',
+  {
+    defaultMessage: 'Successfully deleted role mapping',
+  }
+);
+
+export const ROLE_MAPPING_CREATED_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.roleMappingCreatedMessage',
+  {
+    defaultMessage: 'Role mapping successfully created.',
+  }
+);
+
+export const ROLE_MAPPING_UPDATED_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.roleMappingUpdatedMessage',
+  {
+    defaultMessage: 'Role mapping successfully updated.',
+  }
+);
+
 export const DEFAULT_GROUP_NAME = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.roleMapping.defaultGroupName',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -7,7 +7,11 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { clearFlashMessages, flashAPIErrors } from '../../../shared/flash_messages';
+import {
+  clearFlashMessages,
+  flashAPIErrors,
+  setSuccessMessage,
+} from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
 import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
@@ -15,7 +19,13 @@ import { AttributeName } from '../../../shared/types';
 import { ROLE_MAPPINGS_PATH } from '../../routes';
 import { RoleGroup, WSRoleMapping, Role } from '../../types';
 
-import { DELETE_ROLE_MAPPING_MESSAGE, DEFAULT_GROUP_NAME } from './constants';
+import {
+  DELETE_ROLE_MAPPING_MESSAGE,
+  ROLE_MAPPING_DELETED_MESSAGE,
+  ROLE_MAPPING_CREATED_MESSAGE,
+  ROLE_MAPPING_UPDATED_MESSAGE,
+  DEFAULT_GROUP_NAME,
+} from './constants';
 
 interface RoleMappingsServerDetails {
   multipleAuthProvidersConfig: boolean;
@@ -265,6 +275,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         try {
           await http.delete(route);
           navigateToUrl(ROLE_MAPPINGS_PATH);
+          setSuccessMessage(ROLE_MAPPING_DELETED_MESSAGE);
         } catch (e) {
           flashAPIErrors(e);
         }
@@ -297,9 +308,14 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         ? http.post('/api/workplace_search/org/role_mappings', { body })
         : http.put(`/api/workplace_search/org/role_mappings/${roleMapping.id}`, { body });
 
+      const SUCCESS_MESSAGE = !roleMapping
+        ? ROLE_MAPPING_CREATED_MESSAGE
+        : ROLE_MAPPING_UPDATED_MESSAGE;
+
       try {
         await request;
         navigateToUrl(ROLE_MAPPINGS_PATH);
+        setSuccessMessage(SUCCESS_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);
       }


### PR DESCRIPTION
## Summary

This PR handles a few bugs/cleanup items for 7.13.

1. Fix the private sources doc link that was incorrect. (https://github.com/elastic/kibana/commit/8f03b2ca854039d4c034dbbe36f6625b72dae035)
2. Adds (mostly) all zero state shadows that were missed in a previous PR (https://github.com/elastic/kibana/commit/9ff7dfb9528427d14a794dc87a730952010f5b31).
3. Adds success messages to WS Role Mappings (https://github.com/elastic/kibana/commit/cb4e1628cfe82c8ca05c4b19e31a16688225130d)
4. Fixes a bug where the `sourceId` was being persisted from org to personal dashboard and then refactored how and when we reset the state in the source components, as a result (https://github.com/elastic/kibana/commit/4873a70b0056a873351013d98a01fd6f4a1e39b1)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
