### PR TITLE
Fix missing localization in Discover options

### DIFF
--- a/src/plugins/discover/public/application/components/top_nav/open_options_popover.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_options_popover.tsx
@@ -14,6 +14,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { EuiSpacer, EuiButton, EuiText, EuiWrappingPopover, EuiCode } from '@elastic/eui';
 import { getServices } from '../../../kibana_services';
 import './open_options_popover.scss';
+import { DOC_TABLE_LEGACY } from '../../../../common';
 
 let isOpen = false;
 
@@ -27,7 +28,7 @@ export function OptionsPopover(props: OptionsPopoverProps) {
     core: { uiSettings },
     addBasePath,
   } = getServices();
-  const isLegacy = uiSettings.get('doc_table:legacy');
+  const isLegacy = uiSettings.get(DOC_TABLE_LEGACY);
 
   const mode = isLegacy
     ? i18n.translate('discover.openOptionsPopover.legacyTableText', {
@@ -42,8 +43,21 @@ export function OptionsPopover(props: OptionsPopoverProps) {
       <div className="dscOptionsPopover">
         <EuiText color="subdued" size="s">
           <p>
-            <strong>Current view mode:</strong>{' '}
-            <EuiCode data-test-subj="docTableMode">{mode}</EuiCode>
+            <FormattedMessage
+              id="discover.topNav.optionsPopover.currentViewMode"
+              defaultMessage="{viewModeLabel}: {currentViewMode}"
+              values={{
+                viewModeLabel: (
+                  <strong>
+                    <FormattedMessage
+                      id="discover.topNav.optionsPopover.currentViewModeLabel"
+                      defaultMessage="Current view mode"
+                    />
+                  </strong>
+                ),
+                currentViewMode: <EuiCode data-test-subj="docTableMode">{mode}</EuiCode>,
+              }}
+            />
           </p>
         </EuiText>
         <EuiSpacer size="s" />
@@ -57,7 +71,7 @@ export function OptionsPopover(props: OptionsPopoverProps) {
         <EuiButton
           iconType="tableDensityNormal"
           fullWidth
-          href={addBasePath('/app/management/kibana/settings?query=Use legacy table')}
+          href={addBasePath(`/app/management/kibana/settings?query=${DOC_TABLE_LEGACY}`)}
         >
           {i18n.translate('discover.openOptionsPopover.goToAdvancedSettings', {
             defaultMessage: 'Go to Advanced Settings',


### PR DESCRIPTION
## Summary

This fixes some issues with localization in the new discover options.

* Add i18n calls for some hardcoded string.
* Change the link to advanced setting, that it will not use the title of the setting (which might be named differently when not using the default locale and then not finding anything), but instead the ID to link to.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
