### PR TITLE
[App Search] Improve focus UX of MultiInputRows

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/input_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/input_row.test.tsx
@@ -17,6 +17,7 @@ describe('InputRow', () => {
   const props = {
     value: 'some value',
     placeholder: 'Enter a value',
+    autoFocus: false,
     onChange: jest.fn(),
     onDelete: jest.fn(),
     disableDelete: false,
@@ -33,6 +34,7 @@ describe('InputRow', () => {
     expect(wrapper.find(EuiFieldText)).toHaveLength(1);
     expect(wrapper.find(EuiFieldText).prop('value')).toEqual('some value');
     expect(wrapper.find(EuiFieldText).prop('placeholder')).toEqual('Enter a value');
+    expect(wrapper.find(EuiFieldText).prop('autoFocus')).toEqual(false);
     expect(wrapper.find('[data-test-subj="deleteInputRowButton"]').prop('title')).toEqual(
       'Delete value'
     );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/input_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/input_row.tsx
@@ -12,6 +12,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiFieldText, EuiButtonIcon } from '@elastic
 interface Props {
   value: string;
   placeholder: string;
+  autoFocus: boolean;
   onChange(newValue: string): void;
   onDelete(): void;
   disableDelete: boolean;
@@ -23,6 +24,7 @@ import './input_row.scss';
 export const InputRow: React.FC<Props> = ({
   value,
   placeholder,
+  autoFocus,
   onChange,
   onDelete,
   disableDelete,
@@ -35,7 +37,7 @@ export const InputRow: React.FC<Props> = ({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        autoFocus
+        autoFocus={autoFocus}
       />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.test.tsx
@@ -27,6 +27,7 @@ describe('MultiInputRows', () => {
   };
   const values = {
     values: ['a', 'b', 'c'],
+    addedNewRow: false,
     hasEmptyValues: false,
     hasOnlyOneValue: false,
   };
@@ -54,6 +55,20 @@ describe('MultiInputRows', () => {
     expect(wrapper.find(InputRow).at(0).prop('value')).toEqual('a');
     expect(wrapper.find(InputRow).at(1).prop('value')).toEqual('b');
     expect(wrapper.find(InputRow).at(2).prop('value')).toEqual('c');
+  });
+
+  it('focuses the first input row on load, but focuses new input rows on add', () => {
+    setMockValues({ ...values, addedNewRow: false });
+    const wrapper = shallow(<MultiInputRows {...props} />);
+
+    expect(wrapper.find(InputRow).first().prop('autoFocus')).toEqual(true);
+    expect(wrapper.find(InputRow).last().prop('autoFocus')).toEqual(false);
+
+    setMockValues({ ...values, addedNewRow: true });
+    rerender(wrapper);
+
+    expect(wrapper.find(InputRow).first().prop('autoFocus')).toEqual(false);
+    expect(wrapper.find(InputRow).last().prop('autoFocus')).toEqual(true);
   });
 
   it('calls editValue when the InputRow value changes', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.tsx
@@ -44,7 +44,7 @@ export const MultiInputRows: React.FC<Props> = ({
   inputPlaceholder = INPUT_ROW_PLACEHOLDER,
 }) => {
   const logic = MultiInputRowsLogic({ id, values: initialValues });
-  const { values, hasEmptyValues, hasOnlyOneValue } = useValues(logic);
+  const { values, addedNewRow, hasEmptyValues, hasOnlyOneValue } = useValues(logic);
   const { addValue, editValue, deleteValue } = useActions(logic);
 
   useEffect(() => {
@@ -55,17 +55,22 @@ export const MultiInputRows: React.FC<Props> = ({
 
   return (
     <>
-      {values.map((value: string, index: number) => (
-        <InputRow
-          key={`inputRow${index}`}
-          value={value}
-          placeholder={inputPlaceholder}
-          onChange={(newValue) => editValue(index, newValue)}
-          onDelete={() => deleteValue(index)}
-          disableDelete={hasOnlyOneValue}
-          deleteLabel={deleteRowLabel}
-        />
-      ))}
+      {values.map((value: string, index: number) => {
+        const firstRow = index === 0;
+        const lastRow = index === values.length - 1;
+        return (
+          <InputRow
+            key={`inputRow-${id}-${index}`}
+            value={value}
+            placeholder={inputPlaceholder}
+            autoFocus={addedNewRow ? lastRow : firstRow}
+            onChange={(newValue) => editValue(index, newValue)}
+            onDelete={() => deleteValue(index)}
+            disableDelete={hasOnlyOneValue}
+            deleteLabel={deleteRowLabel}
+          />
+        );
+      })}
       <EuiButtonEmpty
         size="s"
         iconType="plusInCircle"

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows_logic.test.ts
@@ -22,6 +22,7 @@ describe('MultiInputRowsLogic', () => {
   };
   const DEFAULT_VALUES = {
     values: MOCK_VALUES,
+    addedNewRow: false,
     hasEmptyValues: false,
     hasOnlyOneValue: false,
   };
@@ -48,11 +49,12 @@ describe('MultiInputRowsLogic', () => {
     });
 
     describe('addValue', () => {
-      it('appends an empty string to the values array', () => {
+      it('appends an empty string to the values array & sets addedNewRow to true', () => {
         logic.actions.addValue();
 
         expect(logic.values).toEqual({
           ...DEFAULT_VALUES,
+          addedNewRow: true,
           hasEmptyValues: true,
           values: ['a', 'b', 'c', ''],
         });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows_logic.ts
@@ -9,6 +9,7 @@ import { kea, MakeLogicType } from 'kea';
 
 interface MultiInputRowsValues {
   values: string[];
+  addedNewRow: boolean;
   hasEmptyValues: boolean;
   hasOnlyOneValue: boolean;
 }
@@ -49,6 +50,12 @@ export const MultiInputRowsLogic = kea<
           newState[index] = newValueValue;
           return newState;
         },
+      },
+    ],
+    addedNewRow: [
+      false,
+      {
+        addValue: () => true,
       },
     ],
   }),


### PR DESCRIPTION
## Summary

I noticed this while QAing/working on Synonyms and thought I'd push a separate PR to improve it since it also improves Curations etc.

### Previous behavior

With `autoFocus` on for all inputs, the last input row would always be focused when the component loaded with initial values:

![before](https://user-images.githubusercontent.com/549407/115441323-937cf000-a1c5-11eb-8ff3-57d08e75fcb7.gif)

This is particularly bad for synonyms, which loads in with two empty values like so, and typing into the 2nd input by default feels weird:

<img width="466" alt="" src="https://user-images.githubusercontent.com/549407/115441081-50bb1800-a1c5-11eb-9273-2b1d3c5fd45e.png">

### New behavior

Hopefully the best of both worlds: on initial load, the **first** row will be focused. Once a new row is added, however, the last row (which should be the new input) is focused.

![after](https://user-images.githubusercontent.com/549407/115440549-b6f36b00-a1c4-11eb-8052-31621adf9868.gif)

<img width="460" alt="" src="https://user-images.githubusercontent.com/549407/115440978-308b5900-a1c5-11eb-808c-3ba9d8b83790.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)