### PR TITLE
[Workplace Search] Add target _blank to search link

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
@@ -97,7 +97,7 @@ export const AccountHeader: React.FC = () => {
           >
             <EuiContextMenuPanel size="s" items={accountNavItems} />
           </EuiPopover>
-          <EuiButton href={getWorkplaceSearchUrl('/search')} iconType="search">
+          <EuiButton href={getWorkplaceSearchUrl('/search')} target="_blank" iconType="search">
             {ACCOUNT_NAV.SEARCH}
           </EuiButton>
         </EuiHeaderLinks>


### PR DESCRIPTION
## Summary

Adds `target="_blank"` to search link in Personal dashboard.