### PR TITLE
[Discover] Increase default pagination size of document table

### DIFF
--- a/src/plugins/discover/public/application/components/discover_grid/constants.ts
+++ b/src/plugins/discover/public/application/components/discover_grid/constants.ts
@@ -15,8 +15,8 @@ export const gridStyle = {
   rowHover: 'none',
 };
 
-export const pageSizeArr = [25, 50, 100];
-export const defaultPageSize = 25;
+export const pageSizeArr = [25, 50, 100, 250];
+export const defaultPageSize = 100;
 export const toolbarVisibility = {
   showColumnSelector: {
     allowHide: false,


### PR DESCRIPTION
## Summary

Now with bugfixes of  EUI 32.1.0 being merged in #97276, we can increase the default number of records displayed in the document table of Discover from 25 to 100.  Adds other option to have a size of 250 records. 

Theoretically we could also offer 500, but I think we should switch to paginate using Elasticsearch in a later step, so more records would be loaded on demand. This would improve performance and memory usage of Discover. In this case I think we shouldn't offer 500 records to be loaded initially.

