### PR TITLE
[Security-Solution] Adds warning message for selected ML jobs not running, adds tooltip to combobox

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { HelpText } from './help_text';
+
+describe('MlJobSelect help text', () => {
+  it('does not show warning if all jobs are running', () => {
+    const wrapper = shallow(<HelpText href={'https://test.com'} notRunningJobIds={[]} />);
+    expect(wrapper.find('[data-test-subj="ml-warning-not-running-jobs"]')).toHaveLength(0);
+  });
+
+  it('shows warning if there are jobs not running', () => {
+    const wrapper = shallow(<HelpText href={'https://test.com'} notRunningJobIds={['id']} />);
+    expect(wrapper.find('[data-test-subj="ml-warning-not-running-jobs"]')).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
@@ -22,7 +22,7 @@ const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> 
   <>
     <FormattedMessage
       id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText"
-      defaultMessage={`We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of “security” to those jobs in the {machineLearning} application to make them appear here.`}
+      defaultMessage="We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of 'security' to those jobs in the {machineLearning} application to make them appear here."
       values={{
         machineLearning: (
           <EuiLink href={href} target="_blank">
@@ -42,7 +42,7 @@ const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> 
             {notRunningJobIds.length === 1 ? (
               <FormattedMessage
                 id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobSingle"
-                defaultMessage={`The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via "ML job settings" before activating this rule.`}
+                defaultMessage="The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via 'ML job settings' before activating this rule."
                 values={{
                   jobName: notRunningJobIds[0],
                 }}
@@ -50,7 +50,7 @@ const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> 
             ) : (
               <FormattedMessage
                 id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobMulti"
-                defaultMessage={`The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via "ML job settings" before activating this rule.`}
+                defaultMessage="The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via 'ML job settings' before activating this rule."
                 values={{
                   jobNames: notRunningJobIds.reduce(
                     (acc, value, i, array) => acc + (i < array.length - 1 ? ', ' : ', and ') + value

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { EuiIcon, EuiLink, EuiText } from '@elastic/eui';
 import styled from 'styled-components';
 
@@ -15,59 +15,58 @@ const HelpTextWarningContainer = styled.div`
   margin-top: 10px;
 `;
 
-export const HelpText: React.FC<{ href: string; notRunningJobIds: string[] }> = ({
+const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> = ({
   href,
   notRunningJobIds,
-}) => {
-  const warningMessageProps = useMemo(() => {
-    if (notRunningJobIds.length > 0) {
-      const isSingleJob = notRunningJobIds.length === 1;
-      return {
-        id: `xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJob${
-          isSingleJob ? `Single` : `Multi`
-        }`,
-        defaultMessage: isSingleJob
-          ? 'The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via "ML job settings" before activating this rule.'
-          : 'The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via "ML job settings" before activating this rule.',
-        values: isSingleJob
-          ? {
-              jobName: notRunningJobIds[0],
-            }
-          : {
-              jobNames: notRunningJobIds.reduce(
-                (acc, value, i, array) => acc + (i < array.length - 1 ? ', ' : ', and ') + value
-              ),
-            },
-      };
-    }
-  }, [notRunningJobIds]);
-
-  return (
-    <>
-      <FormattedMessage
-        id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText"
-        defaultMessage="We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of “security” to those jobs in the {machineLearning} application to make them appear here."
-        values={{
-          machineLearning: (
-            <EuiLink href={href} target="_blank">
+}) => (
+  <>
+    <FormattedMessage
+      id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText"
+      defaultMessage="We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of “security” to those jobs in the {machineLearning} application to make them appear here."
+      values={{
+        machineLearning: (
+          <EuiLink href={href} target="_blank">
+            <FormattedMessage
+              id="xpack.securitySolution.components.mlJobSelect.machineLearningLink"
+              defaultMessage="Machine Learning"
+            />
+          </EuiLink>
+        ),
+      }}
+    />
+    {notRunningJobIds.length > 0 && (
+      <HelpTextWarningContainer data-test-subj="ml-warning-not-running-jobs">
+        <EuiText size="xs" color="warning">
+          <EuiIcon type="alert" />
+          <span>
+            {notRunningJobIds.length === 1 ? (
               <FormattedMessage
-                id="xpack.securitySolution.components.mlJobSelect.machineLearningLink"
-                defaultMessage="Machine Learning"
+                id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobSingle"
+                defaultMessage={
+                  'The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via "ML job settings" before activating this rule.'
+                }
+                values={{
+                  jobName: notRunningJobIds[0],
+                }}
               />
-            </EuiLink>
-          ),
-        }}
-      />
-      {warningMessageProps && (
-        <HelpTextWarningContainer data-test-subj="ml-warning-not-running-jobs">
-          <EuiText size="xs" color="warning">
-            <EuiIcon type="alert" />
-            <span>
-              <FormattedMessage {...warningMessageProps} />
-            </span>
-          </EuiText>
-        </HelpTextWarningContainer>
-      )}
-    </>
-  );
-};
+            ) : (
+              <FormattedMessage
+                id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobMulti"
+                defaultMessage={
+                  'The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via "ML job settings" before activating this rule.'
+                }
+                values={{
+                  jobNames: notRunningJobIds.reduce(
+                    (acc, value, i, array) => acc + (i < array.length - 1 ? ', ' : ', and ') + value
+                  ),
+                }}
+              />
+            )}
+          </span>
+        </EuiText>
+      </HelpTextWarningContainer>
+    )}
+  </>
+);
+
+export const HelpText = React.memo(HelpTextComponent);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
@@ -22,7 +22,7 @@ const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> 
   <>
     <FormattedMessage
       id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText"
-      defaultMessage="We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of “security” to those jobs in the {machineLearning} application to make them appear here."
+      defaultMessage={`We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of “security” to those jobs in the {machineLearning} application to make them appear here.`}
       values={{
         machineLearning: (
           <EuiLink href={href} target="_blank">
@@ -42,9 +42,7 @@ const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> 
             {notRunningJobIds.length === 1 ? (
               <FormattedMessage
                 id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobSingle"
-                defaultMessage={
-                  'The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via "ML job settings" before activating this rule.'
-                }
+                defaultMessage={`The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via "ML job settings" before activating this rule.`}
                 values={{
                   jobName: notRunningJobIds[0],
                 }}
@@ -52,9 +50,7 @@ const HelpTextComponent: React.FC<{ href: string; notRunningJobIds: string[] }> 
             ) : (
               <FormattedMessage
                 id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobMulti"
-                defaultMessage={
-                  'The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via "ML job settings" before activating this rule.'
-                }
+                defaultMessage={`The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via "ML job settings" before activating this rule.`}
                 values={{
                   jobNames: notRunningJobIds.reduce(
                     (acc, value, i, array) => acc + (i < array.length - 1 ? ', ' : ', and ') + value

--- a/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/ml_job_select/help_text.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiIcon, EuiLink, EuiText } from '@elastic/eui';
+import styled from 'styled-components';
+
+import { FormattedMessage } from '@kbn/i18n/react';
+
+const HelpTextWarningContainer = styled.div`
+  margin-top: 10px;
+`;
+
+export const HelpText: React.FC<{ href: string; notRunningJobIds: string[] }> = ({
+  href,
+  notRunningJobIds,
+}) => {
+  const warningMessageProps = useMemo(() => {
+    if (notRunningJobIds.length > 0) {
+      const isSingleJob = notRunningJobIds.length === 1;
+      return {
+        id: `xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJob${
+          isSingleJob ? `Single` : `Multi`
+        }`,
+        defaultMessage: isSingleJob
+          ? 'The selected ML job, {jobName}, is not currently running. Please set {jobName} to run via "ML job settings" before activating this rule.'
+          : 'The selected ML jobs, {jobNames}, are not currently running. Please set all of these jobs to run via "ML job settings" before activating this rule.',
+        values: isSingleJob
+          ? {
+              jobName: notRunningJobIds[0],
+            }
+          : {
+              jobNames: notRunningJobIds.reduce(
+                (acc, value, i, array) => acc + (i < array.length - 1 ? ', ' : ', and ') + value
+              ),
+            },
+      };
+    }
+  }, [notRunningJobIds]);
+
+  return (
+    <>
+      <FormattedMessage
+        id="xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText"
+        defaultMessage="We've provided a few common jobs to get you started. To add your own custom jobs, assign a group of “security” to those jobs in the {machineLearning} application to make them appear here."
+        values={{
+          machineLearning: (
+            <EuiLink href={href} target="_blank">
+              <FormattedMessage
+                id="xpack.securitySolution.components.mlJobSelect.machineLearningLink"
+                defaultMessage="Machine Learning"
+              />
+            </EuiLink>
+          ),
+        }}
+      />
+      {warningMessageProps && (
+        <HelpTextWarningContainer data-test-subj="ml-warning-not-running-jobs">
+          <EuiText size="xs" color="warning">
+            <EuiIcon type="alert" />
+            <span>
+              <FormattedMessage {...warningMessageProps} />
+            </span>
+          </EuiText>
+        </HelpTextWarningContainer>
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/translations.tsx
@@ -64,14 +64,6 @@ export const ML_JOB_SELECT_PLACEHOLDER_TEXT = i18n.translate(
   }
 );
 
-export const ENABLE_ML_JOB_WARNING = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobWarningTitle',
-  {
-    defaultMessage:
-      'One or more selected ML jobs are not currently running. Please set these job(s) to run via "ML job settings" before activating this rule.',
-  }
-);
-
 export const QUERY_BAR_LABEL = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.fieldQuerBarLabel',
   {

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -18486,7 +18486,6 @@
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.indicesHelperDescription": "このルールを実行するElasticsearchインデックスのパターンを入力します。デフォルトでは、セキュリティソリューション詳細設定で定義されたインデックスパターンが含まれます。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText": "手始めに使えるように、一般的なジョブがいくつか提供されています。独自のカスタムジョブを追加するには、{machineLearning} アプリケーションでジョブに「security」のグループを割り当て、ここに表示されるようにします。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdRequired": "機械学習ジョブが必要です。",
-    "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobWarningTitle": "このMLジョブは現在実行されていません。このルールを有効にする前に、このジョブを「MLジョブ設定」で実行するように設定してください。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlJobSelectPlaceholderText": "ジョブを選択してください",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.outputIndiceNameFieldRequiredError": "インデックスパターンが最低1つ必要です。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.referencesUrlInvalidError": "URLの形式が無効です",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -18757,7 +18757,6 @@
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.indicesHelperDescription": "输入要运行此规则的 Elasticsearch 索引的模式。默认情况下，将包括 Security Solution 高级设置中定义的索引模式。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdHelpText": "我们提供了一些常见作业来帮助您入门。要添加自己的定制规则，请在 {machineLearning} 应用程序中将一组“security”分配给这些作业，以使其显示在此处。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.machineLearningJobIdRequired": "Machine Learning 作业必填。",
-    "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlEnableJobWarningTitle": "此 ML 作业当前未运行。在激活此规则之前请通过“ML 作业设置”设置此作业以使其运行。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.mlJobSelectPlaceholderText": "选择作业",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.outputIndiceNameFieldRequiredError": "至少需要一个索引模式。",
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.referencesUrlInvalidError": "Url 的格式无效",


### PR DESCRIPTION
## Summary
This PR 

- alters the warning messages if the ML jobs selected are not running (includes the job name(s) as a part of the message)
- adds a tooltip for the cut-off ML job description.


tooltip on message hover
<img width="538" alt="Screen Shot 2021-04-20 at 6 38 17 PM" src="https://user-images.githubusercontent.com/18617331/115472331-a87a7300-a207-11eb-95c6-b9ce92fd1477.png">

multiple jobs not running message
<img width="411" alt="Screen Shot 2021-04-20 at 6 38 06 PM" src="https://user-images.githubusercontent.com/18617331/115472332-a87a7300-a207-11eb-9384-d4d1b0674dec.png">

single job not running message
<img width="470" alt="Screen Shot 2021-04-20 at 6 37 56 PM" src="https://user-images.githubusercontent.com/18617331/115472329-a7e1dc80-a207-11eb-8d61-2dcb2cbf5cce.png">### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
