### PR TITLE
[Enterprise Search] Fix unstyled UI for Schema Errors

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.scss
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+.schemaFieldError {
+  border-top: 1px solid $euiColorLightShade;
+
+  &:last-child {
+    border-bottom: 1px solid $euiColorLightShade;
+  }
+
+  // Something about the EuiFlexGroup being inside a button collapses the row of items.
+  // This wrapper div was injected by EUI and had 'with: auto' on it.
+  .euiIEFlexWrapFix {
+    width: 100%;
+  }
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.test.tsx
@@ -11,7 +11,7 @@ import { shallow } from 'enzyme';
 
 import { EuiAccordion, EuiTableRow } from '@elastic/eui';
 
-import { EuiLinkTo } from '../react_router_helpers';
+import { EuiButtonEmptyTo } from '../react_router_helpers';
 
 import { SchemaErrorsAccordion } from './schema_errors_accordion';
 
@@ -40,12 +40,12 @@ describe('SchemaErrorsAccordion', () => {
 
     expect(wrapper.find(EuiAccordion)).toHaveLength(1);
     expect(wrapper.find(EuiTableRow)).toHaveLength(2);
-    expect(wrapper.find(EuiLinkTo)).toHaveLength(0);
+    expect(wrapper.find(EuiButtonEmptyTo)).toHaveLength(0);
   });
 
   it('renders document buttons', () => {
     const wrapper = shallow(<SchemaErrorsAccordion {...props} itemId="123" getRoute={jest.fn()} />);
 
-    expect(wrapper.find(EuiLinkTo)).toHaveLength(2);
+    expect(wrapper.find(EuiButtonEmptyTo)).toHaveLength(2);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
@@ -61,10 +61,12 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="none">
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="xl">
-              <EuiFlexItem className="field-error__field-name">
-                <TruncatedContent content={fieldName} length={32} />
+              <EuiFlexItem>
+                <strong>
+                  <TruncatedContent content={fieldName} length={32} />
+                </strong>
               </EuiFlexItem>
-              <EuiFlexItem className="field-error__field-type">{schema[fieldName]}</EuiFlexItem>
+              <EuiFlexItem>{schema[fieldName]}</EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -80,12 +82,12 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
         <EuiAccordion
           key={fieldNameIndex}
           id={`accordion${fieldNameIndex}`}
-          className="euiAccordionForm field-error"
+          className="schemaFieldError"
           buttonClassName="euiAccordionForm__button field-error__header"
           buttonContent={accordionHeader}
           paddingSize="xl"
         >
-          <EuiTable>
+          <EuiTable tableLayout="auto">
             <EuiTableHeader>
               <EuiTableHeaderCell>{ERROR_TABLE_ID_HEADER}</EuiTableHeaderCell>
               <EuiTableHeaderCell>{ERROR_TABLE_ERROR_HEADER}</EuiTableHeaderCell>
@@ -103,21 +105,15 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
                 );
 
                 return (
-                  <EuiTableRow
-                    key={`schema-change-document-error-${fieldName}-${errorIndex} field-error-document`}
-                  >
-                    <EuiTableRowCell className="field-error-document__id">
-                      <div className="data-type--id">
-                        <TruncatedContent
-                          tooltipType="title"
-                          content={error.external_id}
-                          length={22}
-                        />
-                      </div>
+                  <EuiTableRow key={`schema-change-document-error-${fieldName}-${errorIndex}`}>
+                    <EuiTableRowCell>
+                      <TruncatedContent
+                        tooltipType="title"
+                        content={error.external_id}
+                        length={22}
+                      />
                     </EuiTableRowCell>
-                    <EuiTableRowCell className="field-error-document__field-content">
-                      {error.error}
-                    </EuiTableRowCell>
+                    <EuiTableRowCell>{error.error}</EuiTableRowCell>
                     {showViewButton ? viewButton : <EuiTableRowCell />}
                   </EuiTableRow>
                 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
@@ -24,6 +24,8 @@ import { EuiButtonEmptyTo } from '../react_router_helpers';
 
 import { TruncatedContent } from '../truncate';
 
+import './schema_errors_accordion.scss';
+
 import {
   ERROR_TABLE_ID_HEADER,
   ERROR_TABLE_ERROR_HEADER,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
@@ -108,7 +108,7 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
 
                 return (
                   <EuiTableRow key={`schema-change-document-error-${fieldName}-${errorIndex}`}>
-                    <EuiTableRowCell>
+                    <EuiTableRowCell truncateText>
                       <TruncatedContent
                         tooltipType="title"
                         content={error.external_id}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import {
   EuiAccordion,
+  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTable,
@@ -67,7 +68,10 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <span className="field-error__control button">{ERROR_TABLE_REVIEW_CONTROL}</span>
+            {/* href is needed here because a button cannot be nested in a button or console will error and EuiAccordion uses a button to wrap this. */}
+            <EuiButton size="s" href="#">
+              {ERROR_TABLE_REVIEW_CONTROL}
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.tsx
@@ -20,7 +20,7 @@ import {
   EuiTableRowCell,
 } from '@elastic/eui';
 
-import { EuiLinkTo } from '../react_router_helpers';
+import { EuiButtonEmptyTo } from '../react_router_helpers';
 
 import { TruncatedContent } from '../truncate';
 
@@ -97,15 +97,8 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
                 const documentPath = getRoute && itemId ? getRoute(itemId, error.external_id) : '';
 
                 const viewButton = showViewButton && (
-                  <EuiTableRowCell className="field-error-document__actions">
-                    <EuiLinkTo
-                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                      to={documentPath}
-                    >
-                      <span className="euiButtonEmpty__content">
-                        <span className="euiButtonEmpty__text">{ERROR_TABLE_VIEW_LINK}</span>
-                      </span>
-                    </EuiLinkTo>
+                  <EuiTableRowCell>
+                    <EuiButtonEmptyTo to={documentPath}>{ERROR_TABLE_VIEW_LINK}</EuiButtonEmptyTo>
                   </EuiTableRowCell>
                 );
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
@@ -10,8 +10,6 @@ import { useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiSpacer } from '@elastic/eui';
-
 import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 
@@ -32,16 +30,13 @@ export const SchemaChangeErrors: React.FC = () => {
   }, []);
 
   return (
-    <div>
+    <>
       <ViewContentHeader title={SCHEMA_ERRORS_HEADING} />
-      <EuiSpacer size="xl" />
-      <main>
-        <SchemaErrorsAccordion
-          fieldCoercionErrors={fieldCoercionErrors}
-          schema={serverSchema}
-          itemId={sourceId}
-        />
-      </main>
-    </div>
+      <SchemaErrorsAccordion
+        fieldCoercionErrors={fieldCoercionErrors}
+        schema={serverSchema}
+        itemId={sourceId}
+      />
+    </>
   );
 };


### PR DESCRIPTION
### closes https://github.com/elastic/workplace-search-team/issues/1668

## Summary

When the Schema errors component was migrated, the styles were not added and were missed on the design pass. This PR adds minimal styles and cleans up the component a bit. 

The last commit fixes a bug that [already existed](https://github.com/elastic/ent-search/pull/3479) that causes the ID to break on multi-character IDs. 

**Before**
![before](https://user-images.githubusercontent.com/1869731/115487994-66f5c200-a21f-11eb-8fcb-421a1d9ccd6f.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/115488001-6b21df80-a21f-11eb-8d2a-537bd597c648.gif)

**Legacy for comparison**
![legacy](https://user-images.githubusercontent.com/1869731/115488027-75dc7480-a21f-11eb-8b8c-d7b649432364.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios