### PR TITLE
Fix broken advanced setting i18n

### DIFF
--- a/src/plugins/discover/server/plugin.ts
+++ b/src/plugins/discover/server/plugin.ts
@@ -7,14 +7,14 @@
  */
 
 import { CoreSetup, CoreStart, Plugin } from 'kibana/server';
-import { uiSettings } from './ui_settings';
+import { getUiSettings } from './ui_settings';
 import { capabilitiesProvider } from './capabilities_provider';
 import { searchSavedObjectType } from './saved_objects';
 
 export class DiscoverServerPlugin implements Plugin<object, object> {
   public setup(core: CoreSetup) {
     core.capabilities.registerProvider(capabilitiesProvider);
-    core.uiSettings.register(uiSettings);
+    core.uiSettings.register(getUiSettings());
     core.savedObjects.registerType(searchSavedObjectType);
 
     return {};

--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -27,7 +27,7 @@ import {
   MAX_DOC_FIELDS_DISPLAYED,
 } from '../common';
 
-export const uiSettings: Record<string, UiSettingsParams> = {
+export const getUiSettings: () => Record<string, UiSettingsParams> = () => ({
   [DEFAULT_COLUMNS_SETTING]: {
     name: i18n.translate('discover.advancedSettings.defaultColumnsTitle', {
       defaultMessage: 'Default columns',
@@ -186,10 +186,17 @@ export const uiSettings: Record<string, UiSettingsParams> = {
     },
   },
   [SEARCH_FIELDS_FROM_SOURCE]: {
-    name: 'Read fields from _source',
-    description: `When enabled will load documents directly from \`_source\`. This is soon going to be deprecated. When disabled, will retrieve fields via the new Fields API in the high-level search service.`,
+    name: i18n.translate('discover.advancedSettings.discover.readFieldsFromSource', {
+      defaultMessage: 'Read fields from _source',
+    }),
+    description: i18n.translate(
+      'discover.advancedSettings.discover.readFieldsFromSourceDescription',
+      {
+        defaultMessage: `When enabled will load documents directly from \`_source\`. This is soon going to be deprecated. When disabled, will retrieve fields via the new Fields API in the high-level search service.`,
+      }
+    ),
     value: false,
     category: ['discover'],
     schema: schema.boolean(),
   },
-};
+});

--- a/src/plugins/vis_type_timeseries/server/plugin.ts
+++ b/src/plugins/vis_type_timeseries/server/plugin.ts
@@ -24,7 +24,7 @@ import { PluginStart } from '../../data/server';
 import { IndexPatternsService } from '../../data/common';
 import { visDataRoutes } from './routes/vis';
 import { fieldsRoutes } from './routes/fields';
-import { uiSettings } from './ui_settings';
+import { getUiSettings } from './ui_settings';
 import type {
   VisTypeTimeseriesRequestHandlerContext,
   VisTypeTimeseriesVisDataRequest,
@@ -83,7 +83,7 @@ export class VisTypeTimeseriesPlugin implements Plugin<VisTypeTimeseriesSetup> {
     plugins: VisTypeTimeseriesPluginSetupDependencies
   ) {
     const logger = this.initializerContext.logger.get('visTypeTimeseries');
-    core.uiSettings.register(uiSettings);
+    core.uiSettings.register(getUiSettings());
     const config$ = this.initializerContext.config.create<VisTypeTimeseriesConfig>();
     // Global config contains things like the ES shard timeout
     const globalConfig$ = this.initializerContext.config.legacy.globalConfig$;

--- a/src/plugins/vis_type_timeseries/server/ui_settings.ts
+++ b/src/plugins/vis_type_timeseries/server/ui_settings.ts
@@ -13,7 +13,7 @@ import { UiSettingsParams } from 'kibana/server';
 
 import { MAX_BUCKETS_SETTING } from '../common/constants';
 
-export const uiSettings: Record<string, UiSettingsParams> = {
+export const getUiSettings: () => Record<string, UiSettingsParams> = () => ({
   [MAX_BUCKETS_SETTING]: {
     name: i18n.translate('visTypeTimeseries.advancedSettings.maxBucketsTitle', {
       defaultMessage: 'TSVB buckets limit',
@@ -25,4 +25,4 @@ export const uiSettings: Record<string, UiSettingsParams> = {
     }),
     schema: schema.number(),
   },
-};
+});

--- a/src/plugins/vis_type_vislib/server/plugin.ts
+++ b/src/plugins/vis_type_vislib/server/plugin.ts
@@ -7,11 +7,11 @@
  */
 
 import { CoreSetup, CoreStart, Plugin } from 'kibana/server';
-import { uiSettings } from './ui_settings';
+import { getUiSettings } from './ui_settings';
 
 export class VisTypeVislibServerPlugin implements Plugin<object, object> {
   public setup(core: CoreSetup) {
-    core.uiSettings.register(uiSettings);
+    core.uiSettings.register(getUiSettings());
     return {};
   }
 

--- a/src/plugins/vis_type_vislib/server/ui_settings.ts
+++ b/src/plugins/vis_type_vislib/server/ui_settings.ts
@@ -12,7 +12,7 @@ import { schema } from '@kbn/config-schema';
 import { UiSettingsParams } from 'kibana/server';
 import { DIMMING_OPACITY_SETTING, HEATMAP_MAX_BUCKETS_SETTING } from '../common';
 
-export const uiSettings: Record<string, UiSettingsParams> = {
+export const getUiSettings: () => Record<string, UiSettingsParams> = () => ({
   // TODO: move this to vis_type_xy when vislib is removed
   // https://github.com/elastic/kibana/issues/56143
   [DIMMING_OPACITY_SETTING]: {
@@ -47,4 +47,4 @@ export const uiSettings: Record<string, UiSettingsParams> = {
     category: ['visualization'],
     schema: schema.number(),
   },
-};
+});

--- a/src/plugins/vis_type_xy/server/plugin.ts
+++ b/src/plugins/vis_type_xy/server/plugin.ts
@@ -13,7 +13,7 @@ import { CoreSetup, Plugin, UiSettingsParams } from 'kibana/server';
 
 import { LEGACY_CHARTS_LIBRARY } from '../common';
 
-export const uiSettingsConfig: Record<string, UiSettingsParams<boolean>> = {
+export const getUiSettingsConfig: () => Record<string, UiSettingsParams<boolean>> = () => ({
   // TODO: Remove this when vis_type_vislib is removed
   // https://github.com/elastic/kibana/issues/56143
   [LEGACY_CHARTS_LIBRARY]: {
@@ -31,11 +31,11 @@ export const uiSettingsConfig: Record<string, UiSettingsParams<boolean>> = {
     category: ['visualization'],
     schema: schema.boolean(),
   },
-};
+});
 
 export class VisTypeXyServerPlugin implements Plugin<object, object> {
   public setup(core: CoreSetup) {
-    core.uiSettings.register(uiSettingsConfig);
+    core.uiSettings.register(getUiSettingsConfig());
 
     return {};
   }


### PR DESCRIPTION
## Summary

This fixes an issue with i18n in our advanced settings. Currently you cannot use the `i18n.translate` call server side in a module directly (at least not if it's loaded in the page load bundle), since it will trigger before the i18n is setup completely, thus leaving those strings to always be returned in the default locale.

Wrapping them in a function call, and only calling that function once the plugin's setup method is called give the i18n framework enough time to intatiate correctly and will work properly.

This PR also fixes one Discover advanced setting that was forgot to be i18n'ed.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
