### PR TITLE
[App Search] Disabled Save button when nothing selected

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
@@ -86,7 +86,7 @@ describe('ResultSettings', () => {
     expect(saveButton.prop('disabled')).toBe(true);
   });
 
-  it('renders the "save" button as disabled if everything is disablec', () => {
+  it('renders the "save" button as disabled if everything is disabled', () => {
     setMockValues({
       ...values,
       stagedUpdates: true,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
@@ -86,6 +86,17 @@ describe('ResultSettings', () => {
     expect(saveButton.prop('disabled')).toBe(true);
   });
 
+  it('renders the "save" button as disabled if everything is disablec', () => {
+    setMockValues({
+      ...values,
+      stagedUpdates: true,
+      isEverythingDisabled: true,
+    });
+    const buttons = findButtons(subject());
+    const saveButton = shallow(buttons[0]);
+    expect(saveButton.prop('disabled')).toBe(true);
+  });
+
   it('renders a "restore defaults" button that will reset all values to their defaults', () => {
     const buttons = findButtons(subject());
     expect(buttons.length).toBe(3);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
@@ -90,7 +90,7 @@ describe('ResultSettings', () => {
     setMockValues({
       ...values,
       stagedUpdates: true,
-      isEverythingDisabled: true,
+      resultFieldsEmpty: true,
     });
     const buttons = findButtons(subject());
     const saveButton = shallow(buttons[0]);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
@@ -46,9 +46,13 @@ const UNSAVED_MESSAGE = i18n.translate(
 );
 
 export const ResultSettings: React.FC = () => {
-  const { dataLoading, schema, stagedUpdates, resultFieldsAtDefaultSettings } = useValues(
-    ResultSettingsLogic
-  );
+  const {
+    dataLoading,
+    schema,
+    stagedUpdates,
+    resultFieldsAtDefaultSettings,
+    isEverythingDisabled,
+  } = useValues(ResultSettingsLogic);
   const {
     initializeResultSettingsData,
     saveResultSettings,
@@ -81,7 +85,7 @@ export const ResultSettings: React.FC = () => {
                   color="primary"
                   fill
                   onClick={saveResultSettings}
-                  disabled={!stagedUpdates}
+                  disabled={isEverythingDisabled || !stagedUpdates}
                 >
                   {SAVE_BUTTON_LABEL}
                 </EuiButton>,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
@@ -51,7 +51,7 @@ export const ResultSettings: React.FC = () => {
     schema,
     stagedUpdates,
     resultFieldsAtDefaultSettings,
-    isEverythingDisabled,
+    resultFieldsEmpty,
   } = useValues(ResultSettingsLogic);
   const {
     initializeResultSettingsData,
@@ -85,7 +85,7 @@ export const ResultSettings: React.FC = () => {
                   color="primary"
                   fill
                   onClick={saveResultSettings}
-                  disabled={isEverythingDisabled || !stagedUpdates}
+                  disabled={resultFieldsEmpty || !stagedUpdates}
                 >
                   {SAVE_BUTTON_LABEL}
                 </EuiButton>,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
@@ -46,6 +46,7 @@ describe('ResultSettingsLogic', () => {
   const SELECTORS = {
     serverResultFields: {},
     reducedServerResultFields: {},
+    isEverythingDisabled: true,
     resultFieldsAtDefaultSettings: true,
     stagedUpdates: false,
     nonTextResultFields: {},
@@ -330,6 +331,20 @@ describe('ResultSettingsLogic', () => {
         });
 
         expect(ResultSettingsLogic.values.resultFieldsAtDefaultSettings).toEqual(false);
+      });
+    });
+
+    describe('isEverythingDisabled', () => {
+      it('should return true if no raw or snippet fields are enabled', () => {
+        mount({
+          resultFields: {
+            foo: { raw: false },
+            bar: {},
+            baz: { raw: false, snippet: false },
+          },
+        });
+
+        expect(ResultSettingsLogic.values.isEverythingDisabled).toEqual(true);
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
@@ -46,7 +46,7 @@ describe('ResultSettingsLogic', () => {
   const SELECTORS = {
     serverResultFields: {},
     reducedServerResultFields: {},
-    isEverythingDisabled: true,
+    resultFieldsEmpty: true,
     resultFieldsAtDefaultSettings: true,
     stagedUpdates: false,
     nonTextResultFields: {},
@@ -334,7 +334,7 @@ describe('ResultSettingsLogic', () => {
       });
     });
 
-    describe('isEverythingDisabled', () => {
+    describe('resultFieldsEmpty', () => {
       it('should return true if no raw or snippet fields are enabled', () => {
         mount({
           resultFields: {
@@ -344,7 +344,7 @@ describe('ResultSettingsLogic', () => {
           },
         });
 
-        expect(ResultSettingsLogic.values.isEverythingDisabled).toEqual(true);
+        expect(ResultSettingsLogic.values.resultFieldsEmpty).toEqual(true);
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
@@ -24,6 +24,7 @@ import {
 
 import {
   areFieldsAtDefaultSettings,
+  areFieldsEmpty,
   clearAllFields,
   convertServerResultFieldsToResultFields,
   convertToServerFieldResultSetting,
@@ -73,7 +74,7 @@ interface ResultSettingsValues {
   nonTextResultFields: FieldResultSettingObject;
   serverResultFields: ServerFieldResultSettingObject;
   resultFieldsAtDefaultSettings: boolean;
-  resultFieldsEmpty: boolean;
+  isEverythingDisabled: boolean;
   stagedUpdates: true;
   reducedServerResultFields: ServerFieldResultSettingObject;
   queryPerformanceScore: number;
@@ -196,6 +197,10 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
     resultFieldsAtDefaultSettings: [
       () => [selectors.resultFields],
       (resultFields) => areFieldsAtDefaultSettings(resultFields),
+    ],
+    isEverythingDisabled: [
+      () => [selectors.resultFields],
+      (resultFields) => areFieldsEmpty(resultFields),
     ],
     stagedUpdates: [
       () => [selectors.lastSavedResultFields, selectors.resultFields],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
@@ -74,7 +74,7 @@ interface ResultSettingsValues {
   nonTextResultFields: FieldResultSettingObject;
   serverResultFields: ServerFieldResultSettingObject;
   resultFieldsAtDefaultSettings: boolean;
-  isEverythingDisabled: boolean;
+  resultFieldsEmpty: boolean;
   stagedUpdates: true;
   reducedServerResultFields: ServerFieldResultSettingObject;
   queryPerformanceScore: number;
@@ -198,7 +198,7 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
       () => [selectors.resultFields],
       (resultFields) => areFieldsAtDefaultSettings(resultFields),
     ],
-    isEverythingDisabled: [
+    resultFieldsEmpty: [
       () => [selectors.resultFields],
       (resultFields) => areFieldsEmpty(resultFields),
     ],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.test.ts
@@ -14,6 +14,7 @@ import {
   clearAllFields,
   resetAllFields,
   splitResultFields,
+  areFieldsEmpty,
 } from './utils';
 
 describe('clearAllFields', () => {
@@ -141,6 +142,37 @@ describe('splitResultFields', () => {
       },
       textResultFields: { foo: { raw: true, rawSize: 5, snippet: false, snippetFallback: false } },
     });
+  });
+});
+
+describe('areFieldsEmpty', () => {
+  it('should return true if all fields are empty or have all properties disabled', () => {
+    expect(
+      areFieldsEmpty({
+        foo: {},
+        bar: { raw: false, snippet: false },
+        baz: { raw: false },
+      })
+    ).toBe(true);
+  });
+
+  it('should return false otherwise', () => {
+    expect(
+      areFieldsEmpty({
+        foo: {
+          raw: true,
+          rawSize: 5,
+          snippet: false,
+          snippetFallback: false,
+        },
+        bar: {
+          raw: true,
+          rawSize: 5,
+          snippet: false,
+          snippetFallback: false,
+        },
+      })
+    ).toBe(false);
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.ts
@@ -112,6 +112,13 @@ export const splitResultFields = (resultFields: FieldResultSettingObject, schema
   return { textResultFields, nonTextResultFields };
 };
 
+export const areFieldsEmpty = (fields: FieldResultSettingObject) => {
+  const anyNonEmptyField = Object.values(fields).find((field) => {
+    return (field as FieldResultSetting).raw || (field as FieldResultSetting).snippet;
+  });
+  return !anyNonEmptyField;
+};
+
 export const areFieldsAtDefaultSettings = (fields: FieldResultSettingObject) => {
   const anyNonDefaultSettingsValue = Object.values(fields).find((resultSettings) => {
     return !isEqual(resultSettings, DEFAULT_FIELD_SETTINGS);


### PR DESCRIPTION
## Summary

Fixes an issue in Result Settings. Users should *not* be allowed to submit forms that have nothing selected.

This was in the old UI, but it was broken. I migrated it to this UI and fixed it.

![latest](https://user-images.githubusercontent.com/1427475/115614353-9954fd00-a2bb-11eb-8d15-e9624bb66c50.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
