### PR TITLE
[Workplace Search] PR#3358 to Kibana

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
@@ -33,6 +33,7 @@ describe('SourceLogic', () => {
     flashAPIErrors,
     setSuccessMessage,
     setQueuedSuccessMessage,
+    setErrorMessage,
   } = mockFlashMessageHelpers;
   const { navigateToUrl } = mockKibanaValues;
   const { mount, getListeners } = new LogicMounter(SourceLogic);
@@ -203,6 +204,19 @@ describe('SourceLogic', () => {
         await expectedAsyncError(promise);
 
         expect(navigateToUrl).toHaveBeenCalledWith(NOT_FOUND_PATH);
+      });
+
+      it('renders error messages passed in success response from server', async () => {
+        const errors = ['ERROR'];
+        const promise = Promise.resolve({
+          ...contentSource,
+          errors,
+        });
+        http.get.mockReturnValue(promise);
+        SourceLogic.actions.initializeSource(contentSource.id);
+        await promise;
+
+        expect(setErrorMessage).toHaveBeenCalledWith(errors);
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -13,6 +13,7 @@ import { DEFAULT_META } from '../../../shared/constants';
 import {
   flashAPIErrors,
   setSuccessMessage,
+  setErrorMessage,
   setQueuedSuccessMessage,
   clearFlashMessages,
 } from '../../../shared/flash_messages';
@@ -147,6 +148,11 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         actions.onInitializeSource(response);
         if (response.isFederatedSource) {
           actions.initializeFederatedSummary(sourceId);
+        }
+        if (response.errors) {
+          setErrorMessage(response.errors);
+        } else {
+          clearFlashMessages();
         }
       } catch (e) {
         if (e.response.status === 404) {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.test.tsx
@@ -8,6 +8,8 @@
 import '../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../__mocks__';
+import { mockLocation } from '../../../__mocks__/react_router_history.mock';
+import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 import { contentSources } from '../../__mocks__/content_sources.mock';
 
 import React from 'react';
@@ -30,6 +32,7 @@ import { SourceRouter } from './source_router';
 
 describe('SourceRouter', () => {
   const initializeSource = jest.fn();
+  const resetSourceState = jest.fn();
   const contentSource = contentSources[1];
   const customSource = contentSources[0];
   const mockValues = {
@@ -40,10 +43,11 @@ describe('SourceRouter', () => {
   beforeEach(() => {
     setMockActions({
       initializeSource,
+      resetSourceState,
     });
     setMockValues({ ...mockValues });
     (useParams as jest.Mock).mockImplementationOnce(() => ({
-      sourceId: '1',
+      sourceId: contentSource.id,
     }));
   });
 
@@ -113,5 +117,23 @@ describe('SourceRouter', () => {
       ...loadingBreadcrumbs,
       NAV.DISPLAY_SETTINGS,
     ]);
+  });
+
+  describe('reset state', () => {
+    it('does not reset state when switching between source tree views', () => {
+      mockLocation.pathname = `/sources/${contentSource.id}`;
+      shallow(<SourceRouter />);
+      unmountHandler();
+
+      expect(resetSourceState).not.toHaveBeenCalled();
+    });
+
+    it('resets state when leaving source tree', () => {
+      mockLocation.pathname = '/home';
+      shallow(<SourceRouter />);
+      unmountHandler();
+
+      expect(resetSourceState).toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useEffect } from 'react';
-import { Route, Switch, useParams } from 'react-router-dom';
+
+import { Route, Switch, useLocation, useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 import moment from 'moment';
@@ -47,14 +48,18 @@ import { SourceLogic } from './source_logic';
 
 export const SourceRouter: React.FC = () => {
   const { sourceId } = useParams() as { sourceId: string };
+  const { pathname } = useLocation();
   const { initializeSource, resetSourceState } = useActions(SourceLogic);
   const { contentSource, dataLoading } = useValues(SourceLogic);
   const { isOrganization } = useValues(AppLogic);
 
   useEffect(() => {
     initializeSource(sourceId);
-    return resetSourceState;
-  }, []);
+    return () => {
+      // We only want to reset the state when leaving the source section. Otherwise there is an unwanted flash of UI.
+      if (!pathname.includes(sourceId)) resetSourceState();
+    };
+  }, [pathname]);
 
   if (dataLoading) return <Loading />;
 


### PR DESCRIPTION
### closes https://github.com/elastic/workplace-search-team/issues/1620
## Summary

Ports https://github.com/elastic/ent-search/pull/3358 to Kibana. 

**Note**
There was an issue where a recent [fix](https://github.com/elastic/kibana/commit/4873a70b0056a873351013d98a01fd6f4a1e39b1) for a Kibana bug caused this port to surface a bug when changing routes. The issue was that the nav and loading states were triggered between route changes. Added conditional to prevent resetting between in-source changes.

**Before fix**
![without-check](https://user-images.githubusercontent.com/1869731/115624489-56495880-a2c0-11eb-88f2-2a760daf9c5d.gif)

**After fix**
![with-check](https://user-images.githubusercontent.com/1869731/115624495-58abb280-a2c0-11eb-846e-0feeaa195247.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
