### PR TITLE
[Lens] Make Lens report internal code errors correctly

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -563,7 +563,12 @@ export const InnerVisualizationWrapper = ({
         onData$={onData$}
         renderMode="edit"
         renderError={(errorMessage?: string | null, error?: ExpressionRenderError | null) => {
-          const visibleErrorMessages = getOriginalRequestErrorMessages(error) || [errorMessage];
+          const errorsFromRequest = getOriginalRequestErrorMessages(error);
+          const visibleErrorMessages = errorsFromRequest.length
+            ? errorsFromRequest
+            : errorMessage
+            ? [errorMessage]
+            : [];
 
           return (
             <EuiFlexGroup>


### PR DESCRIPTION
## Summary

when investigating another bug I noticed JS errors were not bubbling up correctly in the workspace correctly, due to some changes in #96611 .

This fix gives priority to network/ES/esaggs errors when available, then internal JS ones, without hiding them.
