### PR TITLE
Introduce support for the session user data.

### DIFF
--- a/x-pack/plugins/security/server/index.ts
+++ b/x-pack/plugins/security/server/index.ts
@@ -30,6 +30,7 @@ export type { CheckPrivilegesPayload } from './authorization';
 export { LegacyAuditLogger, AuditLogger, AuditEvent } from './audit';
 export type { SecurityPluginSetup, SecurityPluginStart };
 export type { AuthenticatedUser } from '../common/model';
+export type { SessionUserDataStorage, SessionUserDataStorageScope } from './session_management';
 
 export const config: PluginConfigDescriptor<TypeOf<typeof ConfigSchema>> = {
   schema: ConfigSchema,

--- a/x-pack/plugins/security/server/mocks.ts
+++ b/x-pack/plugins/security/server/mocks.ts
@@ -13,6 +13,7 @@ import { mockAuthenticatedUser } from '../common/model/authenticated_user.mock';
 import { auditServiceMock } from './audit/index.mock';
 import { authenticationServiceMock } from './authentication/authentication_service.mock';
 import { authorizationMock } from './authorization/index.mock';
+import { sessionUserDataStorageMock } from './session_management/session_user_data_storage.mock';
 
 function createSetupMock() {
   const mockAuthz = authorizationMock.create();
@@ -27,6 +28,7 @@ function createSetupMock() {
     },
     registerSpacesService: jest.fn(),
     license: licenseMock.create(),
+    session: { userData: { registerScope: jest.fn() } },
   };
 }
 
@@ -43,6 +45,10 @@ function createStartMock() {
       checkPrivilegesWithRequest: mockAuthz.checkPrivilegesWithRequest,
       checkPrivilegesDynamicallyWithRequest: mockAuthz.checkPrivilegesDynamicallyWithRequest,
       mode: mockAuthz.mode,
+    },
+    session: {
+      hasActiveSession: jest.fn(),
+      userData: { getStorage: jest.fn().mockReturnValue(sessionUserDataStorageMock.create()) },
     },
   };
 }

--- a/x-pack/plugins/security/server/plugin.test.ts
+++ b/x-pack/plugins/security/server/plugin.test.ts
@@ -119,6 +119,11 @@ describe('Security Plugin', () => {
             "isEnabled": [Function],
             "isLicenseAvailable": [Function],
           },
+          "session": Object {
+            "userData": Object {
+              "registerScope": [Function],
+            },
+          },
         }
       `);
     });
@@ -167,6 +172,12 @@ describe('Security Plugin', () => {
             "checkPrivilegesWithRequest": [Function],
             "mode": Object {
               "useRbacForRequest": [Function],
+            },
+          },
+          "session": Object {
+            "hasActiveSession": [Function],
+            "userData": Object {
+              "getStorage": [Function],
             },
           },
         }

--- a/x-pack/plugins/security/server/session_management/index.ts
+++ b/x-pack/plugins/security/server/session_management/index.ts
@@ -10,3 +10,5 @@ export {
   SessionManagementServiceStart,
   SessionManagementService,
 } from './session_management_service';
+export type { SessionUserDataStorageScope } from './session_user_data_storage_service';
+export type { SessionUserDataStorage } from './session_user_data_storage';

--- a/x-pack/plugins/security/server/session_management/session_management_service.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_management_service.test.ts
@@ -43,7 +43,7 @@ describe('SessionManagementService', () => {
           }),
           taskManager: mockTaskManager,
         })
-      ).toBeUndefined();
+      ).toEqual({ userData: { registerScope: expect.any(Function) } });
 
       expect(mockTaskManager.registerTaskDefinitions).toHaveBeenCalledTimes(1);
       expect(mockTaskManager.registerTaskDefinitions).toHaveBeenCalledWith({
@@ -97,7 +97,11 @@ describe('SessionManagementService', () => {
           online$: mockStatusSubject.asObservable(),
           taskManager: mockTaskManager,
         })
-      ).toEqual({ session: expect.any(Session) });
+      ).toEqual({
+        session: expect.any(Session),
+        hasActiveSession: expect.any(Function),
+        userData: { getStorage: expect.any(Function) },
+      });
     });
 
     it('registers proper session index cleanup task runner', () => {

--- a/x-pack/plugins/security/server/session_management/session_user_data_storage.mock.ts
+++ b/x-pack/plugins/security/server/session_management/session_user_data_storage.mock.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PublicMethodsOf } from '@kbn/utility-types';
+
+import type { SessionUserDataStorage } from './session_user_data_storage';
+
+export const sessionUserDataStorageMock = {
+  create: (): jest.Mocked<PublicMethodsOf<SessionUserDataStorage>> => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    remove: jest.fn(),
+  }),
+};

--- a/x-pack/plugins/security/server/session_management/session_user_data_storage.ts
+++ b/x-pack/plugins/security/server/session_management/session_user_data_storage.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { KibanaRequest, Logger } from 'src/core/server';
+
+import type { Session } from './session';
+
+/**
+ * Session user data storage allows to manage any custom data associated with the session.
+ */
+export class SessionUserDataStorage {
+  readonly #scopePrefix: string;
+  readonly #session: PublicMethodsOf<Readonly<Session>>;
+  readonly #logger: Logger;
+
+  constructor(logger: Logger, scopePrefix: string, session: PublicMethodsOf<Readonly<Session>>) {
+    this.#logger = logger;
+    this.#scopePrefix = scopePrefix;
+    this.#session = session;
+  }
+
+  /**
+   * Retrieves user data from the session by the specified key. If requested value isn't found, or
+   * there is no active session, this method with return `null`.
+   * @param request Request used to get the session for.
+   * @param key Unique key associated with the data to retrieve.
+   */
+  async get<TValue = unknown>(request: KibanaRequest, key: string) {
+    this.#logger.debug(`Retrieving user data for key ${key}.`);
+    const sessionValue = await this.#session.get(request);
+    return (sessionValue?.userData?.get(`${this.#scopePrefix}#${key}`) as TValue) ?? null;
+  }
+
+  /**
+   * Stores provided value as the part of the session user data by the specified key.
+   * @param request Request used to get the session for.
+   * @param key Unique key associated with the data to store.
+   * @param value A JSON-serializable data to store.
+   * @throws This method will throw if there is no active session.
+   */
+  async set(request: KibanaRequest, key: string, value: unknown) {
+    this.#logger.debug(`Setting user data for key ${key}.`);
+
+    const sessionValue = await this.#session.get(request);
+    if (!sessionValue) {
+      throw new Error('Request does not have associated user session.');
+    }
+
+    if (!sessionValue.userData) {
+      sessionValue.userData = new Map();
+    }
+
+    sessionValue.userData.set(`${this.#scopePrefix}#${key}`, value);
+    await this.#session.update(request, sessionValue);
+  }
+
+  /**
+   * Removes user data from the session by the specified key. It's a no-op if the key isn't found,
+   * or there is no active session.
+   * @param request Request used to get the session for.
+   * @param key Unique key associated with the data to remove.
+   */
+  async remove(request: KibanaRequest, key: string) {
+    this.#logger.debug(`Removing user data for key ${key}.`);
+
+    const sessionValue = await this.#session.get(request);
+    const dataKey = `${this.#scopePrefix}#${key}`;
+    if (sessionValue?.userData?.has(dataKey) !== true) {
+      return;
+    }
+
+    sessionValue.userData.delete(dataKey);
+    await this.#session.update(request, sessionValue);
+  }
+}

--- a/x-pack/plugins/security/server/session_management/session_user_data_storage_service.ts
+++ b/x-pack/plugins/security/server/session_management/session_user_data_storage_service.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { Logger } from 'src/core/server';
+
+import type { Session } from './session';
+import { SessionUserDataStorage } from './session_user_data_storage';
+
+export type SessionUserDataStorageScope = symbol;
+export class SessionUserDataStorageService {
+  readonly #scopes: Map<string, SessionUserDataStorageScope> = new Map();
+  readonly #logger: Logger;
+
+  constructor(logger: Logger) {
+    this.#logger = logger;
+  }
+
+  registerScope(scopePrefix: string): SessionUserDataStorageScope {
+    if (!scopePrefix) {
+      throw new Error(`Scope prefix should be a valid non-empty string, but got ${scopePrefix}.`);
+    }
+
+    if (scopePrefix.includes('#')) {
+      throw new Error('Scope prefix cannot contain `#` characters.');
+    }
+
+    const scopeLowerCase = scopePrefix.toLowerCase();
+    if (this.#scopes.has(scopeLowerCase)) {
+      throw new Error(`Scope with the "${scopeLowerCase}" prefix is already registered.`);
+    }
+
+    this.#logger.debug(`Registering session user data scope with the "${scopeLowerCase}" prefix.`);
+
+    const scope = Object.freeze(Symbol(scopeLowerCase));
+    this.#scopes.set(scopeLowerCase, scope);
+    return scope;
+  }
+
+  getStorage(session: PublicMethodsOf<Readonly<Session>>, scope: SessionUserDataStorageScope) {
+    const scopePrefix = this.getScopePrefix(scope);
+    return Object.freeze(
+      new SessionUserDataStorage(this.#logger.get('userData', scopePrefix), scopePrefix, session)
+    );
+  }
+
+  private getScopePrefix(scope: SessionUserDataStorageScope) {
+    const scopePrefix = scope.description;
+    if (scopePrefix === undefined || this.#scopes.get(scopePrefix) !== scope) {
+      throw new Error(`Scope "${scopePrefix}" is not valid.`);
+    }
+
+    return scopePrefix;
+  }
+}

--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -46,6 +46,7 @@ const onlyNotInCoverageTests = [
   require.resolve('../test/security_api_integration/session_idle.config.ts'),
   require.resolve('../test/security_api_integration/session_invalidate.config.ts'),
   require.resolve('../test/security_api_integration/session_lifespan.config.ts'),
+  require.resolve('../test/security_api_integration/session_user_data.config.ts'),
   require.resolve('../test/security_api_integration/login_selector.config.ts'),
   require.resolve('../test/security_api_integration/audit.config.ts'),
   require.resolve('../test/security_api_integration/kerberos.config.ts'),

--- a/x-pack/test/security_api_integration/fixtures/session/session_user_data/kibana.json
+++ b/x-pack/test/security_api_integration/fixtures/session/session_user_data/kibana.json
@@ -1,0 +1,8 @@
+{
+  "id": "sessionUserDataPlugin",
+  "version": "8.0.0",
+  "kibanaVersion": "kibana",
+  "requiredPlugins": ["security"],
+  "server": true,
+  "ui": false
+}

--- a/x-pack/test/security_api_integration/fixtures/session/session_user_data/server/index.ts
+++ b/x-pack/test/security_api_integration/fixtures/session/session_user_data/server/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoreSetup, PluginInitializer } from '../../../../../../../src/core/server';
+import { initRoutes } from './init_routes';
+import {
+  SecurityPluginSetup,
+  SecurityPluginStart,
+} from '../../../../../../plugins/security/server';
+
+export const plugin: PluginInitializer<
+  void,
+  void,
+  { security: SecurityPluginSetup },
+  { security: SecurityPluginStart }
+> = () => {
+  return {
+    setup: (core: CoreSetup<{ security: SecurityPluginStart }>, { security }) => {
+      initRoutes(core, security.session.userData.registerScope('xpack.sessionUserDataPlugin'));
+    },
+    start: () => {},
+    stop: () => {},
+  };
+};

--- a/x-pack/test/security_api_integration/fixtures/session/session_user_data/server/init_routes.ts
+++ b/x-pack/test/security_api_integration/fixtures/session/session_user_data/server/init_routes.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CoreSetup } from '../../../../../../../src/core/server';
+import {
+  SecurityPluginStart,
+  SessionUserDataStorageScope,
+} from '../../../../../../plugins/security/server';
+
+export function initRoutes(
+  core: CoreSetup<{ security: SecurityPluginStart }>,
+  userDataScope: SessionUserDataStorageScope
+) {
+  const router = core.http.createRouter();
+  const userDataStoragePromise = core
+    .getStartServices()
+    .then(([, { security }]) => security.session.userData.getStorage(userDataScope));
+  router.get(
+    {
+      path: '/api/session_user_data/{key}',
+      validate: { params: schema.object({ key: schema.string() }) },
+    },
+    async (context, request, response) => {
+      const userDataStorage = await userDataStoragePromise;
+      return response.ok({ body: (await userDataStorage.get(request, request.params.key)) || {} });
+    }
+  );
+
+  router.post(
+    {
+      path: '/api/session_user_data/{key}',
+      validate: { params: schema.object({ key: schema.string() }), body: schema.any() },
+    },
+    async (context, request, response) => {
+      const userDataStorage = await userDataStoragePromise;
+      await userDataStorage.set(request, request.params.key, request.body);
+      return response.ok();
+    }
+  );
+
+  router.delete(
+    {
+      path: '/api/session_user_data/{key}',
+      validate: { params: schema.object({ key: schema.string() }) },
+    },
+    async (context, request, response) => {
+      const userDataStorage = await userDataStoragePromise;
+      await userDataStorage.remove(request, request.params.key);
+      return response.ok();
+    }
+  );
+}

--- a/x-pack/test/security_api_integration/session_user_data.config.ts
+++ b/x-pack/test/security_api_integration/session_user_data.config.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { resolve } from 'path';
+import { FtrConfigProviderContext } from '@kbn/test/types/ftr';
+import { services } from './services';
+
+// the default export of config files must be a config provider
+// that returns an object with the projects config values
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));
+  const plugin = resolve(__dirname, './fixtures/session/session_user_data');
+
+  return {
+    testFiles: [resolve(__dirname, './tests/session_user_data')],
+    services,
+    servers: xPackAPITestsConfig.get('servers'),
+    esTestCluster: xPackAPITestsConfig.get('esTestCluster'),
+    kbnTestServer: {
+      ...xPackAPITestsConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
+        `--plugin-path=${plugin}`,
+      ],
+    },
+
+    junit: {
+      reportName: 'X-Pack Security API Integration Tests (Session User Data)',
+    },
+  };
+}

--- a/x-pack/test/security_api_integration/tests/session_user_data/basic_functionality.ts
+++ b/x-pack/test/security_api_integration/tests/session_user_data/basic_functionality.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import request from 'request';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertestWithoutAuth');
+  const es = getService('es');
+  const esDeleteAllIndices = getService('esDeleteAllIndices');
+  const notSuperuserTestUser = { username: 'test_user', password: 'changeme' };
+
+  async function login(credentials: { username: string; password: string }) {
+    const authenticationResponse = await supertest
+      .post('/internal/security/login')
+      .set('kbn-xsrf', 'xxx')
+      .send({
+        providerType: 'basic',
+        providerName: 'basic',
+        currentURL: '/',
+        params: credentials,
+      })
+      .expect(200);
+    return request.cookie(authenticationResponse.headers['set-cookie'][0])!;
+  }
+
+  describe('Session User Data', () => {
+    beforeEach(async () => {
+      await es.cluster.health({ index: '.kibana_security_session*', wait_for_status: 'green' });
+      await esDeleteAllIndices('.kibana_security_session*');
+    });
+
+    it('should be able to store and retrieve user data from session', async function () {
+      const basicSessionCookie = await login(notSuperuserTestUser);
+
+      // There is no session user data yet.
+      await supertest
+        .get('/api/session_user_data/some-key-1')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, {});
+      await supertest
+        .get('/api/session_user_data/some-key-2')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, {});
+
+      // Save some session user data for key-1.
+      await supertest
+        .post('/api/session_user_data/some-key-1')
+        .set('kbn-xsrf', 'xxx')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .send({ someData: 'some-data-key-1', someOtherData: 'some-other-data-key-1' })
+        .expect(200);
+
+      // Now we should have some session user data, but only for key-1.
+      await supertest
+        .get('/api/session_user_data/some-key-1')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, { someData: 'some-data-key-1', someOtherData: 'some-other-data-key-1' });
+      await supertest
+        .get('/api/session_user_data/some-key-2')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, {});
+
+      // Save some session user data for key-2.
+      await supertest
+        .post('/api/session_user_data/some-key-2')
+        .set('kbn-xsrf', 'xxx')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .send({ someData: 'some-data-key-2', someOtherData: 'some-other-data-key-2' })
+        .expect(200);
+
+      // Now we should have some session user data for both keys.
+      await supertest
+        .get('/api/session_user_data/some-key-1')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, { someData: 'some-data-key-1', someOtherData: 'some-other-data-key-1' });
+      await supertest
+        .get('/api/session_user_data/some-key-2')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, { someData: 'some-data-key-2', someOtherData: 'some-other-data-key-2' });
+
+      // Remove data for key-1.
+      await supertest
+        .delete('/api/session_user_data/some-key-1')
+        .set('kbn-xsrf', 'xxx')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200);
+
+      // Now we should have some session user data only for key-2
+      await supertest
+        .get('/api/session_user_data/some-key-1')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, {});
+      await supertest
+        .get('/api/session_user_data/some-key-2')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, { someData: 'some-data-key-2', someOtherData: 'some-other-data-key-2' });
+
+      // Remove data for key-2.
+      await supertest
+        .delete('/api/session_user_data/some-key-2')
+        .set('kbn-xsrf', 'xxx')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200);
+
+      // There should be no data for both keys anymore.
+      await supertest
+        .get('/api/session_user_data/some-key-1')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, {});
+      await supertest
+        .get('/api/session_user_data/some-key-2')
+        .set('Cookie', basicSessionCookie.cookieString())
+        .expect(200, {});
+    });
+  });
+}

--- a/x-pack/test/security_api_integration/tests/session_user_data/index.ts
+++ b/x-pack/test/security_api_integration/tests/session_user_data/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('security APIs - Session User Data', function () {
+    this.tags('ciGroup6');
+
+    loadTestFile(require.resolve('./basic_functionality'));
+  });
+}


### PR DESCRIPTION
## Summary

In this PR we're introducing a new session user data API exposed as a part of the `Security` plugin public contract:

```ts
// `setup` contract
export interface SecurityPluginSetup {
  .....
  readonly session: {
    readonly userData: { registerScope: (scopePrefix: string) => SessionUserDataStorageScope };
  };
}

// `start` contract
export interface SecurityPluginStart {
  .....
  readonly session: {
    readonly hasActiveSession: (request: KibanaRequest) => Promise<boolean>;
    readonly userData: {
      getStorage: (scope: SessionUserDataStorageScope) => PublicMethodsOf<SessionUserDataStorage>;
    };
  };
}

// Consumer `setup`
setup: (core: CoreSetup<{ security: SecurityPluginSetup}>, { security }) => {
  this.#userDataStorageScope = security.session.userData.registerScope('xpack.myPlugin');
}

// Consumer `start`
start: (core: CoreStart, { security }) => {
  const userDataStorage = security.session.userData.getStorage(this.#userDataStorageScope);
}

// Consumer HTTP handler
async handler(request: KibanaRequest) {
  if (await security.session.hasActiveSession(request)) {
    await userDataStorage.set(request, 'some-data-key', 'some-data');
  }
  .....
  const data = await userDataStorage.get<string>(request, 'some-data-key'));
  .....
  await userDataStorage.remove(request, 'some-data-key');
}
```

__Fixes: https://github.com/elastic/kibana/issues/92558__
