### PR TITLE
[Canvas] Hide global banner list in fullscreen mode

### DIFF
--- a/x-pack/plugins/canvas/public/components/fullscreen/fullscreen.scss
+++ b/x-pack/plugins/canvas/public/components/fullscreen/fullscreen.scss
@@ -19,6 +19,11 @@ body.canvas-isFullscreen {
     display: none;
   }
 
+  // hide global banners
+  #globalBannerList {
+    display: none;
+  }
+
   // set the background color
   .canvasLayout {
     background: $euiColorInk;


### PR DESCRIPTION
## Summary

Fixes #59697.

This hides the global banner list when you're in fullscreen mode in Canvas.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
