### PR TITLE
[App Search] Synonyms: initial logic, cards, & pagination

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/empty_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/empty_state.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';
+
+import { EmptyState } from './';
+
+describe('EmptyState', () => {
+  it('renders', () => {
+    const wrapper = shallow(<EmptyState />)
+      .find(EuiEmptyPrompt)
+      .dive();
+
+    expect(wrapper.find('h2').text()).toEqual('Create your first synonym set');
+    expect(wrapper.find(EuiButton).prop('href')).toEqual(
+      expect.stringContaining('/synonyms-guide.html')
+    );
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/empty_state.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiPanel, EuiEmptyPrompt, EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { DOCS_PREFIX } from '../../../routes';
+
+import { SynonymIcon } from './';
+
+export const EmptyState: React.FC = () => {
+  return (
+    <EuiPanel color="subdued">
+      <EuiEmptyPrompt
+        iconType={SynonymIcon}
+        title={
+          <h2>
+            {i18n.translate('xpack.enterpriseSearch.appSearch.engine.synonyms.empty.title', {
+              defaultMessage: 'Create your first synonym set',
+            })}
+          </h2>
+        }
+        body={
+          <p>
+            {i18n.translate('xpack.enterpriseSearch.appSearch.engine.synonyms.empty.description', {
+              defaultMessage:
+                'Synonyms relate queries with similar context or meaning together. Use them to guide users to relevant content.',
+            })}
+          </p>
+        }
+        actions={
+          <EuiButton
+            size="s"
+            target="_blank"
+            iconType="popout"
+            href={`${DOCS_PREFIX}/synonyms-guide.html`}
+          >
+            {i18n.translate('xpack.enterpriseSearch.appSearch.engine.synonyms.empty.buttonLabel', {
+              defaultMessage: 'Read the synonyms guide',
+            })}
+          </EuiButton>
+        }
+      />
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/index.ts
@@ -7,3 +7,4 @@
 
 export { SynonymIcon } from './synonym_icon';
 export { SynonymCard } from './synonym_card';
+export { EmptyState } from './empty_state';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { SynonymIcon } from './synonym_icon';
+export { SynonymCard } from './synonym_card';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_card.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiCard, EuiButton } from '@elastic/eui';
+
+import { SynonymCard, SynonymIcon } from './';
+
+describe('SynonymCard', () => {
+  const MOCK_SYNONYM_SET = {
+    id: 'syn-1234567890',
+    synonyms: ['lorem', 'ipsum', 'dolor', 'sit', 'amet'],
+  };
+
+  const wrapper = shallow(<SynonymCard {...MOCK_SYNONYM_SET} />)
+    .find(EuiCard)
+    .dive();
+
+  it('renders with the first synonym as the title', () => {
+    expect(wrapper.find('h2').text()).toEqual('lorem');
+  });
+
+  it('renders a synonym icon for each subsequent synonym', () => {
+    expect(wrapper.find(SynonymIcon)).toHaveLength(4);
+  });
+
+  it('renders a manage synonym button', () => {
+    wrapper.find(EuiButton).simulate('click');
+    // TODO: expect open modal action
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_card.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiCard, EuiFlexGroup, EuiFlexItem, EuiText, EuiButton } from '@elastic/eui';
+
+import { MANAGE_BUTTON_LABEL } from '../../../../shared/constants';
+
+import { SynonymSet } from '../types';
+
+import { SynonymIcon } from './';
+
+export const SynonymCard: React.FC<SynonymSet> = (synonymSet) => {
+  const [firstSynonym, ...remainingSynonyms] = synonymSet.synonyms;
+
+  return (
+    <EuiCard
+      display="subdued"
+      title={firstSynonym}
+      titleElement="h2"
+      titleSize="s"
+      textAlign="left"
+      footer={
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={() => {} /* TODO */}>{MANAGE_BUTTON_LABEL}</EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+    >
+      <EuiText size="m">
+        {remainingSynonyms.map((synonym) => (
+          <div key={synonym}>
+            <SynonymIcon /> {synonym}
+          </div>
+        ))}
+      </EuiText>
+    </EuiCard>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_icon.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_icon.test.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { SynonymIcon } from './';
+
+describe('SynonymIcon', () => {
+  it('renders', () => {
+    const wrapper = shallow(<SynonymIcon />);
+    expect(wrapper.hasClass('euiIcon')).toBe(true);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_icon.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/components/synonym_icon.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { i18n } from '@kbn/i18n';
+
+export const SynonymIcon: React.FC = ({ ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 18 18"
+    width="18"
+    height="18"
+    className="euiIcon euiIcon--subdued euiIcon--medium"
+    {...props}
+    aria-label={i18n.translate('xpack.enterpriseSearch.appSearch.engine.synonyms.iconAriaLabel', {
+      defaultMessage: 'synonym for',
+    })}
+  >
+    <path d="M5.477 4.69c-1.1-.043-2.176.7-3.365 2.596a.65.65 0 01-1.101-.69c1.413-2.255 2.883-3.27 4.518-3.204 1.214.048 2.125.522 3.977 1.812l.075.052c3.175 2.212 4.387 2.352 6.33-.339a.65.65 0 111.054.761c-2.48 3.436-4.447 3.209-8.128.645l-.074-.052c-1.64-1.142-2.415-1.546-3.286-1.58zm0 6.35c-1.1-.043-2.176.7-3.365 2.596a.65.65 0 01-1.101-.69c1.413-2.255 2.883-3.27 4.518-3.204 1.214.048 2.125.522 3.977 1.812l.075.052c3.175 2.212 4.387 2.352 6.33-.338a.65.65 0 111.054.76c-2.48 3.436-4.447 3.209-8.128.645l-.074-.052c-1.64-1.142-2.415-1.546-3.286-1.58z" />
+  </svg>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/constants.ts
@@ -7,6 +7,15 @@
 
 import { i18n } from '@kbn/i18n';
 
+import { DEFAULT_META } from '../../../shared/constants';
+
+export const SYNONYMS_PAGE_META = {
+  page: {
+    ...DEFAULT_META.page,
+    size: 12, // Use a multiple of 3, since synonym cards are in rows of 3
+  },
+};
+
 export const SYNONYMS_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.engine.synonyms.title',
   { defaultMessage: 'Synonyms' }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms.test.tsx
@@ -5,17 +5,123 @@
  * 2.0.
  */
 
+import { setMockValues, setMockActions, rerender } from '../../../__mocks__';
+import '../../../__mocks__/shallow_useeffect.mock';
 import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { EuiPageHeader, EuiButton, EuiPagination } from '@elastic/eui';
+
+import { Loading } from '../../../shared/loading';
+
+import { SynonymCard, EmptyState } from './components';
+
 import { Synonyms } from './';
 
 describe('Synonyms', () => {
+  const MOCK_SYNONYM_SET = {
+    id: 'syn-1234567890',
+    synonyms: ['a', 'b', 'c'],
+  };
+
+  const values = {
+    synonymSets: [MOCK_SYNONYM_SET, MOCK_SYNONYM_SET, MOCK_SYNONYM_SET],
+    meta: { page: { current: 1 } },
+    dataLoading: false,
+  };
+  const actions = {
+    loadSynonyms: jest.fn(),
+    onPaginate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues(values);
+    setMockActions(actions);
+  });
+
   it('renders', () => {
-    shallow(<Synonyms />);
-    // TODO: Check for Synonym cards, Synonym modal
+    const wrapper = shallow(<Synonyms />);
+
+    expect(wrapper.find(SynonymCard)).toHaveLength(3);
+    // TODO: Check for synonym modal
+  });
+
+  it('renders a create action button', () => {
+    const wrapper = shallow(<Synonyms />)
+      .find(EuiPageHeader)
+      .dive()
+      .children()
+      .dive();
+
+    wrapper.find(EuiButton).simulate('click');
+    // TODO: Expect open modal action
+  });
+
+  it('renders an empty state if no synonyms exist', () => {
+    setMockValues({ ...values, synonymSets: [] });
+    const wrapper = shallow(<Synonyms />);
+
+    expect(wrapper.find(EmptyState)).toHaveLength(1);
+  });
+
+  describe('loading', () => {
+    it('renders a loading state on initial page load', () => {
+      setMockValues({ ...values, synonymSets: [], dataLoading: true });
+      const wrapper = shallow(<Synonyms />);
+
+      expect(wrapper.find(Loading)).toHaveLength(1);
+    });
+
+    it('does not render a full loading state after initial page load', () => {
+      setMockValues({ ...values, synonymSets: [MOCK_SYNONYM_SET], dataLoading: true });
+      const wrapper = shallow(<Synonyms />);
+
+      expect(wrapper.find(Loading)).toHaveLength(0);
+    });
+  });
+
+  describe('API & pagination', () => {
+    it('loads synonyms on page load and on pagination', () => {
+      const wrapper = shallow(<Synonyms />);
+      expect(actions.loadSynonyms).toHaveBeenCalledTimes(1);
+
+      setMockValues({ ...values, meta: { page: { current: 5 } } });
+      rerender(wrapper);
+      expect(actions.loadSynonyms).toHaveBeenCalledTimes(2);
+    });
+
+    it('automatically paginations users back a page if they delete the only remaining synonym on the page', () => {
+      setMockValues({ ...values, meta: { page: { current: 5 } }, synonymSets: [] });
+      shallow(<Synonyms />);
+
+      expect(actions.onPaginate).toHaveBeenCalledWith(4);
+    });
+
+    it('does not paginate backwards if the user is on the first page (should show the state instead)', () => {
+      setMockValues({ ...values, meta: { page: { current: 1 } }, synonymSets: [] });
+      const wrapper = shallow(<Synonyms />);
+
+      expect(actions.onPaginate).not.toHaveBeenCalled();
+      expect(wrapper.find(EmptyState)).toHaveLength(1);
+    });
+
+    it('handles off-by-one shenanigans between EuiPagination and our API', () => {
+      setMockValues({
+        ...values,
+        meta: { page: { total_pages: 10, current: 1 } },
+      });
+      const wrapper = shallow(<Synonyms />);
+      const pagination = wrapper.find(EuiPagination);
+
+      expect(pagination.prop('pageCount')).toEqual(10);
+      expect(pagination.prop('activePage')).toEqual(0);
+
+      pagination.simulate('pageClick', 4);
+      expect(actions.onPaginate).toHaveBeenCalledWith(5);
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms.tsx
@@ -5,23 +5,86 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { EuiPageHeader, EuiPageContentBody } from '@elastic/eui';
+import { useValues, useActions } from 'kea';
+
+import {
+  EuiPageHeader,
+  EuiButton,
+  EuiPageContentBody,
+  EuiSpacer,
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiPagination,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { Loading } from '../../../shared/loading';
 import { getEngineBreadcrumbs } from '../engine';
 
+import { SynonymCard, EmptyState } from './components';
 import { SYNONYMS_TITLE } from './constants';
 
+import { SynonymsLogic } from './';
+
 export const Synonyms: React.FC = () => {
+  const { loadSynonyms, onPaginate } = useActions(SynonymsLogic);
+  const { synonymSets, meta, dataLoading } = useValues(SynonymsLogic);
+  const hasSynonyms = synonymSets.length > 0;
+
+  useEffect(() => {
+    loadSynonyms();
+  }, [meta.page.current]);
+
+  useEffect(() => {
+    // If users delete the only synonym set on the page, send them back to the previous page
+    if (!hasSynonyms && meta.page.current !== 1) {
+      onPaginate(meta.page.current - 1);
+    }
+  }, [synonymSets]);
+
+  if (dataLoading && !hasSynonyms) return <Loading />;
+
   return (
     <>
       <SetPageChrome trail={getEngineBreadcrumbs([SYNONYMS_TITLE])} />
-      <EuiPageHeader pageTitle={SYNONYMS_TITLE} />
+      <EuiPageHeader
+        pageTitle={SYNONYMS_TITLE}
+        rightSideItems={[
+          <EuiButton fill onClick={() => {} /* TODO */}>
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.engine.synonyms.createSynonymSetButtonLabel',
+              { defaultMessage: 'Create a synonym set' }
+            )}
+          </EuiButton>,
+        ]}
+      />
       <FlashMessages />
-      <EuiPageContentBody>TODO</EuiPageContentBody>
+      <EuiPageContentBody>
+        <EuiSpacer size="s" />
+        {hasSynonyms ? (
+          <>
+            <EuiFlexGrid columns={3}>
+              {synonymSets.map(({ id, synonyms }) => (
+                <EuiFlexItem key={id}>
+                  <SynonymCard id={id} synonyms={synonyms} />
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGrid>
+            <EuiSpacer />
+            <EuiPagination
+              pageCount={meta.page.total_pages}
+              activePage={meta.page.current - 1}
+              onPageClick={(pageIndex) => onPaginate(pageIndex + 1)}
+            />
+          </>
+        ) : (
+          <EmptyState />
+        )}
+      </EuiPageContentBody>
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms_logic.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogicMounter, mockHttpValues, mockFlashMessageHelpers } from '../../../__mocks__';
+import '../../__mocks__/engine_logic.mock';
+
+import { nextTick } from '@kbn/test/jest';
+
+import { SYNONYMS_PAGE_META } from './constants';
+
+import { SynonymsLogic } from './';
+
+describe('SynonymsLogic', () => {
+  const { mount } = new LogicMounter(SynonymsLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+
+  const MOCK_SYNONYMS_RESPONSE = {
+    meta: {
+      page: {
+        current: 1,
+        size: 12,
+        total_results: 1,
+        total_pages: 1,
+      },
+    },
+    results: [
+      {
+        id: 'some-synonym-id',
+        synonyms: ['hello', 'world'],
+      },
+    ],
+  };
+
+  const DEFAULT_VALUES = {
+    dataLoading: true,
+    synonymSets: [],
+    meta: SYNONYMS_PAGE_META,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has expected default values', () => {
+    mount();
+    expect(SynonymsLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    describe('onSynonymsLoad', () => {
+      it('should set synonyms and meta state, & dataLoading to false', () => {
+        mount();
+
+        SynonymsLogic.actions.onSynonymsLoad(MOCK_SYNONYMS_RESPONSE);
+
+        expect(SynonymsLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          synonymSets: MOCK_SYNONYMS_RESPONSE.results,
+          meta: MOCK_SYNONYMS_RESPONSE.meta,
+          dataLoading: false,
+        });
+      });
+    });
+
+    describe('onPaginate', () => {
+      it('should set meta.page.current state', () => {
+        mount();
+
+        SynonymsLogic.actions.onPaginate(3);
+
+        expect(SynonymsLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          meta: { page: { ...DEFAULT_VALUES.meta.page, current: 3 } },
+        });
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('loadSynonyms', () => {
+      it('should set dataLoading state', () => {
+        mount({ dataLoading: false });
+
+        SynonymsLogic.actions.loadSynonyms();
+
+        expect(SynonymsLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: true,
+        });
+      });
+
+      it('should make an API call and set synonyms & meta state', async () => {
+        http.get.mockReturnValueOnce(Promise.resolve(MOCK_SYNONYMS_RESPONSE));
+        mount();
+        jest.spyOn(SynonymsLogic.actions, 'onSynonymsLoad');
+
+        SynonymsLogic.actions.loadSynonyms();
+        await nextTick();
+
+        expect(http.get).toHaveBeenCalledWith('/api/app_search/engines/some-engine/synonyms', {
+          query: {
+            'page[current]': 1,
+            'page[size]': 12,
+          },
+        });
+        expect(SynonymsLogic.actions.onSynonymsLoad).toHaveBeenCalledWith(MOCK_SYNONYMS_RESPONSE);
+      });
+
+      it('handles errors', async () => {
+        http.get.mockReturnValueOnce(Promise.reject('error'));
+        mount();
+
+        SynonymsLogic.actions.loadSynonyms();
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms_logic.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { Meta } from '../../../../../common/types';
+import { flashAPIErrors } from '../../../shared/flash_messages';
+import { HttpLogic } from '../../../shared/http';
+import { updateMetaPageIndex } from '../../../shared/table_pagination';
+import { EngineLogic } from '../engine';
+
+import { SYNONYMS_PAGE_META } from './constants';
+import { SynonymSet, SynonymsApiResponse } from './types';
+
+interface SynonymsValues {
+  dataLoading: boolean;
+  synonymSets: SynonymSet[];
+  meta: Meta;
+}
+
+interface SynonymsActions {
+  loadSynonyms(): void;
+  onSynonymsLoad(response: SynonymsApiResponse): SynonymsApiResponse;
+  onPaginate(newPageIndex: number): { newPageIndex: number };
+}
+
+export const SynonymsLogic = kea<MakeLogicType<SynonymsValues, SynonymsActions>>({
+  path: ['enterprise_search', 'app_search', 'synonyms_logic'],
+  actions: () => ({
+    loadSynonyms: true,
+    onSynonymsLoad: ({ results, meta }) => ({ results, meta }),
+    onPaginate: (newPageIndex) => ({ newPageIndex }),
+  }),
+  reducers: () => ({
+    dataLoading: [
+      true,
+      {
+        loadSynonyms: () => true,
+        onSynonymsLoad: () => false,
+      },
+    ],
+    synonymSets: [
+      [],
+      {
+        onSynonymsLoad: (_, { results }) => results,
+      },
+    ],
+    meta: [
+      SYNONYMS_PAGE_META,
+      {
+        onSynonymsLoad: (_, { meta }) => meta,
+        onPaginate: (state, { newPageIndex }) => updateMetaPageIndex(state, newPageIndex),
+      },
+    ],
+  }),
+  listeners: ({ actions, values }) => ({
+    loadSynonyms: async () => {
+      const { meta } = values;
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const response = await http.get(`/api/app_search/engines/${engineName}/synonyms`, {
+          query: {
+            'page[current]': meta.page.current,
+            'page[size]': meta.page.size,
+          },
+        });
+        actions.onSynonymsLoad(response);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/types.ts
@@ -5,6 +5,14 @@
  * 2.0.
  */
 
-export { SYNONYMS_TITLE } from './constants';
-export { Synonyms } from './synonyms';
-export { SynonymsLogic } from './synonyms_logic';
+import { Meta } from '../../../../../common/types';
+
+export interface SynonymSet {
+  id: string;
+  synonyms: string[];
+}
+
+export interface SynonymsApiResponse {
+  results: SynonymSet[];
+  meta: Meta;
+}


### PR DESCRIPTION
## Summary

This adds the following Synonyms functionality:

- Initial SynonymsLogic file, mostly just to do with initial load + pagination
- Added components: EmptyState, SynonymCard, SynonymIcon
- Updated Synonyms view w/ new loading/cards/pagination

### Screencaps

Fancy new cards:
<img width="1179" alt="" src="https://user-images.githubusercontent.com/549407/115806947-8c5c0a80-a39c-11eb-95b7-2e7dc515f3bb.png">

Empty State:
<img width="943" alt="" src="https://user-images.githubusercontent.com/549407/115806962-9251eb80-a39c-11eb-8164-792597fb94b3.png">

Pagination:
![pagination](https://user-images.githubusercontent.com/549407/115807038-af86ba00-a39c-11eb-868f-6c5ae5a37534.gif)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)