### PR TITLE
[Lens] Prevent React error on first field drop

### DIFF
--- a/x-pack/plugins/lens/public/drag_drop/drag_drop.tsx
+++ b/x-pack/plugins/lens/public/drag_drop/drag_drop.tsx
@@ -485,14 +485,18 @@ const DropsInner = memo(function DropsInner(props: DropsInnerProps) {
   }, [order, registerDropTarget, dropTypes, keyboardMode]);
 
   useEffect(() => {
+    let isMounted = true;
     if (activeDropTarget && activeDropTarget.id !== value.id) {
       setIsInZone(false);
     }
     setTimeout(() => {
-      if (!activeDropTarget) {
+      if (!activeDropTarget && isMounted) {
         setIsInZone(false);
       }
     }, 1000);
+    return () => {
+      isMounted = false;
+    };
   }, [activeDropTarget, setIsInZone, value.id]);
 
   const dragEnter = () => {


### PR DESCRIPTION
## Summary

Fixes #97967 

The `setIsInZone` callback was called after the `useEffect` hook was unmounted. This PR should address that by using a mounted flag on the hook.

Maybe it is worth porting it to 7.13 as well?