### PR TITLE
[Workplace Search] Fix an issue where lack of ees host in config hides chrome

### DIFF
--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -116,7 +116,7 @@ export class EnterpriseSearchPlugin implements Plugin {
 
         // The Workplace Search Personal dashboard needs the chrome hidden. We hide it globally
         // here first to prevent a flash of chrome on the Personal dashboard and unhide it for admin routes.
-        chrome.setIsVisible(false);
+        if (this.config.host) chrome.setIsVisible(false);
         await this.getInitialData(http);
         const pluginData = this.getPluginData();
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the lack of Enterprise Search host in the Kibana config hides the app chrome, which is only desirable on the Personal dashboard.

We are investigating creating separate apps for the personal and org dashboards in a future release.

**Before**
![before](https://user-images.githubusercontent.com/1869731/116107277-7ee2a100-a678-11eb-9274-f9a489dcdd37.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/116107289-81dd9180-a678-11eb-80e9-d996d6686c75.gif)
