### PR TITLE
docs: remove apm_user

### DIFF
--- a/docs/apm/apm-app-users.asciidoc
+++ b/docs/apm/apm-app-users.asciidoc
@@ -60,11 +60,6 @@ include::./tab-widgets/apm-app-reader/widget.asciidoc[]
 TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
 Add the privileges under the **Data streams** tab.
 
-If your APM data is being sent to APM Server, you're using classic APM indices.
-
-If your APM data is ingested into `apm-*` indices, you're using classic APM indices.
-If you're
-
 . Assign the `read-apm` role created in the previous step, and the following built-in roles to
 any APM reader users:
 +

--- a/docs/apm/apm-app-users.asciidoc
+++ b/docs/apm/apm-app-users.asciidoc
@@ -10,7 +10,7 @@
 <titleabbrev>Users and privileges</titleabbrev>
 ++++
 
-You can use role-based access control to grant users access to secured
+Use role-based access control to grant users access to secured
 resources. The roles that you set up depend on your organization's security
 requirements and the minimum privileges required to use specific features.
 
@@ -24,6 +24,13 @@ In general, there are three types of privileges you'll work with:
 * **Elasticsearch index privileges**: Control access to the data in specific indices your cluster.
 * **Kibana space privileges**: Grant users write or read access to features and apps within Kibana.
 
+Select your use-case to get started:
+
+* <<apm-app-reader>>
+* <<apm-app-annotation-user-create>>
+* <<apm-app-central-config-user>>
+* <<apm-app-api-user>>
+
 ////
 ***********************************  ***********************************
 ////
@@ -36,13 +43,30 @@ In general, there are three types of privileges you'll work with:
 <titleabbrev>Create an APM reader user</titleabbrev>
 ++++
 
-[[apm-app-reader-full]]
-==== Full APM reader
-
-APM reader users typically need to view the APM app, dashboards, and visualizations that contain APM data.
+APM reader users typically need to view the APM app and dashboards and visualizations that use APM data.
 These users might also need to create and edit dashboards, visualizations, and machine learning jobs.
 
-. Assign the following built-in roles:
+[[apm-app-reader-full]]
+==== APM reader
+
+To create an APM reader user:
+
+. Create a new role, named something like `read-apm`, and assign the following privileges:
++
+--
+include::./tab-widgets/apm-app-reader/widget.asciidoc[]
+--
++
+TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
+Add the privileges under the **Data streams** tab.
+
+If your APM data is being sent to APM Server, you're using classic APM indices.
+
+If your APM data is ingested into `apm-*` indices, you're using classic APM indices.
+If you're
+
+. Assign the `read-apm` role created in the previous step, and the following built-in roles to
+any APM reader users:
 +
 [options="header"]
 |====
@@ -50,9 +74,6 @@ These users might also need to create and edit dashboards, visualizations, and m
 
 |`kibana_admin`
 |Grants access to all features in Kibana.
-
-|`apm_user`
-|Grants the privileges required for APM users on +{beat_default_index_prefix}*+ indices
 
 |`machine_learning_admin`
 |Grants the privileges required to create, update, and view machine learning jobs
@@ -63,14 +84,14 @@ These users might also need to create and edit dashboards, visualizations, and m
 
 In some instances, you may wish to restrict certain Kibana apps that a user has access to.
 
-. Assign the following built in roles:
+. Create a new role, named something like `read-apm-partial`, and assign the following privileges:
 +
-[options="header"]
-|====
-|Role | Purpose
-|`apm_user`
-|Grants the privileges required for APM users on +{beat_default_index_prefix}*+ indices
-|====
+--
+include::./tab-widgets/apm-app-reader/widget.asciidoc[]
+--
++
+TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
+Add the privileges under the **Data streams** tab.
 
 . Assign space privileges to any Kibana space that the user needs access to.
 Here are two examples:
@@ -97,6 +118,8 @@ Here are two examples:
 |`machine_learning_admin`
 |Grants the privileges required to create, update, and view machine learning jobs
 |====
+
+include::./tab-widgets/code.asciidoc[]
 
 ////
 ***********************************  ***********************************
@@ -138,7 +161,7 @@ and assign the following privileges:
 ^1^ +\{ANNOTATION_INDEX\}+ should be the index name you've defined in
 <<apm-settings-kb,`xpack.observability.annotations.index`>>.
 
-. Assign the `annotation_user` created previously, and the built-in roles necessary to create
+. Assign the `annotation_user` created previously, and the roles and privileges necessary to create
 a <<apm-app-reader-full,full>> or <<apm-app-reader-partial,partial>> APM reader to any users that need to view annotations in the APM app
 
 [[apm-app-annotation-api]]
@@ -163,17 +186,17 @@ See <<apm-app-api-user>>.
 
 Central configuration users need to be able to view, create, update, and delete Agent configurations.
 
-. Assign the following built-in roles:
+. Create a new role, named something like `central-config-manager`, and assign the following privileges:
 +
-[options="header"]
-|====
-|Role | Purpose
+--
+include::./tab-widgets/central-config-users/widget.asciidoc[]
+--
++
+TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
+Add the privileges under the **Data streams** tab.
 
-|`apm_user`
-|Grants the privileges required for APM users on +{beat_default_index_prefix}*+ indices
-|====
-
-. Assign the following Kibana space privileges:
+. Assign the `central-config-manager` role created in the previous step, and the following Kibana space privileges to
+anyone who needs to manage central configurations:
 +
 [options="header"]
 |====
@@ -190,16 +213,17 @@ Central configuration users need to be able to view, create, update, and delete 
 In some instances, you may wish to create a user that can only read central configurations,
 but not create, update, or delete them.
 
-. Assign the following built-in roles:
+. Create a new role, named something like `central-config-reader`, and assign the following privileges:
 +
-[options="header"]
-|====
-|Role | Purpose
-|`apm_user`
-|Grants the privileges required for APM users on +{beat_default_index_prefix}*+ indices
-|====
+--
+include::./tab-widgets/central-config-users/widget.asciidoc[]
+--
++
+TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
+Add the privileges under the **Data streams** tab.
 
-. Assign the following Kibana space privileges:
+. Assign the `central-config-reader` role created in the previous step, and the following Kibana space privileges to
+anyone who needs to read central configurations:
 +
 [options="header"]
 |====
@@ -214,6 +238,8 @@ but not create, update, or delete them.
 ==== Central configuration API
 
 See <<apm-app-api-user>>.
+
+include::./tab-widgets/code.asciidoc[]
 
 ////
 ***********************************  ***********************************

--- a/docs/apm/tab-widgets/apm-app-reader/content.asciidoc
+++ b/docs/apm/tab-widgets/apm-app-reader/content.asciidoc
@@ -1,0 +1,45 @@
+// tag::classic-indices[]
+[options="header"]
+|====
+|Type |Privilege |Purpose
+
+|Index
+|`read` on `apm-*`
+|Read-only access to `apm-*` data
+
+|Index
+|`view_index_metadata` on `apm-*`
+|Read-only access to `apm-*` index metadata
+|====
+// end::classic-indices[]
+
+// tag::data-streams[]
+[options="header"]
+|====
+|Type |Privilege |Purpose
+
+|Index
+|`read` on `logs-apm*`
+|Read-only access to `logs-apm*` data
+
+|Index
+|`view_index_metadata` on `logs-apm*`
+|Read-only access to `logs-apm*` index metadata
+
+|Index
+|`read` on `metrics-apm*`
+|Read-only access to `metrics-apm*` data
+
+|Index
+|`view_index_metadata` on `metrics-apm*`
+|Read-only access to `metrics-apm*` index metadata
+
+|Index
+|`read` on `traces-apm*`
+|Read-only access to `traces-apm*` data
+
+|Index
+|`view_index_metadata` on `traces-apm*`
+|Read-only access to `traces-apm*` index metadata
+|====
+// end::data-streams[]

--- a/docs/apm/tab-widgets/apm-app-reader/widget.asciidoc
+++ b/docs/apm/tab-widgets/apm-app-reader/widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="apm-app-reader">
+  <div role="tablist" aria-label="APM app reader">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="classic-indices-tab"
+            id="classic-indices">
+      Classic APM indices
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="data-streams-tab"
+            id="data-streams"
+            tabindex="-1">
+      Data streams
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="classic-indices-tab"
+       aria-labelledby="classic-indices">
+++++
+
+include::content.asciidoc[tag=classic-indices]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="data-streams-tab"
+       aria-labelledby="data-streams"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=data-streams]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/apm/tab-widgets/central-config-users/content.asciidoc
+++ b/docs/apm/tab-widgets/central-config-users/content.asciidoc
@@ -1,0 +1,53 @@
+// tag::classic-indices[]
+[options="header"]
+|====
+|Type |Privilege |Purpose
+
+|Index
+|`read` on `apm-*`
+|Read-only access to `apm-*` data
+
+|Index
+|`view_index_metadata` on `apm-*`
+|Read-only access to `apm-*` index metadata
+|====
+// end::classic-indices[]
+
+// tag::data-streams[]
+[options="header"]
+|====
+|Type |Privilege |Purpose
+
+|Index
+|`read` on `apm-agent-configuration`
+|Read-only access to `apm-agent-configuration` data
+
+|Index
+|`view_index_metadata` on `apm-agent-configuration`
+|Read-only access to `apm-agent-configuration` index metadata
+
+|Index
+|`read` on `logs-apm*`
+|Read-only access to `logs-apm*` data
+
+|Index
+|`view_index_metadata` on `logs-apm*`
+|Read-only access to `logs-apm*` index metadata
+
+|Index
+|`read` on `metrics-apm*`
+|Read-only access to `metrics-apm*` data
+
+|Index
+|`view_index_metadata` on `metrics-apm*`
+|Read-only access to `metrics-apm*` index metadata
+
+|Index
+|`read` on `traces-apm*`
+|Read-only access to `traces-apm*` data
+
+|Index
+|`view_index_metadata` on `traces-apm*`
+|Read-only access to `traces-apm*` index metadata
+|====
+// end::data-streams[]

--- a/docs/apm/tab-widgets/central-config-users/widget.asciidoc
+++ b/docs/apm/tab-widgets/central-config-users/widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="central-config-manager">
+  <div role="tablist" aria-label="Central config manager">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="classic-indices-tab"
+            id="classic-indices">
+      Classic APM indices
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="data-streams-tab"
+            id="data-streams"
+            tabindex="-1">
+      Data streams
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="classic-indices-tab"
+       aria-labelledby="classic-indices">
+++++
+
+include::content.asciidoc[tag=classic-indices]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="data-streams-tab"
+       aria-labelledby="data-streams"
+       hidden="">
+++++
+
+include::content.asciidoc[tag=data-streams]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/apm/tab-widgets/code.asciidoc
+++ b/docs/apm/tab-widgets/code.asciidoc
@@ -1,0 +1,166 @@
+// Defining styles and script here for simplicity.
+++++
+<style>
+.tabs {
+  width: 100%;
+}
+[role="tablist"] {
+  margin: 0 0 -0.1em;
+  overflow: visible;
+}
+[role="tab"] {
+  position: relative;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background: hsl(220, 20%, 94%);
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before,
+[role="tab"][aria-selected="true"]::before {
+  position: absolute;
+  bottom: 100%;
+  right: -1px;
+  left: -1px;
+  border-radius: 0.2em 0.2em 0 0;
+  border-top: 3px solid hsl(219, 1%, 72%);
+  content: '';
+}
+[role="tab"][aria-selected="true"] {
+  border-radius: 0;
+  background: hsl(220, 43%, 99%);
+  outline: 0;
+}
+[role="tab"][aria-selected="true"]:not(:focus):not(:hover)::before {
+  border-top: 5px solid hsl(218, 96%, 48%);
+}
+[role="tab"][aria-selected="true"]::after {
+  position: absolute;
+  z-index: 3;
+  bottom: -1px;
+  right: 0;
+  left: 0;
+  height: 0.3em;
+  background: hsl(220, 43%, 99%);
+  box-shadow: none;
+  content: '';
+}
+[role="tab"]:hover,
+[role="tab"]:focus,
+[role="tab"]:active {
+  outline: 0;
+  border-radius: 0;
+  color: inherit;
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before {
+  border-color: hsl(218, 96%, 48%);
+}
+[role="tabpanel"] {
+  position: relative;
+  z-index: 2;
+  padding: 1em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0 0.2em 0.2em 0.2em;
+  box-shadow: 0 0 0.2em hsl(219, 1%, 72%);
+  background: hsl(220, 43%, 99%);
+  margin-bottom: 1em;
+}
+[role="tabpanel"] p {
+  margin: 0;
+}
+[role="tabpanel"] * + p {
+  margin-top: 1em;
+}
+</style>
+
+<script>
+window.addEventListener("DOMContentLoaded", () => {
+  const tabs = document.querySelectorAll('[role="tab"]');
+  const tabList = document.querySelector('[role="tablist"]');
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+  tabList.addEventListener("keydown", e => {
+    // Move right
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+});
+
+function setActiveTab(target) {
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+  // console.log(grandparent);
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+
+function changeTabs(e) {
+  // get the containing list of the tab that was just clicked
+  const tabList = e.target.parentNode;
+
+  // get all of the sibling tabs
+  const buttons = Array.apply(null, tabList.querySelectorAll('button'));
+
+  // loop over the siblings to discover which index thje clicked one was
+  const { index } = buttons.reduce(({ found, index }, button) => {
+    if (!found && buttons[index] === e.target) {
+      return { found: true, index };
+    } else if (!found) {
+      return { found, index: index + 1 };
+    } else {
+      return { found, index };
+    }
+  }, { found: false, index: 0 });
+
+  // get the tab container
+  const container = tabList.parentNode;
+  // read the data-tab-group value from the container, e.g. "os"
+  const { tabGroup } = container.dataset;
+  // get a list of all the tab groups that match this value on the page
+  const groups = document.querySelectorAll('[data-tab-group=' + tabGroup + ']');
+
+  // for each of the found tab groups, find the tab button at the previously discovered index and select it for each group
+  groups.forEach((group) => {
+    const target = group.querySelectorAll('button')[index];
+    setActiveTab(target);
+  });
+}
+</script>
+++++


### PR DESCRIPTION
## Summary

#### [**Click here for a documentation preview**](https://kibana_98401.docs-preview.app.elstc.co/guide/en/kibana/master/apm-app-reader.html)

The `apm_user` role is being deprecated in `7.13` and removed in `8.0` (https://github.com/elastic/elasticsearch/pull/68749). This PR updates the APM app users and privileges documentation to remove references to the built-in `apm_user` role. It also adds rbac information for APM data stored in data streams.

These instructions will change again in the near future due to:

* Inject agent config directly into APM Fleet policies https://github.com/elastic/kibana/issues/95501
* Solutions-first role management https://github.com/elastic/kibana/issues/80634

There are a lot of index-level privileges required for some of these use-cases. Please let me know if there's any way to simplify.

For https://github.com/elastic/observability-docs/issues/516.