### PR TITLE
integration-test i18n test changes

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.js
+++ b/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.js
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }) {
     it('filebeat- should have hit count GT 0', async function () {
       await PageObjects.common.navigateToApp('discover', { insertTimestamp: false });
       await PageObjects.discover.selectIndexPattern('filebeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Last_30 days');
+      // await PageObjects.timePicker.setCommonlyUsedTime('Last_30 days');
       await retry.try(async () => {
         const hitCount = parseInt(await PageObjects.discover.getHitCount());
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/management/_index_pattern_create.js
+++ b/x-pack/test/stack_functional_integration/apps/management/_index_pattern_create.js
@@ -41,16 +41,26 @@ export default ({ getService, getPageObjects }) => {
 
       it('should have expected table headers', async function checkingHeader() {
         const headers = await PageObjects.settings.getTableHeader();
+        headers.map(async function compareHead(header) {
+          const text = await header.getVisibleText();
+          log.debug(text);
+        });
         log.debug('header.length = ' + headers.length);
-        const expectedHeaders = [
-          'Name',
-          'Type',
-          'Format',
-          'Searchable',
-          'Aggregatable',
-          'Excluded',
-        ];
-
+        let expectedHeaders;
+        log.debug(`process.env.LOCALE=${process.env.LOCALE}`);
+        switch (process.env.LOCALE) {
+          case 'ja-JP':
+            log.debug('testing Japanese now ------------');
+            expectedHeaders = ['名前', '型', 'フォーマット', '検索可能', '集約可能', '除外'];
+            break;
+          case 'zh-CN':
+            log.debug('testing Chinese now ------------');
+            expectedHeaders = ['名称', '类型', '格式', '可搜索', '可聚合', '已排除'];
+            break;
+          default:
+            log.debug('testing default English now ------------');
+            expectedHeaders = ['Name', 'Type', 'Format', 'Searchable', 'Aggregatable', 'Excluded'];
+        }
         expect(headers.length).to.be(expectedHeaders.length);
 
         await Promise.all(

--- a/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.js
+++ b/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.js
@@ -25,7 +25,7 @@ export default function ({ getService, getPageObjects }) {
       }
 
       await PageObjects.discover.selectIndexPattern('metricbeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Today');
+      // await PageObjects.timePicker.setCommonlyUsedTime('Today');
       await retry.try(async function () {
         const hitCount = parseInt(await PageObjects.discover.getHitCount());
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.js
+++ b/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.js
@@ -29,7 +29,7 @@ export default function ({ getService, getPageObjects }) {
         await appsMenu.clickLink('Discover');
       }
       await PageObjects.discover.selectIndexPattern('packetbeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Today');
+      // await PageObjects.timePicker.setCommonlyUsedTime('Today');
       await retry.try(async function () {
         const hitCount = parseInt(await PageObjects.discover.getHitCount());
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/winlogbeat/_winlogbeat.js
+++ b/x-pack/test/stack_functional_integration/apps/winlogbeat/_winlogbeat.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
         await appsMenu.clickLink('Discover');
       }
       await PageObjects.discover.selectIndexPattern('winlogbeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Today');
+      // await PageObjects.timePicker.setCommonlyUsedTime('Today');
       await retry.try(async function () {
         const hitCount = parseInt(await PageObjects.discover.getHitCount());
         expect(hitCount).to.be.greaterThan(0);


### PR DESCRIPTION
## Summary

Adds a switch statement based on locale for an index management test so that it can verify the headers in Japanese or Chinese local.  The configuration for locale is part of the provisioning in the integration-test repo.

Only the test that creates index patterns has i18n checks.  But I also changes several beats tests to not try to change the timepicker because we'd have to select them in the appropriate language, and we typically don't have to because data would show up in the default "Last 15 min".

### Checklist

Delete any items that are not applicable to this PR.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
