### PR TITLE
[Security Solution][Tech Debt] - Fix flakey notes tab cypress test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/timelines/notes_tab.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/notes_tab.spec.ts
@@ -41,8 +41,8 @@ describe('Timeline notes tab', () => {
           .click({ force: true })
           .then(() => {
             waitForEventsPanelToBeLoaded();
-            goToNotesTab();
             addNotesToTimeline(timeline.notes);
+            goToNotesTab();
           });
       });
   });

--- a/x-pack/plugins/security_solution/cypress/screens/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/timeline.ts
@@ -63,7 +63,7 @@ export const NOTE_CONTENT = (noteId: string) => `${NOTE_BY_NOTE_ID(noteId)} p`;
 
 export const NOTES_TEXT_AREA = '[data-test-subj="add-a-note"] textarea';
 
-export const NOTES_TAB_BUTTON = '[data-test-subj="timelineTabs-notes"]';
+export const NOTES_TAB_BUTTON = 'button[data-test-subj="timelineTabs-notes"]';
 
 export const NOTES_TEXT = '.euiMarkdownFormat';
 

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -207,7 +207,7 @@ export const openTimelineTemplateFromSettings = (id: string) => {
 };
 
 export const openTimelineById = (timelineId: string) => {
-  return cy.get(TIMELINE_TITLE_BY_ID(timelineId)).click({ force: true });
+  return cy.get(TIMELINE_TITLE_BY_ID(timelineId)).pipe(($el) => $el.trigger('click'));
 };
 
 export const pinFirstEvent = () => {

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -90,7 +90,9 @@ export const addNameAndDescriptionToTimeline = (timeline: Timeline) => {
 };
 
 export const goToNotesTab = () => {
-  return cy.get(NOTES_TAB_BUTTON).click({ force: true });
+  cy.get(NOTES_TAB_BUTTON)
+    .pipe(($el) => $el.trigger('click'))
+    .should('be.visible');
 };
 
 export const getNotePreviewByNoteId = (noteId: string) => {


### PR DESCRIPTION
## Summary

Update some of the cypress helpers to make notes tab test less flakey. Was failing pretty frequently.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
