### PR TITLE
[Lens] Do not debounce chart

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -43,7 +43,6 @@ import {
 import { DragDrop, DragContext, DragDropIdentifier } from '../../../drag_drop';
 import { Suggestion, switchToSuggestion } from '../suggestion_helpers';
 import { buildExpression } from '../expression_helpers';
-import { debouncedComponent } from '../../../debounced_component';
 import { trackUiEvent } from '../../../lens_ui_telemetry';
 import {
   UiActionsStart,
@@ -368,7 +367,7 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   );
 });
 
-export const InnerVisualizationWrapper = ({
+export const VisualizationWrapper = ({
   expression,
   framePublicAPI,
   timefilter,
@@ -619,5 +618,3 @@ export const InnerVisualizationWrapper = ({
     </div>
   );
 };
-
-export const VisualizationWrapper = debouncedComponent(InnerVisualizationWrapper);


### PR DESCRIPTION
We got client side caching in Lens now, but the chart itself is still debounced by a quarter of a second. We introduced that a long time ago because the user typing would directly update the state, but as we are debouncing the inputs directly now, I don't see a reason to keep this debouncing behavior (as it slows down quart rendering quite a bit).

To be sure we are not introducing something super expensive here, I would suggest only merging this into 7.14, not 7.13