### PR TITLE
[7.x] [kbn/es] disable geoip downloader at the root (#98372)

### DIFF
--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -246,7 +246,11 @@ exports.Cluster = class Cluster {
     this._log.info(chalk.bold('Starting'));
     this._log.indent(4);
 
-    const esArgs = ['action.destructive_requires_name=true'].concat(options.esArgs || []);
+    const esArgs = [
+      'action.destructive_requires_name=true',
+      'ingest.geoip.downloader.enabled=false',
+    ].concat(options.esArgs || []);
+
     // Add to esArgs if ssl is enabled
     if (this._ssl) {
       esArgs.push('xpack.security.http.ssl.enabled=true');
@@ -271,7 +275,7 @@ exports.Cluster = class Cluster {
     // especially because we currently run many instances of ES on the same machine during CI
     options.esEnvVars.ES_JAVA_OPTS =
       (options.esEnvVars.ES_JAVA_OPTS ? `${options.esEnvVars.ES_JAVA_OPTS} ` : '') +
-      '-Xms2g -Xmx2g';
+      '-Xms1g -Xmx1g';
 
     this._process = execa(ES_BIN, args, {
       cwd: installPath,

--- a/packages/kbn-es/src/integration_tests/cluster.test.js
+++ b/packages/kbn-es/src/integration_tests/cluster.test.js
@@ -266,6 +266,7 @@ describe('#start(installPath)', () => {
         Array [
           Array [
             "action.destructive_requires_name=true",
+            "ingest.geoip.downloader.enabled=false",
           ],
           undefined,
           Object {
@@ -344,6 +345,7 @@ describe('#run()', () => {
         Array [
           Array [
             "action.destructive_requires_name=true",
+            "ingest.geoip.downloader.enabled=false",
           ],
           undefined,
           Object {

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -21,7 +21,7 @@ export default function () {
     servers,
 
     esTestCluster: {
-      serverArgs: ['xpack.security.enabled=false', 'geoip.downloader.enabled=false'],
+      serverArgs: ['xpack.security.enabled=false'],
     },
 
     kbnTestServer: {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [kbn/es] disable geoip downloader at the root (#98372)