### PR TITLE
[Metrics UI] Fixing race condition in Metric Threshold alerts

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
@@ -43,7 +43,7 @@ export function useMetricsExplorerData(
 
   const from = DateMath.parse(timerange.from);
   const to = DateMath.parse(timerange.to, { roundUp: true });
-  const [request, makeRequest] = useTrackedPromise(
+  const [, makeRequest] = useTrackedPromise(
     {
       cancelPreviousOn: 'creation',
       createPromise: () => {

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
@@ -7,7 +7,7 @@
 
 import DateMath from '@elastic/datemath';
 import { isEqual } from 'lodash';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { IIndexPattern } from 'src/plugins/data/public';
 import { MetricsSourceConfigurationProperties } from '../../../../../common/metrics_sources';
 import {
@@ -18,6 +18,7 @@ import { convertKueryToElasticSearchQuery } from '../../../../utils/kuery';
 import { MetricsExplorerOptions, MetricsExplorerTimeOptions } from './use_metrics_explorer_options';
 import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
 import { decodeOrThrow } from '../../../../../common/runtime_types';
+import { useTrackedPromise } from '../../../../utils/use_tracked_promise';
 
 function isSameOptions(current: MetricsExplorerOptions, next: MetricsExplorerOptions) {
   return isEqual(current, next);
@@ -40,52 +41,58 @@ export function useMetricsExplorerData(
   const [lastOptions, setLastOptions] = useState<MetricsExplorerOptions | null>(null);
   const [lastTimerange, setLastTimerange] = useState<MetricsExplorerTimeOptions | null>(null);
 
-  const loadData = useCallback(() => {
-    (async () => {
-      setLoading(true);
-      try {
-        const from = DateMath.parse(timerange.from);
-        const to = DateMath.parse(timerange.to, { roundUp: true });
+  const from = DateMath.parse(timerange.from);
+  const to = DateMath.parse(timerange.to, { roundUp: true });
+  const [request, makeRequest] = useTrackedPromise(
+    {
+      cancelPreviousOn: 'creation',
+      createPromise: () => {
+        setLoading(true);
         if (!from || !to) {
-          throw new Error('Unalble to parse timerange');
+          return Promise.reject(new Error('Unalble to parse timerange'));
         }
         if (!fetchFn) {
-          throw new Error('HTTP service is unavailable');
+          return Promise.reject(new Error('HTTP service is unavailable'));
         }
         if (!source) {
-          throw new Error('Source is unavailable');
+          return Promise.reject(new Error('Source is unavailable'));
         }
-        const response = decodeOrThrow(metricsExplorerResponseRT)(
-          await fetchFn('/api/infra/metrics_explorer', {
-            method: 'POST',
-            body: JSON.stringify({
-              forceInterval: options.forceInterval,
-              dropLastBucket: options.dropLastBucket != null ? options.dropLastBucket : true,
-              metrics:
-                options.aggregation === 'count'
-                  ? [{ aggregation: 'count' }]
-                  : options.metrics.map((metric) => ({
-                      aggregation: metric.aggregation,
-                      field: metric.field,
-                    })),
-              groupBy: options.groupBy,
-              afterKey,
-              limit: options.limit,
-              indexPattern: source.metricAlias,
-              filterQuery:
-                (options.filterQuery &&
-                  convertKueryToElasticSearchQuery(options.filterQuery, derivedIndexPattern)) ||
-                void 0,
-              timerange: {
-                ...timerange,
-                field: source.fields.timestamp,
-                from: from.valueOf(),
-                to: to.valueOf(),
-              },
-            }),
-          })
-        );
+        if (!fetchFn) {
+          return Promise.reject(new Error('HTTP service is unavailable'));
+        }
 
+        return fetchFn('/api/infra/metrics_explorer', {
+          method: 'POST',
+          body: JSON.stringify({
+            forceInterval: options.forceInterval,
+            dropLastBucket: options.dropLastBucket != null ? options.dropLastBucket : true,
+            metrics:
+              options.aggregation === 'count'
+                ? [{ aggregation: 'count' }]
+                : options.metrics.map((metric) => ({
+                    aggregation: metric.aggregation,
+                    field: metric.field,
+                  })),
+            groupBy: options.groupBy,
+            afterKey,
+            limit: options.limit,
+            indexPattern: source.metricAlias,
+            filterQuery:
+              (options.filterQuery &&
+                convertKueryToElasticSearchQuery(options.filterQuery, derivedIndexPattern)) ||
+              void 0,
+            timerange: {
+              ...timerange,
+              field: source.fields.timestamp,
+              from: from.valueOf(),
+              to: to.valueOf(),
+            },
+          }),
+        });
+      },
+      onResolve: (resp: unknown) => {
+        setLoading(false);
+        const response = decodeOrThrow(metricsExplorerResponseRT)(resp);
         if (response) {
           if (
             data &&
@@ -107,20 +114,20 @@ export function useMetricsExplorerData(
           setLastTimerange(timerange);
           setError(null);
         }
-      } catch (e) {
-        setError(e);
-      }
-      setLoading(false);
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options, source, timerange, signal, afterKey]);
+      },
+      onReject: (e: unknown) => {
+        setError(e as Error);
+        setLoading(false);
+      },
+    },
+    [source, timerange, options, signal, afterKey]
+  );
 
   useEffect(() => {
     if (!shouldLoadImmediately) {
       return;
     }
-
-    loadData();
-  }, [loadData, shouldLoadImmediately]);
-  return { error, loading, data, loadData };
+    makeRequest();
+  }, [makeRequest, shouldLoadImmediately]);
+  return { error, loading, data, loadData: makeRequest };
 }


### PR DESCRIPTION
## Summary

This PR fixes #97150 by refactoring `useMetricsExplorerData` to use `useTrackedPromises` and then rely on the `cancelPreviousOn` set to `creation` to cancel the previous request. Since the basic behavior should remain the same the original `use_metrics_explorer_data.test.tsx` tests should pass.

#### Setup for Testing

In order to test this, you need to put the Metrics Explorer code into a state where the some requests are delayed. To do this add the following code to `x-pack/plugins/infra/server/routes/metrics_explorer/index.ts` starting on line 57:
```typescript
const sleep = (milliseconds: number) => {
  return new Promise((resolve) => setTimeout(resolve, milliseconds));
};

const hasHostName = /host\.name/.test(optionsWithInterval.filterQuery || '');
const hasEventDataset = /event\.dataset/.test(optionsWithInterval.filterQuery || '');
console.log('hasHostName', hasHostName, 'hasEventDataset', hasEventDataset);

if (hasHostName && !hasEventDataset) {
  await sleep(3000);
}

```
#### Steps for Testing

1. Open a browser with the network traffic tab open in the dev console
1. Create some hosts using the[ latest version of Slingshot](https://github.com/jasonrhodes/slingshot) via:
    `./bin/slingshot.ts load --config ./configs/hosts.json --purge --start now-5d/d --end now+1d/d`
1. Create a  Metric Threshold alert for `Average of system.cpu.total.pct` and filter by `host.name: "host-0" and event.dataset: "system.memory"`
1. Select ` and event.dataset: "system.memory"`, cut it then paste it immediately. 

Before the fix, it should make a request for only `host.name: "host-0"`, which should take ~3 seconds and then a request with `host.name: "host-0" and event.dataset: "system.memory"` should happen but return almost immediately. The screen will update with a blank chart (from the second request) and then update to a chart with data (from the first request). 

After the fix the chart should display the results from the second request, even when the first request completes afterwards.