### PR TITLE
[Discover] Do not set fieldsFromSource when not using fields API

### DIFF
--- a/src/plugins/data/common/search/search_source/search_source.test.ts
+++ b/src/plugins/data/common/search/search_source/search_source.test.ts
@@ -352,6 +352,13 @@ describe('SearchSource', () => {
         const request = searchSource.getSearchRequestBody();
         expect(request.stored_fields).toEqual(['*']);
       });
+
+      test('fieldsFromSource is not set when using the fields API', async () => {
+        searchSource.setField('fields', ['*']);
+        const request = searchSource.getSearchRequestBody();
+        expect(request.fields).toEqual(['*']);
+        expect(request._source).toEqual(false);
+      });
     });
 
     describe('source filters handling', () => {

--- a/src/plugins/data/common/search/search_source/search_source.test.ts
+++ b/src/plugins/data/common/search/search_source/search_source.test.ts
@@ -353,7 +353,7 @@ describe('SearchSource', () => {
         expect(request.stored_fields).toEqual(['*']);
       });
 
-      test('fieldsFromSource is not set when using the fields API', async () => {
+      test('_source is not set when using the fields API', async () => {
         searchSource.setField('fields', ['*']);
         const request = searchSource.getSearchRequestBody();
         expect(request.fields).toEqual(['*']);

--- a/src/plugins/discover/public/application/helpers/update_search_source.test.ts
+++ b/src/plugins/discover/public/application/helpers/update_search_source.test.ts
@@ -136,4 +136,34 @@ describe('updateSearchSource', () => {
     ]);
     expect(volatileSearchSourceMock.getField('fieldsFromSource')).toBe(undefined);
   });
+
+  test('does not explicitly request fieldsFromSource when not using fields API', async () => {
+    const persistentSearchSourceMock = createSearchSourceMock({});
+    const volatileSearchSourceMock = createSearchSourceMock({});
+    const sampleSize = 250;
+    updateSearchSource({
+      persistentSearchSource: persistentSearchSourceMock,
+      volatileSearchSource: volatileSearchSourceMock,
+      indexPattern: indexPatternMock,
+      services: ({
+        data: dataPluginMock.createStartContract(),
+        uiSettings: ({
+          get: (key: string) => {
+            if (key === SAMPLE_SIZE_SETTING) {
+              return sampleSize;
+            }
+            return false;
+          },
+        } as unknown) as IUiSettingsClient,
+      } as unknown) as DiscoverServices,
+      sort: [] as SortOrder[],
+      columns: [],
+      useNewFieldsApi: false,
+      showUnmappedFields: false,
+    });
+    expect(persistentSearchSourceMock.getField('index')).toEqual(indexPatternMock);
+    expect(volatileSearchSourceMock.getField('size')).toEqual(sampleSize);
+    expect(volatileSearchSourceMock.getField('fields')).toEqual(undefined);
+    expect(volatileSearchSourceMock.getField('fieldsFromSource')).toBe(undefined);
+  });
 });

--- a/src/plugins/discover/public/application/helpers/update_search_source.ts
+++ b/src/plugins/discover/public/application/helpers/update_search_source.ts
@@ -65,8 +65,6 @@ export function updateSearchSource({
       volatileSearchSource.setField('fields', [fields]);
     } else {
       volatileSearchSource.removeField('fields');
-      const fieldNames = indexPattern.fields.map((field) => field.name);
-      volatileSearchSource.setField('fieldsFromSource', fieldNames);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/97724

See [comment](https://github.com/elastic/kibana/issues/97724#issuecomment-827931275) in the issue above for detailed explanation.

With this change, `source` part of the request looks like:
```
"_source": {
    "excludes": []
  },
```
instead of the ginormous
```
"_source": {
    "includes": [~4000 fields]
  },
```  

### Testing
Steps to reproduce:
You'll need an index pattern with ~4000 fields. Metricbeat serves nicely for this purpose.
1. Setup a new 7.12.0 stack consisting of Kibana, Elasticsearch, and Metricbeat
2. Run through Metricbeat's setup process + start it with
3. Create `metricbeat-*` index pattern
4. Add a scripted field to the `metricbeat-*` index pattern (e.g doc['@timestamp'].value.hourOfDay)
5. Edit Kibana advanced settings and enable `discover:searchFieldsFromSource`
6. Visit the `metricbeat-*`  index pattern in Discover.

Before this change:
1. Discover breaks

After this change:
1. Discover works :) 

### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
