### PR TITLE
[APM] Service overview page fetches data with wrong transaction type

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/transaction_type_select.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_type_select.tsx
@@ -10,7 +10,6 @@ import React, { FormEvent, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { useApmServiceContext } from '../../context/apm_service/use_apm_service_context';
-import { useUrlParams } from '../../context/url_params_context/use_url_params';
 import * as urlHelpers from './Links/url_helpers';
 
 // The default transaction type (for non-RUM services) is "request". Set the
@@ -21,11 +20,8 @@ const EuiSelectWithWidth = styled(EuiSelect)`
 `;
 
 export function TransactionTypeSelect() {
-  const { transactionTypes } = useApmServiceContext();
+  const { transactionTypes, transactionType } = useApmServiceContext();
   const history = useHistory();
-  const {
-    urlParams: { transactionType },
-  } = useUrlParams();
 
   const handleChange = useCallback(
     (event: FormEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
closes #97997

<img width="2880" alt="Screen Shot 2021-04-28 at 13 03 08" src="https://user-images.githubusercontent.com/55978943/116444469-c016b480-a822-11eb-95d1-6140c81fc011.png">
<img width="2880" alt="Screen Shot 2021-04-28 at 13 03 53" src="https://user-images.githubusercontent.com/55978943/116444473-c147e180-a822-11eb-8cf7-e124f7f105fe.png">
