### PR TITLE
[7.x] [Security Solution][Timeline] Fixes an issue where many `OR` clauses take up too much vertical space (#98706)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/hooks/use_add_to_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_add_to_timeline.tsx
@@ -65,6 +65,7 @@ export const getDropTargetCoordinate = (): Position | null => {
   const emptyGroup = document.querySelector(`.${EMPTY_PROVIDERS_GROUP_CLASS_NAME}`);
 
   if (emptyGroup != null) {
+    emptyGroup.scrollIntoView();
     return getPosition(emptyGroup);
   }
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.test.tsx
@@ -71,5 +71,59 @@ describe('DataProviders', () => {
         'Drop anythinghighlightedhere to build anORquery+ Add field'
       );
     });
+
+    describe('resizable drop target', () => {
+      const manageTimelineForTesting = {
+        foo: {
+          ...getTimelineDefaults('test'),
+          filterManager,
+        },
+      };
+
+      test('it may be resized vertically via a resize handle', () => {
+        const wrapper = mount(
+          <TestProviders>
+            <ManageGlobalTimeline manageTimelineForTesting={manageTimelineForTesting}>
+              <DataProviders timelineId="test" />
+            </ManageGlobalTimeline>
+          </TestProviders>
+        );
+
+        expect(wrapper.find('[data-test-subj="dataProviders"]').first()).toHaveStyleRule(
+          'resize',
+          'vertical'
+        );
+      });
+
+      test('it never grows taller than one third (33%) of the view height', () => {
+        const wrapper = mount(
+          <TestProviders>
+            <ManageGlobalTimeline manageTimelineForTesting={manageTimelineForTesting}>
+              <DataProviders timelineId="test" />
+            </ManageGlobalTimeline>
+          </TestProviders>
+        );
+
+        expect(wrapper.find('[data-test-subj="dataProviders"]').first()).toHaveStyleRule(
+          'max-height',
+          '33vh'
+        );
+      });
+
+      test('it automatically displays scroll bars when the width or height of the data providers exceeds the drop target', () => {
+        const wrapper = mount(
+          <TestProviders>
+            <ManageGlobalTimeline manageTimelineForTesting={manageTimelineForTesting}>
+              <DataProviders timelineId="test" />
+            </ManageGlobalTimeline>
+          </TestProviders>
+        );
+
+        expect(wrapper.find('[data-test-subj="dataProviders"]').first()).toHaveStyleRule(
+          'overflow',
+          'auto'
+        );
+      });
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/index.tsx
@@ -51,15 +51,17 @@ const DropTargetDataProvidersContainer = styled.div`
 const DropTargetDataProviders = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   padding-bottom: 2px;
   position: relative;
   border: 0.2rem dashed ${({ theme }) => theme.eui.euiColorMediumShade};
   border-radius: 5px;
   padding: ${({ theme }) => theme.eui.euiSizeXS} 0;
   margin: 2px 0 2px 0;
+  max-height: 33vh;
   min-height: 100px;
-  overflow-y: auto;
+  overflow: auto;
+  resize: vertical;
   background-color: ${({ theme }) => theme.eui.euiFormBackgroundColor};
 `;
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution][Timeline] Fixes an issue where many `OR` clauses take up too much vertical space (#98706)