### PR TITLE
document additional Logstash pipeline settings

### DIFF
--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -27,7 +27,13 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
   (Required, string) The pipeline definition.
 
 `settings`::
-  (Optional, object) The pipeline settings. Supported settings, represented as object keys, are `pipeline.workers`, `pipeline.batch.size`, `pipeline.batch.delay`, `queue.type`, `queue.max_bytes`, and `queue.checkpoint.writes`.
+(Optional, object) The pipeline settings. Supported settings, represented as object keys, are
+  `pipeline.workers`,
+  `pipeline.batch.size`,
+  `pipeline.batch.delay`,
+  `queue.type`,
+  `queue.max_bytes`, and
+  `queue.checkpoint.writes`.
 
 [[logstash-configuration-management-api-create-codes]]
 ==== Response code

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -31,6 +31,8 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
   `pipeline.workers`,
   `pipeline.batch.size`,
   `pipeline.batch.delay`,
+  `pipeline.ecs_compatibility`,
+  `pipeline.ordered`,
   `queue.type`,
   `queue.max_bytes`, and
   `queue.checkpoint.writes`.

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -27,7 +27,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
   (Required, string) The pipeline definition.
 
 `settings`::
-(Optional, object) The pipeline settings. Supported settings, represented as object keys, are
+(Optional, object) The pipeline settings, represented as object keys, include the following:
   `pipeline.workers`,
   `pipeline.batch.size`,
   `pipeline.batch.delay`,

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -30,7 +30,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 (Optional, object) The pipeline settings, represented as object keys, include the following:
  * `pipeline.workers`
   `pipeline.batch.size`,
-  `pipeline.batch.delay`,
+*  `pipeline.batch.delay`
   `pipeline.ecs_compatibility`,
   `pipeline.ordered`,
   `queue.type`,

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -34,7 +34,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 *  `pipeline.ecs_compatibility`
 *  `pipeline.ordered`
 *  `queue.type`
-  `queue.max_bytes`, and
+*  `queue.max_bytes`
   `queue.checkpoint.writes`.
 
 [[logstash-configuration-management-api-create-codes]]

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -35,7 +35,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 *  `pipeline.ordered`
 *  `queue.type`
 *  `queue.max_bytes`
-  `queue.checkpoint.writes`.
+*  `queue.checkpoint.writes`
 
 [[logstash-configuration-management-api-create-codes]]
 ==== Response code

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -31,7 +31,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
  * `pipeline.workers`
 *  `pipeline.batch.size`
 *  `pipeline.batch.delay`
-  `pipeline.ecs_compatibility`,
+*  `pipeline.ecs_compatibility`
   `pipeline.ordered`,
   `queue.type`,
   `queue.max_bytes`, and

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -32,7 +32,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 *  `pipeline.batch.size`
 *  `pipeline.batch.delay`
 *  `pipeline.ecs_compatibility`
-  `pipeline.ordered`,
+*  `pipeline.ordered`
   `queue.type`,
   `queue.max_bytes`, and
   `queue.checkpoint.writes`.

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -29,7 +29,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 `settings`::
 (Optional, object) The pipeline settings, represented as object keys, include the following:
  * `pipeline.workers`
-  `pipeline.batch.size`,
+*  `pipeline.batch.size`
 *  `pipeline.batch.delay`
   `pipeline.ecs_compatibility`,
   `pipeline.ordered`,

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -33,7 +33,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 *  `pipeline.batch.delay`
 *  `pipeline.ecs_compatibility`
 *  `pipeline.ordered`
-  `queue.type`,
+*  `queue.type`
   `queue.max_bytes`, and
   `queue.checkpoint.writes`.
 

--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -28,7 +28,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 
 `settings`::
 (Optional, object) The pipeline settings, represented as object keys, include the following:
-  `pipeline.workers`,
+ * `pipeline.workers`
   `pipeline.batch.size`,
   `pipeline.batch.delay`,
   `pipeline.ecs_compatibility`,


### PR DESCRIPTION
## Summary

Reflect recently-added support for additional Logstash pipeline settings `pipeline.ecs_compatibility` and `pipeline.ordered` (depends on https://github.com/elastic/logstash/pull/12861).

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
