### PR TITLE
[7.x] [RAC][Alert Triage][TGrid] Update the alerts table/tgrid API to support customized leadingControlColumns and trailingControlColumns (#98845)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -44,6 +44,10 @@ import { RowRenderer } from '../../../timelines/components/timeline/body/rendere
 import { GraphOverlay } from '../../../timelines/components/graph_overlay';
 import { CellValueElementProps } from '../../../timelines/components/timeline/cell_rendering';
 import { SELECTOR_TIMELINE_GLOBAL_CONTAINER } from '../../../timelines/components/timeline/styles';
+import {
+  defaultControlColumn,
+  ControlColumnProps,
+} from '../../../timelines/components/timeline/body/control_columns';
 
 export const EVENTS_VIEWER_HEADER_HEIGHT = 90; // px
 const UTILITY_BAR_HEIGHT = 19; // px
@@ -273,6 +277,9 @@ const EventsViewerComponent: React.FC<Props> = ({
     setIsQueryLoading(loading);
   }, [loading]);
 
+  const leadingControlColumns: ControlColumnProps[] = [defaultControlColumn];
+  const trailingControlColumns: ControlColumnProps[] = [];
+
   return (
     <StyledEuiPanel
       data-test-subj="events-viewer-panel"
@@ -323,6 +330,8 @@ const EventsViewerComponent: React.FC<Props> = ({
                       itemsCount: totalCountMinusDeleted,
                       itemsPerPage,
                     })}
+                    leadingControlColumns={leadingControlColumns}
+                    trailingControlColumns={trailingControlColumns}
                   />
                   <Footer
                     activePage={pageInfo.activePage}

--- a/x-pack/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/mock_timeline_control_columns.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiCheckbox,
+  EuiButtonIcon,
+  EuiPopover,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopoverTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import { ControlColumnProps } from '../../timelines/components/timeline/body/control_columns';
+
+const SelectionHeaderCell = () => {
+  return (
+    <div data-test-subj="test-header-control-column-cell">
+      <EuiCheckbox id="selection-toggle" aria-label="Select all rows" onChange={() => null} />
+    </div>
+  );
+};
+
+const SimpleHeaderCell = () => {
+  return (
+    <div
+      style={{
+        fontSize: '12px',
+        fontWeight: 600,
+        lineHeight: 1.5,
+        minWidth: 0,
+        padding: '4px',
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+      }}
+      data-test-subj="test-header-action-cell"
+    >
+      {'Additional Actions'}
+    </div>
+  );
+};
+
+const SelectionRowCell = ({ rowIndex }: { rowIndex: number }) => {
+  return (
+    <div data-test-subj="test-body-control-column-cell">
+      <EuiCheckbox
+        id={`${rowIndex}`}
+        aria-label={`Select row test`}
+        checked={false}
+        onChange={() => null}
+      />
+    </div>
+  );
+};
+
+const TestTrailingColumn = () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  return (
+    <EuiPopover
+      isOpen={isPopoverOpen}
+      anchorPosition="upCenter"
+      panelPaddingSize="s"
+      button={
+        <EuiButtonIcon
+          aria-label="show actions"
+          iconType="boxesHorizontal"
+          color="text"
+          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+        />
+      }
+      data-test-subj="test-trailing-column-popover-button"
+      closePopover={() => setIsPopoverOpen(false)}
+    >
+      <EuiPopoverTitle>{'Actions'}</EuiPopoverTitle>
+      <div style={{ width: 150 }}>
+        <button type="button" onClick={() => {}}>
+          <EuiFlexGroup alignItems="center" component="span" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon aria-label="Pin selected items" iconType="pin" color="text" />
+            </EuiFlexItem>
+            <EuiFlexItem>{'Pin'}</EuiFlexItem>
+          </EuiFlexGroup>
+        </button>
+        <EuiSpacer size="s" />
+        <button type="button" onClick={() => {}}>
+          <EuiFlexGroup alignItems="center" component="span" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon aria-label="Delete selected items" iconType="trash" color="text" />
+            </EuiFlexItem>
+            <EuiFlexItem>{'Delete'}</EuiFlexItem>
+          </EuiFlexGroup>
+        </button>
+      </div>
+    </EuiPopover>
+  );
+};
+
+export const testTrailingControlColumns = [
+  {
+    id: 'actions',
+    width: 96,
+    headerCellRender: SimpleHeaderCell,
+    rowCellRender: TestTrailingColumn,
+  },
+];
+
+export const testLeadingControlColumn: ControlColumnProps = {
+  id: 'test-leading-control',
+  headerCellRender: SelectionHeaderCell,
+  rowCellRender: SelectionRowCell,
+  width: 100,
+};

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/header_actions.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/header_actions.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useCallback } from 'react';
+import {
+  EuiButtonIcon,
+  EuiCheckbox,
+  EuiDataGridSorting,
+  EuiToolTip,
+  useDataGridColumnSorting,
+} from '@elastic/eui';
+import { useDispatch } from 'react-redux';
+
+import styled from 'styled-components';
+import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
+import { EXIT_FULL_SCREEN } from '../../../../../common/components/exit_full_screen/translations';
+import { FULL_SCREEN_TOGGLED_CLASS_NAME } from '../../../../../../common/constants';
+import {
+  useGlobalFullScreen,
+  useTimelineFullScreen,
+} from '../../../../../common/containers/use_full_screen';
+import { BrowserFields } from '../../../../../common/containers/source';
+import { ColumnHeaderOptions } from '../../../../../timelines/store/timeline/model';
+import { OnSelectAll } from '../../events';
+import { DEFAULT_ICON_BUTTON_WIDTH } from '../../helpers';
+import { StatefulFieldsBrowser } from '../../../fields_browser';
+import { StatefulRowRenderersBrowser } from '../../../row_renderers_browser';
+import { FIELD_BROWSER_HEIGHT, FIELD_BROWSER_WIDTH } from '../../../fields_browser/helpers';
+import { EventsTh, EventsThContent } from '../../styles';
+import { Sort, SortDirection } from '../sort';
+import { EventsSelect } from '../column_headers/events_select';
+import * as i18n from '../column_headers/translations';
+import { timelineActions } from '../../../../store/timeline';
+import { isFullScreen } from '../column_headers';
+
+export interface HeaderActionProps {
+  width: number;
+  browserFields: BrowserFields;
+  columnHeaders: ColumnHeaderOptions[];
+  isEventViewer?: boolean;
+  isSelectAllChecked: boolean;
+  onSelectAll: OnSelectAll;
+  showEventsSelect: boolean;
+  showSelectAllCheckbox: boolean;
+  sort: Sort[];
+  tabType: TimelineTabs;
+  timelineId: string;
+}
+
+const SortingColumnsContainer = styled.div`
+  button {
+    color: ${({ theme }) => theme.eui.euiColorPrimary};
+  }
+
+  .euiPopover .euiButtonEmpty .euiButtonContent {
+    padding: 0;
+
+    .euiButtonEmpty__text {
+      display: none;
+    }
+  }
+`;
+
+const HeaderActionsComponent: React.FC<HeaderActionProps> = ({
+  width,
+  browserFields,
+  columnHeaders,
+  isEventViewer = false,
+  isSelectAllChecked,
+  onSelectAll,
+  showEventsSelect,
+  showSelectAllCheckbox,
+  sort,
+  tabType,
+  timelineId,
+}) => {
+  const { globalFullScreen, setGlobalFullScreen } = useGlobalFullScreen();
+  const { timelineFullScreen, setTimelineFullScreen } = useTimelineFullScreen();
+  const dispatch = useDispatch();
+  const toggleFullScreen = useCallback(() => {
+    if (timelineId === TimelineId.active) {
+      setTimelineFullScreen(!timelineFullScreen);
+    } else {
+      setGlobalFullScreen(!globalFullScreen);
+    }
+  }, [
+    timelineId,
+    setTimelineFullScreen,
+    timelineFullScreen,
+    setGlobalFullScreen,
+    globalFullScreen,
+  ]);
+
+  const fullScreen = useMemo(
+    () => isFullScreen({ globalFullScreen, timelineId, timelineFullScreen }),
+    [globalFullScreen, timelineId, timelineFullScreen]
+  );
+  const handleSelectAllChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onSelectAll({ isSelected: event.currentTarget.checked });
+    },
+    [onSelectAll]
+  );
+
+  const onSortColumns = useCallback(
+    (cols: EuiDataGridSorting['columns']) =>
+      dispatch(
+        timelineActions.updateSort({
+          id: timelineId,
+          sort: cols.map(({ id, direction }) => ({
+            columnId: id,
+            columnType: columnHeaders.find((ch) => ch.id === id)?.type ?? 'text',
+            sortDirection: direction as SortDirection,
+          })),
+        })
+      ),
+    [columnHeaders, dispatch, timelineId]
+  );
+
+  const sortedColumns = useMemo(
+    () => ({
+      onSort: onSortColumns,
+      columns: sort.map<{ id: string; direction: 'asc' | 'desc' }>(
+        ({ columnId, sortDirection }) => ({
+          id: columnId,
+          direction: sortDirection as 'asc' | 'desc',
+        })
+      ),
+    }),
+    [onSortColumns, sort]
+  );
+  const displayValues = useMemo(
+    () => columnHeaders.reduce((acc, ch) => ({ ...acc, [ch.id]: ch.displayAsText ?? ch.id }), {}),
+    [columnHeaders]
+  );
+
+  const myColumns = useMemo(
+    () =>
+      columnHeaders.map(({ aggregatable, displayAsText, id, type }) => ({
+        id,
+        isSortable: aggregatable,
+        displayAsText,
+        schema: type,
+      })),
+    [columnHeaders]
+  );
+
+  const ColumnSorting = useDataGridColumnSorting(myColumns, sortedColumns, {}, [], displayValues);
+
+  return (
+    <>
+      {showSelectAllCheckbox && (
+        <EventsTh role="checkbox">
+          <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
+            <EuiCheckbox
+              data-test-subj="select-all-events"
+              id={'select-all-events'}
+              checked={isSelectAllChecked}
+              onChange={handleSelectAllChange}
+            />
+          </EventsThContent>
+        </EventsTh>
+      )}
+
+      <EventsTh role="button">
+        <StatefulFieldsBrowser
+          browserFields={browserFields}
+          columnHeaders={columnHeaders}
+          data-test-subj="field-browser"
+          height={FIELD_BROWSER_HEIGHT}
+          timelineId={timelineId}
+          width={FIELD_BROWSER_WIDTH}
+        />
+      </EventsTh>
+
+      <EventsTh role="button">
+        <StatefulRowRenderersBrowser
+          data-test-subj="row-renderers-browser"
+          timelineId={timelineId}
+        />
+      </EventsTh>
+
+      <EventsTh role="button">
+        <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
+          <EuiToolTip content={fullScreen ? EXIT_FULL_SCREEN : i18n.FULL_SCREEN}>
+            <EuiButtonIcon
+              aria-label={
+                isFullScreen({ globalFullScreen, timelineId, timelineFullScreen })
+                  ? EXIT_FULL_SCREEN
+                  : i18n.FULL_SCREEN
+              }
+              className={fullScreen ? FULL_SCREEN_TOGGLED_CLASS_NAME : ''}
+              color={fullScreen ? 'ghost' : 'primary'}
+              data-test-subj={
+                // a full screen button gets created for timeline and for the host page
+                // this sets the data-test-subj for each case so that tests can differentiate between them
+                timelineId === TimelineId.active ? 'full-screen-active' : 'full-screen'
+              }
+              iconType="fullScreen"
+              onClick={toggleFullScreen}
+            />
+          </EuiToolTip>
+        </EventsThContent>
+      </EventsTh>
+      {tabType !== TimelineTabs.eql && (
+        <EventsTh role="button" data-test-subj="timeline-sorting-fields">
+          <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
+            <EuiToolTip content={i18n.SORT_FIELDS}>
+              <SortingColumnsContainer>{ColumnSorting}</SortingColumnsContainer>
+            </EuiToolTip>
+          </EventsThContent>
+        </EventsTh>
+      )}
+
+      {showEventsSelect && (
+        <EventsTh role="button">
+          <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
+            <EventsSelect checkState="unchecked" timelineId={timelineId} />
+          </EventsThContent>
+        </EventsTh>
+      )}
+    </>
+  );
+};
+
+HeaderActionsComponent.displayName = 'HeaderActionsComponent';
+
+export const HeaderActions = React.memo(HeaderActionsComponent);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.test.tsx
@@ -8,10 +8,13 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import { TestProviders, mockTimelineModel } from '../../../../../common/mock';
-import { DEFAULT_ACTIONS_COLUMN_WIDTH } from '../constants';
+import { TestProviders, mockTimelineModel, mockTimelineData } from '../../../../../common/mock';
 import { Actions } from '.';
 import { useShallowEqualSelector } from '../../../../../common/hooks/use_selector';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+
+jest.mock('../../../../../common/hooks/use_experimental_features');
+const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 jest.mock('../../../../../common/hooks/use_selector', () => ({
   useShallowEqualSelector: jest.fn(),
@@ -20,20 +23,33 @@ jest.mock('../../../../../common/hooks/use_selector', () => ({
 describe('Actions', () => {
   beforeEach(() => {
     (useShallowEqualSelector as jest.Mock).mockReturnValue(mockTimelineModel);
+    useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
   });
 
   test('it renders a checkbox for selecting the event when `showCheckboxes` is `true`', () => {
     const wrapper = mount(
       <TestProviders>
         <Actions
-          actionsColumnWidth={DEFAULT_ACTIONS_COLUMN_WIDTH}
           ariaRowindex={2}
+          columnId={''}
+          index={2}
           checked={false}
           columnValues={'abc def'}
+          data={mockTimelineData[0].data}
+          ecsData={mockTimelineData[0].ecs}
+          eventIdToNoteIds={{}}
           eventId="abc"
           loadingEventIds={[]}
           onEventDetailsPanelOpened={jest.fn()}
+          onPinEvent={jest.fn()}
+          onUnPinEvent={jest.fn()}
           onRowSelected={jest.fn()}
+          showNotes={false}
+          isEventPinned={false}
+          rowIndex={10}
+          toggleShowNotes={jest.fn()}
+          timelineId={'test'}
+          refetch={jest.fn()}
           showCheckboxes={true}
         />
       </TestProviders>
@@ -46,10 +62,22 @@ describe('Actions', () => {
     const wrapper = mount(
       <TestProviders>
         <Actions
-          actionsColumnWidth={DEFAULT_ACTIONS_COLUMN_WIDTH}
           ariaRowindex={2}
           checked={false}
           columnValues={'abc def'}
+          data={mockTimelineData[0].data}
+          ecsData={mockTimelineData[0].ecs}
+          eventIdToNoteIds={{}}
+          showNotes={false}
+          isEventPinned={false}
+          rowIndex={10}
+          toggleShowNotes={jest.fn()}
+          timelineId={'test'}
+          refetch={jest.fn()}
+          onPinEvent={jest.fn()}
+          onUnPinEvent={jest.fn()}
+          columnId={''}
+          index={2}
           eventId="abc"
           loadingEventIds={[]}
           onEventDetailsPanelOpened={jest.fn()}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/actions/index.tsx
@@ -5,18 +5,38 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { EuiButtonIcon, EuiCheckbox, EuiLoadingSpinner, EuiToolTip } from '@elastic/eui';
-
-import { EventsTdContent, EventsTdGroupActions } from '../../styles';
+import {
+  eventHasNotes,
+  getEventType,
+  getPinOnClick,
+  InvestigateInResolverAction,
+} from '../helpers';
+import { AlertContextMenu } from '../../../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
+import { InvestigateInTimelineAction } from '../../../../../detections/components/alerts_table/timeline_actions/investigate_in_timeline_action';
+import { AddEventNoteAction } from '../actions/add_note_icon_item';
+import { PinEventAction } from '../actions/pin_event_action';
+import { EventsTdContent } from '../../styles';
 import * as i18n from '../translations';
-import { OnRowSelected } from '../../events';
 import { DEFAULT_ICON_BUTTON_WIDTH } from '../../helpers';
+import { useShallowEqualSelector } from '../../../../../common/hooks/use_selector';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import { AddToCaseAction } from '../../../../../cases/components/timeline_actions/add_to_case_action';
+import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
+import { timelineSelectors } from '../../../../store/timeline';
+import { timelineDefaults } from '../../../../store/timeline/defaults';
+import { Ecs } from '../../../../../../common/ecs';
+import { inputsModel } from '../../../../../common/store';
+import { TimelineNonEcsData } from '../../../../../../common/search_strategy/timeline';
+import { OnPinEvent, OnRowSelected, OnUnPinEvent } from '../../events';
+import { RowCellRender } from '../control_columns';
 
 interface Props {
   ariaRowindex: number;
-  actionsColumnWidth: number;
-  additionalActions?: JSX.Element[];
+  action?: RowCellRender;
+  width?: number;
+  columnId: string;
   columnValues: string;
   checked: boolean;
   onRowSelected: OnRowSelected;
@@ -24,20 +44,53 @@ interface Props {
   loadingEventIds: Readonly<string[]>;
   onEventDetailsPanelOpened: () => void;
   showCheckboxes: boolean;
+  data: TimelineNonEcsData[];
+  ecsData: Ecs;
+  index: number;
+  eventIdToNoteIds: Readonly<Record<string, string[]>>;
+  isEventPinned: boolean;
+  isEventViewer?: boolean;
+  onPinEvent: OnPinEvent;
+  onUnPinEvent: OnUnPinEvent;
+  refetch: inputsModel.Refetch;
+  rowIndex: number;
+  onRuleChange?: () => void;
+  showNotes: boolean;
+  tabType?: TimelineTabs;
+  timelineId: string;
+  toggleShowNotes: () => void;
 }
 
-const ActionsComponent: React.FC<Props> = ({
+export type ActionProps = Props;
+
+const ActionsComponent: React.FC<ActionProps> = ({
   ariaRowindex,
-  actionsColumnWidth,
-  additionalActions,
+  width,
   checked,
   columnValues,
   eventId,
+  data,
+  ecsData,
+  eventIdToNoteIds,
+  isEventPinned = false,
+  isEventViewer = false,
   loadingEventIds,
   onEventDetailsPanelOpened,
+  onPinEvent,
   onRowSelected,
+  onUnPinEvent,
+  refetch,
+  onRuleChange,
   showCheckboxes,
+  showNotes,
+  timelineId,
+  toggleShowNotes,
 }) => {
+  const emptyNotes: string[] = [];
+  const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
+
+  const isEventFilteringEnabled = useIsExperimentalFeatureEnabled('eventFilteringEnabled');
+
   const handleSelectEvent = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) =>
       onRowSelected({
@@ -46,13 +99,24 @@ const ActionsComponent: React.FC<Props> = ({
       }),
     [eventId, onRowSelected]
   );
+  const handlePinClicked = useCallback(
+    () =>
+      getPinOnClick({
+        allowUnpinning: !eventHasNotes(eventIdToNoteIds[eventId]),
+        eventId,
+        onPinEvent,
+        onUnPinEvent,
+        isEventPinned,
+      }),
+    [eventIdToNoteIds, eventId, isEventPinned, onPinEvent, onUnPinEvent]
+  );
+  const timelineType = useShallowEqualSelector(
+    (state) => (getTimeline(state, timelineId) ?? timelineDefaults).timelineType
+  );
+  const eventType = getEventType(ecsData);
 
   return (
-    <EventsTdGroupActions
-      actionsColumnWidth={actionsColumnWidth}
-      data-test-subj="event-actions-container"
-      tabIndex={0}
-    >
+    <>
       {showCheckboxes && (
         <div key="select-event-container" data-test-subj="select-event-container">
           <EventsTdContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
@@ -82,9 +146,63 @@ const ActionsComponent: React.FC<Props> = ({
           </EuiToolTip>
         </EventsTdContent>
       </div>
+      <>
+        <InvestigateInResolverAction
+          ariaLabel={i18n.ACTION_INVESTIGATE_IN_RESOLVER_FOR_ROW({ ariaRowindex, columnValues })}
+          key="investigate-in-resolver"
+          timelineId={timelineId}
+          ecsData={ecsData}
+        />
+        {timelineId !== TimelineId.active && eventType === 'signal' && (
+          <InvestigateInTimelineAction
+            ariaLabel={i18n.SEND_ALERT_TO_TIMELINE_FOR_ROW({ ariaRowindex, columnValues })}
+            key="investigate-in-timeline"
+            ecsRowData={ecsData}
+            nonEcsRowData={data}
+          />
+        )}
 
-      <>{additionalActions}</>
-    </EventsTdGroupActions>
+        {!isEventViewer && (
+          <>
+            <AddEventNoteAction
+              ariaLabel={i18n.ADD_NOTES_FOR_ROW({ ariaRowindex, columnValues })}
+              key="add-event-note"
+              showNotes={showNotes}
+              toggleShowNotes={toggleShowNotes}
+              timelineType={timelineType}
+            />
+            <PinEventAction
+              ariaLabel={i18n.PIN_EVENT_FOR_ROW({ ariaRowindex, columnValues, isEventPinned })}
+              key="pin-event"
+              onPinClicked={handlePinClicked}
+              noteIds={eventIdToNoteIds[eventId] || emptyNotes}
+              eventIsPinned={isEventPinned}
+              timelineType={timelineType}
+            />
+          </>
+        )}
+        {[
+          TimelineId.detectionsPage,
+          TimelineId.detectionsRulesDetailsPage,
+          TimelineId.active,
+        ].includes(timelineId as TimelineId) && (
+          <AddToCaseAction
+            ariaLabel={i18n.ATTACH_ALERT_TO_CASE_FOR_ROW({ ariaRowindex, columnValues })}
+            key="attach-to-case"
+            ecsRowData={ecsData}
+          />
+        )}
+        <AlertContextMenu
+          ariaLabel={i18n.MORE_ACTIONS_FOR_ROW({ ariaRowindex, columnValues })}
+          key="alert-context-menu"
+          ecsRowData={ecsData}
+          timelineId={timelineId}
+          disabled={eventType !== 'signal' && (!isEventFilteringEnabled || eventType !== 'raw')}
+          refetch={refetch}
+          onRuleChange={onRuleChange}
+        />
+      </>
+    </>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/__snapshots__/index.test.tsx.snap
@@ -506,6 +506,23 @@ exports[`ColumnHeaders rendering renders correctly against snapshot 1`] = `
     ]
   }
   isSelectAllChecked={false}
+  leadingControlColumns={
+    Array [
+      Object {
+        "headerCellRender": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": [Function],
+        },
+        "id": "default-timeline-control-column",
+        "rowCellRender": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": [Function],
+        },
+      },
+    ]
+  }
   onSelectAll={[Function]}
   showEventsSelect={false}
   showSelectAllCheckbox={false}
@@ -520,5 +537,6 @@ exports[`ColumnHeaders rendering renders correctly against snapshot 1`] = `
   }
   tabType="query"
   timelineId="test"
+  trailingControlColumns={Array []}
 />
 `;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.test.tsx
@@ -21,6 +21,8 @@ import { cloneDeep } from 'lodash/fp';
 import { timelineActions } from '../../../../store/timeline';
 import { TimelineTabs } from '../../../../../../common/types/timeline';
 import { Direction } from '../../../../../../common/search_strategy';
+import { defaultControlColumn } from '../control_columns';
+import { testTrailingControlColumns } from '../../../../../common/mock/mock_timeline_control_columns';
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -59,6 +61,8 @@ describe('ColumnHeaders', () => {
             sort={sort}
             tabType={TimelineTabs.query}
             timelineId={timelineId}
+            leadingControlColumns={[defaultControlColumn]}
+            trailingControlColumns={[]}
           />
         </TestProviders>
       );
@@ -79,6 +83,8 @@ describe('ColumnHeaders', () => {
             sort={sort}
             tabType={TimelineTabs.query}
             timelineId={timelineId}
+            leadingControlColumns={[defaultControlColumn]}
+            trailingControlColumns={[]}
           />
         </TestProviders>
       );
@@ -100,6 +106,8 @@ describe('ColumnHeaders', () => {
             sort={sort}
             tabType={TimelineTabs.query}
             timelineId={timelineId}
+            leadingControlColumns={[defaultControlColumn]}
+            trailingControlColumns={[]}
           />
         </TestProviders>
       );
@@ -159,6 +167,8 @@ describe('ColumnHeaders', () => {
             sort={mockSort}
             tabType={TimelineTabs.query}
             timelineId={timelineId}
+            leadingControlColumns={[defaultControlColumn]}
+            trailingControlColumns={[]}
           />
         </TestProviders>
       );
@@ -201,6 +211,8 @@ describe('ColumnHeaders', () => {
             sort={mockSort}
             tabType={TimelineTabs.query}
             timelineId={timelineId}
+            leadingControlColumns={[defaultControlColumn]}
+            trailingControlColumns={[]}
           />
         </TestProviders>
       );
@@ -238,6 +250,8 @@ describe('ColumnHeaders', () => {
             sort={mockSort}
             tabType={TimelineTabs.query}
             timelineId={timelineId}
+            leadingControlColumns={[defaultControlColumn]}
+            trailingControlColumns={[]}
           />
         </TestProviders>
       );
@@ -259,6 +273,29 @@ describe('ColumnHeaders', () => {
           ],
         })
       );
+    });
+    test('Does not render the default leading action column header and renders a custom trailing header', () => {
+      const wrapper = mount(
+        <TestProviders>
+          <ColumnHeadersComponent
+            actionsColumnWidth={DEFAULT_ACTIONS_COLUMN_WIDTH}
+            browserFields={mockBrowserFields}
+            columnHeaders={mockDefaultHeaders}
+            isSelectAllChecked={false}
+            onSelectAll={jest.fn()}
+            showEventsSelect={false}
+            showSelectAllCheckbox={false}
+            sort={mockSort}
+            tabType={TimelineTabs.query}
+            timelineId={timelineId}
+            leadingControlColumns={[]}
+            trailingControlColumns={testTrailingControlColumns}
+          />
+        </TestProviders>
+      );
+
+      expect(wrapper.exists('[data-test-subj="field-browser"]')).toBeFalsy();
+      expect(wrapper.exists('[data-test-subj="test-header-action-cell"]')).toBeTruthy();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/index.tsx
@@ -4,19 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import {
-  EuiButtonIcon,
-  EuiCheckbox,
-  EuiDataGridSorting,
-  EuiToolTip,
-  useDataGridColumnSorting,
-} from '@elastic/eui';
 import deepEqual from 'fast-deep-equal';
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Droppable, DraggableChildrenFn } from 'react-beautiful-dnd';
-import { useDispatch } from 'react-redux';
-import styled from 'styled-components';
 
 import { DragEffects } from '../../../../../common/components/drag_and_drop/draggable_wrapper';
 import { DraggableFieldBadge } from '../../../../../common/components/draggables/field_badge';
@@ -26,46 +16,19 @@ import {
   DRAG_TYPE_FIELD,
   droppableTimelineColumnsPrefix,
 } from '../../../../../common/components/drag_and_drop/helpers';
-import { EXIT_FULL_SCREEN } from '../../../../../common/components/exit_full_screen/translations';
-import { FULL_SCREEN_TOGGLED_CLASS_NAME } from '../../../../../../common/constants';
-import {
-  useGlobalFullScreen,
-  useTimelineFullScreen,
-} from '../../../../../common/containers/use_full_screen';
 import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
 import { OnSelectAll } from '../../events';
-import { DEFAULT_ICON_BUTTON_WIDTH } from '../../helpers';
-import { StatefulFieldsBrowser } from '../../../fields_browser';
-import { StatefulRowRenderersBrowser } from '../../../row_renderers_browser';
-import { FIELD_BROWSER_HEIGHT, FIELD_BROWSER_WIDTH } from '../../../fields_browser/helpers';
 import {
   EventsTh,
-  EventsThContent,
   EventsThead,
-  EventsThGroupActions,
   EventsThGroupData,
   EventsTrHeader,
+  EventsThGroupActions,
 } from '../../styles';
-import { Sort, SortDirection } from '../sort';
-import { EventsSelect } from './events_select';
+import { Sort } from '../sort';
 import { ColumnHeader } from './column_header';
-
-import * as i18n from './translations';
-import { timelineActions } from '../../../../store/timeline';
-
-const SortingColumnsContainer = styled.div`
-  button {
-    color: ${({ theme }) => theme.eui.euiColorPrimary};
-  }
-
-  .euiPopover .euiButtonEmpty .euiButtonContent {
-    padding: 0;
-
-    .euiButtonEmpty__text {
-      display: none;
-    }
-  }
-`;
+import { ControlColumnProps } from '../control_columns';
+import { HeaderActionProps } from '../actions/header_actions';
 
 interface Props {
   actionsColumnWidth: number;
@@ -79,6 +42,8 @@ interface Props {
   sort: Sort[];
   tabType: TimelineTabs;
   timelineId: string;
+  leadingControlColumns: ControlColumnProps[];
+  trailingControlColumns: ControlColumnProps[];
 }
 
 interface DraggableContainerProps {
@@ -126,32 +91,10 @@ export const ColumnHeadersComponent = ({
   sort,
   tabType,
   timelineId,
+  leadingControlColumns,
+  trailingControlColumns,
 }: Props) => {
-  const dispatch = useDispatch();
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
-  const { globalFullScreen, setGlobalFullScreen } = useGlobalFullScreen();
-  const { timelineFullScreen, setTimelineFullScreen } = useTimelineFullScreen();
-
-  const toggleFullScreen = useCallback(() => {
-    if (timelineId === TimelineId.active) {
-      setTimelineFullScreen(!timelineFullScreen);
-    } else {
-      setGlobalFullScreen(!globalFullScreen);
-    }
-  }, [
-    timelineId,
-    setTimelineFullScreen,
-    timelineFullScreen,
-    setGlobalFullScreen,
-    globalFullScreen,
-  ]);
-
-  const handleSelectAllChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      onSelectAll({ isSelected: event.currentTarget.checked });
-    },
-    [onSelectAll]
-  );
 
   const renderClone: DraggableChildrenFn = useCallback(
     (dragProvided, _dragSnapshot, rubric) => {
@@ -195,11 +138,6 @@ export const ColumnHeadersComponent = ({
     [columnHeaders, timelineId, draggingIndex, sort, tabType]
   );
 
-  const fullScreen = useMemo(
-    () => isFullScreen({ globalFullScreen, timelineId, timelineFullScreen }),
-    [globalFullScreen, timelineId, timelineFullScreen]
-  );
-
   const DroppableContent = useCallback(
     (dropProvided, snapshot) => (
       <>
@@ -216,129 +154,115 @@ export const ColumnHeadersComponent = ({
     [ColumnHeaderList]
   );
 
-  const myColumns = useMemo(
+  const leadingHeaderCells = useMemo(
     () =>
-      columnHeaders.map(({ aggregatable, displayAsText, id, type }) => ({
-        id,
-        isSortable: aggregatable,
-        displayAsText,
-        schema: type,
-      })),
-    [columnHeaders]
+      leadingControlColumns ? leadingControlColumns.map((column) => column.headerCellRender) : [],
+    [leadingControlColumns]
   );
 
-  const onSortColumns = useCallback(
-    (cols: EuiDataGridSorting['columns']) =>
-      dispatch(
-        timelineActions.updateSort({
-          id: timelineId,
-          sort: cols.map(({ id, direction }) => ({
-            columnId: id,
-            columnType: columnHeaders.find((ch) => ch.id === id)?.type ?? 'text',
-            sortDirection: direction as SortDirection,
-          })),
-        })
-      ),
-    [columnHeaders, dispatch, timelineId]
+  const trailingHeaderCells = useMemo(
+    () =>
+      trailingControlColumns ? trailingControlColumns.map((column) => column.headerCellRender) : [],
+    [trailingControlColumns]
   );
-  const sortedColumns = useMemo(
-    () => ({
-      onSort: onSortColumns,
-      columns: sort.map<{ id: string; direction: 'asc' | 'desc' }>(
-        ({ columnId, sortDirection }) => ({
-          id: columnId,
-          direction: sortDirection as 'asc' | 'desc',
-        })
-      ),
-    }),
-    [onSortColumns, sort]
-  );
-  const displayValues = useMemo(
-    () => columnHeaders.reduce((acc, ch) => ({ ...acc, [ch.id]: ch.displayAsText ?? ch.id }), {}),
-    [columnHeaders]
-  );
-  const ColumnSorting = useDataGridColumnSorting(myColumns, sortedColumns, {}, [], displayValues);
 
+  const LeadingHeaderActions = useMemo(() => {
+    return leadingHeaderCells.map(
+      (Header: React.ComponentType<HeaderActionProps> | React.ComponentType | undefined, index) => {
+        const passedWidth = leadingControlColumns[index] && leadingControlColumns[index].width;
+        const width = passedWidth ? passedWidth : actionsColumnWidth;
+        return (
+          <EventsThGroupActions
+            actionsColumnWidth={width}
+            data-test-subj="actions-container"
+            isEventViewer={isEventViewer}
+            key={index}
+          >
+            {Header && (
+              <Header
+                width={width}
+                browserFields={browserFields}
+                columnHeaders={columnHeaders}
+                isEventViewer={isEventViewer}
+                isSelectAllChecked={isSelectAllChecked}
+                onSelectAll={onSelectAll}
+                showEventsSelect={showEventsSelect}
+                showSelectAllCheckbox={showSelectAllCheckbox}
+                sort={sort}
+                tabType={tabType}
+                timelineId={timelineId}
+              />
+            )}
+          </EventsThGroupActions>
+        );
+      }
+    );
+  }, [
+    leadingHeaderCells,
+    leadingControlColumns,
+    actionsColumnWidth,
+    browserFields,
+    columnHeaders,
+    isEventViewer,
+    isSelectAllChecked,
+    onSelectAll,
+    showEventsSelect,
+    showSelectAllCheckbox,
+    sort,
+    tabType,
+    timelineId,
+  ]);
+
+  const TrailingHeaderActions = useMemo(() => {
+    return trailingHeaderCells.map(
+      (Header: React.ComponentType<HeaderActionProps> | React.ComponentType | undefined, index) => {
+        const passedWidth = trailingControlColumns[index] && trailingControlColumns[index].width;
+        const width = passedWidth ? passedWidth : actionsColumnWidth;
+        return (
+          <EventsThGroupActions
+            actionsColumnWidth={width}
+            data-test-subj="actions-container"
+            isEventViewer={isEventViewer}
+            key={index}
+          >
+            {Header && (
+              <Header
+                width={width}
+                browserFields={browserFields}
+                columnHeaders={columnHeaders}
+                isEventViewer={isEventViewer}
+                isSelectAllChecked={isSelectAllChecked}
+                onSelectAll={onSelectAll}
+                showEventsSelect={showEventsSelect}
+                showSelectAllCheckbox={showSelectAllCheckbox}
+                sort={sort}
+                tabType={tabType}
+                timelineId={timelineId}
+              />
+            )}
+          </EventsThGroupActions>
+        );
+      }
+    );
+  }, [
+    trailingHeaderCells,
+    trailingControlColumns,
+    actionsColumnWidth,
+    browserFields,
+    columnHeaders,
+    isEventViewer,
+    isSelectAllChecked,
+    onSelectAll,
+    showEventsSelect,
+    showSelectAllCheckbox,
+    sort,
+    tabType,
+    timelineId,
+  ]);
   return (
     <EventsThead data-test-subj="column-headers">
       <EventsTrHeader>
-        <EventsThGroupActions
-          actionsColumnWidth={actionsColumnWidth}
-          data-test-subj="actions-container"
-          isEventViewer={isEventViewer}
-        >
-          {showSelectAllCheckbox && (
-            <EventsTh role="checkbox">
-              <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
-                <EuiCheckbox
-                  data-test-subj="select-all-events"
-                  id={'select-all-events'}
-                  checked={isSelectAllChecked}
-                  onChange={handleSelectAllChange}
-                />
-              </EventsThContent>
-            </EventsTh>
-          )}
-
-          <EventsTh role="button">
-            <StatefulFieldsBrowser
-              browserFields={browserFields}
-              columnHeaders={columnHeaders}
-              data-test-subj="field-browser"
-              height={FIELD_BROWSER_HEIGHT}
-              timelineId={timelineId}
-              width={FIELD_BROWSER_WIDTH}
-            />
-          </EventsTh>
-
-          <EventsTh role="button">
-            <StatefulRowRenderersBrowser
-              data-test-subj="row-renderers-browser"
-              timelineId={timelineId}
-            />
-          </EventsTh>
-
-          <EventsTh role="button">
-            <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
-              <EuiToolTip content={fullScreen ? EXIT_FULL_SCREEN : i18n.FULL_SCREEN}>
-                <EuiButtonIcon
-                  aria-label={
-                    isFullScreen({ globalFullScreen, timelineId, timelineFullScreen })
-                      ? EXIT_FULL_SCREEN
-                      : i18n.FULL_SCREEN
-                  }
-                  className={fullScreen ? FULL_SCREEN_TOGGLED_CLASS_NAME : ''}
-                  color={fullScreen ? 'ghost' : 'primary'}
-                  data-test-subj={
-                    // a full screen button gets created for timeline and for the host page
-                    // this sets the data-test-subj for each case so that tests can differentiate between them
-                    timelineId === TimelineId.active ? 'full-screen-active' : 'full-screen'
-                  }
-                  iconType="fullScreen"
-                  onClick={toggleFullScreen}
-                />
-              </EuiToolTip>
-            </EventsThContent>
-          </EventsTh>
-          {tabType !== TimelineTabs.eql && (
-            <EventsTh role="button" data-test-subj="timeline-sorting-fields">
-              <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
-                <EuiToolTip content={i18n.SORT_FIELDS}>
-                  <SortingColumnsContainer>{ColumnSorting}</SortingColumnsContainer>
-                </EuiToolTip>
-              </EventsThContent>
-            </EventsTh>
-          )}
-
-          {showEventsSelect && (
-            <EventsTh role="button">
-              <EventsThContent textAlign="center" width={DEFAULT_ICON_BUTTON_WIDTH}>
-                <EventsSelect checkState="unchecked" timelineId={timelineId} />
-              </EventsThContent>
-            </EventsTh>
-          )}
-        </EventsThGroupActions>
-
+        {LeadingHeaderActions}
         <Droppable
           direction={'horizontal'}
           droppableId={`${droppableTimelineColumnsPrefix}-${tabType}.${timelineId}`}
@@ -348,6 +272,7 @@ export const ColumnHeadersComponent = ({
         >
           {DroppableContent}
         </Droppable>
+        {TrailingHeaderActions}
       </EventsTrHeader>
     </EventsThead>
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/control_columns/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/control_columns/index.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ComponentType, JSXElementConstructor } from 'react';
+import { EuiDataGridControlColumn, EuiDataGridCellValueElementProps } from '@elastic/eui';
+import { OnRowSelected } from '../../events';
+import { ActionProps, Actions } from '../actions';
+import { HeaderActions, HeaderActionProps } from '../actions/header_actions';
+
+export type GenericActionRowCellRenderProps = Pick<
+  EuiDataGridCellValueElementProps,
+  'rowIndex' | 'columnId'
+>;
+
+export type HeaderCellRender = ComponentType | ComponentType<HeaderActionProps>;
+export type RowCellRender =
+  | JSXElementConstructor<GenericActionRowCellRenderProps>
+  | ((props: GenericActionRowCellRenderProps) => JSX.Element)
+  | JSXElementConstructor<ActionProps>
+  | ((props: ActionProps) => JSX.Element);
+
+interface AdditionalControlColumnProps {
+  ariaRowindex: number;
+  actionsColumnWidth: number;
+  columnValues: string;
+  checked: boolean;
+  onRowSelected: OnRowSelected;
+  eventId: string;
+  id: string;
+  columnId: string;
+  loadingEventIds: Readonly<string[]>;
+  onEventDetailsPanelOpened: () => void;
+  showCheckboxes: boolean;
+  // Override these type definitions to support either a generic custom component or the one used in security_solution today.
+  headerCellRender: HeaderCellRender;
+  rowCellRender: RowCellRender;
+  // If not provided, calculated dynamically
+  width?: number;
+}
+
+export type ControlColumnProps = Omit<
+  EuiDataGridControlColumn,
+  keyof AdditionalControlColumnProps
+> &
+  Partial<AdditionalControlColumnProps>;
+
+export const defaultControlColumn: ControlColumnProps = {
+  id: 'default-timeline-control-column',
+  headerCellRender: HeaderActions,
+  rowCellRender: Actions,
+};

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/__snapshots__/index.test.tsx.snap
@@ -4,649 +4,971 @@ exports[`Columns it renders the expected columns 1`] = `
 <styled.div
   data-test-subj="data-driven-columns"
 >
-  <styled.div
-    $ariaColumnIndex={2}
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "message",
+        "initialWidth": 180,
+      }
+    }
+    index={0}
     key="message"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 2
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "message",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
-  <styled.div
-    $ariaColumnIndex={3}
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "event.category",
+        "initialWidth": 180,
+      }
+    }
+    index={1}
     key="event.category"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 3
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "event.category",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
-  <styled.div
-    $ariaColumnIndex={4}
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "event.action",
+        "initialWidth": 180,
+      }
+    }
+    index={2}
     key="event.action"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 4
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "event.action",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
-  <styled.div
-    $ariaColumnIndex={5}
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "host.name",
+        "initialWidth": 180,
+      }
+    }
+    index={3}
     key="host.name"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 5
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "host.name",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
-  <styled.div
-    $ariaColumnIndex={6}
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "source.ip",
+        "initialWidth": 180,
+      }
+    }
+    index={4}
     key="source.ip"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 6
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "source.ip",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
-  <styled.div
-    $ariaColumnIndex={7}
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "destination.ip",
+        "initialWidth": 180,
+      }
+    }
+    index={5}
     key="destination.ip"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 7
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "destination.ip",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
-  <styled.div
-    $ariaColumnIndex={8}
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
+  <TgridTdCell
+    _id="1"
+    ariaRowindex={2}
+    data={
+      Array [
+        Object {
+          "field": "@timestamp",
+          "value": Array [
+            "2018-11-05T19:03:25.937Z",
+          ],
+        },
+        Object {
+          "field": "event.severity",
+          "value": Array [
+            "3",
+          ],
+        },
+        Object {
+          "field": "event.category",
+          "value": Array [
+            "Access",
+          ],
+        },
+        Object {
+          "field": "event.action",
+          "value": Array [
+            "Action",
+          ],
+        },
+        Object {
+          "field": "host.name",
+          "value": Array [
+            "apache",
+          ],
+        },
+        Object {
+          "field": "source.ip",
+          "value": Array [
+            "192.168.0.1",
+          ],
+        },
+        Object {
+          "field": "destination.ip",
+          "value": Array [
+            "192.168.0.3",
+          ],
+        },
+        Object {
+          "field": "destination.bytes",
+          "value": Array [
+            "123456",
+          ],
+        },
+        Object {
+          "field": "user.name",
+          "value": Array [
+            "john.dee",
+          ],
+        },
+      ]
+    }
+    ecsData={
+      Object {
+        "_id": "1",
+        "destination": Object {
+          "ip": Array [
+            "192.168.0.3",
+          ],
+          "port": Array [
+            6343,
+          ],
+        },
+        "event": Object {
+          "action": Array [
+            "Action",
+          ],
+          "category": Array [
+            "Access",
+          ],
+          "id": Array [
+            "1",
+          ],
+          "module": Array [
+            "nginx",
+          ],
+          "severity": Array [
+            3,
+          ],
+        },
+        "geo": Object {
+          "country_iso_code": Array [
+            "xx",
+          ],
+          "region_name": Array [
+            "xx",
+          ],
+        },
+        "host": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "name": Array [
+            "apache",
+          ],
+        },
+        "source": Object {
+          "ip": Array [
+            "192.168.0.1",
+          ],
+          "port": Array [
+            80,
+          ],
+        },
+        "timestamp": "2018-11-05T19:03:25.937Z",
+        "user": Object {
+          "id": Array [
+            "1",
+          ],
+          "name": Array [
+            "john.dee",
+          ],
+        },
+      }
+    }
+    hasRowRenderers={false}
+    header={
+      Object {
+        "columnHeaderType": "not-filtered",
+        "id": "user.name",
+        "initialWidth": 180,
+      }
+    }
+    index={6}
     key="user.name"
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
-    width={180}
-  >
-    <styled.div
-      data-test-subj="cell-container"
-    >
-      <EuiScreenReaderOnly
-        data-test-subj="screenReaderOnly"
-      >
-        <p>
-          You are in a table cell. row: 2, column: 8
-        </p>
-      </EuiScreenReaderOnly>
-      <Memo(StatefulCellComponent)
-        ariaRowindex={2}
-        data={
-          Array [
-            Object {
-              "field": "@timestamp",
-              "value": Array [
-                "2018-11-05T19:03:25.937Z",
-              ],
-            },
-            Object {
-              "field": "event.severity",
-              "value": Array [
-                "3",
-              ],
-            },
-            Object {
-              "field": "event.category",
-              "value": Array [
-                "Access",
-              ],
-            },
-            Object {
-              "field": "event.action",
-              "value": Array [
-                "Action",
-              ],
-            },
-            Object {
-              "field": "host.name",
-              "value": Array [
-                "apache",
-              ],
-            },
-            Object {
-              "field": "source.ip",
-              "value": Array [
-                "192.168.0.1",
-              ],
-            },
-            Object {
-              "field": "destination.ip",
-              "value": Array [
-                "192.168.0.3",
-              ],
-            },
-            Object {
-              "field": "destination.bytes",
-              "value": Array [
-                "123456",
-              ],
-            },
-            Object {
-              "field": "user.name",
-              "value": Array [
-                "john.dee",
-              ],
-            },
-          ]
-        }
-        eventId="1"
-        header={
-          Object {
-            "columnHeaderType": "not-filtered",
-            "id": "user.name",
-            "initialWidth": 180,
-          }
-        }
-        linkValues={Array []}
-        renderCellValue={[Function]}
-        timelineId="test"
-      />
-    </styled.div>
-  </styled.div>
+    notesCount={0}
+    renderCellValue={[Function]}
+    timelineId="test"
+  />
 </styled.div>
 `;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.test.tsx
@@ -13,6 +13,7 @@ import { DefaultCellRenderer } from '../../cell_rendering/default_cell_renderer'
 import '../../../../../common/mock/match_media';
 import { mockTimelineData } from '../../../../../common/mock';
 import { defaultHeaders } from '../column_headers/default_headers';
+import { defaultControlColumn } from '../control_columns';
 
 import { DataDrivenColumns } from '.';
 
@@ -23,7 +24,9 @@ describe('Columns', () => {
     const wrapper = shallow(
       <DataDrivenColumns
         ariaRowindex={2}
-        _id={mockTimelineData[0]._id}
+        id={mockTimelineData[0]._id}
+        actionsColumnWidth={50}
+        checked={false}
         columnHeaders={headersSansTimestamp}
         data={mockTimelineData[0].data}
         ecsData={mockTimelineData[0].ecs}
@@ -31,6 +34,21 @@ describe('Columns', () => {
         notesCount={0}
         renderCellValue={DefaultCellRenderer}
         timelineId="test"
+        columnValues={'abc def'}
+        showCheckboxes={false}
+        onPinEvent={jest.fn()}
+        selectedEventIds={{}}
+        loadingEventIds={[]}
+        onEventDetailsPanelOpened={jest.fn()}
+        onUnPinEvent={jest.fn()}
+        onRowSelected={jest.fn()}
+        showNotes={false}
+        isEventPinned={false}
+        toggleShowNotes={jest.fn()}
+        refetch={jest.fn()}
+        eventIdToNoteIds={{}}
+        leadingControlColumns={[defaultControlColumn]}
+        trailingControlColumns={[]}
       />
     );
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/index.tsx
@@ -6,25 +6,36 @@
  */
 
 import { EuiScreenReaderOnly } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { getOr } from 'lodash/fp';
 
 import { CellValueElementProps } from '../../cell_rendering';
+import { ControlColumnProps, RowCellRender } from '../control_columns';
 import { DRAGGABLE_KEYBOARD_WRAPPER_CLASS_NAME } from '../../../../../common/components/drag_and_drop/helpers';
 import { Ecs } from '../../../../../../common/ecs';
 import { TimelineNonEcsData } from '../../../../../../common/search_strategy/timeline';
 import { TimelineTabs } from '../../../../../../common/types/timeline';
 import { ColumnHeaderOptions } from '../../../../../timelines/store/timeline/model';
 import { ARIA_COLUMN_INDEX_OFFSET } from '../../helpers';
-import { EventsTd, EVENTS_TD_CLASS_NAME, EventsTdContent, EventsTdGroupData } from '../../styles';
+import { OnPinEvent, OnRowSelected, OnUnPinEvent } from '../../events';
+import { ActionProps } from '../actions';
+import { inputsModel } from '../../../../../common/store';
+import {
+  EventsTd,
+  EVENTS_TD_CLASS_NAME,
+  EventsTdContent,
+  EventsTdGroupData,
+  EventsTdGroupActions,
+} from '../../styles';
 
 import { StatefulCell } from './stateful_cell';
 import * as i18n from './translations';
 
-interface Props {
+interface CellProps {
   _id: string;
   ariaRowindex: number;
-  columnHeaders: ColumnHeaderOptions[];
+  index: number;
+  header: ColumnHeaderOptions;
   data: TimelineNonEcsData[];
   ecsData: Ecs;
   hasRowRenderers: boolean;
@@ -32,6 +43,38 @@ interface Props {
   renderCellValue: (props: CellValueElementProps) => React.ReactNode;
   tabType?: TimelineTabs;
   timelineId: string;
+}
+
+interface DataDrivenColumnProps {
+  id: string;
+  actionsColumnWidth: number;
+  ariaRowindex: number;
+  checked: boolean;
+  columnHeaders: ColumnHeaderOptions[];
+  columnValues: string;
+  data: TimelineNonEcsData[];
+  ecsData: Ecs;
+  eventIdToNoteIds: Readonly<Record<string, string[]>>;
+  isEventPinned: boolean;
+  isEventViewer?: boolean;
+  loadingEventIds: Readonly<string[]>;
+  notesCount: number;
+  onEventDetailsPanelOpened: () => void;
+  onPinEvent: OnPinEvent;
+  onRowSelected: OnRowSelected;
+  onUnPinEvent: OnUnPinEvent;
+  refetch: inputsModel.Refetch;
+  onRuleChange?: () => void;
+  hasRowRenderers: boolean;
+  selectedEventIds: Readonly<Record<string, TimelineNonEcsData[]>>;
+  showCheckboxes: boolean;
+  showNotes: boolean;
+  renderCellValue: (props: CellValueElementProps) => React.ReactNode;
+  tabType?: TimelineTabs;
+  timelineId: string;
+  toggleShowNotes: () => void;
+  trailingControlColumns: ControlColumnProps[];
+  leadingControlColumns: ControlColumnProps[];
 }
 
 const SPACE = ' ';
@@ -78,61 +121,313 @@ export const onKeyDown = (keyboardEvent: React.KeyboardEvent) => {
   }
 };
 
-export const DataDrivenColumns = React.memo<Props>(
+const TgridActionTdCell = ({
+  action: Action,
+  width,
+  actionsColumnWidth,
+  ariaRowindex,
+  columnId,
+  columnValues,
+  data,
+  ecsData,
+  eventIdToNoteIds,
+  index,
+  isEventPinned,
+  isEventViewer,
+  eventId,
+  loadingEventIds,
+  notesCount,
+  onEventDetailsPanelOpened,
+  onPinEvent,
+  onRowSelected,
+  onUnPinEvent,
+  refetch,
+  rowIndex,
+  hasRowRenderers,
+  onRuleChange,
+  selectedEventIds,
+  showCheckboxes,
+  showNotes,
+  tabType,
+  timelineId,
+  toggleShowNotes,
+}: ActionProps & {
+  columnId: string;
+  hasRowRenderers: boolean;
+  actionsColumnWidth: number;
+  notesCount: number;
+  selectedEventIds: Readonly<Record<string, TimelineNonEcsData[]>>;
+}) => {
+  const displayWidth = width ? width : actionsColumnWidth;
+  return (
+    <EventsTdGroupActions
+      width={displayWidth}
+      data-test-subj="event-actions-container"
+      tabIndex={0}
+    >
+      <EventsTd
+        $ariaColumnIndex={index + ARIA_COLUMN_INDEX_OFFSET}
+        key={tabType != null ? `${eventId}_${tabType}` : `${eventId}`}
+        onKeyDown={onKeyDown}
+        role="button"
+        tabIndex={0}
+        width={width}
+      >
+        <EventsTdContent data-test-subj="cell-container">
+          <>
+            <EuiScreenReaderOnly data-test-subj="screenReaderOnly">
+              <p>{i18n.YOU_ARE_IN_A_TABLE_CELL({ row: ariaRowindex, column: index + 2 })}</p>
+            </EuiScreenReaderOnly>
+            {Action && (
+              <Action
+                ariaRowindex={ariaRowindex}
+                width={width}
+                checked={Object.keys(selectedEventIds).includes(eventId)}
+                columnId={columnId}
+                columnValues={columnValues}
+                eventId={eventId}
+                data={data}
+                ecsData={ecsData}
+                eventIdToNoteIds={eventIdToNoteIds}
+                index={index}
+                isEventPinned={isEventPinned}
+                isEventViewer={isEventViewer}
+                loadingEventIds={loadingEventIds}
+                onEventDetailsPanelOpened={onEventDetailsPanelOpened}
+                onPinEvent={onPinEvent}
+                onRowSelected={onRowSelected}
+                onUnPinEvent={onUnPinEvent}
+                refetch={refetch}
+                rowIndex={rowIndex}
+                onRuleChange={onRuleChange}
+                showCheckboxes={showCheckboxes}
+                showNotes={showNotes}
+                timelineId={timelineId}
+                toggleShowNotes={toggleShowNotes}
+              />
+            )}
+          </>
+        </EventsTdContent>
+        {hasRowRenderers ? (
+          <EuiScreenReaderOnly data-test-subj="hasRowRendererScreenReaderOnly">
+            <p>{i18n.EVENT_HAS_AN_EVENT_RENDERER(ariaRowindex)}</p>
+          </EuiScreenReaderOnly>
+        ) : null}
+
+        {notesCount ? (
+          <EuiScreenReaderOnly data-test-subj="hasNotesScreenReaderOnly">
+            <p>{i18n.EVENT_HAS_NOTES({ row: ariaRowindex, notesCount })}</p>
+          </EuiScreenReaderOnly>
+        ) : null}
+      </EventsTd>
+    </EventsTdGroupActions>
+  );
+};
+
+const TgridTdCell = ({
+  _id,
+  ariaRowindex,
+  index,
+  header,
+  data,
+  ecsData,
+  hasRowRenderers,
+  notesCount,
+  renderCellValue,
+  tabType,
+  timelineId,
+}: CellProps) => {
+  return (
+    <EventsTd
+      $ariaColumnIndex={index + ARIA_COLUMN_INDEX_OFFSET}
+      key={tabType != null ? `${header.id}_${tabType}` : `${header.id}`}
+      onKeyDown={onKeyDown}
+      role="button"
+      tabIndex={0}
+      width={header.initialWidth}
+    >
+      <EventsTdContent data-test-subj="cell-container">
+        <>
+          <EuiScreenReaderOnly data-test-subj="screenReaderOnly">
+            <p>{i18n.YOU_ARE_IN_A_TABLE_CELL({ row: ariaRowindex, column: index + 2 })}</p>
+          </EuiScreenReaderOnly>
+          <StatefulCell
+            ariaRowindex={ariaRowindex}
+            data={data}
+            header={header}
+            eventId={_id}
+            linkValues={getOr([], header.linkField ?? '', ecsData)}
+            renderCellValue={renderCellValue}
+            tabType={tabType}
+            timelineId={timelineId}
+          />
+        </>
+      </EventsTdContent>
+      {hasRowRenderers ? (
+        <EuiScreenReaderOnly data-test-subj="hasRowRendererScreenReaderOnly">
+          <p>{i18n.EVENT_HAS_AN_EVENT_RENDERER(ariaRowindex)}</p>
+        </EuiScreenReaderOnly>
+      ) : null}
+
+      {notesCount ? (
+        <EuiScreenReaderOnly data-test-subj="hasNotesScreenReaderOnly">
+          <p>{i18n.EVENT_HAS_NOTES({ row: ariaRowindex, notesCount })}</p>
+        </EuiScreenReaderOnly>
+      ) : null}
+    </EventsTd>
+  );
+};
+
+export const DataDrivenColumns = React.memo<DataDrivenColumnProps>(
   ({
-    _id,
     ariaRowindex,
+    actionsColumnWidth,
     columnHeaders,
+    columnValues,
     data,
     ecsData,
-    hasRowRenderers,
+    eventIdToNoteIds,
+    isEventPinned,
+    isEventViewer,
+    id: _id,
+    loadingEventIds,
     notesCount,
+    onEventDetailsPanelOpened,
+    onPinEvent,
+    onRowSelected,
+    onUnPinEvent,
+    refetch,
+    hasRowRenderers,
+    onRuleChange,
     renderCellValue,
+    selectedEventIds,
+    showCheckboxes,
+    showNotes,
     tabType,
     timelineId,
-  }) => (
-    <EventsTdGroupData data-test-subj="data-driven-columns">
-      {columnHeaders.map((header, i) => (
-        <EventsTd
-          $ariaColumnIndex={i + ARIA_COLUMN_INDEX_OFFSET}
-          key={tabType != null ? `${header.id}_${tabType}` : `${header.id}`}
-          onKeyDown={onKeyDown}
-          role="button"
-          tabIndex={0}
-          width={header.initialWidth}
-        >
-          <EventsTdContent data-test-subj="cell-container">
-            <>
-              <EuiScreenReaderOnly data-test-subj="screenReaderOnly">
-                <p>{i18n.YOU_ARE_IN_A_TABLE_CELL({ row: ariaRowindex, column: i + 2 })}</p>
-              </EuiScreenReaderOnly>
-              <StatefulCell
+    toggleShowNotes,
+    trailingControlColumns,
+    leadingControlColumns,
+  }) => {
+    const trailingActionCells = useMemo(
+      () =>
+        trailingControlColumns ? trailingControlColumns.map((column) => column.rowCellRender) : [],
+      [trailingControlColumns]
+    );
+    const leadingAndDataColumnCount = useMemo(
+      () => leadingControlColumns.length + columnHeaders.length,
+      [leadingControlColumns, columnHeaders]
+    );
+    const TrailingActions = useMemo(
+      () =>
+        trailingActionCells.map((Action: RowCellRender | undefined, index) => {
+          return (
+            Action && (
+              <TgridActionTdCell
+                action={Action}
+                width={trailingControlColumns[index].width}
+                actionsColumnWidth={actionsColumnWidth}
                 ariaRowindex={ariaRowindex}
-                data={data}
-                header={header}
+                checked={Object.keys(selectedEventIds).includes(_id)}
+                columnId={trailingControlColumns[index].id || ''}
+                columnValues={columnValues}
+                onRowSelected={onRowSelected}
+                data-test-subj="actions"
                 eventId={_id}
-                linkValues={getOr([], header.linkField ?? '', ecsData)}
-                renderCellValue={renderCellValue}
+                data={data}
+                key={index}
+                index={leadingAndDataColumnCount + index}
+                rowIndex={ariaRowindex}
+                ecsData={ecsData}
+                loadingEventIds={loadingEventIds}
+                onEventDetailsPanelOpened={onEventDetailsPanelOpened}
+                showCheckboxes={showCheckboxes}
+                eventIdToNoteIds={eventIdToNoteIds}
+                isEventPinned={isEventPinned}
+                isEventViewer={isEventViewer}
+                notesCount={notesCount}
+                onPinEvent={onPinEvent}
+                onUnPinEvent={onUnPinEvent}
+                refetch={refetch}
+                hasRowRenderers={hasRowRenderers}
+                onRuleChange={onRuleChange}
+                selectedEventIds={selectedEventIds}
+                showNotes={showNotes}
                 tabType={tabType}
                 timelineId={timelineId}
+                toggleShowNotes={toggleShowNotes}
               />
-            </>
-          </EventsTdContent>
-          {hasRowRenderers ? (
-            <EuiScreenReaderOnly data-test-subj="hasRowRendererScreenReaderOnly">
-              <p>{i18n.EVENT_HAS_AN_EVENT_RENDERER(ariaRowindex)}</p>
-            </EuiScreenReaderOnly>
-          ) : null}
-
-          {notesCount ? (
-            <EuiScreenReaderOnly data-test-subj="hasNotesScreenReaderOnly">
-              <p>{i18n.EVENT_HAS_NOTES({ row: ariaRowindex, notesCount })}</p>
-            </EuiScreenReaderOnly>
-          ) : null}
-        </EventsTd>
-      ))}
-    </EventsTdGroupData>
-  )
+            )
+          );
+        }),
+      [
+        trailingControlColumns,
+        _id,
+        data,
+        ecsData,
+        onRowSelected,
+        onPinEvent,
+        isEventPinned,
+        isEventViewer,
+        actionsColumnWidth,
+        ariaRowindex,
+        columnValues,
+        eventIdToNoteIds,
+        hasRowRenderers,
+        leadingAndDataColumnCount,
+        loadingEventIds,
+        notesCount,
+        onEventDetailsPanelOpened,
+        onRuleChange,
+        onUnPinEvent,
+        refetch,
+        selectedEventIds,
+        showCheckboxes,
+        showNotes,
+        tabType,
+        timelineId,
+        toggleShowNotes,
+        trailingActionCells,
+      ]
+    );
+    const ColumnHeaders = useMemo(
+      () =>
+        columnHeaders.map((header, index) => (
+          <TgridTdCell
+            _id={_id}
+            index={index}
+            header={header}
+            key={tabType != null ? `${header.id}_${tabType}` : `${header.id}`}
+            ariaRowindex={ariaRowindex}
+            data={data}
+            ecsData={ecsData}
+            hasRowRenderers={hasRowRenderers}
+            notesCount={notesCount}
+            renderCellValue={renderCellValue}
+            tabType={tabType}
+            timelineId={timelineId}
+          />
+        )),
+      [
+        _id,
+        ariaRowindex,
+        columnHeaders,
+        data,
+        ecsData,
+        hasRowRenderers,
+        notesCount,
+        renderCellValue,
+        tabType,
+        timelineId,
+      ]
+    );
+    return (
+      <EventsTdGroupData data-test-subj="data-driven-columns">
+        {ColumnHeaders}
+        {TrailingActions}
+      </EventsTdGroupData>
+    );
+  }
 );
 
 DataDrivenColumns.displayName = 'DataDrivenColumns';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/stateful_cell.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/stateful_cell.tsx
@@ -38,7 +38,6 @@ const StatefulCellComponent = ({
   timelineId: string;
 }) => {
   const [cellProps, setCellProps] = useState<CommonProps & HTMLAttributes<HTMLDivElement>>({});
-
   return (
     <div data-test-subj="statefulCell" {...cellProps}>
       {renderCellValue({

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/event_column_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/event_column_view.test.tsx
@@ -18,6 +18,8 @@ import { DefaultCellRenderer } from '../../cell_rendering/default_cell_renderer'
 import { TimelineTabs, TimelineType, TimelineId } from '../../../../../../common/types/timeline';
 import { useShallowEqualSelector } from '../../../../../common/hooks/use_selector';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import { defaultControlColumn } from '../control_columns';
+import { testLeadingControlColumn } from '../../../../../common/mock/mock_timeline_control_columns';
 
 jest.mock('../../../../../common/hooks/use_experimental_features');
 const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
@@ -71,6 +73,8 @@ describe('EventColumnView', () => {
     toggleShowNotes: jest.fn(),
     updateNote: jest.fn(),
     isEventPinned: false,
+    leadingControlColumns: [defaultControlColumn],
+    trailingControlColumns: [],
   };
 
   test('it does NOT render a notes button when isEventsViewer is true', () => {
@@ -159,5 +163,21 @@ describe('EventColumnView', () => {
     });
 
     expect(wrapper.find('[data-test-subj="add-to-case-action"]').exists()).toBeFalsy();
+  });
+
+  test('it renders a custom control column in addition to the default control column', () => {
+    const wrapper = mount(
+      <EventColumnView
+        {...props}
+        timelineId="timeline-test"
+        leadingControlColumns={[testLeadingControlColumn, defaultControlColumn]}
+      />,
+      {
+        wrappingComponent: TestProviders,
+      }
+    );
+
+    expect(wrapper.find('[data-test-subj="expand-event"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-test-subj="test-body-control-column-cell"]').exists()).toBeTruthy();
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { isEmpty } from 'lodash';
 
 import { CellValueElementProps } from '../../cell_rendering';
+import { ControlColumnProps } from '../control_columns';
 import { inputsModel } from '../../../../../common/store';
 import { BrowserFields } from '../../../../../common/containers/source';
 import {
@@ -46,6 +47,8 @@ interface Props {
   selectedEventIds: Readonly<Record<string, TimelineNonEcsData[]>>;
   showCheckboxes: boolean;
   tabType?: TimelineTabs;
+  leadingControlColumns: ControlColumnProps[];
+  trailingControlColumns: ControlColumnProps[];
 }
 
 const EventsComponent: React.FC<Props> = ({
@@ -68,6 +71,8 @@ const EventsComponent: React.FC<Props> = ({
   selectedEventIds,
   showCheckboxes,
   tabType,
+  leadingControlColumns,
+  trailingControlColumns,
 }) => (
   <EventsTbody data-test-subj="events">
     {data.map((event, i) => (
@@ -95,6 +100,8 @@ const EventsComponent: React.FC<Props> = ({
         showCheckboxes={showCheckboxes}
         tabType={tabType}
         timelineId={id}
+        leadingControlColumns={leadingControlColumns}
+        trailingControlColumns={trailingControlColumns}
       />
     ))}
   </EventsTbody>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/stateful_event.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/stateful_event.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { CellValueElementProps } from '../../cell_rendering';
+import { ControlColumnProps } from '../control_columns';
 import { useDeepEqualSelector } from '../../../../../common/hooks/use_selector';
 import {
   TimelineExpandedDetailType,
@@ -61,6 +62,8 @@ interface Props {
   showCheckboxes: boolean;
   tabType?: TimelineTabs;
   timelineId: string;
+  leadingControlColumns: ControlColumnProps[];
+  trailingControlColumns: ControlColumnProps[];
 }
 
 const emptyNotes: string[] = [];
@@ -93,6 +96,8 @@ const StatefulEventComponent: React.FC<Props> = ({
   showCheckboxes,
   tabType,
   timelineId,
+  leadingControlColumns,
+  trailingControlColumns,
 }) => {
   const trGroupRef = useRef<HTMLDivElement | null>(null);
   const dispatch = useDispatch();
@@ -282,6 +287,8 @@ const StatefulEventComponent: React.FC<Props> = ({
           tabType={tabType}
           timelineId={timelineId}
           toggleShowNotes={onToggleShowNotes}
+          leadingControlColumns={leadingControlColumns}
+          trailingControlColumns={trailingControlColumns}
         />
 
         <EventsTrSupplementContainerWrapper>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.test.tsx
@@ -17,14 +17,11 @@ import { TestProviders } from '../../../../common/mock/test_providers';
 
 import { BodyComponent, StatefulBodyProps } from '.';
 import { Sort } from './sort';
+import { defaultControlColumn } from './control_columns';
 import { useMountAppended } from '../../../../common/utils/use_mount_appended';
 import { timelineActions } from '../../../store/timeline';
 import { TimelineTabs } from '../../../../../common/types/timeline';
 import { defaultRowRenderers } from './renderers';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-
-jest.mock('../../../../common/hooks/use_experimental_features');
-const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 const mockSort: Sort[] = [
   {
@@ -90,9 +87,9 @@ describe('Body', () => {
     showCheckboxes: false,
     tabType: TimelineTabs.query,
     totalPages: 1,
+    leadingControlColumns: [defaultControlColumn],
+    trailingControlColumns: [],
   };
-
-  useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
 
   describe('rendering', () => {
     test('it renders the column headers', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/eql_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/eql_tab_content/index.tsx
@@ -51,6 +51,7 @@ import { activeTimeline } from '../../../containers/active_timeline_context';
 import { ToggleDetailPanel } from '../../../store/timeline/actions';
 import { DetailsPanel } from '../../side_panel';
 import { EqlQueryBarTimeline } from '../query_bar/eql';
+import { defaultControlColumn, ControlColumnProps } from '../body/control_columns';
 import { Sort } from '../body/sort';
 
 const TimelineHeaderContainer = styled.div`
@@ -232,6 +233,9 @@ export const EqlTabContentComponent: React.FC<Props> = ({
     setIsTimelineLoading({ id: timelineId, isLoading: isQueryLoading || loadingSourcerer });
   }, [loadingSourcerer, timelineId, isQueryLoading, setIsTimelineLoading]);
 
+  const leadingControlColumns: ControlColumnProps[] = [defaultControlColumn];
+  const trailingControlColumns: ControlColumnProps[] = [];
+
   return (
     <>
       <InPortal node={eqlEventsCountPortalNode}>
@@ -298,6 +302,8 @@ export const EqlTabContentComponent: React.FC<Props> = ({
                   itemsCount: totalCount,
                   itemsPerPage,
                 })}
+                leadingControlColumns={leadingControlColumns}
+                trailingControlColumns={trailingControlColumns}
               />
             </StyledEuiFlyoutBody>
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/pinned_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/pinned_tab_content/index.tsx
@@ -36,6 +36,7 @@ import { TimelineTabs } from '../../../../../common/types/timeline';
 import { DetailsPanel } from '../../side_panel';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { ExitFullScreen } from '../../../../common/components/exit_full_screen';
+import { defaultControlColumn, ControlColumnProps } from '../body/control_columns';
 
 const StyledEuiFlyoutBody = styled(EuiFlyoutBody)`
   overflow-y: hidden;
@@ -198,6 +199,9 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
     onEventClosed({ tabType: TimelineTabs.pinned, timelineId });
   }, [timelineId, onEventClosed]);
 
+  const leadingControlColumns: ControlColumnProps[] = [defaultControlColumn];
+  const trailingControlColumns: ControlColumnProps[] = [];
+
   return (
     <>
       <FullWidthFlexGroup data-test-subj={`${TimelineTabs.pinned}-tab`}>
@@ -229,6 +233,8 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
                   itemsCount: totalCount,
                   itemsPerPage,
                 })}
+                leadingControlColumns={leadingControlColumns}
+                trailingControlColumns={trailingControlColumns}
               />
             </StyledEuiFlyoutBody>
             <StyledEuiFlyoutFooter

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -58,6 +58,7 @@ import { activeTimeline } from '../../../containers/active_timeline_context';
 import { ToggleDetailPanel } from '../../../store/timeline/actions';
 import { DetailsPanel } from '../../side_panel';
 import { ExitFullScreen } from '../../../../common/components/exit_full_screen';
+import { defaultControlColumn, ControlColumnProps } from '../body/control_columns';
 
 const TimelineHeaderContainer = styled.div`
   margin-top: 6px;
@@ -272,6 +273,9 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     setIsTimelineLoading({ id: timelineId, isLoading: isQueryLoading || loadingSourcerer });
   }, [loadingSourcerer, timelineId, isQueryLoading, setIsTimelineLoading]);
 
+  const leadingControlColumns: ControlColumnProps[] = [defaultControlColumn];
+  const trailingControlColumns: ControlColumnProps[] = [];
+
   return (
     <>
       <InPortal node={timelineEventsCountPortalNode}>
@@ -344,6 +348,8 @@ export const QueryTabContentComponent: React.FC<Props> = ({
                   itemsCount: totalCount,
                   itemsPerPage,
                 })}
+                leadingControlColumns={leadingControlColumns}
+                trailingControlColumns={trailingControlColumns}
               />
             </StyledEuiFlyoutBody>
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/styles.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/styles.tsx
@@ -299,10 +299,10 @@ export const EventsTdGroupActions = styled.div.attrs(({ className = '' }) => ({
   'aria-colindex': `${ACTIONS_COLUMN_ARIA_COL_INDEX}`,
   className: `siemEventsTable__tdGroupActions ${className}`,
   role: 'gridcell',
-}))<{ actionsColumnWidth: number }>`
+}))<{ width: number }>`
   align-items: center;
   display: flex;
-  flex: 0 0 ${({ actionsColumnWidth }) => `${actionsColumnWidth}px`};
+  flex: 0 0 ${({ width }) => `${width}px`};
   min-width: 0;
 `;
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [RAC][Alert Triage][TGrid] Update the alerts table/tgrid API to support customized leadingControlColumns and trailingControlColumns (#98845)