### PR TITLE
Input Controls - Starter Kit - Options 1a and 1b

### DIFF
--- a/src/plugins/presentation_util/public/components/input_controls/__stories__/decorators.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/__stories__/decorators.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { Story } from '@storybook/react';
+
+const bar = '#c5ced8';
+const panel = '#f7f9fa';
+const background = '#e0e6ec';
+const minHeight = 60;
+
+const panelStyle = {
+  height: 165,
+  width: 400,
+  background: panel,
+};
+
+const kqlBarStyle = { background: bar, padding: 16, minHeight, fontStyle: 'italic' };
+
+const inputBarStyle = { background: '#fff', padding: 4, minHeight };
+
+const layout = (OptionStory: Story) => (
+  <EuiFlexGroup style={{ background }} direction="column">
+    <EuiFlexItem style={kqlBarStyle}>KQL Bar</EuiFlexItem>
+    <EuiFlexItem style={inputBarStyle}>
+      <OptionStory />
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiFlexGroup>
+        <EuiFlexItem style={panelStyle} />
+        <EuiFlexItem style={panelStyle} />
+        <EuiFlexItem style={panelStyle} />
+      </EuiFlexGroup>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiFlexGroup>
+        <EuiFlexItem style={panelStyle} />
+        <EuiFlexItem style={panelStyle} />
+        <EuiFlexItem style={panelStyle} />
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
+export const decorators = [layout];

--- a/src/plugins/presentation_util/public/components/input_controls/__stories__/flights.ts
+++ b/src/plugins/presentation_util/public/components/input_controls/__stories__/flights.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { map, uniq } from 'lodash';
+import { EuiSelectableOption } from '@elastic/eui';
+
+import { flights } from '../../fixtures/flights';
+
+export type Flight = typeof flights[number];
+export type FlightField = keyof Flight;
+
+export const getOptions = <T extends FlightField>(field: T) => uniq(map(flights, field)).sort();
+
+export const getEuiSelectableOptions = <T extends FlightField>(field: T): EuiSelectableOption[] =>
+  getOptions(field).map((option) => ({
+    label: option + '',
+    searchableLabel: option + '',
+  }));
+
+export const flightFieldLabels: Record<FlightField, string> = {
+  AvgTicketPrice: 'Average Ticket Price',
+  Cancelled: 'Cancelled',
+  Carrier: 'Carrier',
+  dayOfWeek: 'Day of Week',
+  Dest: 'Destination',
+  DestAirportID: 'Destination Airport ID',
+  DestCityName: 'Destination City',
+  DestCountry: 'Destination Country',
+  DestLocation: 'Destination Location',
+  DestRegion: 'Destination Region',
+  DestWeather: 'Destination Weather',
+  DistanceKilometers: 'Distance (km)',
+  DistanceMiles: 'Distance (mi)',
+  FlightDelay: 'Flight Delay',
+  FlightDelayMin: 'Flight Delay (min)',
+  FlightDelayType: 'Flight Delay Type',
+  FlightNum: 'Flight Number',
+  FlightTimeHour: 'Flight Time (hr)',
+  FlightTimeMin: 'Flight Time (min)',
+  Origin: 'Origin',
+  OriginAirportID: 'Origin Airport ID',
+  OriginCityName: 'Origin City',
+  OriginCountry: 'Origin Country',
+  OriginLocation: 'Origin Location',
+  OriginRegion: 'Origin Region',
+  OriginWeather: 'Origin Weather',
+  timestamp: 'Timestamp',
+};
+
+export const flightFields = Object.keys(flightFieldLabels) as FlightField[];

--- a/src/plugins/presentation_util/public/components/input_controls/__stories__/input_controls.stories.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/__stories__/input_controls.stories.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { Selectable1A } from '../selectable1a';
+import { Selectable1B } from '../selectable1b';
+
+import { decorators } from './decorators';
+import { getEuiSelectableOptions, FlightField, flightFieldLabels, flightFields } from './flights';
+
+export default {
+  title: 'Input Controls',
+  description: '',
+  decorators,
+};
+
+const storybookArgs = {
+  fields: ['OriginCityName', 'OriginWeather', 'DestCityName', 'DestWeather'],
+};
+
+const storybookArgTypes = {
+  fields: {
+    control: {
+      type: 'check',
+      options: flightFields,
+    },
+  },
+};
+
+export const Option1a = ({ fields }: { fields: FlightField[] }) => (
+  <EuiFlexGroup alignItems="center" gutterSize="s">
+    {fields.map((field) => (
+      <EuiFlexItem grow={false} key={field}>
+        <Selectable1A
+          onChange={action('onChange')}
+          options={getEuiSelectableOptions(field)}
+          label={flightFieldLabels[field]}
+        />
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGroup>
+);
+
+export const Option1b = ({ fields }: { fields: FlightField[] }) => (
+  <EuiFlexGroup alignItems="center" gutterSize="s" wrap={true}>
+    {fields.map((field) => (
+      <EuiFlexItem key={field} style={{ width: '33%' }}>
+        <Selectable1B
+          onChange={action('onChange')}
+          options={getEuiSelectableOptions(field)}
+          label={flightFieldLabels[field]}
+        />
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGroup>
+);
+
+Option1a.args = storybookArgs;
+Option1a.argTypes = storybookArgTypes;
+Option1b.args = storybookArgs;
+Option1b.argTypes = storybookArgTypes;

--- a/src/plugins/presentation_util/public/components/input_controls/index.ts
+++ b/src/plugins/presentation_util/public/components/input_controls/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */

--- a/src/plugins/presentation_util/public/components/input_controls/selectable1a.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/selectable1a.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState, useMemo } from 'react';
+import { EuiSelectable, EuiSelectableProps, EuiPopover, EuiButton } from '@elastic/eui';
+
+export interface Props extends Pick<EuiSelectableProps, 'options' | 'onChange'> {
+  label: string;
+}
+
+export const Selectable1A = ({ label, options }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectableOptions, setSelectableOptions] = useState(options);
+
+  const selected = selectableOptions.filter((option) => option.checked);
+
+  const button = useMemo(
+    () => (
+      <EuiButton iconSide="right" iconType="arrowDown" onClick={() => setIsOpen(!isOpen)}>
+        {label}
+        {selected && selected.length > 0 ? ` (${selected.length})` : ''}
+      </EuiButton>
+    ),
+    [selected, isOpen, label]
+  );
+
+  return (
+    <EuiPopover
+      panelPaddingSize="s"
+      isOpen={isOpen}
+      button={button}
+      attachToAnchor={true}
+      closePopover={() => setIsOpen(false)}
+    >
+      <EuiSelectable
+        aria-label="Input Control Option 1.1"
+        searchable
+        options={selectableOptions}
+        onChange={(newOptions) => setSelectableOptions(newOptions)}
+      >
+        {(list, search) => (
+          <>
+            {search}
+            {list}
+          </>
+        )}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};

--- a/src/plugins/presentation_util/public/components/input_controls/selectable1b.scss
+++ b/src/plugins/presentation_util/public/components/input_controls/selectable1b.scss
@@ -1,0 +1,19 @@
+
+.s1bButton {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.s1bAnchor {
+  width: 100%;
+
+  .euiButtonContent {
+    justify-content: end;
+  }
+
+  .euiButtonEmpty__text {
+    width: 100%;
+    text-align: left;
+  }
+}

--- a/src/plugins/presentation_util/public/components/input_controls/selectable1b.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/selectable1b.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState, useMemo } from 'react';
+import {
+  EuiSelectable,
+  EuiSelectableProps,
+  EuiPopover,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+
+import './selectable1b.scss';
+
+export interface Props extends Pick<EuiSelectableProps, 'options' | 'onChange'> {
+  label: string;
+}
+
+export const Selectable1B = ({ label, options }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectableOptions, setSelectableOptions] = useState(options);
+
+  const selected = selectableOptions.filter((option) => option.checked);
+
+  const button = useMemo(
+    () => (
+      <EuiButtonEmpty
+        iconSide="right"
+        iconType="arrowDown"
+        onClick={() => setIsOpen(!isOpen)}
+        className="s1bButton"
+      >
+        {selected.map((item) => item.label).join(', ')}
+      </EuiButtonEmpty>
+    ),
+    [selected, isOpen]
+  );
+
+  return (
+    <EuiFlexGroup alignItems="center" style={{ border: '1px solid #c5ced8' }} gutterSize="none">
+      <EuiFlexItem
+        grow={false}
+        style={{ padding: 12, background: '#f7f9fa', whiteSpace: 'nowrap' }}
+      >
+        {label}
+        {selected && selected.length > 0 ? ` (${selected.length})` : ''}
+      </EuiFlexItem>
+      <EuiFlexItem style={{ overflow: 'hidden' }}>
+        <EuiPopover
+          panelPaddingSize="s"
+          isOpen={isOpen}
+          button={button}
+          attachToAnchor={true}
+          closePopover={() => setIsOpen(false)}
+          anchorClassName="s1bAnchor"
+        >
+          <EuiSelectable
+            aria-label="Input Control Option 1.1"
+            searchable
+            options={selectableOptions}
+            onChange={(newOptions) => setSelectableOptions(newOptions)}
+          >
+            {(list, search) => (
+              <>
+                {search}
+                {list}
+              </>
+            )}
+          </EuiSelectable>
+        </EuiPopover>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/plugins/presentation_util/tsconfig.json
+++ b/src/plugins/presentation_util/tsconfig.json
@@ -10,6 +10,7 @@
   "include": [
     "common/**/*",
     "public/**/*",
+    "public/**/*.json",
     "server/**/*",
     "storybook/**/*",
     "../../../typings/**/*"


### PR DESCRIPTION
## Summary

> NOTE: These components are *not* intended to be committed to `master`.

This is a WIP pull to create base data and Storybook stories for visual design explorations for Input Controls.  This is technically a starter kit, in that I've created two of the options thus far.

These stories and components are meant to be bare-bones and rough, to demonstrate feasibility through code and "clickable" assets.  They are meant to be iterated upon, perhaps even live.

<img width="1099" alt="Screen Shot 2021-05-01 at 3 11 25 PM" src="https://user-images.githubusercontent.com/297604/116802444-650de780-aad8-11eb-8b8a-833e757cddcb.png">

<img width="1922" alt="Screen Shot 2021-05-01 at 11 45 28 PM" src="https://user-images.githubusercontent.com/297604/116802445-65a67e00-aad8-11eb-8852-9f43df9938b9.png">

cc: @ThomThomson @mdefazio @kmartastic 

## Preview Storybook

CI builds a static version of the Storybook instance on each commit.

1/ Find the latest entry from `Kibana Machine`.
2/ Click `Storybooks Preview`
<img width="487" alt="Screen Shot 2021-05-02 at 11 35 10 AM" src="https://user-images.githubusercontent.com/297604/116820429-c070c180-ab3a-11eb-953a-0a52679e63f0.png">
3/ Click `presentation`
<img width="258" alt="Screen Shot 2021-05-02 at 11 35 23 AM" src="https://user-images.githubusercontent.com/297604/116820438-cebedd80-ab3a-11eb-9cf5-d412852f4274.png">
4/ Expand `Input Controls`
<img width="688" alt="Screen Shot 2021-05-02 at 11 35 40 AM" src="https://user-images.githubusercontent.com/297604/116820448-d54d5500-ab3a-11eb-986a-ee5e75fcad89.png">