### PR TITLE
updating time picker refresh interval default

### DIFF
--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -325,7 +325,7 @@ export function getUiSettings(
       }),
       value: `{
   "pause": false,
-  "value": 0
+  "value": 60000
 }`,
       type: 'json',
       description: i18n.translate('data.advancedSettings.timepicker.refreshIntervalDefaultsText', {


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/kibana/issues/70562

updates time picker refresh interval default to 60 seconds


