### PR TITLE
[Enterprise Search] Refactor shared SchemaErrorsAccordion component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/constants.ts
@@ -14,31 +14,3 @@ export const FIELD_NAME = i18n.translate('xpack.enterpriseSearch.schema.fieldNam
 export const FIELD_TYPE = i18n.translate('xpack.enterpriseSearch.schema.fieldTypeLabel', {
   defaultMessage: 'Field type',
 });
-
-export const ERROR_TABLE_ID_HEADER = i18n.translate(
-  'xpack.enterpriseSearch.schema.errorsTable.heading.id',
-  {
-    defaultMessage: 'id',
-  }
-);
-
-export const ERROR_TABLE_ERROR_HEADER = i18n.translate(
-  'xpack.enterpriseSearch.schema.errorsTable.heading.error',
-  {
-    defaultMessage: 'Error',
-  }
-);
-
-export const ERROR_TABLE_REVIEW_CONTROL = i18n.translate(
-  'xpack.enterpriseSearch.schema.errorsTable.control.review',
-  {
-    defaultMessage: 'Review',
-  }
-);
-
-export const ERROR_TABLE_VIEW_LINK = i18n.translate(
-  'xpack.enterpriseSearch.schema.errorsTable.link.view',
-  {
-    defaultMessage: 'View',
-  }
-);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/constants.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ERROR_TABLE_ID_HEADER = i18n.translate(
+  'xpack.enterpriseSearch.schema.errorsTable.heading.id',
+  { defaultMessage: 'ID' }
+);
+
+export const ERROR_TABLE_ERROR_HEADER = i18n.translate(
+  'xpack.enterpriseSearch.schema.errorsTable.heading.error',
+  { defaultMessage: 'Error' }
+);
+
+export const ERROR_TABLE_REVIEW_CONTROL = i18n.translate(
+  'xpack.enterpriseSearch.schema.errorsTable.control.review',
+  { defaultMessage: 'Review' }
+);
+
+export const ERROR_TABLE_VIEW_LINK = i18n.translate(
+  'xpack.enterpriseSearch.schema.errorsTable.link.view',
+  { defaultMessage: 'View' }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
@@ -13,7 +13,9 @@ import { EuiAccordion, EuiTableRow } from '@elastic/eui';
 
 import { EuiButtonEmptyTo } from '../../react_router_helpers';
 
-import { SchemaErrorsAccordion } from './schema_errors_accordion';
+import { SchemaType } from '../types';
+
+import { SchemaErrorsAccordion } from './';
 
 describe('SchemaErrorsAccordion', () => {
   const props = {
@@ -30,8 +32,7 @@ describe('SchemaErrorsAccordion', () => {
       ],
     },
     schema: {
-      id: 'string',
-      name: 'boolean',
+      id: SchemaType.Text,
     },
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
@@ -11,7 +11,7 @@ import { shallow } from 'enzyme';
 
 import { EuiAccordion, EuiTableRow } from '@elastic/eui';
 
-import { EuiButtonEmptyTo } from '../react_router_helpers';
+import { EuiButtonEmptyTo } from '../../react_router_helpers';
 
 import { SchemaErrorsAccordion } from './schema_errors_accordion';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.test.tsx
@@ -9,9 +9,9 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiAccordion, EuiTableRow } from '@elastic/eui';
+import { EuiAccordion, EuiTableRow, EuiTableHeaderCell } from '@elastic/eui';
 
-import { EuiButtonEmptyTo } from '../../react_router_helpers';
+import { EuiLinkTo } from '../../react_router_helpers';
 
 import { SchemaType } from '../types';
 
@@ -41,12 +41,16 @@ describe('SchemaErrorsAccordion', () => {
 
     expect(wrapper.find(EuiAccordion)).toHaveLength(1);
     expect(wrapper.find(EuiTableRow)).toHaveLength(2);
-    expect(wrapper.find(EuiButtonEmptyTo)).toHaveLength(0);
   });
 
-  it('renders document buttons', () => {
-    const wrapper = shallow(<SchemaErrorsAccordion {...props} itemId="123" getRoute={jest.fn()} />);
+  it('conditionally renders a view column', () => {
+    const generateViewPath = jest.fn((id: string) => `/documents/${id}`);
+    const wrapper = shallow(
+      <SchemaErrorsAccordion {...props} generateViewPath={generateViewPath} />
+    );
 
-    expect(wrapper.find(EuiButtonEmptyTo)).toHaveLength(2);
+    expect(wrapper.find(EuiTableHeaderCell)).toHaveLength(3);
+    expect(wrapper.find(EuiLinkTo)).toHaveLength(2);
+    expect(wrapper.find(EuiLinkTo).first().prop('to')).toEqual('/documents/foo');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
@@ -19,7 +19,7 @@ import {
   EuiTableRowCell,
 } from '@elastic/eui';
 
-import { EuiButtonEmptyTo } from '../../react_router_helpers';
+import { EuiLinkTo } from '../../react_router_helpers';
 import { TruncatedContent } from '../../truncate';
 
 import { Schema, FieldCoercionErrors } from '../types';
@@ -36,15 +36,13 @@ import './schema_errors_accordion.scss';
 interface Props {
   fieldCoercionErrors: FieldCoercionErrors;
   schema: Schema;
-  itemId?: string;
-  getRoute?(itemId: string, externalId: string): string;
+  generateViewPath?(externalId: string): string;
 }
 
 export const SchemaErrorsAccordion: React.FC<Props> = ({
   fieldCoercionErrors,
   schema,
-  itemId,
-  getRoute,
+  generateViewPath,
 }) => (
   <>
     {Object.keys(fieldCoercionErrors).map((fieldName) => {
@@ -87,28 +85,22 @@ export const SchemaErrorsAccordion: React.FC<Props> = ({
             <EuiTableHeader>
               <EuiTableHeaderCell>{ERROR_TABLE_ID_HEADER}</EuiTableHeaderCell>
               <EuiTableHeaderCell>{ERROR_TABLE_ERROR_HEADER}</EuiTableHeaderCell>
-              <EuiTableHeaderCell />
+              {generateViewPath && <EuiTableHeaderCell aria-hidden />}
             </EuiTableHeader>
             <EuiTableBody>
               {errors.map((error) => {
                 const { external_id: id, error: errorMessage } = error;
-
-                const showViewButton = getRoute && itemId;
-                const documentPath = getRoute && itemId ? getRoute(itemId, error.external_id) : '';
-
-                const viewButton = showViewButton && (
-                  <EuiTableRowCell>
-                    <EuiButtonEmptyTo to={documentPath}>{ERROR_TABLE_VIEW_LINK}</EuiButtonEmptyTo>
-                  </EuiTableRowCell>
-                );
-
                 return (
                   <EuiTableRow key={`schemaErrorDocument-${fieldName}-${id}`}>
                     <EuiTableRowCell truncateText>
                       <TruncatedContent tooltipType="title" content={id} length={22} />
                     </EuiTableRowCell>
                     <EuiTableRowCell>{errorMessage}</EuiTableRowCell>
-                    {showViewButton ? viewButton : <EuiTableRowCell />}
+                    {generateViewPath && (
+                      <EuiTableRowCell>
+                        <EuiLinkTo to={generateViewPath(id)}>{ERROR_TABLE_VIEW_LINK}</EuiLinkTo>
+                      </EuiTableRowCell>
+                    )}
                   </EuiTableRow>
                 );
               })}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
@@ -20,9 +20,8 @@ import {
   EuiTableRowCell,
 } from '@elastic/eui';
 
-import { EuiButtonEmptyTo } from '../react_router_helpers';
-
-import { TruncatedContent } from '../truncate';
+import { EuiButtonEmptyTo } from '../../react_router_helpers';
+import { TruncatedContent } from '../../truncate';
 
 import './schema_errors_accordion.scss';
 
@@ -31,8 +30,8 @@ import {
   ERROR_TABLE_ERROR_HEADER,
   ERROR_TABLE_REVIEW_CONTROL,
   ERROR_TABLE_VIEW_LINK,
-} from './constants';
-import { FieldCoercionErrors } from './types';
+} from '../constants';
+import { FieldCoercionErrors } from '../types';
 
 interface ISchemaErrorsAccordionProps {
   fieldCoercionErrors: FieldCoercionErrors;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
@@ -22,7 +22,7 @@ import {
 import { EuiButtonEmptyTo } from '../../react_router_helpers';
 import { TruncatedContent } from '../../truncate';
 
-import { FieldCoercionErrors } from '../types';
+import { Schema, FieldCoercionErrors } from '../types';
 
 import {
   ERROR_TABLE_ID_HEADER,
@@ -33,23 +33,23 @@ import {
 
 import './schema_errors_accordion.scss';
 
-interface ISchemaErrorsAccordionProps {
+interface Props {
   fieldCoercionErrors: FieldCoercionErrors;
-  schema: { [key: string]: string };
+  schema: Schema;
   itemId?: string;
   getRoute?(itemId: string, externalId: string): string;
 }
 
-export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
+export const SchemaErrorsAccordion: React.FC<Props> = ({
   fieldCoercionErrors,
   schema,
   itemId,
   getRoute,
 }) => (
   <>
-    {Object.keys(fieldCoercionErrors).map((fieldName, fieldNameIndex) => {
+    {Object.keys(fieldCoercionErrors).map((fieldName) => {
       const fieldType = schema[fieldName];
-      const errorInfos = fieldCoercionErrors[fieldName];
+      const errors = fieldCoercionErrors[fieldName];
 
       const accordionHeader = (
         <EuiFlexGroup
@@ -77,8 +77,8 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
 
       return (
         <EuiAccordion
-          key={fieldNameIndex}
-          id={`accordion${fieldNameIndex}`}
+          key={fieldName}
+          id={`schemaErrorAccordion-${fieldName}`}
           className="schemaErrorsAccordion euiAccordionForm"
           buttonClassName="euiAccordionForm__button"
           buttonContent={accordionHeader}
@@ -90,7 +90,9 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
               <EuiTableHeaderCell />
             </EuiTableHeader>
             <EuiTableBody>
-              {errorInfos.map((error, errorIndex) => {
+              {errors.map((error) => {
+                const { external_id: id, error: errorMessage } = error;
+
                 const showViewButton = getRoute && itemId;
                 const documentPath = getRoute && itemId ? getRoute(itemId, error.external_id) : '';
 
@@ -101,15 +103,11 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
                 );
 
                 return (
-                  <EuiTableRow key={`schema-change-document-error-${fieldName}-${errorIndex}`}>
+                  <EuiTableRow key={`schemaErrorDocument-${fieldName}-${id}`}>
                     <EuiTableRowCell truncateText>
-                      <TruncatedContent
-                        tooltipType="title"
-                        content={error.external_id}
-                        length={22}
-                      />
+                      <TruncatedContent tooltipType="title" content={id} length={22} />
                     </EuiTableRowCell>
-                    <EuiTableRowCell>{error.error}</EuiTableRowCell>
+                    <EuiTableRowCell>{errorMessage}</EuiTableRowCell>
                     {showViewButton ? viewButton : <EuiTableRowCell />}
                   </EuiTableRow>
                 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
@@ -22,15 +22,16 @@ import {
 import { EuiButtonEmptyTo } from '../../react_router_helpers';
 import { TruncatedContent } from '../../truncate';
 
-import './schema_errors_accordion.scss';
+import { FieldCoercionErrors } from '../types';
 
 import {
   ERROR_TABLE_ID_HEADER,
   ERROR_TABLE_ERROR_HEADER,
   ERROR_TABLE_REVIEW_CONTROL,
   ERROR_TABLE_VIEW_LINK,
-} from '../constants';
-import { FieldCoercionErrors } from '../types';
+} from './constants';
+
+import './schema_errors_accordion.scss';
 
 interface ISchemaErrorsAccordionProps {
   fieldCoercionErrors: FieldCoercionErrors;
@@ -78,10 +79,9 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
         <EuiAccordion
           key={fieldNameIndex}
           id={`accordion${fieldNameIndex}`}
-          className="schemaFieldError"
-          buttonClassName="euiAccordionForm__button field-error__header"
+          className="schemaErrorsAccordion euiAccordionForm"
+          buttonClassName="euiAccordionForm__button"
           buttonContent={accordionHeader}
-          paddingSize="xl"
         >
           <EuiTable tableLayout="auto">
             <EuiTableHeader>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/index.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 
 import {
   EuiAccordion,
-  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTable,
@@ -48,25 +47,29 @@ export const SchemaErrorsAccordion: React.FC<ISchemaErrorsAccordionProps> = ({
 }) => (
   <>
     {Object.keys(fieldCoercionErrors).map((fieldName, fieldNameIndex) => {
+      const fieldType = schema[fieldName];
       const errorInfos = fieldCoercionErrors[fieldName];
 
       const accordionHeader = (
-        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="none">
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          gutterSize="xl"
+          responsive={false}
+        >
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup alignItems="center" gutterSize="xl">
-              <EuiFlexItem>
-                <strong>
-                  <TruncatedContent content={fieldName} length={32} />
-                </strong>
-              </EuiFlexItem>
-              <EuiFlexItem>{schema[fieldName]}</EuiFlexItem>
-            </EuiFlexGroup>
+            <strong>
+              <TruncatedContent content={fieldName} length={32} />
+            </strong>
+          </EuiFlexItem>
+          <EuiFlexItem grow>
+            <code>{fieldType}</code>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            {/* href is needed here because a button cannot be nested in a button or console will error and EuiAccordion uses a button to wrap this. */}
-            <EuiButton size="s" href="#">
+            {/* Mock an EuiButton without actually creating one - we shouldn't nest a button within a button */}
+            <div className="euiButton euiButton--primary euiButton--small">
               {ERROR_TABLE_REVIEW_CONTROL}
-            </EuiButton>
+            </div>
           </EuiFlexItem>
         </EuiFlexGroup>
       );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/schema_errors_accordion.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/schema_errors_accordion.scss
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
- .schemaFieldError {
-  border-top: 1px solid $euiColorLightShade;
-
-  &:last-child {
-    border-bottom: 1px solid $euiColorLightShade;
+.schemaErrorsAccordion {
+  // Fixes the accordion button content not stretching to full-width
+  .euiAccordion__button > :last-child {
+    flex-grow: 1;
   }
 
-  // Something about the EuiFlexGroup being inside a button collapses the row of items.
-  // This wrapper div was injected by EUI and had 'with: auto' on it.
-  .euiIEFlexWrapFix {
-    width: 100%;
+  // Tweak spacing
+  .euiAccordion__childWrapper {
+    position: relative;
+    top: -($euiSizeS);
+    padding-left: $euiSizeL;
+    padding-right: $euiSizeL;
+  }
+
+  // Remove extra border-bottom on last table row
+  .euiTableRow:last-child .euiTableRowCell {
+    border-bottom: none;
   }
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/schema_errors_accordion.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/errors_accordion/schema_errors_accordion.scss
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-.schemaFieldError {
+ .schemaFieldError {
   border-top: 1px solid $euiColorLightShade;
 
   &:last-child {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/index.ts
@@ -8,3 +8,4 @@
 export { SchemaAddFieldModal } from './add_field_modal';
 export { SchemaFieldTypeSelect } from './field_type_select';
 export { SchemaErrorsCallout } from './errors_callout';
+export { SchemaErrorsAccordion } from './errors_accordion';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.test.tsx
@@ -14,7 +14,7 @@ import { useParams } from 'react-router-dom';
 
 import { shallow } from 'enzyme';
 
-import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
+import { SchemaErrorsAccordion } from '../../../../../shared/schema';
 
 import { SchemaChangeErrors } from './schema_change_errors';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 
-import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
+import { SchemaErrorsAccordion } from '../../../../../shared/schema';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 
 import { SCHEMA_ERRORS_HEADING } from './constants';
@@ -32,11 +32,7 @@ export const SchemaChangeErrors: React.FC = () => {
   return (
     <>
       <ViewContentHeader title={SCHEMA_ERRORS_HEADING} />
-      <SchemaErrorsAccordion
-        fieldCoercionErrors={fieldCoercionErrors}
-        schema={serverSchema}
-        itemId={sourceId}
-      />
+      <SchemaErrorsAccordion fieldCoercionErrors={fieldCoercionErrors} schema={serverSchema} />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Contains code cleanup/organization and some UI tweaks/changes.

- Code refactors:
  - Move component into its own folder for organization (scss and constants move with it) + add top-level export
  - Prefer unique IDs over index #s for React keys, improve var names, simplify types
  - Simplify "view" logic/props/conditional:
    - Rename prop to match AS's `generateXPath` helpers
    - Remove need for itemId - AS should be able to generate its own URL route without it
- UI refactors:
  - Fix responsive behavior of accordion header
  - Fix accessibility of accordion header - should not use an `<a>` link in a button
  - Add `<code>` markup for field type
  - Fix accessibility of view column - should be totally hidden to screen readers if not present
  - Fix semantics of view link - should be an `<a>` link not a button
  - [Opinionated] Tweak spacing of accordion content
  - CSS cleanup, use some OOTB [EUI classes for the accordion](https://elastic.github.io/eui/#/layout/accordion#styled-for-forms)

### Screencaps

**Closed accordions**: Before (left) / After (right)
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/116902526-16ec0780-abf0-11eb-8e69-eab3f1523cdd.png"> <img width="400" alt="" src="https://user-images.githubusercontent.com/549407/116902536-194e6180-abf0-11eb-951d-102cef407f11.png">

**Mobile accordions**: Before (left) / After (right)
<img width="320" alt="" src="https://user-images.githubusercontent.com/549407/116902760-62061a80-abf0-11eb-89cc-5538f895918b.png"> <img width="320" alt="" src="https://user-images.githubusercontent.com/549407/116902764-63374780-abf0-11eb-8936-5f2261b793d9.png">

**Open accordions**: Before (left) / After (right)
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/116902878-8cf06e80-abf0-11eb-8baa-00c2686de14a.png"> <img width="400" alt="" src="https://user-images.githubusercontent.com/549407/116902884-8e219b80-abf0-11eb-8f12-534c755c1e50.png">

## QA

- Functionally, the error accordion should behave as exactly as before for WS.
- For AS, the "view" link should work (not yet in code, but I've spiked/tested locally and it's working fine)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)