### PR TITLE
[Bug] Fixes #9184

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_es_interval.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/calc_es_interval.ts
@@ -12,7 +12,7 @@ import dateMath, { Unit } from '@elastic/datemath';
 import { parseEsInterval } from '../../../utils';
 
 const unitsDesc = dateMath.unitsDesc;
-const largeMax = unitsDesc.indexOf('M');
+const largeMax = unitsDesc.indexOf('w');
 
 export interface EsInterval {
   expression: string;

--- a/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.test.ts
+++ b/src/plugins/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.test.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 
 import { TimeBuckets, TimeBucketsConfig } from './time_buckets';
 import { autoInterval } from '../../_interval_options';
+import { InvalidEsCalendarIntervalError } from '../../../utils';
 
 describe('TimeBuckets', () => {
   const timeBucketConfig: TimeBucketsConfig = {
@@ -136,5 +137,15 @@ describe('TimeBuckets', () => {
     timeBuckets.getScaledDateFormat();
     const format = timeBuckets.getScaledDateFormat();
     expect(format).toEqual('HH:mm');
+  });
+
+  test('allows days but throws error on weeks', () => {
+    const timeBuckets = new TimeBuckets(timeBucketConfig);
+    timeBuckets.setInterval('14d');
+    const interval = timeBuckets.getInterval(false);
+    expect(interval.esUnit).toEqual('d');
+
+    timeBuckets.setInterval('2w');
+    expect(() => timeBuckets.getInterval(false)).toThrow(InvalidEsCalendarIntervalError);
   });
 });

--- a/test/functional/apps/visualize/_area_chart.ts
+++ b/test/functional/apps/visualize/_area_chart.ts
@@ -505,7 +505,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
 
         it('should show error when calendar interval invalid', async () => {
-          await PageObjects.visEditor.setInterval('14d', { type: 'custom' });
+          await PageObjects.visEditor.setInterval('2w', { type: 'custom' });
           const intervalErrorMessage = await find.byCssSelector(
             '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
           );


### PR DESCRIPTION
## Summary

Resolves #9184

This PR implements @jimczi suggestion from https://github.com/elastic/kibana/issues/9184#issuecomment-831148493, by converting any interval with a unit of `weeks` and above and any value other than `1` into `days`. 

Since `parseEsInterval` is also used by `rollups`, and is validated both on the server and on the client, I moved this validation logic into the`rollup` plugin.

## Testing

Visualizations should now allow creating date histograms with buckets like `2w`, `3M` and `4y`. Internally those are converted into `days`. Note that visualization labels show the intervals in `days`, and if this is an issue, it can be addressed in a separate PR.

Rollups validations and behavior should stay the same. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
