### PR TITLE
[Enterprise Search] Add callouts on product selector for license and trial status

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
@@ -7,13 +7,6 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const LICENSE_CALLOUT_HEADING = i18n.translate(
-  'xpack.enterpriseSearch.licenseCalloutHeading',
-  {
-    defaultMessage: 'Enterprise-grade functionality for teams big and small',
-  }
-);
-
 export const LICENSE_CALLOUT_BODY = i18n.translate('xpack.enterpriseSearch.licenseCalloutBody', {
   defaultMessage:
     'Enterprise authentication via SAML, document-level permission and authorization support, custom search experiences and more are available with a valid Platinum license.',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const LICENSE_CALLOUT_HEADING = i18n.translate(
+  'xpack.enterpriseSearch.licenseCalloutHeading',
+  {
+    defaultMessage: 'Enterprise-grade functionality for teams big and small',
+  }
+);
+
+export const LICENSE_CALLOUT_BODY = i18n.translate('xpack.enterpriseSearch.licenseCalloutBody', {
+  defaultMessage:
+    'Enterprise authentication via SAML, document-level permission and authorization support, custom search experiences and more are available with a valid Platinum license.',
+});
+
+export const LICENSE_CALLOUT_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.licenseCalloutButton',
+  {
+    defaultMessage: 'License management',
+  }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
@@ -15,6 +15,6 @@ export const LICENSE_CALLOUT_BODY = i18n.translate('xpack.enterpriseSearch.licen
 export const LICENSE_CALLOUT_BUTTON = i18n.translate(
   'xpack.enterpriseSearch.licenseCalloutButton',
   {
-    defaultMessage: 'License management',
+    defaultMessage: 'Manage your license',
   }
 );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { LicenseCallout } from './license_callout';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
@@ -26,7 +26,7 @@ describe('LicenseCallout', () => {
     const wrapper = shallow(<LicenseCallout />);
 
     expect(wrapper.find(EuiPanel)).toHaveLength(1);
-    expect(wrapper.find(EuiText)).toHaveLength(3);
+    expect(wrapper.find(EuiText)).toHaveLength(2);
     expect(wrapper.find(EuiButtonTo).prop('to')).toEqual(
       '/app/management/stack/license_management'
     );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../__mocks__';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiPanel, EuiButton, EuiText } from '@elastic/eui';
+
+import { LicenseCallout } from './';
+
+describe('LicenseCallout', () => {
+  it('renders when non-platinum or on trial', () => {
+    setMockValues({
+      hasPlatinumLicense: false,
+      isTrial: true,
+    });
+    const wrapper = shallow(<LicenseCallout />);
+
+    expect(wrapper.find(EuiPanel)).toHaveLength(1);
+    expect(wrapper.find(EuiText)).toHaveLength(3);
+    expect(wrapper.find(EuiButton).prop('href')).toEqual(
+      '/app/management/stack/license_management'
+    );
+  });
+
+  it('does not render for platinum', () => {
+    setMockValues({
+      hasPlatinumLicense: true,
+      isTrial: false,
+    });
+    const wrapper = shallow(<LicenseCallout />);
+
+    expect(wrapper.find(EuiPanel)).toHaveLength(0);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
@@ -11,7 +11,9 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiPanel, EuiButton, EuiText } from '@elastic/eui';
+import { EuiPanel, EuiText } from '@elastic/eui';
+
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 
 import { LicenseCallout } from './';
 
@@ -25,7 +27,7 @@ describe('LicenseCallout', () => {
 
     expect(wrapper.find(EuiPanel)).toHaveLength(1);
     expect(wrapper.find(EuiText)).toHaveLength(3);
-    expect(wrapper.find(EuiButton).prop('href')).toEqual(
+    expect(wrapper.find(EuiButtonTo).prop('to')).toEqual(
       '/app/management/stack/license_management'
     );
   });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
@@ -37,6 +37,6 @@ describe('LicenseCallout', () => {
     });
     const wrapper = shallow(<LicenseCallout />);
 
-    expect(wrapper.find(EuiPanel)).toHaveLength(0);
+    expect(wrapper.isEmptyRender()).toBe(true);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -34,7 +34,7 @@ export const LicenseCallout: React.FC = () => {
         <EuiFlexItem grow={1}>
           <div />
         </EuiFlexItem>
-        <EuiFlexItem grow={2}>
+        <EuiFlexItem>
           <div>
             <EuiButton href="/app/management/stack/license_management">
               <EuiText size="s">{LICENSE_CALLOUT_BUTTON}</EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -9,9 +9,10 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButton, EuiText } from '@elastic/eui';
+import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 
 import { LicensingLogic } from '../../../shared/licensing';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 
 import { PRODUCT_SELECTOR_CALLOUT_HEADING } from '../../constants';
 
@@ -36,9 +37,9 @@ export const LicenseCallout: React.FC = () => {
         </EuiFlexItem>
         <EuiFlexItem>
           <div>
-            <EuiButton href="/app/management/stack/license_management">
+            <EuiButtonTo to="/app/management/stack/license_management" shouldNotCreateHref>
               <EuiText size="s">{LICENSE_CALLOUT_BUTTON}</EuiText>
-            </EuiButton>
+            </EuiButtonTo>
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -38,7 +38,7 @@ export const LicenseCallout: React.FC = () => {
         <EuiFlexItem>
           <div>
             <EuiButtonTo to="/app/management/stack/license_management" shouldNotCreateHref>
-              <EuiText size="s">{LICENSE_CALLOUT_BUTTON}</EuiText>
+              {LICENSE_CALLOUT_BUTTON}
             </EuiButtonTo>
           </div>
         </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -32,15 +32,11 @@ export const LicenseCallout: React.FC = () => {
           </EuiText>
           <EuiText size="s">{LICENSE_CALLOUT_BODY}</EuiText>
         </EuiFlexItem>
-        <EuiFlexItem grow={1}>
-          <div />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <div>
-            <EuiButtonTo to="/app/management/stack/license_management" shouldNotCreateHref>
-              {LICENSE_CALLOUT_BUTTON}
-            </EuiButtonTo>
-          </div>
+        <EuiFlexItem grow={1} />
+        <EuiFlexItem grow={false}>
+          <EuiButtonTo to="/app/management/stack/license_management" shouldNotCreateHref>
+            {LICENSE_CALLOUT_BUTTON}
+          </EuiButtonTo>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -13,7 +13,9 @@ import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButton, EuiText } from '@elasti
 
 import { LicensingLogic } from '../../../shared/licensing';
 
-import { LICENSE_CALLOUT_HEADING, LICENSE_CALLOUT_BODY, LICENSE_CALLOUT_BUTTON } from './constants';
+import { PRODUCT_SELECTOR_CALLOUT_HEADING } from '../../constants';
+
+import { LICENSE_CALLOUT_BODY, LICENSE_CALLOUT_BUTTON } from './constants';
 
 export const LicenseCallout: React.FC = () => {
   const { hasPlatinumLicense, isTrial } = useValues(LicensingLogic);
@@ -25,7 +27,7 @@ export const LicenseCallout: React.FC = () => {
       <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
         <EuiFlexItem grow={7}>
           <EuiText>
-            <h3>{LICENSE_CALLOUT_HEADING}</h3>
+            <h3>{PRODUCT_SELECTOR_CALLOUT_HEADING}</h3>
           </EuiText>
           <EuiText size="s">{LICENSE_CALLOUT_BODY}</EuiText>
         </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButton, EuiText } from '@elastic/eui';
+
+import { LicensingLogic } from '../../../shared/licensing';
+
+import { LICENSE_CALLOUT_HEADING, LICENSE_CALLOUT_BODY, LICENSE_CALLOUT_BUTTON } from './constants';
+
+export const LicenseCallout: React.FC = () => {
+  const { hasPlatinumLicense, isTrial } = useValues(LicensingLogic);
+
+  if (hasPlatinumLicense && !isTrial) return null;
+
+  return (
+    <EuiPanel hasShadow={false} hasBorder className="productCard" paddingSize="l">
+      <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
+        <EuiFlexItem grow={7}>
+          <EuiText>
+            <h3>{LICENSE_CALLOUT_HEADING}</h3>
+          </EuiText>
+          <EuiText size="s">{LICENSE_CALLOUT_BODY}</EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={1}>
+          <div />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <div>
+            <EuiButton href="/app/management/stack/license_management">
+              <EuiText size="s">{LICENSE_CALLOUT_BUTTON}</EuiText>
+            </EuiButton>
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
@@ -32,6 +32,7 @@ describe('ProductSelector', () => {
   });
 
   it('renders the license and trial callouts', () => {
+    setMockValues({ config: { host: 'localhost' } });
     const wrapper = shallow(<ProductSelector access={{}} />);
 
     expect(wrapper.find(TrialCallout)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
@@ -21,14 +21,13 @@ import { TrialCallout } from '../trial_callout';
 import { ProductSelector } from './';
 
 describe('ProductSelector', () => {
-  it('renders the overview page, product cards, setup guide CTAs, & callouts with no host set', () => {
+  it('renders the overview page, product cards, & setup guide CTAs with no host set', () => {
     setMockValues({ config: { host: '' } });
     const wrapper = shallow(<ProductSelector access={{}} />);
 
     expect(wrapper.find(EuiPage).hasClass('enterpriseSearchOverview')).toBe(true);
     expect(wrapper.find(ProductCard)).toHaveLength(2);
     expect(wrapper.find(SetupGuideCta)).toHaveLength(1);
-    expect(wrapper.find(TrialCallout)).toHaveLength(1);
     expect(wrapper.find(LicenseCallout)).toHaveLength(0);
   });
 
@@ -61,9 +60,10 @@ describe('ProductSelector', () => {
       expect(wrapper.find(ProductCard)).toHaveLength(0);
     });
 
-    it('renders the license callout', () => {
+    it('renders the license and trial callouts', () => {
       const wrapper = shallow(<ProductSelector access={{}} />);
 
+      expect(wrapper.find(TrialCallout)).toHaveLength(1);
       expect(wrapper.find(LicenseCallout)).toHaveLength(1);
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
@@ -31,6 +31,13 @@ describe('ProductSelector', () => {
     expect(wrapper.find(LicenseCallout)).toHaveLength(0);
   });
 
+  it('renders the license and trial callouts', () => {
+    const wrapper = shallow(<ProductSelector access={{}} />);
+
+    expect(wrapper.find(TrialCallout)).toHaveLength(1);
+    expect(wrapper.find(LicenseCallout)).toHaveLength(1);
+  });
+
   describe('access checks when host is set', () => {
     beforeEach(() => {
       setMockValues({ config: { host: 'localhost' } });
@@ -58,13 +65,6 @@ describe('ProductSelector', () => {
       const wrapper = shallow(<ProductSelector access={{}} />);
 
       expect(wrapper.find(ProductCard)).toHaveLength(0);
-    });
-
-    it('renders the license and trial callouts', () => {
-      const wrapper = shallow(<ProductSelector access={{}} />);
-
-      expect(wrapper.find(TrialCallout)).toHaveLength(1);
-      expect(wrapper.find(LicenseCallout)).toHaveLength(1);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
@@ -13,19 +13,23 @@ import { shallow } from 'enzyme';
 
 import { EuiPage } from '@elastic/eui';
 
+import { LicenseCallout } from '../license_callout';
 import { ProductCard } from '../product_card';
 import { SetupGuideCta } from '../setup_guide';
+import { TrialCallout } from '../trial_callout';
 
 import { ProductSelector } from './';
 
 describe('ProductSelector', () => {
-  it('renders the overview page, product cards, & setup guide CTAs with no host set', () => {
+  it('renders the overview page, product cards, setup guide CTAs, & callouts with no host set', () => {
     setMockValues({ config: { host: '' } });
     const wrapper = shallow(<ProductSelector access={{}} />);
 
     expect(wrapper.find(EuiPage).hasClass('enterpriseSearchOverview')).toBe(true);
     expect(wrapper.find(ProductCard)).toHaveLength(2);
     expect(wrapper.find(SetupGuideCta)).toHaveLength(1);
+    expect(wrapper.find(TrialCallout)).toHaveLength(1);
+    expect(wrapper.find(LicenseCallout)).toHaveLength(0);
   });
 
   describe('access checks when host is set', () => {
@@ -55,6 +59,12 @@ describe('ProductSelector', () => {
       const wrapper = shallow(<ProductSelector access={{}} />);
 
       expect(wrapper.find(ProductCard)).toHaveLength(0);
+    });
+
+    it('renders the license callout', () => {
+      const wrapper = shallow(<ProductSelector access={{}} />);
+
+      expect(wrapper.find(LicenseCallout)).toHaveLength(1);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
@@ -29,8 +29,10 @@ import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/
 
 import AppSearchImage from '../../assets/app_search.png';
 import WorkplaceSearchImage from '../../assets/workplace_search.png';
+import { LicenseCallout } from '../license_callout';
 import { ProductCard } from '../product_card';
 import { SetupGuideCta } from '../setup_guide';
+import { TrialCallout } from '../trial_callout';
 
 interface ProductSelectorProps {
   access: {
@@ -53,6 +55,7 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({ access }) => {
       <SendTelemetry action="viewed" metric="overview" />
 
       <EuiPageBody>
+        <TrialCallout />
         <EuiPageHeader>
           <EuiPageHeaderSection className="enterpriseSearchOverview__header">
             <EuiTitle size="l">
@@ -88,8 +91,8 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({ access }) => {
               </EuiFlexItem>
             )}
           </EuiFlexGroup>
-          <EuiSpacer />
-          {!config.host && <SetupGuideCta />}
+          <EuiSpacer size="xxl" />
+          {config.host ? <LicenseCallout /> : <SetupGuideCta />}
         </EuiPageContentBody>
       </EuiPageBody>
     </EuiPage>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { EuiPanelTo } from '../../../shared/react_router_helpers';
+import { PRODUCT_SELECTOR_CALLOUT_HEADING } from '../../constants';
 
 import CtaImage from './assets/getting_started.png';
 import './setup_guide_cta.scss';
@@ -20,11 +21,7 @@ export const SetupGuideCta: React.FC = () => (
     <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
       <EuiFlexItem className="enterpriseSearchSetupCta__text">
         <EuiTitle size="s">
-          <h2>
-            {i18n.translate('xpack.enterpriseSearch.overview.setupCta.title', {
-              defaultMessage: 'Enterprise-grade functionality for teams big and small',
-            })}
-          </h2>
+          <h2>{PRODUCT_SELECTOR_CALLOUT_HEADING}</h2>
         </EuiTitle>
         <EuiText size="s" color="subdued">
           {i18n.translate('xpack.enterpriseSearch.overview.setupCta.description', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { TrialCallout } from './trial_callout';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../__mocks__';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiCallOut } from '@elastic/eui';
+
+import { TrialCallout } from './';
+
+describe('TrialCallout', () => {
+  it('renders when non-platinum or on trial', () => {
+    setMockValues({ isTrial: true });
+    const wrapper = shallow(<TrialCallout />);
+
+    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
+  });
+
+  it('does not render when not on trial', () => {
+    setMockValues({ isTrial: false });
+    const wrapper = shallow(<TrialCallout />);
+
+    expect(wrapper.find(EuiCallOut)).toHaveLength(0);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.tsx
@@ -21,18 +21,23 @@ export const TrialCallout: React.FC = () => {
   if (!isTrial) return null;
 
   const title = (
-    <FormattedMessage
-      id="xpack.enterpriseSearch.trialCalloutTitle"
-      defaultMessage="Your Elastic Stack Trial license, which enables Platinum features, expires in {days, plural, one {# day} other {# days}}. {link}"
-      values={{
-        days: moment(license?.expiryDateInMillis).diff(moment({ hours: 0 }), 'days'),
-        link: (
-          <EuiLink href="https://www.elastic.co/subscriptions" target="_blank">
-            <strong>Learn more about Elastic Stack licenses.</strong>
-          </EuiLink>
-        ),
-      }}
-    />
+    <>
+      <FormattedMessage
+        id="xpack.enterpriseSearch.trialCalloutTitle"
+        defaultMessage="Your Elastic Stack Trial license, which enables Platinum features, expires in {days, plural, one {# day} other {# days}}."
+        values={{
+          days: moment(license?.expiryDateInMillis).diff(moment({ hours: 0 }), 'days'),
+        }}
+      />{' '}
+      <EuiLink href="https://www.elastic.co/subscriptions" target="_blank">
+        <u>
+          <FormattedMessage
+            id="xpack.enterpriseSearch.trialCalloutLink"
+            defaultMessage="Learn more about Elastic Stack licenses."
+          />
+        </u>
+      </EuiLink>
+    </>
   );
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.tsx
@@ -42,7 +42,7 @@ export const TrialCallout: React.FC = () => {
 
   return (
     <>
-      <EuiCallOut size="s" title={title} iconType="iInCircle" />
+      <EuiCallOut size="s" title={title} iconType="iInCircle" style={{ margin: '0 auto' }} />
       <EuiSpacer size="xxl" />
     </>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/trial_callout/trial_callout.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+import moment from 'moment';
+
+import { EuiCallOut, EuiLink, EuiSpacer } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { LicensingLogic } from '../../../shared/licensing';
+
+export const TrialCallout: React.FC = () => {
+  const { license, isTrial } = useValues(LicensingLogic);
+
+  if (!isTrial) return null;
+
+  const title = (
+    <FormattedMessage
+      id="xpack.enterpriseSearch.trialCalloutTitle"
+      defaultMessage="Your Elastic Stack Trial license, which enables Platinum features, expires in {days, plural, one {# day} other {# days}}. {link}"
+      values={{
+        days: moment(license?.expiryDateInMillis).diff(moment({ hours: 0 }), 'days'),
+        link: (
+          <EuiLink href="https://www.elastic.co/subscriptions" target="_blank">
+            <strong>Learn more about Elastic Stack licenses.</strong>
+          </EuiLink>
+        ),
+      }}
+    />
+  );
+
+  return (
+    <>
+      <EuiCallOut size="s" title={title} iconType="iInCircle" />
+      <EuiSpacer size="xxl" />
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/constants.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const PRODUCT_SELECTOR_CALLOUT_HEADING = i18n.translate(
+  'xpack.enterpriseSearch.productSelectorCalloutHeading',
+  {
+    defaultMessage: 'Enterprise-grade functionality for teams big and small',
+  }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/constants.ts
@@ -8,7 +8,7 @@
 import { i18n } from '@kbn/i18n';
 
 export const PRODUCT_SELECTOR_CALLOUT_HEADING = i18n.translate(
-  'xpack.enterpriseSearch.productSelectorCalloutHeading',
+  'xpack.enterpriseSearch.productSelectorCalloutTitle',
   {
     defaultMessage: 'Enterprise-grade functionality for teams big and small',
   }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.test.ts
@@ -158,5 +158,34 @@ describe('LicensingLogic', () => {
         expect(LicensingLogic.values.hasGoldLicense).toEqual(false);
       });
     });
+
+    describe('isTrial', () => {
+      it('is true for active trial license', () => {
+        updateLicense({ status: 'active', type: 'trial' });
+        expect(LicensingLogic.values.isTrial).toEqual(true);
+      });
+
+      it('is false if the trial license is expired', () => {
+        updateLicense({ status: 'expired', type: 'trial' });
+        expect(LicensingLogic.values.isTrial).toEqual(false);
+      });
+
+      it('is false for all non-trial licenses', () => {
+        updateLicense({ status: 'active', type: 'basic' });
+        expect(LicensingLogic.values.isTrial).toEqual(false);
+
+        updateLicense({ status: 'active', type: 'standard' });
+        expect(LicensingLogic.values.isTrial).toEqual(false);
+
+        updateLicense({ status: 'active', type: 'gold' });
+        expect(LicensingLogic.values.isTrial).toEqual(false);
+
+        updateLicense({ status: 'active', type: 'platinum' });
+        expect(LicensingLogic.values.isTrial).toEqual(false);
+
+        updateLicense({ status: 'active', type: 'enterprise' });
+        expect(LicensingLogic.values.isTrial).toEqual(false);
+      });
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.ts
@@ -15,6 +15,7 @@ interface LicensingValues {
   licenseSubscription: Subscription | null;
   hasPlatinumLicense: boolean;
   hasGoldLicense: boolean;
+  isTrial: boolean;
 }
 interface LicensingActions {
   setLicense(license: ILicense): ILicense;
@@ -55,6 +56,10 @@ export const LicensingLogic = kea<MakeLogicType<LicensingValues, LicensingAction
         const qualifyingLicenses = ['gold', 'platinum', 'enterprise', 'trial'];
         return license?.isActive && qualifyingLicenses.includes(license?.type);
       },
+    ],
+    isTrial: [
+      (selectors) => [selectors.license],
+      (license) => license?.isActive && license?.type === 'trial',
     ],
   },
   events: ({ props, actions, values }) => ({

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7617,7 +7617,6 @@
     "xpack.enterpriseSearch.overview.productCard.launchButton": "{productName}の起動",
     "xpack.enterpriseSearch.overview.productCard.setupButton": "{productName} のセットアップ",
     "xpack.enterpriseSearch.overview.setupCta.description": "Elastic App Search および Workplace Search を使用して、アプリまたは社内組織に検索を追加できます。検索が簡単になるとどのような利点があるのかについては、動画をご覧ください。",
-    "xpack.enterpriseSearch.overview.setupCta.title": "あらゆる規模のチームに対応するエンタープライズ級の機能",
     "xpack.enterpriseSearch.overview.setupHeading": "セットアップする製品を選択し、開始してください。",
     "xpack.enterpriseSearch.overview.subheading": "開始する製品を選択します。",
     "xpack.enterpriseSearch.productName": "エンタープライズサーチ",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7620,6 +7620,7 @@
     "xpack.enterpriseSearch.overview.setupHeading": "セットアップする製品を選択し、開始してください。",
     "xpack.enterpriseSearch.overview.subheading": "開始する製品を選択します。",
     "xpack.enterpriseSearch.productName": "エンタープライズサーチ",
+    "xpack.enterpriseSearch.productSelectorCalloutTitle": "あらゆる規模のチームに対応するエンタープライズ級の機能",
     "xpack.enterpriseSearch.readOnlyMode.warning": "エンタープライズ サーチは読み取り専用モードです。作成、編集、削除などの変更を実行できません。",
     "xpack.enterpriseSearch.schema.addFieldModal.fieldNameNote.addField": "フィールドの追加",
     "xpack.enterpriseSearch.schema.addFieldModal.fieldNameNote.correct": "フィールド名には、小文字、数字、アンダースコアのみを使用できます。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7690,6 +7690,7 @@
     "xpack.enterpriseSearch.overview.setupHeading": "选择产品进行设置并开始使用。",
     "xpack.enterpriseSearch.overview.subheading": "选择产品开始使用。",
     "xpack.enterpriseSearch.productName": "企业搜索",
+    "xpack.enterpriseSearch.productSelectorCalloutTitle": "适用于大型和小型团队的企业级功能",
     "xpack.enterpriseSearch.readOnlyMode.warning": "企业搜索处于只读模式。您将无法执行更改，例如创建、编辑或删除。",
     "xpack.enterpriseSearch.schema.addFieldModal.fieldNameNote.addField": "添加字段",
     "xpack.enterpriseSearch.schema.addFieldModal.fieldNameNote.correct": "字段名称只能包含小写字母、数字和下划线",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7687,7 +7687,6 @@
     "xpack.enterpriseSearch.overview.productCard.launchButton": "推出 {productName}",
     "xpack.enterpriseSearch.overview.productCard.setupButton": "设置 {productName}",
     "xpack.enterpriseSearch.overview.setupCta.description": "通过 Elastic App Search 和 Workplace Search，将搜索添加到您的应用或内部组织中。观看视频，了解方便易用的搜索功能可以帮您做些什么。",
-    "xpack.enterpriseSearch.overview.setupCta.title": "适用于大型和小型团队的企业级功能",
     "xpack.enterpriseSearch.overview.setupHeading": "选择产品进行设置并开始使用。",
     "xpack.enterpriseSearch.overview.subheading": "选择产品开始使用。",
     "xpack.enterpriseSearch.productName": "企业搜索",


### PR DESCRIPTION
### closes https://github.com/elastic/workplace-search-team/issues/1663

## Summary

This PR adds callouts for both trial users and non-platinum users on the Enterprise Search product selector.

**Notes**
- Because we decided not to have a platinum features page in Kibana, the link text was changed to simply "Manage your license", to match the link in the Stack management of Kibana.
- I chose to hide the licensing callout for users on a Platinum license because we don't have any copy yet on the subscription page and a decision was never made to have a callout for platinum users. If this changes in the future, we can address it in a separate PR.

**Legacy**
![legacy](https://user-images.githubusercontent.com/1869731/116929760-7d8b1880-ac24-11eb-96f7-cba92960f931.png)

**Kibana**
![image](https://user-images.githubusercontent.com/1869731/117052600-8e4b9500-acdd-11eb-80d4-d9e694516522.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
