### PR TITLE
[Security Solution][Endpoint] Trusted apps search throws an error when searching special chars

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.test.ts
@@ -19,7 +19,12 @@ describe('utils', () => {
     });
     it('should parse complex query with term', () => {
       expect(parseQueryFilterToKQL('complex query')).toBe(
-        'exception-list-agnostic.attributes.name:*complex* *query* OR exception-list-agnostic.attributes.description:*complex* *query* OR exception-list-agnostic.attributes.entries.value:*complex* *query* OR exception-list-agnostic.attributes.entries.entries.value:*complex* *query*'
+        'exception-list-agnostic.attributes.name:*complex*query* OR exception-list-agnostic.attributes.description:*complex*query* OR exception-list-agnostic.attributes.entries.value:*complex*query* OR exception-list-agnostic.attributes.entries.entries.value:*complex*query*'
+      );
+    });
+    it('should parse complex query with special chars term', () => {
+      expect(parseQueryFilterToKQL('C:\\tmpes')).toBe(
+        'exception-list-agnostic.attributes.name:*C\\:\\\\tmpes* OR exception-list-agnostic.attributes.description:*C\\:\\\\tmpes* OR exception-list-agnostic.attributes.entries.value:*C\\:\\\\tmpes* OR exception-list-agnostic.attributes.entries.entries.value:*C\\:\\\\tmpes*'
       );
     });
   });

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.test.ts
@@ -19,7 +19,7 @@ describe('utils', () => {
     });
     it('should parse complex query with term', () => {
       expect(parseQueryFilterToKQL('complex query')).toBe(
-        'exception-list-agnostic.attributes.name:*complex*query* OR exception-list-agnostic.attributes.description:*complex*query* OR exception-list-agnostic.attributes.entries.value:*complex*query* OR exception-list-agnostic.attributes.entries.entries.value:*complex*query*'
+        'exception-list-agnostic.attributes.name:*complex\\*query* OR exception-list-agnostic.attributes.description:*complex\\*query* OR exception-list-agnostic.attributes.entries.value:*complex\\*query* OR exception-list-agnostic.attributes.entries.entries.value:*complex\\*query*'
       );
     });
     it('should parse complex query with special chars term', () => {

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.test.ts
@@ -19,7 +19,7 @@ describe('utils', () => {
     });
     it('should parse complex query with term', () => {
       expect(parseQueryFilterToKQL('complex query')).toBe(
-        'exception-list-agnostic.attributes.name:*complex\\*query* OR exception-list-agnostic.attributes.description:*complex\\*query* OR exception-list-agnostic.attributes.entries.value:*complex\\*query* OR exception-list-agnostic.attributes.entries.entries.value:*complex\\*query*'
+        'exception-list-agnostic.attributes.name:*complex*query* OR exception-list-agnostic.attributes.description:*complex*query* OR exception-list-agnostic.attributes.entries.value:*complex*query* OR exception-list-agnostic.attributes.entries.entries.value:*complex*query*'
       );
     });
     it('should parse complex query with special chars term', () => {

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
@@ -5,16 +5,15 @@
  * 2.0.
  */
 
-import { escape } from 'lodash/fp';
-
 export const parseQueryFilterToKQL = (filter: string): string => {
   if (!filter) return '';
   const kuery = [`name`, `description`, `entries.value`, `entries.entries.value`]
     .map(
       (field) =>
-        `exception-list-agnostic.attributes.${field}:*${escape(
-          filter.trim().replace(/\s/gm, '*').replace(/\\/gm, '\\\\').replace(/:/gm, '\\:')
-        )}*`
+        `exception-list-agnostic.attributes.${field}:*${filter
+          .trim()
+          .replace(/([^a-zA-Z0-9])/gm, '\\$&')
+          .replace(/\s/gm, '*')}*`
     )
     .join(' OR ');
 

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
+import { escape } from 'lodash/fp';
+
 export const parseQueryFilterToKQL = (filter: string): string => {
   if (!filter) return '';
   const kuery = [`name`, `description`, `entries.value`, `entries.entries.value`]
     .map(
       (field) =>
-        `exception-list-agnostic.attributes.${field}:*${filter.trim().replace(/\s/gm, '* *')}*`
+        `exception-list-agnostic.attributes.${field}:*${escape(
+          filter.trim().replace(/\s/gm, '*').replace(/\\/gm, '\\\\').replace(/:/gm, '\\:')
+        )}*`
     )
     .join(' OR ');
 

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
@@ -12,7 +12,7 @@ export const parseQueryFilterToKQL = (filter: string): string => {
       (field) =>
         `exception-list-agnostic.attributes.${field}:*${filter
           .trim()
-          .replace(/([^a-zA-Z0-9\s])/gm, '\\$&')
+          .replace(/([^a-zA-Z0-9\s/])/gm, '\\$&')
           .replace(/\s/gm, '*')}*`
     )
     .join(' OR ');

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/store/utils.ts
@@ -12,7 +12,7 @@ export const parseQueryFilterToKQL = (filter: string): string => {
       (field) =>
         `exception-list-agnostic.attributes.${field}:*${filter
           .trim()
-          .replace(/([^a-zA-Z0-9])/gm, '\\$&')
+          .replace(/([^a-zA-Z0-9\s])/gm, '\\$&')
           .replace(/\s/gm, '*')}*`
     )
     .join(' OR ');


### PR DESCRIPTION
## Summary

When you try to search by windows paths with colons and backslashes api throws an error because this characters weren't escaped correctly.
It also happens with other special characters.

![error fixed on trusted apps search](https://user-images.githubusercontent.com/15727784/116993242-796c0300-acd7-11eb-8098-ac3c6b0bfa3a.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
