### PR TITLE
[7.13] [Metrics UI] Use the normalized field for CPU usage for Observability Overview (#98995)

### DIFF
--- a/x-pack/plugins/infra/common/inventory_models/host/metrics/tsvb/host_system_overview.ts
+++ b/x-pack/plugins/infra/common/inventory_models/host/metrics/tsvb/host_system_overview.ts
@@ -24,41 +24,9 @@ export const hostSystemOverview: TSVBMetricModelCreator = (
       split_mode: 'everything',
       metrics: [
         {
-          field: 'system.cpu.user.pct',
-          id: 'avg-cpu-user',
+          field: 'system.cpu.total.norm.pct',
+          id: 'avg-cpu-total',
           type: 'avg',
-        },
-        {
-          field: 'system.cpu.cores',
-          id: 'max-cpu-cores',
-          type: 'max',
-        },
-        {
-          field: 'system.cpu.system.pct',
-          id: 'avg-cpu-system',
-          type: 'avg',
-        },
-        {
-          id: 'calc-user-system-cores',
-          script: '(params.users + params.system) / params.cores',
-          type: 'calculation',
-          variables: [
-            {
-              field: 'avg-cpu-user',
-              id: 'var-users',
-              name: 'users',
-            },
-            {
-              field: 'avg-cpu-system',
-              id: 'var-system',
-              name: 'system',
-            },
-            {
-              field: 'max-cpu-cores',
-              id: 'var-cores',
-              name: 'cores',
-            },
-          ],
         },
       ],
     },

--- a/x-pack/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
+++ b/x-pack/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
@@ -60,7 +60,7 @@ export const createTopNodesQuery = (
           },
           cpu: {
             avg: {
-              field: 'system.cpu.total.pct',
+              field: 'system.cpu.total.norm.pct',
             },
           },
           iowait: {


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [Metrics UI] Use the normalized field for CPU usage for Observability Overview (#98995)