### PR TITLE
[App Search] Create Engine UI polish

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.test.tsx
@@ -15,6 +15,7 @@ import { EngineCreation } from './';
 
 describe('EngineCreation', () => {
   const DEFAULT_VALUES = {
+    isLoading: false,
     name: '',
     rawName: '',
     language: 'Universal',
@@ -85,6 +86,15 @@ describe('EngineCreation', () => {
 
       expect(wrapper.find('[data-test-subj="NewEngineSubmitButton"]').prop('disabled')).toEqual(
         false
+      );
+    });
+
+    it('passes isLoading state', () => {
+      setMockValues({ ...DEFAULT_VALUES, isLoading: true });
+      const wrapper = shallow(<EngineCreation />);
+
+      expect(wrapper.find('[data-test-subj="NewEngineSubmitButton"]').prop('isLoading')).toEqual(
+        true
       );
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation.tsx
@@ -40,7 +40,7 @@ import {
 import { EngineCreationLogic } from './engine_creation_logic';
 
 export const EngineCreation: React.FC = () => {
-  const { name, rawName, language } = useValues(EngineCreationLogic);
+  const { name, rawName, language, isLoading } = useValues(EngineCreationLogic);
   const { setLanguage, setRawName, submitEngine } = useActions(EngineCreationLogic);
 
   return (
@@ -104,10 +104,11 @@ export const EngineCreation: React.FC = () => {
             <EuiSpacer />
             <EuiButton
               disabled={name.length === 0}
+              isLoading={isLoading}
               type="submit"
               data-test-subj="NewEngineSubmitButton"
-              fill
               color="secondary"
+              fill
             >
               {ENGINE_CREATION_FORM_SUBMIT_BUTTON_LABEL}
             </EuiButton>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation_logic.test.ts
@@ -23,6 +23,7 @@ describe('EngineCreationLogic', () => {
   const { setQueuedSuccessMessage, flashAPIErrors } = mockFlashMessageHelpers;
 
   const DEFAULT_VALUES = {
+    isLoading: false,
     name: '',
     rawName: '',
     language: 'Universal',
@@ -61,6 +62,28 @@ describe('EngineCreationLogic', () => {
 
       it('should set name to a sanitized value', () => {
         expect(EngineCreationLogic.values.name).toEqual('name-with-special-characters');
+      });
+    });
+
+    describe('submitEngine', () => {
+      it('sets isLoading to true', () => {
+        mount({ isLoading: false });
+        EngineCreationLogic.actions.submitEngine();
+        expect(EngineCreationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          isLoading: true,
+        });
+      });
+    });
+
+    describe('onSubmitError', () => {
+      it('resets isLoading to false', () => {
+        mount({ isLoading: true });
+        EngineCreationLogic.actions.onSubmitError();
+        expect(EngineCreationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          isLoading: false,
+        });
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_creation/engine_creation_logic.ts
@@ -22,9 +22,11 @@ interface EngineCreationActions {
   setLanguage(language: string): { language: string };
   setRawName(rawName: string): { rawName: string };
   submitEngine(): void;
+  onSubmitError(): void;
 }
 
 interface EngineCreationValues {
+  isLoading: boolean;
   language: string;
   name: string;
   rawName: string;
@@ -37,8 +39,16 @@ export const EngineCreationLogic = kea<MakeLogicType<EngineCreationValues, Engin
     setLanguage: (language) => ({ language }),
     setRawName: (rawName) => ({ rawName }),
     submitEngine: true,
+    onSubmitError: true,
   },
   reducers: {
+    isLoading: [
+      false,
+      {
+        submitEngine: () => true,
+        onSubmitError: () => false,
+      },
+    ],
     language: [
       DEFAULT_LANGUAGE,
       {
@@ -67,6 +77,7 @@ export const EngineCreationLogic = kea<MakeLogicType<EngineCreationValues, Engin
         actions.onEngineCreationSuccess();
       } catch (e) {
         flashAPIErrors(e);
+        actions.onSubmitError();
       }
     },
     onEngineCreationSuccess: () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
@@ -55,7 +55,6 @@ export const EmptyState: React.FC = () => {
             actions={
               <>
                 <EuiButtonTo
-                  iconType="popout"
                   data-test-subj="EmptyStateCreateFirstEngineCta"
                   fill
                   to={ENGINE_CREATION_PATH}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation.test.tsx
@@ -18,6 +18,7 @@ import { MetaEngineCreation } from './';
 
 const DEFAULT_VALUES = {
   // MetaEngineLogic
+  isLoading: false,
   name: 'test-meta-engine',
   rawName: 'test-meta-engine',
   indexedEngineNames: [],
@@ -182,6 +183,14 @@ describe('MetaEngineCreation', () => {
       const submitButton = wrapper.find('[data-test-subj="NewMetaEngineSubmitButton"]');
 
       expect(submitButton.prop('disabled')).toEqual(true);
+    });
+
+    it('passes isLoading state', () => {
+      setMockValues({ ...DEFAULT_VALUES, isLoading: true });
+      const wrapper = shallow(<MetaEngineCreation />);
+      const submitButton = wrapper.find('[data-test-subj="NewMetaEngineSubmitButton"]');
+
+      expect(submitButton.prop('isLoading')).toEqual(true);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation.tsx
@@ -65,7 +65,7 @@ export const MetaEngineCreation: React.FC = () => {
     submitEngine,
   } = useActions(MetaEngineCreationLogic);
 
-  const { rawName, name, indexedEngineNames, selectedIndexedEngineNames } = useValues(
+  const { rawName, name, indexedEngineNames, selectedIndexedEngineNames, isLoading } = useValues(
     MetaEngineCreationLogic
   );
 
@@ -157,10 +157,11 @@ export const MetaEngineCreation: React.FC = () => {
               selectedIndexedEngineNames.length === 0 ||
               selectedIndexedEngineNames.length > maxEnginesPerMetaEngine
             }
+            isLoading={isLoading}
             type="submit"
             data-test-subj="NewMetaEngineSubmitButton"
-            fill
             color="secondary"
+            fill
           >
             {META_ENGINE_CREATION_FORM_SUBMIT_BUTTON_LABEL}
           </EuiButton>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.test.ts
@@ -23,6 +23,7 @@ describe('MetaEngineCreationLogic', () => {
   const { setQueuedSuccessMessage, flashAPIErrors } = mockFlashMessageHelpers;
 
   const DEFAULT_VALUES = {
+    isLoading: false,
     indexedEngineNames: [],
     name: '',
     rawName: '',
@@ -74,6 +75,28 @@ describe('MetaEngineCreationLogic', () => {
           'two',
           'three',
         ]);
+      });
+    });
+
+    describe('submitEngine', () => {
+      it('sets isLoading to true', () => {
+        mount({ isLoading: false });
+        MetaEngineCreationLogic.actions.submitEngine();
+        expect(MetaEngineCreationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          isLoading: true,
+        });
+      });
+    });
+
+    describe('onSubmitError', () => {
+      it('resets isLoading to false', () => {
+        mount({ isLoading: true });
+        MetaEngineCreationLogic.actions.onSubmitError();
+        expect(MetaEngineCreationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          isLoading: false,
+        });
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation_logic.ts
@@ -25,6 +25,7 @@ interface MetaEngineCreationValues {
   name: string;
   rawName: string;
   selectedIndexedEngineNames: string[];
+  isLoading: boolean;
 }
 
 interface MetaEngineCreationActions {
@@ -38,6 +39,7 @@ interface MetaEngineCreationActions {
     selectedIndexedEngineNames: MetaEngineCreationValues['selectedIndexedEngineNames']
   ): { selectedIndexedEngineNames: MetaEngineCreationValues['selectedIndexedEngineNames'] };
   submitEngine(): void;
+  onSubmitError(): void;
 }
 
 export const MetaEngineCreationLogic = kea<
@@ -50,9 +52,17 @@ export const MetaEngineCreationLogic = kea<
     setIndexedEngineNames: (indexedEngineNames) => ({ indexedEngineNames }),
     setRawName: (rawName) => ({ rawName }),
     setSelectedIndexedEngineNames: (selectedIndexedEngineNames) => ({ selectedIndexedEngineNames }),
-    submitEngine: () => null,
+    submitEngine: true,
+    onSubmitError: true,
   },
   reducers: {
+    isLoading: [
+      false,
+      {
+        submitEngine: () => true,
+        onSubmitError: () => false,
+      },
+    ],
     indexedEngineNames: [
       [],
       {
@@ -121,6 +131,7 @@ export const MetaEngineCreationLogic = kea<
         actions.onEngineCreationSuccess();
       } catch (e) {
         flashAPIErrors(e);
+        actions.onSubmitError();
       }
     },
   }),


### PR DESCRIPTION
## Summary

Some UI polish items:

1. Remove incorrect `popout` icon/indicator from the Create Engine button (it stays in-app, it's not an external link)

<img width="500" alt="" src="https://user-images.githubusercontent.com/549407/117076199-e046e780-acea-11eb-88f8-26e54fb14da6.png">

2. Add `isLoading` state to the create engine/create meta engine views. This gives the user some UI affordance/hinting that something is happening, and additionally prevents double-clicking and the "name already exists" error/race condition users sometimes see in ent-search if they double-click the create button.

Basic screencap:
![loading](https://user-images.githubusercontent.com/549407/117076413-3156db80-aceb-11eb-8d39-d8ab474eb0f7.gif)

Screencap with error reset behavior:
![meta-engine-loading](https://user-images.githubusercontent.com/549407/117076450-43d11500-aceb-11eb-927d-0f7c3719a36f.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios