### PR TITLE
[Security Solution] [Endpoint] Update agent status labels and colors

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/agents_summary.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/agents_summary.tsx
@@ -35,7 +35,7 @@ export const AgentsSummary = memo<AgentsSummaryProps>((props) => {
         title: i18n.translate(
           'xpack.securitySolution.endpoint.policyDetails.agentsSummary.totalTitle',
           {
-            defaultMessage: 'Endpoints',
+            defaultMessage: 'Agents',
           }
         ),
         health: '',
@@ -45,10 +45,20 @@ export const AgentsSummary = memo<AgentsSummaryProps>((props) => {
         title: i18n.translate(
           'xpack.securitySolution.endpoint.policyDetails.agentsSummary.onlineTitle',
           {
-            defaultMessage: 'Online',
+            defaultMessage: 'Healthy',
           }
         ),
         health: 'success',
+      },
+      {
+        key: 'error',
+        title: i18n.translate(
+          'xpack.securitySolution.endpoint.policyDetails.agentsSummary.errorTitle',
+          {
+            defaultMessage: 'Unhealthy',
+          }
+        ),
+        health: 'warning',
       },
       {
         key: 'offline',
@@ -58,17 +68,7 @@ export const AgentsSummary = memo<AgentsSummaryProps>((props) => {
             defaultMessage: 'Offline',
           }
         ),
-        health: 'warning',
-      },
-      {
-        key: 'error',
-        title: i18n.translate(
-          'xpack.securitySolution.endpoint.policyDetails.agentsSummary.errorTitle',
-          {
-            defaultMessage: 'Error',
-          }
-        ),
-        health: 'danger',
+        health: 'subdued',
       },
     ];
   }, []);

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_details.test.tsx
@@ -161,7 +161,7 @@ describe('Policy Details', () => {
 
       const agentsSummary = policyView.find('EuiFlexGroup[data-test-subj="policyAgentsSummary"]');
       expect(agentsSummary).toHaveLength(1);
-      expect(agentsSummary.text()).toBe('Endpoints5Online3Offline1Error1');
+      expect(agentsSummary.text()).toBe('Agents5Healthy3Unhealthy1Offline1');
     });
     it('should display cancel button', async () => {
       await asyncActions;


### PR DESCRIPTION
fixes elastic/kibana/issues/97457

## Summary
Policy details agent status labels are updated to be consistent with the table view.
![Screenshot 2021-05-05 at 11 47 47](https://user-images.githubusercontent.com/1849116/117124776-0925b600-ad99-11eb-8e1c-32bd71cbf3ea.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)