### PR TITLE
[Discover] Rebrand legacy table and data grid  to classic table and new table

### DIFF
--- a/src/plugins/discover/public/application/components/top_nav/open_options_popover.test.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_options_popover.test.tsx
@@ -35,7 +35,7 @@ import { OptionsPopover } from './open_options_popover';
 test('should display the correct text if datagrid is selected', () => {
   const element = document.createElement('div');
   const component = mountWithIntl(<OptionsPopover onClose={jest.fn()} anchorElement={element} />);
-  expect(findTestSubject(component, 'docTableMode').text()).toBe('Data grid');
+  expect(findTestSubject(component, 'docTableMode').text()).toBe('New table');
 });
 
 test('should display the correct text if legacy table is selected', () => {
@@ -45,5 +45,5 @@ test('should display the correct text if legacy table is selected', () => {
   uiSettings.set('doc_table:legacy', true);
   const element = document.createElement('div');
   const component = mountWithIntl(<OptionsPopover onClose={jest.fn()} anchorElement={element} />);
-  expect(findTestSubject(component, 'docTableMode').text()).toBe('Legacy table');
+  expect(findTestSubject(component, 'docTableMode').text()).toBe('Classic table');
 });

--- a/src/plugins/discover/public/application/components/top_nav/open_options_popover.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_options_popover.tsx
@@ -32,10 +32,10 @@ export function OptionsPopover(props: OptionsPopoverProps) {
 
   const mode = isLegacy
     ? i18n.translate('discover.openOptionsPopover.legacyTableText', {
-        defaultMessage: 'Legacy table',
+        defaultMessage: 'Classic table',
       })
     : i18n.translate('discover.openOptionsPopover.dataGridText', {
-        defaultMessage: 'Data grid',
+        defaultMessage: 'New table',
       });
 
   return (
@@ -64,7 +64,7 @@ export function OptionsPopover(props: OptionsPopoverProps) {
         <EuiText color="subdued" size="s">
           <FormattedMessage
             id="discover.topNav.openOptionsPopover.description"
-            defaultMessage="The new data grid layout includes enhanced data sorting, drag-and-drop columns, multi-document selection, and a full screen view. Toggle 'Use legacy table' in Advanced Settings to switch modes."
+            defaultMessage="Great news! Discover has better ways to sort data, drag and drop columns, and compare documents. Toggle 'Use classic table' in Advanced Settings to get started."
           />
         </EuiText>
         <EuiSpacer />

--- a/src/plugins/discover/public/application/components/top_nav/open_options_popover.tsx
+++ b/src/plugins/discover/public/application/components/top_nav/open_options_popover.tsx
@@ -74,7 +74,7 @@ export function OptionsPopover(props: OptionsPopoverProps) {
           href={addBasePath(`/app/management/kibana/settings?query=${DOC_TABLE_LEGACY}`)}
         >
           {i18n.translate('discover.openOptionsPopover.goToAdvancedSettings', {
-            defaultMessage: 'Go to Advanced Settings',
+            defaultMessage: 'Get started',
           })}
         </EuiButton>
       </div>

--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -155,13 +155,13 @@ export const getUiSettings: () => Record<string, UiSettingsParams> = () => ({
   },
   [DOC_TABLE_LEGACY]: {
     name: i18n.translate('discover.advancedSettings.docTableVersionName', {
-      defaultMessage: 'Use legacy table',
+      defaultMessage: 'Use classic table',
     }),
     value: true,
     description: i18n.translate('discover.advancedSettings.docTableVersionDescription', {
       defaultMessage:
-        'Discover uses a new table layout that includes better data sorting, drag-and-drop columns, and a full screen ' +
-        'view. Enable this option if you prefer to fall back to the legacy table.',
+        'Discover uses a new table layout that includes better data sorting, drag-and-drop columns, and a full screen view. ' +
+        'Turn on this option to use the classic table. Turn off to use the new table. ',
     }),
     category: ['discover'],
     schema: schema.boolean(),


### PR DESCRIPTION
## Summary

Resolves #99272

This PR rebrands `Legacy table` and `Data grid` to `Classic table` and `New table` in `Discover` and `Advanced settings`. Furthermore description wording is modified.

So it's 
<img width="672" alt="Bildschirmfoto 2021-05-06 um 14 58 46" src="https://user-images.githubusercontent.com/463851/117302708-3a2ae700-ae7c-11eb-85cc-920a330dcfa7.png">
<img width="428" alt="Bildschirmfoto 2021-05-06 um 14 58 35" src="https://user-images.githubusercontent.com/463851/117302712-3bf4aa80-ae7c-11eb-9866-1d2945955f49.png">
<img width="444" alt="Bildschirmfoto 2021-05-06 um 14 58 07" src="https://user-images.githubusercontent.com/463851/117302716-3d25d780-ae7c-11eb-8da1-1dcbbe5a9ab5.png">






### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
