### PR TITLE
[APM] transaction type is not persisted from service inventory

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/home.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/home.spec.ts
@@ -45,4 +45,19 @@ describe('Home page', () => {
     cy.contains('opbeans-java');
     cy.contains('opbeans-node');
   });
+
+  describe('navigations', () => {
+    it('navigates to service overview page with transaction type', () => {
+      const kuery = encodeURIComponent(
+        'transaction.name : "taskManager markAvailableTasksAsClaimed"'
+      );
+      cy.visit(`${baseUrl}&kuery=${kuery}`);
+      cy.contains('taskManager');
+      cy.contains('kibana').click();
+      cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+        'have.value',
+        'taskManager'
+      );
+    });
+  });
 });

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import url from 'url';
+import archives_metadata from '../../../fixtures/es_archiver/archives_metadata';
+import { esArchiverLoad, esArchiverUnload } from '../../../tasks/es_archiver';
+
+const { start, end } = archives_metadata['apm_8.0.0'];
+
+const serviceOverviewPath = '/app/apm/services/opbeans-node/overview';
+const baseUrl = url.format({
+  pathname: serviceOverviewPath,
+  query: { rangeFrom: start, rangeTo: end },
+});
+
+describe('Service Overview', () => {
+  before(() => {
+    esArchiverLoad('apm_8.0.0');
+  });
+  after(() => {
+    esArchiverUnload('apm_8.0.0');
+  });
+  beforeEach(() => {
+    cy.loginAsReadOnlyUser();
+  });
+  it('persists transaction type selected when clicking on Transactions tab', () => {
+    cy.visit(baseUrl);
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'request'
+    );
+    cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'Worker'
+    );
+
+    cy.get('[data-test-subj="tab_transactions"]').click();
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'Worker'
+    );
+  });
+
+  it('persists transaction type selected when clicking on View Transactions link', () => {
+    cy.visit(baseUrl);
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'request'
+    );
+    cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'Worker'
+    );
+
+    cy.contains('View transactions').click();
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'Worker'
+    );
+  });
+});

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/transactions_overview/transactions_overview.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/transactions_overview/transactions_overview.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import url from 'url';
+import archives_metadata from '../../../fixtures/es_archiver/archives_metadata';
+import { esArchiverLoad, esArchiverUnload } from '../../../tasks/es_archiver';
+
+const { start, end } = archives_metadata['apm_8.0.0'];
+
+const serviceOverviewPath = '/app/apm/services/opbeans-node/transactions';
+const baseUrl = url.format({
+  pathname: serviceOverviewPath,
+  query: { rangeFrom: start, rangeTo: end },
+});
+
+describe('Transactions Overview', () => {
+  before(() => {
+    esArchiverLoad('apm_8.0.0');
+  });
+  after(() => {
+    esArchiverUnload('apm_8.0.0');
+  });
+  beforeEach(() => {
+    cy.loginAsReadOnlyUser();
+  });
+  it('persists transaction type selected when clicking on Overview tab', () => {
+    cy.visit(baseUrl);
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'request'
+    );
+    cy.get('[data-test-subj="headerFilterTransactionType"]').select('Worker');
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'Worker'
+    );
+
+    cy.get('[data-test-subj="tab_overview"]').click();
+    cy.get('[data-test-subj="headerFilterTransactionType"]').should(
+      'have.value',
+      'Worker'
+    );
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/service_details/service_detail_tabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_details/service_detail_tabs.tsx
@@ -54,7 +54,7 @@ interface Props {
 }
 
 export function ServiceDetailTabs({ serviceName, tab }: Props) {
-  const { agentName } = useApmServiceContext();
+  const { agentName, transactionType } = useApmServiceContext();
   const {
     core: { uiSettings },
     config,
@@ -65,7 +65,7 @@ export function ServiceDetailTabs({ serviceName, tab }: Props) {
 
   const overviewTab = {
     key: 'overview',
-    href: useServiceOverviewHref(serviceName),
+    href: useServiceOverviewHref({ serviceName, transactionType }),
     text: i18n.translate('xpack.apm.serviceDetails.overviewTabLabel', {
       defaultMessage: 'Overview',
     }),
@@ -76,7 +76,11 @@ export function ServiceDetailTabs({ serviceName, tab }: Props) {
 
   const transactionsTab = {
     key: 'transactions',
-    href: useTransactionsOverviewHref({ serviceName, latencyAggregationType }),
+    href: useTransactionsOverviewHref({
+      serviceName,
+      latencyAggregationType,
+      transactionType,
+    }),
     text: i18n.translate('xpack.apm.serviceDetails.transactionsTabLabel', {
       defaultMessage: 'Transactions',
     }),
@@ -179,7 +183,12 @@ export function ServiceDetailTabs({ serviceName, tab }: Props) {
         {tabs
           .filter((t) => !t.hidden)
           .map(({ href, key, text }) => (
-            <EuiTab href={href} isSelected={key === tab} key={key}>
+            <EuiTab
+              data-test-subj={`tab_${key}`}
+              href={href}
+              isSelected={key === tab}
+              key={key}
+            >
               {text}
             </EuiTab>
           ))}

--- a/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
@@ -97,7 +97,7 @@ export function getServiceColumns({
       }),
       width: '40%',
       sortable: true,
-      render: (_, { serviceName, agentName }) => (
+      render: (_, { serviceName, agentName, transactionType }) => (
         <ToolTipWrapper>
           <EuiToolTip
             delay="long"
@@ -112,7 +112,11 @@ export function getServiceColumns({
                 </EuiFlexItem>
               )}
               <EuiFlexItem className="apmServiceList__serviceNameContainer">
-                <AppLink serviceName={serviceName} className="eui-textTruncate">
+                <AppLink
+                  serviceName={serviceName}
+                  transactionType={transactionType}
+                  className="eui-textTruncate"
+                >
                   {formatString(serviceName)}
                 </AppLink>
               </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_transactions_table/index.tsx
@@ -215,6 +215,7 @@ export function ServiceOverviewTransactionsTable({ serviceName }: Props) {
             <TransactionOverviewLink
               serviceName={serviceName}
               latencyAggregationType={latencyAggregationType}
+              transactionType={transactionType}
             >
               {i18n.translate(
                 'xpack.apm.serviceOverview.transactionsTableLinkText',

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/service_overview_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/service_overview_link.tsx
@@ -7,39 +7,43 @@
 
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
+import { removeUndefinedProps } from '../../../../context/url_params_context/helpers';
 import { APMQueryParams } from '../url_helpers';
 import { APMLinkExtendProps, useAPMHref } from './APMLink';
 
 interface ServiceOverviewLinkProps extends APMLinkExtendProps {
   serviceName: string;
   environment?: string;
+  transactionType?: string;
 }
 
 const persistedFilters: Array<keyof APMQueryParams> = [
   'latencyAggregationType',
 ];
 
-export function useServiceOverviewHref(
-  serviceName: string,
-  environment?: string
-) {
-  const query = environment
-    ? {
-        environment,
-      }
-    : {};
+export function useServiceOverviewHref({
+  serviceName,
+  environment,
+  transactionType,
+}: ServiceOverviewLinkProps) {
+  const query = { environment, transactionType };
   return useAPMHref({
     path: `/services/${serviceName}/overview`,
     persistedFilters,
-    query,
+    query: removeUndefinedProps(query),
   });
 }
 
 export function ServiceOverviewLink({
   serviceName,
   environment,
+  transactionType,
   ...rest
 }: ServiceOverviewLinkProps) {
-  const href = useServiceOverviewHref(serviceName, environment);
+  const href = useServiceOverviewHref({
+    serviceName,
+    environment,
+    transactionType,
+  });
   return <EuiLink href={href} {...rest} />;
 }

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/service_transactions_overview_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/service_transactions_overview_link.test.tsx
@@ -35,7 +35,7 @@ describe('Service or transactions overview link', () => {
   describe('useServiceOrTransactionsOverviewHref', () => {
     it('returns service link', () => {
       const { result } = renderHook(
-        () => useServiceOrTransactionsOverviewHref('foo'),
+        () => useServiceOrTransactionsOverviewHref({ serviceName: 'foo' }),
         { wrapper: wrapper({}) }
       );
       expect(result.current).toEqual('/basepath/app/apm/services/foo');
@@ -43,7 +43,7 @@ describe('Service or transactions overview link', () => {
 
     it('returns service link with persisted query items', () => {
       const { result } = renderHook(
-        () => useServiceOrTransactionsOverviewHref('foo'),
+        () => useServiceOrTransactionsOverviewHref({ serviceName: 'foo' }),
         { wrapper: wrapper({ queryParams: { latencyAggregationType: 'avg' } }) }
       );
       expect(result.current).toEqual(

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/service_transactions_overview_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/service_transactions_overview_link.tsx
@@ -9,6 +9,7 @@ import { EuiLink } from '@elastic/eui';
 import React from 'react';
 import { APMQueryParams } from '../url_helpers';
 import { APMLinkExtendProps, useAPMHref } from './APMLink';
+import { removeUndefinedProps } from '../../../../context/url_params_context/helpers';
 
 const persistedFilters: Array<keyof APMQueryParams> = [
   'transactionResult',
@@ -19,28 +20,35 @@ const persistedFilters: Array<keyof APMQueryParams> = [
   'latencyAggregationType',
 ];
 
-export function useServiceOrTransactionsOverviewHref(
-  serviceName: string,
-  environment?: string
-) {
-  const query = environment ? { environment } : {};
-  return useAPMHref({
-    path: `/services/${serviceName}`,
-    persistedFilters,
-    query,
-  });
-}
-
 interface Props extends APMLinkExtendProps {
   serviceName: string;
   environment?: string;
+  transactionType?: string;
+}
+
+export function useServiceOrTransactionsOverviewHref({
+  serviceName,
+  environment,
+  transactionType,
+}: Props) {
+  const query = { environment, transactionType };
+  return useAPMHref({
+    path: `/services/${serviceName}`,
+    persistedFilters,
+    query: removeUndefinedProps(query),
+  });
 }
 
 export function ServiceOrTransactionsOverviewLink({
   serviceName,
   environment,
+  transactionType,
   ...rest
 }: Props) {
-  const href = useServiceOrTransactionsOverviewHref(serviceName, environment);
+  const href = useServiceOrTransactionsOverviewHref({
+    serviceName,
+    environment,
+    transactionType,
+  });
   return <EuiLink href={href} {...rest} />;
 }

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/transaction_overview_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/transaction_overview_link.tsx
@@ -8,29 +8,31 @@
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { removeUndefinedProps } from '../../../../context/url_params_context/helpers';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { APMLinkExtendProps, getAPMHref } from './APMLink';
 
 interface Props extends APMLinkExtendProps {
   serviceName: string;
   latencyAggregationType?: string;
+  transactionType?: string;
 }
 
 export function useTransactionsOverviewHref({
   serviceName,
   latencyAggregationType,
-}: {
-  serviceName: string;
-  latencyAggregationType?: string;
-}) {
+  transactionType,
+}: Props) {
   const { core } = useApmPluginContext();
   const location = useLocation();
   const { search } = location;
 
+  const query = { latencyAggregationType, transactionType };
+
   return getAPMHref({
     basePath: core.http.basePath,
     path: `/services/${serviceName}/transactions`,
-    query: { ...(latencyAggregationType ? { latencyAggregationType } : {}) },
+    query: removeUndefinedProps(query),
     search,
   });
 }
@@ -38,11 +40,13 @@ export function useTransactionsOverviewHref({
 export function TransactionOverviewLink({
   serviceName,
   latencyAggregationType,
+  transactionType,
   ...rest
 }: Props) {
   const href = useTransactionsOverviewHref({
     serviceName,
     latencyAggregationType,
+    transactionType,
   });
   return <EuiLink href={href} {...rest} />;
 }


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/99317

- Adds transaction type when navigating from service inventory to service overview page
- Persists the transaction type selected when changing tabs (Overview <-> Transactions)
- Persists the transaction type selected when clicking on `View transactions` link
- e2e tests for these scenarios

<img width="1409" alt="Screen Shot 2021-05-05 at 16 06 30" src="https://user-images.githubusercontent.com/55978943/117202562-f53f7b80-adbb-11eb-936c-9bb89dbb57dc.png">
