### PR TITLE
[App Search] Remove reset mappings button from Role mappings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.test.tsx
@@ -8,11 +8,11 @@
 import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../__mocks__';
 
-import React, { MouseEvent } from 'react';
+import React from 'react';
 
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
-import { EuiEmptyPrompt, EuiConfirmModal, EuiPageHeader } from '@elastic/eui';
+import { EuiEmptyPrompt } from '@elastic/eui';
 
 import { Loading } from '../../../shared/loading';
 import { RoleMappingsTable } from '../../../shared/role_mapping';
@@ -22,7 +22,6 @@ import { RoleMappings } from './role_mappings';
 
 describe('RoleMappings', () => {
   const initializeRoleMappings = jest.fn();
-  const handleResetMappings = jest.fn();
   const mockValues = {
     roleMappings: [wsRoleMapping],
     dataLoading: false,
@@ -32,7 +31,6 @@ describe('RoleMappings', () => {
   beforeEach(() => {
     setMockActions({
       initializeRoleMappings,
-      handleResetMappings,
     });
     setMockValues(mockValues);
   });
@@ -55,34 +53,5 @@ describe('RoleMappings', () => {
     const wrapper = shallow(<RoleMappings />);
 
     expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
-  });
-
-  describe('resetMappingsWarningModal', () => {
-    let wrapper: ShallowWrapper;
-
-    beforeEach(() => {
-      wrapper = shallow(<RoleMappings />);
-      const button = wrapper.find(EuiPageHeader).prop('rightSideItems')![0] as any;
-      button.props.onClick();
-    });
-
-    it('renders reset warnings modal', () => {
-      expect(wrapper.find(EuiConfirmModal)).toHaveLength(1);
-    });
-
-    it('hides reset warnings modal', () => {
-      const modal = wrapper.find(EuiConfirmModal);
-      modal.prop('onCancel')();
-
-      expect(wrapper.find(EuiConfirmModal)).toHaveLength(0);
-    });
-
-    it('resets when confirmed', () => {
-      const event = {} as MouseEvent<HTMLButtonElement>;
-      const modal = wrapper.find(EuiConfirmModal);
-      modal.prop('onConfirm')!(event);
-
-      expect(handleResetMappings).toHaveBeenCalled();
-    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.tsx
@@ -5,22 +5,17 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
 import {
-  EuiButton,
-  EuiConfirmModal,
   EuiEmptyPrompt,
-  EuiOverlayMask,
   EuiPageContent,
   EuiPageContentBody,
   EuiPageHeader,
   EuiPanel,
 } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
 
 import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
@@ -34,19 +29,12 @@ import {
 
 import { ROLE_MAPPING_NEW_PATH } from '../../routes';
 
-import {
-  ROLE_MAPPINGS_ENGINE_ACCESS_HEADING,
-  EMPTY_ROLE_MAPPINGS_BODY,
-  ROLE_MAPPINGS_RESET_BUTTON,
-  ROLE_MAPPINGS_RESET_CONFIRM_TITLE,
-  ROLE_MAPPINGS_RESET_CONFIRM_BUTTON,
-  ROLE_MAPPINGS_RESET_CANCEL_BUTTON,
-} from './constants';
+import { ROLE_MAPPINGS_ENGINE_ACCESS_HEADING, EMPTY_ROLE_MAPPINGS_BODY } from './constants';
 import { RoleMappingsLogic } from './role_mappings_logic';
 import { generateRoleMappingPath } from './utils';
 
 export const RoleMappings: React.FC = () => {
-  const { initializeRoleMappings, handleResetMappings, resetState } = useActions(RoleMappingsLogic);
+  const { initializeRoleMappings, resetState } = useActions(RoleMappingsLogic);
   const { roleMappings, multipleAuthProvidersConfig, dataLoading } = useValues(RoleMappingsLogic);
 
   useEffect(() => {
@@ -54,27 +42,7 @@ export const RoleMappings: React.FC = () => {
     return resetState;
   }, []);
 
-  const [isResetWarningVisible, setResetWarningVisibility] = useState(false);
-  const showWarning = () => setResetWarningVisibility(true);
-  const hideWarning = () => setResetWarningVisibility(false);
-
   if (dataLoading) return <Loading />;
-
-  const RESET_MAPPINGS_WARNING_MODAL_BODY = (
-    <FormattedMessage
-      id="xpack.enterpriseSearch.appSearch.resetMappingsWarningModalBody"
-      defaultMessage="{strongText}, and all users who successfully authenticate will be assigned the Owner role and have access to all engines."
-      values={{
-        strongText: (
-          <strong>
-            {i18n.translate('xpack.enterpriseSearch.appSearch.resetMappingsWarningModalBodyBold', {
-              defaultMessage: 'All role mappings will be deleted',
-            })}
-          </strong>
-        ),
-      }}
-    />
-  );
 
   const addMappingButton = <AddRoleMappingButton path={ROLE_MAPPING_NEW_PATH} />;
 
@@ -100,43 +68,16 @@ export const RoleMappings: React.FC = () => {
     />
   );
 
-  const resetMappings = (
-    <EuiButton size="s" color="danger" onClick={showWarning}>
-      {ROLE_MAPPINGS_RESET_BUTTON}
-    </EuiButton>
-  );
-
-  const resetMappingsWarningModal = isResetWarningVisible ? (
-    <EuiOverlayMask>
-      <EuiConfirmModal
-        onCancel={hideWarning}
-        onConfirm={() => handleResetMappings(hideWarning)}
-        title={ROLE_MAPPINGS_RESET_CONFIRM_TITLE}
-        cancelButtonText={ROLE_MAPPINGS_RESET_CANCEL_BUTTON}
-        confirmButtonText={ROLE_MAPPINGS_RESET_CONFIRM_BUTTON}
-        buttonColor="danger"
-        maxWidth={640}
-      >
-        <p>{RESET_MAPPINGS_WARNING_MODAL_BODY}</p>
-      </EuiConfirmModal>
-    </EuiOverlayMask>
-  ) : null;
-
   return (
     <>
       <SetPageChrome trail={[ROLE_MAPPINGS_TITLE]} />
-      <EuiPageHeader
-        rightSideItems={[resetMappings]}
-        pageTitle={ROLE_MAPPINGS_TITLE}
-        description={ROLE_MAPPINGS_DESCRIPTION}
-      />
+      <EuiPageHeader pageTitle={ROLE_MAPPINGS_TITLE} description={ROLE_MAPPINGS_DESCRIPTION} />
       <EuiPageContent hasShadow={false} hasBorder={roleMappings.length > 0}>
         <EuiPageContentBody>
           <FlashMessages />
           {roleMappings.length === 0 ? roleMappingEmptyState : roleMappingsTable}
         </EuiPageContentBody>
       </EuiPageContent>
-      {resetMappingsWarningModal}
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
@@ -311,27 +311,6 @@ describe('RoleMappingsLogic', () => {
       });
     });
 
-    describe('handleResetMappings', () => {
-      const callback = jest.fn();
-      it('calls API and executes callback', async () => {
-        http.post.mockReturnValue(Promise.resolve({}));
-        RoleMappingsLogic.actions.handleResetMappings(callback);
-
-        expect(http.post).toHaveBeenCalledWith('/api/app_search/role_mappings/reset');
-        await nextTick();
-        expect(callback).toHaveBeenCalled();
-      });
-
-      it('handles error', async () => {
-        http.post.mockReturnValue(Promise.reject('this is an error'));
-        RoleMappingsLogic.actions.handleResetMappings(callback);
-        await nextTick();
-
-        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        expect(callback).toHaveBeenCalled();
-      });
-    });
-
     describe('handleSaveMapping', () => {
       const body = {
         roleType: 'owner',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
@@ -64,7 +64,6 @@ interface RoleMappingsActions {
     engineName: string;
     selected: boolean;
   };
-  handleResetMappings(callback: () => void): Function;
   handleRoleChange(roleType: RoleTypes): { roleType: RoleTypes };
   handleSaveMapping(): void;
   initializeRoleMapping(roleId?: string): { roleId?: string };
@@ -113,7 +112,6 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
     initializeRoleMappings: true,
     initializeRoleMapping: (roleId) => ({ roleId }),
     handleDeleteMapping: true,
-    handleResetMappings: (callback) => callback,
     handleSaveMapping: true,
   },
   reducers: {
@@ -296,17 +294,6 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         } catch (e) {
           flashAPIErrors(e);
         }
-      }
-    },
-    handleResetMappings: async (callback) => {
-      const { http } = HttpLogic.values;
-      try {
-        await http.post('/api/app_search/role_mappings/reset');
-        actions.initializeRoleMappings();
-      } catch (e) {
-        flashAPIErrors(e);
-      } finally {
-        callback();
       }
     },
     handleSaveMapping: async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/types.ts
@@ -49,9 +49,6 @@ export interface Role {
 export interface ASRoleMapping extends RoleMapping {
   accessAllEngines: boolean;
   engines: Engine[];
-  toolTip?: {
-    content: string;
-  };
 }
 
 export interface AdvanceRoleType {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -31,4 +31,7 @@ export interface RoleMapping {
   authProvider: string[];
   roleType: string;
   rules: RoleRules;
+  toolTip?: {
+    content: string;
+  };
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.test.ts
@@ -184,27 +184,4 @@ describe('role mappings routes', () => {
       });
     });
   });
-
-  describe('GET /api/app_search/role_mappings/reset', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'post',
-        path: '/api/app_search/role_mappings/reset',
-      });
-
-      registerResetRoleMappingRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/role_mappings/reset',
-      });
-    });
-  });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.test.ts
@@ -11,7 +11,6 @@ import {
   registerRoleMappingsRoute,
   registerRoleMappingRoute,
   registerNewRoleMappingRoute,
-  registerResetRoleMappingRoute,
 } from './role_mappings';
 
 const roleMappingBaseSchema = {

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.ts
@@ -107,24 +107,8 @@ export function registerNewRoleMappingRoute({
   );
 }
 
-export function registerResetRoleMappingRoute({
-  router,
-  enterpriseSearchRequestHandler,
-}: RouteDependencies) {
-  router.post(
-    {
-      path: '/api/app_search/role_mappings/reset',
-      validate: false,
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/role_mappings/reset',
-    })
-  );
-}
-
 export const registerRoleMappingsRoutes = (dependencies: RouteDependencies) => {
   registerRoleMappingsRoute(dependencies);
   registerRoleMappingRoute(dependencies);
   registerNewRoleMappingRoute(dependencies);
-  registerResetRoleMappingRoute(dependencies);
 };


### PR DESCRIPTION
## Summary

This is no longer needed as we move toward the unified Users & roles screen for 7.14

Also moved the `toolTip` type to shared, as Workplace Search also has optional tooltips.