### PR TITLE
[Security Solution] Invalid KQL Query Bug

### DIFF
--- a/x-pack/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/plugins/security_solution/public/app/app.tsx
@@ -64,7 +64,7 @@ const StartAppComponent: FC<StartAppComponent> = ({
                 </UserPrivilegesProvider>
               </MlCapabilitiesProvider>
             </EuiThemeProvider>
-            {/* <ErrorToastDispatcher /> */}
+            <ErrorToastDispatcher />
             <GlobalToaster />
           </ReduxStoreProvider>
         </ManageGlobalToaster>

--- a/x-pack/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/plugins/security_solution/public/app/app.tsx
@@ -64,7 +64,7 @@ const StartAppComponent: FC<StartAppComponent> = ({
                 </UserPrivilegesProvider>
               </MlCapabilitiesProvider>
             </EuiThemeProvider>
-            <ErrorToastDispatcher />
+            {/* <ErrorToastDispatcher /> */}
             <GlobalToaster />
           </ReduxStoreProvider>
         </ManageGlobalToaster>

--- a/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper_hover_content.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper_hover_content.test.tsx
@@ -50,6 +50,7 @@ jest.mock('../../../common/hooks/use_selector', () => ({
   useShallowEqualSelector: jest.fn(),
   useDeepEqualSelector: jest.fn(),
 }));
+jest.mock('../../../common/hooks/use_invalid_filter_query.tsx');
 
 const mockUiSettingsForFilterManager = coreMock.createStart().uiSettings;
 const timelineId = TimelineId.active;

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -6,7 +6,7 @@
  */
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { isEmpty } from 'lodash/fp';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import deepEqual from 'fast-deep-equal';
 
@@ -178,6 +178,13 @@ const EventsViewerComponent: React.FC<Props> = ({
   const { getManageTimelineById, setIsTimelineLoading } = useManageTimeline();
   const { addError } = useAppToasts();
 
+  const handleQueryError = useCallback(
+    (error: Error) => {
+      addError(error, { title: error.name });
+    },
+    [addError]
+  );
+
   useEffect(() => {
     dispatch(timelineActions.updateIsLoading({ id, isLoading: isQueryLoading }));
   }, [dispatch, id, isQueryLoading]);
@@ -209,7 +216,7 @@ const EventsViewerComponent: React.FC<Props> = ({
     kqlQuery: query,
     kqlMode,
     isEventViewer: true,
-    addError,
+    handleError: handleQueryError,
   });
 
   const canQueryTimeline = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -6,7 +6,7 @@
  */
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { isEmpty } from 'lodash/fp';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import deepEqual from 'fast-deep-equal';
 
@@ -55,7 +55,6 @@ import {
   defaultControlColumn,
   ControlColumnProps,
 } from '../../../timelines/components/timeline/body/control_columns';
-import { useAppToasts } from '../../hooks/use_app_toasts';
 
 export const EVENTS_VIEWER_HEADER_HEIGHT = 90; // px
 const UTILITY_BAR_HEIGHT = 19; // px
@@ -176,14 +175,6 @@ const EventsViewerComponent: React.FC<Props> = ({
   const kibana = useKibana();
   const [isQueryLoading, setIsQueryLoading] = useState(false);
   const { getManageTimelineById, setIsTimelineLoading } = useManageTimeline();
-  const { addError } = useAppToasts();
-
-  const handleQueryError = useCallback(
-    (error: Error) => {
-      addError(error, { title: error.name });
-    },
-    [addError]
-  );
 
   useEffect(() => {
     dispatch(timelineActions.updateIsLoading({ id, isLoading: isQueryLoading }));
@@ -216,7 +207,6 @@ const EventsViewerComponent: React.FC<Props> = ({
     kqlQuery: query,
     kqlMode,
     isEventViewer: true,
-    handleError: handleQueryError,
   });
 
   const canQueryTimeline = useMemo(
@@ -257,7 +247,7 @@ const EventsViewerComponent: React.FC<Props> = ({
     sort: sortField,
     startDate: start,
     endDate: end,
-    skip: !canQueryTimeline,
+    skip: !canQueryTimeline || combinedQueries?.filterQuery === undefined,
   });
 
   const totalCountMinusDeleted = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -49,9 +49,13 @@ import {
 import { GraphOverlay } from '../../../timelines/components/graph_overlay';
 import { CellValueElementProps } from '../../../timelines/components/timeline/cell_rendering';
 import { SELECTOR_TIMELINE_GLOBAL_CONTAINER } from '../../../timelines/components/timeline/styles';
-import { defaultControlColumn } from '../../../timelines/components/timeline/body/control_columns';
 import { timelineSelectors, timelineActions } from '../../../timelines/store/timeline';
 import { useDeepEqualSelector } from '../../hooks/use_selector';
+import {
+  defaultControlColumn,
+  ControlColumnProps,
+} from '../../../timelines/components/timeline/body/control_columns';
+import { useAppToasts } from '../../hooks/use_app_toasts';
 
 export const EVENTS_VIEWER_HEADER_HEIGHT = 90; // px
 const UTILITY_BAR_HEIGHT = 19; // px
@@ -171,6 +175,8 @@ const EventsViewerComponent: React.FC<Props> = ({
   const columnsHeader = isEmpty(columns) ? defaultHeaders : columns;
   const kibana = useKibana();
   const [isQueryLoading, setIsQueryLoading] = useState(false);
+  const { getManageTimelineById, setIsTimelineLoading } = useManageTimeline();
+  const { addError } = useAppToasts();
 
   useEffect(() => {
     dispatch(timelineActions.updateIsLoading({ id, isLoading: isQueryLoading }));
@@ -203,6 +209,7 @@ const EventsViewerComponent: React.FC<Props> = ({
     kqlQuery: query,
     kqlMode,
     isEventViewer: true,
+    addError,
   });
 
   const canQueryTimeline = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -247,7 +247,7 @@ const EventsViewerComponent: React.FC<Props> = ({
     sort: sortField,
     startDate: start,
     endDate: end,
-    skip: !canQueryTimeline || combinedQueries?.filterQuery === undefined,
+    skip: !canQueryTimeline || combinedQueries?.filterQuery === undefined, // When the filterQuery comes back as undefined, it means an error has been thrown and the request should be skipped
   });
 
   const totalCountMinusDeleted = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -300,6 +300,7 @@ const EventsViewerComponent: React.FC<Props> = ({
               height={headerFilterGroup ? COMPACT_HEADER_HEIGHT : EVENTS_VIEWER_HEADER_HEIGHT}
               subtitle={utilityBar ? undefined : subtitle}
               title={globalFullScreen ? titleWithExitFullScreen : justTitle}
+              isInspectDisabled={combinedQueries!.filterQuery === undefined}
             >
               {HeaderSectionContent}
             </HeaderSection>

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/events_viewer.tsx
@@ -51,10 +51,7 @@ import { CellValueElementProps } from '../../../timelines/components/timeline/ce
 import { SELECTOR_TIMELINE_GLOBAL_CONTAINER } from '../../../timelines/components/timeline/styles';
 import { timelineSelectors, timelineActions } from '../../../timelines/store/timeline';
 import { useDeepEqualSelector } from '../../hooks/use_selector';
-import {
-  defaultControlColumn,
-  ControlColumnProps,
-} from '../../../timelines/components/timeline/body/control_columns';
+import { defaultControlColumn } from '../../../timelines/components/timeline/body/control_columns';
 
 export const EVENTS_VIEWER_HEADER_HEIGHT = 90; // px
 const UTILITY_BAR_HEIGHT = 19; // px
@@ -174,7 +171,6 @@ const EventsViewerComponent: React.FC<Props> = ({
   const columnsHeader = isEmpty(columns) ? defaultHeaders : columns;
   const kibana = useKibana();
   const [isQueryLoading, setIsQueryLoading] = useState(false);
-  const { getManageTimelineById, setIsTimelineLoading } = useManageTimeline();
 
   useEffect(() => {
     dispatch(timelineActions.updateIsLoading({ id, isLoading: isQueryLoading }));

--- a/x-pack/plugins/security_solution/public/common/components/header_section/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_section/index.tsx
@@ -41,6 +41,7 @@ export interface HeaderSectionProps extends HeaderProps {
   children?: React.ReactNode;
   height?: number;
   id?: string;
+  isInspectDisabled?: boolean;
   split?: boolean;
   subtitle?: string | React.ReactNode;
   title: string | React.ReactNode;
@@ -55,6 +56,7 @@ const HeaderSectionComponent: React.FC<HeaderSectionProps> = ({
   children,
   height,
   id,
+  isInspectDisabled,
   split,
   subtitle,
   title,
@@ -85,7 +87,12 @@ const HeaderSectionComponent: React.FC<HeaderSectionProps> = ({
 
           {id && (
             <EuiFlexItem grow={false}>
-              <InspectButton queryId={id} multiple={inspectMultiple} title={title} />
+              <InspectButton
+                isDisabled={isInspectDisabled}
+                queryId={id}
+                multiple={inspectMultiple}
+                title={title}
+              />
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -91,6 +91,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
   title,
   titleSize,
   yTickFormatter,
+  skip,
 }) => {
   const dispatch = useDispatch();
   const handleBrushEnd = useCallback(
@@ -146,6 +147,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
     stackByField: selectedStackByOption.value,
     isPtrIncluded,
     docValueFields,
+    skip,
   };
 
   const [loading, { data, inspect, totalCount, refetch }] = useMatrixHistogramCombined(

--- a/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/matrix_histogram/index.tsx
@@ -216,6 +216,7 @@ export const MatrixHistogramComponent: React.FC<MatrixHistogramComponentProps> =
             titleSize={titleSize}
             subtitle={subtitleWithCounts}
             inspectMultiple
+            isInspectDisabled={filterQuery === undefined}
           >
             <EuiFlexGroup alignItems="center" gutterSize="none">
               <EuiFlexItem grow={false}>

--- a/x-pack/plugins/security_solution/public/common/components/ml/tables/anomalies_host_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml/tables/anomalies_host_table.tsx
@@ -75,6 +75,7 @@ const AnomaliesHostTableComponent: React.FC<AnomaliesHostTableProps> = ({
           )}`}
           title={i18n.ANOMALIES}
           tooltip={i18n.TOOLTIP}
+          isInspectDisabled={skip}
         />
 
         <BasicTable

--- a/x-pack/plugins/security_solution/public/common/components/ml/tables/anomalies_network_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml/tables/anomalies_network_table.tsx
@@ -65,6 +65,7 @@ const AnomaliesNetworkTableComponent: React.FC<AnomaliesNetworkTableProps> = ({
           )}`}
           title={i18n.ANOMALIES}
           tooltip={i18n.TOOLTIP}
+          isInspectDisabled={skip}
         />
 
         <BasicTable

--- a/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
@@ -262,7 +262,7 @@ export const useMatrixHistogramCombined = (
   const [missingDataLoading, missingDataResponse] = useMatrixHistogram({
     ...matrixHistogramQueryProps,
     includeMissingData: false,
-    skip: skipMissingData,
+    skip: skipMissingData || matrixHistogramQueryProps.filterQuery === undefined,
   });
 
   const combinedLoading = useMemo<boolean>(() => mainLoading || missingDataLoading, [

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect } from 'react';
+import { Query } from 'src/plugins/data/public';
 import { useAppToasts } from './use_app_toasts';
 
 /**
@@ -14,17 +15,23 @@ import { useAppToasts } from './use_app_toasts';
 export const useInvalidFilterQuery = ({
   filterQuery,
   kqlError,
+  query,
+  startDate,
+  endDate,
 }: {
   filterQuery?: string;
   kqlError?: Error;
+  query: Query;
+  startDate: string;
+  endDate: string;
 }) => {
   const { addError } = useAppToasts();
 
   useEffect(() => {
     if (filterQuery === undefined && kqlError != null) {
-      addError(kqlError, { title: kqlError.name });
+      addError(kqlError, { title: kqlError.name, toastMessage: kqlError.message });
     }
     // This disable is required to only trigger the toast once per render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterQuery, addError]);
+  }, [filterQuery, addError, query, startDate, endDate]);
 };

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { EsQueryConfig, Filter, IIndexPattern, Query } from 'src/plugins/data/public';
+import { convertToBuildEsQueryOrError } from '../lib/keury';
+import { useAppToasts } from './use_app_toasts';
+
+export const useInvalidFilterQuery = ({
+  filterQuery,
+  config,
+  indexPattern,
+  queries,
+  filters,
+}: {
+  filterQuery?: string;
+  config: EsQueryConfig;
+  indexPattern: IIndexPattern;
+  queries: Query[];
+  filters: Filter[];
+}) => {
+  const { addError } = useAppToasts();
+
+  useEffect(() => {
+    if (filterQuery === undefined) {
+      const error = convertToBuildEsQueryOrError({
+        config,
+        indexPattern,
+        queries,
+        filters,
+      }) as Error;
+      addError(error, { title: error.name });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterQuery, addError]);
+};

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -29,7 +29,9 @@ export const useInvalidFilterQuery = ({
 
   useEffect(() => {
     if (filterQuery === undefined && kqlError != null) {
-      addError(kqlError, { title: kqlError.name, toastMessage: kqlError.message });
+      // Removes error stack from user view
+      delete kqlError.stack;
+      addError(kqlError, { title: kqlError.name });
     }
     // This disable is required to only trigger the toast once per render
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -5,20 +5,26 @@
  * 2.0.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
 import { Query } from 'src/plugins/data/public';
+import { appSelectors } from '../store';
+import { appActions } from '../store/app';
 import { useAppToasts } from './use_app_toasts';
+import { useDeepEqualSelector } from './use_selector';
 
 /**
  * Adds a toast error message whenever invalid KQL is submitted through the search bar
  */
 export const useInvalidFilterQuery = ({
+  id,
   filterQuery,
   kqlError,
   query,
   startDate,
   endDate,
 }: {
+  id: string;
   filterQuery?: string;
   kqlError?: Error;
   query: Query;
@@ -26,20 +32,33 @@ export const useInvalidFilterQuery = ({
   endDate: string;
 }) => {
   const { addError } = useAppToasts();
+  const dispatch = useDispatch();
+  const getErrorsSelector = useMemo(() => appSelectors.errorsSelector(), []);
+  const errors = useDeepEqualSelector(getErrorsSelector);
 
   useEffect(() => {
     if (filterQuery === undefined && kqlError != null) {
-      // Removes error stack from user view
-      delete kqlError.stack; // Mutates the error object and can possibly lead to side effects, only going this route for type issues. Change when we add a stackless toast error
-      addError(kqlError, { title: kqlError.name });
+      const errorHash = JSON.stringify(kqlError);
+      dispatch(
+        appActions.addErrorHash({
+          id,
+          hash: errorHash,
+          title: kqlError.name,
+          message: [kqlError.message],
+        })
+      );
     }
     // This disable is required to only trigger the toast once per render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterQuery, addError, query, startDate, endDate]);
-};
+  }, [id, filterQuery, addError, query, startDate, endDate]);
 
-/**
- * TODO:
- * fix timeline rerender
- * fix overview rerender
- */
+  useEffect(() => {
+    const myError = errors.find((e) => e.id === id);
+    if (myError != null && myError.displayError && kqlError != null) {
+      // Removes error stack from user view
+      delete kqlError.stack; // Mutates the error object and can possibly lead to side effects, only going this route for type issues. Change when we add a stackless toast error
+
+      addError(kqlError, { title: kqlError.name });
+    }
+  }, [addError, errors, id, kqlError]);
+};

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -37,3 +37,9 @@ export const useInvalidFilterQuery = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterQuery, addError, query, startDate, endDate]);
 };
+
+/**
+ * TODO:
+ * fix timeline rerender
+ * fix overview rerender
+ */

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -38,11 +38,16 @@ export const useInvalidFilterQuery = ({
 
   useEffect(() => {
     if (filterQuery === undefined && kqlError != null) {
-      const errorHash = JSON.stringify(kqlError);
+      // Local util for creating an replicatable error hash
+      const hashCode = kqlError.message
+        .split('')
+        // eslint-disable-next-line no-bitwise
+        .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0)
+        .toString();
       dispatch(
         appActions.addErrorHash({
           id,
-          hash: errorHash,
+          hash: hashCode,
           title: kqlError.name,
           message: [kqlError.message],
         })
@@ -57,7 +62,6 @@ export const useInvalidFilterQuery = ({
     if (myError != null && myError.displayError && kqlError != null) {
       // Removes error stack from user view
       delete kqlError.stack; // Mutates the error object and can possibly lead to side effects, only going this route for type issues. Change when we add a stackless toast error
-      console.log('here');
       addError(kqlError, { title: kqlError.name });
     }
   }, [addError, errors, id, kqlError]);

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -57,7 +57,7 @@ export const useInvalidFilterQuery = ({
     if (myError != null && myError.displayError && kqlError != null) {
       // Removes error stack from user view
       delete kqlError.stack; // Mutates the error object and can possibly lead to side effects, only going this route for type issues. Change when we add a stackless toast error
-
+      console.log('here');
       addError(kqlError, { title: kqlError.name });
     }
   }, [addError, errors, id, kqlError]);

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -30,7 +30,7 @@ export const useInvalidFilterQuery = ({
   useEffect(() => {
     if (filterQuery === undefined && kqlError != null) {
       // Removes error stack from user view
-      delete kqlError.stack;
+      delete kqlError.stack; // Mutates the error object and can possibly lead to side effects, only going this route for type issues. Change when we add a stackless toast error
       addError(kqlError, { title: kqlError.name });
     }
     // This disable is required to only trigger the toast once per render

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -6,35 +6,25 @@
  */
 
 import { useEffect } from 'react';
-import { EsQueryConfig, Filter, IIndexPattern, Query } from 'src/plugins/data/public';
-import { convertToBuildEsQueryOrError } from '../lib/keury';
 import { useAppToasts } from './use_app_toasts';
 
+/**
+ * Adds a toast error message whenever invalid KQL is submitted through the search bar
+ */
 export const useInvalidFilterQuery = ({
   filterQuery,
-  config,
-  indexPattern,
-  queries,
-  filters,
+  kqlError,
 }: {
   filterQuery?: string;
-  config: EsQueryConfig;
-  indexPattern: IIndexPattern;
-  queries: Query[];
-  filters: Filter[];
+  kqlError?: Error;
 }) => {
   const { addError } = useAppToasts();
 
   useEffect(() => {
-    if (filterQuery === undefined) {
-      const error = convertToBuildEsQueryOrError({
-        config,
-        indexPattern,
-        queries,
-        filters,
-      }) as Error;
-      addError(error, { title: error.name });
+    if (filterQuery === undefined && kqlError != null) {
+      addError(kqlError, { title: kqlError.name });
     }
+    // This disable is required to only trigger the toast once per render
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterQuery, addError]);
 };

--- a/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
@@ -71,7 +71,7 @@ const escapeSpecialCharacters = (val: string) => val.replace(/["]/g, '\\$&'); //
 export const escapeKuery = flow(escapeSpecialCharacters, escapeWhitespace);
 
 /**
- * Deprecated in leiu of `convertToBuildEsQueryOrError`
+ * Deprecated in lieu of `convertToBuildEsQueryOrError`
  */
 export const convertToBuildEsQuery = ({
   config,
@@ -83,48 +83,51 @@ export const convertToBuildEsQuery = ({
   indexPattern: IIndexPattern;
   queries: Query[];
   filters: Filter[];
-}): string | undefined => {
+}): [string | undefined, Error | undefined] => {
   try {
-    return JSON.stringify(
-      esQuery.buildEsQuery(
-        indexPattern,
-        queries,
-        filters.filter((f) => f.meta.disabled === false),
-        {
-          ...config,
-          dateFormatTZ: undefined,
-        }
-      )
-    );
-  } catch (exp) {
-    return undefined;
+    return [
+      JSON.stringify(
+        esQuery.buildEsQuery(
+          indexPattern,
+          queries,
+          filters.filter((f) => f.meta.disabled === false),
+          {
+            ...config,
+            dateFormatTZ: undefined,
+          }
+        )
+      ),
+      undefined,
+    ];
+  } catch (error) {
+    return [undefined, error];
   }
 };
 
-export const convertToBuildEsQueryOrError = ({
-  config,
-  indexPattern,
-  queries,
-  filters,
-}: {
-  config: EsQueryConfig;
-  indexPattern: IIndexPattern;
-  queries: Query[];
-  filters: Filter[];
-}): string | Error => {
-  try {
-    return JSON.stringify(
-      esQuery.buildEsQuery(
-        indexPattern,
-        queries,
-        filters.filter((f) => f.meta.disabled === false),
-        {
-          ...config,
-          dateFormatTZ: undefined,
-        }
-      )
-    );
-  } catch (error) {
-    return error;
-  }
-};
+// export const convertToBuildEsQueryOrError = ({
+//   config,
+//   indexPattern,
+//   queries,
+//   filters,
+// }: {
+//   config: EsQueryConfig;
+//   indexPattern: IIndexPattern;
+//   queries: Query[];
+//   filters: Filter[];
+// }): string | Error => {
+//   try {
+//     return JSON.stringify(
+//       esQuery.buildEsQuery(
+//         indexPattern,
+//         queries,
+//         filters.filter((f) => f.meta.disabled === false),
+//         {
+//           ...config,
+//           dateFormatTZ: undefined,
+//         }
+//       )
+//     );
+//   } catch (error) {
+//     return error;
+//   }
+// };

--- a/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
@@ -80,7 +80,7 @@ export const convertToBuildEsQuery = ({
   indexPattern: IIndexPattern;
   queries: Query[];
   filters: Filter[];
-}): [string | undefined, Error | undefined] => {
+}): [string, undefined] | [undefined, Error] => {
   try {
     return [
       JSON.stringify(

--- a/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
@@ -70,18 +70,19 @@ const escapeSpecialCharacters = (val: string) => val.replace(/["]/g, '\\$&'); //
 
 export const escapeKuery = flow(escapeSpecialCharacters, escapeWhitespace);
 
+/**
+ * Deprecated in leiu of `convertToBuildEsQueryOrError`
+ */
 export const convertToBuildEsQuery = ({
   config,
   indexPattern,
   queries,
   filters,
-  handleError,
 }: {
   config: EsQueryConfig;
   indexPattern: IIndexPattern;
   queries: Query[];
   filters: Filter[];
-  handleError: (error: Error) => void;
 }) => {
   try {
     return JSON.stringify(
@@ -95,7 +96,35 @@ export const convertToBuildEsQuery = ({
         }
       )
     );
+  } catch (exp) {
+    return '';
+  }
+};
+
+export const convertToBuildEsQueryOrError = ({
+  config,
+  indexPattern,
+  queries,
+  filters,
+}: {
+  config: EsQueryConfig;
+  indexPattern: IIndexPattern;
+  queries: Query[];
+  filters: Filter[];
+}): string | Error => {
+  try {
+    return JSON.stringify(
+      esQuery.buildEsQuery(
+        indexPattern,
+        queries,
+        filters.filter((f) => f.meta.disabled === false),
+        {
+          ...config,
+          dateFormatTZ: undefined,
+        }
+      )
+    );
   } catch (error) {
-    handleError(error);
+    return error;
   }
 };

--- a/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
@@ -83,7 +83,7 @@ export const convertToBuildEsQuery = ({
   indexPattern: IIndexPattern;
   queries: Query[];
   filters: Filter[];
-}) => {
+}): string | undefined => {
   try {
     return JSON.stringify(
       esQuery.buildEsQuery(
@@ -97,7 +97,7 @@ export const convertToBuildEsQuery = ({
       )
     );
   } catch (exp) {
-    return '';
+    return undefined;
   }
 };
 

--- a/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
@@ -70,9 +70,6 @@ const escapeSpecialCharacters = (val: string) => val.replace(/["]/g, '\\$&'); //
 
 export const escapeKuery = flow(escapeSpecialCharacters, escapeWhitespace);
 
-/**
- * Deprecated in lieu of `convertToBuildEsQueryOrError`
- */
 export const convertToBuildEsQuery = ({
   config,
   indexPattern,
@@ -103,31 +100,3 @@ export const convertToBuildEsQuery = ({
     return [undefined, error];
   }
 };
-
-// export const convertToBuildEsQueryOrError = ({
-//   config,
-//   indexPattern,
-//   queries,
-//   filters,
-// }: {
-//   config: EsQueryConfig;
-//   indexPattern: IIndexPattern;
-//   queries: Query[];
-//   filters: Filter[];
-// }): string | Error => {
-//   try {
-//     return JSON.stringify(
-//       esQuery.buildEsQuery(
-//         indexPattern,
-//         queries,
-//         filters.filter((f) => f.meta.disabled === false),
-//         {
-//           ...config,
-//           dateFormatTZ: undefined,
-//         }
-//       )
-//     );
-//   } catch (error) {
-//     return error;
-//   }
-// };

--- a/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/keury/index.ts
@@ -75,11 +75,13 @@ export const convertToBuildEsQuery = ({
   indexPattern,
   queries,
   filters,
+  handleError,
 }: {
   config: EsQueryConfig;
   indexPattern: IIndexPattern;
   queries: Query[];
   filters: Filter[];
+  handleError: (error: Error) => void;
 }) => {
   try {
     return JSON.stringify(
@@ -93,7 +95,7 @@ export const convertToBuildEsQuery = ({
         }
       )
     );
-  } catch (exp) {
-    return '';
+  } catch (error) {
+    handleError(error);
   }
 };

--- a/x-pack/plugins/security_solution/public/common/store/app/actions.ts
+++ b/x-pack/plugins/security_solution/public/common/store/app/actions.ts
@@ -20,3 +20,10 @@ export const addError = actionCreator<{ id: string; title: string; message: stri
 );
 
 export const removeError = actionCreator<{ id: string }>('REMOVE_ERRORS');
+
+export const addErrorHash = actionCreator<{
+  id: string;
+  hash: string;
+  title: string;
+  message: string[];
+}>('ADD_ERROR_HASH');

--- a/x-pack/plugins/security_solution/public/common/store/app/model.ts
+++ b/x-pack/plugins/security_solution/public/common/store/app/model.ts
@@ -18,6 +18,8 @@ export interface Error {
   id: string;
   title: string;
   message: string[];
+  hash?: string;
+  displayError?: boolean;
 }
 
 export type ErrorModel = Error[];

--- a/x-pack/plugins/security_solution/public/common/store/app/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/app/reducer.ts
@@ -49,7 +49,6 @@ export const appReducer = reducerWithInitialState(initialAppState)
   .case(addErrorHash, (state, { id, hash, title, message }) => {
     const errorIdx = state.errors.findIndex((e) => e.id === id);
     const errorObj = state.errors.find((e) => e.id === id) || { id, title, message };
-    console.log(state, errorIdx, errorObj);
     if (errorIdx === -1) {
       return {
         ...state,

--- a/x-pack/plugins/security_solution/public/common/store/app/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/app/reducer.ts
@@ -9,7 +9,7 @@ import { reducerWithInitialState } from 'typescript-fsa-reducers';
 
 import { Note } from '../../lib/note';
 
-import { addError, addNotes, removeError, updateNote } from './actions';
+import { addError, addErrorHash, addNotes, removeError, updateNote } from './actions';
 import { AppModel, NotesById } from './model';
 
 export type AppState = AppModel;
@@ -46,4 +46,17 @@ export const appReducer = reducerWithInitialState(initialAppState)
     ...state,
     errors: state.errors.filter((error) => error.id !== id),
   }))
+  .case(addErrorHash, (state, { id, hash, title, message }) => {
+    const errorIdx = state.errors.findIndex((e) => e.id === id);
+    const errorObj = state.errors.find((e) => e.id === id) || { id, title, message };
+
+    return {
+      ...state,
+      errors: [
+        ...state.errors.slice(0, errorIdx),
+        { ...errorObj, hash, displayError: !state.errors.some((e) => e.hash === hash) },
+        ...state.errors.slice(errorIdx + 1),
+      ],
+    };
+  })
   .build();

--- a/x-pack/plugins/security_solution/public/common/store/app/reducer.ts
+++ b/x-pack/plugins/security_solution/public/common/store/app/reducer.ts
@@ -49,7 +49,17 @@ export const appReducer = reducerWithInitialState(initialAppState)
   .case(addErrorHash, (state, { id, hash, title, message }) => {
     const errorIdx = state.errors.findIndex((e) => e.id === id);
     const errorObj = state.errors.find((e) => e.id === id) || { id, title, message };
-
+    console.log(state, errorIdx, errorObj);
+    if (errorIdx === -1) {
+      return {
+        ...state,
+        errors: state.errors.concat({
+          ...errorObj,
+          hash,
+          displayError: !state.errors.some((e) => e.hash === hash),
+        }),
+      };
+    }
     return {
       ...state,
       errors: [

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/index.tsx
@@ -129,6 +129,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
     // create a unique, but stable (across re-renders) query id
     const uniqueQueryId = useMemo(() => `${DETECTIONS_HISTOGRAM_ID}-${uuid.v4()}`, []);
     const [isInitialLoading, setIsInitialLoading] = useState(true);
+    const [isInspectDisabled, setIsInspectDisabled] = useState(false);
     const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
     const [totalAlertsObj, setTotalAlertsObj] = useState<AlertsTotal>(defaultTotalAlertsObj);
     const [selectedStackByOption, setSelectedStackByOption] = useState<AlertsHistogramOption>(
@@ -261,7 +262,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
             }
           );
         }
-
+        setIsInspectDisabled(false);
         setAlertsQuery(
           getAlertsHistogramQuery(
             selectedStackByOption.value,
@@ -271,6 +272,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
           )
         );
       } catch (e) {
+        setIsInspectDisabled(true);
         setAlertsQuery(getAlertsHistogramQuery(selectedStackByOption.value, from, to, []));
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -305,6 +307,7 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
             title={titleText}
             titleSize={onlyField == null ? 'm' : 's'}
             subtitle={!isInitialLoading && showTotalAlertsCount && totalAlerts}
+            isInspectDisabled={isInspectDisabled}
           >
             <EuiFlexGroup alignItems="center" gutterSize="none">
               <EuiFlexItem grow={false}>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -136,6 +136,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
 
   useInvalidFilterQuery({
     filterQuery: getGlobalQuery([])?.filterQuery,
+    kqlError: getGlobalQuery([])?.kqlError,
   });
 
   const setEventsLoadingCallback = useCallback(

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -104,7 +104,8 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
   } = useSourcererScope(SourcererScopeName.detections);
   const kibana = useKibana();
   const [, dispatchToaster] = useStateToaster();
-  const { addWarning } = useAppToasts();
+  const { addWarning, addError } = useAppToasts();
+  const { initializeTimeline, setSelectAll } = useManageTimeline();
   // TODO: Once we are past experimental phase this code should be removed
   const ruleRegistryEnabled = useIsExperimentalFeatureEnabled('ruleRegistryEnabled');
 
@@ -125,11 +126,22 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
           kqlQuery: globalQuery,
           kqlMode: globalQuery.language,
           isEventViewer: true,
+          addError,
         });
       }
       return null;
     },
-    [browserFields, defaultFilters, globalFilters, globalQuery, indexPatterns, kibana, to, from]
+    [
+      browserFields,
+      defaultFilters,
+      globalFilters,
+      globalQuery,
+      indexPatterns,
+      kibana,
+      to,
+      from,
+      addError,
+    ]
   );
 
   const setEventsLoadingCallback = useCallback(

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -106,7 +106,6 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
   const kibana = useKibana();
   const [, dispatchToaster] = useStateToaster();
   const { addWarning } = useAppToasts();
-  const { initializeTimeline, setSelectAll } = useManageTimeline();
   // TODO: Once we are past experimental phase this code should be removed
   const ruleRegistryEnabled = useIsExperimentalFeatureEnabled('ruleRegistryEnabled');
 

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -137,6 +137,9 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
   useInvalidFilterQuery({
     filterQuery: getGlobalQuery([])?.filterQuery,
     kqlError: getGlobalQuery([])?.kqlError,
+    query: globalQuery,
+    startDate: from,
+    endDate: to,
   });
 
   const setEventsLoadingCallback = useCallback(

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -136,10 +136,6 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
 
   useInvalidFilterQuery({
     filterQuery: getGlobalQuery([])?.filterQuery,
-    config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
-    indexPattern: indexPatterns,
-    queries: [globalQuery],
-    filters: [...(defaultFilters ?? []), ...globalFilters, ...buildTimeRangeFilter(from, to)],
   });
 
   const setEventsLoadingCallback = useCallback(

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -135,6 +135,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
   );
 
   useInvalidFilterQuery({
+    id: timelineId,
     filterQuery: getGlobalQuery([])?.filterQuery,
     kqlError: getGlobalQuery([])?.kqlError,
     query: globalQuery,

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_query.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_query.tsx
@@ -50,6 +50,7 @@ export const useQueryAlerts = <Hit, Aggs>({
     refetch: null,
   });
   const [loading, setLoading] = useState(false);
+  console.log('Query', query);
 
   useEffect(() => {
     let isSubscribed = true;

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_query.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_query.tsx
@@ -50,7 +50,6 @@ export const useQueryAlerts = <Hit, Aggs>({
     refetch: null,
   });
   const [loading, setLoading] = useState(false);
-  console.log('Query', query);
 
   useEffect(() => {
     let isSubscribed = true;

--- a/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/components/kpi_hosts/types.ts
@@ -9,7 +9,7 @@ import { UpdateDateRange } from '../../../common/components/charts/common';
 import { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 
 export interface HostsKpiProps {
-  filterQuery: string;
+  filterQuery?: string;
   from: string;
   to: string;
   indexNames: string[];

--- a/x-pack/plugins/security_solution/public/hosts/containers/hosts/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/containers/hosts/index.tsx
@@ -33,7 +33,7 @@ import { InspectResponse } from '../../../types';
 import { useTransforms } from '../../../transforms/containers/use_transforms';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 
-const ID = 'hostsAllQuery';
+export const ID = 'hostsAllQuery';
 
 type LoadPage = (newActivePage: number) => void;
 export interface HostsArgs {

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/details_tabs.tsx
@@ -70,7 +70,7 @@ export const HostDetailsTabs = React.memo<HostDetailsTabsProps>(
       deleteQuery,
       endDate: to,
       filterQuery,
-      skip: isInitializing,
+      skip: isInitializing || filterQuery === undefined,
       setQuery,
       startDate: from,
       type,

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
@@ -104,20 +104,14 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     indexNames: selectedPatterns,
     skip: selectedPatterns.length === 0,
   });
-  const filterQuery = convertToBuildEsQuery({
+  const [filterQuery, kqlError] = convertToBuildEsQuery({
     config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
     indexPattern,
     queries: [query],
     filters: getFilters(),
   });
 
-  useInvalidFilterQuery({
-    filterQuery,
-    config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
-    indexPattern,
-    queries: [query],
-    filters: getFilters(),
-  });
+  useInvalidFilterQuery({ filterQuery, kqlError });
 
   useEffect(() => {
     dispatch(setHostDetailsTablesActivePageToZero());

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
@@ -51,6 +51,7 @@ import { useSourcererScope } from '../../../common/containers/sourcerer';
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../../common/hooks/use_selector';
 import { useHostDetails } from '../../containers/hosts/details';
 import { manageQuery } from '../../../common/components/page/manage_query';
+import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 
 const HostOverviewManage = manageQuery(HostOverview);
 
@@ -104,6 +105,14 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     skip: selectedPatterns.length === 0,
   });
   const filterQuery = convertToBuildEsQuery({
+    config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
+    indexPattern,
+    queries: [query],
+    filters: getFilters(),
+  });
+
+  useInvalidFilterQuery({
+    filterQuery,
     config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
     indexPattern,
     queries: [query],

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
@@ -111,7 +111,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     filters: getFilters(),
   });
 
-  useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
   useEffect(() => {
     dispatch(setHostDetailsTablesActivePageToZero());

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
@@ -49,7 +49,7 @@ import { TimelineId } from '../../../../common/types/timeline';
 import { timelineDefaults } from '../../../timelines/store/timeline/defaults';
 import { useSourcererScope } from '../../../common/containers/sourcerer';
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../../common/hooks/use_selector';
-import { useHostDetails } from '../../containers/hosts/details';
+import { ID, useHostDetails } from '../../containers/hosts/details';
 import { manageQuery } from '../../../common/components/page/manage_query';
 import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 
@@ -111,7 +111,7 @@ const HostDetailsComponent: React.FC<HostDetailsProps> = ({ detailName, hostDeta
     filters: getFilters(),
   });
 
-  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
+  useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
 
   useEffect(() => {
     dispatch(setHostDetailsTablesActivePageToZero());

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/types.ts
@@ -61,7 +61,7 @@ export type HostDetailsTabsProps = HostBodyComponentDispatchProps &
     docValueFields?: DocValueFields[];
     indexNames: string[];
     pageFilters?: Filter[];
-    filterQuery: string;
+    filterQuery?: string;
     indexPattern: IIndexPattern;
     type: hostsModel.HostsType;
   };

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -203,7 +203,7 @@ const HostsComponent = () => {
               deleteQuery={deleteQuery}
               docValueFields={docValueFields}
               to={to}
-              filterQuery={tabsFilterQuery || ''} // TODO: is this the right thing to do
+              filterQuery={tabsFilterQuery || ''}
               isInitializing={isInitializing}
               indexNames={selectedPatterns}
               setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -132,7 +132,7 @@ const HostsComponent = () => {
     [indexPattern, query, tabsFilters, uiSettings]
   );
 
-  useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const onSkipFocusBeforeEventsTable = useCallback(() => {
     containerElement.current

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -111,7 +111,7 @@ const HostsComponent = () => {
     [dispatch]
   );
   const { docValueFields, indicesExist, indexPattern, selectedPatterns } = useSourcererScope();
-  const filterQuery = useMemo(
+  const [filterQuery, kqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: esQuery.getEsQueryConfig(uiSettings),
@@ -121,7 +121,7 @@ const HostsComponent = () => {
       }),
     [filters, indexPattern, uiSettings, query]
   );
-  const tabsFilterQuery = useMemo(
+  const [tabsFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: esQuery.getEsQueryConfig(uiSettings),
@@ -132,13 +132,7 @@ const HostsComponent = () => {
     [indexPattern, query, tabsFilters, uiSettings]
   );
 
-  useInvalidFilterQuery({
-    filterQuery,
-    config: esQuery.getEsQueryConfig(uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery, kqlError });
 
   const onSkipFocusBeforeEventsTable = useCallback(() => {
     containerElement.current

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -53,6 +53,7 @@ import { timelineDefaults } from '../../timelines/store/timeline/defaults';
 import { useSourcererScope } from '../../common/containers/sourcerer';
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../common/hooks/use_selector';
 import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_query';
+import { ID } from '../containers/hosts';
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -132,7 +133,7 @@ const HostsComponent = () => {
     [indexPattern, query, tabsFilters, uiSettings]
   );
 
-  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
+  useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const onSkipFocusBeforeEventsTable = useCallback(() => {
     containerElement.current

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts.tsx
@@ -52,6 +52,7 @@ import { timelineSelectors } from '../../timelines/store/timeline';
 import { timelineDefaults } from '../../timelines/store/timeline/defaults';
 import { useSourcererScope } from '../../common/containers/sourcerer';
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../common/hooks/use_selector';
+import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_query';
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -131,6 +132,14 @@ const HostsComponent = () => {
     [indexPattern, query, tabsFilters, uiSettings]
   );
 
+  useInvalidFilterQuery({
+    filterQuery,
+    config: esQuery.getEsQueryConfig(uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
+
   const onSkipFocusBeforeEventsTable = useCallback(() => {
     containerElement.current
       ?.querySelector<HTMLButtonElement>('.inspectButtonComponent:last-of-type')
@@ -183,7 +192,7 @@ const HostsComponent = () => {
                 from={from}
                 setQuery={setQuery}
                 to={to}
-                skip={isInitializing}
+                skip={isInitializing || !filterQuery}
                 narrowDateRange={narrowDateRange}
               />
 
@@ -200,7 +209,7 @@ const HostsComponent = () => {
               deleteQuery={deleteQuery}
               docValueFields={docValueFields}
               to={to}
-              filterQuery={tabsFilterQuery}
+              filterQuery={tabsFilterQuery || ''} // TODO: is this the right thing to do
               isInitializing={isInitializing}
               indexNames={selectedPatterns}
               setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}

--- a/x-pack/plugins/security_solution/public/hosts/pages/hosts_tabs.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/hosts_tabs.tsx
@@ -69,7 +69,7 @@ export const HostsTabs = memo<HostsTabsProps>(
       endDate: to,
       filterQuery,
       indexNames,
-      skip: isInitializing,
+      skip: isInitializing || filterQuery === undefined,
       setQuery,
       startDate: from,
       type,

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/types.ts
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/types.ts
@@ -44,7 +44,7 @@ export type HostsComponentsQueryProps = QueryTabBodyProps & {
 };
 
 export type AlertsComponentQueryProps = HostsComponentsQueryProps & {
-  filterQuery: string;
+  filterQuery?: string;
   pageFilters?: Filter[];
 };
 

--- a/x-pack/plugins/security_solution/public/network/components/kpi_network/types.ts
+++ b/x-pack/plugins/security_solution/public/network/components/kpi_network/types.ts
@@ -9,7 +9,7 @@ import { UpdateDateRange } from '../../../common/components/charts/common';
 import { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 
 export interface NetworkKpiProps {
-  filterQuery: string;
+  filterQuery?: string;
   from: string;
   indexNames: string[];
   to: string;

--- a/x-pack/plugins/security_solution/public/network/containers/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/containers/details/index.tsx
@@ -26,7 +26,7 @@ import { getInspectResponse } from '../../../helpers';
 import { InspectResponse } from '../../../types';
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 
-const ID = 'networkDetailsQuery';
+export const ID = 'networkDetailsQuery';
 
 export interface NetworkDetailsArgs {
   id: string;

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
@@ -49,6 +49,7 @@ import { esQuery } from '../../../../../../../src/plugins/data/public';
 import { networkModel } from '../../store';
 import { SecurityPageName } from '../../../app/types';
 import { useSourcererScope } from '../../../common/containers/sourcerer';
+import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 export { getBreadcrumbs } from './utils';
 
 const NetworkDetailsManage = manageQuery(IpOverview);
@@ -94,6 +95,14 @@ const NetworkDetailsComponent: React.FC = () => {
   const { docValueFields, indicesExist, indexPattern, selectedPatterns } = useSourcererScope();
   const ip = decodeIpv6(detailName);
   const filterQuery = convertToBuildEsQuery({
+    config: esQuery.getEsQueryConfig(uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
+
+  useInvalidFilterQuery({
+    filterQuery,
     config: esQuery.getEsQueryConfig(uiSettings),
     indexPattern,
     queries: [query],
@@ -174,7 +183,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   flowTarget={FlowTargetSourceDest.source}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing}
+                  skip={isInitializing || filterQuery === undefined}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -189,7 +198,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   filterQuery={filterQuery}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing}
+                  skip={isInitializing || filterQuery === undefined}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -208,7 +217,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   flowTarget={FlowTargetSourceDest.source}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing}
+                  skip={isInitializing || filterQuery === undefined}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -223,7 +232,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   filterQuery={filterQuery}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing}
+                  skip={isInitializing || filterQuery === undefined}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -240,7 +249,7 @@ const NetworkDetailsComponent: React.FC = () => {
               flowTarget={flowTarget}
               indexNames={selectedPatterns}
               ip={ip}
-              skip={isInitializing}
+              skip={isInitializing || filterQuery === undefined}
               startDate={from}
               type={type}
               setQuery={setQuery}
@@ -253,7 +262,7 @@ const NetworkDetailsComponent: React.FC = () => {
               filterQuery={filterQuery}
               indexNames={selectedPatterns}
               ip={ip}
-              skip={isInitializing}
+              skip={isInitializing || filterQuery === undefined}
               startDate={from}
               type={type}
               setQuery={setQuery}
@@ -268,7 +277,7 @@ const NetworkDetailsComponent: React.FC = () => {
               indexNames={selectedPatterns}
               ip={ip}
               setQuery={setQuery}
-              skip={isInitializing}
+              skip={isInitializing || filterQuery === undefined}
               startDate={from}
               type={type}
             />
@@ -280,7 +289,7 @@ const NetworkDetailsComponent: React.FC = () => {
               setQuery={setQuery}
               startDate={from}
               endDate={to}
-              skip={isInitializing}
+              skip={isInitializing || filterQuery === undefined}
               indexNames={selectedPatterns}
               ip={ip}
               type={type}

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
@@ -94,20 +94,14 @@ const NetworkDetailsComponent: React.FC = () => {
 
   const { docValueFields, indicesExist, indexPattern, selectedPatterns } = useSourcererScope();
   const ip = decodeIpv6(detailName);
-  const filterQuery = convertToBuildEsQuery({
+  const [filterQuery, kqlError] = convertToBuildEsQuery({
     config: esQuery.getEsQueryConfig(uiSettings),
     indexPattern,
     queries: [query],
     filters,
   });
 
-  useInvalidFilterQuery({
-    filterQuery,
-    config: esQuery.getEsQueryConfig(uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery, kqlError });
 
   const [loading, { id, inspect, networkDetails, refetch }] = useNetworkDetails({
     docValueFields,

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
@@ -123,6 +123,12 @@ const NetworkDetailsComponent: React.FC = () => {
     ip,
   ]);
 
+  // When the filterQuery comes back as undefined, it means an error has been thrown and the request should be skipped
+  const shouldSkip = useMemo(() => isInitializing || filterQuery === undefined, [
+    isInitializing,
+    filterQuery,
+  ]);
+
   return (
     <div data-test-subj="network-details-page">
       {indicesExist ? (
@@ -177,7 +183,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   flowTarget={FlowTargetSourceDest.source}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing || filterQuery === undefined}
+                  skip={shouldSkip}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -192,7 +198,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   filterQuery={filterQuery}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing || filterQuery === undefined}
+                  skip={shouldSkip}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -211,7 +217,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   flowTarget={FlowTargetSourceDest.source}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing || filterQuery === undefined}
+                  skip={shouldSkip}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -226,7 +232,7 @@ const NetworkDetailsComponent: React.FC = () => {
                   filterQuery={filterQuery}
                   indexNames={selectedPatterns}
                   ip={ip}
-                  skip={isInitializing || filterQuery === undefined}
+                  skip={shouldSkip}
                   startDate={from}
                   type={type}
                   setQuery={setQuery}
@@ -243,7 +249,7 @@ const NetworkDetailsComponent: React.FC = () => {
               flowTarget={flowTarget}
               indexNames={selectedPatterns}
               ip={ip}
-              skip={isInitializing || filterQuery === undefined}
+              skip={shouldSkip}
               startDate={from}
               type={type}
               setQuery={setQuery}
@@ -256,7 +262,7 @@ const NetworkDetailsComponent: React.FC = () => {
               filterQuery={filterQuery}
               indexNames={selectedPatterns}
               ip={ip}
-              skip={isInitializing || filterQuery === undefined}
+              skip={shouldSkip}
               startDate={from}
               type={type}
               setQuery={setQuery}
@@ -271,7 +277,7 @@ const NetworkDetailsComponent: React.FC = () => {
               indexNames={selectedPatterns}
               ip={ip}
               setQuery={setQuery}
-              skip={isInitializing || filterQuery === undefined}
+              skip={shouldSkip}
               startDate={from}
               type={type}
             />
@@ -283,7 +289,7 @@ const NetworkDetailsComponent: React.FC = () => {
               setQuery={setQuery}
               startDate={from}
               endDate={to}
-              skip={isInitializing || filterQuery === undefined}
+              skip={shouldSkip}
               indexNames={selectedPatterns}
               ip={ip}
               type={type}

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
@@ -101,7 +101,7 @@ const NetworkDetailsComponent: React.FC = () => {
     filters,
   });
 
-  useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const [loading, { id, inspect, networkDetails, refetch }] = useNetworkDetails({
     docValueFields,

--- a/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/details/index.tsx
@@ -29,7 +29,7 @@ import { FlowTargetSelectConnected } from '../../components/flow_target_select_c
 import { IpOverview } from '../../components/details';
 import { SiemSearchBar } from '../../../common/components/search_bar';
 import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
-import { useNetworkDetails } from '../../containers/details';
+import { useNetworkDetails, ID } from '../../containers/details';
 import { useKibana } from '../../../common/lib/kibana';
 import { decodeIpv6 } from '../../../common/lib/helpers';
 import { convertToBuildEsQuery } from '../../../common/lib/keury';
@@ -101,7 +101,7 @@ const NetworkDetailsComponent: React.FC = () => {
     filters,
   });
 
-  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
+  useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const [loading, { id, inspect, networkDetails, refetch }] = useNetworkDetails({
     docValueFields,

--- a/x-pack/plugins/security_solution/public/network/pages/details/types.ts
+++ b/x-pack/plugins/security_solution/public/network/pages/details/types.ts
@@ -21,7 +21,7 @@ export interface OwnProps {
   type: NetworkType;
   startDate: string;
   endDate: string;
-  filterQuery: string | ESTermQuery;
+  filterQuery?: string | ESTermQuery;
   ip: string;
   indexNames: string[];
   skip: boolean;

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -51,6 +51,7 @@ import { TimelineId } from '../../../common/types/timeline';
 import { timelineDefaults } from '../../timelines/store/timeline/defaults';
 import { useSourcererScope } from '../../common/containers/sourcerer';
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../common/hooks/use_selector';
+import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_query';
 
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
@@ -146,6 +147,14 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       filters: tabsFilters,
     });
 
+    useInvalidFilterQuery({
+      filterQuery,
+      config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
+      indexPattern,
+      queries: [query],
+      filters,
+    });
+
     return (
       <>
         {indicesExist ? (
@@ -184,7 +193,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
                   indexNames={selectedPatterns}
                   narrowDateRange={narrowDateRange}
                   setQuery={setQuery}
-                  skip={isInitializing}
+                  skip={isInitializing || filterQuery === undefined}
                   to={to}
                 />
               </Display>

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -147,7 +147,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       filters: tabsFilters,
     });
 
-    useInvalidFilterQuery({ filterQuery, kqlError });
+    useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
     return (
       <>

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -134,26 +134,20 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       [containerElement, onSkipFocusBeforeEventsTable, onSkipFocusAfterEventsTable]
     );
 
-    const filterQuery = convertToBuildEsQuery({
+    const [filterQuery, kqlError] = convertToBuildEsQuery({
       config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
       indexPattern,
       queries: [query],
       filters,
     });
-    const tabsFilterQuery = convertToBuildEsQuery({
+    const [tabsFilterQuery] = convertToBuildEsQuery({
       config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
       indexPattern,
       queries: [query],
       filters: tabsFilters,
     });
 
-    useInvalidFilterQuery({
-      filterQuery,
-      config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
-      indexPattern,
-      queries: [query],
-      filters,
-    });
+    useInvalidFilterQuery({ filterQuery, kqlError });
 
     return (
       <>

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -52,7 +52,6 @@ import { timelineDefaults } from '../../timelines/store/timeline/defaults';
 import { useSourcererScope } from '../../common/containers/sourcerer';
 import { useDeepEqualSelector, useShallowEqualSelector } from '../../common/hooks/use_selector';
 import { useInvalidFilterQuery } from '../../common/hooks/use_invalid_filter_query';
-
 /**
  * Need a 100% height here to account for the graph/analyze tool, which sets no explicit height parameters, but fills the available space.
  */
@@ -61,6 +60,8 @@ const StyledFullHeightContainer = styled.div`
   flex-direction: column;
   flex: 1 1 auto;
 `;
+
+const ID = 'NetworkQueryId';
 
 const NetworkComponent = React.memo<NetworkComponentProps>(
   ({ hasMlUserPermissions, capabilitiesFetched }) => {
@@ -147,7 +148,7 @@ const NetworkComponent = React.memo<NetworkComponentProps>(
       filters: tabsFilters,
     });
 
-    useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
+    useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
 
     return (
       <>

--- a/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
@@ -33,6 +33,7 @@ import { GlobalTimeArgs } from '../../../common/containers/use_global_time';
 import { SecurityPageName } from '../../../app/types';
 import { useFormatUrl } from '../../../common/components/link_to';
 import { LinkButton } from '../../../common/components/links';
+import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 
 const ID = 'alertsByCategoryOverview';
 
@@ -111,6 +112,14 @@ const AlertsByCategoryComponent: React.FC<Props> = ({
       }),
     [filters, indexPattern, uiSettings, query]
   );
+
+  useInvalidFilterQuery({
+    filterQuery,
+    config: esQuery.getEsQueryConfig(uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
 
   useEffect(() => {
     return () => {

--- a/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
@@ -113,7 +113,7 @@ const AlertsByCategoryComponent: React.FC<Props> = ({
     [filters, indexPattern, uiSettings, query]
   );
 
-  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
+  useInvalidFilterQuery({ id: ID, filterQuery, kqlError, query, startDate: from, endDate: to });
 
   useEffect(() => {
     return () => {

--- a/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
@@ -113,7 +113,7 @@ const AlertsByCategoryComponent: React.FC<Props> = ({
     [filters, indexPattern, uiSettings, query]
   );
 
-  useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
   useEffect(() => {
     return () => {

--- a/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/alerts_by_category/index.tsx
@@ -102,7 +102,7 @@ const AlertsByCategoryComponent: React.FC<Props> = ({
     []
   );
 
-  const filterQuery = useMemo(
+  const [filterQuery, kqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: esQuery.getEsQueryConfig(uiSettings),
@@ -113,13 +113,7 @@ const AlertsByCategoryComponent: React.FC<Props> = ({
     [filters, indexPattern, uiSettings, query]
   );
 
-  useInvalidFilterQuery({
-    filterQuery,
-    config: esQuery.getEsQueryConfig(uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery, kqlError });
 
   useEffect(() => {
     return () => {

--- a/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -46,7 +46,7 @@ const EventCountsComponent: React.FC<Props> = ({
 }) => {
   const { uiSettings } = useKibana().services;
 
-  const hostFilterQuery = useMemo(
+  const [hostFilterQuery, hostKqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: esQuery.getEsQueryConfig(uiSettings),
@@ -57,7 +57,7 @@ const EventCountsComponent: React.FC<Props> = ({
     [filters, indexPattern, query, uiSettings]
   );
 
-  const networkFilterQuery = useMemo(
+  const [networkFilterQuery, networkKqlError] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: esQuery.getEsQueryConfig(uiSettings),
@@ -68,21 +68,9 @@ const EventCountsComponent: React.FC<Props> = ({
     [filters, indexPattern, uiSettings, query]
   );
 
-  useInvalidFilterQuery({
-    filterQuery: hostFilterQuery,
-    config: esQuery.getEsQueryConfig(uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery: hostFilterQuery, kqlError: hostKqlError });
 
-  useInvalidFilterQuery({
-    filterQuery: networkFilterQuery,
-    config: esQuery.getEsQueryConfig(uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery: networkFilterQuery, kqlError: networkKqlError });
 
   return (
     <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">

--- a/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -68,9 +68,21 @@ const EventCountsComponent: React.FC<Props> = ({
     [filters, indexPattern, uiSettings, query]
   );
 
-  useInvalidFilterQuery({ filterQuery: hostFilterQuery, kqlError: hostKqlError });
+  useInvalidFilterQuery({
+    filterQuery: hostFilterQuery,
+    kqlError: hostKqlError,
+    query,
+    startDate: from,
+    endDate: to,
+  });
 
-  useInvalidFilterQuery({ filterQuery: networkFilterQuery, kqlError: networkKqlError });
+  useInvalidFilterQuery({
+    filterQuery: networkFilterQuery,
+    kqlError: networkKqlError,
+    query,
+    startDate: from,
+    endDate: to,
+  });
 
   return (
     <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">

--- a/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -9,6 +9,7 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
+import { ID as OverviewHostQueryId } from '../../containers/overview_host';
 import { OverviewHost } from '../overview_host';
 import { OverviewNetwork } from '../overview_network';
 import { filterHostData } from '../../../hosts/pages/navigation/alerts_query_tab_body';
@@ -57,7 +58,7 @@ const EventCountsComponent: React.FC<Props> = ({
     [filters, indexPattern, query, uiSettings]
   );
 
-  const [networkFilterQuery, networkKqlError] = useMemo(
+  const [networkFilterQuery] = useMemo(
     () =>
       convertToBuildEsQuery({
         config: esQuery.getEsQueryConfig(uiSettings),
@@ -69,6 +70,7 @@ const EventCountsComponent: React.FC<Props> = ({
   );
 
   useInvalidFilterQuery({
+    id: OverviewHostQueryId,
     filterQuery: hostFilterQuery || networkFilterQuery,
     kqlError: hostKqlError,
     query,

--- a/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -69,16 +69,8 @@ const EventCountsComponent: React.FC<Props> = ({
   );
 
   useInvalidFilterQuery({
-    filterQuery: hostFilterQuery,
+    filterQuery: hostFilterQuery || networkFilterQuery,
     kqlError: hostKqlError,
-    query,
-    startDate: from,
-    endDate: to,
-  });
-
-  useInvalidFilterQuery({
-    filterQuery: networkFilterQuery,
-    kqlError: networkKqlError,
     query,
     startDate: from,
     endDate: to,

--- a/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/event_counts/index.tsx
@@ -22,6 +22,7 @@ import {
   Query,
 } from '../../../../../../../src/plugins/data/public';
 import { GlobalTimeArgs } from '../../../common/containers/use_global_time';
+import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 
 const HorizontalSpacer = styled(EuiFlexItem)`
   width: 24px;
@@ -66,6 +67,22 @@ const EventCountsComponent: React.FC<Props> = ({
       }),
     [filters, indexPattern, uiSettings, query]
   );
+
+  useInvalidFilterQuery({
+    filterQuery: hostFilterQuery,
+    config: esQuery.getEsQueryConfig(uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
+
+  useInvalidFilterQuery({
+    filterQuery: networkFilterQuery,
+    config: esQuery.getEsQueryConfig(uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
 
   return (
     <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -129,7 +129,14 @@ const EventsByDatasetComponent: React.FC<Props> = ({
     return [combinedQueries];
   }, [combinedQueries, kibana, indexPattern, query, filters]);
 
-  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
+  useInvalidFilterQuery({
+    id: uniqueQueryId,
+    filterQuery,
+    kqlError,
+    query,
+    startDate: from,
+    endDate: to,
+  });
 
   const eventsByDatasetHistogramConfigs: MatrixHistogramConfigs = useMemo(
     () => ({

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -117,20 +117,19 @@ const EventsByDatasetComponent: React.FC<Props> = ({
     [goToHostEvents, formatUrl]
   );
 
-  const [filterQuery, kqlError] = useMemo(
-    () =>
-      combinedQueries == null
-        ? convertToBuildEsQuery({
-            config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
-            indexPattern,
-            queries: [query],
-            filters,
-          })
-        : combinedQueries,
-    [combinedQueries, kibana, indexPattern, query, filters]
-  );
+  const [filterQuery, kqlError] = useMemo(() => {
+    if (combinedQueries == null) {
+      return convertToBuildEsQuery({
+        config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
+        indexPattern,
+        queries: [query],
+        filters,
+      });
+    }
+    return [combinedQueries];
+  }, [combinedQueries, kibana, indexPattern, query, filters]);
 
-  // useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError });
 
   const eventsByDatasetHistogramConfigs: MatrixHistogramConfigs = useMemo(
     () => ({

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -36,6 +36,7 @@ import * as i18n from '../../pages/translations';
 import { SecurityPageName } from '../../../app/types';
 import { useFormatUrl } from '../../../common/components/link_to';
 import { LinkButton } from '../../../common/components/links';
+import { useInvalidFilterQuery } from '../../../common/hooks/use_invalid_filter_query';
 
 const DEFAULT_STACK_BY = 'event.dataset';
 
@@ -128,6 +129,14 @@ const EventsByDatasetComponent: React.FC<Props> = ({
         : combinedQueries,
     [combinedQueries, kibana, indexPattern, query, filters]
   );
+
+  useInvalidFilterQuery({
+    filterQuery,
+    config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
 
   const eventsByDatasetHistogramConfigs: MatrixHistogramConfigs = useMemo(
     () => ({

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -129,7 +129,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
     return [combinedQueries];
   }, [combinedQueries, kibana, indexPattern, query, filters]);
 
-  useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const eventsByDatasetHistogramConfigs: MatrixHistogramConfigs = useMemo(
     () => ({

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -180,6 +180,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
       setAbsoluteRangeDatePickerTarget={setAbsoluteRangeDatePickerTarget}
       setQuery={setQuery}
       showSpacer={showSpacer}
+      skip={filterQuery === undefined}
       startDate={from}
       timelineId={timelineId}
       {...eventsByDatasetHistogramConfigs}

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -117,7 +117,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
     [goToHostEvents, formatUrl]
   );
 
-  const filterQuery = useMemo(
+  const [filterQuery, kqlError] = useMemo(
     () =>
       combinedQueries == null
         ? convertToBuildEsQuery({
@@ -130,13 +130,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
     [combinedQueries, kibana, indexPattern, query, filters]
   );
 
-  useInvalidFilterQuery({
-    filterQuery,
-    config: esQuery.getEsQueryConfig(kibana.services.uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  // useInvalidFilterQuery({ filterQuery, kqlError });
 
   const eventsByDatasetHistogramConfigs: MatrixHistogramConfigs = useMemo(
     () => ({

--- a/x-pack/plugins/security_solution/public/overview/components/overview_host/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_host/index.tsx
@@ -51,6 +51,7 @@ const OverviewHostComponent: React.FC<OverviewHostProps> = ({
     filterQuery,
     indexNames,
     startDate,
+    skip: filterQuery === undefined,
   });
 
   const goToHost = useCallback(
@@ -117,7 +118,12 @@ const OverviewHostComponent: React.FC<OverviewHostProps> = ({
     <EuiFlexItem>
       <InspectButtonContainer>
         <EuiPanel hasBorder>
-          <HeaderSection id={OverviewHostQueryId} subtitle={subtitle} title={title}>
+          <HeaderSection
+            id={OverviewHostQueryId}
+            subtitle={subtitle}
+            title={title}
+            isInspectDisabled={filterQuery === undefined}
+          >
             <>{hostPageButton}</>
           </HeaderSection>
 

--- a/x-pack/plugins/security_solution/public/overview/components/overview_network/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_network/index.tsx
@@ -53,6 +53,7 @@ const OverviewNetworkComponent: React.FC<OverviewNetworkProps> = ({
     filterQuery,
     indexNames,
     startDate,
+    skip: filterQuery === undefined,
   });
 
   const goToNetwork = useCallback(
@@ -123,7 +124,12 @@ const OverviewNetworkComponent: React.FC<OverviewNetworkProps> = ({
       <InspectButtonContainer>
         <EuiPanel hasBorder data-test-subj="overview-network-query">
           <>
-            <HeaderSection id={OverviewNetworkQueryId} subtitle={subtitle} title={title}>
+            <HeaderSection
+              id={OverviewNetworkQueryId}
+              subtitle={subtitle}
+              title={title}
+              isInspectDisabled={filterQuery === undefined}
+            >
               {networkPageButton}
             </HeaderSection>
 

--- a/x-pack/plugins/security_solution/public/overview/containers/overview_network/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/containers/overview_network/index.tsx
@@ -74,7 +74,7 @@ export const useNetworkOverview = ({
 
   const overviewNetworkSearch = useCallback(
     (request: NetworkOverviewRequestOptions | null) => {
-      if (request == null) {
+      if (request == null || skip) {
         return;
       }
 
@@ -118,7 +118,7 @@ export const useNetworkOverview = ({
       asyncSearch();
       refetch.current = asyncSearch;
     },
-    [data.search, addError, addWarning]
+    [data.search, addError, addWarning, skip]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
@@ -134,7 +134,7 @@ const FlyoutHeaderPanelComponent: React.FC<FlyoutHeaderPanelProps> = ({ timeline
                     queryId={`${timelineId}-${activeTab}`}
                     inputId="timeline"
                     inspectIndex={0}
-                    isDisabled={!isDataInTimeline}
+                    isDisabled={!isDataInTimeline || kqlQuery.filterQuery === undefined}
                     title={i18n.INSPECT_TIMELINE_TITLE}
                   />
                 </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
@@ -69,6 +69,9 @@ interface FlyoutHeaderPanelProps {
 
 const FlyoutHeaderPanelComponent: React.FC<FlyoutHeaderPanelProps> = ({ timelineId }) => {
   const dispatch = useDispatch();
+  const { indexPattern, browserFields } = useSourcererScope(SourcererScopeName.timeline);
+  const { uiSettings } = useKibana().services;
+  const esQueryConfig = useMemo(() => esQuery.getEsQueryConfig(uiSettings), [uiSettings]);
   const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
   const {
     activeTab,
@@ -79,6 +82,8 @@ const FlyoutHeaderPanelComponent: React.FC<FlyoutHeaderPanelProps> = ({ timeline
     status: timelineStatus,
     updated,
     show,
+    filters,
+    kqlMode,
   } = useDeepEqualSelector((state) =>
     pick(
       [
@@ -90,6 +95,8 @@ const FlyoutHeaderPanelComponent: React.FC<FlyoutHeaderPanelProps> = ({ timeline
         'timelineType',
         'updated',
         'show',
+        'filters',
+        'kqlMode',
       ],
       getTimeline(state, timelineId) ?? timelineDefaults
     )
@@ -97,6 +104,30 @@ const FlyoutHeaderPanelComponent: React.FC<FlyoutHeaderPanelProps> = ({ timeline
   const isDataInTimeline = useMemo(
     () => !isEmpty(dataProviders) || !isEmpty(get('filterQuery.kuery.expression', kqlQuery)),
     [dataProviders, kqlQuery]
+  );
+  const getKqlQueryTimeline = useMemo(() => timelineSelectors.getKqlFilterQuerySelector(), []);
+  const kqlQueryTimeline = useSelector((state: State) => getKqlQueryTimeline(state, timelineId)!);
+
+  const kqlQueryExpression =
+    isEmpty(dataProviders) && isEmpty(kqlQueryTimeline) && timelineType === 'template'
+      ? ' '
+      : kqlQueryTimeline;
+  const kqlQueryTest = useMemo(() => ({ query: kqlQueryExpression, language: 'kuery' }), [
+    kqlQueryExpression,
+  ]);
+
+  const combinedQueries = useMemo(
+    () =>
+      combineQueries({
+        config: esQueryConfig,
+        dataProviders,
+        indexPattern,
+        browserFields,
+        filters: filters ? filters : [],
+        kqlQuery: kqlQueryTest,
+        kqlMode,
+      }),
+    [browserFields, dataProviders, esQueryConfig, filters, indexPattern, kqlMode, kqlQueryTest]
   );
 
   const handleClose = useCallback(() => {
@@ -134,7 +165,7 @@ const FlyoutHeaderPanelComponent: React.FC<FlyoutHeaderPanelProps> = ({ timeline
                     queryId={`${timelineId}-${activeTab}`}
                     inputId="timeline"
                     inspectIndex={0}
-                    isDisabled={!isDataInTimeline || kqlQuery.filterQuery === undefined}
+                    isDisabled={!isDataInTimeline || combinedQueries?.filterQuery === undefined}
                     title={i18n.INSPECT_TIMELINE_TITLE}
                   />
                 </EuiFlexItem>
@@ -295,10 +326,6 @@ const FlyoutHeaderComponent: React.FC<FlyoutHeaderProps> = ({ timelineId }) => {
     kqlQueryExpression,
   ]);
 
-  const isBlankTimeline: boolean = useMemo(
-    () => isEmpty(dataProviders) && isEmpty(filters) && isEmpty(kqlQuery.query),
-    [dataProviders, filters, kqlQuery]
-  );
   const combinedQueries = useMemo(
     () =>
       combineQueries({
@@ -312,6 +339,14 @@ const FlyoutHeaderComponent: React.FC<FlyoutHeaderProps> = ({ timelineId }) => {
       }),
     [browserFields, dataProviders, esQueryConfig, filters, indexPattern, kqlMode, kqlQuery]
   );
+
+  const isBlankTimeline: boolean = useMemo(
+    () =>
+      (isEmpty(dataProviders) && isEmpty(filters) && isEmpty(kqlQuery.query)) ||
+      combinedQueries?.filterQuery === undefined,
+    [dataProviders, filters, kqlQuery, combinedQueries]
+  );
+
   const [loading, kpis] = useTimelineKpis({
     defaultIndex: selectedPatterns,
     docValueFields,

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
@@ -105,8 +105,6 @@ export const ExpandableNetworkDetails = ({
     filters,
   });
 
-  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
-
   const [loading, { id, networkDetails }] = useNetworkDetails({
     docValueFields,
     skip: isInitializing || filterQuery === undefined,
@@ -114,6 +112,8 @@ export const ExpandableNetworkDetails = ({
     indexNames: selectedPatterns,
     ip,
   });
+
+  useInvalidFilterQuery({ id, filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const [isLoadingAnomaliesData, anomaliesData] = useAnomaliesTableData({
     criteriaFields: networkToCriteria(ip, flowTarget),

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
@@ -98,20 +98,14 @@ export const ExpandableNetworkDetails = ({
   } = useKibana();
 
   const { docValueFields, indicesExist, indexPattern, selectedPatterns } = useSourcererScope();
-  const filterQuery = convertToBuildEsQuery({
+  const [filterQuery, kqlError] = convertToBuildEsQuery({
     config: esQuery.getEsQueryConfig(uiSettings),
     indexPattern,
     queries: [query],
     filters,
   });
 
-  useInvalidFilterQuery({
-    filterQuery,
-    config: esQuery.getEsQueryConfig(uiSettings),
-    indexPattern,
-    queries: [query],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery, kqlError });
 
   const [loading, { id, networkDetails }] = useNetworkDetails({
     docValueFields,

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
+import { useInvalidFilterQuery } from '../../../../common/hooks/use_invalid_filter_query';
 import { FlowTarget } from '../../../../../common/search_strategy';
 import { NetworkDetailsLink } from '../../../../common/components/links';
 import { IpOverview } from '../../../../network/components/details';
@@ -104,9 +105,17 @@ export const ExpandableNetworkDetails = ({
     filters,
   });
 
+  useInvalidFilterQuery({
+    filterQuery,
+    config: esQuery.getEsQueryConfig(uiSettings),
+    indexPattern,
+    queries: [query],
+    filters,
+  });
+
   const [loading, { id, networkDetails }] = useNetworkDetails({
     docValueFields,
-    skip: isInitializing,
+    skip: isInitializing || filterQuery === undefined,
     filterQuery,
     indexNames: selectedPatterns,
     ip,

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/network_details/expandable_network.tsx
@@ -105,7 +105,7 @@ export const ExpandableNetworkDetails = ({
     filters,
   });
 
-  useInvalidFilterQuery({ filterQuery, kqlError });
+  useInvalidFilterQuery({ filterQuery, kqlError, query, startDate: from, endDate: to });
 
   const [loading, { id, networkDetails }] = useNetworkDetails({
     docValueFields,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.test.tsx
@@ -305,7 +305,7 @@ describe('Combined Queries', () => {
 
   test('Only Data Provider', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -317,13 +317,14 @@ describe('Combined Queries', () => {
     expect(filterQuery).toEqual(
       '{"bool":{"must":[],"filter":[{"bool":{"should":[{"match_phrase":{"name":"Provider 1"}}],"minimum_should_match":1}}],"should":[],"must_not":[]}}'
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Only Data Provider with timestamp (string input)', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
     dataProviders[0].queryMatch.field = '@timestamp';
     dataProviders[0].queryMatch.value = '2018-03-23T23:36:23.232Z';
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -335,13 +336,14 @@ describe('Combined Queries', () => {
     expect(filterQuery).toMatchInlineSnapshot(
       `"{\\"bool\\":{\\"must\\":[],\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"range\\":{\\"@timestamp\\":{\\"gte\\":\\"1521848183232\\",\\"lte\\":\\"1521848183232\\"}}}],\\"minimum_should_match\\":1}}],\\"should\\":[],\\"must_not\\":[]}}"`
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Only Data Provider with timestamp (numeric input)', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
     dataProviders[0].queryMatch.field = '@timestamp';
     dataProviders[0].queryMatch.value = 1521848183232;
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -353,13 +355,14 @@ describe('Combined Queries', () => {
     expect(filterQuery).toMatchInlineSnapshot(
       `"{\\"bool\\":{\\"must\\":[],\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"range\\":{\\"@timestamp\\":{\\"gte\\":\\"1521848183232\\",\\"lte\\":\\"1521848183232\\"}}}],\\"minimum_should_match\\":1}}],\\"should\\":[],\\"must_not\\":[]}}"`
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Only Data Provider with a date type (string input)', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
     dataProviders[0].queryMatch.field = 'event.end';
     dataProviders[0].queryMatch.value = '2018-03-23T23:36:23.232Z';
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -371,13 +374,14 @@ describe('Combined Queries', () => {
     expect(filterQuery).toMatchInlineSnapshot(
       `"{\\"bool\\":{\\"must\\":[],\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"match\\":{\\"event.end\\":\\"1521848183232\\"}}],\\"minimum_should_match\\":1}}],\\"should\\":[],\\"must_not\\":[]}}"`
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Only Data Provider with date type (numeric input)', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
     dataProviders[0].queryMatch.field = 'event.end';
     dataProviders[0].queryMatch.value = 1521848183232;
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -389,10 +393,11 @@ describe('Combined Queries', () => {
     expect(filterQuery).toMatchInlineSnapshot(
       `"{\\"bool\\":{\\"must\\":[],\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"match\\":{\\"event.end\\":\\"1521848183232\\"}}],\\"minimum_should_match\\":1}}],\\"should\\":[],\\"must_not\\":[]}}"`
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Only KQL search/filter query', () => {
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders: [],
       indexPattern: mockIndexPattern,
@@ -404,11 +409,26 @@ describe('Combined Queries', () => {
     expect(filterQuery).toEqual(
       '{"bool":{"must":[],"filter":[{"bool":{"should":[{"match_phrase":{"host.name":"host-1"}}],"minimum_should_match":1}}],"should":[],"must_not":[]}}'
     );
+    expect(kqlError).toBeUndefined();
+  });
+
+  test('Invalid KQL search/filter query', () => {
+    const { filterQuery, kqlError } = combineQueries({
+      config,
+      dataProviders: [],
+      indexPattern: mockIndexPattern,
+      browserFields: mockBrowserFields,
+      filters: [],
+      kqlQuery: { query: 'host.name: "host-1', language: 'kuery' },
+      kqlMode: 'search',
+    })!;
+    expect(filterQuery).toBeUndefined();
+    expect(kqlError).toBeDefined(); // Not testing on the error message since we don't control changes to them
   });
 
   test('Data Provider & KQL search query', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -420,11 +440,12 @@ describe('Combined Queries', () => {
     expect(filterQuery).toEqual(
       '{"bool":{"must":[],"filter":[{"bool":{"should":[{"bool":{"should":[{"match_phrase":{"name":"Provider 1"}}],"minimum_should_match":1}},{"bool":{"should":[{"match_phrase":{"host.name":"host-1"}}],"minimum_should_match":1}}],"minimum_should_match":1}}],"should":[],"must_not":[]}}'
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Data Provider & KQL filter query', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 1));
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -436,13 +457,14 @@ describe('Combined Queries', () => {
     expect(filterQuery).toEqual(
       '{"bool":{"must":[],"filter":[{"bool":{"filter":[{"bool":{"should":[{"match_phrase":{"name":"Provider 1"}}],"minimum_should_match":1}},{"bool":{"should":[{"match_phrase":{"host.name":"host-1"}}],"minimum_should_match":1}}]}}],"should":[],"must_not":[]}}'
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Data Provider & KQL search query multiple', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 2));
     dataProviders[0].and = cloneDeep(mockDataProviders.slice(2, 4));
     dataProviders[1].and = cloneDeep(mockDataProviders.slice(4, 5));
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -454,13 +476,14 @@ describe('Combined Queries', () => {
     expect(filterQuery).toMatchInlineSnapshot(
       `"{\\"bool\\":{\\"must\\":[],\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"bool\\":{\\"should\\":[{\\"bool\\":{\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 1\\"}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 3\\"}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 4\\"}}],\\"minimum_should_match\\":1}}]}},{\\"bool\\":{\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 2\\"}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 5\\"}}],\\"minimum_should_match\\":1}}]}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"host.name\\":\\"host-1\\"}}],\\"minimum_should_match\\":1}}],\\"minimum_should_match\\":1}}],\\"should\\":[],\\"must_not\\":[]}}"`
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Data Provider & KQL filter query multiple', () => {
     const dataProviders = cloneDeep(mockDataProviders.slice(0, 2));
     dataProviders[0].and = cloneDeep(mockDataProviders.slice(2, 4));
     dataProviders[1].and = cloneDeep(mockDataProviders.slice(4, 5));
-    const { filterQuery } = combineQueries({
+    const { filterQuery, kqlError } = combineQueries({
       config,
       dataProviders,
       indexPattern: mockIndexPattern,
@@ -472,6 +495,7 @@ describe('Combined Queries', () => {
     expect(filterQuery).toMatchInlineSnapshot(
       `"{\\"bool\\":{\\"must\\":[],\\"filter\\":[{\\"bool\\":{\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"bool\\":{\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 1\\"}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 3\\"}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 4\\"}}],\\"minimum_should_match\\":1}}]}},{\\"bool\\":{\\"filter\\":[{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 2\\"}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"name\\":\\"Provider 5\\"}}],\\"minimum_should_match\\":1}}]}}],\\"minimum_should_match\\":1}},{\\"bool\\":{\\"should\\":[{\\"match_phrase\\":{\\"host.name\\":\\"host-1\\"}}],\\"minimum_should_match\\":1}}]}}],\\"should\\":[],\\"must_not\\":[]}}"`
     );
+    expect(kqlError).toBeUndefined();
   });
 
   test('Data Provider & kql filter query with nested field that exists', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
@@ -161,7 +161,7 @@ export const combineQueries = ({
   kqlQuery: Query;
   kqlMode: string;
   isEventViewer?: boolean;
-}): { filterQuery?: string } | null => {
+}): { filterQuery?: string; kqlError?: Error } | null => {
   const kuery: Query = { query: '', language: kqlQuery.language };
   if (isEmpty(dataProviders) && isEmpty(kqlQuery.query) && isEmpty(filters) && !isEventViewer) {
     return null;
@@ -178,6 +178,7 @@ export const combineQueries = ({
     });
     return {
       filterQuery,
+      kqlError,
     };
   } else if (isEmpty(dataProviders) && !isEmpty(kqlQuery.query)) {
     kuery.query = `(${kqlQuery.query})`;
@@ -189,6 +190,7 @@ export const combineQueries = ({
     });
     return {
       filterQuery,
+      kqlError,
     };
   } else if (!isEmpty(dataProviders) && isEmpty(kqlQuery)) {
     kuery.query = `(${buildGlobalQuery(dataProviders, browserFields)})`;
@@ -200,6 +202,7 @@ export const combineQueries = ({
     });
     return {
       filterQuery,
+      kqlError,
     };
   }
   const operatorKqlQuery = kqlMode === 'filter' ? 'and' : 'or';
@@ -215,6 +218,7 @@ export const combineQueries = ({
   });
   return {
     filterQuery,
+    kqlError,
   };
 };
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
@@ -170,33 +170,36 @@ export const combineQueries = ({
     isEmpty(kqlQuery.query) &&
     (isEventViewer || !isEmpty(filters))
   ) {
+    const [filterQuery, kqlError] = convertToBuildEsQuery({
+      config,
+      queries: [kuery],
+      indexPattern,
+      filters,
+    });
     return {
-      filterQuery: convertToBuildEsQuery({
-        config,
-        queries: [kuery],
-        indexPattern,
-        filters,
-      }),
+      filterQuery,
     };
   } else if (isEmpty(dataProviders) && !isEmpty(kqlQuery.query)) {
     kuery.query = `(${kqlQuery.query})`;
+    const [filterQuery, kqlError] = convertToBuildEsQuery({
+      config,
+      queries: [kuery],
+      indexPattern,
+      filters,
+    });
     return {
-      filterQuery: convertToBuildEsQuery({
-        config,
-        queries: [kuery],
-        indexPattern,
-        filters,
-      }),
+      filterQuery,
     };
   } else if (!isEmpty(dataProviders) && isEmpty(kqlQuery)) {
     kuery.query = `(${buildGlobalQuery(dataProviders, browserFields)})`;
+    const [filterQuery, kqlError] = convertToBuildEsQuery({
+      config,
+      queries: [kuery],
+      indexPattern,
+      filters,
+    });
     return {
-      filterQuery: convertToBuildEsQuery({
-        config,
-        queries: [kuery],
-        indexPattern,
-        filters,
-      }),
+      filterQuery,
     };
   }
   const operatorKqlQuery = kqlMode === 'filter' ? 'and' : 'or';
@@ -204,8 +207,14 @@ export const combineQueries = ({
   kuery.query = `((${buildGlobalQuery(dataProviders, browserFields)})${postpend(
     kqlQuery.query as string
   )})`;
+  const [filterQuery, kqlError] = convertToBuildEsQuery({
+    config,
+    queries: [kuery],
+    indexPattern,
+    filters,
+  });
   return {
-    filterQuery: convertToBuildEsQuery({ config, queries: [kuery], indexPattern, filters }),
+    filterQuery,
   };
 };
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -261,7 +261,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     fields: getTimelineQueryFields(),
     language: kqlQuery.language,
     limit: itemsPerPage,
-    filterQuery: combinedQueries?.filterQuery ?? '',
+    filterQuery: combinedQueries?.filterQuery,
     startDate: start,
     skip: !canQueryTimeline() || combinedQueries?.filterQuery === undefined,
     sort: timelineQuerySortField,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -21,6 +21,7 @@ import { connect, ConnectedProps, useDispatch } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import { InPortal } from 'react-reverse-portal';
 
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { timelineActions, timelineSelectors } from '../../../store/timeline';
 import { CellValueElementProps } from '../cell_rendering';
 import { Direction, TimelineItem } from '../../../../../common/search_strategy';
@@ -198,6 +199,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     query: string;
     language: KueryFilterQueryKind;
   } = { query: kqlQueryExpression, language: 'kuery' };
+  const { addError } = useAppToasts();
 
   const combinedQueries = combineQueries({
     config: esQueryConfig,
@@ -207,6 +209,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     filters,
     kqlQuery,
     kqlMode,
+    addError,
   });
 
   const isBlankTimeline: boolean =

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -198,7 +198,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const kqlQuery: {
     query: string;
     language: KueryFilterQueryKind;
-  } = { query: kqlQueryExpression, language: 'kuery' };
+  } = useMemo(() => ({ query: kqlQueryExpression, language: 'kuery' }), [kqlQueryExpression]);
 
   const combinedQueries = combineQueries({
     config: esQueryConfig,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -199,7 +199,6 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     query: string;
     language: KueryFilterQueryKind;
   } = { query: kqlQueryExpression, language: 'kuery' };
-  const { addError } = useAppToasts();
 
   const combinedQueries = combineQueries({
     config: esQueryConfig,
@@ -209,7 +208,6 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     filters,
     kqlQuery,
     kqlMode,
-    addError,
   });
 
   const isBlankTimeline: boolean =

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -210,13 +210,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     kqlMode,
   });
 
-  useInvalidFilterQuery({
-    filterQuery: combinedQueries?.filterQuery,
-    config: esQueryConfig,
-    indexPattern,
-    queries: [kqlQuery],
-    filters,
-  });
+  useInvalidFilterQuery({ filterQuery: combinedQueries?.filterQuery });
 
   const isBlankTimeline: boolean =
     isEmpty(dataProviders) && isEmpty(filters) && isEmpty(kqlQuery.query);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -213,6 +213,9 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   useInvalidFilterQuery({
     filterQuery: combinedQueries?.filterQuery,
     kqlError: combinedQueries?.kqlError,
+    query: kqlQuery,
+    startDate: start,
+    endDate: end,
   });
 
   const isBlankTimeline: boolean =

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -210,7 +210,10 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     kqlMode,
   });
 
-  useInvalidFilterQuery({ filterQuery: combinedQueries?.filterQuery });
+  useInvalidFilterQuery({
+    filterQuery: combinedQueries?.filterQuery,
+    kqlError: combinedQueries?.kqlError,
+  });
 
   const isBlankTimeline: boolean =
     isEmpty(dataProviders) && isEmpty(filters) && isEmpty(kqlQuery.query);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -211,6 +211,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   });
 
   useInvalidFilterQuery({
+    id: timelineId,
     filterQuery: combinedQueries?.filterQuery,
     kqlError: combinedQueries?.kqlError,
     query: kqlQuery,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -21,7 +21,7 @@ import { connect, ConnectedProps, useDispatch } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import { InPortal } from 'react-reverse-portal';
 
-import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { useInvalidFilterQuery } from '../../../../common/hooks/use_invalid_filter_query';
 import { timelineActions, timelineSelectors } from '../../../store/timeline';
 import { CellValueElementProps } from '../cell_rendering';
 import { Direction, TimelineItem } from '../../../../../common/search_strategy';
@@ -210,6 +210,14 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     kqlMode,
   });
 
+  useInvalidFilterQuery({
+    filterQuery: combinedQueries?.filterQuery,
+    config: esQueryConfig,
+    indexPattern,
+    queries: [kqlQuery],
+    filters,
+  });
+
   const isBlankTimeline: boolean =
     isEmpty(dataProviders) && isEmpty(filters) && isEmpty(kqlQuery.query);
 
@@ -255,7 +263,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     limit: itemsPerPage,
     filterQuery: combinedQueries?.filterQuery ?? '',
     startDate: start,
-    skip: !canQueryTimeline(),
+    skip: !canQueryTimeline() || combinedQueries?.filterQuery === undefined,
     sort: timelineQuerySortField,
     timerangeKind,
   });


### PR DESCRIPTION
## Summary

Addresses #98283

Currently, our method of converting KQL to Elasticsearch queries silently suppresses errors bubbled up by ES and returns an empty query string. This makes it so the entire query, including filters, etc. gets wiped out and potentially incorrect data is displayed. 

This PR addresses that by bubbling up the errors and putting them in a toast component as well as cancelling any request that was made with the invalid query so that incorrect data is never fetched.

![Screen Shot 2021-05-11 at 5 05 24 PM](https://user-images.githubusercontent.com/56367316/117895214-e8bf9500-b28b-11eb-83a6-522deebecbe2.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
