### PR TITLE
Feature fix 99239

### DIFF
--- a/x-pack/plugins/maps/public/components/distance_filter_form.tsx
+++ b/x-pack/plugins/maps/public/components/distance_filter_form.tsx
@@ -16,15 +16,15 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ActionExecutionContext, Action } from 'src/plugins/ui_actions/public';
-import { MultiIndexGeoFieldSelect } from './multi_index_geo_field_select';
-import { GeoFieldWithIndex } from './geo_field_with_index';
+import { GeoFieldSelect } from './geo_field_select';
+import { IFieldType } from '../../../../../plugins/data/public';
 import { ActionSelect } from './action_select';
 import { ACTION_GLOBAL_APPLY_FILTER } from '../../../../../src/plugins/data/public';
 
 interface Props {
   className?: string;
   buttonLabel: string;
-  geoFields: GeoFieldWithIndex[];
+  geoFields: IFieldType[];
   getFilterActions?: () => Promise<Action[]>;
   getActionContext?: () => ActionExecutionContext;
   onSubmit: ({
@@ -42,7 +42,7 @@ interface Props {
 
 interface State {
   actionId: string;
-  selectedField: GeoFieldWithIndex | undefined;
+  selectedField: IFieldType | undefined;
   filterLabel: string;
 }
 
@@ -53,7 +53,7 @@ export class DistanceFilterForm extends Component<Props, State> {
     filterLabel: '',
   };
 
-  _onGeoFieldChange = (selectedField: GeoFieldWithIndex | undefined) => {
+  _onGeoFieldChange = (selectedField: IFieldType | undefined) => {
     this.setState({ selectedField });
   };
 
@@ -74,8 +74,7 @@ export class DistanceFilterForm extends Component<Props, State> {
     this.props.onSubmit({
       actionId: this.state.actionId,
       filterLabel: this.state.filterLabel,
-      indexPatternId: this.state.selectedField.indexPatternId,
-      geoFieldName: this.state.selectedField.geoFieldName,
+      geoFieldName: this.state.selectedField,
     });
   };
 
@@ -95,9 +94,9 @@ export class DistanceFilterForm extends Component<Props, State> {
           />
         </EuiFormRow>
 
-        <MultiIndexGeoFieldSelect
-          selectedField={this.state.selectedField}
-          fields={this.props.geoFields}
+        <GeoFieldSelect
+          value={this.state.selectedField}
+          geoFields={this.props.geoFields}
           onChange={this._onGeoFieldChange}
         />
 

--- a/x-pack/plugins/maps/public/components/geometry_filter_form.js
+++ b/x-pack/plugins/maps/public/components/geometry_filter_form.js
@@ -20,7 +20,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { ES_GEO_FIELD_TYPE, ES_SPATIAL_RELATIONS } from '../../common/constants';
 import { getEsSpatialRelationLabel } from '../../common/i18n_getters';
-import { MultiIndexGeoFieldSelect } from './multi_index_geo_field_select';
+import { GeoFieldSelect } from './geo_field_select';
 import { ActionSelect } from './action_select';
 import { ACTION_GLOBAL_APPLY_FILTER } from '../../../../../src/plugins/data/public';
 
@@ -71,8 +71,7 @@ export class GeometryFilterForm extends Component {
     this.props.onSubmit({
       actionId: this.state.actionId,
       geometryLabel: this.state.geometryLabel,
-      indexPatternId: this.state.selectedField.indexPatternId,
-      geoFieldName: this.state.selectedField.geoFieldName,
+      geoFieldName: this.state.selectedField,
       relation: this.state.relation,
     });
   };
@@ -137,9 +136,9 @@ export class GeometryFilterForm extends Component {
           />
         </EuiFormRow>
 
-        <MultiIndexGeoFieldSelect
-          selectedField={this.state.selectedField}
-          fields={this.props.geoFields}
+        <GeoFieldSelect
+          value={this.state.selectedField}
+          geoFields={this.props.geoFields}
           onChange={this._onGeoFieldChange}
         />
 

--- a/x-pack/plugins/maps/public/connected_components/map_container/index.ts
+++ b/x-pack/plugins/maps/public/connected_components/map_container/index.ts
@@ -16,7 +16,7 @@ import {
   getRefreshConfig,
   getMapInitError,
   getMapSettings,
-  getQueryableUniqueIndexPatternIds,
+  getQueryableUniqueIndexPatternIdsAndFieldNames,
 } from '../../selectors/map_selectors';
 import { MapStoreState } from '../../reducers/store';
 import { getCoreChrome } from '../../kibana_services';
@@ -28,7 +28,7 @@ function mapStateToProps(state: MapStoreState) {
     isFullScreen: getIsFullScreen(state),
     refreshConfig: getRefreshConfig(state),
     mapInitError: getMapInitError(state),
-    indexPatternIds: getQueryableUniqueIndexPatternIds(state),
+    indexPatternIdsAndFieldNames: getQueryableUniqueIndexPatternIdsAndFieldNames(state),
     settings: getMapSettings(state),
   };
 }

--- a/x-pack/plugins/maps/public/connected_components/mb_map/draw_control/draw_filter_control/draw_filter_control.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/draw_control/draw_filter_control/draw_filter_control.tsx
@@ -33,12 +33,7 @@ export interface Props {
 
 export class DrawFilterControl extends Component<Props, {}> {
   _onDraw = async (e: { features: Feature[] }) => {
-    if (
-      !e.features.length ||
-      !this.props.drawState ||
-      !this.props.drawState.geoFieldName ||
-      !this.props.drawState.indexPatternId
-    ) {
+    if (!e.features.length || !this.props.drawState || !this.props.drawState.geoFieldName) {
       return;
     }
 

--- a/x-pack/plugins/maps/public/connected_components/mb_map/features_tooltip/feature_geometry_filter_form.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/features_tooltip/feature_geometry_filter_form.tsx
@@ -21,7 +21,7 @@ import {
 import { ES_SPATIAL_RELATIONS, GEO_JSON_TYPE } from '../../../../common/constants';
 // @ts-expect-error
 import { GeometryFilterForm } from '../../../components/geometry_filter_form';
-import { GeoFieldWithIndex } from '../../../components/geo_field_with_index';
+import { IFieldType } from '../../../../../../../src/plugins/data/public';
 
 // over estimated and imprecise value to ensure filter has additional room for any meta keys added when filter is mapped.
 const META_OVERHEAD = 100;
@@ -29,7 +29,7 @@ const META_OVERHEAD = 100;
 interface Props {
   onClose: () => void;
   geometry: Geometry;
-  geoFields: GeoFieldWithIndex[];
+  geoFields: IFieldType[];
   addFilters: (filters: Filter[], actionId: string) => Promise<void>;
   getFilterActions?: () => Promise<Action[]>;
   getActionContext?: () => ActionExecutionContext;

--- a/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
+++ b/x-pack/plugins/maps/public/connected_components/mb_map/mb_map.tsx
@@ -42,7 +42,7 @@ import {
   // @ts-expect-error
 } from './utils';
 import { ResizeChecker } from '../../../../../../src/plugins/kibana_utils/public';
-import { GeoFieldWithIndex } from '../../components/geo_field_with_index';
+import { IFieldType } from '../../../../../../src/plugins/data/public';
 import { RenderToolTipContent } from '../../classes/tooltips/tooltip_property';
 import { MapExtentState } from '../../actions';
 import { TileStatusTracker } from './tile_status_tracker';
@@ -74,7 +74,7 @@ export interface Props {
   getFilterActions?: () => Promise<Action[]>;
   getActionContext?: () => ActionExecutionContext;
   onSingleValueTrigger?: (actionId: string, key: string, value: RawValue) => void;
-  geoFields: GeoFieldWithIndex[];
+  geoFields: IFieldType[];
   renderTooltipContent?: RenderToolTipContent;
   setAreTilesLoaded: (layerId: string, areTilesLoaded: boolean) => void;
 }

--- a/x-pack/plugins/maps/public/connected_components/toolbar_overlay/toolbar_overlay.tsx
+++ b/x-pack/plugins/maps/public/connected_components/toolbar_overlay/toolbar_overlay.tsx
@@ -7,16 +7,15 @@
 
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { Filter } from 'src/plugins/data/public';
+import { IFieldType, Filter } from 'src/plugins/data/public';
 import { ActionExecutionContext, Action } from 'src/plugins/ui_actions/public';
 import { SetViewControl } from './set_view_control';
 import { ToolsControl } from './tools_control';
 import { FitToData } from './fit_to_data';
-import { GeoFieldWithIndex } from '../../components/geo_field_with_index';
 
 export interface Props {
   addFilters?: ((filters: Filter[], actionId: string) => Promise<void>) | null;
-  geoFields: GeoFieldWithIndex[];
+  geoFields: IFieldType[];
   getFilterActions?: () => Promise<Action[]>;
   getActionContext?: () => ActionExecutionContext;
 }

--- a/x-pack/plugins/maps/public/connected_components/toolbar_overlay/tools_control/tools_control.tsx
+++ b/x-pack/plugins/maps/public/connected_components/toolbar_overlay/tools_control/tools_control.tsx
@@ -22,7 +22,7 @@ import { DRAW_TYPE, ES_GEO_FIELD_TYPE, ES_SPATIAL_RELATIONS } from '../../../../
 // @ts-expect-error
 import { GeometryFilterForm } from '../../../components/geometry_filter_form';
 import { DistanceFilterForm } from '../../../components/distance_filter_form';
-import { GeoFieldWithIndex } from '../../../components/geo_field_with_index';
+import { IFieldType } from '../../../../../plugins/data/public';
 import { DrawState } from '../../../../common/descriptor_types';
 
 const DRAW_SHAPE_LABEL = i18n.translate('xpack.maps.toolbarOverlay.drawShapeLabel', {
@@ -54,7 +54,7 @@ const DRAW_DISTANCE_LABEL_SHORT = i18n.translate(
 
 export interface Props {
   cancelDraw: () => void;
-  geoFields: GeoFieldWithIndex[];
+  geoFields: IFieldType[];
   initiateDraw: (drawState: DrawState) => void;
   isDrawingFilter: boolean;
   getFilterActions?: () => Promise<Action[]>;

--- a/x-pack/plugins/maps/public/index_pattern_util.ts
+++ b/x-pack/plugins/maps/public/index_pattern_util.ts
@@ -29,6 +29,27 @@ export function getGeoTileAggNotSupportedReason(field: IFieldType): string | nul
   return null;
 }
 
+export async function getFieldFromIndexByName(indexPatternId: string, fieldName: string) {
+  const indexPattern = await getIndexPatternService().get(indexPatternId);
+  const field = indexPattern.fields.getByName(fieldName);
+  return { indexPattern, field };
+}
+
+export async function getFieldsFromIds(indexPatternIdsWithFields) {
+  const promises: IndexPattern[] = [];
+  indexPatternIdsWithFields.forEach(async ({ indexPatternId, fieldName }) => {
+    try {
+      // @ts-ignore
+      promises.push(getFieldFromIndexByName(indexPatternId, fieldName));
+    } catch (error) {
+      // Unable to load index pattern, better to not throw error so map can render
+      // Error will be surfaced by layer since it too will be unable to locate the index pattern
+      return null;
+    }
+  });
+  return await Promise.all(promises);
+}
+
 export async function getIndexPatternsFromIds(
   indexPatternIds: string[] = []
 ): Promise<IndexPattern[]> {

--- a/x-pack/plugins/maps/public/routes/map_page/map_app/index.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/index.ts
@@ -14,7 +14,7 @@ import { getFlyoutDisplay, getIsFullScreen } from '../../../selectors/ui_selecto
 import {
   getFilters,
   getQuery,
-  getQueryableUniqueIndexPatternIds,
+  getQueryableUniqueIndexPatternIdsAndFieldNames,
   getRefreshConfig,
   getTimeFilters,
   hasDirtyState,
@@ -31,7 +31,7 @@ function mapStateToProps(state: MapStoreState) {
     isOpenSettingsDisabled: getFlyoutDisplay(state) !== FLYOUT_STATE.NONE,
     isSaveDisabled: hasDirtyState(state),
     inspectorAdapters: getInspectorAdapters(state),
-    nextIndexPatternIds: getQueryableUniqueIndexPatternIds(state),
+    nextIndexPatternIdsAndFieldNames: getQueryableUniqueIndexPatternIdsAndFieldNames(state),
     flyoutDisplay: getFlyoutDisplay(state),
     refreshConfig: getRefreshConfig(state),
     filters: getFilters(state),

--- a/x-pack/plugins/maps/public/selectors/map_selectors.ts
+++ b/x-pack/plugins/maps/public/selectors/map_selectors.ts
@@ -24,6 +24,7 @@ import {
 import { TiledVectorLayer } from '../classes/layers/tiled_vector_layer/tiled_vector_layer';
 import { copyPersistentState, TRACKED_LAYER_DESCRIPTOR } from '../reducers/copy_persistent_state';
 import { InnerJoin } from '../classes/joins/inner_join';
+import { IESSource } from '../classes/sources/es_source';
 import { getSourceByType } from '../classes/sources/source_registry';
 import { GeoJsonFileSource } from '../classes/sources/geojson_file_source';
 import {
@@ -398,6 +399,39 @@ export const getQueryableUniqueIndexPatternIds = createSelector(
       });
     }
     return _.uniq(indexPatternIds);
+  }
+);
+
+// Get list of unique index patterns, excluding index patterns from layers that disable applyGlobalQuery
+export const getQueryableUniqueIndexPatternIdsAndFieldNames = createSelector(
+  getLayerList,
+  getWaitingForMapReadyLayerListRaw,
+  (layerList, waitingForMapReadyLayerList) => {
+    const indexPatternIdsAndFieldNames: Array<{ indexPatternId: string; fieldName: string }> = [];
+
+    if (waitingForMapReadyLayerList.length) {
+      waitingForMapReadyLayerList.forEach((layerDescriptor) => {
+        const layer = createLayerInstance(layerDescriptor);
+        const indexPatternIds = layer.getQueryableIndexPatternIds();
+        if (layer.getSource().isESSource()) {
+          const fieldName = (layer.getSource() as IESSource).getGeoFieldName();
+          indexPatternIds.forEach((indexPatternId) => {
+            indexPatternIdsAndFieldNames.push({ indexPatternId, fieldName });
+          });
+        }
+      });
+    } else {
+      layerList.forEach((layer) => {
+        const indexPatternIds = layer.getQueryableIndexPatternIds();
+        if (layer.getSource().isESSource()) {
+          const fieldName = (layer.getSource() as IESSource).getGeoFieldName();
+          indexPatternIds.forEach((indexPatternId) => {
+            indexPatternIdsAndFieldNames.push({ indexPatternId, fieldName });
+          });
+        }
+      });
+    }
+    return _.uniq(indexPatternIdsAndFieldNames);
   }
 );
 


### PR DESCRIPTION
## Summary

This PR provides a proof-of-concept fix for #99239.  It likely needs iteration before being merged into the baseline.  It makes the following usability improvements:

* Only include geo-fields that are actually being used in layers.  This may be a debatable point (i.e. I want to render fieldA but filter on fieldB) when drawing shapes; if that is a desired feature, then I suggest that the "Filtering field" list be ordered such that those other fields are lower on the list and in a visually distinct manner. 
* When multiple index patterns have the same field name, it's redundant to show each of them in the list because the ultimate filter that is created is agnostic to the index.  Instead, the control now shows the geoFieldType and deduplicates based off name/type.

![image](https://user-images.githubusercontent.com/229922/117320292-15be1300-ae5a-11eb-9d04-583a3dc1fc31.png)

This PR was developed against v7.11.2.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
