### PR TITLE
[7.x] [Security Solution] [Detections] Adds investigate in timeline test for indicator match generated alerts (#99214)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
@@ -54,10 +54,12 @@ import {
   TIMELINE_FIELD,
   TIMELINE_TEMPLATE_DETAILS,
 } from '../../screens/rule_details';
+import { INDICATOR_MATCH_ROW_RENDER, PROVIDER_BADGE } from '../../screens/timeline';
 
 import {
   expandFirstAlert,
   goToManageAlertsDetectionRules,
+  investigateFirstAlertInTimeline,
   waitForAlertsIndexToBeCreated,
   waitForAlertsPanelToBeLoaded,
 } from '../../tasks/alerts';
@@ -75,6 +77,7 @@ import {
   checkDuplicatedRule,
 } from '../../tasks/alerts_detection_rules';
 import { createCustomIndicatorRule } from '../../tasks/api_calls/rules';
+import { loadPrepackagedTimelineTemplates } from '../../tasks/api_calls/timelines';
 import { cleanKibana, reload } from '../../tasks/common';
 import {
   createAndActivateRule,
@@ -392,15 +395,15 @@ describe('indicator match', () => {
       beforeEach(() => {
         cleanKibana();
         loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+      });
+
+      it('Creates and activates a new Indicator Match rule', () => {
         waitForAlertsPanelToBeLoaded();
         waitForAlertsIndexToBeCreated();
         goToManageAlertsDetectionRules();
         waitForRulesTableToBeLoaded();
         goToCreateNewRule();
         selectIndicatorMatchType();
-      });
-
-      it('Creates and activates a new Indicator Match rule', () => {
         fillDefineIndicatorMatchRuleAndContinue(newThreatIndicatorRule);
         fillAboutRuleAndContinue(newThreatIndicatorRule);
         fillScheduleRuleAndContinue(newThreatIndicatorRule);
@@ -446,7 +449,7 @@ describe('indicator match', () => {
         cy.get(DEFINITION_DETAILS).within(() => {
           getDetails(INDEX_PATTERNS_DETAILS).should(
             'have.text',
-            newThreatIndicatorRule.index!.join('')
+            newThreatIndicatorRule.index.join('')
           );
           getDetails(CUSTOM_QUERY_DETAILS).should('have.text', '*:*');
           getDetails(RULE_TYPE_DETAILS).should('have.text', 'Indicator Match');
@@ -484,6 +487,35 @@ describe('indicator match', () => {
           .first()
           .should('have.text', newThreatIndicatorRule.severity.toLowerCase());
         cy.get(ALERT_RULE_RISK_SCORE).first().should('have.text', newThreatIndicatorRule.riskScore);
+      });
+
+      it('Investigate alert in timeline', () => {
+        const accessibilityText = `Press enter for options, or press space to begin dragging.`;
+        const threatIndicatorPath =
+          '../../../x-pack/test/security_solution_cypress/es_archives/threat_indicator/data.json';
+
+        loadPrepackagedTimelineTemplates();
+
+        goToManageAlertsDetectionRules();
+        createCustomIndicatorRule(newThreatIndicatorRule);
+
+        reload();
+        goToRuleDetails();
+        waitForAlertsToPopulate();
+        investigateFirstAlertInTimeline();
+
+        cy.get(PROVIDER_BADGE).should('have.length', 3);
+        cy.get(PROVIDER_BADGE).should(
+          'have.text',
+          `threat.indicator.matched.atomic: "${newThreatIndicatorRule.atomic}"threat.indicator.matched.type: "${newThreatIndicatorRule.type}"threat.indicator.matched.field: "${newThreatIndicatorRule.indicatorMappingField}"`
+        );
+
+        cy.readFile(threatIndicatorPath).then((threatIndicator) => {
+          cy.get(INDICATOR_MATCH_ROW_RENDER).should(
+            'have.text',
+            `threat.indicator.matched.field${newThreatIndicatorRule.indicatorMappingField}${accessibilityText}matched${newThreatIndicatorRule.indicatorMappingField}${newThreatIndicatorRule.atomic}${accessibilityText}threat.indicator.matched.type${newThreatIndicatorRule.type}${accessibilityText}fromthreat.indicator.event.dataset${threatIndicator.value.source.event.dataset}${accessibilityText}:threat.indicator.event.reference${threatIndicator.value.source.event.reference}(opens in a new tab or window)${accessibilityText}`
+          );
+        });
       });
     });
 

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @kbn/eslint/no-restricted-paths */
 import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_rules/index';
 import { mockThreatData } from '../../public/detections/mitre/mitre_tactics_techniques';
-import { CompleteTimeline, timeline } from './timeline';
+import { timeline, CompleteTimeline, indicatorMatchTimelineTemplate } from './timeline';
 
 export const totalNumberOfPrebuiltRules = rawRules.length;
 
@@ -41,7 +41,7 @@ export interface CustomRule {
   customQuery?: string;
   name: string;
   description: string;
-  index?: string[];
+  index: string[];
   interval?: string;
   severity: string;
   riskScore: string;
@@ -334,7 +334,7 @@ export const newThreatIndicatorRule: ThreatIndicatorRule = {
   indicatorIndexField: 'threatintel.indicator.file.hash.sha256',
   type: 'file',
   atomic: 'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
-  timeline,
+  timeline: indicatorMatchTimelineTemplate,
   maxSignals: 100,
 };
 

--- a/x-pack/plugins/security_solution/cypress/objects/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/timeline.ts
@@ -15,6 +15,7 @@ export interface Timeline {
 export interface CompleteTimeline extends Timeline {
   notes: string;
   filter: TimelineFilter;
+  templateTimelineId?: string;
 }
 
 export interface TimelineFilter {
@@ -35,6 +36,12 @@ export const timeline: CompleteTimeline = {
   query: 'host.name: *',
   notes: 'Yes, the best timeline',
   filter,
+};
+
+export const indicatorMatchTimelineTemplate: CompleteTimeline = {
+  ...timeline,
+  title: 'Generic Threat Match Timeline',
+  templateTimelineId: '495ad7a7-316e-4544-8a0f-9c098daee76e',
 };
 
 /**

--- a/x-pack/plugins/security_solution/cypress/screens/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/timeline.ts
@@ -26,6 +26,8 @@ export const CASE = (id: string) => {
 
 export const CLOSE_TIMELINE_BTN = '[data-test-subj="close-timeline"]';
 
+export const COLUMN_HEADERS = '[data-test-subj="column-headers"] [data-test-subj^=header-text]';
+
 export const COMBO_BOX = '.euiComboBoxOption__content';
 
 export const CREATE_NEW_TIMELINE = '[data-test-subj="timeline-new"]';
@@ -93,6 +95,8 @@ export const SAVE_FILTER_BTN = '[data-test-subj="saveFilter"]';
 
 export const SEARCH_OR_FILTER_CONTAINER =
   '[data-test-subj="timeline-search-or-filter-search-container"]';
+
+export const INDICATOR_MATCH_ROW_RENDER = '[data-test-subj="threat-match-row"]';
 
 export const QUERY_TAB_EVENTS_TABLE = '[data-test-subj="query-events-table"]';
 

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/rules.ts
@@ -41,6 +41,8 @@ export const createCustomIndicatorRule = (rule: ThreatIndicatorRule, ruleId = 'r
       name: rule.name,
       severity: rule.severity.toLocaleLowerCase(),
       type: 'threat_match',
+      timeline_id: rule.timeline.templateTimelineId,
+      timeline_title: rule.timeline.title,
       threat_mapping: [
         {
           entries: [

--- a/x-pack/plugins/security_solution/cypress/tasks/api_calls/timelines.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/api_calls/timelines.ts
@@ -112,3 +112,10 @@ export const getTimelineById = (timelineId: string) =>
     url: `api/timeline?id=${timelineId}`,
     headers: { 'kbn-xsrf': 'timeline-by-id' },
   });
+
+export const loadPrepackagedTimelineTemplates = () =>
+  cy.request({
+    method: 'POST',
+    url: 'api/timeline/_prepackaged',
+    headers: { 'kbn-xsrf': 'cypress-creds' },
+  });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution] [Detections] Adds investigate in timeline test for indicator match generated alerts (#99214)