### PR TITLE
[7.12] [ftr] auto assign ciGroupDocker to suites with dockerServers (#99393)

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/load_test_files.js
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/load_test_files.js
@@ -17,6 +17,7 @@ import { decorateSnapshotUi } from '../snapshots/decorate_snapshot_ui';
  *
  *  @param  {Mocha} mocha
  *  @param  {ToolingLog} log
+ *  @param  {Config} config
  *  @param  {ProviderCollection} providers
  *  @param  {String} path
  *  @return {undefined} - mutates mocha, no return value
@@ -24,12 +25,16 @@ import { decorateSnapshotUi } from '../snapshots/decorate_snapshot_ui';
 export const loadTestFiles = ({
   mocha,
   log,
+  config,
   lifecycle,
   providers,
   paths,
   updateBaselines,
   updateSnapshots,
 }) => {
+  const dockerServers = config.get('dockerServers');
+  const isDockerGroup = dockerServers && Object.keys(dockerServers).length;
+
   decorateSnapshotUi({ lifecycle, updateSnapshots, isCi: !!process.env.CI });
 
   const innerLoadTestFile = (path) => {
@@ -55,7 +60,9 @@ export const loadTestFiles = ({
     loadTracer(provider, `testProvider[${path}]`, () => {
       // mocha.suite hocus-pocus comes from: https://git.io/vDnXO
 
-      const context = decorateMochaUi(lifecycle, global);
+      const context = decorateMochaUi(log, lifecycle, global, {
+        isDockerGroup,
+      });
       mocha.suite.emit('pre-require', context, path, mocha);
 
       const returnVal = provider({

--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/setup_mocha.js
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/setup_mocha.js
@@ -39,6 +39,7 @@ export async function setupMocha(lifecycle, log, config, providers) {
   loadTestFiles({
     mocha,
     log,
+    config,
     lifecycle,
     providers,
     paths: config.get('testFiles'),

--- a/x-pack/test/fleet_api_integration/apis/index.js
+++ b/x-pack/test/fleet_api_integration/apis/index.js
@@ -7,7 +7,6 @@
 
 export default function ({ loadTestFile }) {
   describe('Fleet Endpoints', function () {
-    this.tags('ciGroupDocker');
     // Fleet setup
     loadTestFile(require.resolve('./fleet_setup'));
 

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -16,7 +16,6 @@ export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
   describe('endpoint', function () {
-    this.tags('ciGroupDocker');
     const ingestManager = getService('ingestManager');
     const log = getService('log');
 

--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -15,7 +15,6 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
   describe('Endpoint plugin', function () {
     const ingestManager = getService('ingestManager');
 
-    this.tags('ciGroupDocker');
     const log = getService('log');
 
     if (!isRegistryEnabled()) {


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [ftr] auto assign ciGroupDocker to suites with dockerServers (#99393)