### PR TITLE
[Lens] display pie chart properly for only falsy correct data

### DIFF
--- a/x-pack/plugins/lens/public/pie_visualization/render_function.test.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/render_function.test.tsx
@@ -43,12 +43,12 @@ describe('PieVisualization component', () => {
           type: 'datatable',
           columns: [
             { id: 'a', name: 'a', meta: { type: 'number' } },
-            { id: 'b', name: 'b', meta: { type: 'number' } },
-            { id: 'c', name: 'c', meta: { type: 'string' } },
+            { id: 'b', name: 'b', meta: { type: 'string' } },
+            { id: 'c', name: 'c', meta: { type: 'number' } },
           ],
           rows: [
-            { a: 6, b: 2, c: 'I', d: 'Row 1' },
-            { a: 1, b: 5, c: 'J', d: 'Row 2' },
+            { a: 6, b: 'I', c: 2, d: 'Row 1' },
+            { a: 1, b: 'J', c: 5, d: 'Row 2' },
           ],
         },
       },
@@ -250,14 +250,14 @@ describe('PieVisualization component', () => {
                   Object {
                     "id": "b",
                     "meta": Object {
-                      "type": "number",
+                      "type": "string",
                     },
                     "name": "b",
                   },
                   Object {
                     "id": "c",
                     "meta": Object {
-                      "type": "string",
+                      "type": "number",
                     },
                     "name": "c",
                   },
@@ -265,14 +265,14 @@ describe('PieVisualization component', () => {
                 "rows": Array [
                   Object {
                     "a": 6,
-                    "b": 2,
-                    "c": "I",
+                    "b": "I",
+                    "c": 2,
                     "d": "Row 1",
                   },
                   Object {
                     "a": 1,
-                    "b": 5,
-                    "c": "J",
+                    "b": "J",
+                    "c": 5,
                     "d": "Row 2",
                   },
                 ],
@@ -293,7 +293,7 @@ describe('PieVisualization component', () => {
       expect(component.find(Settings).first().prop('onElementClick')).toBeUndefined();
     });
 
-    test('it renders the chart for only 0 data', () => {
+    test('it renders the empty placeholder when metric contains only falsy data', () => {
       const defaultData = getDefaultArgs().data;
       const emptyData: LensMultiTable = {
         ...defaultData,
@@ -301,8 +301,8 @@ describe('PieVisualization component', () => {
           first: {
             ...defaultData.tables.first,
             rows: [
-              { a: 0, b: 0, c: 'I', d: 'Row 1' },
-              { a: 0, b: 0, c: 'J', d: 'Row 2' },
+              { a: 0, b: 'I', c: 0, d: 'Row 1' },
+              { a: 0, b: 'J', c: null, d: 'Row 2' },
             ],
           },
         },
@@ -311,6 +311,26 @@ describe('PieVisualization component', () => {
       const component = shallow(
         <PieComponent args={args} {...getDefaultArgs()} data={emptyData} />
       );
+      expect(component.find(EmptyPlaceholder)).toHaveLength(1);
+    });
+
+    test('it renders the chart when metric contains truthy data and buckets contain only falsy data', () => {
+      const defaultData = getDefaultArgs().data;
+      const emptyData: LensMultiTable = {
+        ...defaultData,
+        tables: {
+          first: {
+            ...defaultData.tables.first,
+            // a and b are buckets, c is a metric
+            rows: [{ a: 0, b: undefined, c: 12 }],
+          },
+        },
+      };
+
+      const component = shallow(
+        <PieComponent args={args} {...getDefaultArgs()} data={emptyData} />
+      );
+
       expect(component.find(EmptyPlaceholder)).toHaveLength(0);
       expect(component.find(Chart)).toHaveLength(1);
     });
@@ -323,8 +343,8 @@ describe('PieVisualization component', () => {
           first: {
             ...defaultData.tables.first,
             rows: [
-              { a: undefined, b: undefined, c: 'I', d: 'Row 1' },
-              { a: undefined, b: undefined, c: 'J', d: 'Row 2' },
+              { a: undefined, b: 'I', c: undefined, d: 'Row 1' },
+              { a: undefined, b: 'J', c: undefined, d: 'Row 2' },
             ],
           },
         },

--- a/x-pack/plugins/lens/public/pie_visualization/render_function.test.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/render_function.test.tsx
@@ -13,6 +13,7 @@ import {
   NodeColorAccessor,
   ShapeTreeNode,
   HierarchyOfArrays,
+  Chart,
 } from '@elastic/charts';
 import { shallow } from 'enzyme';
 import { LensMultiTable } from '../types';
@@ -290,6 +291,28 @@ describe('PieVisualization component', () => {
         <PieComponent args={{ ...args }} {...defaultArgs} renderMode="noInteractivity" />
       );
       expect(component.find(Settings).first().prop('onElementClick')).toBeUndefined();
+    });
+
+    test('it renders the chart for only 0 data', () => {
+      const defaultData = getDefaultArgs().data;
+      const emptyData: LensMultiTable = {
+        ...defaultData,
+        tables: {
+          first: {
+            ...defaultData.tables.first,
+            rows: [
+              { a: 0, b: 0, c: 'I', d: 'Row 1' },
+              { a: 0, b: 0, c: 'J', d: 'Row 2' },
+            ],
+          },
+        },
+      };
+
+      const component = shallow(
+        <PieComponent args={args} {...getDefaultArgs()} data={emptyData} />
+      );
+      expect(component.find(EmptyPlaceholder)).toHaveLength(0);
+      expect(component.find(Chart)).toHaveLength(1);
     });
 
     test('it shows emptyPlaceholder for undefined grouped data', () => {

--- a/x-pack/plugins/lens/public/pie_visualization/render_function.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/render_function.tsx
@@ -224,9 +224,7 @@ export function PieComponent(
   });
   const isEmpty =
     firstTable.rows.length === 0 ||
-    firstTable.rows.every((row) =>
-      groups.every((colId) => !row[colId] || typeof row[colId] === 'undefined')
-    );
+    firstTable.rows.every((row) => groups.every((colId) => typeof row[colId] === 'undefined'));
 
   if (isEmpty) {
     return <EmptyPlaceholder icon={LensIconChartDonut} />;

--- a/x-pack/plugins/lens/public/pie_visualization/render_function.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/render_function.tsx
@@ -222,9 +222,15 @@ export function PieComponent(
     const value = row[metricColumn.id];
     return typeof value === 'number' && value < 0;
   });
+
+  const isMetricEmpty = firstTable.rows.every((row) => {
+    return !row[metricColumn.id];
+  });
+
   const isEmpty =
     firstTable.rows.length === 0 ||
-    firstTable.rows.every((row) => groups.every((colId) => typeof row[colId] === 'undefined'));
+    firstTable.rows.every((row) => groups.every((colId) => typeof row[colId] === 'undefined')) ||
+    isMetricEmpty;
 
   if (isEmpty) {
     return <EmptyPlaceholder icon={LensIconChartDonut} />;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/99579

I also checked all the other types of visualizations we have and this was the only one with too strong condition that includes all the falsy values (zeroes or false) `groups.every((colId) => !row[colId] || typeof row[colId] === 'undefined')`.
The rest  
1. xy_vis checks if type of all rows is undefined ,
2. metric vis checks if the whole table exists  
3. datatable checks if there are rows or if, when bucket Columns exist, they all `==null`

