### PR TITLE
[Workplace Search] Fix bug with updating a role mapping

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/role_mappings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/role_mappings.ts
@@ -66,10 +66,7 @@ export function registerOrgRoleMappingRoute({
     {
       path: '/api/workplace_search/org/role_mappings/{id}',
       validate: {
-        body: schema.object({
-          ...roleMappingBaseSchema,
-          id: schema.string(),
-        }),
+        body: schema.object(roleMappingBaseSchema),
         params: schema.object({
           id: schema.string(),
         }),


### PR DESCRIPTION
## Summary

This fixes a bug where updating a Role mapping would throw an error in the UI. 

`id` is not needed by the server as a body prop, as it’s inferred from the params. This was [already fixed](https://github.com/elastic/kibana/blob/master/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.ts#L69) on App Search but I forgot to do it for Workplace Search as well. 
