### PR TITLE
Update reporting troubleshooting docs with section about Elastic Maps Service

### DIFF
--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -169,7 +169,7 @@ Chromium is not compatible with ARM RHEL/CentOS.
 [[reporting-troubleshooting-maps-ems]]
 === Unable to connect to Elastic Maps Service
 
-https://www.elastic.co/elastic-maps-service[Elastic Maps Service (EMS)] is a service that hosts
+https://www.elastic.co/elastic-maps-service[{ems} ({ems-init})] is a service that hosts
 tile layers and vector shapes of administrative boundaries.
 Reports containing Maps with missing basemap layers or administrative boundaries is due to the kibana server not having access to EMS.
 See <<maps-connect-to-ems>> for information on how to connect your {kib} server to EMS.

--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -172,4 +172,4 @@ Chromium is not compatible with ARM RHEL/CentOS.
 https://www.elastic.co/elastic-maps-service[Elastic Maps Service (EMS)] is a service that hosts
 tile layers and vector shapes of administrative boundaries.
 Reports containing Maps with missing basemap layers or administrative boundaries is due to the kibana server not having access to EMS.
-See <<maps-connect-to-ems>> for more information on how to connect your kibana server to EMS.
+See <<maps-connect-to-ems>> for information on how to connect your {kib} server to EMS.

--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -16,6 +16,7 @@ Having trouble? Here are solutions to common problems you might encounter while 
 * <<reporting-troubleshooting-puppeteer-debug-logs>>
 * <<reporting-troubleshooting-system-requirements>>
 * <<reporting-troubleshooting-arm-systems>>
+* <<reporting-troubleshooting-maps-ems>>
 
 [float]
 [[reporting-diagnostics]]
@@ -163,3 +164,12 @@ In this case, try increasing the memory for the {kib} instance to 2GB.
 === ARM systems
 
 Chromium is not compatible with ARM RHEL/CentOS.
+
+[float]
+[[reporting-troubleshooting-maps-ems]]
+=== Unable to connect to Elastic Maps Service
+
+https://www.elastic.co/elastic-maps-service[Elastic Maps Service (EMS)] is a service that hosts
+tile layers and vector shapes of administrative boundaries.
+Reports containing Maps with missing basemap layers or administrative boundaries is due to the kibana server not having access to EMS.
+See <<maps-connect-to-ems>> for more information on how to connect your kibana server to EMS.

--- a/docs/user/reporting/reporting-troubleshooting.asciidoc
+++ b/docs/user/reporting/reporting-troubleshooting.asciidoc
@@ -171,5 +171,5 @@ Chromium is not compatible with ARM RHEL/CentOS.
 
 https://www.elastic.co/elastic-maps-service[{ems} ({ems-init})] is a service that hosts
 tile layers and vector shapes of administrative boundaries.
-Reports containing Maps with missing basemap layers or administrative boundaries is due to the kibana server not having access to EMS.
-See <<maps-connect-to-ems>> for information on how to connect your {kib} server to EMS.
+If a report contains a map with a missing basemap layer or administrative boundary, the {kib} server does not have access to {ems-init}.
+See <<maps-connect-to-ems>> for information on how to connect your {kib} server to {ems-init}.


### PR DESCRIPTION
Maps team occasionally gets questions about base maps not showing up in reporting. Adding a section to reporting troubleshooting docs to point users to connecting to EMS docs.