### PR TITLE
[App Search] Support pre-populated Search UI fields

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/search_ui_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/search_ui_logic.test.ts
@@ -128,6 +128,10 @@ describe('SearchUILogic', () => {
       validFields: ['test'],
       validSortFields: ['test'],
       validFacetFields: ['test'],
+      defaultValues: {
+        urlField: 'url',
+        titleField: 'title',
+      },
     };
 
     describe('loadFieldData', () => {
@@ -142,7 +146,13 @@ describe('SearchUILogic', () => {
         expect(http.get).toHaveBeenCalledWith(
           '/api/app_search/engines/engine1/search_ui/field_config'
         );
-        expect(SearchUILogic.actions.onFieldDataLoaded).toHaveBeenCalledWith(MOCK_RESPONSE);
+        expect(SearchUILogic.actions.onFieldDataLoaded).toHaveBeenCalledWith({
+          validFields: ['test'],
+          validSortFields: ['test'],
+          validFacetFields: ['test'],
+          urlField: 'url',
+          titleField: 'title',
+        });
       });
 
       it('handles errors', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/search_ui_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/search_ui_logic.ts
@@ -17,6 +17,8 @@ interface InitialFieldValues {
   validFields: string[];
   validSortFields: string[];
   validFacetFields: string[];
+  urlField?: string;
+  titleField?: string;
 }
 interface SearchUIActions {
   loadFieldData(): void;
@@ -61,8 +63,20 @@ export const SearchUILogic = kea<MakeLogicType<SearchUIValues, SearchUIActions>>
     validFields: [[], { onFieldDataLoaded: (_, { validFields }) => validFields }],
     validSortFields: [[], { onFieldDataLoaded: (_, { validSortFields }) => validSortFields }],
     validFacetFields: [[], { onFieldDataLoaded: (_, { validFacetFields }) => validFacetFields }],
-    titleField: ['', { onTitleFieldChange: (_, { titleField }) => titleField }],
-    urlField: ['', { onUrlFieldChange: (_, { urlField }) => urlField }],
+    titleField: [
+      '',
+      {
+        onTitleFieldChange: (_, { titleField }) => titleField,
+        onFieldDataLoaded: (_, { titleField }) => titleField || '',
+      },
+    ],
+    urlField: [
+      '',
+      {
+        onUrlFieldChange: (_, { urlField }) => urlField,
+        onFieldDataLoaded: (_, { urlField }) => urlField || '',
+      },
+    ],
     facetFields: [[], { onFacetFieldsChange: (_, { facetFields }) => facetFields }],
     sortFields: [[], { onSortFieldsChange: (_, { sortFields }) => sortFields }],
     activeField: [ActiveField.None, { onActiveFieldChange: (_, { activeField }) => activeField }],
@@ -76,8 +90,20 @@ export const SearchUILogic = kea<MakeLogicType<SearchUIValues, SearchUIActions>>
 
       try {
         const initialFieldValues = await http.get(url);
+        const {
+          defaultValues: { urlField, titleField },
+          validFields,
+          validSortFields,
+          validFacetFields,
+        } = initialFieldValues;
 
-        actions.onFieldDataLoaded(initialFieldValues);
+        actions.onFieldDataLoaded({
+          validFields,
+          validSortFields,
+          validFacetFields,
+          urlField,
+          titleField,
+        });
       } catch (e) {
         flashAPIErrors(e);
       }


### PR DESCRIPTION
## Summary

Re-added support pre-populated Search UI fields.

This was part of the old UI but I missed it in the original migration.

This predominantly affects:
- Sample engines
- Crawler engines

![latest](https://user-images.githubusercontent.com/1427475/117833252-2bf61580-b244-11eb-8070-7e3f5a341d5c.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
