### PR TITLE
[App Search] Removed fromKibana param

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/utils.test.ts
@@ -33,7 +33,7 @@ describe('generatePreviewUrl', () => {
         empty2: [''], // Empty fields should be stripped
       })
     ).toEqual(
-      'http://localhost:3002/as/engines/national-parks-demo/reference_application/preview?facets[]=baz&facets[]=qux&fromKibana=true&sortFields[]=quux&sortFields[]=quuz&titleField=foo&urlField=bar'
+      'http://localhost:3002/as/engines/national-parks-demo/reference_application/preview?facets[]=baz&facets[]=qux&sortFields[]=quux&sortFields[]=quuz&titleField=foo&urlField=bar'
     );
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/utils.ts
@@ -14,10 +14,7 @@ export const generatePreviewUrl = (query: ParsedQuery) => {
   const { engineName } = EngineLogic.values;
   return queryString.stringifyUrl(
     {
-      query: {
-        ...query,
-        fromKibana: 'true',
-      },
+      query,
       url: getAppSearchUrl(`/engines/${engineName}/reference_application/preview`),
     },
     { arrayFormat: 'bracket', skipEmptyString: true }


### PR DESCRIPTION
## Summary

I'm entering a PR for enterprise search that changes the experience to no longer require a `fromKibana` param, so I am removing it from here.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
