### PR TITLE
[Enterprise Search] Fix FlashMessages live region axe issue

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
@@ -10,6 +10,7 @@ import React, { Fragment } from 'react';
 import { useValues, useActions } from 'kea';
 
 import { EuiCallOut, EuiSpacer, EuiGlobalToastList } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { FLASH_MESSAGE_TYPES, DEFAULT_TOAST_TIMEOUT } from './constants';
 import { FlashMessagesLogic } from './flash_messages_logic';
@@ -25,7 +26,14 @@ export const Callouts: React.FC = ({ children }) => {
   const { messages } = useValues(FlashMessagesLogic);
 
   return (
-    <div aria-live="polite" role="region" data-test-subj="FlashMessages">
+    <div
+      aria-live="polite"
+      role="region"
+      aria-label={i18n.translate('xpack.enterpriseSearch.flashMessages.regionAriaLabel', {
+        defaultMessage: 'Flash messages',
+      })}
+      data-test-subj="FlashMessages"
+    >
       {messages.map(({ type, message, description }, index) => (
         <Fragment key={index}>
           <EuiCallOut


### PR DESCRIPTION
## Summary

While checking out some other reported axe devtools issues, I noticed this one I'd introduced in https://github.com/elastic/kibana/pull/95981#discussion_r605208310 🤦‍♀️ 

Basically it wants a unique `aria-label` due to the `role="region"` attribute.

### Before:
<img width="1431" alt="" src="https://user-images.githubusercontent.com/549407/117903069-b742cb80-b283-11eb-9b04-2d1510aafdd1.png">

### After:
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/117903048-ae51fa00-b283-11eb-8862-618178e7aaf9.png">

### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))