### PR TITLE
[APM] Updating the color and opacity values of the comparison series

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/time_comparison/get_time_range_comparison.ts
+++ b/x-pack/plugins/apm/public/components/shared/time_comparison/get_time_range_comparison.ts
@@ -19,9 +19,9 @@ export function getComparisonChartTheme(theme: EuiTheme) {
   return {
     areaSeriesStyle: {
       area: {
-        fill: theme.eui.euiColorLightestShade,
+        fill: theme.eui.euiColorLightShade,
         visible: true,
-        opacity: 1,
+        opacity: 0.5,
       },
       line: {
         stroke: theme.eui.euiColorMediumShade,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/observability-design/issues/41

To improve the legibility of the palette used for the time comparison series in APM especially for the larger charts that have axis gridlines, the chosen fill color has been changed and set an opacity value instead.

<details>
<summary>Before (light and dark mode)</summary>

<img width="1908" alt="Screenshot 2021-05-12 at 14 05 25" src="https://user-images.githubusercontent.com/4104278/117973048-2ffd6280-b32c-11eb-8882-15e0eb5213d0.png">
<img width="1914" alt="Screenshot 2021-05-12 at 14 05 55" src="https://user-images.githubusercontent.com/4104278/117973058-325fbc80-b32c-11eb-9914-6e7277d714fb.png">

</details>

<details>
<summary>After (light and dark mode)</summary>

<img width="1912" alt="Screenshot 2021-05-12 at 14 04 20" src="https://user-images.githubusercontent.com/4104278/117973108-42779c00-b32c-11eb-956d-3fa227d5cfdd.png">
<img width="1914" alt="Screenshot 2021-05-12 at 14 04 48" src="https://user-images.githubusercontent.com/4104278/117973117-44d9f600-b32c-11eb-8981-1f52302551d2.png">

</details>
