### PR TITLE
[App Search] Schema reindex job errors view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job.test.tsx
@@ -5,12 +5,18 @@
  * 2.0.
  */
 
+import { setMockValues, setMockActions } from '../../../../__mocks__';
 import '../../../../__mocks__/react_router_history.mock';
+import '../../../../__mocks__/shallow_useeffect.mock';
+import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
 import { shallow } from 'enzyme';
+
+import { Loading } from '../../../../shared/loading';
+import { SchemaErrorsAccordion } from '../../../../shared/schema';
 
 import { ReindexJob } from './';
 
@@ -18,13 +24,53 @@ describe('ReindexJob', () => {
   const props = {
     schemaBreadcrumb: ['Engines', 'some-engine', 'Schema'],
   };
+  const values = {
+    dataLoading: false,
+    fieldCoercionErrors: {},
+    engine: {
+      schema: {
+        some_field: 'text',
+      },
+    },
+  };
+  const actions = {
+    loadReindexJob: jest.fn(),
+  };
 
   beforeEach(() => {
     (useParams as jest.Mock).mockReturnValueOnce({ reindexJobId: 'abc1234567890' });
+    setMockValues(values);
+    setMockActions(actions);
   });
 
   it('renders', () => {
+    const wrapper = shallow(<ReindexJob {...props} />);
+
+    expect(wrapper.find(SchemaErrorsAccordion)).toHaveLength(1);
+    expect(wrapper.find(SchemaErrorsAccordion).prop('generateViewPath')).toHaveLength(1);
+  });
+
+  it('calls loadReindexJob on page load', () => {
     shallow(<ReindexJob {...props} />);
-    // TODO: Check child components
+
+    expect(actions.loadReindexJob).toHaveBeenCalledWith('abc1234567890');
+  });
+
+  it('renders a loading state', () => {
+    setMockValues({ ...values, dataLoading: true });
+    const wrapper = shallow(<ReindexJob {...props} />);
+
+    expect(wrapper.find(Loading)).toHaveLength(1);
+  });
+
+  it('renders schema errors with links to document pages', () => {
+    const wrapper = shallow(<ReindexJob {...props} />);
+    const generateViewPath = wrapper
+      .find(SchemaErrorsAccordion)
+      .prop('generateViewPath') as Function;
+
+    expect(generateViewPath('some-document-id')).toEqual(
+      '/engines/some-engine/documents/some-document-id'
+    );
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job_logic.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../../../__mocks__';
+import '../../../__mocks__/engine_logic.mock';
+
+import { nextTick } from '@kbn/test/jest';
+
+import { ReindexJobLogic } from './reindex_job_logic';
+
+describe('ReindexJobLogic', () => {
+  const { mount } = new LogicMounter(ReindexJobLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+
+  const MOCK_RESPONSE = {
+    fieldCoercionErrors: {
+      some_erroring_field: [
+        {
+          external_id: 'document-1',
+          error: "Value 'some text' cannot be parsed as a number",
+        },
+      ],
+      another_erroring_field: [
+        {
+          external_id: 'document-2',
+          error: "Value '123' cannot be parsed as a date",
+        },
+      ],
+    },
+  };
+
+  const DEFAULT_VALUES = {
+    dataLoading: true,
+    fieldCoercionErrors: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has expected default values', () => {
+    mount();
+    expect(ReindexJobLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    describe('onLoadSuccess', () => {
+      it('stores fieldCoercionErrors state and sets dataLoading to false', () => {
+        mount({ fieldCoercionErrors: {}, dataLoading: true });
+
+        ReindexJobLogic.actions.onLoadSuccess(MOCK_RESPONSE);
+
+        expect(ReindexJobLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: false,
+          fieldCoercionErrors: MOCK_RESPONSE.fieldCoercionErrors,
+        });
+      });
+    });
+
+    describe('onLoadError', () => {
+      it('sets dataLoading to false', () => {
+        mount({ dataLoading: true });
+
+        ReindexJobLogic.actions.onLoadError();
+
+        expect(ReindexJobLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: false,
+        });
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('loadReindexJob', () => {
+      it('sets dataLoading to true', () => {
+        mount({ dataLoading: false });
+
+        ReindexJobLogic.actions.loadReindexJob('some-job-id');
+
+        expect(ReindexJobLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: true,
+        });
+      });
+
+      it('should make an API call and then set schema state', async () => {
+        http.get.mockReturnValueOnce(Promise.resolve(MOCK_RESPONSE));
+        mount();
+        jest.spyOn(ReindexJobLogic.actions, 'onLoadSuccess');
+
+        ReindexJobLogic.actions.loadReindexJob('some-job-id');
+        await nextTick();
+
+        expect(http.get).toHaveBeenCalledWith(
+          '/api/app_search/engines/some-engine/reindex_job/some-job-id'
+        );
+        expect(ReindexJobLogic.actions.onLoadSuccess).toHaveBeenCalledWith(MOCK_RESPONSE);
+      });
+
+      it('handles errors', async () => {
+        http.get.mockReturnValueOnce(Promise.reject('error'));
+        mount();
+        jest.spyOn(ReindexJobLogic.actions, 'onLoadError');
+
+        ReindexJobLogic.actions.loadReindexJob('some-bad-id');
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+        expect(ReindexJobLogic.actions.onLoadError).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/reindex_job/reindex_job_logic.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { flashAPIErrors } from '../../../../shared/flash_messages';
+import { HttpLogic } from '../../../../shared/http';
+import { EngineLogic } from '../../engine';
+
+import { ReindexJobApiResponse } from '../types';
+
+export interface ReindexJobValues {
+  dataLoading: boolean;
+  fieldCoercionErrors: ReindexJobApiResponse['fieldCoercionErrors'];
+}
+
+export interface ReindexJobActions {
+  loadReindexJob(id: string): string;
+  onLoadSuccess(response: ReindexJobApiResponse): ReindexJobApiResponse;
+  onLoadError(): void;
+}
+
+export const ReindexJobLogic = kea<MakeLogicType<ReindexJobValues, ReindexJobActions>>({
+  path: ['enterprise_search', 'app_search', 'reindex_job_logic'],
+  actions: {
+    loadReindexJob: (id) => id,
+    onLoadSuccess: (response) => response,
+    onLoadError: true,
+  },
+  reducers: {
+    dataLoading: [
+      true,
+      {
+        loadReindexJob: () => true,
+        onLoadSuccess: () => false,
+        onLoadError: () => false,
+      },
+    ],
+    fieldCoercionErrors: [
+      {},
+      {
+        onLoadSuccess: (_, { fieldCoercionErrors }) => fieldCoercionErrors,
+      },
+    ],
+  },
+  listeners: ({ actions }) => ({
+    loadReindexJob: async (id) => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const response = await http.get(`/api/app_search/engines/${engineName}/reindex_job/${id}`);
+        actions.onLoadSuccess(response);
+      } catch (e) {
+        flashAPIErrors(e);
+        actions.onLoadError();
+      }
+    },
+  }),
+});


### PR DESCRIPTION
## Summary

This is best tested on top of #99868 but can be reviewed/QA'd separately in conjunction with the standalone UI. Relatively small PR since most of the heavy lifting is done by the shared `SchemaErrorsAccordion` component.

![errors](https://user-images.githubusercontent.com/549407/117999733-00356700-b2fa-11eb-96d5-fe1934c70b28.gif)

## QA

- In the standalone UI
  - Go to the sample engine and change (e.g.) the `visitors` field to a date, and the `description` field to a geolocation
  - Click on the "View errors" button in the subsequent error callout, and copy the reindex job ID in your URL bar
- In Kibana
    - Go to `http://localhost:5601/xyz/app/enterprise_search/app_search/engines/national-parks-demo/schema/reindex_job/{paste_id_here}`
    - [x] Confirm the schema errors accordion shows up with the correct erroring fields
    - [x] Confirm the error messages make sense and match the actual errors
    - [x] Confirm the "View" link takes you to the correct engine document
- Error testing
    - Go to http://localhost:5601/xyz/app/enterprise_search/app_search/engines/national-parks-demo/schema/reindex_job/doesnt_exist
  - [x] Confirm a 404 not found error message appears

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)