### PR TITLE
[App Search] Add red alert icon to Schema nav link if engine has schema reindex errors

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -43,6 +43,7 @@ describe('EngineLogic', () => {
     engineName: '',
     isMetaEngine: false,
     isSampleEngine: false,
+    hasSchemaErrors: false,
     hasSchemaConflicts: false,
     hasUnconfirmedSchemaFields: false,
     engineNotFound: false,
@@ -224,6 +225,24 @@ describe('EngineLogic', () => {
           ...DEFAULT_VALUES,
           engine: mockMetaEngine,
           isMetaEngine: true,
+        });
+      });
+    });
+
+    describe('hasSchemaErrors', () => {
+      it('should be set based on engine.activeReindexJob.numDocumentsWithErrors', () => {
+        const mockSchemaEngine = {
+          ...mockEngineData,
+          activeReindexJob: {
+            numDocumentsWithErrors: 10,
+          },
+        };
+        mount({ engine: mockSchemaEngine });
+
+        expect(EngineLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          engine: mockSchemaEngine,
+          hasSchemaErrors: true,
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -88,28 +88,6 @@ describe('EngineLogic', () => {
       });
     });
 
-    describe('setIndexingStatus', () => {
-      describe('engine', () => {
-        it('should set the nested obj property to the provided value', () => {
-          mount({ engine: mockEngineData });
-          const mockReindexJob = {
-            percentageComplete: 50,
-            numDocumentsWithErrors: 2,
-            activeReindexJobId: '123',
-          };
-          EngineLogic.actions.setIndexingStatus(mockReindexJob);
-
-          expect(EngineLogic.values).toEqual({
-            ...DEFAULT_VALUES,
-            engine: {
-              ...mockEngineData,
-              activeReindexJob: mockReindexJob,
-            },
-          });
-        });
-      });
-    });
-
     describe('setEngineNotFound', () => {
       describe('engineNotFound', () => {
         it('should be set to the provided value', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -8,7 +8,6 @@
 import { kea, MakeLogicType } from 'kea';
 
 import { HttpLogic } from '../../../shared/http';
-import { IIndexingStatus } from '../../../shared/schema/types';
 
 import { EngineDetails, EngineTypes } from './types';
 
@@ -27,7 +26,6 @@ interface EngineValues {
 interface EngineActions {
   setEngineData(engine: EngineDetails): { engine: EngineDetails };
   setEngineName(engineName: string): { engineName: string };
-  setIndexingStatus(activeReindexJob: IIndexingStatus): { activeReindexJob: IIndexingStatus };
   setEngineNotFound(notFound: boolean): { notFound: boolean };
   clearEngine(): void;
   initializeEngine(): void;
@@ -38,7 +36,6 @@ export const EngineLogic = kea<MakeLogicType<EngineValues, EngineActions>>({
   actions: {
     setEngineData: (engine) => ({ engine }),
     setEngineName: (engineName) => ({ engineName }),
-    setIndexingStatus: (activeReindexJob) => ({ activeReindexJob }),
     setEngineNotFound: (notFound) => ({ notFound }),
     clearEngine: true,
     initializeEngine: true,
@@ -56,10 +53,6 @@ export const EngineLogic = kea<MakeLogicType<EngineValues, EngineActions>>({
       {
         setEngineData: (_, { engine }) => engine,
         clearEngine: () => ({}),
-        setIndexingStatus: (state, { activeReindexJob }) => ({
-          ...state,
-          activeReindexJob,
-        }),
       },
     ],
     engineName: [

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -18,6 +18,7 @@ interface EngineValues {
   engineName: string;
   isMetaEngine: boolean;
   isSampleEngine: boolean;
+  hasSchemaErrors: boolean;
   hasSchemaConflicts: boolean;
   hasUnconfirmedSchemaFields: boolean;
   engineNotFound: boolean;
@@ -79,6 +80,12 @@ export const EngineLogic = kea<MakeLogicType<EngineValues, EngineActions>>({
   selectors: ({ selectors }) => ({
     isMetaEngine: [() => [selectors.engine], (engine) => engine?.type === EngineTypes.meta],
     isSampleEngine: [() => [selectors.engine], (engine) => !!engine?.sample],
+    // Indexed engines
+    hasSchemaErrors: [
+      () => [selectors.engine],
+      ({ activeReindexJob }) => activeReindexJob?.numDocumentsWithErrors > 0,
+    ],
+    // Meta engines
     hasSchemaConflicts: [
       () => [selectors.engine],
       (engine) => !!(engine?.schemaConflicts && Object.keys(engine.schemaConflicts).length > 0),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -78,6 +78,12 @@ describe('EngineNav', () => {
   describe('schema nav icons', () => {
     const myRole = { canViewEngineSchema: true };
 
+    it('renders schema errors alert icon', () => {
+      setMockValues({ ...values, myRole, hasSchemaErrors: true });
+      const wrapper = shallow(<EngineNav />);
+      expect(wrapper.find('[data-test-subj="EngineNavSchemaErrors"]')).toHaveLength(1);
+    });
+
     it('renders unconfirmed schema fields info icon', () => {
       setMockValues({ ...values, myRole, hasUnconfirmedSchemaFields: true });
       const wrapper = shallow(<EngineNav />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -70,6 +70,7 @@ export const EngineNav: React.FC = () => {
     dataLoading,
     isSampleEngine,
     isMetaEngine,
+    hasSchemaErrors,
     hasSchemaConflicts,
     hasUnconfirmedSchemaFields,
     engine,
@@ -131,6 +132,16 @@ export const EngineNav: React.FC = () => {
           <EuiFlexGroup justifyContent="spaceBetween" gutterSize="none">
             <EuiFlexItem>{SCHEMA_TITLE}</EuiFlexItem>
             <EuiFlexItem className="appSearchNavIcons">
+              {hasSchemaErrors && (
+                <EuiIcon
+                  type="alert"
+                  color="danger"
+                  title={i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.errors', {
+                    defaultMessage: 'Schema change errors',
+                  })}
+                  data-test-subj="EngineNavSchemaErrors"
+                />
+              )}
               {hasUnconfirmedSchemaFields && (
                 <EuiIcon
                   type="iInCircle"

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -129,7 +129,7 @@ export const EngineNav: React.FC = () => {
           shouldShowActiveForSubroutes
           data-test-subj="EngineSchemaLink"
         >
-          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="none">
+          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="none" responsive={false}>
             <EuiFlexItem>{SCHEMA_TITLE}</EuiFlexItem>
             <EuiFlexItem className="appSearchNavIcons">
               {hasSchemaErrors && (
@@ -190,7 +190,7 @@ export const EngineNav: React.FC = () => {
           to={generateEnginePath(ENGINE_RELEVANCE_TUNING_PATH)}
           data-test-subj="EngineRelevanceTuningLink"
         >
-          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="none">
+          <EuiFlexGroup justifyContent="spaceBetween" gutterSize="none" responsive={false}>
             <EuiFlexItem>{RELEVANCE_TUNING_TITLE}</EuiFlexItem>
             <EuiFlexItem className="appSearchNavIcons">
               {invalidBoosts && (


### PR DESCRIPTION
## Summary

NOTE: This requires being on latest ent-search (see linked/mentioned PR) for the API to send back the correct `mostRecentIndexJob` data.

### Main change (008d0d4, b4e8946)

Adds a red alert icon to the Schema nav link if a schema index change causes errors. This should serve as a persistent UI notification if users forget to fix schema errors and come back later without having fixed them.

Screenshot:
<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/118016987-e8b2aa00-b30a-11eb-8da4-32e374fe0887.png">

Screencap of icon appearing/disappearing:
![schema_errors](https://user-images.githubusercontent.com/549407/118025996-30d6ca00-b315-11eb-940d-b2deea42108f.gif)

NOTE: QAing the above screencap with the error callout requires #99868 to be merged locally. You can test creating schema errors w/ the standalone UI to see this icon in Kibana for now.

### Extra changes

- f4fcfb9: Removes the `setIndexingStatus` action (previously used by ent-search in SchemaLogic). SchemaLogic now instead calls/refetches the engine detail API fully.

- dd895c0: I realized at some point the nav links w/ icons were broken-looking on mobile 🤦‍♀️ This fixes it.
    <img width="200" alt="" src="https://user-images.githubusercontent.com/549407/118026712-f7528e80-b315-11eb-9950-493a53f616a5.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)