### PR TITLE
[Enterprise Search] Fix SchemaFieldTypeSelect axe issues

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/schema_table.tsx
@@ -35,7 +35,9 @@ export const SchemaTable: React.FC = () => {
       <EuiTableHeader>
         <EuiTableHeaderCell>{FIELD_NAME}</EuiTableHeaderCell>
         <EuiTableHeaderCell aria-hidden />
-        <EuiTableHeaderCell align="right">{FIELD_TYPE}</EuiTableHeaderCell>
+        <EuiTableHeaderCell align="right" id="schemaFieldType">
+          {FIELD_TYPE}
+        </EuiTableHeaderCell>
       </EuiTableHeader>
       <EuiTableBody>
         <EuiTableRow style={{ height: 56 }}>
@@ -74,6 +76,7 @@ export const SchemaTable: React.FC = () => {
                   fieldName={fieldName}
                   fieldType={fieldType}
                   updateExistingFieldType={updateSchemaFieldType}
+                  aria-labelledby="schemaFieldType"
                 />
               </EuiTableRowCell>
             </EuiTableRow>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/field_type_select/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/field_type_select/index.test.tsx
@@ -39,4 +39,10 @@ describe('SchemaFieldTypeSelect', () => {
 
     expect(wrapper.find(EuiSelect).prop('disabled')).toEqual(true);
   });
+
+  it('passes arbitrary props', () => {
+    const wrapper = shallow(<SchemaFieldTypeSelect {...props} disabled aria-label="Test label" />);
+
+    expect(wrapper.find(EuiSelect).prop('aria-label')).toEqual('Test label');
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/field_type_select/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/field_type_select/index.tsx
@@ -23,10 +23,12 @@ export const SchemaFieldTypeSelect: React.FC<Props> = ({
   fieldType,
   updateExistingFieldType,
   disabled,
+  ...rest
 }) => {
   const fieldTypeOptions = Object.values(SchemaType).map((type) => ({ value: type, text: type }));
   return (
     <EuiSelect
+      {...rest}
       name={fieldName}
       required
       value={fieldType}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
@@ -38,7 +38,7 @@ export const SchemaFieldsTable: React.FC = () => {
     <EuiTable tableLayout="auto">
       <EuiTableHeader>
         <EuiTableHeaderCell>{SCHEMA_ERRORS_TABLE_FIELD_NAME_HEADER}</EuiTableHeaderCell>
-        <EuiTableHeaderCell align="right">
+        <EuiTableHeaderCell align="right" id="schemaDataType">
           {SCHEMA_ERRORS_TABLE_DATA_TYPE_HEADER}
         </EuiTableHeaderCell>
       </EuiTableHeader>
@@ -58,6 +58,7 @@ export const SchemaFieldsTable: React.FC = () => {
                 fieldName={fieldName}
                 fieldType={filteredSchemaFields[fieldName]}
                 updateExistingFieldType={updateExistingFieldType}
+                aria-labelledby="schemaDataType"
               />
             </EuiTableRowCell>
           </EuiTableRow>


### PR DESCRIPTION
## Summary

The shared `<SchemaFieldTypeSelect />` component currently used in our schema table components was registering an axe failure for each select, because it was missing a `label` of some kind (in this case, I simply used `aria-labelledby` to re-use the table column heading as a label).

### Before

<img width="1423" alt="" src="https://user-images.githubusercontent.com/549407/118137546-2a4e5e00-b3ba-11eb-8f17-1d0120ece342.png">

### After

<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/118137795-75687100-b3ba-11eb-83ae-99cf07763b3b.png">

### Checklist

Functionally, I didn't notice a difference while QAing in VoiceOver in FIrefox, but I think that's because the select is in a table - so the table column heading already comes before the cell content while navigating.

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
