### PR TITLE
[App Search] Meta engines schema view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/index.ts
@@ -8,3 +8,4 @@
 export { SchemaCallouts } from './schema_callouts';
 export { SchemaTable } from './schema_table';
 export { EmptyState } from './empty_state';
+export { TruncatedEnginesList } from './truncated_engines_list';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/index.ts
@@ -8,4 +8,5 @@
 export { SchemaCallouts } from './schema_callouts';
 export { SchemaTable } from './schema_table';
 export { EmptyState } from './empty_state';
+export { MetaEnginesSchemaTable } from './meta_engines_schema_table';
 export { TruncatedEnginesList } from './truncated_engines_list';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/index.ts
@@ -9,4 +9,5 @@ export { SchemaCallouts } from './schema_callouts';
 export { SchemaTable } from './schema_table';
 export { EmptyState } from './empty_state';
 export { MetaEnginesSchemaTable } from './meta_engines_schema_table';
+export { MetaEnginesConflictsTable } from './meta_engines_conflicts_table';
 export { TruncatedEnginesList } from './truncated_engines_list';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_conflicts_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_conflicts_table.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__';
+
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import { EuiTable, EuiTableHeaderCell, EuiTableRow } from '@elastic/eui';
+
+import { MetaEnginesConflictsTable } from './';
+
+describe('MetaEnginesConflictsTable', () => {
+  const values = {
+    conflictingFields: {
+      hello_field: {
+        text: ['engine1'],
+        number: ['engine2'],
+        date: ['engine3'],
+      },
+      world_field: {
+        text: ['engine1'],
+        location: ['engine2', 'engine3', 'engine4'],
+      },
+    },
+  };
+
+  setMockValues(values);
+  const wrapper = mount(<MetaEnginesConflictsTable />);
+  const fieldNames = wrapper.find('EuiTableRowCell[data-test-subj="fieldName"]');
+  const fieldTypes = wrapper.find('EuiTableRowCell[data-test-subj="fieldTypes"]');
+  const engines = wrapper.find('EuiTableRowCell[data-test-subj="enginesPerFieldType"]');
+
+  it('renders', () => {
+    expect(wrapper.find(EuiTable)).toHaveLength(1);
+    expect(wrapper.find(EuiTableHeaderCell).at(0).text()).toEqual('Field name');
+    expect(wrapper.find(EuiTableHeaderCell).at(1).text()).toEqual('Field type conflicts');
+    expect(wrapper.find(EuiTableHeaderCell).at(2).text()).toEqual('Engines');
+  });
+
+  it('renders a rowspan on the initial field name column so that it stretches to all associated field conflict rows', () => {
+    expect(fieldNames).toHaveLength(2);
+    expect(fieldNames.at(0).prop('rowSpan')).toEqual(3);
+    expect(fieldNames.at(1).prop('rowSpan')).toEqual(2);
+  });
+
+  it('renders a row for each field type conflict and the engines that have that field type', () => {
+    expect(wrapper.find(EuiTableRow)).toHaveLength(5);
+
+    expect(fieldNames.at(0).text()).toEqual('hello_field');
+    expect(fieldTypes.at(0).text()).toEqual('text');
+    expect(engines.at(0).text()).toEqual('engine1');
+    expect(fieldTypes.at(1).text()).toEqual('number');
+    expect(engines.at(1).text()).toEqual('engine2');
+    expect(fieldTypes.at(2).text()).toEqual('date');
+    expect(engines.at(2).text()).toEqual('engine3');
+
+    expect(fieldNames.at(1).text()).toEqual('world_field');
+    expect(fieldTypes.at(3).text()).toEqual('text');
+    expect(engines.at(3).text()).toEqual('engine1');
+    expect(fieldTypes.at(4).text()).toEqual('location');
+    expect(engines.at(4).text()).toEqual('engine2, engine3, +1');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_conflicts_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_conflicts_table.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import {
+  EuiTable,
+  EuiTableHeader,
+  EuiTableHeaderCell,
+  EuiTableBody,
+  EuiTableRow,
+  EuiTableRowCell,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { FIELD_NAME } from '../../../../shared/schema/constants';
+import { ENGINES_TITLE } from '../../engines';
+
+import { MetaEngineSchemaLogic } from '../schema_meta_engine_logic';
+
+import { TruncatedEnginesList } from './';
+
+export const MetaEnginesConflictsTable: React.FC = () => {
+  const { conflictingFields } = useValues(MetaEngineSchemaLogic);
+
+  return (
+    <EuiTable tableLayout="auto">
+      <EuiTableHeader>
+        <EuiTableHeaderCell>{FIELD_NAME}</EuiTableHeaderCell>
+        <EuiTableHeaderCell>
+          {i18n.translate(
+            'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.fieldTypeConflicts',
+            { defaultMessage: 'Field type conflicts' }
+          )}
+        </EuiTableHeaderCell>
+        <EuiTableHeaderCell>{ENGINES_TITLE}</EuiTableHeaderCell>
+      </EuiTableHeader>
+      <EuiTableBody>
+        {Object.entries(conflictingFields).map(([fieldName, conflicts]) =>
+          Object.entries(conflicts).map(([fieldType, engines], i) => {
+            const isFirstRow = i === 0;
+            return (
+              <EuiTableRow key={`${fieldName}-${fieldType}`}>
+                {isFirstRow && (
+                  <EuiTableRowCell
+                    rowSpan={Object.values(conflicts).length}
+                    data-test-subj="fieldName"
+                  >
+                    <code>{fieldName}</code>
+                  </EuiTableRowCell>
+                )}
+                <EuiTableRowCell data-test-subj="fieldTypes">{fieldType}</EuiTableRowCell>
+                <EuiTableRowCell data-test-subj="enginesPerFieldType">
+                  <TruncatedEnginesList engines={engines} cutoff={2} />
+                </EuiTableRowCell>
+              </EuiTableRow>
+            );
+          })
+        )}
+      </EuiTableBody>
+    </EuiTable>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_schema_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_schema_table.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__';
+
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import { EuiTable, EuiTableHeaderCell, EuiTableRow, EuiTableRowCell } from '@elastic/eui';
+
+import { MetaEnginesSchemaTable } from './';
+
+describe('MetaEnginesSchemaTable', () => {
+  const values = {
+    schema: {
+      some_text_field: 'text',
+      some_number_field: 'number',
+    },
+    fields: {
+      some_text_field: {
+        text: ['engine1', 'engine2'],
+      },
+      some_number_field: {
+        number: ['engine1', 'engine2', 'engine3', 'engine4'],
+      },
+    },
+  };
+
+  setMockValues(values);
+  const wrapper = mount(<MetaEnginesSchemaTable />);
+  const fieldNames = wrapper.find('EuiTableRowCell[data-test-subj="fieldName"]');
+  const engines = wrapper.find('EuiTableRowCell[data-test-subj="engines"]');
+  const fieldTypes = wrapper.find('EuiTableRowCell[data-test-subj="fieldType"]');
+
+  it('renders', () => {
+    expect(wrapper.find(EuiTable)).toHaveLength(1);
+    expect(wrapper.find(EuiTableHeaderCell).at(0).text()).toEqual('Field name');
+    expect(wrapper.find(EuiTableHeaderCell).at(1).text()).toEqual('Engines');
+    expect(wrapper.find(EuiTableHeaderCell).at(2).text()).toEqual('Field type');
+  });
+
+  it('always renders an initial ID row', () => {
+    expect(wrapper.find('code').at(0).text()).toEqual('id');
+    expect(wrapper.find(EuiTableRowCell).at(1).text()).toEqual('All');
+  });
+
+  it('renders subsequent table rows for each schema field', () => {
+    expect(wrapper.find(EuiTableRow)).toHaveLength(3);
+
+    expect(fieldNames.at(0).text()).toEqual('some_text_field');
+    expect(engines.at(0).text()).toEqual('engine1, engine2');
+    expect(fieldTypes.at(0).text()).toEqual('text');
+
+    expect(fieldNames.at(1).text()).toEqual('some_number_field');
+    expect(engines.at(1).text()).toEqual('engine1, engine2, engine3, +1');
+    expect(fieldTypes.at(1).text()).toEqual('number');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_schema_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/meta_engines_schema_table.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import {
+  EuiTable,
+  EuiTableHeader,
+  EuiTableHeaderCell,
+  EuiTableBody,
+  EuiTableRow,
+  EuiTableRowCell,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { FIELD_NAME, FIELD_TYPE } from '../../../../shared/schema/constants';
+import { ENGINES_TITLE } from '../../engines';
+
+import { MetaEngineSchemaLogic } from '../schema_meta_engine_logic';
+
+import { TruncatedEnginesList } from './';
+
+export const MetaEnginesSchemaTable: React.FC = () => {
+  const { schema, fields } = useValues(MetaEngineSchemaLogic);
+
+  return (
+    <EuiTable tableLayout="auto">
+      <EuiTableHeader>
+        <EuiTableHeaderCell>{FIELD_NAME}</EuiTableHeaderCell>
+        <EuiTableHeaderCell>{ENGINES_TITLE}</EuiTableHeaderCell>
+        <EuiTableHeaderCell align="right">{FIELD_TYPE}</EuiTableHeaderCell>
+      </EuiTableHeader>
+      <EuiTableBody>
+        <EuiTableRow>
+          <EuiTableRowCell>
+            <EuiText color="subdued">
+              <code>id</code>
+            </EuiText>
+          </EuiTableRowCell>
+          <EuiTableRowCell>
+            <EuiText color="subdued" size="s">
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.allEngines',
+                { defaultMessage: 'All' }
+              )}
+            </EuiText>
+          </EuiTableRowCell>
+          <EuiTableRowCell aria-hidden />
+        </EuiTableRow>
+        {Object.keys(fields).map((fieldName) => {
+          const fieldType = schema[fieldName];
+          const engines = fields[fieldName][fieldType];
+
+          return (
+            <EuiTableRow key={fieldName}>
+              <EuiTableRowCell data-test-subj="fieldName">
+                <code>{fieldName}</code>
+              </EuiTableRowCell>
+              <EuiTableRowCell data-test-subj="engines">
+                <TruncatedEnginesList engines={engines} />
+              </EuiTableRowCell>
+              <EuiTableRowCell align="right" data-test-subj="fieldType">
+                {fieldType}
+              </EuiTableRowCell>
+            </EuiTableRow>
+          );
+        })}
+      </EuiTableBody>
+    </EuiTable>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/truncated_engines_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/truncated_engines_list.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { TruncatedEnginesList } from './';
+
+describe('TruncatedEnginesList', () => {
+  it('renders a list of engines with links to their schema pages', () => {
+    const wrapper = shallow(<TruncatedEnginesList engines={['engine1', 'engine2', 'engine3']} />);
+
+    expect(wrapper.find('[data-test-subj="displayedEngine"]')).toHaveLength(3);
+    expect(wrapper.find('[data-test-subj="displayedEngine"]').first().prop('to')).toEqual(
+      '/engines/engine1/schema'
+    );
+  });
+
+  it('renders a tooltip when the number of engines is greater than the cutoff', () => {
+    const wrapper = shallow(
+      <TruncatedEnginesList engines={['engine1', 'engine2', 'engine3']} cutoff={1} />
+    );
+
+    expect(wrapper.find('[data-test-subj="displayedEngine"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test-subj="hiddenEnginesTooltip"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test-subj="hiddenEnginesTooltip"]').prop('content')).toEqual(
+      'engine2, engine3'
+    );
+  });
+
+  it('does not render if no engines are passed', () => {
+    const wrapper = shallow(<TruncatedEnginesList engines={[]} />);
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/truncated_engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/truncated_engines_list.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment } from 'react';
+
+import { EuiText, EuiToolTip, EuiButtonEmpty } from '@elastic/eui';
+
+import { EuiLinkTo } from '../../../../shared/react_router_helpers';
+import { ENGINE_SCHEMA_PATH } from '../../../routes';
+import { generateEncodedPath } from '../../../utils/encode_path_params';
+
+interface Props {
+  engines?: string[];
+  cutoff?: number;
+}
+
+export const TruncatedEnginesList: React.FC<Props> = ({ engines, cutoff = 3 }) => {
+  if (!engines?.length) return null;
+
+  const displayedEngines = engines.slice(0, cutoff);
+  const hiddenEngines = engines.slice(cutoff);
+  const SEPARATOR = ', ';
+
+  return (
+    <EuiText size="s">
+      {displayedEngines.map((engineName, i) => {
+        const isLast = i === displayedEngines.length - 1;
+        return (
+          <Fragment key={engineName}>
+            <EuiLinkTo
+              to={generateEncodedPath(ENGINE_SCHEMA_PATH, { engineName })}
+              data-test-subj="displayedEngine"
+            >
+              {engineName}
+            </EuiLinkTo>
+            {!isLast ? SEPARATOR : ''}
+          </Fragment>
+        );
+      })}
+      {hiddenEngines.length > 0 && (
+        <>
+          {SEPARATOR}
+          <EuiToolTip
+            position="bottom"
+            content={hiddenEngines.join(SEPARATOR)}
+            data-test-subj="hiddenEnginesTooltip"
+          >
+            <EuiButtonEmpty size="xs" flush="both" data-test-subj="hiddenEnginesToggle">
+              +{hiddenEngines.length}
+            </EuiButtonEmpty>
+          </EuiToolTip>
+        </>
+      )}
+    </EuiText>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/truncated_engines_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/components/truncated_engines_list.tsx
@@ -49,7 +49,7 @@ export const TruncatedEnginesList: React.FC<Props> = ({ engines, cutoff = 3 }) =
             content={hiddenEngines.join(SEPARATOR)}
             data-test-subj="hiddenEnginesTooltip"
           >
-            <EuiButtonEmpty size="xs" flush="both" data-test-subj="hiddenEnginesToggle">
+            <EuiButtonEmpty size="xs" flush="both">
               +{hiddenEngines.length}
             </EuiButtonEmpty>
           </EuiToolTip>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.test.tsx
@@ -14,6 +14,8 @@ import { shallow } from 'enzyme';
 
 import { Loading } from '../../../../shared/loading';
 
+import { MetaEnginesSchemaTable } from '../components';
+
 import { MetaEngineSchema } from './';
 
 describe('MetaEngineSchema', () => {
@@ -33,8 +35,7 @@ describe('MetaEngineSchema', () => {
   it('renders', () => {
     const wrapper = shallow(<MetaEngineSchema />);
 
-    expect(wrapper.isEmptyRender()).toBe(false);
-    // TODO: Check for schema components
+    expect(wrapper.find(MetaEnginesSchemaTable)).toHaveLength(1);
   });
 
   it('calls loadSchema on mount', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.test.tsx
@@ -12,9 +12,11 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { EuiCallOut } from '@elastic/eui';
+
 import { Loading } from '../../../../shared/loading';
 
-import { MetaEnginesSchemaTable } from '../components';
+import { MetaEnginesSchemaTable, MetaEnginesConflictsTable } from '../components';
 
 import { MetaEngineSchema } from './';
 
@@ -49,5 +51,13 @@ describe('MetaEngineSchema', () => {
     const wrapper = shallow(<MetaEngineSchema />);
 
     expect(wrapper.find(Loading)).toHaveLength(1);
+  });
+
+  it('renders an inactive fields callout & table when source engines have schema conflicts', () => {
+    setMockValues({ ...values, hasConflicts: true, conflictingFieldsCount: 5 });
+    const wrapper = shallow(<MetaEngineSchema />);
+
+    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
+    expect(wrapper.find(MetaEnginesConflictsTable)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.tsx
@@ -14,7 +14,9 @@ import { i18n } from '@kbn/i18n';
 
 import { FlashMessages } from '../../../../shared/flash_messages';
 import { Loading } from '../../../../shared/loading';
+import { DataPanel } from '../../data_panel';
 
+import { MetaEnginesSchemaTable } from '../components';
 import { MetaEngineSchemaLogic } from '../schema_meta_engine_logic';
 
 export const MetaEngineSchema: React.FC = () => {
@@ -40,7 +42,27 @@ export const MetaEngineSchema: React.FC = () => {
         )}
       />
       <FlashMessages />
-      <EuiPageContentBody>TODO</EuiPageContentBody>
+      <EuiPageContentBody>
+        TODO: Conflicts callout
+        <DataPanel
+          hasBorder
+          title={
+            <h2>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.activeFieldsTitle',
+                { defaultMessage: 'Active fields' }
+              )}
+            </h2>
+          }
+          subtitle={i18n.translate(
+            'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.activeFieldsDescription',
+            { defaultMessage: 'Fields which belong to one or more engine.' }
+          )}
+        >
+          <MetaEnginesSchemaTable />
+        </DataPanel>
+        TODO: Conflicts table
+      </EuiPageContentBody>
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/meta_engine_schema.tsx
@@ -9,19 +9,19 @@ import React, { useEffect } from 'react';
 
 import { useValues, useActions } from 'kea';
 
-import { EuiPageHeader, EuiPageContentBody } from '@elastic/eui';
+import { EuiPageHeader, EuiPageContentBody, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { FlashMessages } from '../../../../shared/flash_messages';
 import { Loading } from '../../../../shared/loading';
 import { DataPanel } from '../../data_panel';
 
-import { MetaEnginesSchemaTable } from '../components';
+import { MetaEnginesSchemaTable, MetaEnginesConflictsTable } from '../components';
 import { MetaEngineSchemaLogic } from '../schema_meta_engine_logic';
 
 export const MetaEngineSchema: React.FC = () => {
   const { loadSchema } = useActions(MetaEngineSchemaLogic);
-  const { dataLoading } = useValues(MetaEngineSchemaLogic);
+  const { dataLoading, hasConflicts, conflictingFieldsCount } = useValues(MetaEngineSchemaLogic);
 
   useEffect(() => {
     loadSchema();
@@ -43,7 +43,33 @@ export const MetaEngineSchema: React.FC = () => {
       />
       <FlashMessages />
       <EuiPageContentBody>
-        TODO: Conflicts callout
+        {hasConflicts && (
+          <>
+            <EuiCallOut
+              iconType="alert"
+              color="warning"
+              title={i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.conflictsCalloutTitle',
+                {
+                  defaultMessage:
+                    '{conflictingFieldsCount, plural, one {# field is} other {# fields are}} not searchable',
+                  values: { conflictingFieldsCount },
+                }
+              )}
+            >
+              <p>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.conflictsCalloutDescription',
+                  {
+                    defaultMessage:
+                      'The field(s) have an inconsistent field-type across the source engines that make up this meta engine. Apply a consistent field-type from the source engines to make these fields searchable.',
+                  }
+                )}
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
         <DataPanel
           hasBorder
           title={
@@ -61,7 +87,29 @@ export const MetaEngineSchema: React.FC = () => {
         >
           <MetaEnginesSchemaTable />
         </DataPanel>
-        TODO: Conflicts table
+        <EuiSpacer />
+        {hasConflicts && (
+          <DataPanel
+            hasBorder
+            title={
+              <h2>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.inactiveFieldsTitle',
+                  { defaultMessage: 'Inactive fields' }
+                )}
+              </h2>
+            }
+            subtitle={i18n.translate(
+              'xpack.enterpriseSearch.appSearch.engine.schema.metaEngine.inactiveFieldsDescription',
+              {
+                defaultMessage:
+                  'These fields have type conflicts. To activate these fields, change types in the source engines to match.',
+              }
+            )}
+          >
+            <MetaEnginesConflictsTable />
+          </DataPanel>
+        )}
       </EuiPageContentBody>
     </>
   );


### PR DESCRIPTION
## Summary

Meta engines do not have documents/schema themselves, so they instead display an overview of the source engine schema as well as showing any conflicts in types for source engines.

### Screencaps

![meta engines conflicts](https://user-images.githubusercontent.com/549407/118184783-9f3c8a80-b3f0-11eb-945c-02fe79f5b9bc.png)

### New in Kibana / different from ent-search

1. The inactive fields table got a huge cleanup/redesign thanks to the ineffable @daveyholler!
    - Before:
      <img width="968" alt="" src="https://user-images.githubusercontent.com/549407/118186291-6c939180-b3f2-11eb-8c48-e80e13d62256.png">
    - After:
      <img width="893" alt="" src="https://user-images.githubusercontent.com/549407/118186892-1a9f3b80-b3f3-11eb-828b-b2760a859c3b.png">
    - The code is much cleaner with less one-off styling, and handles larger amounts of data better in terms of visual rhythm.
2. I made engine names links to the source engine schema pages. This should hopefully make it significantly easier to fix type conflicts.
    - Davey has some even cooler ideas here about potentially adding a new button or piece of logic to update/set all source engines to a certain type all at once. Not in this PR, but maybe before 7.14.

## QA

- Ensure you have a trial/platinum license
- Create at least 2 source engines
- Add just 1 source engine to a new meta engine
- [x] Confirm the Schema page shows only the active fields table and no conflicts callout or table
- Add another source engine with a conflicting field type
- [x] Confirm the Schema page now shows a callout and the inactive fields table
- Fix the schema conflict and go back to the meta engine schema
- [x] Confirm the conflict callout is gone

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
  - _NB: No critical issues, but a `Links with the same name have a similar purpose` warning is flagged for manual review, which is intentional given that links are within tables._
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
  - _NB: All of our schema tables are kind of janky on phones unfortunately. Might have to be something we revisit later_
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)