### PR TITLE
[7.x] Added missing padding to the popover title and footer in 'Test documents' popover (#99921)

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/documents_dropdown/documents_dropdown.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/documents_dropdown/documents_dropdown.tsx
@@ -109,13 +109,13 @@ export const DocumentsDropdown: FunctionComponent<Props> = ({
       >
         {(list) => (
           <>
-            <EuiPopoverTitle>{i18nTexts.popoverTitle}</EuiPopoverTitle>
+            <EuiPopoverTitle paddingSize="s">{i18nTexts.popoverTitle}</EuiPopoverTitle>
             {list}
           </>
         )}
       </EuiSelectable>
 
-      <EuiPopoverFooter>
+      <EuiPopoverFooter paddingSize="s">
         <EuiButton
           size="s"
           fullWidth


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Added missing padding to the popover title and footer in 'Test documents' popover (#99921)