### PR TITLE
[Index patterns] Update documentation of index pattern field types

### DIFF
--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.estypes.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.estypes.md
@@ -4,6 +4,8 @@
 
 ## IFieldType.esTypes property
 
+elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.md
@@ -18,7 +18,7 @@ export interface IFieldType
 |  [count](./kibana-plugin-plugins-data-public.ifieldtype.count.md) | <code>number</code> |  |
 |  [customLabel](./kibana-plugin-plugins-data-public.ifieldtype.customlabel.md) | <code>string</code> |  |
 |  [displayName](./kibana-plugin-plugins-data-public.ifieldtype.displayname.md) | <code>string</code> |  |
-|  [esTypes](./kibana-plugin-plugins-data-public.ifieldtype.estypes.md) | <code>string[]</code> |  |
+|  [esTypes](./kibana-plugin-plugins-data-public.ifieldtype.estypes.md) | <code>string[]</code> | elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents |
 |  [filterable](./kibana-plugin-plugins-data-public.ifieldtype.filterable.md) | <code>boolean</code> |  |
 |  [format](./kibana-plugin-plugins-data-public.ifieldtype.format.md) | <code>any</code> |  |
 |  [lang](./kibana-plugin-plugins-data-public.ifieldtype.lang.md) | <code>string</code> |  |
@@ -28,8 +28,8 @@ export interface IFieldType
 |  [scripted](./kibana-plugin-plugins-data-public.ifieldtype.scripted.md) | <code>boolean</code> |  |
 |  [searchable](./kibana-plugin-plugins-data-public.ifieldtype.searchable.md) | <code>boolean</code> |  |
 |  [sortable](./kibana-plugin-plugins-data-public.ifieldtype.sortable.md) | <code>boolean</code> |  |
-|  [subType](./kibana-plugin-plugins-data-public.ifieldtype.subtype.md) | <code>IFieldSubType</code> |  |
+|  [subType](./kibana-plugin-plugins-data-public.ifieldtype.subtype.md) | <code>IFieldSubType</code> | expresses the structure of multi and nested fields |
 |  [toSpec](./kibana-plugin-plugins-data-public.ifieldtype.tospec.md) | <code>(options?: {</code><br/><code>        getFormatterForField?: IndexPattern['getFormatterForField'];</code><br/><code>    }) =&gt; FieldSpec</code> |  |
-|  [type](./kibana-plugin-plugins-data-public.ifieldtype.type.md) | <code>string</code> |  |
+|  [type](./kibana-plugin-plugins-data-public.ifieldtype.type.md) | <code>string</code> | kibana/javascript type - string, number, etc |
 |  [visualizable](./kibana-plugin-plugins-data-public.ifieldtype.visualizable.md) | <code>boolean</code> |  |
 

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.subtype.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.subtype.md
@@ -4,6 +4,8 @@
 
 ## IFieldType.subType property
 
+expresses the structure of multi and nested fields
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.type.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.ifieldtype.type.md
@@ -4,6 +4,8 @@
 
 ## IFieldType.type property
 
+kibana/javascript type - string, number, etc
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.estypes.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.estypes.md
@@ -4,6 +4,8 @@
 
 ## IndexPatternField.esTypes property
 
+elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.md
@@ -25,7 +25,7 @@ export declare class IndexPatternField implements IFieldType
 |  [count](./kibana-plugin-plugins-data-public.indexpatternfield.count.md) |  | <code>number</code> | Count is used for field popularity |
 |  [customLabel](./kibana-plugin-plugins-data-public.indexpatternfield.customlabel.md) |  | <code>string &#124; undefined</code> |  |
 |  [displayName](./kibana-plugin-plugins-data-public.indexpatternfield.displayname.md) |  | <code>string</code> |  |
-|  [esTypes](./kibana-plugin-plugins-data-public.indexpatternfield.estypes.md) |  | <code>string[] &#124; undefined</code> |  |
+|  [esTypes](./kibana-plugin-plugins-data-public.indexpatternfield.estypes.md) |  | <code>string[] &#124; undefined</code> | elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents |
 |  [filterable](./kibana-plugin-plugins-data-public.indexpatternfield.filterable.md) |  | <code>boolean</code> |  |
 |  [isMapped](./kibana-plugin-plugins-data-public.indexpatternfield.ismapped.md) |  | <code>boolean &#124; undefined</code> | Is the field part of the index mapping? |
 |  [lang](./kibana-plugin-plugins-data-public.indexpatternfield.lang.md) |  | <code>string &#124; undefined</code> | Script field language |
@@ -37,8 +37,8 @@ export declare class IndexPatternField implements IFieldType
 |  [searchable](./kibana-plugin-plugins-data-public.indexpatternfield.searchable.md) |  | <code>boolean</code> |  |
 |  [sortable](./kibana-plugin-plugins-data-public.indexpatternfield.sortable.md) |  | <code>boolean</code> |  |
 |  [spec](./kibana-plugin-plugins-data-public.indexpatternfield.spec.md) |  | <code>FieldSpec</code> |  |
-|  [subType](./kibana-plugin-plugins-data-public.indexpatternfield.subtype.md) |  | <code>import(&quot;../types&quot;).IFieldSubType &#124; undefined</code> |  |
-|  [type](./kibana-plugin-plugins-data-public.indexpatternfield.type.md) |  | <code>string</code> |  |
+|  [subType](./kibana-plugin-plugins-data-public.indexpatternfield.subtype.md) |  | <code>import(&quot;../types&quot;).IFieldSubType &#124; undefined</code> | expresses the structure of multi and nested fields |
+|  [type](./kibana-plugin-plugins-data-public.indexpatternfield.type.md) |  | <code>string</code> | kibana/javascript type - string, number, etc |
 |  [visualizable](./kibana-plugin-plugins-data-public.indexpatternfield.visualizable.md) |  | <code>boolean</code> |  |
 
 ## Methods

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.subtype.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.subtype.md
@@ -4,6 +4,8 @@
 
 ## IndexPatternField.subType property
 
+expresses the structure of multi and nested fields
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.type.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpatternfield.type.md
@@ -4,6 +4,8 @@
 
 ## IndexPatternField.type property
 
+kibana/javascript type - string, number, etc
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.estypes.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.estypes.md
@@ -4,6 +4,8 @@
 
 ## IFieldType.esTypes property
 
+elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.md
@@ -18,7 +18,7 @@ export interface IFieldType
 |  [count](./kibana-plugin-plugins-data-server.ifieldtype.count.md) | <code>number</code> |  |
 |  [customLabel](./kibana-plugin-plugins-data-server.ifieldtype.customlabel.md) | <code>string</code> |  |
 |  [displayName](./kibana-plugin-plugins-data-server.ifieldtype.displayname.md) | <code>string</code> |  |
-|  [esTypes](./kibana-plugin-plugins-data-server.ifieldtype.estypes.md) | <code>string[]</code> |  |
+|  [esTypes](./kibana-plugin-plugins-data-server.ifieldtype.estypes.md) | <code>string[]</code> | elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents |
 |  [filterable](./kibana-plugin-plugins-data-server.ifieldtype.filterable.md) | <code>boolean</code> |  |
 |  [format](./kibana-plugin-plugins-data-server.ifieldtype.format.md) | <code>any</code> |  |
 |  [lang](./kibana-plugin-plugins-data-server.ifieldtype.lang.md) | <code>string</code> |  |
@@ -28,8 +28,8 @@ export interface IFieldType
 |  [scripted](./kibana-plugin-plugins-data-server.ifieldtype.scripted.md) | <code>boolean</code> |  |
 |  [searchable](./kibana-plugin-plugins-data-server.ifieldtype.searchable.md) | <code>boolean</code> |  |
 |  [sortable](./kibana-plugin-plugins-data-server.ifieldtype.sortable.md) | <code>boolean</code> |  |
-|  [subType](./kibana-plugin-plugins-data-server.ifieldtype.subtype.md) | <code>IFieldSubType</code> |  |
+|  [subType](./kibana-plugin-plugins-data-server.ifieldtype.subtype.md) | <code>IFieldSubType</code> | expresses the structure of multi and nested fields |
 |  [toSpec](./kibana-plugin-plugins-data-server.ifieldtype.tospec.md) | <code>(options?: {</code><br/><code>        getFormatterForField?: IndexPattern['getFormatterForField'];</code><br/><code>    }) =&gt; FieldSpec</code> |  |
-|  [type](./kibana-plugin-plugins-data-server.ifieldtype.type.md) | <code>string</code> |  |
+|  [type](./kibana-plugin-plugins-data-server.ifieldtype.type.md) | <code>string</code> | kibana/javascript type - string, number, etc |
 |  [visualizable](./kibana-plugin-plugins-data-server.ifieldtype.visualizable.md) | <code>boolean</code> |  |
 

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.subtype.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.subtype.md
@@ -4,6 +4,8 @@
 
 ## IFieldType.subType property
 
+expresses the structure of multi and nested fields
+
 <b>Signature:</b>
 
 ```typescript

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.type.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.ifieldtype.type.md
@@ -4,6 +4,8 @@
 
 ## IFieldType.type property
 
+kibana/javascript type - string, number, etc
+
 <b>Signature:</b>
 
 ```typescript

--- a/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
+++ b/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
@@ -98,12 +98,18 @@ export class IndexPatternField implements IFieldType {
       : this.spec.name;
   }
 
+  /**
+   * kibana/javascript type - string, number, etc
+   */
   public get type() {
     return this.runtimeField?.type
       ? castEsToKbnFieldTypeName(this.runtimeField?.type)
       : this.spec.type;
   }
 
+  /**
+   * elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+   */
   public get esTypes() {
     return this.runtimeField?.type ? [this.runtimeField?.type] : this.spec.esTypes;
   }
@@ -124,6 +130,9 @@ export class IndexPatternField implements IFieldType {
     return !!(this.spec.readFromDocValues && !this.scripted);
   }
 
+  /**
+   * expresses the structure of multi and nested fields
+   */
   public get subType() {
     return this.spec.subType;
   }

--- a/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
+++ b/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
@@ -99,7 +99,7 @@ export class IndexPatternField implements IFieldType {
   }
 
   /**
-   * kibana/javascript type - string, number, etc
+   * Kibana/javascript type - string, number, etc
    */
   public get type() {
     return this.runtimeField?.type
@@ -108,7 +108,7 @@ export class IndexPatternField implements IFieldType {
   }
 
   /**
-   * elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+   * Elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
    */
   public get esTypes() {
     return this.runtimeField?.type ? [this.runtimeField?.type] : this.spec.esTypes;
@@ -131,7 +131,7 @@ export class IndexPatternField implements IFieldType {
   }
 
   /**
-   * expresses the structure of multi and nested fields
+   * Expresses the structure of multi and nested fields
    */
   public get subType() {
     return this.spec.subType;

--- a/src/plugins/data/common/index_patterns/fields/types.ts
+++ b/src/plugins/data/common/index_patterns/fields/types.ts
@@ -11,14 +11,14 @@ import { FieldSpec, IFieldSubType, IndexPattern } from '../..';
 export interface IFieldType {
   name: string;
   /**
-   * kibana/javascript type - string, number, etc
+   * Kibana/javascript type - string, number, etc
    */
   type: string;
   script?: string;
   lang?: string;
   count?: number;
   /**
-   * elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+   * Elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
    */
   esTypes?: string[];
   aggregatable?: boolean;
@@ -29,7 +29,7 @@ export interface IFieldType {
   readFromDocValues?: boolean;
   scripted?: boolean;
   /**
-   * expresses the structure of multi and nested fields
+   * Expresses the structure of multi and nested fields
    */
   subType?: IFieldSubType;
   displayName?: string;

--- a/src/plugins/data/common/index_patterns/fields/types.ts
+++ b/src/plugins/data/common/index_patterns/fields/types.ts
@@ -10,12 +10,16 @@ import { FieldSpec, IFieldSubType, IndexPattern } from '../..';
 
 export interface IFieldType {
   name: string;
+  /**
+   * kibana/javascript type - string, number, etc
+   */
   type: string;
   script?: string;
   lang?: string;
   count?: number;
-  // esTypes might be undefined on old index patterns that have not been refreshed since we added
-  // this prop. It is also undefined on scripted fields.
+  /**
+   * elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+   */
   esTypes?: string[];
   aggregatable?: boolean;
   filterable?: boolean;
@@ -24,6 +28,9 @@ export interface IFieldType {
   visualizable?: boolean;
   readFromDocValues?: boolean;
   scripted?: boolean;
+  /**
+   * expresses the structure of multi and nested fields
+   */
   subType?: IFieldSubType;
   displayName?: string;
   customLabel?: string;

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -204,11 +204,11 @@ export interface FieldSpec {
   format?: SerializedFieldFormat;
   name: string;
   /**
-   * kibana/javascript type - string, number, etc
+   * Kibana/javascript type - string, number, etc
    */
   type: string;
   /**
-   * elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+   * Elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
    */
   esTypes?: string[];
   scripted?: boolean;
@@ -216,7 +216,7 @@ export interface FieldSpec {
   aggregatable: boolean;
   readFromDocValues?: boolean;
   /**
-   * expresses the structure of multi and nested fields
+   * Expresses the structure of multi and nested fields
    */
   subType?: IFieldSubType;
   indexed?: boolean;

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -19,7 +19,7 @@ export type FieldFormatMap = Record<string, SerializedFieldFormat>;
 export type RuntimeType = typeof RUNTIME_FIELD_TYPES[number];
 export interface RuntimeField {
   /**
-   * also used as a IndexPatternField's ES type
+   * Also used as a IndexPatternField's ES type
    */
   type: RuntimeType;
   script?: {

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -18,6 +18,9 @@ export type FieldFormatMap = Record<string, SerializedFieldFormat>;
 
 export type RuntimeType = typeof RUNTIME_FIELD_TYPES[number];
 export interface RuntimeField {
+  /**
+   * also used as a IndexPatternField's ES type
+   */
   type: RuntimeType;
   script?: {
     source: string;
@@ -200,12 +203,21 @@ export interface FieldSpec {
   conflictDescriptions?: Record<string, string[]>;
   format?: SerializedFieldFormat;
   name: string;
+  /**
+   * kibana/javascript type - string, number, etc
+   */
   type: string;
+  /**
+   * elasticsearch types. Multiple ES types may or may not conflict depending upon their kibana equivalents
+   */
   esTypes?: string[];
   scripted?: boolean;
   searchable: boolean;
   aggregatable: boolean;
   readFromDocValues?: boolean;
+  /**
+   * expresses the structure of multi and nested fields
+   */
   subType?: IFieldSubType;
   indexed?: boolean;
   customLabel?: string;

--- a/src/plugins/data/public/public.api.md
+++ b/src/plugins/data/public/public.api.md
@@ -1188,7 +1188,6 @@ export interface IFieldType {
     customLabel?: string;
     // (undocumented)
     displayName?: string;
-    // (undocumented)
     esTypes?: string[];
     // (undocumented)
     filterable?: boolean;
@@ -1208,13 +1207,11 @@ export interface IFieldType {
     searchable?: boolean;
     // (undocumented)
     sortable?: boolean;
-    // (undocumented)
     subType?: IFieldSubType;
     // (undocumented)
     toSpec?: (options?: {
         getFormatterForField?: IndexPattern['getFormatterForField'];
     }) => FieldSpec;
-    // (undocumented)
     type: string;
     // (undocumented)
     visualizable?: boolean;
@@ -1475,7 +1472,6 @@ export class IndexPatternField implements IFieldType {
     deleteCount(): void;
     // (undocumented)
     get displayName(): string;
-    // (undocumented)
     get esTypes(): string[] | undefined;
     // (undocumented)
     get filterable(): boolean;
@@ -1499,7 +1495,6 @@ export class IndexPatternField implements IFieldType {
     get sortable(): boolean;
     // (undocumented)
     readonly spec: FieldSpec;
-    // (undocumented)
     get subType(): import("../types").IFieldSubType | undefined;
     // (undocumented)
     toJSON(): {
@@ -1521,7 +1516,6 @@ export class IndexPatternField implements IFieldType {
     toSpec({ getFormatterForField, }?: {
         getFormatterForField?: IndexPattern['getFormatterForField'];
     }): FieldSpec;
-    // (undocumented)
     get type(): string;
     // (undocumented)
     get visualizable(): boolean;

--- a/src/plugins/data/server/server.api.md
+++ b/src/plugins/data/server/server.api.md
@@ -702,7 +702,6 @@ export interface IFieldType {
     customLabel?: string;
     // (undocumented)
     displayName?: string;
-    // (undocumented)
     esTypes?: string[];
     // (undocumented)
     filterable?: boolean;
@@ -722,7 +721,6 @@ export interface IFieldType {
     searchable?: boolean;
     // (undocumented)
     sortable?: boolean;
-    // (undocumented)
     subType?: IFieldSubType;
     // Warning: (ae-forgotten-export) The symbol "FieldSpec" needs to be exported by the entry point index.d.ts
     //
@@ -730,7 +728,6 @@ export interface IFieldType {
     toSpec?: (options?: {
         getFormatterForField?: IndexPattern['getFormatterForField'];
     }) => FieldSpec;
-    // (undocumented)
     type: string;
     // (undocumented)
     visualizable?: boolean;


### PR DESCRIPTION
Improved documentation of index pattern fields types - `type`, `esTypes`, `subType`, and `runtimeField.type` across `FieldSpec`, `IndexPatternField`, and `IFieldType`