### PR TITLE
Fix status page functional test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,7 +203,6 @@
 /packages/kbn-legacy-logging/ @elastic/kibana-core
 /packages/kbn-crypto/ @elastic/kibana-core
 /packages/kbn-http-tools/ @elastic/kibana-core
-/src/plugins/status_page/ @elastic/kibana-core
 /src/plugins/saved_objects_management/ @elastic/kibana-core
 /src/dev/run_check_published_api_changes.ts @elastic/kibana-core
 /src/plugins/home/public @elastic/kibana-core
@@ -215,7 +214,6 @@
 #CC# /src/plugins/legacy_export/ @elastic/kibana-core
 #CC# /src/plugins/xpack_legacy/ @elastic/kibana-core
 #CC# /src/plugins/saved_objects/ @elastic/kibana-core
-#CC# /src/plugins/status_page/ @elastic/kibana-core
 #CC# /x-pack/plugins/cloud/ @elastic/kibana-core
 #CC# /x-pack/plugins/features/ @elastic/kibana-core
 #CC# /x-pack/plugins/global_search/ @elastic/kibana-core

--- a/x-pack/test/functional/apps/status_page/status_page.ts
+++ b/x-pack/test/functional/apps/status_page/status_page.ts
@@ -12,17 +12,16 @@ export default function statusPageFunctonalTests({
   getPageObjects,
 }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
-  const PageObjects = getPageObjects(['security', 'statusPage', 'home']);
+  const PageObjects = getPageObjects(['security', 'statusPage', 'common']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/50448
-  describe.skip('Status Page', function () {
+  describe('Status Page', function () {
     this.tags(['skipCloud', 'includeFirefox']);
     before(async () => await esArchiver.load('empty_kibana'));
     after(async () => await esArchiver.unload('empty_kibana'));
 
     it('allows user to navigate without authentication', async () => {
       await PageObjects.security.forceLogout();
-      await PageObjects.statusPage.navigateToPage();
+      await PageObjects.common.navigateToApp('status_page', { shouldLoginIfPrompted: false });
       await PageObjects.statusPage.expectStatusPage();
     });
   });

--- a/x-pack/test/functional/page_objects/status_page.ts
+++ b/x-pack/test/functional/page_objects/status_page.ts
@@ -5,36 +5,18 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export function StatusPagePageProvider({ getService }: FtrProviderContext) {
-  const retry = getService('retry');
   const log = getService('log');
-  const browser = getService('browser');
   const find = getService('find');
-  const deployment = getService('deployment');
-
   class StatusPage {
     async initTests() {
       log.debug('StatusPage:initTests');
     }
 
-    async navigateToPage() {
-      return await retry.try(async () => {
-        const url = deployment.getHostPort() + '/status';
-        log.info(`StatusPage:navigateToPage(): ${url}`);
-        await browser.get(url);
-      });
-    }
-
     async expectStatusPage(): Promise<void> {
-      return await retry.try(async () => {
-        log.debug(`expectStatusPage()`);
-        await find.byCssSelector('[data-test-subj="statusPageRoot"]', 20000);
-        const url = await browser.getCurrentUrl();
-        expect(url).to.contain(`/status`);
-      });
+      await find.byCssSelector('[data-test-subj="statusPageRoot"]', 20000);
     }
   }
 


### PR DESCRIPTION
## Summary

Re-enabling status page test by changing navigation method. If it will fail, we will get a clear message but not timeout error as right now

closes #50448

Flaky test runner
- Chrome: https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1546/ (42x - passed)
 - Firefox: https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1547/ (30x - passed)
 https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1548/ (30x - passed, 1 non-related failure in Spaces app)

