### PR TITLE
[7.12] [status_page test] use navigateToApp (#100146)

### DIFF
--- a/x-pack/test/functional/apps/status_page/status_page.ts
+++ b/x-pack/test/functional/apps/status_page/status_page.ts
@@ -12,17 +12,16 @@ export default function statusPageFunctonalTests({
   getPageObjects,
 }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
-  const PageObjects = getPageObjects(['security', 'statusPage', 'home']);
+  const PageObjects = getPageObjects(['security', 'statusPage', 'common']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/50448
-  describe.skip('Status Page', function () {
+  describe('Status Page', function () {
     this.tags(['skipCloud', 'includeFirefox']);
     before(async () => await esArchiver.load('empty_kibana'));
     after(async () => await esArchiver.unload('empty_kibana'));
 
     it('allows user to navigate without authentication', async () => {
       await PageObjects.security.forceLogout();
-      await PageObjects.statusPage.navigateToPage();
+      await PageObjects.common.navigateToApp('status_page', { shouldLoginIfPrompted: false });
       await PageObjects.statusPage.expectStatusPage();
     });
   });

--- a/x-pack/test/functional/page_objects/status_page.ts
+++ b/x-pack/test/functional/page_objects/status_page.ts
@@ -5,36 +5,18 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export function StatusPagePageProvider({ getService }: FtrProviderContext) {
-  const retry = getService('retry');
   const log = getService('log');
-  const browser = getService('browser');
   const find = getService('find');
-  const deployment = getService('deployment');
-
   class StatusPage {
     async initTests() {
       log.debug('StatusPage:initTests');
     }
 
-    async navigateToPage() {
-      return await retry.try(async () => {
-        const url = deployment.getHostPort() + '/status';
-        log.info(`StatusPage:navigateToPage(): ${url}`);
-        await browser.get(url);
-      });
-    }
-
     async expectStatusPage(): Promise<void> {
-      return await retry.try(async () => {
-        log.debug(`expectStatusPage()`);
-        await find.byCssSelector('[data-test-subj="statusPageRoot"]', 20000);
-        const url = await browser.getCurrentUrl();
-        expect(url).to.contain(`/status`);
-      });
+      await find.byCssSelector('[data-test-subj="statusPageRoot"]', 20000);
     }
   }
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [status_page test] use navigateToApp (#100146)