### PR TITLE
Refactor spaces usage collector to handle 404 as any other error

### DIFF
--- a/x-pack/plugins/spaces/server/usage_collection/spaces_usage_collector.test.ts
+++ b/x-pack/plugins/spaces/server/usage_collection/spaces_usage_collector.test.ts
@@ -115,23 +115,7 @@ const getMockedEsClient = (esClientMock: jest.Mock) => {
 };
 
 describe('error handling', () => {
-  it('handles a 404 when searching for space usage', async () => {
-    const { features, licensing, usageCollection, usageStatsService } = setup({
-      license: { isAvailable: true, type: 'basic' },
-    });
-    const collector = getSpacesUsageCollector(usageCollection as any, {
-      kibanaIndexConfig$: Rx.of({ kibana: { index: '.kibana' } }),
-      features,
-      licensing,
-      usageStatsServicePromise: Promise.resolve(usageStatsService),
-    });
-    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
-    esClient.search.mockRejectedValue({ status: 404 });
-
-    await collector.fetch(getMockFetchContext(esClient));
-  });
-
-  it('throws error for a non-404', async () => {
+  it('throws error if cluster unavailable', async () => {
     const { features, licensing, usageCollection, usageStatsService } = setup({
       license: { isAvailable: true, type: 'basic' },
     });
@@ -143,7 +127,7 @@ describe('error handling', () => {
     });
     const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
-    const statusCodes = [401, 402, 403, 500];
+    const statusCodes = [401, 402, 403, 404, 500];
     for (const statusCode of statusCodes) {
       const error = { status: statusCode };
       esClient.search.mockRejectedValue(error);


### PR DESCRIPTION
## Summary

Refactor away the TS expected error and introduce additional type safety. Handle 404s the same as any other error.
Background: I work on the sec solution telemetry and looking for inspiration. I stumbled across this. 


```
node scripts/jest.js spaces/server --silent=false
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
