### PR TITLE
Formatting issues on Chromium settings

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -197,11 +197,11 @@ a| `xpack.reporting.capture.browser`
   Defaults to `false`.
 
 a| `xpack.reporting.capture.browser`
-.chromium.proxy.server`
+`.chromium.proxy.server`
   | The uri for the proxy server. Providing the username and password for the proxy server via the uri is not supported.
 
 a| `xpack.reporting.capture.browser`
-.chromium.proxy.bypass`
+`.chromium.proxy.bypass`
   | An array of hosts that should not go through the proxy server and should use a direct connection instead.
   Examples of valid entries are "elastic.co", "*.elastic.co", ".elastic.co", ".elastic.co:5601".
 


### PR DESCRIPTION
Broken formatting

## Summary

Fixing the formatting of the Chromium settings for reporting:
- `xpack.reporting.capture.browser` .chromium.proxy.server`
- `xpack.reporting.capture.browser` .chromium.proxy.bypass`

![Screenshot 2021-05-20 at 12 05 17](https://user-images.githubusercontent.com/4738843/118960540-af5de800-b963-11eb-8ab6-fef2642bec16.png)


### Checklist

Delete any items that are not applicable to this PR.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
