### PR TITLE
[Gauge] Fixes wrong translations on ranges less than symbol

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4215,7 +4215,7 @@
     "visDefaultEditor.controls.ranges.fromLabel": "開始：",
     "visDefaultEditor.controls.ranges.greaterThanOrEqualPrepend": "≧",
     "visDefaultEditor.controls.ranges.greaterThanOrEqualTooltip": "よりも大きいまたは等しい",
-    "visDefaultEditor.controls.ranges.lessThanPrepend": "&lt;",
+    "visDefaultEditor.controls.ranges.lessThanPrepend": "<",
     "visDefaultEditor.controls.ranges.lessThanTooltip": "より小さい",
     "visDefaultEditor.controls.ranges.removeRangeButtonAriaLabel": "{from}から{to}の範囲を削除",
     "visDefaultEditor.controls.ranges.toLabel": "終了：",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4241,7 +4241,7 @@
     "visDefaultEditor.controls.ranges.fromLabel": "自",
     "visDefaultEditor.controls.ranges.greaterThanOrEqualPrepend": "≥",
     "visDefaultEditor.controls.ranges.greaterThanOrEqualTooltip": "大于或等于",
-    "visDefaultEditor.controls.ranges.lessThanPrepend": "&lt;",
+    "visDefaultEditor.controls.ranges.lessThanPrepend": "<",
     "visDefaultEditor.controls.ranges.lessThanTooltip": "小于",
     "visDefaultEditor.controls.ranges.removeRangeButtonAriaLabel": "移除范围 {from} 至 {to}",
     "visDefaultEditor.controls.ranges.toLabel": "至",


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/97610

It seems that on Gauge ranges panel the translations for the `less than` symbol were not rendered correctly. `Greater than` is translated correctly so I used the same format. Not it renders currently.

Before
<img src="https://user-images.githubusercontent.com/24651136/115389748-10cd5280-a210-11eb-9069-5303408a40b0.png" />

Now
![image](https://user-images.githubusercontent.com/17003240/119479841-b7e66200-bd59-11eb-9a89-c4331d39a306.png)
