### PR TITLE
[ftr] migrate "docTable" service to FtrService class

### DIFF
--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -6,177 +6,170 @@
  * Side Public License, v 1.
  */
 
-import { FtrProviderContext } from '../ftr_provider_context';
+import { FtrService } from '../ftr_provider_context';
 import { WebElementWrapper } from './lib/web_element_wrapper';
 
-export function DocTableProvider({ getService, getPageObjects }: FtrProviderContext) {
-  const testSubjects = getService('testSubjects');
-  const retry = getService('retry');
-  const PageObjects = getPageObjects(['common', 'header']);
+interface SelectOptions {
+  isAnchorRow?: boolean;
+  rowIndex?: number;
+}
 
-  interface SelectOptions {
-    isAnchorRow?: boolean;
-    rowIndex?: number;
+export class DocTableService extends FtrService {
+  private readonly testSubjects = this.ctx.getService('testSubjects');
+  private readonly retry = this.ctx.getService('retry');
+  private readonly PageObjects = this.ctx.getPageObjects(['common', 'header']);
+
+  public async getTable(selector?: string) {
+    return await this.testSubjects.find(selector ? selector : 'docTable');
   }
 
-  class DocTable {
-    public async getTable(selector?: string) {
-      return await testSubjects.find(selector ? selector : 'docTable');
-    }
-
-    public async getRowsText() {
-      const table = await this.getTable();
-      const $ = await table.parseDomContent();
-      return $.findTestSubjects('~docTableRow')
-        .toArray()
-        .map((row: any) => $(row).text().trim());
-    }
-
-    public async getBodyRows(): Promise<WebElementWrapper[]> {
-      const table = await this.getTable();
-      return await table.findAllByTestSubject('~docTableRow');
-    }
-
-    public async getAnchorRow(): Promise<WebElementWrapper> {
-      const table = await this.getTable();
-      return await table.findByTestSubject('~docTableAnchorRow');
-    }
-
-    public async getRow({
-      isAnchorRow = false,
-      rowIndex = 0,
-    }: SelectOptions = {}): Promise<WebElementWrapper> {
-      return isAnchorRow ? await this.getAnchorRow() : (await this.getBodyRows())[rowIndex];
-    }
-
-    public async getDetailsRow(): Promise<WebElementWrapper> {
-      const table = await this.getTable();
-      return await table.findByCssSelector('[data-test-subj~="docTableDetailsRow"]');
-    }
-
-    public async getAnchorDetailsRow(): Promise<WebElementWrapper> {
-      const table = await this.getTable();
-      return await table.findByCssSelector(
-        '[data-test-subj~="docTableAnchorRow"] + [data-test-subj~="docTableDetailsRow"]'
-      );
-    }
-
-    public async clickRowToggle(
-      options: SelectOptions = { isAnchorRow: false, rowIndex: 0 }
-    ): Promise<void> {
-      const row = await this.getRow(options);
-      const toggle = await row.findByTestSubject('~docTableExpandToggleColumn');
-      await toggle.click();
-    }
-
-    public async getDetailsRows(): Promise<WebElementWrapper[]> {
-      const table = await this.getTable();
-      return await table.findAllByCssSelector(
-        '[data-test-subj~="docTableRow"] + [data-test-subj~="docTableDetailsRow"]'
-      );
-    }
-
-    public async getRowActions({ isAnchorRow = false, rowIndex = 0 }: SelectOptions = {}): Promise<
-      WebElementWrapper[]
-    > {
-      const detailsRow = isAnchorRow
-        ? await this.getAnchorDetailsRow()
-        : (await this.getDetailsRows())[rowIndex];
-      return await detailsRow.findAllByTestSubject('~docTableRowAction');
-    }
-
-    public async getFields(options: { isAnchorRow: boolean } = { isAnchorRow: false }) {
-      const table = await this.getTable();
-      const $ = await table.parseDomContent();
-      const rowLocator = options.isAnchorRow ? '~docTableAnchorRow' : '~docTableRow';
-      const rows = $.findTestSubjects(rowLocator).toArray();
-      return rows.map((row: any) =>
-        $(row)
-          .find('[data-test-subj~="docTableField"]')
-          .toArray()
-          .map((field: any) => $(field).text())
-      );
-    }
-
-    public async getHeaderFields(selector?: string): Promise<string[]> {
-      const table = await this.getTable(selector);
-      const $ = await table.parseDomContent();
-      return $.findTestSubjects('~docTableHeaderField')
-        .toArray()
-        .map((field: any) => $(field).text().trim());
-    }
-
-    public async getHeaders(selector?: string): Promise<string[]> {
-      return this.getHeaderFields(selector);
-    }
-
-    public async getTableDocViewRow(
-      detailsRow: WebElementWrapper,
-      fieldName: string
-    ): Promise<WebElementWrapper> {
-      return await detailsRow.findByTestSubject(`~tableDocViewRow-${fieldName}`);
-    }
-
-    public async getAddInclusiveFilterButton(
-      tableDocViewRow: WebElementWrapper
-    ): Promise<WebElementWrapper> {
-      return await tableDocViewRow.findByTestSubject(`~addInclusiveFilterButton`);
-    }
-
-    public async addInclusiveFilter(
-      detailsRow: WebElementWrapper,
-      fieldName: string
-    ): Promise<void> {
-      const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
-      const addInclusiveFilterButton = await this.getAddInclusiveFilterButton(tableDocViewRow);
-      await addInclusiveFilterButton.click();
-      await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
-    }
-
-    public async getRemoveInclusiveFilterButton(
-      tableDocViewRow: WebElementWrapper
-    ): Promise<WebElementWrapper> {
-      return await tableDocViewRow.findByTestSubject(`~removeInclusiveFilterButton`);
-    }
-
-    public async removeInclusiveFilter(
-      detailsRow: WebElementWrapper,
-      fieldName: string
-    ): Promise<void> {
-      const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
-      const addInclusiveFilterButton = await this.getRemoveInclusiveFilterButton(tableDocViewRow);
-      await addInclusiveFilterButton.click();
-      await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
-    }
-
-    public async getAddExistsFilterButton(
-      tableDocViewRow: WebElementWrapper
-    ): Promise<WebElementWrapper> {
-      return await tableDocViewRow.findByTestSubject(`~addExistsFilterButton`);
-    }
-
-    public async addExistsFilter(detailsRow: WebElementWrapper, fieldName: string): Promise<void> {
-      const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
-      const addInclusiveFilterButton = await this.getAddExistsFilterButton(tableDocViewRow);
-      await addInclusiveFilterButton.click();
-      await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
-    }
-
-    public async toggleRowExpanded({
-      isAnchorRow = false,
-      rowIndex = 0,
-    }: SelectOptions = {}): Promise<WebElementWrapper> {
-      await this.clickRowToggle({ isAnchorRow, rowIndex });
-      await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
-      return await retry.try(async () => {
-        const row = isAnchorRow ? await this.getAnchorRow() : (await this.getBodyRows())[rowIndex];
-        const detailsRow = await row.findByXpath(
-          './following-sibling::*[@data-test-subj="docTableDetailsRow"]'
-        );
-        return detailsRow.findByTestSubject('~docViewer');
-      });
-    }
+  public async getRowsText() {
+    const table = await this.getTable();
+    const $ = await table.parseDomContent();
+    return $.findTestSubjects('~docTableRow')
+      .toArray()
+      .map((row: any) => $(row).text().trim());
   }
 
-  return new DocTable();
+  public async getBodyRows(): Promise<WebElementWrapper[]> {
+    const table = await this.getTable();
+    return await table.findAllByTestSubject('~docTableRow');
+  }
+
+  public async getAnchorRow(): Promise<WebElementWrapper> {
+    const table = await this.getTable();
+    return await table.findByTestSubject('~docTableAnchorRow');
+  }
+
+  public async getRow({
+    isAnchorRow = false,
+    rowIndex = 0,
+  }: SelectOptions = {}): Promise<WebElementWrapper> {
+    return isAnchorRow ? await this.getAnchorRow() : (await this.getBodyRows())[rowIndex];
+  }
+
+  public async getDetailsRow(): Promise<WebElementWrapper> {
+    const table = await this.getTable();
+    return await table.findByCssSelector('[data-test-subj~="docTableDetailsRow"]');
+  }
+
+  public async getAnchorDetailsRow(): Promise<WebElementWrapper> {
+    const table = await this.getTable();
+    return await table.findByCssSelector(
+      '[data-test-subj~="docTableAnchorRow"] + [data-test-subj~="docTableDetailsRow"]'
+    );
+  }
+
+  public async clickRowToggle(
+    options: SelectOptions = { isAnchorRow: false, rowIndex: 0 }
+  ): Promise<void> {
+    const row = await this.getRow(options);
+    const toggle = await row.findByTestSubject('~docTableExpandToggleColumn');
+    await toggle.click();
+  }
+
+  public async getDetailsRows(): Promise<WebElementWrapper[]> {
+    const table = await this.getTable();
+    return await table.findAllByCssSelector(
+      '[data-test-subj~="docTableRow"] + [data-test-subj~="docTableDetailsRow"]'
+    );
+  }
+
+  public async getRowActions({ isAnchorRow = false, rowIndex = 0 }: SelectOptions = {}): Promise<
+    WebElementWrapper[]
+  > {
+    const detailsRow = isAnchorRow
+      ? await this.getAnchorDetailsRow()
+      : (await this.getDetailsRows())[rowIndex];
+    return await detailsRow.findAllByTestSubject('~docTableRowAction');
+  }
+
+  public async getFields(options: { isAnchorRow: boolean } = { isAnchorRow: false }) {
+    const table = await this.getTable();
+    const $ = await table.parseDomContent();
+    const rowLocator = options.isAnchorRow ? '~docTableAnchorRow' : '~docTableRow';
+    const rows = $.findTestSubjects(rowLocator).toArray();
+    return rows.map((row: any) =>
+      $(row)
+        .find('[data-test-subj~="docTableField"]')
+        .toArray()
+        .map((field: any) => $(field).text())
+    );
+  }
+
+  public async getHeaderFields(selector?: string): Promise<string[]> {
+    const table = await this.getTable(selector);
+    const $ = await table.parseDomContent();
+    return $.findTestSubjects('~docTableHeaderField')
+      .toArray()
+      .map((field: any) => $(field).text().trim());
+  }
+
+  public async getHeaders(selector?: string): Promise<string[]> {
+    return this.getHeaderFields(selector);
+  }
+
+  public async getTableDocViewRow(
+    detailsRow: WebElementWrapper,
+    fieldName: string
+  ): Promise<WebElementWrapper> {
+    return await detailsRow.findByTestSubject(`~tableDocViewRow-${fieldName}`);
+  }
+
+  public async getAddInclusiveFilterButton(
+    tableDocViewRow: WebElementWrapper
+  ): Promise<WebElementWrapper> {
+    return await tableDocViewRow.findByTestSubject(`~addInclusiveFilterButton`);
+  }
+
+  public async addInclusiveFilter(detailsRow: WebElementWrapper, fieldName: string): Promise<void> {
+    const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
+    const addInclusiveFilterButton = await this.getAddInclusiveFilterButton(tableDocViewRow);
+    await addInclusiveFilterButton.click();
+    await this.PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+  }
+
+  public async getRemoveInclusiveFilterButton(
+    tableDocViewRow: WebElementWrapper
+  ): Promise<WebElementWrapper> {
+    return await tableDocViewRow.findByTestSubject(`~removeInclusiveFilterButton`);
+  }
+
+  public async removeInclusiveFilter(
+    detailsRow: WebElementWrapper,
+    fieldName: string
+  ): Promise<void> {
+    const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
+    const addInclusiveFilterButton = await this.getRemoveInclusiveFilterButton(tableDocViewRow);
+    await addInclusiveFilterButton.click();
+    await this.PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+  }
+
+  public async getAddExistsFilterButton(
+    tableDocViewRow: WebElementWrapper
+  ): Promise<WebElementWrapper> {
+    return await tableDocViewRow.findByTestSubject(`~addExistsFilterButton`);
+  }
+
+  public async addExistsFilter(detailsRow: WebElementWrapper, fieldName: string): Promise<void> {
+    const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
+    const addInclusiveFilterButton = await this.getAddExistsFilterButton(tableDocViewRow);
+    await addInclusiveFilterButton.click();
+    await this.PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+  }
+
+  public async toggleRowExpanded({
+    isAnchorRow = false,
+    rowIndex = 0,
+  }: SelectOptions = {}): Promise<WebElementWrapper> {
+    await this.clickRowToggle({ isAnchorRow, rowIndex });
+    await this.PageObjects.header.awaitGlobalLoadingIndicatorHidden();
+    return await this.retry.try(async () => {
+      const row = isAnchorRow ? await this.getAnchorRow() : (await this.getBodyRows())[rowIndex];
+      const detailsRow = await row.findByXpath(
+        './following-sibling::*[@data-test-subj="docTableDetailsRow"]'
+      );
+      return detailsRow.findByTestSubject('~docViewer');
+    });
+  }
 }

--- a/test/functional/services/index.ts
+++ b/test/functional/services/index.ts
@@ -25,7 +25,7 @@ import {
   DashboardPanelActionsProvider,
   DashboardVisualizationProvider,
 } from './dashboard';
-import { DocTableProvider } from './doc_table';
+import { DocTableService } from './doc_table';
 import { EmbeddingProvider } from './embedding';
 import { FilterBarProvider } from './filter_bar';
 import { FlyoutProvider } from './flyout';
@@ -57,7 +57,7 @@ export const services = {
   queryBar: QueryBarProvider,
   find: FindProvider,
   testSubjects: TestSubjectsProvider,
-  docTable: DocTableProvider,
+  docTable: DocTableService,
   screenshots: ScreenshotsProvider,
   snapshots: SnapshotsProvider,
   dashboardVisualizations: DashboardVisualizationProvider,


### PR DESCRIPTION
In order to migrate the root `test` directory to its own TypeScript project that can be ref'd we need to stop returning class expressions from provider functions. Part of https://github.com/elastic/kibana/pull/99148

Migrates the "docTable" service to the new `FtrService` class, basically just extracted the class from the provider and remapped services/PageObjects referenced in scope to access private properties on the service instance. Viewing changes with whitespace disabled will help with review.