### PR TITLE
[ftr] migrate "globalNav" service to FtrService class

### DIFF
--- a/test/functional/services/global_nav.ts
+++ b/test/functional/services/global_nav.ts
@@ -7,50 +7,49 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../ftr_provider_context';
+import { FtrService } from '../ftr_provider_context';
 
-export function GlobalNavProvider({ getService }: FtrProviderContext) {
-  const testSubjects = getService('testSubjects');
+export class GlobalNavService extends FtrService {
+  private readonly testSubjects = this.ctx.getService('testSubjects');
 
-  class GlobalNav {
-    public async moveMouseToLogo(): Promise<void> {
-      await testSubjects.moveMouseTo('headerGlobalNav > logo');
-    }
-
-    public async clickLogo(): Promise<void> {
-      return await testSubjects.click('headerGlobalNav > logo');
-    }
-
-    public async clickNewsfeed(): Promise<void> {
-      return await testSubjects.click('headerGlobalNav > newsfeed');
-    }
-
-    public async exists(): Promise<boolean> {
-      return await testSubjects.exists('headerGlobalNav');
-    }
-
-    public async getFirstBreadcrumb(): Promise<string> {
-      return await testSubjects.getVisibleText(
-        'headerGlobalNav > breadcrumbs > ~breadcrumb & ~first'
-      );
-    }
-
-    public async getLastBreadcrumb(): Promise<string> {
-      return await testSubjects.getVisibleText(
-        'headerGlobalNav > breadcrumbs > ~breadcrumb & ~last'
-      );
-    }
-
-    public async badgeExistsOrFail(expectedLabel: string): Promise<void> {
-      await testSubjects.existOrFail('headerBadge');
-      const actualLabel = await testSubjects.getAttribute('headerBadge', 'data-test-badge-label');
-      expect(actualLabel.toUpperCase()).to.equal(expectedLabel.toUpperCase());
-    }
-
-    public async badgeMissingOrFail(): Promise<void> {
-      await testSubjects.missingOrFail('headerBadge');
-    }
+  public async moveMouseToLogo(): Promise<void> {
+    await this.testSubjects.moveMouseTo('headerGlobalNav > logo');
   }
 
-  return new GlobalNav();
+  public async clickLogo(): Promise<void> {
+    return await this.testSubjects.click('headerGlobalNav > logo');
+  }
+
+  public async clickNewsfeed(): Promise<void> {
+    return await this.testSubjects.click('headerGlobalNav > newsfeed');
+  }
+
+  public async exists(): Promise<boolean> {
+    return await this.testSubjects.exists('headerGlobalNav');
+  }
+
+  public async getFirstBreadcrumb(): Promise<string> {
+    return await this.testSubjects.getVisibleText(
+      'headerGlobalNav > breadcrumbs > ~breadcrumb & ~first'
+    );
+  }
+
+  public async getLastBreadcrumb(): Promise<string> {
+    return await this.testSubjects.getVisibleText(
+      'headerGlobalNav > breadcrumbs > ~breadcrumb & ~last'
+    );
+  }
+
+  public async badgeExistsOrFail(expectedLabel: string): Promise<void> {
+    await this.testSubjects.existOrFail('headerBadge');
+    const actualLabel = await this.testSubjects.getAttribute(
+      'headerBadge',
+      'data-test-badge-label'
+    );
+    expect(actualLabel.toUpperCase()).to.equal(expectedLabel.toUpperCase());
+  }
+
+  public async badgeMissingOrFail(): Promise<void> {
+    await this.testSubjects.missingOrFail('headerBadge');
+  }
 }

--- a/test/functional/services/index.ts
+++ b/test/functional/services/index.ts
@@ -29,7 +29,7 @@ import { DocTableProvider } from './doc_table';
 import { EmbeddingProvider } from './embedding';
 import { FilterBarProvider } from './filter_bar';
 import { FlyoutProvider } from './flyout';
-import { GlobalNavProvider } from './global_nav';
+import { GlobalNavService } from './global_nav';
 import { InspectorProvider } from './inspector';
 import { FieldEditorProvider } from './field_editor';
 import { ManagementMenuProvider } from './management';
@@ -78,7 +78,7 @@ export const services = {
   fieldEditor: FieldEditorProvider,
   vegaDebugInspector: VegaDebugInspectorViewProvider,
   appsMenu: AppsMenuProvider,
-  globalNav: GlobalNavProvider,
+  globalNav: GlobalNavService,
   toasts: ToastsProvider,
   savedQueryManagementComponent: SavedQueryManagementComponentProvider,
   elasticChart: ElasticChartProvider,


### PR DESCRIPTION
In order to migrate the root `test` directory to its own TypeScript project that can be ref'd we need to stop returning class expressions from provider functions. Part of https://github.com/elastic/kibana/pull/99148

Migrates the "globalNav" service to the new `FtrService` class, basically just extracted the class from the provider and remapped services/PageObjects referenced in scope to access private properties on the service instance. Viewing changes with whitespace disabled will help with review.