### PR TITLE
[TSVB] [Table tab] Fix "Math" aggregation

### DIFF
--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/math.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/math.js
@@ -8,9 +8,9 @@
 
 import { mathAgg } from '../series/math';
 
-export function math(bucket, panel, series) {
+export function math(bucket, panel, series, meta, extractFields) {
   return (next) => (results) => {
-    const mathFn = mathAgg({ aggregations: bucket }, panel, series);
+    const mathFn = mathAgg({ aggregations: bucket }, panel, series, meta, extractFields);
     return mathFn(next)(results);
   };
 }


### PR DESCRIPTION
Closes: #100892
## Summary

"Math" aggregation not working at all for table view due to executing with wrong arguments. 

## Steps to reproduce: 
1) Open `TSVB` and go to `Table` tab
2) Configure some Math aggregation like e.g 
![image](https://user-images.githubusercontent.com/20072247/119826001-409f0280-bf00-11eb-8faf-c80ea53fbbc0.png)

**Expected result:** 
Table should contain some data

**Actual result:** 
![image](https://user-images.githubusercontent.com/20072247/119826154-675d3900-bf00-11eb-9276-204be9d7ddcb.png)

## Console log:
```
   │ proc [kibana] TypeError: extractFields is not a function
   │ proc [kibana]     at getSplits (/Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_splits.js:26:46)
   │ proc [kibana]     at /Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/series/math.js:30:26
   │ proc [kibana]     at next (/Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/math.js:14:12)
   │ proc [kibana]     at next (/Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/std_sibling.js:17:47)
   │ proc [kibana]     at /Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/response_processors/table/std_metric.js:43:12
   │ proc [kibana]     at runMicrotasks (<anonymous>)
   │ proc [kibana]     at processTicksAndRejections (internal/process/task_queues.js:95:5)
   │ proc [kibana]     at /Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/table/process_bucket.js:50:30
   │ proc [kibana]     at async Promise.all (index 0)
   │ proc [kibana]     at /Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/table/process_bucket.js:28:20
   │ proc [kibana]     at async Promise.all (index 0)
   │ proc [kibana]     at getTableData (/Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/lib/vis_data/get_table_data.ts:100:20)
   │ proc [kibana]     at async Promise.all (index 0)
   │ proc [kibana]     at /Users/Documents/Kibana/src/plugins/vis_type_timeseries/server/routes/vis.ts:36:23
   │ proc [kibana]     at Router.handle (/Users/Documents/Kibana/src/core/server/http/router/router.ts:273:30)
   │ proc [kibana]     at handler (/Users/Documents/Kibana/src/core/server/http/router/router.ts:228:11)
```
 


