### PR TITLE
[Enterprise Search] Log warning for Kibana/EntSearch version mismatches

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -12,9 +12,16 @@ import fetch from 'node-fetch';
 
 const { Response } = jest.requireActual('node-fetch');
 
+jest.mock('@kbn/utils', () => ({
+  kibanaPackageJson: { version: '1.0.0' },
+}));
+
 import { loggingSystemMock } from 'src/core/server/mocks';
 
-import { callEnterpriseSearchConfigAPI } from './enterprise_search_config_api';
+import {
+  callEnterpriseSearchConfigAPI,
+  warnMismatchedVersions,
+} from './enterprise_search_config_api';
 
 describe('callEnterpriseSearchConfigAPI', () => {
   const mockConfig = {
@@ -217,5 +224,23 @@ describe('callEnterpriseSearchConfigAPI', () => {
     expect(mockDependencies.log.warn).toHaveBeenCalledWith(
       "Exceeded 200ms timeout while checking http://localhost:3002. Please consider increasing your enterpriseSearch.accessCheckTimeout value so that users aren't prevented from accessing Enterprise Search plugins due to slow responses."
     );
+  });
+
+  describe('warnMismatchedVersions', () => {
+    it("logs a warning when Enterprise Search and Kibana's versions are not the same", () => {
+      warnMismatchedVersions('1.1.0', mockDependencies.log);
+
+      expect(mockDependencies.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Your Kibana instance (v1.0.0) is not the same version as your Enterprise Search instance (v1.1.0)'
+        )
+      );
+    });
+
+    it("does not log a warning when Enterprise Search and Kibana's versions are the same", () => {
+      warnMismatchedVersions('1.0.0', mockDependencies.log);
+
+      expect(mockDependencies.log.warn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -8,6 +8,8 @@
 import AbortController from 'abort-controller';
 import fetch from 'node-fetch';
 
+import { kibanaPackageJson } from '@kbn/utils';
+
 import { KibanaRequest, Logger } from 'src/core/server';
 
 import { stripTrailingSlash } from '../../common/strip_slashes';
@@ -57,6 +59,8 @@ export const callEnterpriseSearchConfigAPI = async ({
       signal: controller.signal,
     });
     const data = await response.json();
+
+    warnMismatchedVersions(data?.version?.number, log);
 
     return {
       access: {
@@ -133,5 +137,15 @@ export const callEnterpriseSearchConfigAPI = async ({
   } finally {
     clearTimeout(warningTimeout);
     clearTimeout(timeout);
+  }
+};
+
+export const warnMismatchedVersions = (enterpriseSearchVersion: string, log: Logger) => {
+  const kibanaVersion = kibanaPackageJson.version;
+
+  if (enterpriseSearchVersion !== kibanaVersion) {
+    log.warn(
+      `Your Kibana instance (v${kibanaVersion}) is not the same version as your Enterprise Search instance (v${enterpriseSearchVersion}). Please upgrade your instances accordingly to matching versions, otherwise you may see breaking or otherwise buggy behavior.`
+    );
   }
 };

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -145,7 +145,7 @@ export const warnMismatchedVersions = (enterpriseSearchVersion: string, log: Log
 
   if (enterpriseSearchVersion !== kibanaVersion) {
     log.warn(
-      `Your Kibana instance (v${kibanaVersion}) is not the same version as your Enterprise Search instance (v${enterpriseSearchVersion}). Please upgrade your instances accordingly to matching versions, otherwise you may see breaking or otherwise buggy behavior.`
+      `Your Kibana instance (v${kibanaVersion}) is not the same version as your Enterprise Search instance (v${enterpriseSearchVersion}), which may cause unexpected behavior. Use matching versions for the best experience.`
     );
   }
 };


### PR DESCRIPTION
## Summary

Adds a small Kibana log warning whenever Enterprise Search polls the config data endpoint (e.g. for access check, on plugin load) and warns if versions are mismatched.

We should always see this on dev since Kibana's master is 8.0.0 and Ent Search's is 7.x:

<img width="1075" alt="" src="https://user-images.githubusercontent.com/549407/119875352-83021880-bedb-11eb-9596-8ef13f52d05a.png">

### Checklist

FYI, no i18n for log messages is required from my last recollection of asking this question.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios