### PR TITLE
[SO migrationsv2] Explicitly transition to a cleanup phase before migration fails

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/actions/cleanup.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/cleanup.ts
@@ -11,12 +11,12 @@ import { closePit } from './index';
 import { ElasticsearchClient } from '../../../elasticsearch';
 import { RetryableEsClientError } from './catch_retryable_es_client_errors';
 
-export interface CleanupFatalFailed {
+export interface CleanupFailed {
   type: 'cleanup_failed';
   // adding properties to pass through the closePit error that we surface when logging migration transitions
   cleanupFatalError: RetryableEsClientError;
 }
-export interface CleanupFatalSuccess {
+export interface CleanupSuccess {
   type: 'cleanup_complete' | 'cleanup_closepit_skipped';
 }
 /**
@@ -26,7 +26,25 @@ export interface CleanupFatalSuccess {
 const cleanupFatal = (
   client: ElasticsearchClient,
   pitId?: string
-): TaskEither.TaskEither<CleanupFatalFailed, CleanupFatalSuccess> => async () => {
+): TaskEither.TaskEither<CleanupFailed, CleanupSuccess> => async () => {
+  if (!pitId) return Either.right({ type: 'cleanup_closepit_skipped' }); // there's nothing to do here, we simply pass through
+  const result = await closePit(client, pitId)();
+  if (result._tag === 'Right') {
+    return Either.right({ type: 'cleanup_complete' });
+  } else {
+    const cleanupFatalError = { ...result.left };
+    return Either.left({ type: 'cleanup_failed', cleanupFatalError }); // passing through the error from closePit
+  }
+};
+
+/**
+ * Performs clean up steps before failing the migration
+ * If more cleanup steps are needed, use chaining here. See waitForReindexTask for implementation example
+ */
+const cleanupBadResponse = (
+  client: ElasticsearchClient,
+  pitId?: string
+): TaskEither.TaskEither<CleanupFailed, CleanupSuccess> => async () => {
   if (!pitId) return Either.right({ type: 'cleanup_closepit_skipped' }); // there's nothing to do here, we simply pass through
   const result = await closePit(client, pitId)();
   if (result._tag === 'Right') {
@@ -39,4 +57,4 @@ const cleanupFatal = (
 
 // allows us to create mocks for the module
 // might need to modify the export type a bit here
-export const cleanup = { cleanupFatal };
+export const cleanup = { cleanupFatal, cleanupBadResponse };

--- a/src/core/server/saved_objects/migrationsv2/actions/cleanup.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/cleanup.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import * as Either from 'fp-ts/lib/Either';
+import * as TaskEither from 'fp-ts/lib/TaskEither';
+import { closePit } from './index';
+import { ElasticsearchClient } from '../../../elasticsearch';
+import { RetryableEsClientError } from './catch_retryable_es_client_errors';
+
+export interface CleanupFatalFailed {
+  type: 'cleanup_failed';
+  // adding properties to pass through the closePit error that we surface when logging migration transitions
+  cleanupFatalError: RetryableEsClientError;
+}
+export interface CleanupFatalSuccess {
+  type: 'cleanup_complete' | 'cleanup_closepit_skipped';
+}
+/**
+ * Performs clean up steps before failing the migration
+ * If more cleanup steps are needed, use chaining here. See waitForReindexTask for implementation example
+ */
+const cleanupFatal = (
+  client: ElasticsearchClient,
+  pitId?: string
+): TaskEither.TaskEither<CleanupFatalFailed, CleanupFatalSuccess> => async () => {
+  if (!pitId) return Either.right({ type: 'cleanup_closepit_skipped' }); // there's nothing to do here, we simply pass through
+  const result = await closePit(client, pitId)();
+  if (result._tag === 'Right') {
+    return Either.right({ type: 'cleanup_complete' });
+  } else {
+    const cleanupFatalError = { ...result.left };
+    return Either.left({ type: 'cleanup_failed', cleanupFatalError }); // passing through the error from closePit
+  }
+};
+
+// allows us to create mocks for the module
+// might need to modify the export type a bit here
+export const cleanup = { cleanupFatal };

--- a/src/core/server/saved_objects/migrationsv2/actions/index.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.test.ts
@@ -129,14 +129,6 @@ describe('actions', () => {
     });
   });
 
-  describe('cleanupFatal', () => {
-    // to properly spy on mocks and create the mocks for actions being called within other actions, we either need to:
-    // refactor a split out all the actions into indivudual files (https://github.com/elastic/kibana/issues/99479)
-    // export an object containing all the actions
-    it.todo('calls closePit');
-    it.todo("doesn't call closePit if there isn't one to close");
-  });
-
   describe('reindex', () => {
     it('calls catchRetryableEsClientErrors when the promise rejects', async () => {
       const task = Actions.reindex(

--- a/src/core/server/saved_objects/migrationsv2/actions/index.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.test.ts
@@ -129,6 +129,14 @@ describe('actions', () => {
     });
   });
 
+  describe('cleanupFatal', () => {
+    // to properly spy on mocks and create the mocks for actions being called within other actions, we either need to:
+    // refactor a split out all the actions into indivudual files (https://github.com/elastic/kibana/issues/99479)
+    // export an object containing all the actions
+    it.todo('calls closePit');
+    it.todo("doesn't call closePit if there isn't one to close");
+  });
+
   describe('reindex', () => {
     it('calls catchRetryableEsClientErrors when the promise rejects', async () => {
       const task = Actions.reindex(

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -240,7 +240,8 @@ export const cloneIndex = (
             settings: {
               index: {
                 // The source we're cloning from will have a write block set, so
-                // we need to remove it to allow writes to our newly cloned index
+                // we need to explicitly overwrite the blocks.write setting during cloning
+                // otherwise we won't allow writes to our newly cloned index
                 'blocks.write': false,
                 number_of_shards: INDEX_NUMBER_OF_SHARDS,
                 auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -27,6 +27,7 @@ import {
   DocumentsTransformSuccess,
 } from '../../migrations/core/migrate_raw_docs';
 export type { RetryableEsClientError };
+export { cleanup } from './cleanup';
 
 /**
  * Batch size for updateByQuery and reindex operations.

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.test.ts
@@ -55,6 +55,7 @@ describe('migrationsStateActionMachine', () => {
   // A model that transitions through all the provided states
   const transitionModel = (states: AllControlStates[]) => {
     let i = 0;
+
     return (s: State, res: Either.Either<unknown, string>): State => {
       if (i < states.length) {
         const newState = {
@@ -709,38 +710,5 @@ describe('migrationsStateActionMachine', () => {
         ],
       ]
     `);
-  });
-  describe('cleanup', () => {
-    beforeEach(() => {
-      cleanupMock.mockClear();
-    });
-    it('calls cleanup function when an action throws', async () => {
-      await expect(
-        migrationStateActionMachine({
-          initialState: { ...initialState, reason: 'the fatal reason' } as State,
-          logger: mockLogger.get(),
-          model: transitionModel(['LEGACY_REINDEX', 'LEGACY_DELETE', 'FATAL']),
-          next: () => {
-            throw new Error('this action throws');
-          },
-          client: esClient,
-        })
-      ).rejects.toThrow();
-
-      expect(cleanupMock).toHaveBeenCalledTimes(1);
-    });
-    it('calls cleanup function when reaching the FATAL state', async () => {
-      await expect(
-        migrationStateActionMachine({
-          initialState: { ...initialState, reason: 'the fatal reason' } as State,
-          logger: mockLogger.get(),
-          model: transitionModel(['LEGACY_REINDEX', 'LEGACY_DELETE', 'FATAL']),
-          next,
-          client: esClient,
-        })
-      ).rejects.toThrow();
-
-      expect(cleanupMock).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.test.ts
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { cleanupMock } from './migrations_state_machine_cleanup.mocks';
 import { migrationStateActionMachine } from './migrations_state_action_machine';
 import { loggingSystemMock, elasticsearchServiceMock } from '../../mocks';
 import * as Either from 'fp-ts/lib/Either';

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
@@ -120,15 +120,12 @@ export async function migrationStateActionMachine({
   // indicate which messages come from which index upgrade.
   const logMessagePrefix = `[${initialState.indexPrefix}] `;
   let prevTimestamp = startTime;
-  let lastState: State | undefined;
   try {
     // we either return from here or an error is thrown
     const finalState = await stateActionMachine<State>(
       initialState,
       (state) => next(state),
       (state, res) => {
-        lastState = state;
-
         executionLog.push({
           type: 'response',
           res,

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
@@ -123,6 +123,7 @@ export async function migrationStateActionMachine({
   let prevTimestamp = startTime;
   let lastState: State | undefined;
   try {
+    // we either return from here or an error is thrown
     const finalState = await stateActionMachine<State>(
       initialState,
       (state) => next(state),

--- a/src/core/server/saved_objects/migrationsv2/next.ts
+++ b/src/core/server/saved_objects/migrationsv2/next.ts
@@ -40,6 +40,7 @@ import type {
   RefreshTarget,
   OutdatedDocumentsRefresh,
   CleanupFatalState,
+  CleanupBadResponse,
 } from './types';
 import * as Actions from './actions';
 import { ElasticsearchClient } from '../../elasticsearch';
@@ -161,7 +162,10 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
       Actions.waitForReindexTask(client, state.legacyReindexTaskId, '60s'),
     LEGACY_DELETE: (state: LegacyDeleteState) =>
       Actions.updateAliases(client, state.legacyPreMigrationDoneActions),
+    // the following two control states trigger pretty much the same cleanup actions but these might change.
     CLEANUP_FATAL: (state: CleanupFatalState) => Actions.cleanup.cleanupFatal(client, state.pitId), // right now, we only need state.pitId
+    CLEANUP_BAD_RESPONSE: (state: CleanupBadResponse) =>
+      Actions.cleanup.cleanupBadResponse(client, state.pitId), // right now, we only need state.pitId
   };
 };
 

--- a/src/core/server/saved_objects/migrationsv2/next.ts
+++ b/src/core/server/saved_objects/migrationsv2/next.ts
@@ -39,6 +39,7 @@ import type {
   OutdatedDocumentsSearchClosePit,
   RefreshTarget,
   OutdatedDocumentsRefresh,
+  CleanupFatalState,
 } from './types';
 import * as Actions from './actions';
 import { ElasticsearchClient } from '../../elasticsearch';
@@ -160,6 +161,7 @@ export const nextActionMap = (client: ElasticsearchClient, transformRawDocs: Tra
       Actions.waitForReindexTask(client, state.legacyReindexTaskId, '60s'),
     LEGACY_DELETE: (state: LegacyDeleteState) =>
       Actions.updateAliases(client, state.legacyPreMigrationDoneActions),
+    CLEANUP_FATAL: (state: CleanupFatalState) => Actions.cleanup.cleanupFatal(client, state.pitId), // right now, we only need state.pitId
   };
 };
 

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -10,7 +10,7 @@ import * as TaskEither from 'fp-ts/lib/TaskEither';
 import * as Option from 'fp-ts/lib/Option';
 import { estypes } from '@elastic/elasticsearch';
 import { ControlState } from './state_action_machine';
-import { AliasAction } from './actions';
+import { AliasAction, RetryableEsClientError } from './actions';
 import { IndexMapping } from '../mappings';
 import { SavedObjectsRawDoc } from '..';
 import { TransformErrorObjects } from '../migrations/core';
@@ -381,6 +381,17 @@ export interface LegacyDeleteState extends LegacyBaseState {
   readonly controlState: 'LEGACY_DELETE';
 }
 
+export interface CleanupFatalState extends PostInitState {
+  /**
+   * Before transitioning to the FATAL state, we need to execute any cleanup actions
+   * e.g. closePit
+   */
+  readonly controlState: 'CLEANUP_FATAL';
+  readonly fatalReason: string;
+  readonly pitId?: string;
+  readonly cleanupFatalError?: RetryableEsClientError;
+}
+
 export type State = Readonly<
   | FatalState
   | InitState
@@ -412,6 +423,7 @@ export type State = Readonly<
   | LegacyReindexState
   | LegacyReindexWaitForTaskState
   | LegacyDeleteState
+  | CleanupFatalState
 >;
 
 export type AllControlStates = State['controlState'];

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -392,6 +392,23 @@ export interface CleanupFatalState extends PostInitState {
   readonly cleanupFatalError?: RetryableEsClientError;
 }
 
+/** @internal */
+export interface BadResponseSource {
+  state: State;
+  res: any;
+}
+export interface CleanupBadResponse extends PostInitState {
+  /**
+   * Before throwing the bad response, we need to execute any cleanup actions
+   * e.g. closePit
+   * the bad response takes the state.controlState that threw and the res from that controlState's action, so we pass those along
+   */
+  readonly controlState: 'CLEANUP_BAD_RESPONSE';
+  readonly badResponseSource: BadResponseSource;
+  readonly pitId?: string;
+  readonly cleanupFatalError?: RetryableEsClientError;
+}
+
 export type State = Readonly<
   | FatalState
   | InitState
@@ -424,6 +441,7 @@ export type State = Readonly<
   | LegacyReindexWaitForTaskState
   | LegacyDeleteState
   | CleanupFatalState
+  | CleanupBadResponse
 >;
 
 export type AllControlStates = State['controlState'];

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -224,7 +224,9 @@ export type SetTempWriteBlock = PostInitState & {
 
 export interface CloneTempToSource extends PostInitState {
   /**
-   * Clone the temporary reindex index into
+   * Clone the temporary reindex index into the target index
+   * sourceIndex is the temp index
+   * target is the destination index
    */
   readonly controlState: 'CLONE_TEMP_TO_TARGET';
   readonly sourceIndex: Option.Some<string>;


### PR DESCRIPTION
[[On Hold](https://github.com/elastic/kibana/issues/100650#issuecomment-850507378)]
## Summary
Resolves https://github.com/elastic/kibana/issues/100650
Main changed to the model:
- transition to `CLEANUP_FATAL` before `FATAL`
- transition to `CLEANUP_BAD_RESPONSE` before `throwBadResponse`

The only cleanup action performed at this stage is to close any remaining open pit search. For this reason, the transitions to `CLEANUP_*` before `FATAL` or `throwBadResponse` are only applied during relevant migration transitions.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios (**partially updated**)
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
