### PR TITLE
Fix typo in spaces doc

### DIFF
--- a/docs/spaces/index.asciidoc
+++ b/docs/spaces/index.asciidoc
@@ -28,7 +28,7 @@ Kibana supports spaces in several ways.  You can:
 [float]
 ==== Required permissions
 
-The `kibana_admin` role or equivilent is required to manage **Spaces**.
+The `kibana_admin` role or equivalent is required to manage **Spaces**.
 
 [float]
 [[spaces-managing]]


### PR DESCRIPTION
equivilent => equivalent

## Summary

Simple typo corrected in one location.

### Checklist

N/A

### For maintainers

N/A