### PR TITLE
[WIP] [Lens] Gauge charts

### DIFF
--- a/x-pack/plugins/lens/public/async_services.ts
+++ b/x-pack/plugins/lens/public/async_services.ts
@@ -16,6 +16,7 @@
 
 export * from './datatable_visualization/datatable_visualization';
 export * from './metric_visualization/metric_visualization';
+export * from './gauge_visualization/gauge_visualization';
 export * from './pie_visualization/pie_visualization';
 export * from './xy_visualization/xy_visualization';
 

--- a/x-pack/plugins/lens/public/gauge_visualization/expression.scss
+++ b/x-pack/plugins/lens/public/gauge_visualization/expression.scss
@@ -1,0 +1,13 @@
+.lnsGaugeExpression__container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+
+  .echChart {
+    width: 100%;
+  }
+}

--- a/x-pack/plugins/lens/public/gauge_visualization/expression.tsx
+++ b/x-pack/plugins/lens/public/gauge_visualization/expression.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import './expression.scss';
+import { I18nProvider } from '@kbn/i18n/react';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { scaleLinear } from 'd3-scale';
+import { Chart, Goal } from '@elastic/charts';
+import {
+  ExpressionFunctionDefinition,
+  ExpressionRenderDefinition,
+  IInterpreterRenderHandlers,
+} from '../../../../../src/plugins/expressions/public';
+import { GaugeConfig } from './types';
+import { FormatFactory, LensMultiTable } from '../types';
+import { VisualizationContainer } from '../visualization_container';
+import { EmptyPlaceholder } from '../shared_components';
+
+export interface GaugeChartProps {
+  data: LensMultiTable;
+  args: GaugeConfig;
+}
+
+export interface GaugeRender {
+  type: 'render';
+  as: 'lens_gauge_chart_renderer';
+  value: GaugeChartProps;
+}
+
+export const gaugeChart: ExpressionFunctionDefinition<
+  'lens_gauge_chart',
+  LensMultiTable,
+  Omit<GaugeConfig, 'layerId'>,
+  GaugeRender
+> = {
+  name: 'lens_gauge_chart',
+  type: 'render',
+  help: 'A gauge chart',
+  args: {
+    title: {
+      types: ['string'],
+      help: 'The chart title.',
+    },
+    description: {
+      types: ['string'],
+      help: '',
+    },
+    gaugeTitle: {
+      types: ['string'],
+      help: 'The title of the gauge shown.',
+    },
+    accessor: {
+      types: ['string'],
+      help: 'The column whose value is being displayed',
+    },
+    target: {
+      types: ['number'],
+      help: '',
+    },
+    min: {
+      types: ['number'],
+      help: '',
+    },
+    max: {
+      types: ['number'],
+      help: '',
+    },
+    type: {
+      types: ['string'],
+      help: '',
+    },
+    subTitle: {
+      types: ['string'],
+      help: '',
+    },
+    mode: {
+      types: ['string'],
+      options: ['reduced', 'full'],
+      default: 'full',
+      help:
+        'The display mode of the chart - reduced will only show the gauge itself without min size',
+    },
+  },
+  inputTypes: ['lens_multitable'],
+  fn(data, args) {
+    return {
+      type: 'render',
+      as: 'lens_gauge_chart_renderer',
+      value: {
+        data,
+        args,
+      },
+    } as GaugeRender;
+  },
+};
+
+export const getGaugeChartRenderer = (
+  formatFactory: Promise<FormatFactory>
+): ExpressionRenderDefinition<GaugeChartProps> => ({
+  name: 'lens_gauge_chart_renderer',
+  displayName: 'Gauge chart',
+  help: 'Gauge chart renderer',
+  validate: () => undefined,
+  reuseDomNode: true,
+  render: async (
+    domNode: Element,
+    config: GaugeChartProps,
+    handlers: IInterpreterRenderHandlers
+  ) => {
+    const resolvedFormatFactory = await formatFactory;
+    ReactDOM.render(
+      <I18nProvider>
+        <GaugeChart {...config} formatFactory={resolvedFormatFactory} />
+      </I18nProvider>,
+      domNode,
+      () => {
+        handlers.done();
+      }
+    );
+    handlers.onDestroy(() => ReactDOM.unmountComponentAtNode(domNode));
+  },
+});
+
+export function GaugeChart({
+  data,
+  args,
+  formatFactory,
+}: GaugeChartProps & { formatFactory: FormatFactory }) {
+  const {
+    gaugeTitle,
+    title,
+    description,
+    accessor,
+    mode,
+    target,
+    max: maxConfig,
+    min: minConfig,
+    type,
+    subTitle,
+  } = args;
+  const firstTable = Object.values(data.tables)[0];
+  if (!accessor) {
+    return (
+      <VisualizationContainer
+        reportTitle={title}
+        reportDescription={description}
+        className="lnsGaugeExpression__container"
+      />
+    );
+  }
+
+  if (!firstTable) {
+    return <EmptyPlaceholder icon="visGauge" />;
+  }
+
+  const column = firstTable.columns[0];
+  const row = firstTable.rows[0];
+
+  // NOTE: Cardinality and Sum never receives "null" as value, but always 0, even for empty dataset.
+  // Mind falsy values here as 0!
+  const shouldShowResults = row[accessor] != null;
+
+  if (!shouldShowResults) {
+    return <EmptyPlaceholder icon="visGauge" />;
+  }
+
+  const numberValue = Number(row[accessor]);
+
+  const formatter = column.meta?.params ? formatFactory(column.meta?.params) : undefined;
+
+  const value =
+    column && formatter
+      ? formatter.convert(row[accessor])
+      : Number(Number(row[accessor]).toFixed(3)).toString();
+
+  const min = Math.min(numberValue, minConfig ?? 0);
+  const max = Math.max(maxConfig ?? Math.round(Math.abs(numberValue) * 1.5), numberValue);
+
+  const ticks = scaleLinear().domain([min, max]).nice().ticks(5);
+
+  return (
+    <VisualizationContainer
+      reportTitle={title}
+      reportDescription={description}
+      className="lnsGaugeExpression__container"
+    >
+      <Chart>
+        <Goal
+          id="spec_1"
+          subtype={type}
+          base={min}
+          target={target ?? numberValue}
+          actual={numberValue}
+          bands={[]}
+          ticks={ticks}
+          tickValueFormatter={({ value: tickValue }) =>
+            formatter ? formatter.convert(tickValue) : String(tickValue)
+          }
+          labelMajor={gaugeTitle}
+          labelMinor={subTitle}
+          centralMajor={value}
+          centralMinor=" "
+          config={{ angleStart: Math.PI, angleEnd: 0 }}
+        />
+      </Chart>
+    </VisualizationContainer>
+  );
+}

--- a/x-pack/plugins/lens/public/gauge_visualization/gauge_visualization.ts
+++ b/x-pack/plugins/lens/public/gauge_visualization/gauge_visualization.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './expression';
+export * from './visualization';

--- a/x-pack/plugins/lens/public/gauge_visualization/index.ts
+++ b/x-pack/plugins/lens/public/gauge_visualization/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoreSetup } from 'kibana/public';
+import { ExpressionsSetup } from '../../../../../src/plugins/expressions/public';
+import { EditorFrameSetup, FormatFactory } from '../types';
+
+export interface GaugeVisualizationPluginSetupPlugins {
+  expressions: ExpressionsSetup;
+  formatFactory: Promise<FormatFactory>;
+  editorFrame: EditorFrameSetup;
+}
+
+export class GaugeVisualization {
+  constructor() {}
+
+  setup(
+    _core: CoreSetup | null,
+    { expressions, formatFactory, editorFrame }: GaugeVisualizationPluginSetupPlugins
+  ) {
+    editorFrame.registerVisualization(async () => {
+      const { gaugeVisualization, gaugeChart, getGaugeChartRenderer } = await import(
+        '../async_services'
+      );
+
+      expressions.registerFunction(() => gaugeChart);
+
+      expressions.registerRenderer(() => getGaugeChartRenderer(formatFactory));
+      return gaugeVisualization;
+    });
+  }
+}

--- a/x-pack/plugins/lens/public/gauge_visualization/index.ts
+++ b/x-pack/plugins/lens/public/gauge_visualization/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { CoreSetup } from 'kibana/public';
+import { ChartsPluginSetup } from 'src/plugins/charts/public';
 import { ExpressionsSetup } from '../../../../../src/plugins/expressions/public';
 import { EditorFrameSetup, FormatFactory } from '../types';
 
@@ -13,6 +14,7 @@ export interface GaugeVisualizationPluginSetupPlugins {
   expressions: ExpressionsSetup;
   formatFactory: Promise<FormatFactory>;
   editorFrame: EditorFrameSetup;
+  charts: ChartsPluginSetup;
 }
 
 export class GaugeVisualization {
@@ -20,17 +22,18 @@ export class GaugeVisualization {
 
   setup(
     _core: CoreSetup | null,
-    { expressions, formatFactory, editorFrame }: GaugeVisualizationPluginSetupPlugins
+    { expressions, formatFactory, editorFrame, charts }: GaugeVisualizationPluginSetupPlugins
   ) {
     editorFrame.registerVisualization(async () => {
-      const { gaugeVisualization, gaugeChart, getGaugeChartRenderer } = await import(
+      const { getGaugeVisualization, gaugeChart, getGaugeChartRenderer } = await import(
         '../async_services'
       );
+      const palettes = await charts.palettes.getPalettes();
 
       expressions.registerFunction(() => gaugeChart);
 
       expressions.registerRenderer(() => getGaugeChartRenderer(formatFactory));
-      return gaugeVisualization;
+      return getGaugeVisualization(palettes);
     });
   }
 }

--- a/x-pack/plugins/lens/public/gauge_visualization/types.ts
+++ b/x-pack/plugins/lens/public/gauge_visualization/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { PaletteOutput } from 'src/plugins/charts/public';
+
 export interface GaugeState {
   layerId: string;
   accessor?: string;
@@ -13,6 +15,7 @@ export interface GaugeState {
   max?: number;
   subTitle?: string;
   type: 'goal' | 'horizontalBullet' | 'verticalBullet';
+  palette?: PaletteOutput;
 }
 
 export interface GaugeConfig extends GaugeState {

--- a/x-pack/plugins/lens/public/gauge_visualization/types.ts
+++ b/x-pack/plugins/lens/public/gauge_visualization/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface GaugeState {
+  layerId: string;
+  accessor?: string;
+  target?: number;
+  min?: number;
+  max?: number;
+  subTitle?: string;
+  type: 'goal' | 'horizontalBullet' | 'verticalBullet';
+}
+
+export interface GaugeConfig extends GaugeState {
+  title: string;
+  description: string;
+  gaugeTitle: string;
+  mode: 'reduced' | 'full';
+}

--- a/x-pack/plugins/lens/public/gauge_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/gauge_visualization/visualization.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { Ast } from '@kbn/interpreter/target/common';
+import { render } from 'react-dom';
+import { EuiFormRow, EuiFieldNumber, EuiFieldText } from '@elastic/eui';
+import { getSuggestions } from './gauge_suggestions';
+import { Visualization, OperationMetadata, DatasourcePublicAPI } from '../types';
+import { GaugeState } from './types';
+
+const toExpression = (
+  state: GaugeState,
+  datasourceLayers: Record<string, DatasourcePublicAPI>,
+  attributes?: { mode?: 'reduced' | 'full'; title?: string; description?: string }
+): Ast | null => {
+  if (!state.accessor) {
+    return null;
+  }
+
+  const [datasource] = Object.values(datasourceLayers);
+  const operation = datasource && datasource.getOperationForColumnId(state.accessor);
+
+  return {
+    type: 'expression',
+    chain: [
+      {
+        type: 'function',
+        function: 'lens_gauge_chart',
+        arguments: {
+          title: [attributes?.title || ''],
+          description: [attributes?.description || ''],
+          gaugeTitle: [(operation && operation.label) || ''],
+          accessor: [state.accessor],
+          target: typeof state.target !== 'undefined' ? [state.target] : [],
+          min: typeof state.min !== 'undefined' ? [state.min] : [],
+          max: typeof state.max !== 'undefined' ? [state.max] : [],
+          type: [state.type],
+          mode: [attributes?.mode || 'full'],
+          subTitle: [state.subTitle || ''],
+        },
+      },
+    ],
+  };
+};
+
+export const gaugeVisualization: Visualization<GaugeState> = {
+  id: 'lnsGauge',
+
+  visualizationTypes: [
+    {
+      id: 'goal',
+      icon: 'visGauge',
+      label: i18n.translate('xpack.lens.gauge.label', {
+        defaultMessage: 'Gauge',
+      }),
+      groupLabel: i18n.translate('xpack.lens.gauge.groupLabel', {
+        defaultMessage: 'Tabular and single value',
+      }),
+      sortPriority: 1,
+    },
+    {
+      id: 'verticalBullet',
+      icon: 'visGauge',
+      label: i18n.translate('xpack.lens.gauge.label', {
+        defaultMessage: 'Bullet vertical',
+      }),
+      groupLabel: i18n.translate('xpack.lens.gauge.groupLabel', {
+        defaultMessage: 'Tabular and single value',
+      }),
+      sortPriority: 1,
+    },
+    {
+      id: 'horizontalBullet',
+      icon: 'visGauge',
+      label: i18n.translate('xpack.lens.gauge.label', {
+        defaultMessage: 'Bullet horizontal',
+      }),
+      groupLabel: i18n.translate('xpack.lens.gauge.groupLabel', {
+        defaultMessage: 'Tabular and single value',
+      }),
+      sortPriority: 1,
+    },
+  ],
+
+  switchVisualizationType(type: string, state: GaugeState) {
+    return {
+      ...state,
+      type: type as GaugeState['type'],
+    };
+  },
+
+  getVisualizationTypeId(state) {
+    return state.type;
+  },
+
+  clearLayer(state) {
+    return {
+      ...state,
+      accessor: undefined,
+    };
+  },
+
+  getLayerIds(state) {
+    return [state.layerId];
+  },
+
+  getDescription(state) {
+    return {
+      icon: 'visGauge',
+      label:
+        state.type === 'goal'
+          ? 'Gauge'
+          : state.type === 'horizontalBullet'
+          ? 'Horizontal bullet'
+          : 'Vertical bullet',
+    };
+  },
+
+  getSuggestions,
+
+  initialize(frame, state) {
+    return (
+      state || {
+        layerId: frame.addNewLayer(),
+        accessor: undefined,
+        type: 'goal',
+      }
+    );
+  },
+
+  getConfiguration(props) {
+    return {
+      groups: [
+        {
+          groupId: 'value',
+          groupLabel: i18n.translate('xpack.lens.gauge.valueLabel', { defaultMessage: 'Value' }),
+          layerId: props.state.layerId,
+          accessors: props.state.accessor ? [{ columnId: props.state.accessor }] : [],
+          supportsMoreColumns: !props.state.accessor,
+          filterOperations: (op: OperationMetadata) => !op.isBucketed && op.dataType === 'number',
+          enableDimensionEditor: true,
+        },
+      ],
+    };
+  },
+
+  toExpression,
+  toPreviewExpression: (state, datasourceLayers) =>
+    toExpression(state, datasourceLayers, { mode: 'reduced' }),
+
+  setDimension({ prevState, columnId, groupId }) {
+    return { ...prevState, accessor: columnId };
+  },
+
+  removeDimension({ prevState }) {
+    return {
+      ...prevState,
+      accessor: undefined,
+    };
+  },
+
+  getErrorMessages(state) {
+    // Is it possible to break it?
+    return undefined;
+  },
+
+  renderDimensionEditor(el, props) {
+    render(
+      <>
+        <EuiFormRow label="Min">
+          <EuiFieldNumber
+            value={props.state.min || ''}
+            onChange={(e) => {
+              props.setState({ ...props.state, min: Number(e.target.value) });
+            }}
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Max">
+          <EuiFieldNumber
+            value={props.state.max || ''}
+            onChange={(e) => {
+              props.setState({ ...props.state, max: Number(e.target.value) });
+            }}
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Target">
+          <EuiFieldNumber
+            value={props.state.target || ''}
+            onChange={(e) => {
+              props.setState({ ...props.state, target: Number(e.target.value) });
+            }}
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Sub title">
+          <EuiFieldText
+            value={props.state.subTitle || ''}
+            onChange={(e) => {
+              props.setState({ ...props.state, subTitle: e.target.value });
+            }}
+          />
+        </EuiFormRow>
+      </>,
+      el
+    );
+  },
+};

--- a/x-pack/plugins/lens/public/gauge_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/gauge_visualization/visualization.tsx
@@ -5,18 +5,42 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { Ast } from '@kbn/interpreter/target/common';
 import { render } from 'react-dom';
-import { EuiFormRow, EuiFieldNumber, EuiFieldText } from '@elastic/eui';
+import {
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiButtonEmpty,
+  EuiColorPaletteDisplay,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+import { PaletteOutput } from 'src/plugins/charts/common';
+import { PaletteRegistry } from 'src/plugins/charts/public';
 import { getSuggestions } from './gauge_suggestions';
-import { Visualization, OperationMetadata, DatasourcePublicAPI } from '../types';
+import {
+  Visualization,
+  OperationMetadata,
+  DatasourcePublicAPI,
+  VisualizationDimensionEditorProps,
+} from '../types';
 import { GaugeState } from './types';
+import { PalettePanelContainer } from '../datatable_visualization/components/palette_panel_container';
+import {
+  applyPaletteParams,
+  CustomPaletteParams,
+  FIXED_PROGRESSION,
+  CustomizablePalette,
+  CUSTOM_PALETTE,
+} from '../shared_components';
 
 const toExpression = (
   state: GaugeState,
   datasourceLayers: Record<string, DatasourcePublicAPI>,
+  paletteService: PaletteRegistry,
   attributes?: { mode?: 'reduced' | 'full'; title?: string; description?: string }
 ): Ast | null => {
   if (!state.accessor) {
@@ -25,6 +49,19 @@ const toExpression = (
 
   const [datasource] = Object.values(datasourceLayers);
   const operation = datasource && datasource.getOperationForColumnId(state.accessor);
+
+  const paletteCurrentParams = (state.palette?.params || {}) as CustomPaletteParams;
+
+  const paletteParams = {
+    ...paletteCurrentParams,
+    // rewrite colors and stops as two distinct arguments
+    colors: (paletteCurrentParams?.stops || []).map(({ color }) => color),
+    stops:
+      paletteCurrentParams?.name === 'custom'
+        ? (paletteCurrentParams?.stops || []).map(({ stop }) => stop)
+        : [],
+    reverse: false, // managed at UI level
+  };
 
   return {
     type: 'expression',
@@ -42,6 +79,9 @@ const toExpression = (
           max: typeof state.max !== 'undefined' ? [state.max] : [],
           type: [state.type],
           mode: [attributes?.mode || 'full'],
+          palette: state.palette?.params
+            ? [paletteService.get(CUSTOM_PALETTE).toExpression(paletteParams)]
+            : [paletteService.get('default').toExpression()],
           subTitle: [state.subTitle || ''],
         },
       },
@@ -49,7 +89,9 @@ const toExpression = (
   };
 };
 
-export const gaugeVisualization: Visualization<GaugeState> = {
+export const getGaugeVisualization = (
+  paletteService: PaletteRegistry
+): Visualization<GaugeState> => ({
   id: 'lnsGauge',
 
   visualizationTypes: [
@@ -150,9 +192,10 @@ export const gaugeVisualization: Visualization<GaugeState> = {
     };
   },
 
-  toExpression,
+  toExpression: (state, layers, attributes) =>
+    toExpression(state, layers, paletteService, attributes),
   toPreviewExpression: (state, datasourceLayers) =>
-    toExpression(state, datasourceLayers, { mode: 'reduced' }),
+    toExpression(state, datasourceLayers, paletteService, { mode: 'reduced' }),
 
   setDimension({ prevState, columnId, groupId }) {
     return { ...prevState, accessor: columnId };
@@ -171,42 +214,122 @@ export const gaugeVisualization: Visualization<GaugeState> = {
   },
 
   renderDimensionEditor(el, props) {
-    render(
-      <>
-        <EuiFormRow label="Min">
-          <EuiFieldNumber
-            value={props.state.min || ''}
-            onChange={(e) => {
-              props.setState({ ...props.state, min: Number(e.target.value) });
-            }}
-          />
-        </EuiFormRow>
-        <EuiFormRow label="Max">
-          <EuiFieldNumber
-            value={props.state.max || ''}
-            onChange={(e) => {
-              props.setState({ ...props.state, max: Number(e.target.value) });
-            }}
-          />
-        </EuiFormRow>
-        <EuiFormRow label="Target">
-          <EuiFieldNumber
-            value={props.state.target || ''}
-            onChange={(e) => {
-              props.setState({ ...props.state, target: Number(e.target.value) });
-            }}
-          />
-        </EuiFormRow>
-        <EuiFormRow label="Sub title">
-          <EuiFieldText
-            value={props.state.subTitle || ''}
-            onChange={(e) => {
-              props.setState({ ...props.state, subTitle: e.target.value });
-            }}
-          />
-        </EuiFormRow>
-      </>,
-      el
-    );
+    render(<GaugeDimensionEditor {...props} paletteService={paletteService} />, el);
   },
-};
+});
+
+function GaugeDimensionEditor(
+  props: VisualizationDimensionEditorProps<GaugeState> & {
+    paletteService: PaletteRegistry;
+  }
+) {
+  const { state, setState, frame, accessor } = props;
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+
+  if (state?.accessor !== accessor) return null;
+
+  const currentData = frame.activeData?.[state.layerId];
+
+  const val = currentData?.rows[0][accessor];
+
+  const activePalette = state?.palette || {
+    type: 'palette',
+    name: 'default',
+  };
+  // need to tell the helper that the colorStops are required to display
+  const displayStops = applyPaletteParams(
+    props.paletteService,
+    activePalette as PaletteOutput<CustomPaletteParams>,
+    { min: state.min!, max: state.max! }
+  );
+
+  return (
+    <>
+      <EuiFormRow label="Min">
+        <EuiFieldNumber
+          value={props.state.min || ''}
+          onChange={(e) => {
+            props.setState({ ...props.state, min: Number(e.target.value) });
+          }}
+        />
+      </EuiFormRow>
+      <EuiFormRow label="Max">
+        <EuiFieldNumber
+          value={props.state.max || ''}
+          onChange={(e) => {
+            props.setState({ ...props.state, max: Number(e.target.value) });
+          }}
+        />
+      </EuiFormRow>
+      <EuiFormRow label="Target">
+        <EuiFieldNumber
+          value={props.state.target || ''}
+          onChange={(e) => {
+            props.setState({ ...props.state, target: Number(e.target.value) });
+          }}
+        />
+      </EuiFormRow>
+      <EuiFormRow label="Sub title">
+        <EuiFieldText
+          value={props.state.subTitle || ''}
+          onChange={(e) => {
+            props.setState({ ...props.state, subTitle: e.target.value });
+          }}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        className="lnsDynamicColoringRow"
+        display="columnCompressed"
+        fullWidth
+        label={i18n.translate('xpack.lens.paletteTableGradient.label', {
+          defaultMessage: 'Color',
+        })}
+      >
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem>
+            <EuiColorPaletteDisplay
+              data-test-subj="lnsDatatable_dynamicColoring_palette"
+              palette={displayStops}
+              type={FIXED_PROGRESSION}
+              onClick={() => {
+                setIsPaletteOpen(!isPaletteOpen);
+              }}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              data-test-subj="lnsDatatable_dynamicColoring_trigger"
+              iconType="controlsHorizontal"
+              onClick={() => {
+                setIsPaletteOpen(!isPaletteOpen);
+              }}
+              size="xs"
+              flush="both"
+            >
+              {i18n.translate('xpack.lens.paletteTableGradient.customize', {
+                defaultMessage: 'Edit',
+              })}
+            </EuiButtonEmpty>
+            <PalettePanelContainer
+              siblingRef={props.panelRef}
+              isOpen={isPaletteOpen}
+              handleClose={() => setIsPaletteOpen(!isPaletteOpen)}
+            >
+              <CustomizablePalette
+                palettes={props.paletteService}
+                activePalette={activePalette as PaletteOutput<CustomPaletteParams>}
+                dataBounds={{ min: state.min || 0, max: state.max ?? val * 1.5 }}
+                setPalette={(newPalette) => {
+                  setState({
+                    ...state,
+                    palette: newPalette,
+                  });
+                }}
+              />
+            </PalettePanelContainer>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFormRow>
+    </>
+  );
+}

--- a/x-pack/plugins/lens/public/plugin.ts
+++ b/x-pack/plugins/lens/public/plugin.ts
@@ -54,6 +54,7 @@ import {
   EmbeddableComponentProps,
   getEmbeddableComponent,
 } from './editor_frame_service/embeddable/embeddable_component';
+import { GaugeVisualization } from './gauge_visualization';
 
 export interface LensPluginSetupDependencies {
   urlForwarding: UrlForwardingSetup;
@@ -118,6 +119,7 @@ export class LensPlugin {
   private indexpatternDatasource: IndexPatternDatasource;
   private xyVisualization: XyVisualization;
   private metricVisualization: MetricVisualization;
+  private gaugeVisualization: GaugeVisualization;
   private pieVisualization: PieVisualization;
 
   private stopReportManager?: () => void;
@@ -128,6 +130,7 @@ export class LensPlugin {
     this.indexpatternDatasource = new IndexPatternDatasource();
     this.xyVisualization = new XyVisualization();
     this.metricVisualization = new MetricVisualization();
+    this.gaugeVisualization = new GaugeVisualization();
     this.pieVisualization = new PieVisualization();
   }
 
@@ -177,6 +180,7 @@ export class LensPlugin {
     this.xyVisualization.setup(core, dependencies);
     this.datatableVisualization.setup(core, dependencies);
     this.metricVisualization.setup(core, dependencies);
+    this.gaugeVisualization.setup(core, dependencies);
     this.pieVisualization.setup(core, dependencies);
 
     visualizations.registerAlias(getLensAliasConfig());


### PR DESCRIPTION
Adds Gauge charts to Lens
<img width="1356" alt="Screenshot 2021-05-31 at 17 45 31" src="https://user-images.githubusercontent.com/1508364/120217367-89282a00-c238-11eb-8273-13a6539fe62c.png">
<img width="1357" alt="Screenshot 2021-05-31 at 17 45 51" src="https://user-images.githubusercontent.com/1508364/120217380-8c231a80-c238-11eb-854c-149a4eb0df92.png">
<img width="1360" alt="Screenshot 2021-05-31 at 17 46 12" src="https://user-images.githubusercontent.com/1508364/120217383-8cbbb100-c238-11eb-9dab-a216759b5d18.png">
<img width="1628" alt="Screenshot 2021-05-31 at 17 48 52" src="https://user-images.githubusercontent.com/1508364/120217385-8d544780-c238-11eb-941b-0a14dabdcd96.png">

Supported features:
* Specify min and max
* Specify target separate from value (image 1)
* Specify a subtitle
* Choose between gauge and horizontal/vertical bullet
* Specify a color palette (buggy)

## Concerns

* Does this chart make sense without min/max? I wouldn't say so. Right now min is 0 and max is 1.5 * current value if the user didn't specify anything
  * Visualize defaults to min: 0, max: 100 which is also not great
  * Should we display a warning message or something as long as min/max is not specified?
* Should all of these settings be part of the metric flyout or should they live somewhere else?
* Should target be another dynamic metric? Can't think of a good use case...
* What about suggestions? Only suggest one of them? None? It's hard because the user has to specify min/max before this makes any sense


cc @ghudgins @MichaelMarcialis @wylieconlon @mbondyra @dej611 @markov00 