### PR TITLE
[Lens] Mock htmlIDGenerator to avoid warnings when running tests

### DIFF
--- a/x-pack/plugins/lens/public/shared_components/coloring/color_stops.test.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_stops.test.tsx
@@ -11,6 +11,19 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { CustomStops, CustomStopsProps } from './color_stops';
 
+// mocking random id generator function
+jest.mock('@elastic/eui', () => {
+  const original = jest.requireActual('@elastic/eui');
+
+  return {
+    ...original,
+    htmlIdGenerator: (fn: unknown) => {
+      let counter = 0;
+      return () => counter++;
+    },
+  };
+});
+
 describe('Color Stops component', () => {
   let props: CustomStopsProps;
   beforeEach(() => {

--- a/x-pack/plugins/lens/public/shared_components/coloring/palette_configuration.test.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/palette_configuration.test.tsx
@@ -15,6 +15,19 @@ import { CustomPaletteParams } from './types';
 import { applyPaletteParams } from './utils';
 import { CustomizablePalette } from './palette_configuration';
 
+// mocking random id generator function
+jest.mock('@elastic/eui', () => {
+  const original = jest.requireActual('@elastic/eui');
+
+  return {
+    ...original,
+    htmlIdGenerator: (fn: unknown) => {
+      let counter = 0;
+      return () => counter++;
+    },
+  };
+});
+
 describe('palette utilities', () => {
   const paletteRegistry = chartPluginMock.createPaletteRegistry();
   describe('applyPaletteParams', () => {


### PR DESCRIPTION
## Summary

When running tests, there are multiple warnings about duplicate keys: 
<img width="661" alt="Screenshot 2021-06-01 at 13 48 07" src="https://user-images.githubusercontent.com/4283304/120318305-ffcc3280-c2df-11eb-8c6c-a79d41685ded.png">


Mocking the function `htmlIDGenerator` deals with it. 
