### PR TITLE
Gauge/goal: Tooltip always includes "_all"

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.js
@@ -31,6 +31,7 @@ export function pointSeriesTooltipFormatter() {
 
     const details = [];
     const isGauge = config.get('gauge', false);
+    const chartType = config.get('type', undefined);
     const isPercentageMode = config.get(isGauge ? 'gauge.percentageMode' : 'percentageMode', false);
     const isSetColorRange = config.get('setColorRange', false);
 
@@ -44,7 +45,8 @@ export function pointSeriesTooltipFormatter() {
       });
     }
 
-    if (datum.x !== null && datum.x !== undefined) {
+    // For goal and gauge we have only one value for x - '_all'. It doesn't have sense to show it
+    if (datum.x !== null && datum.x !== undefined && !['goal', 'gauge'].includes(chartType)) {
       addDetail(data.xAxisLabel, data.xAxisFormatter(datum.x));
     }
 

--- a/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.test.js
+++ b/src/plugins/vis_type_vislib/public/vislib/components/tooltip/_pointseries_tooltip_formatter.test.js
@@ -96,4 +96,27 @@ describe('tooltipFormatter', function () {
     const $rows = $el.find('tr');
     expect($rows.length).toBe(3);
   });
+
+  it('renders correctly for gauge/goal visualizations', function () {
+    const event = _.cloneDeep(baseEvent);
+    let type = 'gauge';
+    event.config.get = (name) => {
+      const config = {
+        setColorRange: false,
+        gauge: false,
+        percentageMode: false,
+        type,
+      };
+      return config[name];
+    };
+
+    let $el = $(tooltipFormatter(event, uiSettings));
+    let $rows = $el.find('tr');
+    expect($rows.length).toBe(2);
+
+    type = 'goal';
+    $el = $(tooltipFormatter(event, uiSettings));
+    $rows = $el.find('tr');
+    expect($rows.length).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes: #93030

## Summary

Removes from tootlip row 'All docs: _all' for goal and gauge visualizations.

