### PR TITLE
[Lens] setFocusTrap after animation is ended and not with timeout

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/dimension_container.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/dimension_container.tsx
@@ -44,15 +44,6 @@ export function DimensionContainer({
     setFocusTrapIsEnabled(false);
   }, [handleClose]);
 
-  useEffect(() => {
-    if (isOpen) {
-      // without setTimeout here the flyout pushes content when animating
-      setTimeout(() => {
-        setFocusTrapIsEnabled(true);
-      }, 255);
-    }
-  }, [isOpen]);
-
   const closeOnEscape = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === keys.ESCAPE) {
@@ -83,6 +74,13 @@ export function DimensionContainer({
             role="dialog"
             aria-labelledby="lnsDimensionContainerTitle"
             className="lnsDimensionContainer euiFlyout"
+            onAnimationEnd={() => {
+              if (isOpen) {
+                // EuiFocusTrap interferes with animating elements with absolute position:
+                // running this onAnimationEnd, otherwise the flyout pushes content when animating
+                setFocusTrapIsEnabled(true);
+              }
+            }}
           >
             <EuiFlyoutHeader hasBorder className="lnsDimensionContainer__header">
               <EuiFlexGroup


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/100653

@flash1293 you were suspecting that the line with `setTimeout` causes the problem, but that was actually solution to it, just not fixing all the cases. For some reason EuiFocusTrap messes up the animation when the element has a `position: absolute`. I am not sure what styles it modifies, didn't look enough to find a low-level root cause (I did spend some time on it, but I failed to figure it out).

But I think we can ensure to avoid the animation problem with running the callback function not in timeout function, but on the callback `onAnimationEnd`.

EDIT: I just realized we have an advanced setting about not using animations at all, I'll see if we should solve it differently in this case. EDIT 2: Still works correctly even with animations off. 