### PR TITLE
[Metrics UI] Move date histogram inside composite for Snapshot API

### DIFF
--- a/x-pack/plugins/infra/common/http_api/snapshot_api.ts
+++ b/x-pack/plugins/infra/common/http_api/snapshot_api.ts
@@ -110,6 +110,7 @@ export const SnapshotRequestRT = rt.intersection([
     filterQuery: rt.union([rt.string, rt.null]),
     includeTimeseries: rt.boolean,
     overrideCompositeSize: rt.number,
+    combinedComposite: rt.boolean,
   }),
 ]);
 

--- a/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/cpu.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/cpu.ts
@@ -5,24 +5,28 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { MetricsUISnapshotMetric } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
 
-export const cpu: MetricsUIAggregation = {
-  cpu_avg: {
-    avg: {
-      field: 'aws.ec2.cpu.total.pct',
+export const cpu: MetricsUISnapshotMetric = {
+  aggs: {
+    cpu_avg: {
+      avg: {
+        field: 'aws.ec2.cpu.total.pct',
+      },
+    },
+    cpu: {
+      bucket_script: {
+        buckets_path: {
+          cpu: 'cpu_avg',
+        },
+        script: {
+          source: 'params.cpu / 100',
+          lang: 'painless',
+        },
+        gap_policy: 'skip',
+      },
     },
   },
-  cpu: {
-    bucket_script: {
-      buckets_path: {
-        cpu: 'cpu_avg',
-      },
-      script: {
-        source: 'params.cpu / 100',
-        lang: 'painless',
-      },
-      gap_policy: 'skip',
-    },
-  },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/disk_io_read_bytes.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/disk_io_read_bytes.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const diskIOReadBytes: MetricsUIAggregation = {
-  diskIOReadBytes: {
-    avg: {
-      field: 'aws.ec2.diskio.read.bytes_per_sec',
+export const diskIOReadBytes: MetricsUISnapshotMetric = {
+  aggs: {
+    diskIOReadBytes: {
+      avg: {
+        field: 'aws.ec2.diskio.read.bytes_per_sec',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/disk_io_write_bytes.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/disk_io_write_bytes.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const diskIOWriteBytes: MetricsUIAggregation = {
-  diskIOWriteBytes: {
-    avg: {
-      field: 'aws.ec2.diskio.write.bytes_per_sec',
+export const diskIOWriteBytes: MetricsUISnapshotMetric = {
+  aggs: {
+    diskIOWriteBytes: {
+      avg: {
+        field: 'aws.ec2.diskio.write.bytes_per_sec',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/rx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/rx.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const rx: MetricsUIAggregation = {
-  rx: {
-    avg: {
-      field: 'aws.ec2.network.in.bytes_per_sec',
+export const rx: MetricsUISnapshotMetric = {
+  aggs: {
+    rx: {
+      avg: {
+        field: 'aws.ec2.network.in.bytes_per_sec',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/tx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_ec2/metrics/snapshot/tx.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const tx: MetricsUIAggregation = {
-  tx: {
-    avg: {
-      field: 'aws.ec2.network.in.bytes_per_sec',
+export const tx: MetricsUISnapshotMetric = {
+  aggs: {
+    tx: {
+      avg: {
+        field: 'aws.ec2.network.in.bytes_per_sec',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/cpu.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/cpu.ts
@@ -5,24 +5,28 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const cpu: MetricsUIAggregation = {
-  cpu_avg: {
-    avg: {
-      field: 'aws.rds.cpu.total.pct',
+export const cpu: MetricsUISnapshotMetric = {
+  aggs: {
+    cpu_avg: {
+      avg: {
+        field: 'aws.rds.cpu.total.pct',
+      },
+    },
+    cpu: {
+      bucket_script: {
+        buckets_path: {
+          cpu: 'cpu_avg',
+        },
+        script: {
+          source: 'params.cpu / 100',
+          lang: 'painless',
+        },
+        gap_policy: 'skip',
+      },
     },
   },
-  cpu: {
-    bucket_script: {
-      buckets_path: {
-        cpu: 'cpu_avg',
-      },
-      script: {
-        source: 'params.cpu / 100',
-        lang: 'painless',
-      },
-      gap_policy: 'skip',
-    },
-  },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_active_transactions.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_active_transactions.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const rdsActiveTransactions: MetricsUIAggregation = {
-  rdsActiveTransactions: {
-    avg: {
-      field: 'aws.rds.transactions.active',
+export const rdsActiveTransactions: MetricsUISnapshotMetric = {
+  aggs: {
+    rdsActiveTransactions: {
+      avg: {
+        field: 'aws.rds.transactions.active',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_connections.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_connections.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const rdsConnections: MetricsUIAggregation = {
-  rdsConnections: {
-    avg: {
-      field: 'aws.rds.database_connections',
+export const rdsConnections: MetricsUISnapshotMetric = {
+  aggs: {
+    rdsConnections: {
+      avg: {
+        field: 'aws.rds.database_connections',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_latency.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_latency.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const rdsLatency: MetricsUIAggregation = {
-  rdsLatency: {
-    avg: {
-      field: 'aws.rds.latency.dml',
+export const rdsLatency: MetricsUISnapshotMetric = {
+  aggs: {
+    rdsLatency: {
+      avg: {
+        field: 'aws.rds.latency.dml',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_queries_executed.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_rds/metrics/snapshot/rds_queries_executed.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const rdsQueriesExecuted: MetricsUIAggregation = {
-  rdsQueriesExecuted: {
-    avg: {
-      field: 'aws.rds.queries',
+export const rdsQueriesExecuted: MetricsUISnapshotMetric = {
+  aggs: {
+    rdsQueriesExecuted: {
+      avg: {
+        field: 'aws.rds.queries',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_bucket_size.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_bucket_size.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const s3BucketSize: MetricsUIAggregation = {
-  s3BucketSize: {
-    max: {
-      field: 'aws.s3_daily_storage.bucket.size.bytes',
+export const s3BucketSize: MetricsUISnapshotMetric = {
+  aggs: {
+    s3BucketSize: {
+      max: {
+        field: 'aws.s3_daily_storage.bucket.size.bytes',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_download_bytes.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_download_bytes.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const s3DownloadBytes: MetricsUIAggregation = {
-  s3DownloadBytes: {
-    max: {
-      field: 'aws.s3_request.downloaded.bytes',
+export const s3DownloadBytes: MetricsUISnapshotMetric = {
+  aggs: {
+    s3DownloadBytes: {
+      max: {
+        field: 'aws.s3_request.downloaded.bytes',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_number_of_objects.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_number_of_objects.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const s3NumberOfObjects: MetricsUIAggregation = {
-  s3NumberOfObjects: {
-    max: {
-      field: 'aws.s3_daily_storage.number_of_objects',
+export const s3NumberOfObjects: MetricsUISnapshotMetric = {
+  aggs: {
+    s3NumberOfObjects: {
+      max: {
+        field: 'aws.s3_daily_storage.number_of_objects',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_total_requests.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_total_requests.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const s3TotalRequests: MetricsUIAggregation = {
-  s3TotalRequests: {
-    max: {
-      field: 'aws.s3_request.requests.total',
+export const s3TotalRequests: MetricsUISnapshotMetric = {
+  aggs: {
+    s3TotalRequests: {
+      max: {
+        field: 'aws.s3_request.requests.total',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_upload_bytes.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_s3/metrics/snapshot/s3_upload_bytes.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const s3UploadBytes: MetricsUIAggregation = {
-  s3UploadBytes: {
-    max: {
-      field: 'aws.s3_request.uploaded.bytes',
+export const s3UploadBytes: MetricsUISnapshotMetric = {
+  aggs: {
+    s3UploadBytes: {
+      max: {
+        field: 'aws.s3_request.uploaded.bytes',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_delayed.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_delayed.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const sqsMessagesDelayed: MetricsUIAggregation = {
-  sqsMessagesDelayed: {
-    max: {
-      field: 'aws.sqs.messages.delayed',
+export const sqsMessagesDelayed: MetricsUISnapshotMetric = {
+  aggs: {
+    sqsMessagesDelayed: {
+      max: {
+        field: 'aws.sqs.messages.delayed',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_empty.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_empty.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const sqsMessagesEmpty: MetricsUIAggregation = {
-  sqsMessagesEmpty: {
-    max: {
-      field: 'aws.sqs.messages.not_visible',
+export const sqsMessagesEmpty: MetricsUISnapshotMetric = {
+  aggs: {
+    sqsMessagesEmpty: {
+      max: {
+        field: 'aws.sqs.messages.not_visible',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_sent.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_sent.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const sqsMessagesSent: MetricsUIAggregation = {
-  sqsMessagesSent: {
-    max: {
-      field: 'aws.sqs.messages.sent',
+export const sqsMessagesSent: MetricsUISnapshotMetric = {
+  aggs: {
+    sqsMessagesSent: {
+      max: {
+        field: 'aws.sqs.messages.sent',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_visible.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_messages_visible.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const sqsMessagesVisible: MetricsUIAggregation = {
-  sqsMessagesVisible: {
-    avg: {
-      field: 'aws.sqs.messages.visible',
+export const sqsMessagesVisible: MetricsUISnapshotMetric = {
+  aggs: {
+    sqsMessagesVisible: {
+      avg: {
+        field: 'aws.sqs.messages.visible',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_oldest_message.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_sqs/metrics/snapshot/sqs_oldest_message.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const sqsOldestMessage: MetricsUIAggregation = {
-  sqsOldestMessage: {
-    max: {
-      field: 'aws.sqs.oldest_message_age.sec',
+export const sqsOldestMessage: MetricsUISnapshotMetric = {
+  aggs: {
+    sqsOldestMessage: {
+      max: {
+        field: 'aws.sqs.oldest_message_age.sec',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/cpu.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/cpu.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const cpu: MetricsUIAggregation = {
-  cpu: {
-    avg: {
-      field: 'docker.cpu.total.pct',
+export const cpu: MetricsUISnapshotMetric = {
+  aggs: {
+    cpu: {
+      avg: {
+        field: 'docker.cpu.total.pct',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/memory.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/memory.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const memory: MetricsUIAggregation = {
-  memory: { avg: { field: 'docker.memory.usage.pct' } },
+export const memory: MetricsUISnapshotMetric = {
+  aggs: {
+    memory: { avg: { field: 'docker.memory.usage.pct' } },
+  },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/rx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/rx.ts
@@ -5,9 +5,15 @@
  * 2.0.
  */
 
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 import { networkTrafficWithInterfaces } from '../../../shared/metrics/snapshot/network_traffic_with_interfaces';
-export const rx = networkTrafficWithInterfaces(
-  'rx',
-  'docker.network.inbound.bytes',
-  'docker.network.interface'
-);
+
+export const rx: MetricsUISnapshotMetric = {
+  aggs: networkTrafficWithInterfaces(
+    'rx',
+    'docker.network.inbound.bytes',
+    'docker.network.interface'
+  ),
+  transformer: noop,
+};

--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/tx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/tx.ts
@@ -5,9 +5,15 @@
  * 2.0.
  */
 
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 import { networkTrafficWithInterfaces } from '../../../shared/metrics/snapshot/network_traffic_with_interfaces';
-export const tx = networkTrafficWithInterfaces(
-  'tx',
-  'docker.network.outbound.bytes',
-  'docker.network.interface'
-);
+
+export const tx: MetricsUISnapshotMetric = {
+  aggs: networkTrafficWithInterfaces(
+    'tx',
+    'docker.network.outbound.bytes',
+    'docker.network.interface'
+  ),
+  transformer: noop,
+};

--- a/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/cpu.ts
+++ b/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/cpu.ts
@@ -5,36 +5,40 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const cpu: MetricsUIAggregation = {
-  cpu_user: {
-    avg: {
-      field: 'system.cpu.user.pct',
-    },
-  },
-  cpu_system: {
-    avg: {
-      field: 'system.cpu.system.pct',
-    },
-  },
-  cpu_cores: {
-    max: {
-      field: 'system.cpu.cores',
-    },
-  },
-  cpu: {
-    bucket_script: {
-      buckets_path: {
-        user: 'cpu_user',
-        system: 'cpu_system',
-        cores: 'cpu_cores',
+export const cpu: MetricsUISnapshotMetric = {
+  aggs: {
+    cpu_user: {
+      avg: {
+        field: 'system.cpu.user.pct',
       },
-      script: {
-        source: '(params.user + params.system) / params.cores',
-        lang: 'painless',
+    },
+    cpu_system: {
+      avg: {
+        field: 'system.cpu.system.pct',
       },
-      gap_policy: 'skip',
+    },
+    cpu_cores: {
+      max: {
+        field: 'system.cpu.cores',
+      },
+    },
+    cpu: {
+      bucket_script: {
+        buckets_path: {
+          user: 'cpu_user',
+          system: 'cpu_system',
+          cores: 'cpu_cores',
+        },
+        script: {
+          source: '(params.user + params.system) / params.cores',
+          lang: 'painless',
+        },
+        gap_policy: 'skip',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/log_rate.ts
+++ b/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/log_rate.ts
@@ -5,29 +5,21 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const logRate: MetricsUIAggregation = {
-  count: {
-    bucket_script: {
-      buckets_path: { count: '_count' },
-      script: {
-        source: 'count * 1',
-        lang: 'expression',
+export const logRate: MetricsUISnapshotMetric = {
+  aggs: {
+    logRate: {
+      bucket_script: {
+        buckets_path: { count: '_count' },
+        script: {
+          source: 'count * 1',
+          lang: 'expression',
+        },
+        gap_policy: 'skip',
       },
-      gap_policy: 'skip',
     },
   },
-  cumsum: {
-    cumulative_sum: {
-      buckets_path: 'count',
-    },
-  },
-  logRate: {
-    derivative: {
-      buckets_path: 'cumsum',
-      gap_policy: 'skip',
-      unit: '1s',
-    },
-  },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/memory.ts
+++ b/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/memory.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const memory: MetricsUIAggregation = {
-  memory: { avg: { field: 'system.memory.actual.used.pct' } },
+export const memory: MetricsUISnapshotMetric = {
+  aggs: {
+    memory: { avg: { field: 'system.memory.actual.used.pct' } },
+  },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/rx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/rx.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 import { networkTrafficWithInterfaces } from '../../../shared/metrics/snapshot/network_traffic_with_interfaces';
-export const rx = networkTrafficWithInterfaces(
-  'rx',
-  'system.network.in.bytes',
-  'system.network.name'
-);
+
+export const rx: MetricsUISnapshotMetric = {
+  aggs: networkTrafficWithInterfaces('rx', 'system.network.in.bytes', 'system.network.name'),
+  transformer: noop,
+};

--- a/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/tx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/host/metrics/snapshot/tx.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 import { networkTrafficWithInterfaces } from '../../../shared/metrics/snapshot/network_traffic_with_interfaces';
-export const tx = networkTrafficWithInterfaces(
-  'tx',
-  'system.network.out.bytes',
-  'system.network.name'
-);
+export const tx: MetricsUISnapshotMetric = {
+  aggs: networkTrafficWithInterfaces('tx', 'system.network.out.bytes', 'system.network.name'),
+  transformer: noop,
+};

--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/cpu.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/cpu.ts
@@ -5,30 +5,34 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const cpu: MetricsUIAggregation = {
-  cpu_with_limit: {
-    avg: {
-      field: 'kubernetes.pod.cpu.usage.limit.pct',
-    },
-  },
-  cpu_without_limit: {
-    avg: {
-      field: 'kubernetes.pod.cpu.usage.node.pct',
-    },
-  },
-  cpu: {
-    bucket_script: {
-      buckets_path: {
-        with_limit: 'cpu_with_limit',
-        without_limit: 'cpu_without_limit',
+export const cpu: MetricsUISnapshotMetric = {
+  aggs: {
+    cpu_with_limit: {
+      avg: {
+        field: 'kubernetes.pod.cpu.usage.limit.pct',
       },
-      script: {
-        source: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
-        lang: 'painless',
+    },
+    cpu_without_limit: {
+      avg: {
+        field: 'kubernetes.pod.cpu.usage.node.pct',
       },
-      gap_policy: 'skip',
+    },
+    cpu: {
+      bucket_script: {
+        buckets_path: {
+          with_limit: 'cpu_with_limit',
+          without_limit: 'cpu_without_limit',
+        },
+        script: {
+          source: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
+          lang: 'painless',
+        },
+        gap_policy: 'skip',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/memory.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/memory.ts
@@ -5,30 +5,34 @@
  * 2.0.
  */
 
-import { MetricsUIAggregation } from '../../../types';
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 
-export const memory: MetricsUIAggregation = {
-  memory_with_limit: {
-    avg: {
-      field: 'kubernetes.pod.memory.usage.limit.pct',
-    },
-  },
-  memory_without_limit: {
-    avg: {
-      field: 'kubernetes.pod.memory.usage.node.pct',
-    },
-  },
-  memory: {
-    bucket_script: {
-      buckets_path: {
-        with_limit: 'memory_with_limit',
-        without_limit: 'memory_without_limit',
+export const memory: MetricsUISnapshotMetric = {
+  aggs: {
+    memory_with_limit: {
+      avg: {
+        field: 'kubernetes.pod.memory.usage.limit.pct',
       },
-      script: {
-        source: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
-        lang: 'painless',
+    },
+    memory_without_limit: {
+      avg: {
+        field: 'kubernetes.pod.memory.usage.node.pct',
       },
-      gap_policy: 'skip',
+    },
+    memory: {
+      bucket_script: {
+        buckets_path: {
+          with_limit: 'memory_with_limit',
+          without_limit: 'memory_without_limit',
+        },
+        script: {
+          source: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
+          lang: 'painless',
+        },
+        gap_policy: 'skip',
+      },
     },
   },
+  transformer: noop,
 };

--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/rx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/rx.ts
@@ -5,5 +5,11 @@
  * 2.0.
  */
 
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 import { networkTraffic } from '../../../shared/metrics/snapshot/network_traffic';
-export const rx = networkTraffic('rx', 'kubernetes.pod.network.rx.bytes');
+
+export const rx: MetricsUISnapshotMetric = {
+  aggs: networkTraffic('rx', 'kubernetes.pod.network.rx.bytes'),
+  transformer: noop,
+};

--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/tx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/tx.ts
@@ -5,5 +5,10 @@
  * 2.0.
  */
 
+import { noop } from '../../../shared/lib/transformers/noop';
+import { MetricsUISnapshotMetric } from '../../../types';
 import { networkTraffic } from '../../../shared/metrics/snapshot/network_traffic';
-export const tx = networkTraffic('tx', 'kubernetes.pod.network.tx.bytes');
+export const tx: MetricsUISnapshotMetric = {
+  aggs: networkTraffic('tx', 'kubernetes.pod.network.tx.bytes'),
+  transformer: noop,
+};

--- a/x-pack/plugins/infra/common/inventory_models/shared/lib/transformers/noop.ts
+++ b/x-pack/plugins/infra/common/inventory_models/shared/lib/transformers/noop.ts
@@ -5,12 +5,6 @@
  * 2.0.
  */
 
-import { noop } from '../../../shared/lib/transformers/noop';
-import { MetricsUISnapshotMetric } from '../../../types';
+import { MetricsAPISeries } from '../../../../http_api';
 
-export const load: MetricsUISnapshotMetric = {
-  aggs: {
-    load: { avg: { field: 'system.load.5' } },
-  },
-  transformer: noop,
-};
+export const noop = (series: MetricsAPISeries[]) => series;

--- a/x-pack/plugins/infra/common/inventory_models/shared/metrics/snapshot/network_traffic.ts
+++ b/x-pack/plugins/infra/common/inventory_models/shared/metrics/snapshot/network_traffic.ts
@@ -9,23 +9,6 @@ import { MetricsUIAggregation } from '../../../types';
 
 export const networkTraffic = (id: string, field: string): MetricsUIAggregation => {
   return {
-    [`${id}_max`]: { max: { field } },
-    [`${id}_deriv`]: {
-      derivative: {
-        buckets_path: `${id}_max`,
-        gap_policy: 'skip',
-        unit: '1s',
-      },
-    },
-    [id]: {
-      bucket_script: {
-        buckets_path: { value: `${id}_deriv[normalized_value]` },
-        script: {
-          source: 'params.value > 0.0 ? params.value : 0.0',
-          lang: 'painless',
-        },
-        gap_policy: 'skip',
-      },
-    },
+    [id]: { max: { field } },
   };
 };

--- a/x-pack/plugins/infra/common/inventory_models/shared/metrics/snapshot/network_traffic_with_interfaces.ts
+++ b/x-pack/plugins/infra/common/inventory_models/shared/metrics/snapshot/network_traffic_with_interfaces.ts
@@ -18,26 +18,9 @@ export const networkTrafficWithInterfaces = (
       [`${id}_interface_max`]: { max: { field: metricField } },
     },
   },
-  [`${id}_sum_of_interfaces`]: {
+  [id]: {
     sum_bucket: {
       buckets_path: `${id}_interfaces>${id}_interface_max`,
-    },
-  },
-  [`${id}_deriv`]: {
-    derivative: {
-      buckets_path: `${id}_sum_of_interfaces`,
-      gap_policy: 'skip',
-      unit: '1s',
-    },
-  },
-  [id]: {
-    bucket_script: {
-      buckets_path: { value: `${id}_deriv[normalized_value]` },
-      script: {
-        source: 'params.value > 0.0 ? params.value : 0.0',
-        lang: 'painless',
-      },
-      gap_policy: 'skip',
     },
   },
 });

--- a/x-pack/plugins/infra/common/inventory_models/shared/metrics/snapshot/rate.ts
+++ b/x-pack/plugins/infra/common/inventory_models/shared/metrics/snapshot/rate.ts
@@ -9,23 +9,6 @@ import { MetricsUIAggregation } from '../../../types';
 
 export const rate = (id: string, field: string): MetricsUIAggregation => {
   return {
-    [`${id}_max`]: { max: { field } },
-    [`${id}_deriv`]: {
-      derivative: {
-        buckets_path: `${id}_max`,
-        gap_policy: 'skip',
-        unit: '1s',
-      },
-    },
-    [id]: {
-      bucket_script: {
-        buckets_path: { value: `${id}_deriv[normalized_value]` },
-        script: {
-          source: 'params.value > 0.0 ? params.value : 0.0',
-          lang: 'painless',
-        },
-        gap_policy: 'skip',
-      },
-    },
+    [id]: { max: { field } },
   };
 };

--- a/x-pack/plugins/infra/common/inventory_models/types.ts
+++ b/x-pack/plugins/infra/common/inventory_models/types.ts
@@ -6,6 +6,7 @@
  */
 
 import * as rt from 'io-ts';
+import { MetricsAPISeries } from '../http_api';
 
 export const ItemTypeRT = rt.keyof({
   host: null,
@@ -347,9 +348,14 @@ export const SnapshotMetricTypeRT = rt.keyof(SnapshotMetricTypeKeys);
 
 export type SnapshotMetricType = rt.TypeOf<typeof SnapshotMetricTypeRT>;
 
+export interface MetricsUISnapshotMetric {
+  aggs: MetricsUIAggregation;
+  transformer: (timeSeries: MetricsAPISeries[]) => MetricsAPISeries[];
+}
+
 export interface InventoryMetrics {
   tsvb: { [name: string]: TSVBMetricModelCreator };
-  snapshot: { [name: string]: MetricsUIAggregation };
+  snapshot: { [name: string]: MetricsUISnapshotMetric };
   defaultSnapshot: SnapshotMetricType;
   /** This is used by the inventory view to calculate the appropriate amount of time for the metrics detail page. Some metris like awsS3 require multiple days where others like host only need an hour.*/
   defaultTimeRangeInSeconds: number;

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/convert_snapshot_buckets_to_snapshot_response.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/convert_snapshot_buckets_to_snapshot_response.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { get, last, mean, max } from 'lodash';
+import { findInventoryFields } from '../../../../common/inventory_models';
+import {
+  SnapshotNodeResponse,
+  SnapshotRequest,
+  SnapshotNode,
+  SnapshotNodePath,
+  SnapshotNodeMetric,
+} from '../../../../common/http_api';
+import { InfraSource } from '../../../lib/sources';
+import { META_KEY } from './constants';
+import { SnapshotAggregationBucket } from './query_all_data';
+
+const extractPathFromBucket = (
+  options: SnapshotRequest,
+  bucket: SnapshotAggregationBucket,
+  source: InfraSource
+): SnapshotNodePath[] => {
+  const inventoryFields = findInventoryFields(options.nodeType, source.configuration.fields);
+  const metadata = bucket[META_KEY].top[0].metrics;
+  const nodeValue = `${bucket.key.node}`;
+  const nodeLabel = metadata[inventoryFields.name] || nodeValue;
+  const nodePath: SnapshotNodePath = { value: nodeValue, label: nodeLabel };
+  if (inventoryFields.ip && metadata[inventoryFields.ip]) {
+    nodePath.ip = metadata[inventoryFields.ip];
+  }
+  const groupPath = Object.keys(options.groupBy || [])
+    .map((index) => {
+      const value = bucket.key[`group_${index}`];
+      if (value) {
+        return { value, label: value };
+      }
+    })
+    .filter(Boolean) as SnapshotNodePath[];
+  return [...groupPath, nodePath];
+};
+
+const pathToKey = (path: SnapshotNodePath[]) => path.map((p) => p.value).join();
+
+const matchBucket = (
+  options: SnapshotRequest,
+  bucket: SnapshotAggregationBucket,
+  source: InfraSource
+) => {
+  const bucketKey = pathToKey(extractPathFromBucket(options, bucket, source));
+  return (node: SnapshotNode) => {
+    const key = pathToKey(node.path);
+    return key === bucketKey;
+  };
+};
+
+const extractMetricsFromBucket = (
+  existingMetrics: SnapshotNodeMetric[],
+  options: SnapshotRequest,
+  bucket: SnapshotAggregationBucket
+): SnapshotNodeMetric[] => {
+  return options.metrics.map((metric, index) => {
+    const metricName = metric.type === 'custom' ? `custom_${index}` : metric.type;
+    const existingMetric = existingMetrics.find((m) => m.name === metricName);
+    if (existingMetric && existingMetric.timeseries) {
+      existingMetric.timeseries.rows.push({
+        timestamp: bucket.key.timeseries as number,
+        metric_0: bucket[metricName]?.value ?? null,
+      });
+      existingMetric.timeseries.rows.sort((a, b) => a.timestamp - b.timestamp);
+      const lastRow = last(existingMetric.timeseries.rows);
+      existingMetric.value = (lastRow && (lastRow.metric_0 as number)) || existingMetric.value;
+      existingMetric.max = max(
+        existingMetric.timeseries.rows.map((r) => r.metric_0 as number).filter(Boolean)
+      );
+      existingMetric.avg = mean(
+        existingMetric.timeseries.rows.map((r) => r.metric_0 as number).filter(Boolean)
+      );
+      return existingMetric;
+    }
+
+    return {
+      name: metricName,
+      avg: bucket[metricName]?.value ?? 0,
+      value: bucket[metricName]?.value ?? 0,
+      max: bucket[metricName]?.value ?? 0,
+      timeseries: {
+        id: metricName,
+        columns: [
+          { name: 'timestamp', type: 'date' },
+          { name: 'metric_0', type: 'number' },
+        ],
+        rows: [
+          {
+            timestamp: bucket.key.timeseries as number,
+            metric_0: bucket[metricName]?.value ?? null,
+          },
+        ],
+      },
+    };
+  });
+};
+
+export const convertSnapshotBucketsToSnapshotResponse = (
+  options: SnapshotRequest,
+  buckets: SnapshotAggregationBucket[],
+  source: InfraSource
+): SnapshotNodeResponse => {
+  const nodeCache = new Map<string, SnapshotNode>();
+  buckets.forEach((bucket) => {
+    const cacheKey = pathToKey(extractPathFromBucket(options, bucket, source));
+    const currentNode = nodeCache.get(cacheKey);
+    if (currentNode) {
+      currentNode.metrics = extractMetricsFromBucket(currentNode.metrics, options, bucket);
+    } else {
+      const newNode: SnapshotNode = {
+        metrics: extractMetricsFromBucket([], options, bucket),
+        path: extractPathFromBucket(options, bucket, source),
+        name: bucket.key.node as string,
+      };
+      nodeCache.set(cacheKey, newNode);
+    }
+  });
+
+  const nodes: SnapshotNode[] = [];
+  for (const node of nodeCache.values()) {
+    nodes.push(node as SnapshotNode);
+  }
+  return { nodes, interval: '60s' };
+};

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
@@ -55,7 +55,8 @@ export const createTimeRangeWithInterval = async (
     };
   }
   const calculatedInterval = await createInterval(client, options);
-  const lookbackSize = Math.max(timerange.lookbackSize || 5, 5);
+  // const lookbackSize = Math.max(timerange.lookbackSize || 5, 5);
+  const lookbackSize = timerange.lookbackSize;
   return {
     interval: `${calculatedInterval}s`,
     from: timerange.to - calculatedInterval * lookbackSize * 1000, // We need at least 5 buckets worth of data

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/get_metrics_aggregations.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/get_metrics_aggregations.ts
@@ -45,7 +45,7 @@ export const metricToAggregation = (
       },
     };
   }
-  return inventoryModel.metrics.snapshot?.[metric.type];
+  return inventoryModel.metrics.snapshot?.[metric.type].aggs;
 };
 
 export const getMetricsAggregations = (

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/query_all_data.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/query_all_data.ts
@@ -5,11 +5,17 @@
  * 2.0.
  */
 
-import { MetricsAPIRequest, MetricsAPIResponse } from '../../../../common/http_api';
+import { estypes } from '@elastic/elasticsearch';
+import {
+  MetricsAPIRequest,
+  MetricsAPIResponse,
+  SnapshotNodeResponse,
+} from '../../../../common/http_api';
 import { ESSearchClient } from '../../../lib/metrics/types';
 import { query } from '../../../lib/metrics';
+import { InfraDatabaseSearchResponse } from '../../../lib/adapters/framework';
 
-const handleResponse = (
+const handleMetricsAPIResponse = (
   client: ESSearchClient,
   options: MetricsAPIRequest,
   previousResponse?: MetricsAPIResponse
@@ -23,12 +29,77 @@ const handleResponse = (
     : resp;
   if (resp.info.afterKey) {
     return query(client, { ...options, afterKey: resp.info.afterKey }).then(
-      handleResponse(client, options, combinedResponse)
+      handleMetricsAPIResponse(client, options, combinedResponse)
     );
   }
   return combinedResponse;
 };
 
 export const queryAllData = (client: ESSearchClient, options: MetricsAPIRequest) => {
-  return query(client, options).then(handleResponse(client, options));
+  return query(client, options).then(handleMetricsAPIResponse(client, options));
+};
+
+export interface SnapshotAggregationBucketMetrics {
+  [id: string]: {
+    value: number | null;
+  };
+}
+
+export type SnapshotAggregationBucket = SnapshotAggregationBucketMetrics & {
+  key: {
+    [id: string]: number | string | null;
+  };
+  doc_count: number;
+  __metadata__: {
+    top: Array<{ metrics: { [id: string]: string } }>;
+  };
+};
+
+interface SnapshotAggregation {
+  nodes: {
+    after_key?: {
+      [key: string]: number | string | null;
+    };
+    buckets: SnapshotAggregationBucket[];
+  };
+}
+
+const handleCompositeResponse = (
+  client: ESSearchClient,
+  params: estypes.SearchRequest,
+  previousResponse?: SnapshotAggregationBucket[]
+) => async (
+  resp: InfraDatabaseSearchResponse<{}, SnapshotAggregation>
+): Promise<SnapshotAggregationBucket[]> => {
+  const nodeBuckets = resp.aggregations?.nodes.buckets ?? [];
+  const combinedResponse = previousResponse ? [...previousResponse, ...nodeBuckets] : nodeBuckets;
+
+  if (resp.aggregations?.nodes.after_key && params.body && params.body.aggs) {
+    const newParams = {
+      ...params,
+      body: {
+        ...params.body,
+        aggs: {
+          ...params.body.aggs,
+          nodes: {
+            ...params.body.aggs.nodes,
+            composite: {
+              ...params.body.aggs.nodes.composite,
+              after: resp.aggregations.nodes.after_key,
+            },
+          },
+        },
+      },
+    };
+
+    return client<{}, SnapshotAggregation>(newParams).then(
+      handleCompositeResponse(client, newParams, combinedResponse)
+    );
+  }
+
+  return combinedResponse;
+};
+
+export const queryAllSnapshotData = (client: ESSearchClient, params: estypes.SearchRequest) => {
+  return client<{}, SnapshotAggregation>(params).then(handleCompositeResponse(client, params));
 };

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/transform_snapshot_metrics_to_metrics_api_metrics.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/transform_snapshot_metrics_to_metrics_api_metrics.ts
@@ -37,6 +37,6 @@ export const transformSnapshotMetricsToMetricsAPIMetrics = (
         },
       };
     }
-    return { id: metric.type, aggregations: inventoryModel.metrics.snapshot?.[metric.type] };
+    return { id: metric.type, aggregations: inventoryModel.metrics.snapshot?.[metric.type].aggs };
   });
 };

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/transform_snapshot_request_to_es_query.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/transform_snapshot_request_to_es_query.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { estypes } from '@elastic/elasticsearch';
+import { findInventoryFields, findInventoryModel } from '../../../../common/inventory_models';
+import { parseFilterQuery } from '../../../utils/serialized_query';
+import { ESSearchClient } from '../../../lib/metrics/types';
+import { InfraSource } from '../../../lib/sources';
+import { SourceOverrides } from './get_nodes';
+import { SnapshotCustomMetricInputRT, SnapshotRequest } from '../../../../common/http_api';
+import { createTimeRangeWithInterval } from './create_timerange_with_interval';
+import { calculateDateHistogramOffset } from '../../../lib/metrics/lib/calculate_date_histogram_offset';
+import { META_KEY } from './constants';
+
+export const transformSnapshotRequestToESQuery = async ({
+  client,
+  source,
+  snapshotRequest,
+  compositeSize,
+  sourceOverrides,
+}: {
+  client: ESSearchClient;
+  source: InfraSource;
+  snapshotRequest: SnapshotRequest;
+  compositeSize: number;
+  sourceOverrides?: SourceOverrides;
+}): Promise<estypes.SearchRequest> => {
+  const timeRangeWithIntervalApplied = await createTimeRangeWithInterval(client, {
+    ...snapshotRequest,
+    filterQuery: parseFilterQuery(snapshotRequest.filterQuery),
+    sourceConfiguration: source.configuration,
+  });
+
+  const timestampField = sourceOverrides?.timestamp ?? source.configuration.fields.timestamp;
+  const filters: estypes.QueryContainer[] = [
+    {
+      range: {
+        [timestampField]: {
+          gte: timeRangeWithIntervalApplied.from,
+          lte: timeRangeWithIntervalApplied.to,
+          format: 'epoch_millis',
+        },
+      },
+    },
+  ];
+
+  const parsedFilters = parseFilterQuery(snapshotRequest.filterQuery);
+  if (parsedFilters) {
+    filters.push(parsedFilters);
+  }
+
+  if (snapshotRequest.accountId) {
+    filters.push({ term: { 'cloud.account.id': snapshotRequest.accountId } });
+  }
+
+  if (snapshotRequest.region) {
+    filters.push({ term: { 'cloud.region': snapshotRequest.region } });
+  }
+
+  const inventoryModel = findInventoryModel(snapshotRequest.nodeType);
+  if (inventoryModel && inventoryModel.nodeFilter) {
+    inventoryModel.nodeFilter?.forEach((f) => filters.push(f));
+  }
+
+  const inventoryFields = findInventoryFields(
+    snapshotRequest.nodeType,
+    source.configuration.fields
+  );
+
+  const metricAggs: Record<string, estypes.AggregationContainer> = snapshotRequest.metrics.reduce(
+    (aggregations, metric, index) => {
+      if (SnapshotCustomMetricInputRT.is(metric)) {
+        if (metric.aggregation === 'rate') {
+          return {
+            ...aggregations,
+            [`custom_${index}`]: {
+              max: {
+                field: metric.field,
+              },
+            },
+          };
+        }
+        return {
+          ...aggregations,
+          ['custom_${index}']: {
+            [metric.aggregation]: {
+              field: metric.field,
+            },
+          },
+        };
+      }
+      return { ...aggregations, ...inventoryModel.metrics.snapshot[metric.type].aggs };
+    },
+    {}
+  );
+
+  const metadataFields = [{ field: inventoryFields.name }];
+
+  if (inventoryFields.ip) {
+    metadataFields.push({ field: inventoryFields.ip });
+  }
+
+  metricAggs[META_KEY] = {
+    top_metrics: {
+      size: 1,
+      metrics: metadataFields,
+      sort: { [timestampField]: 'desc' },
+    },
+  };
+
+  const sources: Array<Record<string, estypes.CompositeAggregationSource>> = [
+    {
+      timeseries: {
+        date_histogram: {
+          field: timestampField,
+          fixed_interval: timeRangeWithIntervalApplied.interval,
+          offset: calculateDateHistogramOffset({
+            to: timeRangeWithIntervalApplied.to,
+            from: timeRangeWithIntervalApplied.from,
+            interval: timeRangeWithIntervalApplied.interval,
+            field: timestampField,
+          }),
+        },
+      },
+    },
+    { node: { terms: { field: inventoryFields.id } } },
+  ];
+
+  if (snapshotRequest.groupBy) {
+    snapshotRequest.groupBy.map((groupBy, index) => {
+      if (groupBy != null && groupBy.field) {
+        sources.push({ [`group_${index}`]: { terms: { field: groupBy.field } } });
+      }
+    });
+  }
+  const topLevelAgg = {
+    nodes: {
+      composite: {
+        sources,
+        size: snapshotRequest.overrideCompositeSize
+          ? snapshotRequest.overrideCompositeSize
+          : compositeSize,
+      },
+      aggs: metricAggs,
+    },
+  };
+
+  const request: estypes.SearchRequest = {
+    index: sourceOverrides?.indexPattern ?? source.configuration.metricAlias,
+    body: {
+      size: 0,
+      track_total_hits: false,
+      query: {
+        bool: {
+          filter: filters,
+        },
+      },
+      aggs: topLevelAgg,
+    },
+  };
+  return request;
+};


### PR DESCRIPTION
## Summary

This PR is an attempt to improve the performance of the Snapshot API by moving the `date_histogram` aggregation into the composite. This PR is for prosperity sake and we have ZERO intention of merging it.

#### Performance Results

![image](https://user-images.githubusercontent.com/41702/120532119-3499c180-c394-11eb-8fab-98ba3336cb15.png)
