### PR TITLE
[Lens] Test migration parity for embeddable and saved objects

### DIFF
--- a/x-pack/plugins/lens/server/embeddable/lens_embeddable_factory.test.ts
+++ b/x-pack/plugins/lens/server/embeddable/lens_embeddable_factory.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import semverGte from 'semver/functions/gte';
+import { lensEmbeddableFactory } from './lens_embeddable_factory';
+import { migrations } from '../migrations/saved_object_migrations';
+
+describe('saved object migrations and embeddable migrations', () => {
+  test('should have same versions registered (>7.13.0)', () => {
+    const savedObjectMigrationVersions = Object.keys(migrations).filter((version) => {
+      return semverGte(version, '7.13.1');
+    });
+    const embeddableMigrationVersions = lensEmbeddableFactory()?.migrations;
+    if (embeddableMigrationVersions) {
+      expect(savedObjectMigrationVersions.sort()).toEqual(
+        Object.keys(embeddableMigrationVersions).sort()
+      );
+    }
+  });
+});


### PR DESCRIPTION
Adds a unit test to make sure migrations stay in sync.