### PR TITLE
[Lens] fix suggestions for filters and filter by

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/advanced_options.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/advanced_options.tsx
@@ -73,10 +73,10 @@ export function AdvancedOptions(props: {
         <>
           <EuiSpacer size="s" />
           {inlineOptions.map((option, index) => (
-            <>
-              {React.cloneElement(option.inlineElement!, { key: option.dataTestSubj })}
+            <React.Fragment key={option.dataTestSubj}>
+              {React.cloneElement(option.inlineElement!)}
               {index !== inlineOptions.length - 1 && <EuiSpacer size="s" />}
-            </>
+            </React.Fragment>
           ))}
         </>
       )}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/advanced_options.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/advanced_options.tsx
@@ -73,10 +73,10 @@ export function AdvancedOptions(props: {
         <>
           <EuiSpacer size="s" />
           {inlineOptions.map((option, index) => (
-            <React.Fragment key={option.dataTestSubj}>
-              {React.cloneElement(option.inlineElement!)}
+            <>
+              {React.cloneElement(option.inlineElement!, { key: option.dataTestSubj })}
               {index !== inlineOptions.length - 1 && <EuiSpacer size="s" />}
-            </React.Fragment>
+            </>
           ))}
         </>
       )}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/filtering.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/filtering.tsx
@@ -114,7 +114,7 @@ export function Filtering({
             }
           >
             <QueryInput
-              indexPattern={indexPattern}
+              indexPatternTitle={indexPattern.title}
               data-test-subj="indexPattern-filter-by-input"
               value={selectedColumn.filter || defaultFilter}
               onChange={(newQuery) => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.test.tsx
@@ -13,6 +13,7 @@ import { createMockedIndexPattern } from '../../../mocks';
 import { FilterPopover } from './filter_popover';
 import { LabelInput } from '../shared_components';
 import { QueryInput } from '../../../query_input';
+import { QueryStringInput } from '../../../../../../../../src/plugins/data/public';
 
 jest.mock('.', () => ({
   isQueryValid: () => true,
@@ -32,13 +33,25 @@ const defaultProps = {
   ),
   initiallyOpen: true,
 };
+jest.mock('../../../../../../../../src/plugins/data/public', () => ({
+  QueryStringInput: () => {
+    return 'QueryStringInput';
+  },
+}));
 
 describe('filter popover', () => {
-  jest.mock('../../../../../../../../src/plugins/data/public', () => ({
-    QueryStringInput: () => {
-      return 'QueryStringInput';
-    },
-  }));
+  it('passes correct props to QueryStringInput', () => {
+    const instance = mount(<FilterPopover {...defaultProps} />);
+    instance.update();
+    expect(instance.find(QueryStringInput).props()).toEqual(
+      expect.objectContaining({
+        dataTestSubj: 'indexPattern-filters-queryStringInput',
+        indexPatterns: ['my-fake-index-pattern'],
+        isInvalid: false,
+        query: { language: 'kuery', query: 'bytes >= 1' },
+      })
+    );
+  });
   it('should be open if is open by creation', () => {
     const instance = mount(<FilterPopover {...defaultProps} />);
     instance.update();

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.tsx
@@ -75,7 +75,7 @@ export const FilterPopover = ({
       <QueryInput
         isInvalid={!isQueryValid(filter.input, indexPattern)}
         value={filter.input}
-        indexPattern={indexPattern}
+        indexPatternTitle={indexPattern.title}
         onChange={setFilterQuery}
         onSubmit={() => {
           if (inputRef.current) inputRef.current.focus();

--- a/x-pack/plugins/lens/public/indexpattern_datasource/query_input.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/query_input.tsx
@@ -7,21 +7,20 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { IndexPattern } from './types';
 import { QueryStringInput, Query } from '../../../../../src/plugins/data/public';
 import { useDebouncedValue } from '../shared_components';
 
 export const QueryInput = ({
   value,
   onChange,
-  indexPattern,
+  indexPatternTitle,
   isInvalid,
   onSubmit,
   disableAutoFocus,
 }: {
   value: Query;
   onChange: (input: Query) => void;
-  indexPattern: IndexPattern;
+  indexPatternTitle: string;
   isInvalid: boolean;
   onSubmit: () => void;
   disableAutoFocus?: boolean;
@@ -35,7 +34,7 @@ export const QueryInput = ({
       disableAutoFocus={disableAutoFocus}
       isInvalid={isInvalid}
       bubbleSubmitEvent={false}
-      indexPatterns={[indexPattern]}
+      indexPatterns={[indexPatternTitle]}
       query={inputValue}
       onChange={handleInputChange}
       onSubmit={() => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/100990

Out of three proposed solutions I've chosen passing the index pattern as a title string. I observed some performance problems yesterday, but I think it was related slowdown in my computer not related to this.

I ruled out the other options because:
- adding `toSpec` to our lens custom IndexPatternField object can cause the same problems in the future if something changes in the data plugin as the shape of IndexPatternField object will be still different than expected from data plugin.
- calculating the indexPattern fields locally is the same what QueryStringInput does internally for passed indexPatterns strings so I don't see any gain here.
