### PR TITLE
[Filter bar] Proposal for fixing too small scrollable space (mob-programming) 

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/_global_filter_group.scss
+++ b/src/plugins/data/public/ui/filter_bar/_global_filter_group.scss
@@ -42,6 +42,10 @@
   max-width: calc(100% - #{$euiSizeXS}); // Width minus margin around each flex itm
 }
 
+.globalFilterBar-collapsed {
+  overflow-y: auto;
+}
+
 @include euiBreakpoint('xs', 's') {
   .globalFilterGroup__wrapper-isVisible {
     // EUI Flexbox adds too much margin between responded items, this just moves it up

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -42,7 +42,10 @@ function FilterBarUI(props: Props) {
   const groupRef = useRef<HTMLDivElement>(null);
   const [isAddFilterPopoverOpen, setIsAddFilterPopoverOpen] = useState(false);
   const kibana = useKibana<IDataPluginServices>();
-  const { appName, usageCollection, uiSettings } = kibana.services;
+  const { appName, usageCollection, uiSettings, storage } = kibana.services;
+  const [isCollapsed, setIsCollapsed] = useState(() =>
+    Boolean(storage.get('FILTER_BAR_COLLAPSED'))
+  );
   if (!uiSettings) return null;
 
   const reportUiCounter = usageCollection?.reportUiCounter.bind(usageCollection, appName);
@@ -183,7 +186,9 @@ function FilterBarUI(props: Props) {
     onFiltersUpdated([]);
   }
 
-  const classes = classNames('globalFilterBar', props.className);
+  const classes = classNames('globalFilterBar', props.className, {
+    'globalFilterBar-collapsed': isCollapsed,
+  });
 
   return (
     <EuiFlexGroup
@@ -201,6 +206,11 @@ function FilterBarUI(props: Props) {
           onToggleAllNegated={onToggleAllNegated}
           onToggleAllDisabled={onToggleAllDisabled}
           onRemoveAll={onRemoveAll}
+          onCollapse={(collapsed: boolean) => {
+            storage.set('FILTER_BAR_COLLAPSED', collapsed);
+            setIsCollapsed(collapsed);
+          }}
+          isCollapsed={isCollapsed}
         />
       </EuiFlexItem>
 
@@ -208,14 +218,15 @@ function FilterBarUI(props: Props) {
         <EuiFlexGroup
           ref={groupRef}
           className={classes}
-          wrap={true}
+          wrap={!isCollapsed}
           responsive={false}
           gutterSize="xs"
           alignItems="center"
           tabIndex={-1}
         >
+          {isCollapsed && renderAddFilter()}
           {renderItems()}
-          {renderAddFilter()}
+          {!isCollapsed && renderAddFilter()}
         </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/plugins/data/public/ui/filter_bar/filter_options.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_options.tsx
@@ -19,7 +19,9 @@ interface Props {
   onToggleAllNegated: () => void;
   onToggleAllDisabled: () => void;
   onRemoveAll: () => void;
+  onCollapse: (isCollapsed: boolean) => void;
   intl: InjectedIntl;
+  isCollapsed: boolean;
 }
 
 interface State {
@@ -131,6 +133,23 @@ class FilterOptionsUI extends Component<Props, State> {
             this.props.onRemoveAll();
           },
           'data-test-subj': 'removeAllFilters',
+        },
+        {
+          name: this.props.isCollapsed
+            ? this.props.intl.formatMessage({
+                id: 'data.filter.options.expandFiltersBar',
+                defaultMessage: 'Expand bar',
+              })
+            : this.props.intl.formatMessage({
+                id: 'data.filter.options.collapseFiltersBar',
+                defaultMessage: 'Collapse bar',
+              }),
+          icon: this.props.isCollapsed ? 'expand' : 'fold',
+          onClick: () => {
+            this.closePopover();
+            this.props.onCollapse(!this.props.isCollapsed);
+          },
+          'data-test-subj': 'collapseBar',
         },
       ],
     };


### PR DESCRIPTION
## Summary

This is a POC for solving a small scrollable space problem in Discover kibana-app came up with on mob-programming session. Please let us know your thoughts!

Proposal for fixing https://github.com/elastic/kibana/issues/100329


Changes include:
- adding a button to filters options popover to collapse/expand filters bar
- when collapsed, the bar takes one scrollable line and doesn't wrap
- when collapsed, the `Add filter` button is moved to the beginning of the list

Here's a demo:


https://user-images.githubusercontent.com/4283304/120807523-563baa00-c548-11eb-8aa0-e27c1e4dcdb5.mp4

