### PR TITLE
[Expressions] Add support of the saved search embeddable by the kibana_context function

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_search.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_search.ts
@@ -43,7 +43,7 @@ export function savedSearch(): ExpressionFunctionDefinition<
     },
     type: EmbeddableExpressionType,
     fn: (input, { id }) => {
-      const filters = input ? input.and : [];
+      const filters = input?.and ?? [];
       return {
         type: EmbeddableExpressionType,
         input: {


### PR DESCRIPTION
## Summary

Update the `kibana_context` function to accept the `savedSearch` function output in the `savedSearchId` argument.

Resolves #67901.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
