### PR TITLE
Address design issues in Discover/Graph

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
@@ -346,6 +346,7 @@ export function DiscoverLayout({
                 verticalPosition={contentCentered ? 'center' : undefined}
                 horizontalPosition={contentCentered ? 'center' : undefined}
                 paddingSize="none"
+                hasShadow={false}
                 className={classNames('dscPageContent', {
                   'dscPageContent--centered': contentCentered,
                 })}

--- a/x-pack/plugins/graph/public/angular/templates/listing_ng_wrapper.html
+++ b/x-pack/plugins/graph/public/angular/templates/listing_ng_wrapper.html
@@ -9,4 +9,5 @@
   initial-filter="initialFilter"
   initialPageSize="initialPageSize"
   core-start="coreStart"
+  class="kbnAppWrapper"
 ></graph-listing>

--- a/x-pack/plugins/graph/public/components/guidance_panel/guidance_panel.tsx
+++ b/x-pack/plugins/graph/public/components/guidance_panel/guidance_panel.tsx
@@ -86,8 +86,8 @@ function GuidancePanelComponent(props: GuidancePanelProps) {
 
   const kibana = useKibana<IDataPluginServices>();
   const { services, overlays } = kibana;
-  const { savedObjects, uiSettings, chrome, application } = services;
-  if (!overlays || !chrome || !application) return null;
+  const { savedObjects, uiSettings, application } = services;
+  if (!overlays || !application) return null;
 
   const onOpenDatasourcePicker = () => {
     openSourceModal({ overlays, savedObjects, uiSettings }, onIndexPatternSelected);
@@ -149,8 +149,9 @@ function GuidancePanelComponent(props: GuidancePanelProps) {
   );
 
   if (noIndexPatterns) {
-    const managementUrl = chrome.navLinks.get('kibana:stack_management')!.url;
-    const indexPatternUrl = `${managementUrl}/kibana/indexPatterns`;
+    const indexPatternUrl = application.getUrlForApp('management', {
+      path: '/kibana/indexPatterns',
+    });
     const sampleDataUrl = `${application.getUrlForApp('home')}#/tutorial_directory/sampleData`;
     content = (
       <EuiPanel paddingSize="none">


### PR DESCRIPTION
## Summary

Addresses the Kibana app part of https://github.com/elastic/kibana/issues/98827 to fix some minor design issues and one bug in Graph:

* Discover panel now no longer has a cut-off shadow. As per suggestion disabled the shadow on the panel.
* Graph now has the `kbnAppWrapper` class on it's listing directive, thus making sure the page is correctly full screen.
* Going to graph without an index pattern, will no longer crash the page.

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
