### PR TITLE
[Maps] fix EMS Boundaries with joins not rendering

### DIFF
--- a/x-pack/plugins/maps/public/actions/data_request_actions.ts
+++ b/x-pack/plugins/maps/public/actions/data_request_actions.ts
@@ -123,7 +123,7 @@ function getDataRequestContext(
       dispatch(endDataLoad(layerId, dataId, requestToken, data, meta)),
     onLoadError: (dataId: string, requestToken: symbol, errorMessage: string) =>
       dispatch(onDataLoadError(layerId, dataId, requestToken, errorMessage)),
-    updateSourceData: (newData: unknown) => {
+    updateSourceData: (newData: object) => {
       dispatch(updateSourceDataRequest(layerId, newData));
     },
     isRequestStillActive: (dataId: string, requestToken: symbol) => {
@@ -316,7 +316,7 @@ function onDataLoadError(
   };
 }
 
-export function updateSourceDataRequest(layerId: string, newData: unknown) {
+export function updateSourceDataRequest(layerId: string, newData: object) {
   return (dispatch: ThunkDispatch<MapStoreState, void, AnyAction>) => {
     dispatch({
       type: UPDATE_SOURCE_DATA_REQUEST,

--- a/x-pack/plugins/maps/public/reducers/map/data_request_utils.ts
+++ b/x-pack/plugins/maps/public/reducers/map/data_request_utils.ts
@@ -38,7 +38,7 @@ export function startDataRequest(
 export function updateSourceDataRequest(
   state: MapState,
   layerId: string,
-  newData?: object
+  newData: object
 ): MapState {
   const dataRequest = getDataRequest(state, layerId, SOURCE_DATA_REQUEST_ID);
   return dataRequest ? setDataRequest(state, layerId, { ...dataRequest, data: newData }) : state;

--- a/x-pack/plugins/maps/public/reducers/map/map.ts
+++ b/x-pack/plugins/maps/public/reducers/map/map.ts
@@ -87,7 +87,7 @@ export const DEFAULT_MAP_STATE: MapState = {
   __rollbackSettings: null,
 };
 
-export function map(state: MapState = DEFAULT_MAP_STATE, action: any) {
+export function map(state: MapState = DEFAULT_MAP_STATE, action: Record<string, any>) {
   switch (action.type) {
     case UPDATE_DRAW_STATE:
       return {
@@ -186,7 +186,7 @@ export function map(state: MapState = DEFAULT_MAP_STATE, action: any) {
         ],
       };
     case UPDATE_SOURCE_DATA_REQUEST:
-      return updateSourceDataRequest(state, action);
+      return updateSourceDataRequest(state, action.layerId, action.newData);
     case LAYER_DATA_LOAD_STARTED:
       return startDataRequest(
         state,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/101497

Regression caused by https://github.com/elastic/kibana/pull/91955. 

UPDATE_SOURCE_DATA_REQUEST redux reducer is not properly passing arguments to a utility function. This resulted in redux state not properly setting updated feature collection with joined values. As a result, the map was displaying feature collection without join results. There is a mapbox filter expressions that filters out features without join results. This resulted in the features not being displayed.

Why did this not break all joins? Deep copying is expensive, especially with large features. As such, the features are updated in a shallow copy so the feature collection object changes but changes to each feature are updating existing features. So even though UPDATE_SOURCE_DATA_REQUEST did not update state, the underlying features did change in state (maybe this should be fixed as well since it breaks fundamentals of redux, but can address outside of this fix). Without the changing the object, another check was failing down stream, https://github.com/nreese/kibana/blob/master/x-pack/plugins/maps/public/classes/layers/vector_layer/vector_layer.tsx#L716, that updated mapbox gl with the latest feature collection from redux. 

This PR fixes the issue and updates action type, which would have flagged this issue.