### PR TITLE
[Canvas] Use @emotion/react to style reveal image renderer.

### DIFF
--- a/src/plugins/expression_reveal_image/public/components/reveal_image.scss
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image.scss
@@ -1,6 +1,4 @@
 .revealImage {
-  // height: 100%;
-  // width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/plugins/expression_reveal_image/public/components/reveal_image.scss
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image.scss
@@ -5,14 +5,4 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
-
-  .revealImageAligner {
-    background-size: contain;
-    background-repeat: no-repeat;
-  }
-
-  // disables selection and dragging
-  .revealImage__image {
-    user-select: none;
-  }
 }

--- a/src/plugins/expression_reveal_image/public/components/reveal_image.scss
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image.scss
@@ -1,6 +1,6 @@
 .revealImage {
-  height: 100%;
-  width: 100%;
+  // height: 100%;
+  // width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
@@ -68,7 +68,7 @@ function RevealImageComponent({
 
   const imgStyles = useMemo(() => {
     if (!imgRef.current || !loaded) {
-      return;
+      return undefined;
     }
 
     const imageAspectRatio = dimensions.height / dimensions.width;
@@ -84,7 +84,6 @@ function RevealImageComponent({
       -ms-user-select: none;
       user-select: none;
 
-      -webkit-clip-path: ${clipPath};
       clip-path: ${clipPath};
 
       width: ${imageAspectRatio > containerHeight / containerWidth
@@ -99,12 +98,12 @@ function RevealImageComponent({
   const alignerStyles = useMemo(
     () =>
       isValidUrl(emptyImage ?? '')
-        && css`
+        ? css`
             background-size: contain;
             background-repeat: no-repeat;
             background-image: url(${emptyImage});
           `
-        ,
+        : undefined,
     [emptyImage]
   );
 


### PR DESCRIPTION
## Summary

~~Blocked by #98157.~~

This converts the reveal image renderer into a React component and uses @emotion/react to handle styling.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
