### PR TITLE
Update datafeed_high_count_network_denies.json

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_network_denies.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_network_denies.json
@@ -13,10 +13,29 @@
           "term": {
             "event.category": "network"
           }
-        },
+        }
+      ],
+      "must": [
         {
-          "term": {
-            "event.outcome": "deny"
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "event.outcome": {
+                    "query": "deny",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "event.type": {
+                    "query": "denied",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
           }
         }
       ]


### PR DESCRIPTION
adds a boolean OR between the two possible field values

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Adds a test to a data feed query, a fix for https://github.com/elastic/kibana/issues/101679

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
