### PR TITLE
Optimize performance for document table

### DIFF
--- a/src/plugins/discover/public/application/helpers/columns.test.ts
+++ b/src/plugins/discover/public/application/helpers/columns.test.ts
@@ -43,4 +43,9 @@ describe('getDisplayedColumns', () => {
       ]
     `);
   });
+  test('returns the same instance of ["_source"] over multiple calls', async () => {
+    const result = getDisplayedColumns([], indexPatternWithTimefieldMock);
+    const result2 = getDisplayedColumns([], indexPatternWithTimefieldMock);
+    expect(result).toBe(result2);
+  });
 });

--- a/src/plugins/discover/public/application/helpers/columns.ts
+++ b/src/plugins/discover/public/application/helpers/columns.ts
@@ -8,6 +8,11 @@
 
 import { IndexPattern } from '../../../../data/common';
 
+// We store this outside the function as a constant, so we're not creating a new array every time
+// the function is returning this. A changing array might cause the data grid to think it got
+// new columns, and thus performing worse than using the same array over multiple renders.
+const SOURCE_ONLY = ['_source'];
+
 /**
  * Function to provide fallback when
  * 1) no columns are given
@@ -19,5 +24,5 @@ export function getDisplayedColumns(stateColumns: string[] = [], indexPattern: I
     // check if all columns where removed except the configured timeField (this can't be removed)
     !(stateColumns.length === 1 && stateColumns[0] === indexPattern.timeFieldName)
     ? stateColumns
-    : ['_source'];
+    : SOURCE_ONLY;
 }


### PR DESCRIPTION
## Summary

Optimize the performance of Discover when showing the default document view. So far we returned a new reference of `['_source']` in every render, which made e.g. toggling checkboxes in this case really slow (~500ms), because data grid thought it got completely new columns. Keeping the reference around improves that significantly and toggling checkboxes in the default document view, is now not feeling laggy anymore.

**To test:** Compare performance of toggling checkboxes in a new discover search using data grid (without any columns, just the "Document") before and with this change.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
