### PR TITLE
[Lens] Memoize operationMatrix computation

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/operations.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/operations.ts
@@ -93,7 +93,7 @@ export function isDocumentOperation(type: string) {
   return documentOperations.has(type);
 }
 
-type OperationFieldTuple =
+export type OperationFieldTuple =
   | {
       type: 'field';
       operationType: OperationType;


### PR DESCRIPTION
## Summary

While investigating on Formula's performance, I did notice that one of the reasons components were rerendering was the `operationSupportMatrix` object reference.
This PR aims at minimize the rerendering via stabilising the object reference: because the `lodash` memoize supports only a single argument, here we need to check two of them ( operations object + filter function), so a different memoization utility has been used, which supports multiple arguments.

Before

<img width="1178" alt="Screenshot 2021-06-09 at 14 58 00" src="https://user-images.githubusercontent.com/924948/121358838-34b93480-c933-11eb-8728-a5fe9460ac58.png">

After

<img width="1179" alt="Screenshot 2021-06-09 at 14 55 05" src="https://user-images.githubusercontent.com/924948/121358868-3a167f00-c933-11eb-8576-4d90e6548e4a.png">

In terms of computation performance it is not saving much, as it is recomputing at every change, but state changes while the dimension panel is open are now reusing the same object.
All the other props can be now memoized within React component. This is more a building block to improve everything else around.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
