### PR TITLE
[Lens] Do not use dynamic coloring for array values

### DIFF
--- a/x-pack/plugins/lens/public/datatable_visualization/components/cell_value.test.tsx
+++ b/x-pack/plugins/lens/public/datatable_visualization/components/cell_value.test.tsx
@@ -192,5 +192,16 @@ describe('datatable cell renderer', () => {
         style: expect.objectContaining({ color: 'blue' }),
       });
     });
+
+    it('should not color the cell when the value is an array', async () => {
+      const columnConfig = getColumnConfiguration();
+      columnConfig.columns[0].colorMode = 'cell';
+
+      const { setCellProps } = await renderCellComponent(columnConfig, {
+        table: { ...table, rows: [{ a: [10, 123] }] },
+      });
+
+      expect(setCellProps).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/lens/public/datatable_visualization/components/cell_value.tsx
+++ b/x-pack/plugins/lens/public/datatable_visualization/components/cell_value.tsx
@@ -13,6 +13,7 @@ import type { DataContextType } from './types';
 import { ColumnConfig } from './table_basic';
 import { getContrastColor } from '../../shared_components/coloring/utils';
 import { getOriginalId } from '../transpose_helpers';
+import { getNumericValue } from './shared_utils';
 
 export const createGridCell = (
   formatters: Record<string, ReturnType<FormatFactory>>,
@@ -37,7 +38,11 @@ export const createGridCell = (
       if (minMaxByColumnId?.[originalId]) {
         if (colorMode !== 'none' && palette?.params && getColorForValue) {
           // workout the bucket the value belongs to
-          const color = getColorForValue(rowValue, palette.params, minMaxByColumnId[originalId]);
+          const color = getColorForValue(
+            getNumericValue(rowValue),
+            palette.params,
+            minMaxByColumnId[originalId]
+          );
           if (color) {
             const style = { [colorMode === 'cell' ? 'backgroundColor' : 'color']: color };
             if (colorMode === 'cell' && color) {

--- a/x-pack/plugins/lens/public/datatable_visualization/components/shared_utils.tsx
+++ b/x-pack/plugins/lens/public/datatable_visualization/components/shared_utils.tsx
@@ -8,6 +8,13 @@
 import { Datatable } from 'src/plugins/expressions';
 import { getOriginalId } from '../transpose_helpers';
 
+export function getNumericValue(rowValue: number | number[] | undefined) {
+  if (rowValue == null || Array.isArray(rowValue)) {
+    return;
+  }
+  return rowValue;
+}
+
 export const findMinMaxByColumnId = (columnIds: string[], table: Datatable | undefined) => {
   const minMax: Record<string, { min: number; max: number; fallback?: boolean }> = {};
 
@@ -17,12 +24,13 @@ export const findMinMaxByColumnId = (columnIds: string[], table: Datatable | und
       minMax[originalId] = minMax[originalId] || { max: -Infinity, min: Infinity };
       table.rows.forEach((row) => {
         const rowValue = row[columnId];
-        if (rowValue != null) {
-          if (minMax[originalId].min > rowValue) {
-            minMax[originalId].min = rowValue;
+        const numericValue = getNumericValue(rowValue);
+        if (numericValue != null) {
+          if (minMax[originalId].min > numericValue) {
+            minMax[originalId].min = numericValue;
           }
-          if (minMax[originalId].max < rowValue) {
-            minMax[originalId].max = rowValue;
+          if (minMax[originalId].max < numericValue) {
+            minMax[originalId].max = numericValue;
           }
         }
       });


### PR DESCRIPTION
## Summary

Fixes #101583 

Silently skip array values for dynamic colouring.

<img width="1051" alt="Screenshot 2021-06-09 at 15 15 32" src="https://user-images.githubusercontent.com/924948/121361705-d6418580-c935-11eb-9715-67a614b74cd5.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
