### PR TITLE
[Security Solution][Detections] Add empty string validation for Tags and Authors

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/schema.tsx
@@ -13,6 +13,7 @@ import {
   FormSchema,
   ValidationFunc,
   ERROR_CODE,
+  VALIDATION_TYPES,
 } from '../../../../shared_imports';
 import { AboutStepRule } from '../../../pages/detection_engine/rules/types';
 import { OptionalFieldLabel } from '../optional_field_label';
@@ -38,6 +39,20 @@ export const schema: FormSchema<AboutStepRule> = {
       }
     ),
     labelAppend: OptionalFieldLabel,
+    validations: [
+      {
+        validator: emptyField(
+          i18n.translate(
+            'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.authorFieldEmptyError',
+            {
+              defaultMessage: 'An author must not be empty',
+            }
+          )
+        ),
+        type: VALIDATION_TYPES.ARRAY_ITEM,
+        isBlocking: false,
+      },
+    ],
   },
   name: {
     type: FIELD_TYPES.TEXT,
@@ -243,6 +258,20 @@ export const schema: FormSchema<AboutStepRule> = {
       }
     ),
     labelAppend: OptionalFieldLabel,
+    validations: [
+      {
+        validator: emptyField(
+          i18n.translate(
+            'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.tagFieldEmptyError',
+            {
+              defaultMessage: 'A tag must not be empty',
+            }
+          )
+        ),
+        type: VALIDATION_TYPES.ARRAY_ITEM,
+        isBlocking: false,
+      },
+    ],
   },
   note: {
     type: FIELD_TYPES.TEXTAREA,


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/91821

Adds a validation that doesn't allow empty strings for Tags and Authors.

#### UI when the user tries to add and empty string ("   ")
![Screenshot 2021-06-09 at 15 46 01](https://user-images.githubusercontent.com/1490444/121366697-f83d0700-c939-11eb-863a-26705cd8d0ce.png)
![Screenshot 2021-06-09 at 15 45 35](https://user-images.githubusercontent.com/1490444/121366701-f8d59d80-c939-11eb-825c-600fc85231a2.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
