### PR TITLE
[APM] Add AWS and Azure icons for additional services

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/span_icon/get_span_icon.ts
+++ b/x-pack/plugins/apm/public/components/shared/span_icon/get_span_icon.ts
@@ -33,13 +33,14 @@ const defaultTypeIcons: { [key: string]: string } = {
   resource: globeIcon,
 };
 
-const typeIcons: { [key: string]: { [key: string]: string } } = {
+export const typeIcons: { [type: string]: { [subType: string]: string } } = {
   aws: {
-    servicename: awsIcon,
+    servicename: 'logoAWS',
   },
   db: {
     cassandra: cassandraIcon,
-    dynamodb: awsIcon,
+    cosmosdb: 'logoAzure',
+    dynamodb: 'logoAWS',
     elasticsearch: elasticsearchIcon,
     mongodb: mongodbIcon,
     mysql: mysqlIcon,
@@ -52,8 +53,18 @@ const typeIcons: { [key: string]: { [key: string]: string } } = {
     websocket: websocketIcon,
   },
   messaging: {
+    azurequeue: 'logoAzure',
+    azureservicebus: 'logoAzure',
     jms: javaIcon,
     kafka: kafkaIcon,
+    sns: 'logoAWS',
+    sqs: 'logoAWS',
+  },
+  storage: {
+    azureblob: 'logoAzure',
+    azurefile: 'logoAzure',
+    azuretable: 'logoAzure',
+    s3: 'logoAWS',
   },
   template: {
     handlebars: handlebarsIcon,

--- a/x-pack/plugins/apm/public/components/shared/span_icon/get_span_icon.ts
+++ b/x-pack/plugins/apm/public/components/shared/span_icon/get_span_icon.ts
@@ -6,7 +6,6 @@
  */
 
 import { maybe } from '../../../../common/utils/maybe';
-import awsIcon from './icons/aws.svg';
 import cassandraIcon from './icons/cassandra.svg';
 import databaseIcon from './icons/database.svg';
 import defaultIcon from './icons/default.svg';

--- a/x-pack/plugins/apm/public/components/shared/span_icon/get_span_icon.ts
+++ b/x-pack/plugins/apm/public/components/shared/span_icon/get_span_icon.ts
@@ -39,6 +39,7 @@ const typeIcons: { [key: string]: { [key: string]: string } } = {
   },
   db: {
     cassandra: cassandraIcon,
+    dynamodb: awsIcon,
     elasticsearch: elasticsearchIcon,
     mongodb: mongodbIcon,
     mysql: mysqlIcon,

--- a/x-pack/plugins/apm/public/components/shared/span_icon/span_icon.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/span_icon/span_icon.stories.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiCopy,
+  EuiPanel,
+  EuiSpacer,
+  EuiCodeBlock,
+} from '@elastic/eui';
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { EuiThemeProvider } from '../../../../../../../src/plugins/kibana_react/common';
+import { SpanIcon } from './index';
+import { typeIcons } from './get_span_icon';
+
+const types = Object.keys(typeIcons);
+
+storiesOf('shared/span_icon/span_icon', module)
+  .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+  .add(
+    'Span icon',
+    () => {
+      return (
+        <>
+          <EuiCodeBlock language="html" isCopyable paddingSize="m">
+            {'<SpanIcon type="db" subtype="cassandra" />'}
+          </EuiCodeBlock>
+
+          <EuiSpacer />
+          <EuiFlexGrid direction="column" columns={3}>
+            {types.map((type) => {
+              const subTypes = Object.keys(typeIcons[type]);
+              return (
+                <>
+                  {subTypes.map((subType) => {
+                    const id = `${type}.${subType}`;
+                    return (
+                      <EuiFlexItem key={id}>
+                        <EuiCopy
+                          display="block"
+                          textToCopy={id}
+                          afterMessage={`${id} copied`}
+                        >
+                          {(copy) => (
+                            <EuiPanel
+                              hasShadow={false}
+                              hasBorder={false}
+                              onClick={copy}
+                              paddingSize="s"
+                            >
+                              <SpanIcon type={type} subType={subType} /> &emsp;{' '}
+                              <small>{id}</small>
+                            </EuiPanel>
+                          )}
+                        </EuiCopy>
+                      </EuiFlexItem>
+                    );
+                  })}
+                </>
+              );
+            })}
+          </EuiFlexGrid>
+        </>
+      );
+    },
+    {}
+  );


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/96284

Added icons for AWS and Azure services and added storybook for better visibility.

![image](https://user-images.githubusercontent.com/209966/121892286-d61dfd00-cd1c-11eb-8d19-77bd8ffc3ee1.png)
