### PR TITLE
App search cleanup

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/constants.ts
@@ -18,7 +18,7 @@ export const CURATIONS_OVERVIEW_TITLE = i18n.translate(
 );
 export const CREATE_NEW_CURATION_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.engine.curations.create.title',
-  { defaultMessage: 'Create new curation' }
+  { defaultMessage: 'Create a new curation' }
 );
 export const MANAGE_CURATION_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.engine.curations.manage.title',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/documents/hidden_documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/documents/hidden_documents.tsx
@@ -80,7 +80,7 @@ export const HiddenDocuments: React.FC = () => {
             <h3>
               {i18n.translate(
                 'xpack.enterpriseSearch.appSearch.engine.curations.hiddenDocuments.emptyTitle',
-                { defaultMessage: 'No documents are being hidden for this query' }
+                { defaultMessage: "You haven't hidden any documents yet" }
               )}
             </h3>
           }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_form.tsx
@@ -42,7 +42,7 @@ export const RelevanceTuningForm: React.FC = () => {
   return (
     <section className="relevanceTuningForm">
       <form>
-        <EuiSpacer size="s" />
+        <EuiSpacer size="m" />
         <EuiTitle size="m">
           <h2>
             {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_preview.tsx
@@ -21,6 +21,7 @@ import { RelevanceTuningLogic } from '.';
 const emptyCallout = (
   <EuiEmptyPrompt
     data-test-subj="EmptyQueryPrompt"
+    iconType="glasses"
     body={i18n.translate(
       'xpack.enterpriseSearch.appSearch.engine.relevanceTuning.preview.enterQueryMessage',
       {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/schema/views/schema.tsx
@@ -53,13 +53,14 @@ export const Schema: React.FC = () => {
           >
             {i18n.translate(
               'xpack.enterpriseSearch.appSearch.engine.schema.updateSchemaButtonLabel',
-              { defaultMessage: 'Update types' }
+              { defaultMessage: 'Save changes' }
             )}
           </EuiButton>,
           <EuiButton
             color="secondary"
             disabled={isUpdating}
             onClick={openModal}
+            iconType="plusInCircleFilled"
             data-test-subj="addSchemaFieldModalButton"
           >
             {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/search_ui.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search_ui/search_ui.tsx
@@ -56,7 +56,7 @@ export const SearchUI: React.FC = () => {
                       <EuiLink target="_blank" href="https://github.com/elastic/search-ui">
                         <FormattedMessage
                           id="xpack.enterpriseSearch.appSearch.engine.searchUI.repositoryLinkText"
-                          defaultMessage="Learn more"
+                          defaultMessage="View the Github repo"
                         />
                       </EuiLink>
                     ),
@@ -72,7 +72,7 @@ export const SearchUI: React.FC = () => {
                       <EuiLink target="_blank" href={`${DOCS_PREFIX}/reference-ui-guide.html`}>
                         <FormattedMessage
                           id="xpack.enterpriseSearch.appSearch.engine.searchUI.guideLinkText"
-                          defaultMessage="Learn more"
+                          defaultMessage="Learn more about Search UI"
                         />
                       </EuiLink>
                     ),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/synonyms/synonyms.tsx
@@ -53,6 +53,13 @@ export const Synonyms: React.FC = () => {
       <SetPageChrome trail={getEngineBreadcrumbs([SYNONYMS_TITLE])} />
       <EuiPageHeader
         pageTitle={SYNONYMS_TITLE}
+        description={i18n.translate(
+          'xpack.enterpriseSearch.appSearch.engine.synonyms.description',
+          {
+            defaultMessage:
+              'Use synonyms to relate queries together that contextually have the same meaning in your dataset.',
+          }
+        )}
         rightSideItems={[
           <EuiButton fill onClick={() => openModal(null)}>
             {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/add_field_modal/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/add_field_modal/index.tsx
@@ -10,6 +10,7 @@ import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -83,8 +84,13 @@ export const SchemaAddFieldModal: React.FC<Props> = ({
         <EuiModalHeaderTitle>{ADD_FIELD_MODAL_TITLE}</EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
-        <p>{ADD_FIELD_MODAL_DESCRIPTION}</p>
-        <EuiSpacer />
+        <EuiCallOut
+          color="warning"
+          size="s"
+          iconType="iInCircle"
+          title={<p>{ADD_FIELD_MODAL_DESCRIPTION}</p>}
+        />
+        <EuiSpacer size="m" />
         <EuiForm component="form" id={FORM_ID} onSubmit={submitForm}>
           <EuiFlexGroup gutterSize="m">
             <EuiFlexItem>


### PR DESCRIPTION
## Summary

This PR makes some small UI adjustments for a lil more polish. Review by commit might be he most straightforward way.

<img width="543" alt="Screen Shot 2021-06-10 at 12 57 30 PM" src="https://user-images.githubusercontent.com/739960/121589024-73122a80-c9eb-11eb-8572-d6b01d89b8a6.png">
<img width="949" alt="Screen Shot 2021-06-10 at 12 57 08 PM" src="https://user-images.githubusercontent.com/739960/121589029-74435780-c9eb-11eb-982f-752fe0fdc039.png">
<img width="1396" alt="Screen Shot 2021-06-10 at 12 36 47 PM" src="https://user-images.githubusercontent.com/739960/121589031-74dbee00-c9eb-11eb-9c2b-7dac8ec3d7c4.png">
<img width="1441" alt="Screen Shot 2021-06-10 at 12 36 35 PM" src="https://user-images.githubusercontent.com/739960/121589035-75748480-c9eb-11eb-880b-832e695fe069.png">
<img width="620" alt="Screen Shot 2021-06-10 at 12 36 21 PM" src="https://user-images.githubusercontent.com/739960/121589037-760d1b00-c9eb-11eb-805b-ea55ea6d7583.png">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
