### PR TITLE
[ML] Functional tests - stabilize alerting flyout test

### DIFF
--- a/x-pack/test/functional/services/ml/alerting.ts
+++ b/x-pack/test/functional/services/ml/alerting.ts
@@ -94,10 +94,10 @@ export function MachineLearningAlertingProvider(
       await this.assertPreviewCalloutVisible();
     },
 
-    async checkPreview(expectedMessage: string) {
+    async checkPreview(expectedMessagePattern: RegExp) {
       await this.clickPreviewButton();
       const previewMessage = await testSubjects.getVisibleText('mlAnomalyAlertPreviewMessage');
-      expect(previewMessage).to.eql(expectedMessage);
+      expect(previewMessage).to.match(expectedMessagePattern);
     },
 
     async assertPreviewCalloutVisible() {

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -541,7 +541,7 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
     },
 
     async waitForDatafeedToNotExist(datafeedId: string) {
-      await retry.waitForWithTimeout(`'${datafeedId}' to exist`, 5 * 1000, async () => {
+      await retry.waitForWithTimeout(`'${datafeedId}' to not exist`, 5 * 1000, async () => {
         if ((await this.datafeedExist(datafeedId)) === false) {
           return true;
         } else {

--- a/x-pack/test/functional_with_es_ssl/apps/ml/alert_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/ml/alert_flyout.ts
@@ -67,8 +67,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
   let testJobId = '';
 
-  // Failing: See https://github.com/elastic/kibana/issues/102012
-  describe.skip('anomaly detection alert', function () {
+  describe('anomaly detection alert', function () {
     this.tags('ciGroup13');
 
     before(async () => {
@@ -93,6 +92,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
 
     after(async () => {
+      await ml.api.deleteAnomalyDetectionJobES(testJobId);
       await ml.api.cleanMlIndices();
       await ml.alerting.cleanAnomalyDetectionRules();
     });
@@ -120,7 +120,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await ml.alerting.assertPreviewButtonState(false);
         await ml.alerting.setTestInterval('2y');
         await ml.alerting.assertPreviewButtonState(true);
-        await ml.alerting.checkPreview('Found 13 anomalies in the last 2y.');
+
+        // don't check the exact number provided by the backend, just make sure it's > 0
+        await ml.alerting.checkPreview(/Found [1-9]\d* anomalies in the last 2y/);
 
         await ml.testExecution.logTestStep('should create an alert');
         await pageObjects.triggersActionsUI.setAlertName('ml-test-alert');


### PR DESCRIPTION
## Summary

This PR stabilizes and re-activates the ML alerting flyout test suite.

### Details

- Similar to how we do it in other locations we don't want to check exact backend calculation results. Instead we're checking for the pattern of the expected text and validate that the number of found anomalies is > 0.
- Also fixes the cleanup, so the test can be run multiple times in a row (before there were cases where the real-time job left something behind when just the `.ml-*` indices were deleted). Now, the test job (+ corresponding datafeed) is explicitly deleted.
- Also fixes a log message, where a missing `not` could cause confusion.

Closes #102012