### PR TITLE
Correct URL when launching from MySQL metrics in-product tutorial

### DIFF
--- a/src/plugins/home/server/tutorials/mysql_metrics/index.ts
+++ b/src/plugins/home/server/tutorials/mysql_metrics/index.ts
@@ -42,7 +42,7 @@ export function mysqlMetricsSpecProvider(context: TutorialContext): TutorialSche
     artifacts: {
       dashboards: [
         {
-          id: '66881e90-0006-11e7-bf7f-c9acc3d3e306-ecs',
+          id: '57b3fb50-6309-11ea-a83e-25b8612d00cc',
           linkLabel: i18n.translate('home.tutorials.mysqlMetrics.artifacts.dashboards.linkLabel', {
             defaultMessage: 'MySQL metrics dashboard',
           }),


### PR DESCRIPTION
See Kibana issue [70081](https://github.com/elastic/kibana/issues/70081) , this fixes the URL for the dashboard.  I have not tested this as I do not have a Beats dev environment.

## Summary

Fixes Kibana issue [70081](https://github.com/elastic/kibana/issues/70081)

Updates the URL associated with this button:

![](https://user-images.githubusercontent.com/25182304/85872384-a7221a80-b79d-11ea-935d-717c3945bce7.png)



### Checklist

Delete any items that are not applicable to this PR.


- [X] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

I have not tested this (I do not have a dev environment), I found the correct URL by looking at the dashboard list, then checked the Metricbeat code to verify that I had the right ID for the dashboard.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
