### PR TITLE
[APM] Change "View full trace" button fill

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/WaterfallWithSummmary/MaybeViewTraceLink.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/WaterfallWithSummmary/MaybeViewTraceLink.tsx
@@ -45,7 +45,7 @@ export const MaybeViewTraceLink = ({
             }
           )}
         >
-          <EuiButton iconType="apmTrace" disabled={true}>
+          <EuiButton fill iconType="apmTrace" disabled={true}>
             {viewFullTraceButtonLabel}
           </EuiButton>
         </EuiToolTip>
@@ -67,7 +67,7 @@ export const MaybeViewTraceLink = ({
             }
           )}
         >
-          <EuiButton iconType="apmTrace" disabled={true}>
+          <EuiButton fill iconType="apmTrace" disabled={true}>
             {viewFullTraceButtonLabel}
           </EuiButton>
         </EuiToolTip>
@@ -92,7 +92,9 @@ export const MaybeViewTraceLink = ({
           environment={nextEnvironment}
           latencyAggregationType={latencyAggregationType}
         >
-          <EuiButton iconType="apmTrace">{viewFullTraceButtonLabel}</EuiButton>
+          <EuiButton fill iconType="apmTrace">
+            {viewFullTraceButtonLabel}
+          </EuiButton>
         </TransactionDetailLink>
       </EuiFlexItem>
     );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/95398

Changed the button fill since the new theme has some improvements to the default button style.

_Before_

<img width="1915" alt="Screenshot 2021-06-14 at 15 42 08" src="https://user-images.githubusercontent.com/4104278/121902034-3d40af00-cd27-11eb-9ea6-ba0391941312.png">

_After_

<img width="1661" alt="Screenshot 2021-06-14 at 15 33 16" src="https://user-images.githubusercontent.com/4104278/121902055-403b9f80-cd27-11eb-9745-cfbe37e45176.png">

