### PR TITLE
[Enterprise Search] Refactor Role mappings to use single endpoint 

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
@@ -16,18 +16,13 @@ import { engines } from '../../__mocks__/engines.mock';
 import { nextTick } from '@kbn/test/jest';
 
 import { asRoleMapping } from '../../../shared/role_mapping/__mocks__/roles';
-import { ANY_AUTH_PROVIDER, ROLE_MAPPING_NOT_FOUND } from '../../../shared/role_mapping/constants';
+import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
 
 import { RoleMappingsLogic } from './role_mappings_logic';
 
 describe('RoleMappingsLogic', () => {
   const { http } = mockHttpValues;
-  const {
-    clearFlashMessages,
-    flashAPIErrors,
-    setSuccessMessage,
-    setErrorMessage,
-  } = mockFlashMessageHelpers;
+  const { clearFlashMessages, flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(RoleMappingsLogic);
   const DEFAULT_VALUES = {
     attributes: [],
@@ -50,15 +45,14 @@ describe('RoleMappingsLogic', () => {
     roleMappingErrors: [],
   };
 
-  const mappingsServerProps = { multipleAuthProvidersConfig: true, roleMappings: [asRoleMapping] };
-  const mappingServerProps = {
+  const mappingsServerProps = {
+    multipleAuthProvidersConfig: true,
+    roleMappings: [asRoleMapping],
     attributes: ['email', 'metadata', 'username', 'role'],
     authProviders: [ANY_AUTH_PROVIDER],
     availableEngines: engines,
     elasticsearchRoles: [],
     hasAdvancedRoles: false,
-    multipleAuthProvidersConfig: false,
-    roleMapping: asRoleMapping,
   };
 
   beforeEach(() => {
@@ -75,48 +69,20 @@ describe('RoleMappingsLogic', () => {
       it('sets data based on server response from the `mappings` (plural) endpoint', () => {
         RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
 
-        expect(RoleMappingsLogic.values.roleMappings).toEqual([asRoleMapping]);
-        expect(RoleMappingsLogic.values.dataLoading).toEqual(false);
-        expect(RoleMappingsLogic.values.multipleAuthProvidersConfig).toEqual(true);
-      });
-    });
-
-    describe('setRoleMappingData', () => {
-      it('sets state based on server response from the `mapping` (singular) endpoint', () => {
-        RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
-
         expect(RoleMappingsLogic.values).toEqual({
           ...DEFAULT_VALUES,
-          roleMapping: asRoleMapping,
+          roleMappings: [asRoleMapping],
           dataLoading: false,
-          attributes: mappingServerProps.attributes,
-          availableAuthProviders: mappingServerProps.authProviders,
-          availableEngines: mappingServerProps.availableEngines,
+          attributes: mappingsServerProps.attributes,
+          availableAuthProviders: mappingsServerProps.authProviders,
+          availableEngines: mappingsServerProps.availableEngines,
           accessAllEngines: true,
-          attributeName: 'role',
-          attributeValue: 'superuser',
-          elasticsearchRoles: mappingServerProps.elasticsearchRoles,
-          selectedEngines: new Set(engines.map((e) => e.name)),
-          selectedOptions: [
-            { label: engines[0].name, value: engines[0].name },
-            { label: engines[1].name, value: engines[1].name },
-          ],
-        });
-      });
-
-      it('will remove all selected engines if no roleMapping was returned from the server', () => {
-        RoleMappingsLogic.actions.setRoleMappingData({
-          ...mappingServerProps,
-          roleMapping: undefined,
-        });
-
-        expect(RoleMappingsLogic.values).toEqual({
-          ...DEFAULT_VALUES,
-          dataLoading: false,
+          multipleAuthProvidersConfig: true,
+          attributeName: 'username',
+          attributeValue: '',
+          elasticsearchRoles: mappingsServerProps.elasticsearchRoles,
           selectedEngines: new Set(),
-          attributes: mappingServerProps.attributes,
-          availableAuthProviders: mappingServerProps.authProviders,
-          availableEngines: mappingServerProps.availableEngines,
+          selectedOptions: [],
         });
       });
     });
@@ -135,11 +101,13 @@ describe('RoleMappingsLogic', () => {
       const engine = engines[0];
       const otherEngine = engines[1];
       const mountedValues = {
-        ...mappingServerProps,
-        roleMapping: {
-          ...asRoleMapping,
-          engines: [engine, otherEngine],
-        },
+        ...mappingsServerProps,
+        roleMappings: [
+          {
+            ...asRoleMapping,
+            engines: [engine, otherEngine],
+          },
+        ],
         selectedEngines: new Set([engine.name]),
       };
 
@@ -153,11 +121,18 @@ describe('RoleMappingsLogic', () => {
         expect(RoleMappingsLogic.values.selectedEngines).toEqual(
           new Set([engine.name, otherEngine.name])
         );
+        expect(RoleMappingsLogic.values.selectedOptions).toEqual([
+          { label: engine.name, value: engine.name },
+          { label: otherEngine.name, value: otherEngine.name },
+        ]);
       });
       it('handles removing an engine from selected engines', () => {
         RoleMappingsLogic.actions.handleEngineSelectionChange([engine.name]);
 
         expect(RoleMappingsLogic.values.selectedEngines).toEqual(new Set([engine.name]));
+        expect(RoleMappingsLogic.values.selectedOptions).toEqual([
+          { label: engine.name, value: engine.name },
+        ]);
       });
     });
 
@@ -175,17 +150,19 @@ describe('RoleMappingsLogic', () => {
 
       it('sets values correctly', () => {
         mount({
-          ...mappingServerProps,
+          ...mappingsServerProps,
           elasticsearchRoles,
         });
         RoleMappingsLogic.actions.handleAttributeSelectorChange('role', elasticsearchRoles[0]);
 
         expect(RoleMappingsLogic.values).toEqual({
           ...DEFAULT_VALUES,
+          multipleAuthProvidersConfig: true,
           attributeValue: elasticsearchRoles[0],
-          roleMapping: asRoleMapping,
-          attributes: mappingServerProps.attributes,
-          availableEngines: mappingServerProps.availableEngines,
+          roleMappings: [asRoleMapping],
+          roleMapping: null,
+          attributes: mappingsServerProps.attributes,
+          availableEngines: mappingsServerProps.availableEngines,
           accessAllEngines: true,
           attributeName: 'role',
           elasticsearchRoles,
@@ -215,11 +192,13 @@ describe('RoleMappingsLogic', () => {
     describe('handleAuthProviderChange', () => {
       beforeEach(() => {
         mount({
-          ...mappingServerProps,
-          roleMapping: {
-            ...asRoleMapping,
-            authProvider: ['foo'],
-          },
+          ...mappingsServerProps,
+          roleMappings: [
+            {
+              ...asRoleMapping,
+              authProvider: ['foo'],
+            },
+          ],
         });
       });
       const providers = ['bar', 'baz'];
@@ -244,11 +223,13 @@ describe('RoleMappingsLogic', () => {
 
       it('handles "any" auth in previous state', () => {
         mount({
-          ...mappingServerProps,
-          roleMapping: {
-            ...asRoleMapping,
-            authProvider: [ANY_AUTH_PROVIDER],
-          },
+          ...mappingsServerProps,
+          roleMappings: [
+            {
+              ...asRoleMapping,
+              authProvider: [ANY_AUTH_PROVIDER],
+            },
+          ],
         });
         RoleMappingsLogic.actions.handleAuthProviderChange(providerWithAny);
 
@@ -258,7 +239,6 @@ describe('RoleMappingsLogic', () => {
 
     it('resetState', () => {
       mount(mappingsServerProps);
-      mount(mappingServerProps);
       RoleMappingsLogic.actions.resetState();
 
       expect(RoleMappingsLogic.values).toEqual(DEFAULT_VALUES);
@@ -266,7 +246,7 @@ describe('RoleMappingsLogic', () => {
     });
 
     it('openRoleMappingFlyout', () => {
-      mount(mappingServerProps);
+      mount(mappingsServerProps);
       RoleMappingsLogic.actions.openRoleMappingFlyout();
 
       expect(RoleMappingsLogic.values.roleMappingFlyoutOpen).toEqual(true);
@@ -275,7 +255,7 @@ describe('RoleMappingsLogic', () => {
 
     it('closeRoleMappingFlyout', () => {
       mount({
-        ...mappingServerProps,
+        ...mappingsServerProps,
         roleMappingFlyoutOpen: true,
       });
       RoleMappingsLogic.actions.closeRoleMappingFlyout();
@@ -307,40 +287,20 @@ describe('RoleMappingsLogic', () => {
     });
 
     describe('initializeRoleMapping', () => {
-      it('calls API and sets values for new mapping', async () => {
-        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMappingData');
-        http.get.mockReturnValue(Promise.resolve(mappingServerProps));
-        RoleMappingsLogic.actions.initializeRoleMapping();
+      it('sets values for existing mapping', () => {
+        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMapping');
+        RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
+        RoleMappingsLogic.actions.initializeRoleMapping(asRoleMapping.id);
 
-        expect(http.get).toHaveBeenCalledWith('/api/app_search/role_mappings/new');
-        await nextTick();
-        expect(setRoleMappingDataSpy).toHaveBeenCalledWith(mappingServerProps);
+        expect(setRoleMappingDataSpy).toHaveBeenCalledWith(asRoleMapping);
       });
 
-      it('calls API and sets values for existing mapping', async () => {
-        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMappingData');
-        http.get.mockReturnValue(Promise.resolve(mappingServerProps));
-        RoleMappingsLogic.actions.initializeRoleMapping('123');
-
-        expect(http.get).toHaveBeenCalledWith('/api/app_search/role_mappings/123');
-        await nextTick();
-        expect(setRoleMappingDataSpy).toHaveBeenCalledWith(mappingServerProps);
-      });
-
-      it('handles error', async () => {
-        http.get.mockReturnValue(Promise.reject('this is an error'));
+      it('does not set data for new mapping', async () => {
+        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMapping');
+        RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
         RoleMappingsLogic.actions.initializeRoleMapping();
-        await nextTick();
 
-        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-      });
-
-      it('shows error when there is a 404 status', async () => {
-        http.get.mockReturnValue(Promise.reject({ status: 404 }));
-        RoleMappingsLogic.actions.initializeRoleMapping();
-        await nextTick();
-
-        expect(setErrorMessage).toHaveBeenCalledWith(ROLE_MAPPING_NOT_FOUND);
+        expect(setRoleMappingDataSpy).not.toHaveBeenCalledWith(asRoleMapping);
       });
     });
 
@@ -362,7 +322,7 @@ describe('RoleMappingsLogic', () => {
           'initializeRoleMappings'
         );
 
-        http.post.mockReturnValue(Promise.resolve(mappingServerProps));
+        http.post.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.handleSaveMapping();
 
         expect(http.post).toHaveBeenCalledWith('/api/app_search/role_mappings', {
@@ -374,13 +334,16 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('calls API and refreshes list when existing mapping', async () => {
-        mount(mappingServerProps);
+        mount({
+          ...mappingsServerProps,
+          roleMapping: asRoleMapping,
+        });
         const initializeRoleMappingsSpy = jest.spyOn(
           RoleMappingsLogic.actions,
           'initializeRoleMappings'
         );
 
-        http.put.mockReturnValue(Promise.resolve(mappingServerProps));
+        http.put.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.handleSaveMapping();
 
         expect(http.put).toHaveBeenCalledWith(`/api/app_search/role_mappings/${asRoleMapping.id}`, {
@@ -396,12 +359,13 @@ describe('RoleMappingsLogic', () => {
         const engine = engines[0];
 
         mount({
-          ...mappingServerProps,
+          ...mappingsServerProps,
           accessAllEngines: false,
           selectedEngines: new Set([engine.name]),
+          roleMapping: asRoleMapping,
         });
 
-        http.put.mockReturnValue(Promise.resolve(mappingServerProps));
+        http.put.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.handleSaveMapping();
 
         expect(http.put).toHaveBeenCalledWith(`/api/app_search/role_mappings/${asRoleMapping.id}`, {
@@ -449,7 +413,7 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('calls API and refreshes list', async () => {
-        mount(mappingServerProps);
+        mount(mappingsServerProps);
         const initializeRoleMappingsSpy = jest.spyOn(
           RoleMappingsLogic.actions,
           'initializeRoleMappings'
@@ -465,7 +429,7 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('handles error', async () => {
-        mount(mappingServerProps);
+        mount(mappingsServerProps);
         http.delete.mockReturnValue(Promise.reject('this is an error'));
         RoleMappingsLogic.actions.handleDeleteMapping(roleMappingId);
         await nextTick();
@@ -474,7 +438,7 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('will do nothing if not confirmed', () => {
-        mount(mappingServerProps);
+        mount(mappingsServerProps);
         jest.spyOn(window, 'confirm').mockReturnValueOnce(false);
         RoleMappingsLogic.actions.handleDeleteMapping(roleMappingId);
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -7,7 +7,7 @@
 
 import React, { Fragment } from 'react';
 
-import { EuiTextColor, EuiInMemoryTable, EuiBasicTableColumn } from '@elastic/eui';
+import { EuiIconTip, EuiTextColor, EuiInMemoryTable, EuiBasicTableColumn } from '@elastic/eui';
 
 import { ASRoleMapping } from '../../app_search/types';
 import { WSRoleMapping } from '../../workplace_search/types';
@@ -124,11 +124,16 @@ export const RoleMappingsTable: React.FC<Props> = ({
     field: 'id',
     name: '',
     align: 'right',
-    render: (_, { id }: SharedRoleMapping) => (
-      <UsersAndRolesRowActions
-        onManageClick={() => initializeRoleMapping(id)}
-        onDeleteClick={() => handleDeleteMapping(id)}
-      />
+    render: (_, { id, toolTip }: SharedRoleMapping) => (
+      <>
+        {id && (
+          <UsersAndRolesRowActions
+            onManageClick={() => initializeRoleMapping(id)}
+            onDeleteClick={() => handleDeleteMapping(id)}
+          />
+        )}
+        {toolTip && <EuiIconTip position="left" content={toolTip.content} />}
+      </>
     ),
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -84,7 +84,7 @@ export const RoleMappingsTable: React.FC<Props> = ({
   const roleCol: EuiBasicTableColumn<SharedRoleMapping> = {
     field: 'roleType',
     name: ROLE_LABEL,
-    render: (_, { rules }: SharedRoleMapping) => getFirstAttributeValue(rules),
+    render: (_, { roleType }: SharedRoleMapping) => roleType,
   };
 
   const accessItemsCol: EuiBasicTableColumn<SharedRoleMapping> = {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
@@ -16,13 +16,13 @@ import { groups } from '../../__mocks__/groups.mock';
 import { nextTick } from '@kbn/test/jest';
 
 import { wsRoleMapping } from '../../../shared/role_mapping/__mocks__/roles';
-import { ANY_AUTH_PROVIDER, ROLE_MAPPING_NOT_FOUND } from '../../../shared/role_mapping/constants';
+import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
 
 import { RoleMappingsLogic } from './role_mappings_logic';
 
 describe('RoleMappingsLogic', () => {
   const { http } = mockHttpValues;
-  const { clearFlashMessages, flashAPIErrors, setErrorMessage } = mockFlashMessageHelpers;
+  const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(RoleMappingsLogic);
   const defaultValues = {
     attributes: [],
@@ -52,14 +52,13 @@ describe('RoleMappingsLogic', () => {
     name: 'Default',
   };
 
-  const mappingsServerProps = { multipleAuthProvidersConfig: true, roleMappings: [wsRoleMapping] };
-  const mappingServerProps = {
+  const mappingsServerProps = {
+    multipleAuthProvidersConfig: true,
+    roleMappings: [wsRoleMapping],
     attributes: [],
     authProviders: [],
     availableGroups: [roleGroup, defaultGroup],
     elasticsearchRoles: [],
-    multipleAuthProvidersConfig: false,
-    roleMapping: wsRoleMapping,
   };
 
   beforeEach(() => {
@@ -78,36 +77,17 @@ describe('RoleMappingsLogic', () => {
       expect(RoleMappingsLogic.values.roleMappings).toEqual([wsRoleMapping]);
       expect(RoleMappingsLogic.values.dataLoading).toEqual(false);
       expect(RoleMappingsLogic.values.multipleAuthProvidersConfig).toEqual(true);
-    });
-
-    describe('setRoleMappingData', () => {
-      it('sets data correctly', () => {
-        RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
-
-        expect(RoleMappingsLogic.values.roleMapping).toEqual(wsRoleMapping);
-        expect(RoleMappingsLogic.values.dataLoading).toEqual(false);
-        expect(RoleMappingsLogic.values.attributes).toEqual(mappingServerProps.attributes);
-        expect(RoleMappingsLogic.values.availableGroups).toEqual(
-          mappingServerProps.availableGroups
-        );
-        expect(RoleMappingsLogic.values.includeInAllGroups).toEqual(true);
-        expect(RoleMappingsLogic.values.elasticsearchRoles).toEqual(
-          mappingServerProps.elasticsearchRoles
-        );
-        expect(RoleMappingsLogic.values.selectedGroups).toEqual(
-          new Set([wsRoleMapping.groups[0].id])
-        );
-        expect(RoleMappingsLogic.values.selectedOptions).toEqual([]);
-      });
-
-      it('sets default group with new role mapping', () => {
-        RoleMappingsLogic.actions.setRoleMappingData({
-          ...mappingServerProps,
-          roleMapping: undefined,
-        });
-
-        expect(RoleMappingsLogic.values.selectedGroups).toEqual(new Set([defaultGroup.id]));
-      });
+      expect(RoleMappingsLogic.values.dataLoading).toEqual(false);
+      expect(RoleMappingsLogic.values.attributes).toEqual(mappingsServerProps.attributes);
+      expect(RoleMappingsLogic.values.availableGroups).toEqual(mappingsServerProps.availableGroups);
+      expect(RoleMappingsLogic.values.includeInAllGroups).toEqual(false);
+      expect(RoleMappingsLogic.values.elasticsearchRoles).toEqual(
+        mappingsServerProps.elasticsearchRoles
+      );
+      expect(RoleMappingsLogic.values.selectedOptions).toEqual([
+        { label: defaultGroup.name, value: defaultGroup.id },
+      ]);
+      expect(RoleMappingsLogic.values.selectedGroups).toEqual(new Set([defaultGroup.id]));
     });
 
     it('handleRoleChange', () => {
@@ -119,14 +99,17 @@ describe('RoleMappingsLogic', () => {
     it('handleGroupSelectionChange', () => {
       const group = wsRoleMapping.groups[0];
       const otherGroup = groups[0];
-      RoleMappingsLogic.actions.setRoleMappingData({
-        ...mappingServerProps,
-        roleMapping: {
-          ...wsRoleMapping,
-          groups: [group, otherGroup],
-        },
+      RoleMappingsLogic.actions.setRoleMappingsData({
+        ...mappingsServerProps,
+        roleMappings: [
+          {
+            ...wsRoleMapping,
+            groups: [group, otherGroup],
+          },
+        ],
       });
 
+      RoleMappingsLogic.actions.initializeRoleMapping(wsRoleMapping.id);
       RoleMappingsLogic.actions.handleGroupSelectionChange([group.id, otherGroup.id]);
       expect(RoleMappingsLogic.values.selectedGroups).toEqual(new Set([group.id, otherGroup.id]));
       expect(RoleMappingsLogic.values.selectedOptions).toEqual([
@@ -147,8 +130,8 @@ describe('RoleMappingsLogic', () => {
       const elasticsearchRoles = ['foo', 'bar'];
 
       it('sets values correctly', () => {
-        RoleMappingsLogic.actions.setRoleMappingData({
-          ...mappingServerProps,
+        RoleMappingsLogic.actions.setRoleMappingsData({
+          ...mappingsServerProps,
           elasticsearchRoles,
         });
         RoleMappingsLogic.actions.handleAttributeSelectorChange('role', elasticsearchRoles[0]);
@@ -172,12 +155,14 @@ describe('RoleMappingsLogic', () => {
 
     describe('handleAuthProviderChange', () => {
       beforeEach(() => {
-        RoleMappingsLogic.actions.setRoleMappingData({
-          ...mappingServerProps,
-          roleMapping: {
-            ...wsRoleMapping,
-            authProvider: ['foo'],
-          },
+        RoleMappingsLogic.actions.setRoleMappingsData({
+          ...mappingsServerProps,
+          roleMappings: [
+            {
+              ...wsRoleMapping,
+              authProvider: ['foo'],
+            },
+          ],
         });
       });
       const providers = ['bar', 'baz'];
@@ -201,12 +186,14 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('handles "any" auth in previous state', () => {
-        RoleMappingsLogic.actions.setRoleMappingData({
-          ...mappingServerProps,
-          roleMapping: {
-            ...wsRoleMapping,
-            authProvider: [ANY_AUTH_PROVIDER],
-          },
+        RoleMappingsLogic.actions.setRoleMappingsData({
+          ...mappingsServerProps,
+          roleMappings: [
+            {
+              ...wsRoleMapping,
+              authProvider: [ANY_AUTH_PROVIDER],
+            },
+          ],
         });
         RoleMappingsLogic.actions.handleAuthProviderChange(providerWithAny);
 
@@ -222,7 +209,6 @@ describe('RoleMappingsLogic', () => {
 
     it('resetState', () => {
       RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
-      RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
       RoleMappingsLogic.actions.resetState();
 
       expect(RoleMappingsLogic.values.dataLoading).toEqual(true);
@@ -234,7 +220,7 @@ describe('RoleMappingsLogic', () => {
     });
 
     it('openRoleMappingFlyout', () => {
-      mount(mappingServerProps);
+      mount(mappingsServerProps);
       RoleMappingsLogic.actions.openRoleMappingFlyout();
 
       expect(RoleMappingsLogic.values.roleMappingFlyoutOpen).toEqual(true);
@@ -243,7 +229,7 @@ describe('RoleMappingsLogic', () => {
 
     it('closeRoleMappingFlyout', () => {
       mount({
-        ...mappingServerProps,
+        ...mappingsServerProps,
         roleMappingFlyoutOpen: true,
       });
       RoleMappingsLogic.actions.closeRoleMappingFlyout();
@@ -275,40 +261,20 @@ describe('RoleMappingsLogic', () => {
     });
 
     describe('initializeRoleMapping', () => {
-      it('calls API and sets values for new mapping', async () => {
-        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMappingData');
-        http.get.mockReturnValue(Promise.resolve(mappingServerProps));
-        RoleMappingsLogic.actions.initializeRoleMapping();
+      it('sets values for existing mapping', () => {
+        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMapping');
+        RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
+        RoleMappingsLogic.actions.initializeRoleMapping(wsRoleMapping.id);
 
-        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/org/role_mappings/new');
-        await nextTick();
-        expect(setRoleMappingDataSpy).toHaveBeenCalledWith(mappingServerProps);
+        expect(setRoleMappingDataSpy).toHaveBeenCalledWith(wsRoleMapping);
       });
 
-      it('calls API and sets values for existing mapping', async () => {
-        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMappingData');
-        http.get.mockReturnValue(Promise.resolve(mappingServerProps));
-        RoleMappingsLogic.actions.initializeRoleMapping('123');
-
-        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/org/role_mappings/123');
-        await nextTick();
-        expect(setRoleMappingDataSpy).toHaveBeenCalledWith(mappingServerProps);
-      });
-
-      it('handles error', async () => {
-        http.get.mockReturnValue(Promise.reject('this is an error'));
+      it('does not set data for new mapping', async () => {
+        const setRoleMappingDataSpy = jest.spyOn(RoleMappingsLogic.actions, 'setRoleMapping');
+        RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
         RoleMappingsLogic.actions.initializeRoleMapping();
-        await nextTick();
 
-        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-      });
-
-      it('shows error when there is a 404 status', async () => {
-        http.get.mockReturnValue(Promise.reject({ status: 404 }));
-        RoleMappingsLogic.actions.initializeRoleMapping();
-        await nextTick();
-
-        expect(setErrorMessage).toHaveBeenCalledWith(ROLE_MAPPING_NOT_FOUND);
+        expect(setRoleMappingDataSpy).not.toHaveBeenCalledWith(wsRoleMapping);
       });
     });
 
@@ -320,7 +286,7 @@ describe('RoleMappingsLogic', () => {
         );
         RoleMappingsLogic.actions.setRoleMappingsData(mappingsServerProps);
 
-        http.post.mockReturnValue(Promise.resolve(mappingServerProps));
+        http.post.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.handleSaveMapping();
 
         expect(http.post).toHaveBeenCalledWith('/api/workplace_search/org/role_mappings', {
@@ -331,7 +297,7 @@ describe('RoleMappingsLogic', () => {
             rules: {
               username: '',
             },
-            groups: [],
+            groups: [defaultGroup.id],
           }),
         });
         await nextTick();
@@ -344,9 +310,9 @@ describe('RoleMappingsLogic', () => {
           RoleMappingsLogic.actions,
           'initializeRoleMappings'
         );
-        RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
+        RoleMappingsLogic.actions.setRoleMapping(wsRoleMapping);
 
-        http.put.mockReturnValue(Promise.resolve(mappingServerProps));
+        http.put.mockReturnValue(Promise.resolve(mappingsServerProps));
         RoleMappingsLogic.actions.handleSaveMapping();
 
         expect(http.put).toHaveBeenCalledWith(
@@ -408,7 +374,7 @@ describe('RoleMappingsLogic', () => {
           RoleMappingsLogic.actions,
           'initializeRoleMappings'
         );
-        RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
+        RoleMappingsLogic.actions.setRoleMapping(wsRoleMapping);
         http.delete.mockReturnValue(Promise.resolve({}));
         RoleMappingsLogic.actions.handleDeleteMapping(roleMappingId);
 
@@ -421,7 +387,7 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('handles error', async () => {
-        RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
+        RoleMappingsLogic.actions.setRoleMapping(wsRoleMapping);
         http.delete.mockReturnValue(Promise.reject('this is an error'));
         RoleMappingsLogic.actions.handleDeleteMapping(roleMappingId);
         await nextTick();
@@ -430,7 +396,7 @@ describe('RoleMappingsLogic', () => {
       });
 
       it('will do nothing if not confirmed', async () => {
-        RoleMappingsLogic.actions.setRoleMappingData(mappingServerProps);
+        RoleMappingsLogic.actions.setRoleMapping(wsRoleMapping);
         window.confirm = () => false;
         RoleMappingsLogic.actions.handleDeleteMapping(roleMappingId);
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
@@ -199,12 +199,6 @@ describe('RoleMappingsLogic', () => {
 
         expect(RoleMappingsLogic.values.selectedAuthProviders).toEqual([providers[1]]);
       });
-
-      it('handles catch-all state', () => {
-        RoleMappingsLogic.actions.handleAuthProviderChange(providerWithAny);
-
-        expect(RoleMappingsLogic.values.selectedAuthProviders).toEqual([ANY_AUTH_PROVIDER]);
-      });
     });
 
     it('resetState', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -13,10 +13,9 @@ import {
   clearFlashMessages,
   flashAPIErrors,
   setSuccessMessage,
-  setErrorMessage,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
-import { ANY_AUTH_PROVIDER, ROLE_MAPPING_NOT_FOUND } from '../../../shared/role_mapping/constants';
+import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
 import { AttributeName } from '../../../shared/types';
 import { RoleGroup, WSRoleMapping, Role } from '../../types';
 
@@ -30,16 +29,11 @@ import {
 
 interface RoleMappingsServerDetails {
   roleMappings: WSRoleMapping[];
-  multipleAuthProvidersConfig: boolean;
-}
-
-interface RoleMappingServerDetails {
   attributes: string[];
   authProviders: string[];
   availableGroups: RoleGroup[];
   elasticsearchRoles: string[];
   multipleAuthProvidersConfig: boolean;
-  roleMapping?: WSRoleMapping;
 }
 
 const getFirstAttributeName = (roleMapping: WSRoleMapping): AttributeName =>
@@ -62,7 +56,7 @@ interface RoleMappingsActions {
   initializeRoleMapping(roleMappingId?: string): { roleMappingId?: string };
   initializeRoleMappings(): void;
   resetState(): void;
-  setRoleMappingData(data: RoleMappingServerDetails): RoleMappingServerDetails;
+  setRoleMapping(roleMapping: WSRoleMapping): { roleMapping: WSRoleMapping };
   setRoleMappingsData(data: RoleMappingsServerDetails): RoleMappingsServerDetails;
   openRoleMappingFlyout(): void;
   closeRoleMappingFlyout(): void;
@@ -93,7 +87,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
   path: ['enterprise_search', 'workplace_search', 'role_mappings'],
   actions: {
     setRoleMappingsData: (data: RoleMappingsServerDetails) => data,
-    setRoleMappingData: (data: RoleMappingServerDetails) => data,
+    setRoleMapping: (roleMapping: WSRoleMapping) => ({ roleMapping }),
     setRoleMappingErrors: (errors: string[]) => ({ errors }),
     handleAuthProviderChange: (value: string[]) => ({ value }),
     handleRoleChange: (roleType: Role) => ({ roleType }),
@@ -117,7 +111,6 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       true,
       {
         setRoleMappingsData: () => false,
-        setRoleMappingData: () => false,
         resetState: () => true,
       },
     ],
@@ -132,32 +125,31 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       false,
       {
         setRoleMappingsData: (_, { multipleAuthProvidersConfig }) => multipleAuthProvidersConfig,
-        setRoleMappingData: (_, { multipleAuthProvidersConfig }) => multipleAuthProvidersConfig,
         resetState: () => false,
       },
     ],
     availableGroups: [
       [],
       {
-        setRoleMappingData: (_, { availableGroups }) => availableGroups,
+        setRoleMappingsData: (_, { availableGroups }) => availableGroups,
       },
     ],
     attributes: [
       [],
       {
-        setRoleMappingData: (_, { attributes }) => attributes,
+        setRoleMappingsData: (_, { attributes }) => attributes,
       },
     ],
     elasticsearchRoles: [
       [],
       {
-        setRoleMappingData: (_, { elasticsearchRoles }) => elasticsearchRoles,
+        setRoleMappingsData: (_, { elasticsearchRoles }) => elasticsearchRoles,
       },
     ],
     roleMapping: [
       null,
       {
-        setRoleMappingData: (_, { roleMapping }) => roleMapping || null,
+        setRoleMapping: (_, { roleMapping }) => roleMapping,
         resetState: () => null,
         closeRoleMappingFlyout: () => null,
       },
@@ -165,23 +157,21 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
     roleType: [
       'admin',
       {
-        setRoleMappingData: (_, { roleMapping }) =>
-          roleMapping ? (roleMapping.roleType as Role) : 'admin',
+        setRoleMapping: (_, { roleMapping }) => roleMapping.roleType as Role,
         handleRoleChange: (_, { roleType }) => roleType,
       },
     ],
     includeInAllGroups: [
       false,
       {
-        setRoleMappingData: (_, { roleMapping }) => (roleMapping ? roleMapping.allGroups : false),
+        setRoleMapping: (_, { roleMapping }) => roleMapping.allGroups,
         handleAllGroupsSelectionChange: (_, { selected }) => selected,
       },
     ],
     attributeValue: [
       '',
       {
-        setRoleMappingData: (_, { roleMapping }) =>
-          roleMapping ? getFirstAttributeValue(roleMapping) : '',
+        setRoleMapping: (_, { roleMapping }) => getFirstAttributeValue(roleMapping),
         handleAttributeSelectorChange: (_, { value, firstElasticsearchRole }) =>
           value === 'role' ? firstElasticsearchRole : '',
         handleAttributeValueChange: (_, { value }) => value,
@@ -192,8 +182,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
     attributeName: [
       'username',
       {
-        setRoleMappingData: (_, { roleMapping }) =>
-          roleMapping ? getFirstAttributeName(roleMapping) : 'username',
+        setRoleMapping: (_, { roleMapping }) => getFirstAttributeName(roleMapping),
         handleAttributeSelectorChange: (_, { value }) => value,
         resetState: () => 'username',
         closeRoleMappingFlyout: () => 'username',
@@ -202,14 +191,14 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
     selectedGroups: [
       new Set(),
       {
-        setRoleMappingData: (_, { roleMapping, availableGroups }) =>
-          roleMapping
-            ? new Set(roleMapping.groups.map((group) => group.id))
-            : new Set(
-                availableGroups
-                  .filter((group) => group.name === DEFAULT_GROUP_NAME)
-                  .map((group) => group.id)
-              ),
+        setRoleMappingsData: (_, { availableGroups }) =>
+          new Set(
+            availableGroups
+              .filter((group) => group.name === DEFAULT_GROUP_NAME)
+              .map((group) => group.id)
+          ),
+        setRoleMapping: (_, { roleMapping }) =>
+          new Set(roleMapping.groups.map((group: RoleGroup) => group.id)),
         handleGroupSelectionChange: (_, { groupIds }) => {
           const newSelectedGroupNames = new Set() as Set<string>;
           groupIds.forEach((groupId) => newSelectedGroupNames.add(groupId));
@@ -221,7 +210,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
     availableAuthProviders: [
       [],
       {
-        setRoleMappingData: (_, { authProviders }) => authProviders,
+        setRoleMappingsData: (_, { authProviders }) => authProviders,
       },
     ],
     selectedAuthProviders: [
@@ -237,8 +226,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
           if (previouslyContainedAny) return value.filter((v) => v !== ANY_AUTH_PROVIDER);
           return [ANY_AUTH_PROVIDER];
         },
-        setRoleMappingData: (_, { roleMapping }) =>
-          roleMapping ? roleMapping.authProvider : [ANY_AUTH_PROVIDER],
+        setRoleMapping: (_, { roleMapping }) => roleMapping.authProvider,
       },
     ],
     roleMappingFlyoutOpen: [
@@ -283,21 +271,8 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       }
     },
     initializeRoleMapping: async ({ roleMappingId }) => {
-      const { http } = HttpLogic.values;
-      const route = roleMappingId
-        ? `/api/workplace_search/org/role_mappings/${roleMappingId}`
-        : '/api/workplace_search/org/role_mappings/new';
-
-      try {
-        const response = await http.get(route);
-        actions.setRoleMappingData(response);
-      } catch (e) {
-        if (e.status === 404) {
-          setErrorMessage(ROLE_MAPPING_NOT_FOUND);
-        } else {
-          flashAPIErrors(e);
-        }
-      }
+      const roleMapping = values.roleMappings.find(({ id }) => id === roleMappingId);
+      if (roleMapping) actions.setRoleMapping(roleMapping);
     },
     handleDeleteMapping: async ({ roleMappingId }) => {
       const { http } = HttpLogic.values;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -219,11 +219,12 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         handleAuthProviderChange: (previous, { value }) => {
           const previouslyContainedAny = previous.includes(ANY_AUTH_PROVIDER);
           const newSelectionsContainAny = value.includes(ANY_AUTH_PROVIDER);
+          const hasItems = value.length > 0;
 
-          if (value.length < 1) return [ANY_AUTH_PROVIDER];
           if (value.length === 1) return value;
-          if (!newSelectionsContainAny) return value;
-          if (previouslyContainedAny) return value.filter((v) => v !== ANY_AUTH_PROVIDER);
+          if (!newSelectionsContainAny && hasItems) return value;
+          if (previouslyContainedAny && hasItems)
+            return value.filter((v) => v !== ANY_AUTH_PROVIDER);
           return [ANY_AUTH_PROVIDER];
         },
         setRoleMapping: (_, { roleMapping }) => roleMapping.authProvider,

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.test.ts
@@ -7,11 +7,7 @@
 
 import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
 
-import {
-  registerRoleMappingsRoute,
-  registerRoleMappingRoute,
-  registerNewRoleMappingRoute,
-} from './role_mappings';
+import { registerRoleMappingsRoute, registerRoleMappingRoute } from './role_mappings';
 
 const roleMappingBaseSchema = {
   rules: { username: 'user' },
@@ -80,29 +76,6 @@ describe('role mappings routes', () => {
     });
   });
 
-  describe('GET /api/app_search/role_mappings/{id}', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'get',
-        path: '/api/app_search/role_mappings/{id}',
-      });
-
-      registerRoleMappingRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/role_mappings/:id',
-      });
-    });
-  });
-
   describe('PUT /api/app_search/role_mappings/{id}', () => {
     let mockRouter: MockRouter;
 
@@ -157,29 +130,6 @@ describe('role mappings routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/role_mappings/:id',
-      });
-    });
-  });
-
-  describe('GET /api/app_search/role_mappings/new', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'get',
-        path: '/api/app_search/role_mappings/new',
-      });
-
-      registerNewRoleMappingRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/role_mappings/new',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/role_mappings.ts
@@ -48,20 +48,6 @@ export function registerRoleMappingRoute({
   router,
   enterpriseSearchRequestHandler,
 }: RouteDependencies) {
-  router.get(
-    {
-      path: '/api/app_search/role_mappings/{id}',
-      validate: {
-        params: schema.object({
-          id: schema.string(),
-        }),
-      },
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/role_mappings/:id',
-    })
-  );
-
   router.put(
     {
       path: '/api/app_search/role_mappings/{id}',
@@ -92,23 +78,7 @@ export function registerRoleMappingRoute({
   );
 }
 
-export function registerNewRoleMappingRoute({
-  router,
-  enterpriseSearchRequestHandler,
-}: RouteDependencies) {
-  router.get(
-    {
-      path: '/api/app_search/role_mappings/new',
-      validate: false,
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/role_mappings/new',
-    })
-  );
-}
-
 export const registerRoleMappingsRoutes = (dependencies: RouteDependencies) => {
   registerRoleMappingsRoute(dependencies);
   registerRoleMappingRoute(dependencies);
-  registerNewRoleMappingRoute(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/role_mappings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/role_mappings.test.ts
@@ -7,11 +7,7 @@
 
 import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
 
-import {
-  registerOrgRoleMappingsRoute,
-  registerOrgRoleMappingRoute,
-  registerOrgNewRoleMappingRoute,
-} from './role_mappings';
+import { registerOrgRoleMappingsRoute, registerOrgRoleMappingRoute } from './role_mappings';
 
 describe('role mappings routes', () => {
   describe('GET /api/workplace_search/org/role_mappings', () => {
@@ -60,29 +56,6 @@ describe('role mappings routes', () => {
     });
   });
 
-  describe('GET /api/workplace_search/org/role_mappings/{id}', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'get',
-        path: '/api/workplace_search/org/role_mappings/{id}',
-      });
-
-      registerOrgRoleMappingRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/role_mappings/:id',
-      });
-    });
-  });
-
   describe('PUT /api/workplace_search/org/role_mappings/{id}', () => {
     let mockRouter: MockRouter;
 
@@ -125,29 +98,6 @@ describe('role mappings routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/role_mappings/:id',
-      });
-    });
-  });
-
-  describe('GET /api/workplace_search/org/role_mappings/new', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'get',
-        path: '/api/workplace_search/org/role_mappings/new',
-      });
-
-      registerOrgNewRoleMappingRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/role_mappings/new',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/role_mappings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/role_mappings.ts
@@ -48,20 +48,6 @@ export function registerOrgRoleMappingRoute({
   router,
   enterpriseSearchRequestHandler,
 }: RouteDependencies) {
-  router.get(
-    {
-      path: '/api/workplace_search/org/role_mappings/{id}',
-      validate: {
-        params: schema.object({
-          id: schema.string(),
-        }),
-      },
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/ws/org/role_mappings/:id',
-    })
-  );
-
   router.put(
     {
       path: '/api/workplace_search/org/role_mappings/{id}',
@@ -92,23 +78,7 @@ export function registerOrgRoleMappingRoute({
   );
 }
 
-export function registerOrgNewRoleMappingRoute({
-  router,
-  enterpriseSearchRequestHandler,
-}: RouteDependencies) {
-  router.get(
-    {
-      path: '/api/workplace_search/org/role_mappings/new',
-      validate: false,
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/ws/org/role_mappings/new',
-    })
-  );
-}
-
 export const registerRoleMappingsRoutes = (dependencies: RouteDependencies) => {
   registerOrgRoleMappingsRoute(dependencies);
   registerOrgRoleMappingRoute(dependencies);
-  registerOrgNewRoleMappingRoute(dependencies);
 };


### PR DESCRIPTION
## Summary

This PR accomplishes 3 things:
1. Fixes two minor bugs from https://github.com/elastic/kibana/pull/101918 (https://github.com/elastic/kibana/commit/ae32dfe7940d3af1fdfecf6d08bc49c311967b98, https://github.com/elastic/kibana/commit/f37d2ead398ff1d82f5d429d52b8ce43a7ba98e3)
2. Refactors the API calls for role mappings. After [this PR](https://github.com/elastic/ent-search/pull/3810), we now receive all data that is needed for rendering role mappings in the initial server request. Previously calls were made when either creating or updating an endpoint to fetch the necessary data for the UI. Since this is now a single-page feature, we no longer need the extra calls. 
3. Fix some logic in Workplace Search to match App Search. This simplifies the logic and matches [App Search](https://github.com/elastic/kibana/blob/master/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts#L235-L248) (https://github.com/elastic/kibana/commit/cc97d98c06808c712a67c365e7bae5ddebc43988)

Please review `ent-search` [companion PR](https://github.com/elastic/ent-search/pull/3818) as a part of this review.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
