### PR TITLE
ES query returning no records for d-rule alerts

### DIFF
--- a/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
@@ -177,6 +177,8 @@ export const updateDetectionRuleUsage = (
   return updatedUsage;
 };
 
+const MAX_RESULTS_WINDOW = 10_000; // elasticsearch index.max_result_window default value
+
 export const getDetectionRuleMetrics = async (
   kibanaIndex: string,
   signalsIndex: string,
@@ -189,14 +191,14 @@ export const getDetectionRuleMetrics = async (
     filterPath: [],
     ignoreUnavailable: true,
     index: kibanaIndex,
-    size: 10_000, // elasticsearch index.max_result_window default value
+    size: MAX_RESULTS_WINDOW,
   };
 
   try {
     const { body: ruleResults } = await esClient.search<RuleSearchResult>(ruleSearchOptions);
     const { body: detectionAlertsResp } = (await esClient.search({
       index: `${signalsIndex}*`,
-      size: 0,
+      size: MAX_RESULTS_WINDOW,
       body: {
         aggs: {
           detectionAlerts: {
@@ -224,7 +226,7 @@ export const getDetectionRuleMetrics = async (
       type: 'cases-comments',
       fields: [],
       page: 1,
-      perPage: 10_000,
+      perPage: MAX_RESULTS_WINDOW,
       filter: 'cases-comments.attributes.type: alert',
     });
 


### PR DESCRIPTION
## Summary

There are no detection alerts showing up in the security telemetry feeds.
It seems that there was a bad query configuration that was not captured by the tests based on how mocks were set up.

```
-     size: 0,      
+     size: MAX_RESULTS_WINDOW,
```

We are going to deploy this out in the next minor release. 
