### PR TITLE
[Security Solution][Endpoint] Actions log entries display relative time only up to 1 hr from now

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/endpoint/formatted_date_time.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/formatted_date_time.tsx
@@ -8,14 +8,10 @@
 import React from 'react';
 import { FormattedDate, FormattedTime, FormattedRelative } from '@kbn/i18n/react';
 
-export const FormattedDateAndTime: React.FC<{ date: Date; showRelativeTime?: boolean }> = ({
-  date,
-  showRelativeTime = false,
-}) => {
+export const FormattedDateAndTime: React.FC<{ date: Date }> = ({ date }) => {
   // If date is greater than or equal to 1h (ago), then show it as a date
-  // and if showRelativeTime is false
   // else, show it as relative to "now"
-  return Date.now() - date.getTime() >= 3.6e6 && !showRelativeTime ? (
+  return Date.now() - date.getTime() >= 3.6e6 ? (
     <>
       <FormattedDate value={date} year="numeric" month="short" day="2-digit" />
       {' @'}

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/log_entry.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/log_entry.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 
 import { EuiComment, EuiText, EuiAvatarProps, EuiCommentProps, IconType } from '@elastic/eui';
 import { Immutable, ActivityLogEntry } from '../../../../../../../common/endpoint/types';
-import { FormattedDateAndTime } from '../../../../../../common/components/endpoint/formatted_date_time';
+import { FormattedRelativePreferenceDate } from '../../../../../../common/components/formatted_date';
 import { LogEntryTimelineIcon } from './log_entry_timeline_icon';
 
 import * as i18 from '../../translations';
@@ -144,9 +144,8 @@ export const LogEntry = memo(({ logEntry }: { logEntry: Immutable<ActivityLogEnt
     <StyledEuiComment
       type={(commentType ?? 'regular') as EuiCommentProps['type']}
       username={username}
-      timestamp={FormattedDateAndTime({
-        date: new Date(logEntry.item.data['@timestamp']),
-        showRelativeTime: true,
+      timestamp={FormattedRelativePreferenceDate({
+        value: logEntry.item.data['@timestamp'],
       })}
       event={<b>{displayResponseEvent ? responseEventTitle : actionEventTitle}</b>}
       timelineIcon={


### PR DESCRIPTION
## Summary

Show relative time up to 1hr in actions log within endpoint details flyout

![Screenshot 2021-06-15 at 10 21 57](https://user-images.githubusercontent.com/1849116/122019811-7844f000-cdc4-11eb-8229-08b83a03f8ef.png)