### PR TITLE
Transmit registry data 

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts
@@ -347,6 +347,9 @@ const allowlistBaseEventFields: AllowlistFields = {
     direction: true,
   },
   registry: {
+    data: {
+      strings: true,
+    },
     hive: true,
     key: true,
     path: true,


### PR DESCRIPTION
## Summary

Related PR: https://github.com/elastic/kibana/pull/101578
Request: https://github.com/elastic/kibana/pull/101578#issuecomment-861429158

An additional requirement came in to grab the string value from when a Windows registry modification event occurs. 