### PR TITLE
[Lens] Add description and owner to kibana.json

### DIFF
--- a/x-pack/plugins/lens/kibana.json
+++ b/x-pack/plugins/lens/kibana.json
@@ -36,5 +36,10 @@
     "kibanaUtils",
     "kibanaReact",
     "embeddable"
-  ]
+  ],
+  "owner": {
+    "name": "Kibana App",
+    "githubTeam": "kibana-app"
+  },
+  "description": "Visualization editor allowing to quickly and easily configure compelling visualizations to use on dashboards and canvas workpads. Exposes components to embed visualizations and link into the Lens editor from within other apps in Kibana."
 }


### PR DESCRIPTION
Adds owner and description to lens `kibana.json` similar to how the `data` plugin handles it.