### PR TITLE
[APM] More styles fixes related to the new page template

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_map/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/index.tsx
@@ -146,7 +146,7 @@ export function ServiceMap({
   return (
     <>
       <SearchBar showKueryBar={false} />
-      <EuiPanel paddingSize="none">
+      <EuiPanel hasBorder={true} paddingSize="none">
         <div
           data-test-subj="ServiceMap"
           style={{ height: heightWithPadding }}

--- a/x-pack/plugins/apm/public/components/app/service_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_metrics/index.tsx
@@ -24,7 +24,7 @@ export function ServiceMetrics() {
       <EuiFlexGrid columns={2} gutterSize="s">
         {data.charts.map((chart) => (
           <EuiFlexItem key={chart.key}>
-            <EuiPanel>
+            <EuiPanel hasBorder={true}>
               <MetricsChart
                 start={start}
                 end={end}

--- a/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
@@ -110,7 +110,8 @@ export function ServiceNodeMetrics({
           />
         </EuiCallOut>
       ) : (
-        <EuiPanel hasShadow={false}>
+        <EuiPanel hasShadow={false} paddingSize={'none'}>
+          <EuiSpacer size={'s'} />
           <EuiFlexGroup gutterSize="xl">
             <EuiFlexItem grow={false}>
               <EuiStat
@@ -163,6 +164,7 @@ export function ServiceNodeMetrics({
               />
             </EuiFlexItem>
           </EuiFlexGroup>
+          <EuiSpacer size={'s'} />
         </EuiPanel>
       )}
 
@@ -171,7 +173,7 @@ export function ServiceNodeMetrics({
           <EuiFlexGrid columns={2} gutterSize="s">
             {data.charts.map((chart) => (
               <EuiFlexItem key={chart.key}>
-                <EuiPanel>
+                <EuiPanel hasBorder={true}>
                   <MetricsChart
                     start={start}
                     end={end}

--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -49,7 +49,7 @@ export function ServiceOverview({ serviceName }: ServiceOverviewProps) {
       <ChartPointerEventContextProvider>
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem>
-            <EuiPanel>
+            <EuiPanel hasBorder={true}>
               <LatencyChart height={200} />
             </EuiPanel>
           </EuiFlexItem>
@@ -63,7 +63,7 @@ export function ServiceOverview({ serviceName }: ServiceOverviewProps) {
                 <ServiceOverviewThroughputChart height={chartHeight} />
               </EuiFlexItem>
               <EuiFlexItem grow={7}>
-                <EuiPanel>
+                <EuiPanel hasBorder={true}>
                   <ServiceOverviewTransactionsTable serviceName={serviceName} />
                 </EuiPanel>
               </EuiFlexItem>
@@ -84,7 +84,7 @@ export function ServiceOverview({ serviceName }: ServiceOverviewProps) {
                 </EuiFlexItem>
               )}
               <EuiFlexItem grow={7}>
-                <EuiPanel>
+                <EuiPanel hasBorder={true}>
                   <ServiceOverviewErrorsTable serviceName={serviceName} />
                 </EuiPanel>
               </EuiFlexItem>
@@ -101,7 +101,7 @@ export function ServiceOverview({ serviceName }: ServiceOverviewProps) {
               </EuiFlexItem>
               {!isRumAgent && (
                 <EuiFlexItem grow={7}>
-                  <EuiPanel>
+                  <EuiPanel hasBorder={true}>
                     <ServiceOverviewDependenciesTable
                       serviceName={serviceName}
                     />

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
@@ -228,7 +228,7 @@ export function ServiceOverviewInstancesChartAndTable({
         />
       </EuiFlexItem>
       <EuiFlexItem grow={7}>
-        <EuiPanel>
+        <EuiPanel hasBorder={true}>
           <ServiceOverviewInstancesTable
             mainStatsItems={currentPeriodOrderedItems}
             mainStatsStatus={mainStatsStatus}

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
@@ -110,7 +110,7 @@ export function ServiceOverviewThroughputChart({
   ];
 
   return (
-    <EuiPanel>
+    <EuiPanel hasBorder={true}>
       <EuiTitle size="xs">
         <h2>
           {i18n.translate('xpack.apm.serviceOverview.throughtputChartTitle', {

--- a/x-pack/plugins/apm/public/components/app/transaction_details/WaterfallWithSummmary/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/WaterfallWithSummmary/index.tsx
@@ -83,13 +83,13 @@ export function WaterfallWithSummmary({
       />
     );
 
-    return <EuiPanel paddingSize="m">{content}</EuiPanel>;
+    return <EuiPanel hasBorder={true}>{content}</EuiPanel>;
   }
 
   const entryTransaction = entryWaterfallTransaction.doc;
 
   return (
-    <EuiPanel paddingSize="m">
+    <EuiPanel hasBorder={true}>
       <EuiFlexGroup>
         <EuiFlexItem style={{ flexDirection: 'row', alignItems: 'center' }}>
           <EuiTitle size="xs">

--- a/x-pack/plugins/apm/public/components/app/transaction_details/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/index.tsx
@@ -76,11 +76,13 @@ export function TransactionDetails() {
 
   return (
     <>
+      <EuiSpacer size="s" />
+
       <EuiTitle>
         <h2>{transactionName}</h2>
       </EuiTitle>
 
-      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
 
       <ChartPointerEventContextProvider>
         <TransactionCharts />
@@ -88,7 +90,7 @@ export function TransactionDetails() {
 
       <EuiHorizontalRule size="full" margin="l" />
 
-      <EuiPanel>
+      <EuiPanel hasBorder={true}>
         <TransactionDistribution
           distribution={distributionData}
           fetchStatus={distributionStatus}

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
@@ -79,7 +79,7 @@ export function TransactionOverview({ serviceName }: TransactionOverviewProps) {
     <>
       <TransactionCharts />
       <EuiSpacer size="s" />
-      <EuiPanel>
+      <EuiPanel hasBorder={true}>
         <EuiTitle size="xs">
           <h3>Transactions</h3>
         </EuiTitle>

--- a/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/index.tsx
@@ -104,7 +104,7 @@ export function InstancesLatencyDistributionChart({
   };
 
   return (
-    <EuiPanel>
+    <EuiPanel hasBorder={true}>
       <EuiTitle size="xs">
         <h2>
           {i18n.translate('xpack.apm.instancesLatencyDistributionChartTitle', {

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/index.tsx
@@ -22,7 +22,7 @@ export function TransactionBreakdownChart({
   const { timeseries } = data;
 
   return (
-    <EuiPanel>
+    <EuiPanel hasBorder={true}>
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiTitle size="xs">

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/index.tsx
@@ -37,13 +37,13 @@ export function TransactionCharts() {
         <ChartPointerEventContextProvider>
           <EuiFlexGrid columns={2} gutterSize="s">
             <EuiFlexItem data-cy={`transaction-duration-charts`}>
-              <EuiPanel>
+              <EuiPanel hasBorder={true}>
                 <LatencyChart />
               </EuiPanel>
             </EuiFlexItem>
 
             <EuiFlexItem style={{ flexShrink: 1 }}>
-              <EuiPanel>
+              <EuiPanel hasBorder={true}>
                 <EuiTitle size="xs">
                   <span>
                     {i18n.translate(

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -135,7 +135,7 @@ export function TransactionErrorRateChart({
   ];
 
   return (
-    <EuiPanel>
+    <EuiPanel hasBorder={true}>
       <EuiTitle size="xs">
         <h2>
           {i18n.translate('xpack.apm.errorRate', {


### PR DESCRIPTION
## Summary

As per the page template guidelines, we should update our panels to not use shadow but border instead to avoid the double shadows on the background panel and the inner content like our chart panels etc. Also cleaned up other related styles to the new page template, some missing spacings and padding sizes.

<img width="1731" alt="Screenshot 2021-06-15 at 19 49 33" src="https://user-images.githubusercontent.com/4104278/122099924-dd273700-ce12-11eb-9da4-42e248dbb1a3.png">

<img width="1731" alt="Screenshot 2021-06-15 at 19 49 47" src="https://user-images.githubusercontent.com/4104278/122099930-def0fa80-ce12-11eb-9574-42725d535085.png">
