### PR TITLE
[Reporting] remove unused reference to path.data config

### DIFF
--- a/x-pack/plugins/reporting/server/config/config.ts
+++ b/x-pack/plugins/reporting/server/config/config.ts
@@ -6,8 +6,7 @@
  */
 
 import { get } from 'lodash';
-import { Observable } from 'rxjs';
-import { first, map } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { CoreSetup, PluginInitializerContext } from 'src/core/server';
 import { LevelLogger } from '../lib';
 import { createConfig$ } from './create_config';
@@ -43,7 +42,6 @@ interface Config<BaseType> {
 }
 
 interface KbnServerConfigType {
-  path: { data: Observable<string> };
   server: {
     basePath: string;
     host: string;
@@ -68,9 +66,6 @@ export const buildConfig = async (
   const serverInfo = http.getServerInfo();
 
   const kbnConfig = {
-    path: {
-      data: initContext.config.legacy.globalConfig$.pipe(map((c) => c.path.data)),
-    },
     server: {
       basePath: core.http.basePath.serverBasePath,
       host: serverInfo.hostname,


### PR DESCRIPTION
## Summary

A few developers had to examine usage of `path.data` in Kibana. They found that Reporting had a reference to it, but didn't seem to be using it. 

This PR removes the reference to simplify the code.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
