### PR TITLE
[Monitoring] Update Kibana rules/alerts language in setup mode

### DIFF
--- a/x-pack/plugins/monitoring/public/alerts/badge.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/badge.tsx
@@ -23,8 +23,12 @@ export const numberOfRulesLabel = (count: number) => `${count} rule${count > 1 ?
 
 const MAX_TO_SHOW_BY_CATEGORY = 8;
 
-const PANEL_TITLE = i18n.translate('xpack.monitoring.alerts.badge.panelTitle', {
+const PANEL_TITLE_ALERTS = i18n.translate('xpack.monitoring.alerts.badge.panelTitle', {
   defaultMessage: 'Alerts',
+});
+
+const PANEL_TITLE_RULES = i18n.translate('xpack.monitoring.rules.badge.panelTitle', {
+  defaultMessage: 'Rules',
 });
 
 const GROUP_BY_NODE = i18n.translate('xpack.monitoring.alerts.badge.groupByNode', {
@@ -55,6 +59,7 @@ export const AlertsBadge: React.FC<Props> = (props: Props) => {
   const [showByNode, setShowByNode] = React.useState(
     !inSetupMode && alertCount > MAX_TO_SHOW_BY_CATEGORY
   );
+  const PANEL_TITLE = inSetupMode ? PANEL_TITLE_RULES : PANEL_TITLE_ALERTS;
 
   React.useEffect(() => {
     if (inSetupMode && showByNode) {

--- a/x-pack/plugins/monitoring/public/alerts/badge.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/badge.tsx
@@ -19,6 +19,7 @@ import { getAlertPanelsByCategory } from './lib/get_alert_panels_by_category';
 import { getAlertPanelsByNode } from './lib/get_alert_panels_by_node';
 
 export const numberOfAlertsLabel = (count: number) => `${count} alert${count > 1 ? 's' : ''}`;
+export const numberOfRulesLabel = (count: number) => `${count} rule${count > 1 ? 's' : ''}`;
 
 const MAX_TO_SHOW_BY_CATEGORY = 8;
 
@@ -93,10 +94,12 @@ export const AlertsBadge: React.FC<Props> = (props: Props) => {
     <EuiBadge
       iconType="bell"
       color={inSetupMode ? 'default' : 'danger'}
-      onClickAriaLabel={numberOfAlertsLabel(alertCount)}
+      onClickAriaLabel={
+        inSetupMode ? numberOfRulesLabel(alertCount) : numberOfAlertsLabel(alertCount)
+      }
       onClick={() => setShowPopover(true)}
     >
-      {numberOfAlertsLabel(alertCount)}
+      {inSetupMode ? numberOfRulesLabel(alertCount) : numberOfAlertsLabel(alertCount)}
     </EuiBadge>
   );
 


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/101977#issuecomment-861583646

This PR changes the "alerts" terminology to "rules" in the setup mode of the Stack Monitoring app.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/26471269/122833494-ec3e3700-d2a1-11eb-9d4e-029c8e6fc131.png)

![image](https://user-images.githubusercontent.com/26471269/122839554-1a754400-d2ad-11eb-98ac-efa1ee9206b8.png)


After:

![image](https://user-images.githubusercontent.com/26471269/122832632-82715d80-d2a0-11eb-87e9-49b7891f7c2e.png)

![image](https://user-images.githubusercontent.com/26471269/122839216-755a6b80-d2ac-11eb-9857-fb67ea3ecab4.png)
