### PR TITLE
[Workplace Search] Convert Overview & Security pages to new page template

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -88,7 +88,7 @@ describe('WorkplaceSearchConfigured', () => {
 
     const wrapper = shallow(<WorkplaceSearchConfigured />);
 
-    expect(wrapper.find(ErrorState)).toHaveLength(2);
+    expect(wrapper.find(ErrorState)).toHaveLength(1);
   });
 
   it('passes readOnlyMode state', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -138,9 +138,7 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
         <RoleMappings />
       </Route>
       <Route path={SECURITY_PATH}>
-        <Layout navigation={<WorkplaceSearchNav />} restrictWidth readOnlyMode={readOnlyMode}>
-          <Security />
-        </Layout>
+        <Security />
       </Route>
       <Route path={ORG_SETTINGS_PATH}>
         <Layout

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -96,13 +96,7 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
         <SourceAdded />
       </Route>
       <Route exact path="/">
-        {errorConnecting ? (
-          <ErrorState />
-        ) : (
-          <Layout navigation={<WorkplaceSearchNav />} restrictWidth readOnlyMode={readOnlyMode}>
-            <Overview />
-          </Layout>
-        )}
+        <Overview />
       </Route>
       <Route path={PERSONAL_SOURCES_PATH}>
         <PersonalDashboardLayout

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.test.tsx
@@ -12,54 +12,40 @@ import React from 'react';
 
 import { shallow, mount } from 'enzyme';
 
-import { Loading } from '../../../shared/loading';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
-
 import { OnboardingSteps } from './onboarding_steps';
 import { OrganizationStats } from './organization_stats';
 import { Overview } from './overview';
 import { RecentActivity } from './recent_activity';
 
 describe('Overview', () => {
-  describe('non-happy-path states', () => {
-    it('isLoading', () => {
-      const wrapper = shallow(<Overview />);
+  it('calls initialize function', async () => {
+    mount(<Overview />);
 
-      expect(wrapper.find(Loading)).toHaveLength(1);
-    });
+    expect(mockActions.initializeOverview).toHaveBeenCalled();
   });
 
-  describe('happy-path states', () => {
-    it('calls initialize function', async () => {
-      mount(<Overview />);
+  it('renders onboarding state', () => {
+    setMockValues({ dataLoading: false });
+    const wrapper = shallow(<Overview />);
 
-      expect(mockActions.initializeOverview).toHaveBeenCalled();
+    expect(wrapper.find(OnboardingSteps)).toHaveLength(1);
+    expect(wrapper.find(OrganizationStats)).toHaveLength(1);
+    expect(wrapper.find(RecentActivity)).toHaveLength(1);
+  });
+
+  it('renders when onboarding complete', () => {
+    setMockValues({
+      dataLoading: false,
+      hasUsers: true,
+      hasOrgSources: true,
+      isOldAccount: true,
+      organization: {
+        name: 'foo',
+        defaultOrgName: 'bar',
+      },
     });
+    const wrapper = shallow(<Overview />);
 
-    it('renders onboarding state', () => {
-      setMockValues({ dataLoading: false });
-      const wrapper = shallow(<Overview />);
-
-      expect(wrapper.find(ViewContentHeader)).toHaveLength(1);
-      expect(wrapper.find(OnboardingSteps)).toHaveLength(1);
-      expect(wrapper.find(OrganizationStats)).toHaveLength(1);
-      expect(wrapper.find(RecentActivity)).toHaveLength(1);
-    });
-
-    it('renders when onboarding complete', () => {
-      setMockValues({
-        dataLoading: false,
-        hasUsers: true,
-        hasOrgSources: true,
-        isOldAccount: true,
-        organization: {
-          name: 'foo',
-          defaultOrgName: 'bar',
-        },
-      });
-      const wrapper = shallow(<Overview />);
-
-      expect(wrapper.find(OnboardingSteps)).toHaveLength(0);
-    });
+    expect(wrapper.find(OnboardingSteps)).toHaveLength(0);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.test.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
+import '../../../__mocks__/shallow_useeffect.mock';
 import './__mocks__/overview_logic.mock';
 import { mockActions, setMockValues } from './__mocks__';
 
 import React from 'react';
 
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { OnboardingSteps } from './onboarding_steps';
 import { OrganizationStats } from './organization_stats';
@@ -19,7 +20,7 @@ import { RecentActivity } from './recent_activity';
 
 describe('Overview', () => {
   it('calls initialize function', async () => {
-    mount(<Overview />);
+    shallow(<Overview />);
 
     expect(mockActions.initializeOverview).toHaveBeenCalled();
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
@@ -12,11 +12,8 @@ import { useActions, useValues } from 'kea';
 import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { Loading } from '../../../shared/loading';
-import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
+import { WorkplaceSearchPageTemplate } from '../../components/layout';
 
 import { OnboardingSteps } from './onboarding_steps';
 import { OrganizationStats } from './organization_stats';
@@ -54,26 +51,26 @@ export const Overview: React.FC = () => {
     initializeOverview();
   }, [initializeOverview]);
 
-  if (dataLoading) {
-    return <Loading />;
-  }
-
   const hideOnboarding = hasUsers && hasOrgSources && isOldAccount && orgName !== defaultOrgName;
 
   const headerTitle = hideOnboarding ? HEADER_TITLE : ONBOARDING_HEADER_TITLE;
   const headerDescription = hideOnboarding ? HEADER_DESCRIPTION : ONBOARDING_HEADER_DESCRIPTION;
 
   return (
-    <>
-      <SetPageChrome />
-      <SendTelemetry action="viewed" metric="overview" />
-
-      <ViewContentHeader title={headerTitle} description={headerDescription} />
+    <WorkplaceSearchPageTemplate
+      pageChrome={[]}
+      pageHeader={{
+        pageTitle: headerTitle,
+        description: headerDescription,
+      }}
+      pageViewTelemetry="overview"
+      isLoading={dataLoading}
+    >
       {!hideOnboarding && <OnboardingSteps />}
       <EuiSpacer size="xl" />
       <OrganizationStats />
       <EuiSpacer size="xl" />
       <RecentActivity />
-    </>
+    </WorkplaceSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
@@ -53,8 +53,9 @@ export const Overview: React.FC = () => {
 
   const hideOnboarding = hasUsers && hasOrgSources && isOldAccount && orgName !== defaultOrgName;
 
-  const headerTitle = hideOnboarding ? HEADER_TITLE : ONBOARDING_HEADER_TITLE;
-  const headerDescription = hideOnboarding ? HEADER_DESCRIPTION : ONBOARDING_HEADER_DESCRIPTION;
+  const headerTitle = dataLoading || hideOnboarding ? HEADER_TITLE : ONBOARDING_HEADER_TITLE;
+  const headerDescription =
+    dataLoading || hideOnboarding ? HEADER_DESCRIPTION : ONBOARDING_HEADER_DESCRIPTION;
 
   return (
     <WorkplaceSearchPageTemplate
@@ -66,8 +67,12 @@ export const Overview: React.FC = () => {
       pageViewTelemetry="overview"
       isLoading={dataLoading}
     >
-      {!hideOnboarding && <OnboardingSteps />}
-      <EuiSpacer size="xl" />
+      {!hideOnboarding && (
+        <>
+          <OnboardingSteps />
+          <EuiSpacer size="xl" />
+        </>
+      )}
       <OrganizationStats />
       <EuiSpacer size="xl" />
       <RecentActivity />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
@@ -14,11 +14,8 @@ import { shallow } from 'enzyme';
 
 import { EuiSwitch, EuiConfirmModal } from '@elastic/eui';
 
-import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-
-import { Loading } from '../../../shared/loading';
 import { UnsavedChangesPrompt } from '../../../shared/unsaved_changes_prompt';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
+import { getPageHeaderActions } from '../../../test_helpers';
 
 import { Security } from './security';
 
@@ -59,9 +56,7 @@ describe('Security', () => {
     setMockValues({ ...mockValues, hasPlatinumLicense: false });
     const wrapper = shallow(<Security />);
 
-    expect(wrapper.find(SetPageChrome)).toHaveLength(1);
     expect(wrapper.find(UnsavedChangesPrompt)).toHaveLength(1);
-    expect(wrapper.find(ViewContentHeader)).toHaveLength(1);
     expect(wrapper.find(EuiSwitch).prop('disabled')).toEqual(true);
   });
 
@@ -69,13 +64,6 @@ describe('Security', () => {
     const wrapper = shallow(<Security />);
 
     expect(wrapper.find(EuiSwitch).prop('disabled')).toEqual(false);
-  });
-
-  it('returns Loading when loading', () => {
-    setMockValues({ ...mockValues, dataLoading: true });
-    const wrapper = shallow(<Security />);
-
-    expect(wrapper.find(Loading)).toHaveLength(1);
   });
 
   it('handles switch click', () => {
@@ -92,8 +80,8 @@ describe('Security', () => {
     setMockValues({ ...mockValues, unsavedChanges: true });
     const wrapper = shallow(<Security />);
 
-    const header = wrapper.find(ViewContentHeader).dive();
-    header.find('[data-test-subj="SaveSettingsButton"]').prop('onClick')!({} as any);
+    const headerActions = getPageHeaderActions(wrapper);
+    headerActions.find('[data-test-subj="SaveSettingsButton"]').prop('onClick')!({} as any);
     const modal = wrapper.find(EuiConfirmModal);
     modal.prop('onConfirm')!({} as any);
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -22,13 +22,10 @@ import {
   EuiConfirmModal,
 } from '@elastic/eui';
 
-import { FlashMessages } from '../../../shared/flash_messages';
-import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { LicensingLogic } from '../../../shared/licensing';
-import { Loading } from '../../../shared/loading';
 import { UnsavedChangesPrompt } from '../../../shared/unsaved_changes_prompt';
+import { WorkplaceSearchPageTemplate } from '../../components/layout';
 import { LicenseCallout } from '../../components/shared/license_callout';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
 import {
   SECURITY_UNSAVED_CHANGES_MESSAGE,
   RESET_BUTTON,
@@ -72,44 +69,24 @@ export const Security: React.FC = () => {
     initializeSourceRestrictions();
   }, []);
 
-  if (dataLoading) return <Loading />;
-
   const savePrivateSources = () => {
     saveSourceRestrictions();
     hideConfirmModal();
   };
 
-  const headerActions = (
-    <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="m">
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty disabled={!unsavedChanges} onClick={resetState}>
-          {RESET_BUTTON}
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiButton
-          disabled={!hasPlatinumLicense || !unsavedChanges}
-          onClick={showConfirmModal}
-          fill
-          data-test-subj="SaveSettingsButton"
-        >
-          {SAVE_SETTINGS_BUTTON}
-        </EuiButton>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-
-  const header = (
-    <>
-      <ViewContentHeader
-        title={PRIVATE_SOURCES}
-        alignItems="flexStart"
-        description={PRIVATE_SOURCES_DESCRIPTION}
-        action={headerActions}
-      />
-      <EuiSpacer />
-    </>
-  );
+  const headerActions = [
+    <EuiButtonEmpty disabled={!unsavedChanges || dataLoading} onClick={resetState}>
+      {RESET_BUTTON}
+    </EuiButtonEmpty>,
+    <EuiButton
+      disabled={!hasPlatinumLicense || !unsavedChanges || dataLoading}
+      onClick={showConfirmModal}
+      fill
+      data-test-subj="SaveSettingsButton"
+    >
+      {SAVE_SETTINGS_BUTTON}
+    </EuiButton>,
+  ];
 
   const allSourcesToggle = (
     <EuiPanel
@@ -180,20 +157,25 @@ export const Security: React.FC = () => {
   );
 
   return (
-    <>
-      <SetPageChrome trail={[NAV.SECURITY]} />
-      <FlashMessages />
+    <WorkplaceSearchPageTemplate
+      pageChrome={[NAV.SECURITY]}
+      pageHeader={{
+        pageTitle: PRIVATE_SOURCES,
+        description: PRIVATE_SOURCES_DESCRIPTION,
+        rightSideItems: headerActions,
+      }}
+      isLoading={dataLoading}
+    >
       <UnsavedChangesPrompt
         hasUnsavedChanges={unsavedChanges}
         messageText={SECURITY_UNSAVED_CHANGES_MESSAGE}
       />
-      {header}
       <EuiPanel color="subdued" hasBorder={false}>
         {allSourcesToggle}
         {!hasPlatinumLicense && platinumLicenseCallout}
         {sourceTables}
       </EuiPanel>
       {confirmModalVisible && confirmModal}
-    </>
+    </WorkplaceSearchPageTemplate>
   );
 };


### PR DESCRIPTION
## Summary

Follow up to #102170 - converts more Workplace Search pages to the new KibanaPageTemplate. I'm attempting to break up the WS layout conversion into smaller, easier to review chunks.

This PR handles the simplest 2 pages without any sub-navigation. As always, follow along by commit!

## Screencap

![screencap](https://user-images.githubusercontent.com/549407/122329482-5774bb80-cee6-11eb-8c33-fb38482b8b51.gif)

NOTE: The current UI shows little dropdown arrows next to the current links w/ sub-navs - this will go away once the actual sub-navs get implemented

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)