### PR TITLE
[Security Solution] [Endpoint] Do not show activity log error popups

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/index.tsx
@@ -32,7 +32,6 @@ import {
   detailsError,
   detailsLoading,
   getActivityLogData,
-  getActivityLogError,
   showView,
   policyResponseConfigurations,
   policyResponseActions,
@@ -86,7 +85,6 @@ export const EndpointDetailsFlyout = memo(() => {
   } = queryParams;
 
   const activityLog = useEndpointSelector(getActivityLogData);
-  const activityError = useEndpointSelector(getActivityLogError);
   const hostDetails = useEndpointSelector(detailsData);
   const hostDetailsLoading = useEndpointSelector(detailsLoading);
   const hostDetailsError = useEndpointSelector(detailsError);
@@ -148,17 +146,7 @@ export const EndpointDetailsFlyout = memo(() => {
         }),
       });
     }
-    if (activityError !== undefined) {
-      toasts.addDanger({
-        title: i18n.translate('xpack.securitySolution.endpoint.activityLog.errorTitle', {
-          defaultMessage: 'Could not find activity log for host',
-        }),
-        text: i18n.translate('xpack.securitySolution.endpoint.activityLog.errorBody', {
-          defaultMessage: 'Please exit the flyout and select another host with actions.',
-        }),
-      });
-    }
-  }, [hostDetailsError, activityError, toasts]);
+  }, [hostDetailsError, toasts]);
 
   return (
     <EuiFlyout


### PR DESCRIPTION
refs 2dd22ed92b3c54da9bdcce467dbe2d7e87097e4d
fixes elastic/kibana/issues/102335

## Summary

This removes error toasts on policy response panel when we have errors when fetching activity log data. We show an empty state on the activity log tab anyway. So this is unnecessary.

**policy response**
<img width="1361" alt="Screenshot 2021-06-17 at 08 49 46" src="https://user-images.githubusercontent.com/1849116/122346288-12ce3c00-cf49-11eb-9952-78bc6ce9527e.png">

**activity log:**
<img width="1649" alt="Screenshot 2021-06-17 at 08 48 29" src="https://user-images.githubusercontent.com/1849116/122346314-1bbf0d80-cf49-11eb-98d8-7a906ba774ca.png">
