### PR TITLE
[Workplace Search] Fix personal dashboard logout link on local dev

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
@@ -47,7 +47,9 @@ export const AccountHeader: React.FC = () => {
       <EuiButtonEmptyTo to={PERSONAL_SETTINGS_PATH}>{ACCOUNT_NAV.SETTINGS}</EuiButtonEmptyTo>
     </EuiContextMenuItem>,
     <EuiContextMenuItem key="logout">
-      <EuiButtonEmpty href={LOGOUT_ROUTE}>{ACCOUNT_NAV.LOGOUT}</EuiButtonEmpty>
+      <EuiButtonEmptyTo to={LOGOUT_ROUTE} shouldNotCreateHref>
+        {ACCOUNT_NAV.LOGOUT}
+      </EuiButtonEmptyTo>
     </EuiContextMenuItem>,
   ];
 


### PR DESCRIPTION
## Summary

The logout link on the Personal Dashboard wasn't taking in the full Kibana URL into account and was broken on local due to the link URL missing the `/xyz` dev randomly generated base path.

![logout](https://user-images.githubusercontent.com/549407/122343393-809f4700-cefa-11eb-9b2e-4f0367ace25f.gif)

With this PR, logout links should work as expected in dev mode (EuiButtonTo takes care of correct Kibana URL generation for us).

### Checklist

- [x] Works on local /xyz/ dev
- [x] Works in spaces
- [x] Works in non-dev mode