### PR TITLE
Load testing/restart stack for simulation

### DIFF
--- a/test/scripts/jenkins_build_load_testing.sh
+++ b/test/scripts/jenkins_build_load_testing.sh
@@ -80,6 +80,7 @@ popd
 
 echo " -> Running gatling load testing"
 for i in "${sim_array[@]}"; do
+  sleep 30
   echo "Running simulation $i .."
   export GATLING_SIMULATIONS="$i"
   node scripts/functional_tests \


### PR DESCRIPTION
## Summary

Sometimes ES/Kibana are left in non-functional state after simulation, causing next simulation fail on start.
This change stats ES/Kibana before each simulation to avoid the issue.

Tested here https://kibana-ci.elastic.co/view/Kibana/job/elastic+kibana+load-testing/500/