### PR TITLE
TSVB visualizations with no timefield do not render after upgrading from 7.12.1 to 7.13.0

### DIFF
--- a/src/plugins/vis_type_timeseries/server/lib/get_vis_data.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/get_vis_data.ts
@@ -38,10 +38,9 @@ export async function getVisData(
       indexPatternsService,
       uiSettings,
       searchStrategyRegistry: framework.searchStrategyRegistry,
-      cachedIndexPatternFetcher: getCachedIndexPatternFetcher(
-        indexPatternsService,
-        Boolean(panel.use_kibana_indexes)
-      ),
+      cachedIndexPatternFetcher: getCachedIndexPatternFetcher(indexPatternsService, {
+        fetchKibanaIndexForStringIndexes: Boolean(panel.use_kibana_indexes),
+      }),
     };
 
     return panel.type === PANEL_TYPES.TABLE

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/lib/cached_index_pattern_fetcher.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/lib/cached_index_pattern_fetcher.ts
@@ -13,12 +13,19 @@ import type { IndexPatternValue, FetchedIndexPattern } from '../../../../common/
 
 export const getCachedIndexPatternFetcher = (
   indexPatternsService: IndexPatternsService,
-  fetchKibanaIndexForStringIndexes: boolean = false
+  globalOptions: {
+    fetchKibanaIndexForStringIndexes: boolean;
+  } = {
+    fetchKibanaIndexForStringIndexes: false,
+  }
 ) => {
   const cache = new Map();
 
-  return async (indexPatternValue: IndexPatternValue): Promise<FetchedIndexPattern> => {
-    const key = getIndexPatternKey(indexPatternValue);
+  return async (
+    indexPatternValue: IndexPatternValue,
+    fetchKibanaIndexForStringIndexes: boolean = globalOptions.fetchKibanaIndexForStringIndexes
+  ): Promise<FetchedIndexPattern> => {
+    const key = `${getIndexPatternKey(indexPatternValue)}:${fetchKibanaIndexForStringIndexes}`;
 
     if (cache.has(key)) {
       return cache.get(key);

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.test.ts
@@ -16,7 +16,7 @@ describe('getIntervalAndTimefield(panel, series)', () => {
     const panel = { time_field: '@timestamp', interval: 'auto' } as Panel;
     const series = {} as Series;
 
-    expect(getIntervalAndTimefield(panel, series, index)).toEqual({
+    expect(getIntervalAndTimefield(panel, index, series)).toEqual({
       timeField: '@timestamp',
       interval: 'auto',
     });
@@ -30,7 +30,7 @@ describe('getIntervalAndTimefield(panel, series)', () => {
       series_time_field: 'time',
     } as unknown) as Series;
 
-    expect(getIntervalAndTimefield(panel, series, index)).toEqual({
+    expect(getIntervalAndTimefield(panel, index, series)).toEqual({
       timeField: 'time',
       interval: '1m',
     });

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/get_interval_and_timefield.ts
@@ -7,12 +7,13 @@
  */
 
 import { AUTO_INTERVAL } from '../../../common/constants';
-import type { FetchedIndexPattern, Panel, Series } from '../../../common/types';
 import { validateField } from '../../../common/fields_utils';
 
-export function getIntervalAndTimefield(panel: Panel, series: Series, index: FetchedIndexPattern) {
+import type { FetchedIndexPattern, Panel, Series } from '../../../common/types';
+
+export function getIntervalAndTimefield(panel: Panel, index: FetchedIndexPattern, series?: Series) {
   const timeField =
-    (series.override_index_pattern ? series.series_time_field : panel.time_field) ||
+    (series?.override_index_pattern ? series.series_time_field : panel.time_field) ||
     index.indexPattern?.timeFieldName;
 
   if (panel.use_kibana_indexes) {
@@ -22,7 +23,7 @@ export function getIntervalAndTimefield(panel: Panel, series: Series, index: Fet
   let interval = panel.interval;
   let maxBars = panel.max_bars;
 
-  if (series.override_index_pattern) {
+  if (series?.override_index_pattern) {
     interval = series.series_interval || AUTO_INTERVAL;
     maxBars = series.series_max_bars;
   }

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -9,7 +9,6 @@
 import { overwrite } from '../../helpers';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { offsetTime } from '../../offset_time';
-import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { isLastValueTimerangeMode } from '../../helpers/get_timerange_mode';
 import { search, UI_SETTINGS } from '../../../../../../../plugins/data/server';
 
@@ -22,13 +21,14 @@ export function dateHistogram(
   esQueryConfig,
   seriesIndex,
   capabilities,
-  uiSettings
+  uiSettings,
+  buildSeriesMetaParams
 ) {
   return (next) => async (doc) => {
     const maxBarsUiSettings = await uiSettings.get(UI_SETTINGS.HISTOGRAM_MAX_BARS);
     const barTargetUiSettings = await uiSettings.get(UI_SETTINGS.HISTOGRAM_BAR_TARGET);
 
-    const { timeField, interval, maxBars } = getIntervalAndTimefield(panel, series, seriesIndex);
+    const { timeField, interval, maxBars } = await buildSeriesMetaParams();
     const { from, to } = offsetTime(req, series.offset_time);
 
     let bucketInterval;

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/date_histogram.test.js
@@ -8,6 +8,7 @@
 
 import { DefaultSearchCapabilities } from '../../../search_strategies/capabilities/default_search_capabilities';
 import { dateHistogram } from './date_histogram';
+import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { UI_SETTINGS } from '../../../../../../data/common';
 
 describe('dateHistogram(req, panel, series)', () => {
@@ -18,6 +19,7 @@ describe('dateHistogram(req, panel, series)', () => {
   let config;
   let indexPattern;
   let uiSettings;
+  let buildSeriesMetaParams;
 
   beforeEach(() => {
     req = {
@@ -44,14 +46,24 @@ describe('dateHistogram(req, panel, series)', () => {
     uiSettings = {
       get: async (key) => (key === UI_SETTINGS.HISTOGRAM_MAX_BARS ? 100 : 50),
     };
+    buildSeriesMetaParams = jest.fn(async () => {
+      return getIntervalAndTimefield(panel, indexPattern, series);
+    });
   });
 
   test('calls next when finished', async () => {
     const next = jest.fn();
 
-    await dateHistogram(req, panel, series, config, indexPattern, capabilities, uiSettings)(next)(
-      {}
-    );
+    await dateHistogram(
+      req,
+      panel,
+      series,
+      config,
+      indexPattern,
+      capabilities,
+      uiSettings,
+      buildSeriesMetaParams
+    )(next)({});
 
     expect(next.mock.calls.length).toEqual(1);
   });
@@ -65,7 +77,8 @@ describe('dateHistogram(req, panel, series)', () => {
       config,
       indexPattern,
       capabilities,
-      uiSettings
+      uiSettings,
+      buildSeriesMetaParams
     )(next)({});
 
     expect(doc).toEqual({
@@ -106,7 +119,8 @@ describe('dateHistogram(req, panel, series)', () => {
       config,
       indexPattern,
       capabilities,
-      uiSettings
+      uiSettings,
+      buildSeriesMetaParams
     )(next)({});
 
     expect(doc).toEqual({
@@ -150,7 +164,8 @@ describe('dateHistogram(req, panel, series)', () => {
       config,
       indexPattern,
       capabilities,
-      uiSettings
+      uiSettings,
+      buildSeriesMetaParams
     )(next)({});
 
     expect(doc).toEqual({
@@ -197,7 +212,8 @@ describe('dateHistogram(req, panel, series)', () => {
         config,
         indexPattern,
         capabilities,
-        uiSettings
+        uiSettings,
+        buildSeriesMetaParams
       )(next)({});
 
       expect(doc.aggs.test.aggs.timeseries.auto_date_histogram).toBeUndefined();
@@ -219,7 +235,8 @@ describe('dateHistogram(req, panel, series)', () => {
         config,
         indexPattern,
         capabilities,
-        uiSettings
+        uiSettings,
+        buildSeriesMetaParams
       )(next)({});
 
       expect(doc.aggs.test.meta).toMatchInlineSnapshot(`
@@ -242,7 +259,8 @@ describe('dateHistogram(req, panel, series)', () => {
         config,
         indexPattern,
         capabilities,
-        uiSettings
+        uiSettings,
+        buildSeriesMetaParams
       )(next)({});
 
       expect(doc).toEqual({

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.js
@@ -7,7 +7,6 @@
  */
 
 import { getBucketSize } from '../../helpers/get_bucket_size';
-import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { bucketTransform } from '../../helpers/bucket_transform';
 import { overwrite } from '../../helpers';
 import { UI_SETTINGS } from '../../../../../../data/common';
@@ -58,12 +57,13 @@ export function positiveRate(
   esQueryConfig,
   seriesIndex,
   capabilities,
-  uiSettings
+  uiSettings,
+  buildSeriesMetaParams
 ) {
   return (next) => async (doc) => {
     const barTargetUiSettings = await uiSettings.get(UI_SETTINGS.HISTOGRAM_BAR_TARGET);
 
-    const { interval } = getIntervalAndTimefield(panel, series, seriesIndex);
+    const { interval } = await buildSeriesMetaParams();
     const { intervalString } = getBucketSize(req, interval, capabilities, barTargetUiSettings);
 
     if (series.metrics.some(filter)) {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/positive_rate.test.js
@@ -12,6 +12,7 @@ describe('positiveRate(req, panel, series)', () => {
   let series;
   let req;
   let uiSettings;
+  let buildSeriesMetaParams;
 
   beforeEach(() => {
     panel = {
@@ -42,6 +43,9 @@ describe('positiveRate(req, panel, series)', () => {
     uiSettings = {
       get: async () => 50,
     };
+    buildSeriesMetaParams = jest.fn().mockResolvedValue({
+      interval: 'auto',
+    });
   });
 
   test('calls next when finished', async () => {
@@ -53,7 +57,8 @@ describe('positiveRate(req, panel, series)', () => {
       {},
       {},
       { maxBucketsLimit: 2000, getValidTimeInterval: jest.fn(() => '1d') },
-      uiSettings
+      uiSettings,
+      buildSeriesMetaParams
     )(next)({});
 
     expect(next.mock.calls.length).toEqual(1);
@@ -68,7 +73,8 @@ describe('positiveRate(req, panel, series)', () => {
       {},
       {},
       { maxBucketsLimit: 2000, getValidTimeInterval: jest.fn(() => '1d') },
-      uiSettings
+      uiSettings,
+      buildSeriesMetaParams
     )(next)({});
 
     expect(doc).toEqual({

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.js
@@ -7,18 +7,28 @@
  */
 
 import { offsetTime } from '../../offset_time';
-import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { esQuery } from '../../../../../../data/server';
 
-export function query(req, panel, series, esQueryConfig, seriesIndex) {
-  return (next) => (doc) => {
-    const { timeField } = getIntervalAndTimefield(panel, series, seriesIndex);
+export function query(
+  req,
+  panel,
+  series,
+  esQueryConfig,
+  seriesIndex,
+  capabilities,
+  uiSettings,
+  buildSeriesMetaParams
+) {
+  return (next) => async (doc) => {
+    const { timeField } = await buildSeriesMetaParams();
     const { from, to } = offsetTime(req, series.offset_time);
 
     doc.size = 0;
+
     const ignoreGlobalFilter = panel.ignore_global_filter || series.ignore_global_filter;
     const queries = !ignoreGlobalFilter ? req.body.query : [];
     const filters = !ignoreGlobalFilter ? req.body.filters : [];
+
     doc.query = esQuery.buildEsQuery(seriesIndex.indexPattern, queries, filters, esQueryConfig);
 
     const timerange = {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/series/query.test.js
@@ -13,6 +13,7 @@ describe('query', () => {
   let series;
   let req;
   let seriesIndex;
+  let buildSeriesMetaParams;
 
   const config = {
     allowLeadingWildcards: true,
@@ -35,17 +36,32 @@ describe('query', () => {
     };
     series = { id: 'test' };
     seriesIndex = {};
+    buildSeriesMetaParams = jest.fn().mockResolvedValue({
+      timeField: panel.time_field,
+      interval: panel.interval,
+    });
   });
 
-  test('calls next when finished', () => {
+  test('calls next when finished', async () => {
     const next = jest.fn();
-    query(req, panel, series, config, seriesIndex)(next)({});
+    await query(req, panel, series, config, seriesIndex, null, null, buildSeriesMetaParams)(next)(
+      {}
+    );
     expect(next.mock.calls.length).toEqual(1);
   });
 
-  test('returns doc with query for timerange', () => {
+  test('returns doc with query for timerange', async () => {
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {
@@ -69,10 +85,19 @@ describe('query', () => {
     });
   });
 
-  test('returns doc with query for timerange (offset by 1h)', () => {
+  test('returns doc with query for timerange (offset by 1h)', async () => {
     series.offset_time = '1h';
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {
@@ -96,7 +121,7 @@ describe('query', () => {
     });
   });
 
-  test('returns doc with global query', () => {
+  test('returns doc with global query', async () => {
     req.body.filters = [
       {
         bool: {
@@ -111,7 +136,16 @@ describe('query', () => {
       },
     ];
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {
@@ -147,10 +181,19 @@ describe('query', () => {
     });
   });
 
-  test('returns doc with series filter', () => {
+  test('returns doc with series filter', async () => {
     series.filter = { query: 'host:web-server', language: 'lucene' };
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {
@@ -188,7 +231,7 @@ describe('query', () => {
       },
     });
   });
-  test('returns doc with panel filter and global', () => {
+  test('returns doc with panel filter and global', async () => {
     req.body.filters = [
       {
         bool: {
@@ -204,7 +247,16 @@ describe('query', () => {
     ];
     panel.filter = { query: 'host:web-server', language: 'lucene' };
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {
@@ -255,7 +307,7 @@ describe('query', () => {
     });
   });
 
-  test('returns doc with panel filter (ignoring globals)', () => {
+  test('returns doc with panel filter (ignoring globals)', async () => {
     req.body.filters = [
       {
         bool: {
@@ -272,7 +324,16 @@ describe('query', () => {
     panel.filter = { query: 'host:web-server', language: 'lucene' };
     panel.ignore_global_filter = true;
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {
@@ -311,7 +372,7 @@ describe('query', () => {
     });
   });
 
-  test('returns doc with panel filter (ignoring globals from series)', () => {
+  test('returns doc with panel filter (ignoring globals from series)', async () => {
     req.body.filters = [
       {
         bool: {
@@ -328,7 +389,16 @@ describe('query', () => {
     panel.filter = { query: 'host:web-server', language: 'lucene' };
     series.ignore_global_filter = true;
     const next = (doc) => doc;
-    const doc = query(req, panel, series, config, seriesIndex)(next)({});
+    const doc = await query(
+      req,
+      panel,
+      series,
+      config,
+      seriesIndex,
+      null,
+      null,
+      buildSeriesMetaParams
+    )(next)({});
     expect(doc).toEqual({
       size: 0,
       query: {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/date_histogram.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/date_histogram.js
@@ -9,17 +9,24 @@
 import { overwrite } from '../../helpers';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { isLastValueTimerangeMode } from '../../helpers/get_timerange_mode';
-import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { getTimerange } from '../../helpers/get_timerange';
 import { calculateAggRoot } from './calculate_agg_root';
 import { search, UI_SETTINGS } from '../../../../../../../plugins/data/server';
 
 const { dateHistogramInterval } = search.aggs;
 
-export function dateHistogram(req, panel, esQueryConfig, seriesIndex, capabilities, uiSettings) {
+export function dateHistogram(
+  req,
+  panel,
+  esQueryConfig,
+  seriesIndex,
+  capabilities,
+  uiSettings,
+  buildSeriesMetaParams
+) {
   return (next) => async (doc) => {
     const barTargetUiSettings = await uiSettings.get(UI_SETTINGS.HISTOGRAM_BAR_TARGET);
-    const { timeField, interval } = getIntervalAndTimefield(panel, {}, seriesIndex);
+    const { timeField, interval } = await buildSeriesMetaParams();
     const { from, to } = getTimerange(req);
 
     const meta = {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/positive_rate.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/positive_rate.js
@@ -7,15 +7,22 @@
  */
 
 import { getBucketSize } from '../../helpers/get_bucket_size';
-import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { calculateAggRoot } from './calculate_agg_root';
 import { createPositiveRate, filter } from '../series/positive_rate';
 import { UI_SETTINGS } from '../../../../../../data/common';
 
-export function positiveRate(req, panel, esQueryConfig, seriesIndex, capabilities, uiSettings) {
+export function positiveRate(
+  req,
+  panel,
+  esQueryConfig,
+  seriesIndex,
+  capabilities,
+  uiSettings,
+  buildSeriesMetaParams
+) {
   return (next) => async (doc) => {
     const barTargetUiSettings = await uiSettings.get(UI_SETTINGS.HISTOGRAM_BAR_TARGET);
-    const { interval } = getIntervalAndTimefield(panel, {}, seriesIndex);
+    const { interval } = await buildSeriesMetaParams();
     const { intervalString } = getBucketSize(req, interval, capabilities, barTargetUiSettings);
 
     panel.series.forEach((column) => {

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/query.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/request_processors/table/query.js
@@ -7,12 +7,19 @@
  */
 
 import { getTimerange } from '../../helpers/get_timerange';
-import { getIntervalAndTimefield } from '../../get_interval_and_timefield';
 import { esQuery } from '../../../../../../data/server';
 
-export function query(req, panel, esQueryConfig, seriesIndex) {
-  return (next) => (doc) => {
-    const { timeField } = getIntervalAndTimefield(panel, {}, seriesIndex);
+export function query(
+  req,
+  panel,
+  esQueryConfig,
+  seriesIndex,
+  capabilities,
+  uiSettings,
+  buildSeriesMetaParams
+) {
+  return (next) => async (doc) => {
+    const { timeField } = await buildSeriesMetaParams();
     const { from, to } = getTimerange(req);
 
     doc.size = 0;

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/build_request_body.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/build_request_body.test.ts
@@ -89,7 +89,10 @@ describe('buildRequestBody(req)', () => {
       capabilities,
       {
         get: async () => 50,
-      }
+      },
+      jest.fn().mockResolvedValue({
+        timeField: '@timestamp',
+      })
     );
 
     expect(doc).toEqual({

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/series/get_request_params.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/series/get_request_params.ts
@@ -7,6 +7,7 @@
  */
 
 import { buildRequestBody } from './build_request_body';
+import { getIntervalAndTimefield } from '../get_interval_and_timefield';
 
 import type { FetchedIndexPattern, Panel, Series } from '../../../../common/types';
 import type {
@@ -34,6 +35,18 @@ export async function getSeriesRequestParams(
     seriesIndex = await cachedIndexPatternFetcher(series.series_index_pattern ?? '');
   }
 
+  const buildSeriesMetaParams = async () => {
+    let index = seriesIndex;
+
+    /** This part of code is required to try to get the default timefield for string indices.
+     *  The rest of the functionality available for Kibana indexes should not be active **/
+    if (!panel.use_kibana_indexes && index.indexPatternString) {
+      index = await cachedIndexPatternFetcher(index.indexPatternString, true);
+    }
+
+    return getIntervalAndTimefield(panel, index, series);
+  };
+
   const request = await buildRequestBody(
     req,
     panel,
@@ -41,7 +54,8 @@ export async function getSeriesRequestParams(
     esQueryConfig,
     seriesIndex,
     capabilities,
-    uiSettings
+    uiSettings,
+    buildSeriesMetaParams
   );
 
   return {


### PR DESCRIPTION
Part of: #100778

## Summary

This is a follow-up PR that should fix the issue where the time field is not showing after upgrading from `7.12.1` to `7.13.0`. Many of our users are using `TSVB` without a configured time field. In the previous implementation, this worked because we had no separation between `ES` and `Kibana` indexes. 

After `7.13.0` we have 2 different modes for `ES` and `Kibana` indexes. The main problem here is that there is no default time field value in the `ES` index. As a result, the users see a message about no data. 


## Steps to reprocude:
1) Install Sample data logs 
2) Import [export (21).ndjson.zip](https://github.com/elastic/kibana/files/6670504/export.21.ndjson.zip)
3) Open imported visualization

**Expected result:** some data should be displayed

## Screens

### Before

![image](https://user-images.githubusercontent.com/20072247/122404940-4e3c2b00-cf88-11eb-9f7d-0c13e0d569eb.png)


### After

![image](https://user-images.githubusercontent.com/20072247/122404302-c48c5d80-cf87-11eb-9ade-121d990e2bdd.png)
