### PR TITLE
Detection Rule Telemetry: Fix the size of the query in 7.13.3

### DIFF
--- a/x-pack/plugins/security_solution/server/usage/detections/detections_metrics_helpers.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/detections_metrics_helpers.ts
@@ -200,7 +200,7 @@ export const getDetectionRuleMetrics = async (
     const { body: ruleResults } = await esClient.search<RuleSearchResult>(ruleSearchOptions);
     const { body: detectionAlertsResp } = (await esClient.search({
       index: `${signalsIndex}*`,
-      size: 0,
+      size: 10_000,
       body: {
         aggs: {
           detectionAlerts: {


### PR DESCRIPTION
## Summary

Fixes 7.13/7.14 security telemetry branch divergence: #102352

## Detailed Description

The usage collector telemetry instrumentation has diverged between the 7.13 and 7.14 series.

First, there was a refactor:

  - https://github.com/elastic/kibana/pull/100480 (Backported to 7.14)

Then a ES query bug was discovered and rectified. 

  - https://github.com/elastic/kibana/pull/102160 (Backported to 7.14, Not backported to 7.13.X)

This PR is necessary because the 7.13.X branch doesn't have the changes contained in https://github.com/elastic/kibana/pull/100480. 

cc: @Bamieh @afharo @donaherc 

