### PR TITLE
remove or replace xs props for text on source connect view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.tsx
@@ -167,7 +167,7 @@ export const ConnectInstance: React.FC<ConnectInstanceProps> = ({
           </h3>
         </EuiTitle>
         <EuiSpacer size="s" />
-        <EuiText color="subdued">
+        <EuiText color="subdued" size="s">
           {!needsPermissions && (
             <span>
               <FormattedMessage

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.tsx
@@ -161,13 +161,13 @@ export const ConnectInstance: React.FC<ConnectInstanceProps> = ({
   const permissionField = (
     <>
       <EuiPanel paddingSize="l" hasShadow={false} color="subdued">
-        <EuiTitle size="xs">
+        <EuiTitle size="s">
           <h3>
             <strong>{CONNECT_DOC_PERMISSIONS_TITLE}</strong>
           </h3>
         </EuiTitle>
         <EuiSpacer size="s" />
-        <EuiText size="xs" color="subdued">
+        <EuiText color="subdued">
           {!needsPermissions && (
             <span>
               <FormattedMessage
@@ -191,11 +191,9 @@ export const ConnectInstance: React.FC<ConnectInstanceProps> = ({
             </span>
           )}
         </EuiText>
-        <EuiSpacer size="s" />
         {!indexPermissionsValue && (
           <>
-            <EuiSpacer size="s" />
-            <EuiCallOut title={CONNECT_NOT_SYNCED_TITLE} color="warning" size="s">
+            <EuiCallOut title={CONNECT_NOT_SYNCED_TITLE} color="warning">
               <p>
                 {CONNECT_NOT_SYNCED_TEXT}
                 {needsPermissions && whichDocsLink}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.tsx
@@ -63,20 +63,20 @@ export const SourceFeatures: React.FC<ConnectInstanceProps> = ({ features, objTy
             </>
           )}
           <EuiFlexItem>
-            <EuiText size="xs">
+            <EuiText size="s">
               <strong>{title}</strong>
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="s" />
-        <EuiText size="xs">{children}</EuiText>
+        <EuiText size="s">{children}</EuiText>
       </>
     );
   };
 
   const SyncFrequencyFeature = (
     <Feature icon="clock" title="Syncs every 2 hours">
-      <EuiText size="xs">
+      <EuiText size="s">
         <p>
           <FormattedMessage
             id="xpack.enterpriseSearch.workplaceSearch.contentSource.sourceFeatures.syncFrequency.text"
@@ -94,11 +94,11 @@ export const SourceFeatures: React.FC<ConnectInstanceProps> = ({ features, objTy
   const SyncedItemsFeature = (
     <Feature icon="documents" title="Synced items">
       <>
-        <EuiText size="xs">
+        <EuiText size="s">
           <p>{SOURCE_FEATURES_SEARCHABLE}</p>
         </EuiText>
         <EuiSpacer size="xs" />
-        <EuiText size="xs">
+        <EuiText size="s">
           <ul>
             {objTypes!.map((objType, i) => (
               <li key={i}>{objType}</li>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.tsx
@@ -178,7 +178,7 @@ export const SourceFeatures: React.FC<ConnectInstanceProps> = ({ features, objTy
 
     return (
       <>
-        <EuiTitle size="xs">
+        <EuiTitle size="s">
           <h3>
             <strong>Included features</strong>
           </h3>


### PR DESCRIPTION
## Summary
Closes [workplace-search-team #1786](https://github.com/elastic/workplace-search-team/issues/1786)

This PR fixes a font size issue by increases the size of text on the source connect view in Workplace Search.

| Old | New |
| --- | --- |
| ![localhost_5601_znc_app_enterprise_search_workplace_search_sources_add_confluence_cloud_connect (1)](https://user-images.githubusercontent.com/7115017/122596598-04277800-d062-11eb-9f5b-764434066abc.png) | ![localhost_5601_znc_app_enterprise_search_workplace_search_sources_add_confluence_cloud_connect](https://user-images.githubusercontent.com/7115017/122596613-0b4e8600-d062-11eb-8aac-19512f9db1df.png) |


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

