### PR TITLE
[Cases] Add owner and description properties to `kibana.json`

### DIFF
--- a/x-pack/plugins/cases/kibana.json
+++ b/x-pack/plugins/cases/kibana.json
@@ -1,18 +1,31 @@
 {
-  "configPath": ["xpack", "cases"],
-  "id": "cases",
-  "kibanaVersion": "kibana",
-  "extraPublicDirs": ["common"],
-  "requiredPlugins": [
-    "actions",
-    "esUiShared",
-    "features",
-    "kibanaReact",
-    "kibanaUtils",
-    "triggersActionsUi"
+  "configPath":[
+     "cases",
+     "xpack"
   ],
-  "optionalPlugins": ["spaces", "security"],
-  "server": true,
-  "ui": true,
-  "version": "8.0.0"
+  "description":"The Case management system in Kibana",
+  "extraPublicDirs":[
+     "common"
+  ],
+  "id":"cases",
+  "kibanaVersion":"kibana",
+  "optionalPlugins":[
+     "security",
+     "spaces"
+  ],
+  "owner":{
+     "githubTeam":"security-threat-hunting",
+     "name":"Security Solution Threat Hunting"
+  },
+  "requiredPlugins":[
+     "actions",
+     "esUiShared",
+     "features",
+     "kibanaReact",
+     "kibanaUtils",
+     "triggersActionsUi"
+  ],
+  "server":true,
+  "ui":true,
+  "version":"8.0.0"
 }


### PR DESCRIPTION
## Summary

It has been requested that all Kibana plugins must add the owner and description properties to their kibana.json files.

The json has been formatted to the JSON standard and the keys has been ordered alphabetically.