### PR TITLE
[APM] Errors: Fix panels styles

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
@@ -85,7 +85,7 @@ export function DetailView({ errorGroup, urlParams }: Props) {
   const status = error.http?.response?.status_code;
 
   return (
-    <EuiPanel>
+    <EuiPanel hasBorder={true}>
       <HeaderContainer>
         <EuiTitle size="s">
           <h3>

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
@@ -146,9 +146,12 @@ export function ErrorGroupDetails({
 
   return (
     <>
+      <EuiSpacer size={'s'} />
+
       <ErrorGroupHeader groupId={groupId} isUnhandled={isUnhandled} />
 
-      <EuiPanel>
+      <EuiSpacer size={'m'} />
+
       <EuiPanel hasBorder={true}>
         {showDetails && (
           <Titles>

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
@@ -149,6 +149,7 @@ export function ErrorGroupDetails({
       <ErrorGroupHeader groupId={groupId} isUnhandled={isUnhandled} />
 
       <EuiPanel>
+      <EuiPanel hasBorder={true}>
         {showDetails && (
           <Titles>
             <EuiText>

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -73,7 +73,7 @@ export function ErrorGroupOverview({ serviceName }: ErrorGroupOverviewProps) {
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
-        <EuiPanel>
+        <EuiPanel hasBorder={true}>
           <ErrorDistribution
             distribution={errorDistributionData}
             title={i18n.translate(
@@ -85,7 +85,7 @@ export function ErrorGroupOverview({ serviceName }: ErrorGroupOverviewProps) {
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiPanel>
+        <EuiPanel hasBorder={true}>
           <EuiTitle size="xs">
             <h3>
               {i18n.translate(


### PR DESCRIPTION
## Summary

In relation to the new page template in APM, the Errors UI didn't get updated, so updating the panel styles.

_Before_

<img width="1500" alt="Screenshot 2021-06-21 at 14 19 31" src="https://user-images.githubusercontent.com/4104278/122760741-beee8a80-d29b-11eb-85b4-6bbf6530274c.png">

<img width="1499" alt="Screenshot 2021-06-21 at 14 19 47" src="https://user-images.githubusercontent.com/4104278/122760747-c0b84e00-d29b-11eb-8274-81445d520277.png">

_After_

<img width="1496" alt="Screenshot 2021-06-21 at 14 16 27" src="https://user-images.githubusercontent.com/4104278/122760492-7a62ef00-d29b-11eb-9124-09aec52c4347.png">

<img width="1497" alt="Screenshot 2021-06-21 at 14 16 38" src="https://user-images.githubusercontent.com/4104278/122760504-7c2cb280-d29b-11eb-8d81-f247185eb484.png">
