### PR TITLE
[Lens] Avoid suggestion rendering and evaluation on fullscreen mode

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
@@ -1370,6 +1370,57 @@ describe('editor_frame', () => {
         })
       );
     });
+
+    it('should avoid completely to compute suggestion when in fullscreen mode', async () => {
+      const props = {
+        ...getDefaultProps(),
+        initialContext: {
+          indexPatternId: '1',
+          fieldName: 'test',
+        },
+        visualizationMap: {
+          testVis: mockVisualization,
+        },
+        datasourceMap: {
+          testDatasource: mockDatasource,
+          testDatasource2: mockDatasource2,
+        },
+
+        ExpressionRenderer: expressionRendererMock,
+      };
+
+      const { instance: el } = await mountWithProvider(
+        <EditorFrame {...props} />,
+        props.plugins.data
+      );
+      instance = el;
+
+      expect(
+        instance.find(FrameLayout).prop('suggestionsPanel') as ReactElement
+      ).not.toBeUndefined();
+
+      await act(async () => {
+        (instance.find(FrameLayout).prop('dataPanel') as ReactElement)!.props.dispatch({
+          type: 'TOGGLE_FULLSCREEN',
+        });
+      });
+
+      instance.update();
+
+      expect(instance.find(FrameLayout).prop('suggestionsPanel') as ReactElement).toBe(false);
+
+      await act(async () => {
+        (instance.find(FrameLayout).prop('dataPanel') as ReactElement)!.props.dispatch({
+          type: 'TOGGLE_FULLSCREEN',
+        });
+      });
+
+      instance.update();
+
+      expect(
+        instance.find(FrameLayout).prop('suggestionsPanel') as ReactElement
+      ).not.toBeUndefined();
+    });
   });
 
   describe('passing state back to the caller', () => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
@@ -452,7 +452,8 @@ export function EditorFrame(props: EditorFrameProps) {
           )
         }
         suggestionsPanel={
-          allLoaded && (
+          allLoaded &&
+          !state.isFullscreenDatasource && (
             <SuggestionPanel
               frame={framePublicAPI}
               activeDatasourceId={state.activeDatasourceId}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/frame_layout.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/frame_layout.scss
@@ -88,8 +88,7 @@ a tilemap in an iframe: https://github.com/elastic/kibana/issues/16457 */
   position: relative;
 }
 
-.lnsFrameLayout-isFullscreen .lnsFrameLayout__sidebar--left,
-.lnsFrameLayout-isFullscreen .lnsFrameLayout__suggestionPanel {
+.lnsFrameLayout-isFullscreen .lnsFrameLayout__sidebar--left {
   // Hide the datapanel and suggestions in fullscreen mode. Using display: none does trigger
   // a rerender when the container becomes visible again, maybe pushing offscreen is better
   display: none;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/frame_layout.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/frame_layout.scss
@@ -89,7 +89,7 @@ a tilemap in an iframe: https://github.com/elastic/kibana/issues/16457 */
 }
 
 .lnsFrameLayout-isFullscreen .lnsFrameLayout__sidebar--left {
-  // Hide the datapanel and suggestions in fullscreen mode. Using display: none does trigger
+  // Hide the datapanel in fullscreen mode. Using display: none does trigger
   // a rerender when the container becomes visible again, maybe pushing offscreen is better
   display: none;
 }


### PR DESCRIPTION
## Summary

Avoid to compute suggestions when the Formula editor is in fullscreen mode: expecially when editing a formula this should lead to better performance.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
