### PR TITLE
[Workplace Search] Replace library interface with EUI version

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { DropResult } from 'react-beautiful-dnd';
-
 import { kea, MakeLogicType } from 'kea';
 import { cloneDeep, isEqual, differenceBy } from 'lodash';
+
+import { DropResult } from '@elastic/eui';
 
 import {
   setSuccessMessage,


### PR DESCRIPTION
## Summary

One of the Workplace Search components was using the 'react-beautiful-dnd' typing for its component. This PR replaces it with the EUI equivalent. Part of https://github.com/elastic/kibana/issues/102689