### PR TITLE
[App Search] Engines Overview polish pass

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/licensing_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/licensing_logic.mock.ts
@@ -11,8 +11,11 @@ export const mockLicensingValues = {
   license: licensingMock.createLicense(),
   hasPlatinumLicense: false,
   hasGoldLicense: false,
+  isTrial: false,
+  canManageLicense: true,
 };
 
 jest.mock('../../shared/licensing', () => ({
+  ...(jest.requireActual('../../shared/licensing') as object),
   LicensingLogic: { values: mockLicensingValues },
 }));

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
-import { LogicMounter } from '../__mocks__/kea_logic';
+import { LogicMounter } from '../__mocks__/kea_logic/logic_mounter.test_helper';
+
+jest.mock('../shared/licensing', () => ({
+  LicensingLogic: { selectors: { hasPlatinumLicense: () => false } },
+}));
 
 import { AppLogic } from './app_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -9,6 +9,8 @@ import { kea, MakeLogicType } from 'kea';
 
 import { InitialAppData } from '../../../common/types';
 
+import { LicensingLogic } from '../shared/licensing';
+
 import { ConfiguredLimits, Account, Role } from './types';
 
 import { getRoleAbilities } from './utils/role';
@@ -43,8 +45,8 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions, Required<Initia
   }),
   selectors: {
     myRole: [
-      (selectors) => [selectors.account],
-      ({ role }) => (role ? getRoleAbilities(role) : {}),
+      (selectors) => [selectors.account, LicensingLogic.selectors.hasPlatinumLicense],
+      ({ role }, hasPlatinumLicense) => (role ? getRoleAbilities(role, hasPlatinumLicense) : {}),
     ],
   },
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
@@ -27,7 +27,7 @@ describe('DataPanel', () => {
     expect(wrapper.find('[data-test-subj="children"]').text()).toEqual('Look at this graph');
   });
 
-  it('conditionally a spacer between the header and children', () => {
+  it('conditionally renders a spacer between the header and children', () => {
     const wrapper = shallow(<DataPanel title={<h1>Test</h1>} />);
 
     expect(wrapper.find(EuiSpacer)).toHaveLength(0);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiIcon, EuiButton } from '@elastic/eui';
+import { EuiIcon, EuiButton, EuiTitle } from '@elastic/eui';
 
 import { LoadingOverlay } from '../../../shared/loading';
 
@@ -70,6 +70,16 @@ describe('DataPanel', () => {
   });
 
   describe('props', () => {
+    it('passes titleSize to the title', () => {
+      const wrapper = shallow(<DataPanel title={<h2>Test</h2>} />);
+
+      expect(wrapper.find(EuiTitle).prop('size')).toEqual('xs'); // Default
+
+      wrapper.setProps({ titleSize: 's' });
+
+      expect(wrapper.find(EuiTitle).prop('size')).toEqual('s');
+    });
+
     it('renders panel color based on filled flag', () => {
       const wrapper = shallow(<DataPanel title={<h1>Test</h1>} />);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiIcon, EuiButton, EuiTitle } from '@elastic/eui';
+import { EuiIcon, EuiButton, EuiTitle, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
 
 import { LoadingOverlay } from '../../../shared/loading';
 
@@ -25,6 +25,16 @@ describe('DataPanel', () => {
 
     expect(wrapper.find('[data-test-subj="title"]').text()).toEqual('Tabula Rasa');
     expect(wrapper.find('[data-test-subj="children"]').text()).toEqual('Look at this graph');
+  });
+
+  it('conditionally a spacer between the header and children', () => {
+    const wrapper = shallow(<DataPanel title={<h1>Test</h1>} />);
+
+    expect(wrapper.find(EuiSpacer)).toHaveLength(0);
+
+    wrapper.setProps({ children: 'hello world' });
+
+    expect(wrapper.find(EuiSpacer)).toHaveLength(1);
   });
 
   describe('components', () => {
@@ -78,6 +88,16 @@ describe('DataPanel', () => {
       wrapper.setProps({ titleSize: 's' });
 
       expect(wrapper.find(EuiTitle).prop('size')).toEqual('s');
+    });
+
+    it('passes responsive to the header flex group', () => {
+      const wrapper = shallow(<DataPanel title={<h1>Test</h1>} />);
+
+      expect(wrapper.find(EuiFlexGroup).first().prop('responsive')).toEqual(false);
+
+      wrapper.setProps({ responsive: true });
+
+      expect(wrapper.find(EuiFlexGroup).first().prop('responsive')).toEqual(true);
     });
 
     it('renders panel color based on filled flag', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
@@ -18,6 +18,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiTitleProps,
 } from '@elastic/eui';
 
 import { LoadingOverlay } from '../../../shared/loading';
@@ -26,6 +27,7 @@ import './data_panel.scss';
 
 interface Props {
   title: React.ReactElement; // e.g., h2 tag
+  titleSize?: EuiTitleProps['size'];
   subtitle?: string;
   iconType?: EuiIconProps['type'];
   action?: React.ReactNode;
@@ -37,6 +39,7 @@ interface Props {
 
 export const DataPanel: React.FC<Props> = ({
   title,
+  titleSize = 'xs',
   subtitle,
   iconType,
   action,
@@ -69,7 +72,7 @@ export const DataPanel: React.FC<Props> = ({
               </EuiFlexItem>
             )}
             <EuiFlexItem>
-              <EuiTitle size="xs">{title}</EuiTitle>
+              <EuiTitle size={titleSize}>{title}</EuiTitle>
             </EuiFlexItem>
           </EuiFlexGroup>
           {subtitle && (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
@@ -28,9 +28,10 @@ import './data_panel.scss';
 interface Props {
   title: React.ReactElement; // e.g., h2 tag
   titleSize?: EuiTitleProps['size'];
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   iconType?: EuiIconProps['type'];
   action?: React.ReactNode;
+  responsive?: boolean;
   filled?: boolean;
   hasBorder?: boolean;
   isLoading?: boolean;
@@ -43,6 +44,7 @@ export const DataPanel: React.FC<Props> = ({
   subtitle,
   iconType,
   action,
+  responsive = false,
   filled,
   hasBorder,
   isLoading,
@@ -63,7 +65,7 @@ export const DataPanel: React.FC<Props> = ({
       hasShadow={false}
       aria-busy={isLoading}
     >
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={responsive}>
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             {iconType && (
@@ -83,8 +85,12 @@ export const DataPanel: React.FC<Props> = ({
         </EuiFlexItem>
         {action && <EuiFlexItem grow={false}>{action}</EuiFlexItem>}
       </EuiFlexGroup>
-      <EuiSpacer />
-      {children}
+      {children && (
+        <>
+          <EuiSpacer />
+          {children}
+        </>
+      )}
       {isLoading && <LoadingOverlay />}
     </EuiPanel>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiIconProps,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -26,7 +27,7 @@ import './data_panel.scss';
 interface Props {
   title: React.ReactElement; // e.g., h2 tag
   subtitle?: string;
-  iconType?: string;
+  iconType?: EuiIconProps['type'];
   action?: React.ReactNode;
   filled?: boolean;
   hasBorder?: boolean;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_meta_engines_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_meta_engines_state.test.tsx
@@ -19,7 +19,7 @@ describe('EmptyMetaEnginesState', () => {
       .find(EuiEmptyPrompt)
       .dive();
 
-    expect(wrapper.find('h2').text()).toEqual('Create your first meta engine');
+    expect(wrapper.find('h3').text()).toEqual('Create your first meta engine');
     expect(wrapper.find(EuiButton).prop('href')).toEqual(
       expect.stringContaining('/meta-engines-guide.html')
     );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_meta_engines_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_meta_engines_state.tsx
@@ -15,12 +15,13 @@ import { DOCS_PREFIX } from '../../../routes';
 export const EmptyMetaEnginesState: React.FC = () => (
   <EuiEmptyPrompt
     title={
-      <h2>
+      <h3>
         {i18n.translate('xpack.enterpriseSearch.appSearch.engines.metaEngines.emptyPromptTitle', {
           defaultMessage: 'Create your first meta engine',
         })}
-      </h2>
+      </h3>
     }
+    titleSize="s"
     body={
       <p>
         {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/constants.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/constants.tsx
@@ -5,7 +5,17 @@
  * 2.0.
  */
 
+import React from 'react';
+
+import { EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { DOCS_PREFIX } from '../../routes';
+import {
+  META_ENGINE_CREATION_FORM_META_ENGINE_DESCRIPTION,
+  META_ENGINE_CREATION_FORM_DOCUMENTATION_LINK,
+} from '../meta_engine_creation/constants';
 
 export const ENGINES_TITLE = i18n.translate('xpack.enterpriseSearch.appSearch.engines.title', {
   defaultMessage: 'Engines',
@@ -19,6 +29,24 @@ export const ENGINES_OVERVIEW_TITLE = i18n.translate(
 export const META_ENGINES_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.metaEngines.title',
   { defaultMessage: 'Meta Engines' }
+);
+
+export const META_ENGINES_DESCRIPTION = (
+  <>
+    {META_ENGINE_CREATION_FORM_META_ENGINE_DESCRIPTION}
+    <br />
+    <FormattedMessage
+      id="xpack.enterpriseSearch.appSearch.metaEngines.upgradeDescription"
+      defaultMessage="{readDocumentationLink} for more information or upgrade to a Platinum license to get started."
+      values={{
+        readDocumentationLink: (
+          <EuiLink href={`${DOCS_PREFIX}/meta-engines-guide.html`} target="_blank">
+            {META_ENGINE_CREATION_FORM_DOCUMENTATION_LINK}
+          </EuiLink>
+        ),
+      }}
+    />
+  </>
 );
 
 export const SOURCE_ENGINES_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -144,6 +144,19 @@ describe('EnginesOverview', () => {
     });
   });
 
+  describe('when an account does not have a platinum license', () => {
+    it('renders a license call to action in place of the meta engines table', () => {
+      setMockValues({
+        ...valuesWithEngines,
+        hasPlatinumLicense: false,
+      });
+      const wrapper = shallow(<EnginesOverview />);
+
+      expect(wrapper.find('[data-test-subj="metaEnginesLicenseCTA"]')).toHaveLength(1);
+      expect(wrapper.find('[data-test-subj="appSearchMetaEngines"]')).toHaveLength(0);
+    });
+  });
+
   describe('pagination', () => {
     const getTablePagination = (wrapper: ShallowWrapper) =>
       wrapper.find(EnginesTable).prop('pagination');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -85,17 +85,25 @@ describe('EnginesOverview', () => {
     expect(actions.loadEngines).toHaveBeenCalled();
   });
 
-  describe('when the user can manage/create engines', () => {
-    it('renders a create engine button which takes users to the create engine page', () => {
+  describe('engine creation', () => {
+    it('renders a create engine action when the users can create engines', () => {
       setMockValues({
         ...valuesWithEngines,
         myRole: { canManageEngines: true },
       });
       const wrapper = shallow(<EnginesOverview />);
 
-      expect(
-        wrapper.find('[data-test-subj="appSearchEnginesEngineCreationButton"]').prop('to')
-      ).toEqual('/engine_creation');
+      expect(wrapper.find('[data-test-subj="appSearchEngines"]').prop('action')).toBeTruthy();
+    });
+
+    it('does not render a create engine action if the user cannot create engines', () => {
+      setMockValues({
+        ...valuesWithEngines,
+        myRole: { canManageEngines: false },
+      });
+      const wrapper = shallow(<EnginesOverview />);
+
+      expect(wrapper.find('[data-test-subj="appSearchEngines"]').prop('action')).toBeFalsy();
     });
   });
 
@@ -111,8 +119,8 @@ describe('EnginesOverview', () => {
       expect(actions.loadMetaEngines).toHaveBeenCalled();
     });
 
-    describe('when the user can manage/create engines', () => {
-      it('renders a create engine button which takes users to the create meta engine page', () => {
+    describe('meta engine creation', () => {
+      it('renders a create engine meta action when the user can create meta engines', () => {
         setMockValues({
           ...valuesWithEngines,
           hasPlatinumLicense: true,
@@ -120,9 +128,18 @@ describe('EnginesOverview', () => {
         });
         const wrapper = shallow(<EnginesOverview />);
 
-        expect(
-          wrapper.find('[data-test-subj="appSearchEnginesMetaEngineCreationButton"]').prop('to')
-        ).toEqual('/meta_engine_creation');
+        expect(wrapper.find('[data-test-subj="appSearchMetaEngines"]').prop('action')).toBeTruthy();
+      });
+
+      it('does not render a create meta engine action if user cannot create meta engines', () => {
+        setMockValues({
+          ...valuesWithEngines,
+          hasPlatinumLicense: true,
+          myRole: { canManageEngines: false },
+        });
+        const wrapper = shallow(<EnginesOverview />);
+
+        expect(wrapper.find('[data-test-subj="appSearchMetaEngines"]').prop('action')).toBeFalsy();
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -120,7 +120,7 @@ describe('EnginesOverview', () => {
     });
 
     describe('meta engine creation', () => {
-      it('renders a create engine meta action when the user can create meta engines', () => {
+      it('renders a create meta engine action when the user can create meta engines', () => {
         setMockValues({
           ...valuesWithEngines,
           hasPlatinumLicense: true,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -42,7 +42,7 @@ describe('EnginesOverview', () => {
     metaEnginesLoading: false,
     hasPlatinumLicense: false,
     // AppLogic
-    myRole: { canManageEngines: false },
+    myRole: { canManageEngines: false, canManageMetaEngines: false },
     // MetaEnginesTableLogic
     expandedSourceEngines: {},
     conflictingEnginesSets: {},
@@ -124,7 +124,7 @@ describe('EnginesOverview', () => {
         setMockValues({
           ...valuesWithEngines,
           hasPlatinumLicense: true,
-          myRole: { canManageEngines: true },
+          myRole: { canManageMetaEngines: true },
         });
         const wrapper = shallow(<EnginesOverview />);
 
@@ -135,7 +135,7 @@ describe('EnginesOverview', () => {
         setMockValues({
           ...valuesWithEngines,
           hasPlatinumLicense: true,
-          myRole: { canManageEngines: false },
+          myRole: { canManageMetaEngines: false },
         });
         const wrapper = shallow(<EnginesOverview />);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -11,7 +11,7 @@ import { useValues, useActions } from 'kea';
 
 import { EuiSpacer } from '@elastic/eui';
 
-import { LicensingLogic } from '../../../shared/licensing';
+import { LicensingLogic, ManageLicenseButton } from '../../../shared/licensing';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
 import { convertMetaToPagination, handlePageChange } from '../../../shared/table_pagination';
 import { AppLogic } from '../../app_logic';
@@ -29,6 +29,7 @@ import {
   CREATE_A_META_ENGINE_BUTTON_LABEL,
   ENGINES_TITLE,
   META_ENGINES_TITLE,
+  META_ENGINES_DESCRIPTION,
 } from './constants';
 import { EnginesLogic } from './engines_logic';
 
@@ -102,42 +103,50 @@ export const EnginesOverview: React.FC = () => {
           onChange={handlePageChange(onEnginesPagination)}
         />
       </DataPanel>
-
-      {hasPlatinumLicense && (
-        <>
-          <EuiSpacer size="xxl" />
-          <DataPanel
-            hasBorder
-            iconType={MetaEngineIcon}
-            title={<h2>{META_ENGINES_TITLE}</h2>}
-            titleSize="s"
-            action={
-              canManageEngines && (
-                <EuiButtonTo
-                  color="secondary"
-                  size="s"
-                  iconType="plusInCircle"
-                  data-test-subj="appSearchEnginesMetaEngineCreationButton"
-                  to={META_ENGINE_CREATION_PATH}
-                >
-                  {CREATE_A_META_ENGINE_BUTTON_LABEL}
-                </EuiButtonTo>
-              )
-            }
-            data-test-subj="appSearchMetaEngines"
-          >
-            <MetaEnginesTable
-              items={metaEngines}
-              loading={metaEnginesLoading}
-              pagination={{
-                ...convertMetaToPagination(metaEnginesMeta),
-                hidePerPageOptions: true,
-              }}
-              noItemsMessage={<EmptyMetaEnginesState />}
-              onChange={handlePageChange(onMetaEnginesPagination)}
-            />
-          </DataPanel>
-        </>
+      <EuiSpacer size="xxl" />
+      {hasPlatinumLicense ? (
+        <DataPanel
+          hasBorder
+          iconType={MetaEngineIcon}
+          title={<h2>{META_ENGINES_TITLE}</h2>}
+          titleSize="s"
+          action={
+            canManageEngines && (
+              <EuiButtonTo
+                color="secondary"
+                size="s"
+                iconType="plusInCircle"
+                data-test-subj="appSearchEnginesMetaEngineCreationButton"
+                to={META_ENGINE_CREATION_PATH}
+              >
+                {CREATE_A_META_ENGINE_BUTTON_LABEL}
+              </EuiButtonTo>
+            )
+          }
+          data-test-subj="appSearchMetaEngines"
+        >
+          <MetaEnginesTable
+            items={metaEngines}
+            loading={metaEnginesLoading}
+            pagination={{
+              ...convertMetaToPagination(metaEnginesMeta),
+              hidePerPageOptions: true,
+            }}
+            noItemsMessage={<EmptyMetaEnginesState />}
+            onChange={handlePageChange(onMetaEnginesPagination)}
+          />
+        </DataPanel>
+      ) : (
+        <DataPanel
+          hasBorder
+          responsive
+          iconType={MetaEngineIcon}
+          title={<h2>{META_ENGINES_TITLE}</h2>}
+          titleSize="s"
+          subtitle={META_ENGINES_DESCRIPTION}
+          action={<ManageLicenseButton />}
+          data-test-subj="metaEnginesLicenseCTA"
+        />
       )}
     </AppSearchPageTemplate>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -36,7 +36,7 @@ import { EnginesLogic } from './engines_logic';
 export const EnginesOverview: React.FC = () => {
   const { hasPlatinumLicense } = useValues(LicensingLogic);
   const {
-    myRole: { canManageEngines },
+    myRole: { canManageEngines, canManageMetaEngines },
   } = useValues(AppLogic);
 
   const {
@@ -111,7 +111,7 @@ export const EnginesOverview: React.FC = () => {
           title={<h2>{META_ENGINES_TITLE}</h2>}
           titleSize="s"
           action={
-            canManageEngines && (
+            canManageMetaEngines && (
               <EuiButtonTo
                 color="secondary"
                 size="s"

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -120,10 +120,12 @@ export const EnginesOverview: React.FC = () => {
             onChange={handlePageChange(onEnginesPagination)}
           />
         </EuiPageContentBody>
+      </EuiPanel>
 
-        {hasPlatinumLicense && (
-          <>
-            <EuiSpacer size="xxl" />
+      {hasPlatinumLicense && (
+        <>
+          <EuiSpacer size="xxl" />
+          <EuiPanel>
             <EuiPageContentHeader>
               <EuiPageContentHeaderSection>
                 <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
@@ -164,9 +166,9 @@ export const EnginesOverview: React.FC = () => {
                 onChange={handlePageChange(onMetaEnginesPagination)}
               />
             </EuiPageContentBody>
-          </>
-        )}
-      </EuiPanel>
+          </EuiPanel>
+        </>
+      )}
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -76,6 +76,7 @@ export const EnginesOverview: React.FC = () => {
         hasBorder
         iconType={EngineIcon}
         title={<h2>{ENGINES_TITLE}</h2>}
+        titleSize="s"
         action={
           canManageEngines && (
             <EuiButtonTo
@@ -109,6 +110,7 @@ export const EnginesOverview: React.FC = () => {
             hasBorder
             iconType={MetaEngineIcon}
             title={<h2>{META_ENGINES_TITLE}</h2>}
+            titleSize="s"
             action={
               canManageEngines && (
                 <EuiButtonTo

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -9,16 +9,7 @@ import React, { useEffect } from 'react';
 
 import { useValues, useActions } from 'kea';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiPageContentHeader,
-  EuiPageContentHeaderSection,
-  EuiPageContentBody,
-  EuiTitle,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
 
 import { LicensingLogic } from '../../../shared/licensing';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
@@ -26,6 +17,7 @@ import { convertMetaToPagination, handlePageChange } from '../../../shared/table
 import { AppLogic } from '../../app_logic';
 import { EngineIcon, MetaEngineIcon } from '../../icons';
 import { ENGINE_CREATION_PATH, META_ENGINE_CREATION_PATH } from '../../routes';
+import { DataPanel } from '../data_panel';
 import { AppSearchPageTemplate } from '../layout';
 
 import { LaunchAppSearchButton, EmptyState, EmptyMetaEnginesState } from './components';
@@ -80,93 +72,69 @@ export const EnginesOverview: React.FC = () => {
       isEmptyState={!engines.length}
       emptyState={<EmptyState />}
     >
-      <EuiPanel hasBorder>
-        <EuiPageContentHeader>
-          <EuiPageContentHeaderSection>
-            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <EngineIcon />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiTitle size="s">
-                  <h2>{ENGINES_TITLE}</h2>
-                </EuiTitle>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPageContentHeaderSection>
-          <EuiPageContentHeaderSection>
-            {canManageEngines && (
-              <EuiButtonTo
-                color="secondary"
-                size="s"
-                iconType="plusInCircle"
-                data-test-subj="appSearchEnginesEngineCreationButton"
-                to={ENGINE_CREATION_PATH}
-              >
-                {CREATE_AN_ENGINE_BUTTON_LABEL}
-              </EuiButtonTo>
-            )}
-          </EuiPageContentHeaderSection>
-        </EuiPageContentHeader>
-        <EuiPageContentBody data-test-subj="appSearchEngines">
-          <EuiSpacer size="m" />
-          <EnginesTable
-            items={engines}
-            loading={enginesLoading}
-            pagination={{
-              ...convertMetaToPagination(enginesMeta),
-              hidePerPageOptions: true,
-            }}
-            onChange={handlePageChange(onEnginesPagination)}
-          />
-        </EuiPageContentBody>
-      </EuiPanel>
+      <DataPanel
+        hasBorder
+        iconType={EngineIcon}
+        title={<h2>{ENGINES_TITLE}</h2>}
+        action={
+          canManageEngines && (
+            <EuiButtonTo
+              color="secondary"
+              size="s"
+              iconType="plusInCircle"
+              data-test-subj="appSearchEnginesEngineCreationButton"
+              to={ENGINE_CREATION_PATH}
+            >
+              {CREATE_AN_ENGINE_BUTTON_LABEL}
+            </EuiButtonTo>
+          )
+        }
+        data-test-subj="appSearchEngines"
+      >
+        <EnginesTable
+          items={engines}
+          loading={enginesLoading}
+          pagination={{
+            ...convertMetaToPagination(enginesMeta),
+            hidePerPageOptions: true,
+          }}
+          onChange={handlePageChange(onEnginesPagination)}
+        />
+      </DataPanel>
 
       {hasPlatinumLicense && (
         <>
           <EuiSpacer size="xxl" />
-          <EuiPanel>
-            <EuiPageContentHeader>
-              <EuiPageContentHeaderSection>
-                <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                  <EuiFlexItem grow={false}>
-                    <MetaEngineIcon />
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <EuiTitle size="s">
-                      <h2>{META_ENGINES_TITLE}</h2>
-                    </EuiTitle>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiPageContentHeaderSection>
-              <EuiPageContentHeaderSection>
-                {canManageEngines && (
-                  <EuiButtonTo
-                    color="secondary"
-                    size="s"
-                    iconType="plusInCircle"
-                    data-test-subj="appSearchEnginesMetaEngineCreationButton"
-                    to={META_ENGINE_CREATION_PATH}
-                  >
-                    {CREATE_A_META_ENGINE_BUTTON_LABEL}
-                  </EuiButtonTo>
-                )}
-              </EuiPageContentHeaderSection>
-            </EuiPageContentHeader>
-            <EuiPageContentBody data-test-subj="appSearchMetaEngines">
-              <EuiSpacer size="m" />
-              <MetaEnginesTable
-                items={metaEngines}
-                loading={metaEnginesLoading}
-                pagination={{
-                  ...convertMetaToPagination(metaEnginesMeta),
-                  hidePerPageOptions: true,
-                }}
-                noItemsMessage={<EmptyMetaEnginesState />}
-                onChange={handlePageChange(onMetaEnginesPagination)}
-              />
-            </EuiPageContentBody>
-          </EuiPanel>
+          <DataPanel
+            hasBorder
+            iconType={MetaEngineIcon}
+            title={<h2>{META_ENGINES_TITLE}</h2>}
+            action={
+              canManageEngines && (
+                <EuiButtonTo
+                  color="secondary"
+                  size="s"
+                  iconType="plusInCircle"
+                  data-test-subj="appSearchEnginesMetaEngineCreationButton"
+                  to={META_ENGINE_CREATION_PATH}
+                >
+                  {CREATE_A_META_ENGINE_BUTTON_LABEL}
+                </EuiButtonTo>
+              )
+            }
+            data-test-subj="appSearchMetaEngines"
+          >
+            <MetaEnginesTable
+              items={metaEngines}
+              loading={metaEnginesLoading}
+              pagination={{
+                ...convertMetaToPagination(metaEnginesMeta),
+                hidePerPageOptions: true,
+              }}
+              noItemsMessage={<EmptyMetaEnginesState />}
+              onChange={handlePageChange(onMetaEnginesPagination)}
+            />
+          </DataPanel>
         </>
       )}
     </AppSearchPageTemplate>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.test.ts
@@ -10,7 +10,7 @@ import { DEFAULT_INITIAL_APP_DATA } from '../../../../../common/__mocks__';
 import { getRoleAbilities } from './';
 
 describe('getRoleAbilities', () => {
-  const mockRole = DEFAULT_INITIAL_APP_DATA.appSearch.role;
+  const mockRole = DEFAULT_INITIAL_APP_DATA.appSearch.role as any;
 
   it('transforms server role data into a flat role obj with helper shorthands', () => {
     expect(getRoleAbilities(mockRole)).toEqual({
@@ -53,9 +53,10 @@ describe('getRoleAbilities', () => {
 
   describe('can()', () => {
     it('sets view abilities to true if manage abilities are true', () => {
-      const role = { ...mockRole };
-      role.ability.view = [];
-      role.ability.manage = ['account_settings'];
+      const role = {
+        ...mockRole,
+        ability: { view: [], manage: ['account_settings'] },
+      };
 
       const myRole = getRoleAbilities(role);
 
@@ -68,6 +69,28 @@ describe('getRoleAbilities', () => {
 
       expect(myRole.can('hello' as any, 'world')).toEqual(false);
       expect(myRole.can('edit', 'fakeSubject')).toEqual(false);
+    });
+  });
+
+  describe('canManageMetaEngines', () => {
+    const canManageEngines = { ability: { manage: ['account_engines'] } };
+
+    it('returns true when the user can manage any engines and the account has a platinum license', () => {
+      const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines }, true);
+
+      expect(myRole.canManageMetaEngines).toEqual(true);
+    });
+
+    it('returns false when the user can manage any engines but the account does not have a platinum license', () => {
+      const myRole = getRoleAbilities({ ...mockRole, ...canManageEngines }, false);
+
+      expect(myRole.canManageMetaEngines).toEqual(false);
+    });
+
+    it('returns false when has a platinum license but the user cannot manage any engines', () => {
+      const myRole = getRoleAbilities({ ...mockRole, ability: { manage: [] } }, true);
+
+      expect(myRole.canManageMetaEngines).toEqual(false);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/get_role_abilities.ts
@@ -13,7 +13,7 @@ import { RoleTypes, AbilityTypes, Role } from './types';
  * Transforms the `role` data we receive from the Enterprise Search
  * server into a more convenient format for front-end use
  */
-export const getRoleAbilities = (role: Account['role']): Role => {
+export const getRoleAbilities = (role: Account['role'], hasPlatinumLicense = false): Role => {
   // Role ability function helpers
   const myRole = {
     can: (action: AbilityTypes, subject: string): boolean => {
@@ -49,7 +49,7 @@ export const getRoleAbilities = (role: Account['role']): Role => {
     canViewSettings: myRole.can('view', 'account_settings'),
     canViewRoleMappings: myRole.can('view', 'role_mappings'),
     canManageEngines: myRole.can('manage', 'account_engines'),
-    canManageMetaEngines: myRole.can('manage', 'account_meta_engines'),
+    canManageMetaEngines: hasPlatinumLicense && myRole.can('manage', 'account_engines'),
     canManageLogSettings: myRole.can('manage', 'account_log_settings'),
     canManageSettings: myRole.can('manage', 'account_settings'),
     canManageEngineCrawler: myRole.can('manage', 'engine_crawler'),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/constants.ts
@@ -11,10 +11,3 @@ export const LICENSE_CALLOUT_BODY = i18n.translate('xpack.enterpriseSearch.licen
   defaultMessage:
     'Enterprise authentication via SAML, document-level permission and authorization support, custom search experiences and more are available with a valid Platinum license.',
 });
-
-export const LICENSE_CALLOUT_BUTTON = i18n.translate(
-  'xpack.enterpriseSearch.licenseCalloutButton',
-  {
-    defaultMessage: 'Manage your license',
-  }
-);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.test.tsx
@@ -13,7 +13,7 @@ import { shallow } from 'enzyme';
 
 import { EuiPanel, EuiText } from '@elastic/eui';
 
-import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { ManageLicenseButton } from '../../../shared/licensing';
 
 import { LicenseCallout } from './';
 
@@ -27,9 +27,7 @@ describe('LicenseCallout', () => {
 
     expect(wrapper.find(EuiPanel)).toHaveLength(1);
     expect(wrapper.find(EuiText)).toHaveLength(2);
-    expect(wrapper.find(EuiButtonTo).prop('to')).toEqual(
-      '/app/management/stack/license_management'
-    );
+    expect(wrapper.find(ManageLicenseButton)).toHaveLength(1);
   });
 
   it('does not render for platinum', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/license_callout/license_callout.tsx
@@ -11,12 +11,11 @@ import { useValues } from 'kea';
 
 import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 
-import { LicensingLogic } from '../../../shared/licensing';
-import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { LicensingLogic, ManageLicenseButton } from '../../../shared/licensing';
 
 import { PRODUCT_SELECTOR_CALLOUT_HEADING } from '../../constants';
 
-import { LICENSE_CALLOUT_BODY, LICENSE_CALLOUT_BUTTON } from './constants';
+import { LICENSE_CALLOUT_BODY } from './constants';
 
 export const LicenseCallout: React.FC = () => {
   const { hasPlatinumLicense, isTrial } = useValues(LicensingLogic);
@@ -34,9 +33,7 @@ export const LicenseCallout: React.FC = () => {
         </EuiFlexItem>
         <EuiFlexItem grow={1} />
         <EuiFlexItem grow={false}>
-          <EuiButtonTo to="/app/management/stack/license_management" shouldNotCreateHref>
-            {LICENSE_CALLOUT_BUTTON}
-          </EuiButtonTo>
+          <ManageLicenseButton />
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -57,6 +57,7 @@ export const renderApp = (
   });
   const unmountLicensingLogic = mountLicensingLogic({
     license$: plugins.licensing.license$,
+    canManageLicense: core.application.capabilities.management?.stack?.license_management,
   });
   const unmountHttpLogic = mountHttpLogic({
     http: core.http,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { LicensingLogic, mountLicensingLogic } from './licensing_logic';
+export { ManageLicenseButton } from './manage_license_button';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.test.ts
@@ -15,11 +15,19 @@ import { LicensingLogic, mountLicensingLogic } from './licensing_logic';
 describe('LicensingLogic', () => {
   const mockLicense = licensingMock.createLicense();
   const mockLicense$ = new BehaviorSubject(mockLicense);
-  const mount = () => mountLicensingLogic({ license$: mockLicense$ });
+  const mount = (props?: object) =>
+    mountLicensingLogic({ license$: mockLicense$, canManageLicense: true, ...props });
 
   beforeEach(() => {
     jest.clearAllMocks();
     resetContext({});
+  });
+
+  describe('canManageLicense', () => {
+    it('sets value from props', () => {
+      mount({ canManageLicense: false });
+      expect(LicensingLogic.values.canManageLicense).toEqual(false);
+    });
   });
 
   describe('setLicense()', () => {
@@ -61,7 +69,7 @@ describe('LicensingLogic', () => {
     describe('on unmount', () => {
       it('unsubscribes to the license observable', () => {
         const mockUnsubscribe = jest.fn();
-        const unmount = mountLicensingLogic({
+        const unmount = mount({
           license$: { subscribe: () => ({ unsubscribe: mockUnsubscribe }) } as any,
         });
         unmount();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/licensing_logic.ts
@@ -16,6 +16,7 @@ interface LicensingValues {
   hasPlatinumLicense: boolean;
   hasGoldLicense: boolean;
   isTrial: boolean;
+  canManageLicense: boolean;
 }
 interface LicensingActions {
   setLicense(license: ILicense): ILicense;
@@ -28,7 +29,7 @@ export const LicensingLogic = kea<MakeLogicType<LicensingValues, LicensingAction
     setLicense: (license) => license,
     setLicenseSubscription: (licenseSubscription) => licenseSubscription,
   },
-  reducers: {
+  reducers: ({ props }) => ({
     license: [
       null,
       {
@@ -41,7 +42,8 @@ export const LicensingLogic = kea<MakeLogicType<LicensingValues, LicensingAction
         setLicenseSubscription: (_, licenseSubscription) => licenseSubscription,
       },
     ],
-  },
+    canManageLicense: [props.canManageLicense || false, {}],
+  }),
   selectors: {
     hasPlatinumLicense: [
       (selectors) => [selectors.license],
@@ -80,6 +82,7 @@ export const LicensingLogic = kea<MakeLogicType<LicensingValues, LicensingAction
  */
 interface LicensingLogicProps {
   license$: Observable<ILicense>;
+  canManageLicense: boolean;
 }
 export const mountLicensingLogic = (props: LicensingLogicProps) => {
   LicensingLogic(props);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/manage_license_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/manage_license_button.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiButton } from '@elastic/eui';
+
+import { EuiButtonTo } from '../react_router_helpers';
+
+import { ManageLicenseButton } from './';
+
+describe('ManageLicenseButton', () => {
+  describe('when the user can access license management', () => {
+    it('renders a SPA link to the license management plugin', () => {
+      setMockValues({ canManageLicense: true });
+      const wrapper = shallow(<ManageLicenseButton />);
+
+      expect(wrapper.find(EuiButtonTo).prop('to')).toEqual(
+        '/app/management/stack/license_management'
+      );
+    });
+  });
+
+  describe('when the user cannot access license management', () => {
+    it('renders an external link to our license management documentation', () => {
+      setMockValues({ canManageLicense: false });
+      const wrapper = shallow(<ManageLicenseButton />);
+
+      expect(wrapper.find(EuiButton).prop('href')).toEqual(
+        expect.stringContaining('/license-management.html')
+      );
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/manage_license_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/manage_license_button.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiButton, EuiButtonProps } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { docLinks } from '../doc_links';
+import { EuiButtonTo } from '../react_router_helpers';
+
+import { LicensingLogic } from './licensing_logic';
+
+export const ManageLicenseButton: React.FC<EuiButtonProps> = (props) => {
+  const { canManageLicense } = useValues(LicensingLogic);
+
+  return canManageLicense ? (
+    <EuiButtonTo {...props} to="/app/management/stack/license_management" shouldNotCreateHref>
+      {i18n.translate('xpack.enterpriseSearch.licenseManagementLink', {
+        defaultMessage: 'Manage your license',
+      })}
+    </EuiButtonTo>
+  ) : (
+    <EuiButton
+      {...props}
+      target="_blank"
+      iconType="popout"
+      href={`${docLinks.enterpriseSearchBase}/license-management.html`}
+    >
+      {i18n.translate('xpack.enterpriseSearch.licenseDocumentationLink', {
+        defaultMessage: 'Learn more about license features',
+      })}
+    </EuiButton>
+  );
+};


### PR DESCRIPTION
## Summary

This PR contains several disparate enhancements to the Engines Overview view. I strongly recommend following along by commit.

### Panel cleanup (749b9ea, 62653fb 48c6c49):

- Converts the Engines section and Meta Engines sections into separate panels, per @daveyholler's feedback a few days ago
- DRY's out the various manual EUI flex groups etc to reuse the `<DataPanel />` component Davey created a while back
- Updates the DataPanel to accept a custom title size + other small typography tweaks

<img width="1242" alt="" src="https://user-images.githubusercontent.com/549407/122802455-3ad7db00-d27a-11eb-8350-5a1fa8cf62c0.png">

### Meta engine license callout (f25efb8, 3bc90b3, 27eadce, f90c3e8)

- Creates a "Manage license" button/link that intelligently falls back to a documentation link if the user does not have permission to manage licenses (+ updates Enterprise Search Overview/home to use said button)
- Adds a new Meta Engine license upgrade CTA, that is always visible if the account does not have a platinum license
- Tweaks our `canManageMetaEngines` capability to include a `hasPlatinumLicense` check instead of relying on the data coming in from the ent-search server, which does not update dynamically

<img width="1330" alt="" src="https://user-images.githubusercontent.com/549407/122802673-7a062c00-d27a-11eb-8146-3bb4324b07b8.png">

**Screencap of CTA + dynamic license behavior:**

![meta_engines_cta](https://user-images.githubusercontent.com/549407/122802079-cd2baf00-d279-11eb-8590-896c33310ef5.gif)

**Dynamic license behavior correctly working on routes:**

![create_meta_engine](https://user-images.githubusercontent.com/549407/122802135-da489e00-d279-11eb-98a0-76f8c07737f2.gif)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)