### PR TITLE
[Agent Packages] Extend 'contains' helper to work on strings

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -131,6 +131,13 @@ password: {{password}}
 hidden_password: {{password}}
 {{/if}}
       `;
+    const streamTemplateWithString = `
+{{#if (contains ".pcap" file)}}
+pcap: true
+{{else}}
+pcap: false
+{{/if}}
+      `;
 
     it('should support when a value is not contained in the array', () => {
       const vars = {
@@ -166,6 +173,28 @@ hidden_password: {{password}}
         processors: [{ add_locale: null }],
         password: '',
         tags: ['foo', 'bar'],
+      });
+    });
+
+    it('should support strings', () => {
+      const vars = {
+        file: { value: 'foo.pcap' },
+      };
+
+      const output = compileTemplate(vars, streamTemplateWithString);
+      expect(output).toEqual({
+        pcap: true,
+      });
+    });
+
+    it('should support strings with no match', () => {
+      const vars = {
+        file: { value: 'file' },
+      };
+
+      const output = compileTemplate(vars, streamTemplateWithString);
+      expect(output).toEqual({
+        pcap: false,
       });
     });
   });

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -9,7 +9,6 @@ import Handlebars from 'handlebars';
 import { safeLoad, safeDump } from 'js-yaml';
 
 import type { PackagePolicyConfigRecord } from '../../../../common';
-import { value } from '../../../../../../../packages/kbn-securitysolution-io-ts-list-types/src/common/value/index';
 
 const handlebars = Handlebars.create();
 

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -9,6 +9,7 @@ import Handlebars from 'handlebars';
 import { safeLoad, safeDump } from 'js-yaml';
 
 import type { PackagePolicyConfigRecord } from '../../../../common';
+import { value } from '../../../../../../../packages/kbn-securitysolution-io-ts-list-types/src/common/value/index';
 
 const handlebars = Handlebars.create();
 
@@ -111,11 +112,12 @@ function buildTemplateVariables(variables: PackagePolicyConfigRecord, templateSt
   return { vars, yamlValues };
 }
 
-function containsHelper(this: any, item: string, list: string[], options: any) {
-  if (Array.isArray(list) && list.includes(item)) {
+function containsHelper(this: any, item: string, check: string | string[], options: any) {
+  if ((Array.isArray(check) || typeof check === 'string') && check.includes(item)) {
     if (options && options.fn) {
       return options.fn(this);
     }
+    return true;
   }
   return '';
 }


### PR DESCRIPTION
## Summary

This adds string support to the Handlebars `contains` helper I added awhile back, it also adds a slight amount of logic so that the helper can be used in conditional statements. This will clean up some logic I'm intending to use in some Packetbeat integration packages that are in flight.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios