### PR TITLE
[App Search] Convert Documents views to new page template + minor UI polish

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/components/empty_state.tsx
@@ -7,43 +7,41 @@
 
 import React from 'react';
 
-import { EuiButton, EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
+import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { DOCS_PREFIX } from '../../../routes';
 
 export const EmptyState = () => (
-  <EuiPanel color="subdued" grow={false}>
-    <EuiEmptyPrompt
-      data-test-subj="EmptyDocumentPrompt"
-      iconType="documents"
-      title={
-        <h2>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.documents.empty.title', {
-            defaultMessage: 'Add your first documents',
-          })}
-        </h2>
-      }
-      body={
-        <p>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.documents.empty.description', {
-            defaultMessage:
-              'You can index documents using the App Search Web Crawler, by uploading JSON, or by using the API.',
-          })}
-        </p>
-      }
-      actions={
-        <EuiButton
-          size="s"
-          target="_blank"
-          iconType="popout"
-          href={`${DOCS_PREFIX}/indexing-documents-guide.html`}
-        >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.documents.empty.buttonLabel', {
-            defaultMessage: 'Read the documents guide',
-          })}
-        </EuiButton>
-      }
-    />
-  </EuiPanel>
+  <EuiEmptyPrompt
+    data-test-subj="EmptyDocumentPrompt"
+    iconType="documents"
+    title={
+      <h2>
+        {i18n.translate('xpack.enterpriseSearch.appSearch.documents.empty.title', {
+          defaultMessage: 'Add your first documents',
+        })}
+      </h2>
+    }
+    body={
+      <p>
+        {i18n.translate('xpack.enterpriseSearch.appSearch.documents.empty.description', {
+          defaultMessage:
+            'You can index documents using the App Search Web Crawler, by uploading JSON, or by using the API.',
+        })}
+      </p>
+    }
+    actions={
+      <EuiButton
+        size="s"
+        target="_blank"
+        iconType="popout"
+        href={`${DOCS_PREFIX}/indexing-documents-guide.html`}
+      >
+        {i18n.translate('xpack.enterpriseSearch.appSearch.engine.documents.empty.buttonLabel', {
+          defaultMessage: 'Read the documents guide',
+        })}
+      </EuiButton>
+    }
+  />
 );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.test.tsx
@@ -14,9 +14,10 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiPageHeader, EuiPageContent, EuiBasicTable } from '@elastic/eui';
+import { EuiPanel, EuiBasicTable } from '@elastic/eui';
 
-import { Loading } from '../../../shared/loading';
+import { getPageHeaderActions } from '../../../test_helpers';
+
 import { ResultFieldValue } from '../result';
 
 import { DocumentDetail } from '.';
@@ -45,7 +46,7 @@ describe('DocumentDetail', () => {
 
   it('renders', () => {
     const wrapper = shallow(<DocumentDetail />);
-    expect(wrapper.find(EuiPageContent).length).toBe(1);
+    expect(wrapper.find(EuiPanel).length).toBe(1);
   });
 
   it('initializes data on mount', () => {
@@ -57,17 +58,6 @@ describe('DocumentDetail', () => {
     shallow(<DocumentDetail />);
     unmountHandler();
     expect(actions.setFields).toHaveBeenCalledWith([]);
-  });
-
-  it('will show a loader while data is loading', () => {
-    setMockValues({
-      ...values,
-      dataLoading: true,
-    });
-
-    const wrapper = shallow(<DocumentDetail />);
-
-    expect(wrapper.find(Loading).length).toBe(1);
   });
 
   describe('field values list', () => {
@@ -102,8 +92,7 @@ describe('DocumentDetail', () => {
 
   it('will delete the document when the delete button is pressed', () => {
     const wrapper = shallow(<DocumentDetail />);
-    const header = wrapper.find(EuiPageHeader).dive().children().dive();
-    const button = header.find('[data-test-subj="DeleteDocumentButton"]');
+    const button = getPageHeaderActions(wrapper).find('[data-test-subj="DeleteDocumentButton"]');
 
     button.simulate('click');
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.tsx
@@ -10,22 +10,13 @@ import { useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 
-import {
-  EuiButton,
-  EuiPageHeader,
-  EuiPageContentBody,
-  EuiPageContent,
-  EuiBasicTable,
-  EuiBasicTableColumn,
-} from '@elastic/eui';
+import { EuiPanel, EuiButton, EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { DELETE_BUTTON_LABEL } from '../../../shared/constants';
-import { FlashMessages } from '../../../shared/flash_messages';
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { Loading } from '../../../shared/loading';
 import { useDecodedParams } from '../../utils/encode_path_params';
 import { getEngineBreadcrumbs } from '../engine';
+import { AppSearchPageTemplate } from '../layout';
 import { ResultFieldValue } from '../result';
 
 import { DOCUMENTS_TITLE } from './constants';
@@ -52,10 +43,6 @@ export const DocumentDetail: React.FC = () => {
     };
   }, []);
 
-  if (dataLoading) {
-    return <Loading />;
-  }
-
   const columns: Array<EuiBasicTableColumn<FieldDetails>> = [
     {
       name: i18n.translate('xpack.enterpriseSearch.appSearch.documentDetail.fieldHeader', {
@@ -74,11 +61,11 @@ export const DocumentDetail: React.FC = () => {
   ];
 
   return (
-    <>
-      <SetPageChrome trail={getEngineBreadcrumbs([DOCUMENTS_TITLE, documentTitle])} />
-      <EuiPageHeader
-        pageTitle={DOCUMENT_DETAIL_TITLE(documentTitle)}
-        rightSideItems={[
+    <AppSearchPageTemplate
+      pageChrome={getEngineBreadcrumbs([DOCUMENTS_TITLE, documentTitle])}
+      pageHeader={{
+        pageTitle: DOCUMENT_DETAIL_TITLE(documentTitle),
+        rightSideItems: [
           <EuiButton
             color="danger"
             iconType="trash"
@@ -87,14 +74,13 @@ export const DocumentDetail: React.FC = () => {
           >
             {DELETE_BUTTON_LABEL}
           </EuiButton>,
-        ]}
-      />
-      <EuiPageContent hasBorder>
-        <EuiPageContentBody>
-          <FlashMessages />
-          <EuiBasicTable columns={columns} items={fields} />
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </>
+        ],
+      }}
+      isLoading={dataLoading}
+    >
+      <EuiPanel hasBorder>
+        <EuiBasicTable columns={columns} items={fields} />
+      </EuiPanel>
+    </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
@@ -10,9 +10,9 @@ import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
-import { EuiPageHeader } from '@elastic/eui';
+import { getPageHeaderActions } from '../../../test_helpers';
 
 import { DocumentCreationButton } from './components';
 import { SearchExperience } from './search_experience';
@@ -36,9 +36,6 @@ describe('Documents', () => {
   });
 
   describe('DocumentCreationButton', () => {
-    const getHeader = (wrapper: ShallowWrapper) =>
-      wrapper.find(EuiPageHeader).dive().children().dive();
-
     it('renders a DocumentCreationButton if the user can manage engine documents', () => {
       setMockValues({
         ...values,
@@ -46,7 +43,7 @@ describe('Documents', () => {
       });
 
       const wrapper = shallow(<Documents />);
-      expect(getHeader(wrapper).find(DocumentCreationButton).exists()).toBe(true);
+      expect(getPageHeaderActions(wrapper).find(DocumentCreationButton).exists()).toBe(true);
     });
 
     it('does not render a DocumentCreationButton if the user cannot manage engine documents', () => {
@@ -56,7 +53,7 @@ describe('Documents', () => {
       });
 
       const wrapper = shallow(<Documents />);
-      expect(getHeader(wrapper).find(DocumentCreationButton).exists()).toBe(false);
+      expect(getPageHeaderActions(wrapper).find(DocumentCreationButton).exists()).toBe(false);
     });
 
     it('does not render a DocumentCreationButton for meta engines even if the user can manage engine documents', () => {
@@ -67,7 +64,7 @@ describe('Documents', () => {
       });
 
       const wrapper = shallow(<Documents />);
-      expect(getHeader(wrapper).find(DocumentCreationButton).exists()).toBe(false);
+      expect(getPageHeaderActions(wrapper).find(DocumentCreationButton).exists()).toBe(false);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
@@ -22,6 +22,7 @@ import { Documents } from '.';
 describe('Documents', () => {
   const values = {
     isMetaEngine: false,
+    engine: { document_count: 1 },
     myRole: { canManageEngineDocuments: true },
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
@@ -9,14 +9,12 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiPageHeader, EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-
-import { FlashMessages } from '../../../shared/flash_messages';
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 
 import { AppLogic } from '../../app_logic';
 import { EngineLogic, getEngineBreadcrumbs } from '../engine';
+import { AppSearchPageTemplate } from '../layout';
 
 import { DocumentCreationButton } from './components';
 import { DOCUMENTS_TITLE } from './constants';
@@ -27,17 +25,14 @@ export const Documents: React.FC = () => {
   const { myRole } = useValues(AppLogic);
 
   return (
-    <>
-      <SetPageChrome trail={getEngineBreadcrumbs([DOCUMENTS_TITLE])} />
-      <EuiPageHeader
-        pageTitle={DOCUMENTS_TITLE}
-        rightSideItems={
-          myRole.canManageEngineDocuments && !isMetaEngine
-            ? [<DocumentCreationButton />]
-            : undefined
-        }
-      />
-      <FlashMessages />
+    <AppSearchPageTemplate
+      pageChrome={getEngineBreadcrumbs([DOCUMENTS_TITLE])}
+      pageHeader={{
+        pageTitle: DOCUMENTS_TITLE,
+        rightSideItems:
+          myRole.canManageEngineDocuments && !isMetaEngine ? [<DocumentCreationButton />] : [],
+      }}
+    >
       {isMetaEngine && (
         <>
           <EuiCallOut
@@ -61,6 +56,6 @@ export const Documents: React.FC = () => {
         </>
       )}
       <SearchExperience />
-    </>
+    </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
@@ -16,12 +16,12 @@ import { AppLogic } from '../../app_logic';
 import { EngineLogic, getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
-import { DocumentCreationButton } from './components';
+import { DocumentCreationButton, EmptyState } from './components';
 import { DOCUMENTS_TITLE } from './constants';
 import { SearchExperience } from './search_experience';
 
 export const Documents: React.FC = () => {
-  const { isMetaEngine } = useValues(EngineLogic);
+  const { isMetaEngine, engine } = useValues(EngineLogic);
   const { myRole } = useValues(AppLogic);
 
   return (
@@ -32,6 +32,8 @@ export const Documents: React.FC = () => {
         rightSideItems:
           myRole.canManageEngineDocuments && !isMetaEngine ? [<DocumentCreationButton />] : [],
       }}
+      isEmptyState={!engine.document_count}
+      emptyState={<EmptyState />}
     >
       {isMetaEngine && (
         <>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.scss
@@ -15,6 +15,7 @@
 
   .documentsSearchExperience__content {
     flex-grow: 4;
+    position: relative;
   }
 
   .documentsSearchExperience__pagingInfo {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.test.tsx
@@ -20,8 +20,6 @@ jest.mock('../../../../shared/use_local_storage', () => ({
 }));
 import { useLocalStorage } from '../../../../shared/use_local_storage';
 
-import { EmptyState } from '../components';
-
 import { CustomizationCallout } from './customization_callout';
 import { CustomizationModal } from './customization_modal';
 import { SearchExperienceContent } from './search_experience_content';
@@ -56,14 +54,6 @@ describe('SearchExperience', () => {
 
     expect(wrapper.find(SearchProvider)).toHaveLength(1);
     expect(wrapper.find(SearchExperienceContent)).toHaveLength(1);
-  });
-
-  it('renders an empty state when the engine does not have documents', () => {
-    setMockValues({ ...values, engine: { ...values.engine, document_count: 0 } });
-    const wrapper = shallow(<SearchExperience />);
-
-    expect(wrapper.find(EmptyState)).toHaveLength(1);
-    expect(wrapper.find(SearchExperienceContent)).toHaveLength(0);
   });
 
   describe('when there are no selected filter fields', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
@@ -21,7 +21,6 @@ import './search_experience.scss';
 import { externalUrl } from '../../../../shared/enterprise_search_url';
 import { useLocalStorage } from '../../../../shared/use_local_storage';
 import { EngineLogic } from '../../engine';
-import { EmptyState } from '../components';
 
 import { buildSearchUIConfig } from './build_search_ui_config';
 import { buildSortOptions } from './build_sort_options';
@@ -141,11 +140,7 @@ export const SearchExperience: React.FC = () => {
             )}
           </EuiFlexItem>
           <EuiFlexItem className="documentsSearchExperience__content">
-            {engine.document_count && engine.document_count > 0 ? (
-              <SearchExperienceContent />
-            ) : (
-              <EmptyState />
-            )}
+            <SearchExperienceContent />
           </EuiFlexItem>
         </EuiFlexGroup>
       </SearchProvider>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.test.tsx
@@ -15,6 +15,7 @@ import { shallow } from 'enzyme';
 // @ts-expect-error types are not available for this package yet
 import { Results } from '@elastic/react-search-ui';
 
+import { Loading } from '../../../../shared/loading';
 import { SchemaType } from '../../../../shared/schema/types';
 
 import { Pagination } from './pagination';
@@ -82,13 +83,13 @@ describe('SearchExperienceContent', () => {
     expect(wrapper.find(Pagination).exists()).toBe(true);
   });
 
-  it('renders empty if a search was not performed yet', () => {
+  it('renders a loading state if a search was not performed yet', () => {
     setMockSearchContextState({
       ...searchState,
       wasSearched: false,
     });
     const wrapper = shallow(<SearchExperienceContent />);
-    expect(wrapper.isEmptyRender()).toBe(true);
+    expect(wrapper.find(Loading)).toHaveLength(1);
   });
 
   it('renders results if a search was performed and there are more than 0 totalResults', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.tsx
@@ -14,6 +14,7 @@ import { EuiFlexGroup, EuiSpacer, EuiEmptyPrompt } from '@elastic/eui';
 import { Results, Paging, ResultsPerPage } from '@elastic/react-search-ui';
 import { i18n } from '@kbn/i18n';
 
+import { Loading } from '../../../../shared/loading';
 import { EngineLogic } from '../../engine';
 import { Result } from '../../result/types';
 
@@ -26,7 +27,7 @@ export const SearchExperienceContent: React.FC = () => {
 
   const { isMetaEngine, engine } = useValues(EngineLogic);
 
-  if (!wasSearched) return null;
+  if (!wasSearched) return <Loading />;
 
   if (totalResults) {
     return (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -94,21 +94,21 @@ export const EngineRouter: React.FC = () => {
       <Route exact path={ENGINE_PATH}>
         <EngineOverview />
       </Route>
+      {canViewEngineDocuments && (
+        <Route path={ENGINE_DOCUMENT_DETAIL_PATH}>
+          <DocumentDetail />
+        </Route>
+      )}
+      {canViewEngineDocuments && (
+        <Route path={ENGINE_DOCUMENTS_PATH}>
+          <Documents />
+        </Route>
+      )}
       {/* TODO: Remove layout once page template migration is over */}
       <Layout navigation={<AppSearchNav />}>
         {canViewEngineAnalytics && (
           <Route path={ENGINE_ANALYTICS_PATH}>
             <AnalyticsRouter />
-          </Route>
-        )}
-        {canViewEngineDocuments && (
-          <Route path={ENGINE_DOCUMENT_DETAIL_PATH}>
-            <DocumentDetail />
-          </Route>
-        )}
-        {canViewEngineDocuments && (
-          <Route path={ENGINE_DOCUMENTS_PATH}>
-            <Documents />
           </Route>
         )}
         {canViewEngineSchema && (


### PR DESCRIPTION
## Summary

Follow up to #102170 - converts more App Search pages to the new KibanaPageTemplate. I'm attempting to break up the AS layout conversion into smaller, easier to review chunks.

This PR handles the Documents view, and additionally handles some UI polish in the form of moving the empty state top level (approved by Davey), and adding a loading indicator on initial page load. As always, follow along by commit (and turn off whitespace diffs)!

## Screencaps

New empty state:

<img width="1301" alt="" src="https://user-images.githubusercontent.com/549407/122816092-25b77800-d28b-11eb-9ad3-45349d00175a.png">

Walkthrough screencap + loading state:

![documents](https://user-images.githubusercontent.com/549407/122816224-4da6db80-d28b-11eb-9579-a5c7bc305c8e.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)