### PR TITLE
[Lens] Disable missing switch for non-string fields

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -513,7 +513,10 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
                   defaultMessage: 'Include documents without this field',
                 })}
                 compressed
-                disabled={!currentColumn.params.otherBucket}
+                disabled={
+                  !currentColumn.params.otherBucket ||
+                  indexPattern.getFieldByName(currentColumn.sourceField)?.type !== 'string'
+                }
                 data-test-subj="indexPattern-terms-missing-bucket"
                 checked={Boolean(currentColumn.params.missingBucket)}
                 onChange={(e: EuiSwitchEvent) =>

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -60,7 +60,7 @@ describe('terms', () => {
             size: 3,
             orderDirection: 'asc',
           },
-          sourceField: 'category',
+          sourceField: 'source',
         },
         col2: {
           label: 'Count',
@@ -88,7 +88,7 @@ describe('terms', () => {
         expect.objectContaining({
           arguments: expect.objectContaining({
             orderBy: ['_key'],
-            field: ['category'],
+            field: ['source'],
             size: [3],
             otherBucket: [true],
           }),
@@ -768,6 +768,34 @@ describe('terms', () => {
         .find(EuiSwitch);
 
       expect(select.prop('disabled')).toEqual(false);
+    });
+
+    it('should disable missing bucket setting if field is not a string', () => {
+      const updateLayerSpy = jest.fn();
+      const instance = shallow(
+        <InlineOptions
+          {...defaultProps}
+          layer={layer}
+          updateLayer={updateLayerSpy}
+          columnId="col1"
+          currentColumn={
+            {
+              ...layer.columns.col1,
+              sourceField: 'bytes',
+              params: {
+                ...layer.columns.col1.params,
+                otherBucket: true,
+              },
+            } as TermsIndexPatternColumn
+          }
+        />
+      );
+
+      const select = instance
+        .find('[data-test-subj="indexPattern-terms-missing-bucket"]')
+        .find(EuiSwitch);
+
+      expect(select.prop('disabled')).toEqual(true);
     });
 
     it('should update state when clicking other bucket toggle', () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/102640

Missing bucket is only supported for string field. This PR makes sure this is correctly reflected in the Lens UI.