### PR TITLE
[ML] Functional tests - explicitly delete jobs after setupModule tests

### DIFF
--- a/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
@@ -1048,6 +1048,9 @@ export default ({ getService }: FtrProviderContext) => {
           for (const dashboard of testData.expected.dashboards) {
             await ml.testResources.deleteDashboardById(dashboard);
           }
+          for (const job of testData.expected.jobs) {
+            await ml.api.deleteAnomalyDetectionJobES(job.jobId);
+          }
           await ml.api.cleanMlIndices();
         });
 


### PR DESCRIPTION
## Summary

This PR explicitly deletes the jobs created by the `setupModule` tests.

### Details

There were cases where the `setupModule` tests timed out while waiting for a created job to finish. In some of those cases the `cleanMlIndices` failed in the suite's `after` method, causing follow-up issues. With this PR we make sure that the jobs (and corresponding datafeeds) are force-deleted via the ES-API, so nothing is left behind after cleanup phase of the suite.
