### PR TITLE
[Lens] Remove rank direction tooltip

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -424,25 +424,9 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
           />
         </EuiFormRow>
         <EuiFormRow
-          label={
-            <>
-              {i18n.translate('xpack.lens.indexPattern.terms.orderDirection', {
-                defaultMessage: 'Rank direction',
-              })}{' '}
-              <EuiIconTip
-                color="subdued"
-                content={i18n.translate('xpack.lens.indexPattern.terms.orderDirectionHelp', {
-                  defaultMessage: `Specifies the ranking order of the top values.`,
-                })}
-                iconProps={{
-                  className: 'eui-alignTop',
-                }}
-                position="top"
-                size="s"
-                type="questionInCircle"
-              />
-            </>
-          }
+          label={i18n.translate('xpack.lens.indexPattern.terms.orderDirection', {
+            defaultMessage: 'Rank direction',
+          })}
           display="columnCompressed"
           fullWidth
         >

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -12756,7 +12756,6 @@
     "xpack.lens.indexPattern.terms.orderByHelp": "上位の値がランク付けされる条件となるディメンションを指定します。",
     "xpack.lens.indexPattern.terms.orderDescending": "降順",
     "xpack.lens.indexPattern.terms.orderDirection": "ランク方向",
-    "xpack.lens.indexPattern.terms.orderDirectionHelp": "上位の値のランク順序を指定します。",
     "xpack.lens.indexPattern.terms.otherBucketDescription": "他の値を「その他」としてグループ化",
     "xpack.lens.indexPattern.terms.otherLabel": "その他",
     "xpack.lens.indexPattern.terms.size": "値の数",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -12927,7 +12927,6 @@
     "xpack.lens.indexPattern.terms.orderByHelp": "指定排名靠前值排名所依据的维度。",
     "xpack.lens.indexPattern.terms.orderDescending": "降序",
     "xpack.lens.indexPattern.terms.orderDirection": "排名方向",
-    "xpack.lens.indexPattern.terms.orderDirectionHelp": "指定排名靠前值的排名顺序。",
     "xpack.lens.indexPattern.terms.otherBucketDescription": "将其他值分组为“其他”",
     "xpack.lens.indexPattern.terms.otherLabel": "其他",
     "xpack.lens.indexPattern.terms.size": "值数目",


### PR DESCRIPTION
## Summary

Fixes #92941

Remove redondant tooltip

<img width="342" alt="Screenshot 2021-06-22 at 12 45 38" src="https://user-images.githubusercontent.com/924948/122911757-e99e1900-d357-11eb-9a09-8f1ec34f1760.png">
