### PR TITLE
[Lens] Update dimension panel copy to suggested one

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/dimension_container.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/dimension_container.tsx
@@ -113,7 +113,7 @@ export function DimensionContainer({
                     >
                       <strong>
                         {i18n.translate('xpack.lens.configure.configurePanelTitle', {
-                          defaultMessage: '{groupLabel} configuration',
+                          defaultMessage: '{groupLabel}',
                           values: {
                             groupLabel,
                           },

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -746,7 +746,7 @@ function getErrorMessage(
   if (selectedColumn && incompleteOperation) {
     if (input === 'field') {
       return i18n.translate('xpack.lens.indexPattern.invalidOperationLabel', {
-        defaultMessage: 'To use this function, select a different field.',
+        defaultMessage: 'This field does not work with the selected function.',
       });
     }
     return i18n.translate('xpack.lens.indexPattern.chooseFieldLabel', {


### PR DESCRIPTION
## Summary

Fixes #78814

* Dimension panel title has no longer `configuration` in it (does it still need i18n?)
* Rewritten wrong field error message

<img width="335" alt="Screenshot 2021-06-22 at 12 54 22" src="https://user-images.githubusercontent.com/924948/122913206-75fd0b80-d359-11eb-9194-1a2d3bd29026.png">
<img width="350" alt="Screenshot 2021-06-22 at 12 52 52" src="https://user-images.githubusercontent.com/924948/122913216-77c6cf00-d359-11eb-8e8b-f529133960d2.png">

