### PR TITLE
[APM] Fix bug when error page is empty

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.stories.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { ComponentType } from 'react';
+import { KibanaContextProvider } from '../../../../../../../../src/plugins/kibana_react/public';
+import {
+  ApmPluginContext,
+  ApmPluginContextValue,
+} from '../../../../context/apm_plugin/apm_plugin_context';
+import { EuiThemeProvider } from '../../../../../../../../src/plugins/kibana_react/common';
+import { ErrorDistribution } from './';
+
+export default {
+  title: 'app/ErrorGroupDetails/Distribution',
+  component: ErrorDistribution,
+  decorators: [
+    (Story: ComponentType) => {
+      const apmPluginContextMock = ({
+        observabilityRuleTypeRegistry: { getFormatter: () => undefined },
+      } as unknown) as ApmPluginContextValue;
+
+      const kibanaContextServices = {
+        uiSettings: { get: () => {} },
+      };
+
+      return (
+        <EuiThemeProvider>
+          <ApmPluginContext.Provider value={apmPluginContextMock}>
+            <KibanaContextProvider services={kibanaContextServices}>
+              <Story />
+            </KibanaContextProvider>
+          </ApmPluginContext.Provider>
+        </EuiThemeProvider>
+      );
+    },
+  ],
+};
+
+export function Example() {
+  const distribution = {
+    noHits: false,
+    bucketSize: 62350,
+    buckets: [
+      { key: 1624279912350, count: 6 },
+      { key: 1624279974700, count: 1 },
+      { key: 1624280037050, count: 2 },
+      { key: 1624280099400, count: 3 },
+      { key: 1624280161750, count: 13 },
+      { key: 1624280224100, count: 1 },
+      { key: 1624280286450, count: 2 },
+      { key: 1624280348800, count: 0 },
+      { key: 1624280411150, count: 4 },
+      { key: 1624280473500, count: 4 },
+      { key: 1624280535850, count: 1 },
+      { key: 1624280598200, count: 4 },
+      { key: 1624280660550, count: 0 },
+      { key: 1624280722900, count: 2 },
+      { key: 1624280785250, count: 3 },
+      { key: 1624280847600, count: 0 },
+    ],
+  };
+
+  return <ErrorDistribution distribution={distribution} title="Foo title" />;
+}
+
+export function EmptyState() {
+  return (
+    <ErrorDistribution
+      distribution={{
+        bucketSize: 10,
+        buckets: [],
+        noHits: true,
+      }}
+      title="Foo title"
+    />
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
@@ -67,6 +67,7 @@ export function ErrorDistribution({ distribution, title }: Props) {
 
   const xFormatter = niceTimeFormatter([xMin, xMax]);
   const { observabilityRuleTypeRegistry } = useApmPluginContext();
+
   const { alerts } = useApmServiceContext();
   const { getFormatter } = observabilityRuleTypeRegistry;
   const [selectedAlertId, setSelectedAlertId] = useState<string | undefined>(
@@ -84,7 +85,7 @@ export function ErrorDistribution({ distribution, title }: Props) {
   };
 
   return (
-    <div>
+    <>
       <EuiTitle size="xs">
         <span>{title}</span>
       </EuiTitle>
@@ -124,7 +125,7 @@ export function ErrorDistribution({ distribution, title }: Props) {
             alerts: alerts?.filter(
               (alert) => alert[RULE_ID]?.[0] === AlertType.ErrorCount
             ),
-            chartStartTime: buckets[0].x0,
+            chartStartTime: buckets[0]?.x0,
             getFormatter,
             selectedAlertId,
             setSelectedAlertId,
@@ -143,6 +144,6 @@ export function ErrorDistribution({ distribution, title }: Props) {
           </Suspense>
         </Chart>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #102737 
Regression introduced in: https://github.com/elastic/kibana/pull/101106/files#diff-640cf1c640580b5a2cf2ffc2ea5cbbd93cbdaf07d0f387db92648b38873d712dR123

Fixed null-pointer exception bug and added storybook for component. My intention is to add a unit test to the storybook with https://github.com/storybookjs/testing-react (@smith is currently looking into how viable this is).