### PR TITLE
[App Search][Polish] API Logs empty state

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/components/api_logs_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/components/api_logs_table.tsx
@@ -26,6 +26,8 @@ import { ApiLogsLogic } from '../index';
 import { ApiLog } from '../types';
 import { getStatusColor } from '../utils';
 
+import { EmptyState } from './';
+
 import './api_logs_table.scss';
 
 interface Props {
@@ -108,6 +110,7 @@ export const ApiLogsTable: React.FC<Props> = ({ hasPagination }) => {
       items={apiLogs}
       responsive
       loading={dataLoading}
+      noItemsMessage={<EmptyState />}
       {...paginationProps}
     />
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/components/empty_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/components/empty_state.test.tsx
@@ -19,7 +19,7 @@ describe('EmptyState', () => {
       .find(EuiEmptyPrompt)
       .dive();
 
-    expect(wrapper.find('h2').text()).toEqual('Perform your first API call');
+    expect(wrapper.find('h2').text()).toEqual('No API events in the last 24 hours');
     expect(wrapper.find(EuiButton).prop('href')).toEqual(
       expect.stringContaining('/api-reference.html')
     );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/components/empty_state.tsx
@@ -18,14 +18,14 @@ export const EmptyState: React.FC = () => (
     title={
       <h2>
         {i18n.translate('xpack.enterpriseSearch.appSearch.engine.apiLogs.emptyTitle', {
-          defaultMessage: 'Perform your first API call',
+          defaultMessage: 'No API events in the last 24 hours',
         })}
       </h2>
     }
     body={
       <p>
         {i18n.translate('xpack.enterpriseSearch.appSearch.engine.apiLogs.emptyDescription', {
-          defaultMessage: "Check back after you've performed some API calls.",
+          defaultMessage: 'Logs will update in real-time when an API request occurs.',
         })}
       </p>
     }


### PR DESCRIPTION
## Summary

I realized right as I mashed merge on https://github.com/elastic/kibana/pull/102820 that the Engine Overview was now missing the empty state in the API logs table 🤪 

I also realized however that the empty state copy didn't make a whole ton of that sense in that view, so I conferred with Davey and we brainstormed some new copy!

### Before

<img width="1087" alt="" src="https://user-images.githubusercontent.com/549407/122988110-397be080-d356-11eb-813a-3208af5fed75.png">

<img width="1361" alt="" src="https://user-images.githubusercontent.com/549407/122988114-3aad0d80-d356-11eb-8a1e-da208e86f682.png">

### After

<img width="1092" alt="" src="https://user-images.githubusercontent.com/549407/122987938-09ccd880-d356-11eb-9cdc-ef486529366f.png">

<img width="1360" alt="" src="https://user-images.githubusercontent.com/549407/122987927-06d1e800-d356-11eb-8fb4-6da317c03e12.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios