### PR TITLE
Note full cli arg for es full featured snapshot

### DIFF
--- a/docs/developer/advanced/running-elasticsearch.asciidoc
+++ b/docs/developer/advanced/running-elasticsearch.asciidoc
@@ -25,7 +25,7 @@ See all available options, like how to specify a specific license, with the `--h
 yarn es snapshot --help
 ----
 
-`trial` will give you access to all capabilities.
+`--license trial` will give you access to all capabilities.
 
 **Keeping data between snapshots**
 


### PR DESCRIPTION
## Summary

Small doc fix to note full switch used to start es snapshot in trial mode.

### Checklist

(All removed)

### Risk Matrix

(None)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
