### PR TITLE
[Lens] Fix filter input debouncing

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/query_input.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/query_input.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { isEqual } from 'lodash';
 import { QueryStringInput, Query } from '../../../../../src/plugins/data/public';
 import { useDebouncedValue } from '../shared_components';
 
@@ -36,7 +37,11 @@ export const QueryInput = ({
       bubbleSubmitEvent={false}
       indexPatterns={[indexPatternTitle]}
       query={inputValue}
-      onChange={handleInputChange}
+      onChange={(newQuery) => {
+        if (!isEqual(newQuery, inputValue)) {
+          handleInputChange(newQuery);
+        }
+      }}
       onSubmit={() => {
         if (inputValue.query) {
           onSubmit();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/102896

It was actually debounced correctly already (the Lens `QueryInput` wrapper takes care of that) - the issue was the underlying component emitting new query objects even if the actual query didn't change (`===` check in the debounce hook doesn't recognize if something actually changed). This PR does a deep equal check to make sure the query is actually different before queueing a change callback.