### PR TITLE
[Discover] Move focus on chart toggle in Discover

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/chart/discover_chart.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/chart/discover_chart.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import moment from 'moment';
 import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 import { IUiSettingsClient } from 'kibana/public';
@@ -47,8 +47,20 @@ export function DiscoverChart({
   stateContainer: GetStateReturn;
   timefield?: string;
 }) {
+  const chartRef = useRef<{ element: HTMLElement | null; moveFocus: boolean }>({
+    element: null,
+    moveFocus: false,
+  });
+
+  useEffect(() => {
+    if (chartRef.current.moveFocus && chartRef.current.element) {
+      chartRef.current.element.focus();
+    }
+  }, [state.hideChart]);
+
   const toggleHideChart = useCallback(() => {
     stateContainer.setAppState({ hideChart: !state.hideChart });
+    chartRef.current.moveFocus = true;
   }, [state, stateContainer]);
 
   const onChangeInterval = useCallback(
@@ -102,9 +114,7 @@ export function DiscoverChart({
               <EuiButtonEmpty
                 size="xs"
                 iconType={!state.hideChart ? 'eyeClosed' : 'eye'}
-                onClick={() => {
-                  toggleHideChart();
-                }}
+                onClick={toggleHideChart}
                 data-test-subj="discoverChartToggle"
               >
                 {!state.hideChart
@@ -122,6 +132,8 @@ export function DiscoverChart({
       {!state.hideChart && chartData && (
         <EuiFlexItem grow={false}>
           <section
+            ref={(element) => (chartRef.current.element = element)}
+            tabIndex={-1}
             aria-label={i18n.translate('discover.histogramOfFoundDocumentsAriaLabel', {
               defaultMessage: 'Histogram of found documents',
             })}

--- a/src/plugins/discover/public/application/apps/main/components/chart/discover_chart.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/chart/discover_chart.tsx
@@ -59,8 +59,9 @@ export function DiscoverChart({
   }, [state.hideChart]);
 
   const toggleHideChart = useCallback(() => {
-    stateContainer.setAppState({ hideChart: !state.hideChart });
-    chartRef.current.moveFocus = true;
+    const newHideChart = !state.hideChart;
+    stateContainer.setAppState({ hideChart: newHideChart });
+    chartRef.current.moveFocus = !newHideChart;
   }, [state, stateContainer]);
 
   const onChangeInterval = useCallback(


### PR DESCRIPTION
Fixes #101065

## Summary

- adds focus move on clicking `Show chart` button


### Checklist

- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [X] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

