### PR TITLE
[Metrics UI] Prevent saved views from trampling URL state

### DIFF
--- a/x-pack/plugins/infra/public/containers/saved_view/saved_view.tsx
+++ b/x-pack/plugins/infra/public/containers/saved_view/saved_view.tsx
@@ -245,7 +245,6 @@ export const useSavedView = (props: Props) => {
     if (loadingDefaultView || currentView || !shouldLoadDefault) {
       return;
     }
-
     loadDefaultViewIfSet();
   }, [loadDefaultViewIfSet, loadingDefaultView, currentView, shouldLoadDefault]);
 
@@ -255,12 +254,21 @@ export const useSavedView = (props: Props) => {
   }, [urlState, setUrlState, currentView, defaultViewId, data]);
 
   useEffect(() => {
-    if (!currentView && !loading && data) {
+    if (!currentView && !loading && data && shouldLoadDefault) {
       const viewToSet = views.find((v) => v.id === urlState.viewId);
       if (viewToSet) setCurrentView(viewToSet);
       else loadDefaultViewIfSet();
     }
-  }, [loading, currentView, data, views, setCurrentView, loadDefaultViewIfSet, urlState.viewId]);
+  }, [
+    loading,
+    currentView,
+    data,
+    views,
+    setCurrentView,
+    loadDefaultViewIfSet,
+    urlState.viewId,
+    shouldLoadDefault,
+  ]);
 
   return {
     views,

--- a/x-pack/plugins/infra/public/containers/saved_view/saved_view.tsx
+++ b/x-pack/plugins/infra/public/containers/saved_view/saved_view.tsx
@@ -245,6 +245,7 @@ export const useSavedView = (props: Props) => {
     if (loadingDefaultView || currentView || !shouldLoadDefault) {
       return;
     }
+
     loadDefaultViewIfSet();
   }, [loadDefaultViewIfSet, loadingDefaultView, currentView, shouldLoadDefault]);
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where saved views is trampling the page state loaded by the URL. Prior to this PR when you tried to load the state from a URL, saved views would trample the view by loading the default view. 

#### Reviewer Notes

To test this:
1. Go to Metrics Explorer and change the view (delete a metric, add a filter, just do something different).
1. Copy the URL
1. Reload the default view (from saved views)
1. Paste the URL into the URL bar
1. It should load the pasted view

Fixes #103216