### PR TITLE
[APM] refactoring sourcemap api to receive form-data

### DIFF
--- a/x-pack/plugins/apm/server/lib/fleet/source_maps.test.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/source_maps.test.ts
@@ -103,12 +103,51 @@ const artifacts = [
 
 describe('Source maps', () => {
   describe('getPackagePolicyWithSourceMap', () => {
-    it('returns unchanged package policy when artifacts is empty', () => {
+    it('removes source map from package policy', () => {
+      const packagePolicyWithSourceMaps = {
+        ...packagePolicy,
+        inputs: [
+          {
+            ...packagePolicy.inputs[0],
+            compiled_input: {
+              'apm-server': {
+                ...packagePolicy.inputs[0].compiled_input['apm-server'],
+                value: {
+                  rum: {
+                    source_mapping: {
+                      metadata: [
+                        {
+                          'service.name': 'service_name',
+                          'service.version': '1.0.0',
+                          'bundle.filepath':
+                            'http://localhost:3000/static/js/main.chunk.js',
+                          'sourcemap.url':
+                            '/api/fleet/artifacts/service_name-1.0.0/my-id-1',
+                        },
+                        {
+                          'service.name': 'service_name',
+                          'service.version': '2.0.0',
+                          'bundle.filepath':
+                            'http://localhost:3000/static/js/main.chunk.js',
+                          'sourcemap.url':
+                            '/api/fleet/artifacts/service_name-2.0.0/my-id-2',
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
       const updatedPackagePolicy = getPackagePolicyWithSourceMap({
-        packagePolicy,
+        packagePolicy: packagePolicyWithSourceMaps,
         artifacts: [],
       });
-      expect(updatedPackagePolicy).toEqual(packagePolicy);
+      expect(updatedPackagePolicy.inputs[0].config).toEqual({
+        'apm-server': { value: { rum: { source_mapping: { metadata: [] } } } },
+      });
     });
     it('adds source maps into the package policy', () => {
       const updatedPackagePolicy = getPackagePolicyWithSourceMap({

--- a/x-pack/plugins/apm/server/lib/fleet/source_maps.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/source_maps.ts
@@ -97,9 +97,6 @@ export function getPackagePolicyWithSourceMap({
   packagePolicy: PackagePolicy;
   artifacts: ArtifactSourceMap[];
 }) {
-  if (!artifacts.length) {
-    return packagePolicy;
-  }
   const [firstInput, ...restInputs] = packagePolicy.inputs;
   return {
     ...packagePolicy,

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -39,6 +39,7 @@ export interface APMRouteCreateOptions {
       | 'access:ml:canGetJobs'
       | 'access:ml:canCreateJob'
     >;
+    body?: { accepts: Array<'application/json' | 'multipart/form-data'> };
   };
 }
 


### PR DESCRIPTION
new post api to upload source map:

`/api/apm/sourcemaps`

```
curl --location --request POST 'http://localhost:5601/foo/api/apm/sourcemaps' \
--header 'kbn-xsrf: teste' \
--header 'Content-Type: multipart/form-data' \
--form 'service_name="foo"' \
--form 'service_version="1.0.0"' \
--form 'bundle_filepath="/test/e2e/general-usecase/bundle.js.map"' \
--form 'sourcemap="{\"version\":3,\"file\":\"static/js/main.chunk.js\",\"sources\":[\"fleet-source-map-client/src/index.css\",\"fleet-source-map-client/src/App.js\",\"webpack:///./src/index.css?bb0a\",\"fleet-source-map-client/src/index.js\",\"fleet-source-map-client/src/reportWebVitals.js\"],\"sourcesContent\":[\"content\"],\"mappings\":\"mapping\",\"sourceRoot\":\"\"}"'
```