### PR TITLE
Use observability plugin breadcrumbs in APM

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/app_root.tsx
+++ b/x-pack/plugins/apm/public/components/routing/app_root.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../context/apm_plugin/apm_plugin_context';
 import { LicenseProvider } from '../../context/license/license_context';
 import { UrlParamsProvider } from '../../context/url_params_context/url_params_context';
-import { useBreadcrumbs } from '../../hooks/use_breadcrumbs';
+import { useApmBreadcrumbs } from '../../hooks/use_apm_breadcrumbs';
 import { ApmPluginStartDeps } from '../../plugin';
 import { HeaderMenuPortal } from '../../../../observability/public';
 import { ApmHeaderActionMenu } from '../shared/apm_header_action_menu';
@@ -79,7 +79,7 @@ export function ApmAppRoot({
 }
 
 function MountApmHeaderActionMenu() {
-  useBreadcrumbs(apmRouteConfig);
+  useApmBreadcrumbs(apmRouteConfig);
   const { setHeaderActionMenu } = useApmPluginContext().appMountParameters;
 
   return (

--- a/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -44,6 +44,7 @@ const mockCore = {
       ml: {},
     },
     currentAppId$: new Observable(),
+    getUrlForApp: (appId: string) => '',
     navigateToUrl: (url: string) => {},
   },
   chrome: {

--- a/x-pack/plugins/apm/public/hooks/use_apm_breadcrumbs.ts
+++ b/x-pack/plugins/apm/public/hooks/use_apm_breadcrumbs.ts
@@ -7,14 +7,15 @@
 
 import { History, Location } from 'history';
 import { ChromeBreadcrumb } from 'kibana/public';
-import { MouseEvent, ReactNode, useEffect } from 'react';
+import { MouseEvent } from 'react';
 import {
+  match as Match,
   matchPath,
   RouteComponentProps,
   useHistory,
-  match as Match,
   useLocation,
 } from 'react-router-dom';
+import { useBreadcrumbs } from '../../../observability/public';
 import { APMRouteDefinition, BreadcrumbTitle } from '../application/routes';
 import { getAPMHref } from '../components/shared/Links/apm/APMLink';
 import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
@@ -165,32 +166,16 @@ function routeDefinitionsToBreadcrumbs({
 }
 
 /**
- * Get an array for a page title from a list of breadcrumbs
- */
-function getTitleFromBreadcrumbs(breadcrumbs: ChromeBreadcrumb[]): string[] {
-  function removeNonStrings(item: ReactNode): item is string {
-    return typeof item === 'string';
-  }
-
-  return breadcrumbs
-    .map(({ text }) => text)
-    .reverse()
-    .filter(removeNonStrings);
-}
-
-/**
  * Determine the breadcrumbs from the routes, set them, and update the page
  * title when the route changes.
  */
-export function useBreadcrumbs(routes: APMRouteDefinition[]) {
+export function useApmBreadcrumbs(routes: APMRouteDefinition[]) {
   const history = useHistory();
   const location = useLocation();
   const { search } = location;
   const { core } = useApmPluginContext();
   const { basePath } = core.http;
   const { navigateToUrl } = core.application;
-  const { docTitle, setBreadcrumbs } = core.chrome;
-  const changeTitle = docTitle.change;
 
   function wrappedGetAPMHref(path: string) {
     return getAPMHref({ basePath, path, search });
@@ -206,10 +191,6 @@ export function useBreadcrumbs(routes: APMRouteDefinition[]) {
     wrappedGetAPMHref,
     navigateToUrl,
   });
-  const title = getTitleFromBreadcrumbs(breadcrumbs);
 
-  useEffect(() => {
-    changeTitle(title);
-    setBreadcrumbs(breadcrumbs);
-  }, [breadcrumbs, changeTitle, location, title, setBreadcrumbs]);
+  useBreadcrumbs(breadcrumbs);
 }


### PR DESCRIPTION
Both APM and Observability plugins have a `useBreadcrumbs` hook.

APM's takes the whole list of route definitions, creates the whole path of breadcrumbs, and has an effect to set the breadcrumbs and the page title.

The Observability plugin's `useBreadcrumbs` just takes an array of breadcrumb objects, adds onclick handlers for them, and has an effect to set the breadcrumbs and the page title.

Rename APM's `useBreadcrumbs` to `useApmBreadcrumbs`. It still constructs the path based on the routes and the current route, but then just calls out to the Observability plugin's `useBreadcrumbs` to do the breadcrumb and title setting.

Now all APM breadcrumbs begin with "Observability" which links to the Observability overview, but the rest of them remain the same:

<img width="660" alt="CleanShot 2021-06-23 at 14 27 52@2x" src="https://user-images.githubusercontent.com/9912/123157138-c777ca00-d42f-11eb-9f3d-5d62818398a9.png">

Fixes #102900.