### PR TITLE
Add redirect routes for detections urls

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/alerts_details.spec.ts
@@ -20,17 +20,17 @@ import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
 import { unmappedRule } from '../../objects/rule';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Alert details with unmapped fields', () => {
   beforeEach(() => {
     cleanKibana();
     esArchiverLoad('unmapped_fields');
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRuleActivated(unmappedRule);
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     expandFirstAlert();
   });

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/alerts_detection_callouts_index_outdated.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/alerts_detection_callouts_index_outdated.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { ROLES } from '../../../common/test';
-import { DETECTIONS_RULE_MANAGEMENT_URL, DETECTIONS_URL } from '../../urls/navigation';
+import { DETECTIONS_RULE_MANAGEMENT_URL, ALERTS_URL } from '../../urls/navigation';
 import { newRule } from '../../objects/rule';
 import { PAGE_TITLE } from '../../screens/common/page';
 
@@ -37,7 +37,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
     // First, we have to open the app on behalf of a privileged user in order to initialize it.
     // Otherwise the app will be disabled and show a "welcome"-like page.
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL, ROLES.platform_engineer);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL, ROLES.platform_engineer);
     waitForAlertsIndexToBeCreated();
 
     // After that we can login as a soc manager.
@@ -57,7 +57,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
       });
       context('On Detections home page', () => {
         beforeEach(() => {
-          loadPageAsPlatformEngineerUser(DETECTIONS_URL);
+          loadPageAsPlatformEngineerUser(ALERTS_URL);
         });
 
         it('We show the need admin primary callout', () => {
@@ -107,7 +107,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
       });
       context('On Detections home page', () => {
         beforeEach(() => {
-          loadPageAsPlatformEngineerUser(DETECTIONS_URL);
+          loadPageAsPlatformEngineerUser(ALERTS_URL);
         });
 
         it('We show the need admin primary callout', () => {
@@ -157,7 +157,7 @@ describe('Detections > Need Admin Callouts indicating an admin is needed to migr
       });
       context('On Detections home page', () => {
         beforeEach(() => {
-          loadPageAsPlatformEngineerUser(DETECTIONS_URL);
+          loadPageAsPlatformEngineerUser(ALERTS_URL);
         });
 
         it('We show the need admin primary callout', () => {

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/attach_to_case.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/attach_to_case.spec.ts
@@ -15,11 +15,11 @@ import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { login, loginAndWaitForPage, waitForPageWithoutDateRange } from '../../tasks/login';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 import { ATTACH_ALERT_TO_CASE_BUTTON } from '../../screens/alerts_detection_rules';
 
 const loadDetectionsPage = (role: ROLES) => {
-  waitForPageWithoutDateRange(DETECTIONS_URL, role);
+  waitForPageWithoutDateRange(ALERTS_URL, role);
   waitForAlertsToPopulate();
 };
 
@@ -27,7 +27,7 @@ describe('Alerts timeline', () => {
   before(() => {
     // First we login as a privileged user to create alerts.
     cleanKibana();
-    loginAndWaitForPage(DETECTIONS_URL, ROLES.platform_engineer);
+    loginAndWaitForPage(ALERTS_URL, ROLES.platform_engineer);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRuleActivated(newRule);

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/closing.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/closing.spec.ts
@@ -31,12 +31,12 @@ import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { loginAndWaitForPage } from '../../tasks/login';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Closing alerts', () => {
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPage(DETECTIONS_URL);
+    loginAndWaitForPage(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRuleActivated(newRule, '1', '100m', 100);

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/in_progress.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/in_progress.spec.ts
@@ -28,12 +28,12 @@ import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { loginAndWaitForPage } from '../../tasks/login';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Marking alerts as in-progress', () => {
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPage(DETECTIONS_URL);
+    loginAndWaitForPage(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRuleActivated(newRule);

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/investigate_in_timeline.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/investigate_in_timeline.spec.ts
@@ -19,12 +19,12 @@ import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { loginAndWaitForPage } from '../../tasks/login';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Alerts timeline', () => {
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPage(DETECTIONS_URL);
+    loginAndWaitForPage(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRuleActivated(newRule);

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/missing_privileges_callout.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/missing_privileges_callout.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { ROLES } from '../../../common/test';
-import { DETECTIONS_RULE_MANAGEMENT_URL, DETECTIONS_URL } from '../../urls/navigation';
+import { DETECTIONS_RULE_MANAGEMENT_URL, ALERTS_URL } from '../../urls/navigation';
 import { newRule } from '../../objects/rule';
 import { PAGE_TITLE } from '../../screens/common/page';
 
@@ -47,7 +47,7 @@ describe.skip('Detections > Callouts', () => {
     // First, we have to open the app on behalf of a privileged user in order to initialize it.
     // Otherwise the app will be disabled and show a "welcome"-like page.
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL, ROLES.platform_engineer);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL, ROLES.platform_engineer);
     waitForAlertsIndexToBeCreated();
 
     // After that we can login as a read-only user.
@@ -57,7 +57,7 @@ describe.skip('Detections > Callouts', () => {
   context('indicating read-only access to resources', () => {
     context('On Detections home page', () => {
       beforeEach(() => {
-        loadPageAsReadOnlyUser(DETECTIONS_URL);
+        loadPageAsReadOnlyUser(ALERTS_URL);
       });
 
       it('We show one primary callout', () => {
@@ -125,7 +125,7 @@ describe.skip('Detections > Callouts', () => {
   context('indicating read-write access to resources', () => {
     context('On Detections home page', () => {
       beforeEach(() => {
-        loadPageAsPlatformEngineer(DETECTIONS_URL);
+        loadPageAsPlatformEngineer(ALERTS_URL);
       });
 
       it('We show no callout', () => {

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/opening.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/opening.spec.ts
@@ -29,12 +29,12 @@ import { waitForAlertsToPopulate } from '../../tasks/create_new_rule';
 import { loginAndWaitForPage } from '../../tasks/login';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe.skip('Opening alerts', () => {
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPage(DETECTIONS_URL);
+    loginAndWaitForPage(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRuleActivated(newRule);

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/custom_query_rule.spec.ts
@@ -110,7 +110,7 @@ import { saveEditedRule, waitForKibana } from '../../tasks/edit_rule';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 import { activatesRule } from '../../tasks/rule_details';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Custom detection rules creation', () => {
   const expectedUrls = newRule.referenceUrls.join('');
@@ -133,7 +133,7 @@ describe('Custom detection rules creation', () => {
   });
 
   it('Creates and activates a new rule', function () {
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();
@@ -226,7 +226,7 @@ describe('Custom detection rules deletion and edition', () => {
   context('Deletion', () => {
     beforeEach(() => {
       cleanKibana();
-      loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+      loginAndWaitForPageWithoutDateRange(ALERTS_URL);
       goToManageAlertsDetectionRules();
       waitForAlertsIndexToBeCreated();
       createCustomRuleActivated(newRule, 'rule1');
@@ -302,7 +302,7 @@ describe('Custom detection rules deletion and edition', () => {
 
     beforeEach(() => {
       cleanKibana();
-      loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+      loginAndWaitForPageWithoutDateRange(ALERTS_URL);
       goToManageAlertsDetectionRules();
       waitForAlertsIndexToBeCreated();
       createCustomRuleActivated(existingRule, 'rule1');

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/event_correlation_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/event_correlation_rule.spec.ts
@@ -75,7 +75,7 @@ import {
 } from '../../tasks/create_new_rule';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Detection rules, EQL', () => {
   const expectedUrls = eqlRule.referenceUrls.join('');
@@ -99,7 +99,7 @@ describe('Detection rules, EQL', () => {
   });
 
   it('Creates and activates a new EQL rule', function () {
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();
@@ -194,7 +194,7 @@ describe('Detection rules, sequence EQL', () => {
   });
 
   it('Creates and activates a new EQL rule with a sequence', function () {
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/export_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/export_rule.spec.ts
@@ -16,7 +16,7 @@ import { createCustomRule } from '../../tasks/api_calls/rules';
 import { cleanKibana } from '../../tasks/common';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Export rules', () => {
   beforeEach(() => {
@@ -25,7 +25,7 @@ describe('Export rules', () => {
       'POST',
       '/api/detection_engine/rules/_export?exclude_export_details=false&file_name=rules_export.ndjson'
     ).as('export');
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRule(newRule).as('ruleResponse');

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
@@ -123,7 +123,7 @@ import { esArchiverLoad, esArchiverUnload } from '../../tasks/es_archiver';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 import { addsFieldsToTimeline, goBackToAllRulesTable } from '../../tasks/rule_details';
 
-import { DETECTIONS_URL, RULE_CREATION } from '../../urls/navigation';
+import { ALERTS_URL, RULE_CREATION } from '../../urls/navigation';
 
 describe('indicator match', () => {
   describe('Detection rules, Indicator Match', () => {
@@ -407,7 +407,7 @@ describe('indicator match', () => {
     describe('Generating signals', () => {
       beforeEach(() => {
         cleanKibana();
-        loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+        loginAndWaitForPageWithoutDateRange(ALERTS_URL);
       });
 
       it('Creates and activates a new Indicator Match rule', () => {
@@ -559,7 +559,7 @@ describe('indicator match', () => {
         cleanKibana();
         esArchiverLoad('threat_indicator');
         esArchiverLoad('suspicious_source_event');
-        loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+        loginAndWaitForPageWithoutDateRange(ALERTS_URL);
         goToManageAlertsDetectionRules();
         createCustomIndicatorRule(newThreatIndicatorRule);
         reload();
@@ -571,7 +571,7 @@ describe('indicator match', () => {
       });
 
       beforeEach(() => {
-        loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+        loginAndWaitForPageWithoutDateRange(ALERTS_URL);
         goToManageAlertsDetectionRules();
         goToRuleDetails();
       });
@@ -687,7 +687,7 @@ describe('indicator match', () => {
     describe('Duplicates the indicator rule', () => {
       beforeEach(() => {
         cleanKibana();
-        loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+        loginAndWaitForPageWithoutDateRange(ALERTS_URL);
         goToManageAlertsDetectionRules();
         createCustomIndicatorRule(newThreatIndicatorRule);
         reload();

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/machine_learning_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/machine_learning_rule.spec.ts
@@ -62,7 +62,7 @@ import {
 } from '../../tasks/create_new_rule';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Detection rules, machine learning', () => {
   const expectedUrls = machineLearningRule.referenceUrls.join('');
@@ -76,7 +76,7 @@ describe('Detection rules, machine learning', () => {
   });
 
   it('Creates and activates a new ml rule', () => {
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/override.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/override.spec.ts
@@ -86,7 +86,7 @@ import {
 } from '../../tasks/create_new_rule';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe('Detection rules, override', () => {
   const expectedUrls = newOverrideRule.referenceUrls.join('');
@@ -108,7 +108,7 @@ describe('Detection rules, override', () => {
   });
 
   it('Creates and activates a new custom rule with override option', function () {
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
@@ -34,7 +34,7 @@ import {
 } from '../../tasks/alerts_detection_rules';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 import { totalNumberOfPrebuiltRules } from '../../objects/rule';
 import { cleanKibana } from '../../tasks/common';
@@ -50,7 +50,7 @@ describe('Alerts rules, prebuilt rules', () => {
     const expectedNumberOfPages = Math.ceil(totalNumberOfPrebuiltRules / rowsPerPage);
     const expectedElasticRulesBtnText = `Elastic rules (${expectedNumberOfRules})`;
 
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();
     waitForRulesTableToBeLoaded();
@@ -72,7 +72,7 @@ describe('Actions with prebuilt rules', () => {
     const expectedElasticRulesBtnText = `Elastic rules (${expectedNumberOfRules})`;
 
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsIndexToBeCreated();
     goToManageAlertsDetectionRules();
     waitForRulesTableToBeLoaded();

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/sorting.spec.ts
@@ -36,7 +36,7 @@ import {
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 import { DEFAULT_RULE_REFRESH_INTERVAL_VALUE } from '../../../common/constants';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 import { createCustomRule } from '../../tasks/api_calls/rules';
 import { cleanKibana } from '../../tasks/common';
 import { existingRule, newOverrideRule, newRule, newThresholdRule } from '../../objects/rule';
@@ -44,7 +44,7 @@ import { existingRule, newOverrideRule, newRule, newThresholdRule } from '../../
 describe('Alerts detection rules', () => {
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
     createCustomRule(newRule, '1');

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/threshold_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/threshold_rule.spec.ts
@@ -81,7 +81,7 @@ import {
 } from '../../tasks/create_new_rule';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 
 describe.skip('Detection rules, threshold', () => {
   const expectedUrls = newThresholdRule.referenceUrls.join('');
@@ -96,7 +96,7 @@ describe.skip('Detection rules, threshold', () => {
     createTimeline(newThresholdRule.timeline).then((response) => {
       rule.timeline.id = response.body.data.persistTimeline.timeline.savedObjectId;
     });
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsPanelToBeLoaded();
     waitForAlertsIndexToBeCreated();
   });

--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_modal.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_modal.spec.ts
@@ -31,7 +31,7 @@ import {
   ADD_EXCEPTIONS_BTN,
 } from '../../screens/exceptions';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 import { cleanKibana } from '../../tasks/common';
 
 // NOTE: You might look at these tests and feel they're overkill,
@@ -42,7 +42,7 @@ import { cleanKibana } from '../../tasks/common';
 describe('Exceptions modal', () => {
   before(() => {
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsIndexToBeCreated();
     createCustomRule(newRule);
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_table.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/exceptions_table.spec.ts
@@ -25,7 +25,7 @@ import {
   waitForTheRuleToBeExecuted,
 } from '../../tasks/rule_details';
 
-import { DETECTIONS_URL, EXCEPTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL, EXCEPTIONS_URL } from '../../urls/navigation';
 import { cleanKibana } from '../../tasks/common';
 import {
   deleteExceptionListWithRuleReference,
@@ -44,7 +44,7 @@ import { createExceptionList } from '../../tasks/api_calls/exceptions';
 describe('Exceptions Table', () => {
   before(() => {
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsIndexToBeCreated();
     createCustomRule(newRule);
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/from_alert.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/from_alert.spec.ts
@@ -33,7 +33,7 @@ import {
 } from '../../tasks/rule_details';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 import { cleanKibana } from '../../tasks/common';
 
 describe('From alert', () => {
@@ -41,7 +41,7 @@ describe('From alert', () => {
 
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsIndexToBeCreated();
     createCustomRule(newRule, 'rule_testing', '10s');
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/from_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/from_rule.spec.ts
@@ -32,14 +32,14 @@ import {
 } from '../../tasks/rule_details';
 import { refreshPage } from '../../tasks/security_header';
 
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 import { cleanKibana } from '../../tasks/common';
 
 describe('From rule', () => {
   const NUMBER_OF_AUDITBEAT_EXCEPTIONS_ALERTS = '1';
   beforeEach(() => {
     cleanKibana();
-    loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+    loginAndWaitForPageWithoutDateRange(ALERTS_URL);
     waitForAlertsIndexToBeCreated();
     createCustomRule(newRule, 'rule_testing', '10s');
     goToManageAlertsDetectionRules();

--- a/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/header/navigation.spec.ts
@@ -21,7 +21,7 @@ import { loginAndWaitForPage } from '../../tasks/login';
 import { navigateFromHeaderTo } from '../../tasks/security_header';
 
 import {
-  DETECTIONS_URL,
+  ALERTS_URL,
   CASES_URL,
   HOSTS_URL,
   KIBANA_HOME,
@@ -60,7 +60,7 @@ describe('top-level navigation common to all pages in the Security app', () => {
 
   it('navigates to the Detections page', () => {
     navigateFromHeaderTo(DETECTIONS);
-    cy.url().should('include', DETECTIONS_URL);
+    cy.url().should('include', ALERTS_URL);
   });
 
   it('navigates to the Hosts page', () => {
@@ -111,7 +111,7 @@ describe('Kibana navigation to all pages in the Security app ', () => {
 
   it('navigates to the Alerts page', () => {
     navigateFromKibanaCollapsibleTo(DETECTIONS_PAGE);
-    cy.url().should('include', DETECTIONS_URL);
+    cy.url().should('include', ALERTS_URL);
   });
 
   it('navigates to the Hosts page', () => {

--- a/x-pack/plugins/security_solution/cypress/integration/urls/compatibility.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/urls/compatibility.spec.ts
@@ -7,7 +7,15 @@
 
 import { loginAndWaitForPage, loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
-import { DETECTIONS } from '../../urls/navigation';
+import {
+  ALERTS_URL,
+  DETECTIONS,
+  DETECTIONS_RULE_MANAGEMENT_URL,
+  RULE_CREATION,
+  SECURITY_DETECTIONS_RULES_CREATION_URL,
+  SECURITY_DETECTIONS_RULES_URL,
+  SECURITY_DETECTIONS_URL,
+} from '../../urls/navigation';
 import { ABSOLUTE_DATE_RANGE } from '../../urls/state';
 import {
   DATE_PICKER_START_DATE_POPOVER_BUTTON,
@@ -25,10 +33,24 @@ describe('URL compatibility', () => {
     cleanKibana();
   });
 
-  it.skip('Redirects to Detection alerts from old Detections URL', () => {
+  it('Redirects to alerts from old siem Detections URL', () => {
     loginAndWaitForPage(DETECTIONS);
+    cy.url().should('include', ALERTS_URL);
+  });
 
-    cy.url().should('include', '/security/alerts');
+  it('Redirects to alerts from old Detections URL', () => {
+    loginAndWaitForPage(SECURITY_DETECTIONS_URL);
+    cy.url().should('include', ALERTS_URL);
+  });
+
+  it('Redirects to rules from old Detections rules URL', () => {
+    loginAndWaitForPage(SECURITY_DETECTIONS_RULES_URL);
+    cy.url().should('include', DETECTIONS_RULE_MANAGEMENT_URL);
+  });
+
+  it('Redirects to rules creation from old Detections rules creation URL', () => {
+    loginAndWaitForPage(SECURITY_DETECTIONS_RULES_CREATION_URL);
+    cy.url().should('include', RULE_CREATION);
   });
 
   it('sets the global start and end dates from the url with timestamps', () => {

--- a/x-pack/plugins/security_solution/cypress/integration/value_lists/value_lists.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/value_lists/value_lists.spec.ts
@@ -7,7 +7,7 @@
 
 import { ROLES } from '../../../common/test';
 import { deleteRoleAndUser, loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
-import { DETECTIONS_URL } from '../../urls/navigation';
+import { ALERTS_URL } from '../../urls/navigation';
 import {
   waitForAlertsPanelToBeLoaded,
   waitForAlertsIndexToBeCreated,
@@ -35,7 +35,7 @@ import {
 describe.skip('value lists', () => {
   describe('management modal', () => {
     beforeEach(() => {
-      loginAndWaitForPageWithoutDateRange(DETECTIONS_URL);
+      loginAndWaitForPageWithoutDateRange(ALERTS_URL);
       waitForAlertsPanelToBeLoaded();
       waitForAlertsIndexToBeCreated();
       waitForListsIndexToBeCreated();
@@ -228,7 +228,7 @@ describe.skip('value lists', () => {
 
   describe('user with restricted access role', () => {
     beforeEach(() => {
-      loginAndWaitForPageWithoutDateRange(DETECTIONS_URL, ROLES.t1_analyst);
+      loginAndWaitForPageWithoutDateRange(ALERTS_URL, ROLES.t1_analyst);
       goToManageAlertsDetectionRules();
     });
 

--- a/x-pack/plugins/security_solution/cypress/urls/navigation.ts
+++ b/x-pack/plugins/security_solution/cypress/urls/navigation.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-export const DETECTIONS_URL = 'app/security/alerts';
+export const ALERTS_URL = 'app/security/alerts';
 export const DETECTIONS_RULE_MANAGEMENT_URL = 'app/security/rules';
 export const detectionsRuleDetailsUrl = (ruleId: string) => `app/security/rules/id/${ruleId}`;
 
 export const CASES_URL = '/app/security/cases';
-export const DETECTIONS = '/app/security/alerts';
+export const DETECTIONS = '/app/siem#/detections';
+export const SECURITY_DETECTIONS_URL = '/app/security/detections';
+export const SECURITY_DETECTIONS_RULES_URL = '/app/security/detections/rules';
+export const SECURITY_DETECTIONS_RULES_CREATION_URL = '/app/security/detections/rules/create';
+
 export const EXCEPTIONS_URL = 'app/security/exceptions';
 
 export const HOSTS_URL = '/app/security/hosts/allHosts';

--- a/x-pack/plugins/security_solution/public/app/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/index.tsx
@@ -45,7 +45,11 @@ export const renderApp = ({
         ].map((route, index) => (
           <Route key={`route-${index}`} {...route} />
         ))}
-
+        <Redirect from="/detections/rules/id/:detailName/edit" to="/rules/id/:detailName/edit" />
+        <Redirect from="/detections/rules/id/:detailName" to="/rules/id/:detailName" />
+        <Redirect from="/detections/rules/create" to="/rules/create" />
+        <Redirect from="/detections/rules" to="/rules" />
+        <Redirect from="/detections" to="/alerts" />
         <Route path="" exact>
           <Redirect to={OVERVIEW_PATH} />
         </Route>

--- a/x-pack/plugins/security_solution/public/helpers.ts
+++ b/x-pack/plugins/security_solution/public/helpers.ts
@@ -99,6 +99,7 @@ export const manageOldSiemRoutes = async (coreStart: CoreStart) => {
         path,
       });
       break;
+    case SecurityPageName.detections:
     case SecurityPageName.alerts:
       application.navigateToApp(APP_ID, {
         deepLinkId: SecurityPageName.alerts,

--- a/x-pack/plugins/security_solution/public/rules/routes.tsx
+++ b/x-pack/plugins/security_solution/public/rules/routes.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { TrackApplicationView } from '../../../../../src/plugins/usage_collection/public';
 import { RULES_PATH, SecurityPageName } from '../../common/constants';


### PR DESCRIPTION
## Summary

- Redirect `/app/siem#/detections` to `app/security/alerts`
- Redirect `/detections` to `/alerts`
- Redirect `/detections/rules/id/:detailName/edit` to `/rules/id/:detailName/edit`
- Redirect `/detections/rules/id/:detailName` to `/rules/id/:detailName`
- Redirect `/detections/rules/create` to `/rules/create`
- Redirect `/detections/rules` to `/rules`

