### PR TITLE
[Lens] Add continuity icons to palette configuration

### DIFF
--- a/x-pack/plugins/lens/public/shared_components/coloring/palette_configuration.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/palette_configuration.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
 import { PaletteOutput, PaletteRegistry } from 'src/plugins/charts/public';
 import {
   EuiFormRow,
@@ -38,6 +38,17 @@ import {
   roundStopValues,
 } from './utils';
 const idPrefix = htmlIdGenerator()();
+
+const ContinuityOption: FC<{ iconType: string }> = ({ children, iconType }) => {
+  return (
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiIcon type={iconType} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>{children}</EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
 
 /**
  * Some name conventions here:
@@ -141,41 +152,45 @@ export function CustomizablePalette({
             options={[
               {
                 value: 'above',
-                inputDisplay: i18n.translate(
-                  'xpack.lens.table.dynamicColoring.continuity.aboveLabel',
-                  {
-                    defaultMessage: 'Above range',
-                  }
+                inputDisplay: (
+                  <ContinuityOption iconType="continuityAbove">
+                    {i18n.translate('xpack.lens.table.dynamicColoring.continuity.aboveLabel', {
+                      defaultMessage: 'Above range',
+                    })}
+                  </ContinuityOption>
                 ),
                 'data-test-subj': 'continuity-above',
               },
               {
                 value: 'below',
-                inputDisplay: i18n.translate(
-                  'xpack.lens.table.dynamicColoring.continuity.belowLabel',
-                  {
-                    defaultMessage: 'Below range',
-                  }
+                inputDisplay: (
+                  <ContinuityOption iconType="continuityBelow">
+                    {i18n.translate('xpack.lens.table.dynamicColoring.continuity.belowLabel', {
+                      defaultMessage: 'Below range',
+                    })}
+                  </ContinuityOption>
                 ),
                 'data-test-subj': 'continuity-below',
               },
               {
                 value: 'all',
-                inputDisplay: i18n.translate(
-                  'xpack.lens.table.dynamicColoring.continuity.allLabel',
-                  {
-                    defaultMessage: 'Above and below range',
-                  }
+                inputDisplay: (
+                  <ContinuityOption iconType="continuityAboveBelow">
+                    {i18n.translate('xpack.lens.table.dynamicColoring.continuity.allLabel', {
+                      defaultMessage: 'Above and below range',
+                    })}
+                  </ContinuityOption>
                 ),
                 'data-test-subj': 'continuity-all',
               },
               {
                 value: 'none',
-                inputDisplay: i18n.translate(
-                  'xpack.lens.table.dynamicColoring.continuity.noneLabel',
-                  {
-                    defaultMessage: 'Within range',
-                  }
+                inputDisplay: (
+                  <ContinuityOption iconType="continuityWithin">
+                    {i18n.translate('xpack.lens.table.dynamicColoring.continuity.noneLabel', {
+                      defaultMessage: 'Within range',
+                    })}
+                  </ContinuityOption>
                 ),
                 'data-test-subj': 'continuity-none',
               },


### PR DESCRIPTION
## Summary

Fix #101364

Add continuity icons to continuity select in the palette configuration.

<img width="344" alt="Screenshot 2021-06-24 at 12 50 32" src="https://user-images.githubusercontent.com/924948/123251898-feabb100-d4eb-11eb-8c1f-adf831a1c42b.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
