### PR TITLE
Prevent showing filter on unfilterable fields in data grid

### DIFF
--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_cell_actions.test.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_cell_actions.test.tsx
@@ -9,14 +9,21 @@
 import React from 'react';
 import { mountWithIntl } from '@kbn/test/jest';
 import { findTestSubject } from '@elastic/eui/lib/test';
-import { FilterInBtn, FilterOutBtn } from './discover_grid_cell_actions';
+import { FilterInBtn, FilterOutBtn, buildCellActions } from './discover_grid_cell_actions';
 import { DiscoverGridContext } from './discover_grid_context';
 
 import { indexPatternMock } from '../../../__mocks__/index_pattern';
 import { esHits } from '../../../__mocks__/es_hits';
 import { EuiButton } from '@elastic/eui';
+import { IndexPatternField } from 'src/plugins/data/common';
 
 describe('Discover cell actions ', function () {
+  it('should not show cell actions for unfilterable fields', async () => {
+    expect(
+      buildCellActions({ name: 'foo', filterable: false } as IndexPatternField)
+    ).toBeUndefined();
+  });
+
   it('triggers filter function when FilterInBtn is clicked', async () => {
     const contextMock = {
       expanded: undefined,

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_cell_actions.tsx
@@ -79,7 +79,7 @@ export const FilterOutBtn = ({
 };
 
 export function buildCellActions(field: IndexPatternField) {
-  if (!field.aggregatable && !field.searchable) {
+  if (!field.filterable) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes #91677

Currently we show the filter button for too many fields, e.g. geo_point fields, which are aggregatable and searchable. We should instead check on the `filterable` property of the fields (which is also what the legacy doc table does), which will correctly be `false` for geo_point fields.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
