### PR TITLE
Add missing i18n in Discover

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/sidebar/discover_field_search.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/sidebar/discover_field_search.tsx
@@ -204,15 +204,21 @@ export function DiscoverFieldSearch({ onChange, value, types, useNewFieldsApi }:
     return [
       {
         id: `${id}-any`,
-        label: 'any',
+        label: i18n.translate('discover.fieldChooser.filter.toggleButton.any', {
+          defaultMessage: 'any',
+        }),
       },
       {
         id: `${id}-true`,
-        label: 'yes',
+        label: i18n.translate('discover.fieldChooser.filter.toggleButton.yes', {
+          defaultMessage: 'yes',
+        }),
       },
       {
         id: `${id}-false`,
-        label: 'no',
+        label: i18n.translate('discover.fieldChooser.filter.toggleButton.no', {
+          defaultMessage: 'no',
+        }),
       },
     ];
   };


### PR DESCRIPTION
## Summary

Fixes #97963

I went through all of Discover UIs and checked for missing translations. Those added here were the last ones I could find that were still missing.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
