### PR TITLE
[Workplace Search] Remove `isFederatedAuth` checks to expose user features

### DIFF
--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -8,7 +8,6 @@
 export const DEFAULT_INITIAL_APP_DATA = {
   readOnlyMode: false,
   ilmEnabled: true,
-  isFederatedAuth: false,
   configuredLimits: {
     appSearch: {
       engine: {

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -17,7 +17,6 @@ import {
 export interface InitialAppData {
   readOnlyMode?: boolean;
   ilmEnabled?: boolean;
-  isFederatedAuth?: boolean;
   configuredLimits?: ConfiguredLimits;
   access?: ProductAccess;
   appSearch?: AppSearchAccount;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -20,7 +20,6 @@ describe('AppLogic', () => {
   const DEFAULT_VALUES = {
     account: {},
     hasInitialized: false,
-    isFederatedAuth: true,
     isOrganization: false,
     organization: {},
   };
@@ -36,7 +35,6 @@ describe('AppLogic', () => {
       viewedOnboardingPage: true,
     },
     hasInitialized: true,
-    isFederatedAuth: false,
     isOrganization: false,
     organization: {
       defaultOrgName: 'My Organization',
@@ -61,7 +59,6 @@ describe('AppLogic', () => {
       expect(AppLogic.values).toEqual({
         ...DEFAULT_VALUES,
         hasInitialized: true,
-        isFederatedAuth: false,
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -16,7 +16,6 @@ import {
 
 interface AppValues extends WorkplaceSearchInitialData {
   hasInitialized: boolean;
-  isFederatedAuth: boolean;
   isOrganization: boolean;
 }
 interface AppActions {
@@ -32,10 +31,7 @@ const emptyAccount = {} as Account;
 export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
   path: ['enterprise_search', 'workplace_search', 'app_logic'],
   actions: {
-    initializeAppData: ({ workplaceSearch, isFederatedAuth }) => ({
-      workplaceSearch,
-      isFederatedAuth,
-    }),
+    initializeAppData: ({ workplaceSearch }) => ({ workplaceSearch }),
     setContext: (isOrganization) => isOrganization,
     setOrgName: (name: string) => name,
     setSourceRestriction: (canCreatePersonalSources: boolean) => canCreatePersonalSources,
@@ -45,12 +41,6 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       false,
       {
         initializeAppData: () => true,
-      },
-    ],
-    isFederatedAuth: [
-      true,
-      {
-        initializeAppData: (_, { isFederatedAuth }) => !!isFederatedAuth,
       },
     ],
     isOrganization: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -68,12 +68,6 @@ describe('WorkplaceSearchConfigured', () => {
     expect(mockKibanaValues.renderHeaderActions).toHaveBeenCalledWith(WorkplaceSearchHeaderActions);
   });
 
-  it('initializes app data with passed props', () => {
-    shallow(<WorkplaceSearchConfigured isFederatedAuth />);
-
-    expect(initializeAppData).toHaveBeenCalledWith({ isFederatedAuth: true });
-  });
-
   it('does not re-initialize app data or re-render header actions', () => {
     setMockValues({ hasInitialized: true });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -7,6 +7,7 @@
 
 import '../__mocks__/react_router';
 import '../__mocks__/shallow_useeffect.mock';
+import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
 import { setMockValues, setMockActions, mockKibanaValues } from '../__mocks__/kea_logic';
 
 import React from 'react';
@@ -66,6 +67,13 @@ describe('WorkplaceSearchConfigured', () => {
 
     expect(mockKibanaValues.setChromeIsVisible).toHaveBeenCalledWith(true);
     expect(mockKibanaValues.renderHeaderActions).toHaveBeenCalledWith(WorkplaceSearchHeaderActions);
+  });
+
+  it('initializes app data with passed props', () => {
+    const { workplaceSearch } = DEFAULT_INITIAL_APP_DATA;
+    shallow(<WorkplaceSearchConfigured workplaceSearch={workplaceSearch} />);
+
+    expect(initializeAppData).toHaveBeenCalledWith({ workplaceSearch });
   });
 
   it('does not re-initialize app data or re-render header actions', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -50,7 +50,6 @@ export const PERSONAL_PATH = '/p';
 
 export const USERS_AND_ROLES_PATH = '/users_and_roles';
 
-export const USERS_PATH = '/users';
 export const SECURITY_PATH = '/security';
 
 export const GROUPS_PATH = '/groups';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -24,7 +24,6 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { TruncatedContent } from '../../../../shared/truncate';
-import { AppLogic } from '../../../app_logic';
 import noSharedSourcesIcon from '../../../assets/share_circle.svg';
 import { WorkplaceSearchPageTemplate } from '../../../components/layout';
 import { ContentSection } from '../../../components/shared/content_section';
@@ -124,8 +123,6 @@ export const GroupOverview: React.FC = () => {
     confirmDeleteModalVisible,
   } = useValues(GroupLogic);
 
-  const { isFederatedAuth } = useValues(AppLogic);
-
   const truncatedName = name && (
     <TruncatedContent tooltipType="title" content={name} length={MAX_NAME_LENGTH} />
   );
@@ -167,7 +164,7 @@ export const GroupOverview: React.FC = () => {
       {MANAGE_SOURCES_BUTTON_TEXT}
     </EuiButton>
   );
-  const manageUsersButton = !isFederatedAuth && (
+  const manageUsersButton = (
     <EuiButton color="primary" onClick={showManageUsersModal}>
       {MANAGE_USERS_BUTTON_TEXT}
     </EuiButton>
@@ -199,7 +196,7 @@ export const GroupOverview: React.FC = () => {
     </>
   );
 
-  const usersSection = !isFederatedAuth && (
+  const usersSection = (
     <ContentSection
       title="Group users"
       description={hasUsers ? GROUP_USERS_DESCRIPTION : EMPTY_USERS_DESCRIPTION}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { setMockValues } from '../../../../__mocks__/kea_logic';
 import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
@@ -19,10 +19,6 @@ import { GroupRow, NO_USERS_MESSAGE, NO_SOURCES_MESSAGE } from './group_row';
 import { GroupUsers } from './group_users';
 
 describe('GroupRow', () => {
-  beforeEach(() => {
-    setMockValues({ isFederatedAuth: true });
-  });
-
   it('renders', () => {
     const wrapper = shallow(<GroupRow {...groups[0]} />);
 
@@ -30,7 +26,6 @@ describe('GroupRow', () => {
   });
 
   it('renders group users', () => {
-    setMockValues({ isFederatedAuth: false });
     const wrapper = shallow(<GroupRow {...groups[0]} />);
 
     expect(wrapper.find(GroupUsers)).toHaveLength(1);
@@ -51,7 +46,6 @@ describe('GroupRow', () => {
   });
 
   it('renders empty users message when no users present', () => {
-    setMockValues({ isFederatedAuth: false });
     const wrapper = shallow(<GroupRow {...groups[0]} usersCount={0} />);
 
     expect(wrapper.find('.user-group__accounts').text()).toEqual(NO_USERS_MESSAGE);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 
-import { useValues } from 'kea';
 import moment from 'moment';
 
 import { EuiTableRow, EuiTableRowCell, EuiIcon } from '@elastic/eui';
@@ -15,7 +14,6 @@ import { i18n } from '@kbn/i18n';
 
 import { EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { TruncatedContent } from '../../../../shared/truncate';
-import { AppLogic } from '../../../app_logic';
 import { getGroupPath } from '../../../routes';
 import { Group } from '../../../types';
 import { MAX_NAME_LENGTH } from '../group_logic';
@@ -50,8 +48,6 @@ export const GroupRow: React.FC<Group> = ({
   users,
   usersCount,
 }) => {
-  const { isFederatedAuth } = useValues(AppLogic);
-
   const GROUP_UPDATED_TEXT = i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.groups.groupUpdatedText',
     {
@@ -80,17 +76,15 @@ export const GroupRow: React.FC<Group> = ({
           )}
         </div>
       </EuiTableRowCell>
-      {!isFederatedAuth && (
-        <EuiTableRowCell>
-          <div className="user-group__accounts">
-            {usersCount > 0 ? (
-              <GroupUsers groupUsers={users} usersCount={usersCount} groupId={id} />
-            ) : (
-              NO_USERS_MESSAGE
-            )}
-          </div>
-        </EuiTableRowCell>
-      )}
+      <EuiTableRowCell>
+        <div className="user-group__accounts">
+          {usersCount > 0 ? (
+            <GroupUsers groupUsers={users} usersCount={usersCount} groupId={id} />
+          ) : (
+            NO_USERS_MESSAGE
+          )}
+        </div>
+      </EuiTableRowCell>
       <EuiTableRowCell align="right">
         <strong>
           <EuiLinkTo to={getGroupPath(id)}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.test.tsx
@@ -23,17 +23,10 @@ const group = groups[0];
 
 describe('GroupUsersTable', () => {
   it('renders', () => {
-    setMockValues({ isFederatedAuth: true, group });
+    setMockValues({ group });
     const wrapper = shallow(<GroupUsersTable />);
 
     expect(wrapper.find(EuiTable)).toHaveLength(1);
-    expect(wrapper.find(TableHeader).prop('headerItems')).toHaveLength(1);
-  });
-
-  it('adds header item for non-federated auth', () => {
-    setMockValues({ isFederatedAuth: false, group });
-    const wrapper = shallow(<GroupUsersTable />);
-
     expect(wrapper.find(TableHeader).prop('headerItems')).toHaveLength(2);
   });
 
@@ -48,7 +41,7 @@ describe('GroupUsersTable', () => {
       });
     });
 
-    setMockValues({ isFederatedAuth: true, group: { users } });
+    setMockValues({ group: { users } });
     const wrapper = shallow(<GroupUsersTable />);
     const pagination = wrapper.find(EuiTablePagination);
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.tsx
@@ -53,7 +53,7 @@ export const GroupUsersTable: React.FC = () => {
   return (
     <>
       <EuiTable>
-        <TableHeader extraCell={false} headerItems={headerItems} />
+        <TableHeader headerItems={headerItems} />
         <EuiTableBody>
           {users.slice(firstItem, lastItem + 1).map((user: User) => (
             <UserRow key={user.id} showEmail user={user} />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.tsx
@@ -14,7 +14,6 @@ import { Pager } from '@elastic/eui';
 
 import { USERNAME_LABEL, EMAIL_LABEL } from '../../../../shared/constants';
 import { TableHeader } from '../../../../shared/table_header';
-import { AppLogic } from '../../../app_logic';
 import { UserRow } from '../../../components/shared/user_row';
 import { User } from '../../../types';
 import { GroupLogic } from '../group_logic';
@@ -22,14 +21,10 @@ import { GroupLogic } from '../group_logic';
 const USERS_PER_PAGE = 10;
 
 export const GroupUsersTable: React.FC = () => {
-  const { isFederatedAuth } = useValues(AppLogic);
   const {
     group: { users },
   } = useValues(GroupLogic);
-  const headerItems = [USERNAME_LABEL];
-  if (!isFederatedAuth) {
-    headerItems.push(EMAIL_LABEL);
-  }
+  const headerItems = [USERNAME_LABEL, EMAIL_LABEL];
 
   const [firstItem, setFirstItem] = useState(0);
   const [lastItem, setLastItem] = useState(USERS_PER_PAGE - 1);
@@ -58,10 +53,10 @@ export const GroupUsersTable: React.FC = () => {
   return (
     <>
       <EuiTable>
-        <TableHeader extraCell={isFederatedAuth} headerItems={headerItems} />
+        <TableHeader extraCell={false} headerItems={headerItems} />
         <EuiTableBody>
           {users.slice(firstItem, lastItem + 1).map((user: User) => (
-            <UserRow key={user.id} showEmail={!isFederatedAuth} user={user} />
+            <UserRow key={user.id} showEmail user={user} />
           ))}
         </EuiTableBody>
       </EuiTable>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.test.tsx
@@ -27,7 +27,6 @@ const mockValues = {
   groupsMeta: DEFAULT_META,
   groups,
   hasFiltersSet: false,
-  isFederatedAuth: true,
 };
 
 describe('GroupsTable', () => {
@@ -41,13 +40,6 @@ describe('GroupsTable', () => {
 
     expect(wrapper.find(EuiTable)).toHaveLength(1);
     expect(wrapper.find(GroupRow)).toHaveLength(1);
-  });
-
-  it('renders extra header for non-federated auth', () => {
-    setMockValues({ ...mockValues, isFederatedAuth: false });
-    const wrapper = shallow(<GroupsTable />);
-
-    expect(wrapper.find(EuiTableHeaderCell)).toHaveLength(4);
   });
 
   it('handles pagination', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.test.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiTable, EuiTableHeaderCell } from '@elastic/eui';
+import { EuiTable } from '@elastic/eui';
 
 import { DEFAULT_META } from '../../../../shared/constants';
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
@@ -18,7 +18,6 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { AppLogic } from '../../../app_logic';
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 import { GroupsLogic } from '../groups_logic';
 
@@ -53,7 +52,6 @@ export const GroupsTable: React.FC<{}> = () => {
     groups,
     hasFiltersSet,
   } = useValues(GroupsLogic);
-  const { isFederatedAuth } = useValues(AppLogic);
 
   const clearFiltersLink = hasFiltersSet ? <ClearFiltersLink /> : undefined;
 
@@ -79,7 +77,7 @@ export const GroupsTable: React.FC<{}> = () => {
         <EuiTableHeader>
           <EuiTableHeaderCell>{GROUP_TABLE_HEADER}</EuiTableHeaderCell>
           <EuiTableHeaderCell>{SOURCES_TABLE_HEADER}</EuiTableHeaderCell>
-          {!isFederatedAuth && <EuiTableHeaderCell>{USERS_TABLE_HEADER}</EuiTableHeaderCell>}
+          {<EuiTableHeaderCell>{USERS_TABLE_HEADER}</EuiTableHeaderCell>}
           <EuiTableHeaderCell />
         </EuiTableHeader>
         <EuiTableBody>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
@@ -77,7 +77,7 @@ export const GroupsTable: React.FC<{}> = () => {
         <EuiTableHeader>
           <EuiTableHeaderCell>{GROUP_TABLE_HEADER}</EuiTableHeaderCell>
           <EuiTableHeaderCell>{SOURCES_TABLE_HEADER}</EuiTableHeaderCell>
-          {<EuiTableHeaderCell>{USERS_TABLE_HEADER}</EuiTableHeaderCell>}
+          <EuiTableHeaderCell>{USERS_TABLE_HEADER}</EuiTableHeaderCell>
           <EuiTableHeaderCell />
         </EuiTableHeader>
         <EuiTableBody>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.test.tsx
@@ -21,7 +21,7 @@ const setFilterValue = jest.fn();
 
 describe('TableFilters', () => {
   beforeEach(() => {
-    setMockValues({ filterValue: '', isFederatedAuth: true });
+    setMockValues({ filterValue: '' });
     setMockActions({ setFilterValue });
   });
   it('renders', () => {
@@ -29,13 +29,6 @@ describe('TableFilters', () => {
 
     expect(wrapper.find(EuiFieldSearch)).toHaveLength(1);
     expect(wrapper.find(TableFilterSourcesDropdown)).toHaveLength(1);
-    expect(wrapper.find(TableFilterUsersDropdown)).toHaveLength(0);
-  });
-
-  it('renders for non-federated Auth', () => {
-    setMockValues({ filterValue: '', isFederatedAuth: false });
-    const wrapper = shallow(<TableFilters />);
-
     expect(wrapper.find(TableFilterUsersDropdown)).toHaveLength(1);
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.tsx
@@ -12,7 +12,6 @@ import { useActions, useValues } from 'kea';
 import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { AppLogic } from '../../../app_logic';
 import { GroupsLogic } from '../groups_logic';
 
 import { TableFilterSourcesDropdown } from './table_filter_sources_dropdown';
@@ -28,7 +27,6 @@ const FILTER_GROUPS_PLACEHOLDER = i18n.translate(
 export const TableFilters: React.FC = () => {
   const { setFilterValue } = useActions(GroupsLogic);
   const { filterValue } = useValues(GroupsLogic);
-  const { isFederatedAuth } = useValues(AppLogic);
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => setFilterValue(e.target.value);
 
@@ -47,11 +45,9 @@ export const TableFilters: React.FC = () => {
           <EuiFlexItem className="user-groups-filters__filter-sources">
             <TableFilterSourcesDropdown />
           </EuiFlexItem>
-          {!isFederatedAuth && (
-            <EuiFlexItem>
-              <TableFilterUsersDropdown />
-            </EuiFlexItem>
-          )}
+          <EuiFlexItem>
+            <TableFilterUsersDropdown />
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.test.tsx
@@ -50,7 +50,6 @@ const mockValues = {
   filteredSources: [],
   filteredUsers: [],
   filterValue: '',
-  isFederatedAuth: false,
 };
 
 describe('GroupOverview', () => {
@@ -112,29 +111,12 @@ describe('GroupOverview', () => {
     expect(wrapper.find(ClearFiltersLink)).toHaveLength(1);
   });
 
-  it('renders inviteUsersButton when not federated auth', () => {
-    setMockValues({
-      ...mockValues,
-      isFederatedAuth: false,
-    });
-
+  it('renders inviteUsersButton', () => {
     const wrapper = shallow(<Groups />);
     const actions = getPageHeaderActions(wrapper);
 
     expect(actions.find('[data-test-subj="InviteUsersButton"]')).toHaveLength(1);
     expect(actions.find(EuiButtonTo)).toHaveLength(1);
-  });
-
-  it('does not render inviteUsersButton when federated auth', () => {
-    setMockValues({
-      ...mockValues,
-      isFederatedAuth: true,
-    });
-
-    const wrapper = shallow(<Groups />);
-    const actions = getPageHeaderActions(wrapper);
-
-    expect(actions.find('[data-test-subj="InviteUsersButton"]')).toHaveLength(0);
   });
 
   it('renders EuiLoadingSpinner when loading', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -14,10 +14,9 @@ import { i18n } from '@kbn/i18n';
 
 import { FlashMessagesLogic } from '../../../shared/flash_messages';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
-import { AppLogic } from '../../app_logic';
 import { WorkplaceSearchPageTemplate } from '../../components/layout';
 import { NAV } from '../../constants';
-import { getGroupPath, USERS_PATH } from '../../routes';
+import { getGroupPath, USERS_AND_ROLES_PATH } from '../../routes';
 
 import { AddGroupModal } from './components/add_group_modal';
 import { ClearFiltersLink } from './components/clear_filters_link';
@@ -43,8 +42,6 @@ export const Groups: React.FC = () => {
     filterValue,
   } = useValues(GroupsLogic);
 
-  const { isFederatedAuth } = useValues(AppLogic);
-
   const hasMessages = messages.length > 0;
 
   useEffect(() => {
@@ -68,7 +65,7 @@ export const Groups: React.FC = () => {
 
   const clearFilters = hasFiltersSet && <ClearFiltersLink />;
   const inviteUsersButton = (
-    <EuiButtonTo to={USERS_PATH} data-test-subj="InviteUsersButton">
+    <EuiButtonTo to={USERS_AND_ROLES_PATH} data-test-subj="InviteUsersButton">
       {i18n.translate('xpack.enterpriseSearch.workplaceSearch.groups.inviteUsers.action', {
         defaultMessage: 'Invite users',
       })}
@@ -81,9 +78,7 @@ export const Groups: React.FC = () => {
       })}
     </EuiButton>
   );
-  const headerActions = !isFederatedAuth
-    ? [inviteUsersButton, createGroupButton]
-    : [createGroupButton];
+  const headerActions = [inviteUsersButton, createGroupButton];
 
   const noResults = (
     <EuiFlexGroup justifyContent="spaceAround">

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
@@ -27,7 +27,7 @@ export const mockActions = {
   initializeOverview: jest.fn(() => ({})),
 };
 
-const mockValues = { ...mockOverviewValues, ...mockAppValues, isFederatedAuth: true };
+const mockValues = { ...mockOverviewValues, ...mockAppValues };
 
 setMockActions({ ...mockActions });
 setMockKeaValues({ ...mockValues });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { SOURCES_PATH, USERS_PATH } from '../../routes';
+import { SOURCES_PATH, USERS_AND_ROLES_PATH } from '../../routes';
 
 import { OnboardingCard } from './onboarding_card';
 import { OnboardingSteps, OrgNameOnboarding } from './onboarding_steps';
@@ -33,9 +33,9 @@ describe('OnboardingSteps', () => {
       setMockValues({ canCreateContentSources: true });
       const wrapper = shallow(<OnboardingSteps />);
 
-      expect(wrapper.find(OnboardingCard)).toHaveLength(1);
-      expect(wrapper.find(OnboardingCard).prop('actionPath')).toBe(SOURCES_PATH);
-      expect(wrapper.find(OnboardingCard).prop('description')).toBe(
+      expect(wrapper.find(OnboardingCard)).toHaveLength(2);
+      expect(wrapper.find(OnboardingCard).first().prop('actionPath')).toBe(SOURCES_PATH);
+      expect(wrapper.find(OnboardingCard).first().prop('description')).toBe(
         'Add shared sources for your organization to start searching.'
       );
     });
@@ -44,7 +44,7 @@ describe('OnboardingSteps', () => {
       setMockValues({ sourcesCount: 2, hasOrgSources: true });
       const wrapper = shallow(<OnboardingSteps />);
 
-      expect(wrapper.find(OnboardingCard).prop('description')).toEqual(
+      expect(wrapper.find(OnboardingCard).first().prop('description')).toEqual(
         'You have added 2 shared sources. Happy searching.'
       );
     });
@@ -53,14 +53,13 @@ describe('OnboardingSteps', () => {
       setMockValues({ canCreateContentSources: false });
       const wrapper = shallow(<OnboardingSteps />);
 
-      expect(wrapper.find(OnboardingCard).prop('actionPath')).toBe(undefined);
+      expect(wrapper.find(OnboardingCard).first().prop('actionPath')).toBe(undefined);
     });
   });
 
   describe('Users & Invitations', () => {
     it('renders 0 users when not on federated auth', () => {
       setMockValues({
-        isFederatedAuth: false,
         account,
         accountsCount: 0,
         hasUsers: false,
@@ -68,7 +67,7 @@ describe('OnboardingSteps', () => {
       const wrapper = shallow(<OnboardingSteps />);
 
       expect(wrapper.find(OnboardingCard)).toHaveLength(2);
-      expect(wrapper.find(OnboardingCard).last().prop('actionPath')).toBe(USERS_PATH);
+      expect(wrapper.find(OnboardingCard).last().prop('actionPath')).toBe(USERS_AND_ROLES_PATH);
       expect(wrapper.find(OnboardingCard).last().prop('description')).toEqual(
         'Invite your colleagues into this organization to search with you.'
       );
@@ -76,7 +75,6 @@ describe('OnboardingSteps', () => {
 
     it('renders completed users state', () => {
       setMockValues({
-        isFederatedAuth: false,
         account,
         accountsCount: 1,
         hasUsers: true,
@@ -90,7 +88,6 @@ describe('OnboardingSteps', () => {
 
     it('disables link when the user cannot create invitations', () => {
       setMockValues({
-        isFederatedAuth: false,
         account: {
           ...account,
           canCreateInvitations: false,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
@@ -58,7 +58,7 @@ describe('OnboardingSteps', () => {
   });
 
   describe('Users & Invitations', () => {
-    it('renders 0 users when not on federated auth', () => {
+    it('renders 0 users state', () => {
       setMockValues({
         account,
         accountsCount: 0,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
@@ -26,7 +26,7 @@ import { TelemetryLogic } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
 import sharedSourcesIcon from '../../components/shared/assets/source_icons/share_circle.svg';
 import { ContentSection } from '../../components/shared/content_section';
-import { SOURCES_PATH, USERS_PATH, ORG_SETTINGS_PATH } from '../../routes';
+import { SOURCES_PATH, USERS_AND_ROLES_PATH, ORG_SETTINGS_PATH } from '../../routes';
 
 import { OnboardingCard } from './onboarding_card';
 import { OverviewLogic } from './overview_logic';
@@ -58,7 +58,6 @@ const ONBOARDING_USERS_CARD_DESCRIPTION = i18n.translate(
 
 export const OnboardingSteps: React.FC = () => {
   const {
-    isFederatedAuth,
     organization: { name, defaultOrgName },
     account: { isCurated, canCreateInvitations },
   } = useValues(AppLogic);
@@ -71,8 +70,7 @@ export const OnboardingSteps: React.FC = () => {
     sourcesCount,
   } = useValues(OverviewLogic);
 
-  const accountsPath =
-    !isFederatedAuth && (canCreateInvitations || isCurated) ? USERS_PATH : undefined;
+  const accountsPath = canCreateInvitations || isCurated ? USERS_AND_ROLES_PATH : undefined;
   const sourcesPath = canCreateContentSources || isCurated ? SOURCES_PATH : undefined;
 
   const SOURCES_CARD_DESCRIPTION = i18n.translate(
@@ -86,7 +84,7 @@ export const OnboardingSteps: React.FC = () => {
 
   return (
     <ContentSection>
-      <EuiFlexGrid columns={isFederatedAuth ? 1 : 2}>
+      <EuiFlexGrid columns={2}>
         <OnboardingCard
           title={SOURCES_TITLE}
           testSubj="sharedSourcesButton"
@@ -104,23 +102,21 @@ export const OnboardingSteps: React.FC = () => {
           actionPath={sourcesPath}
           complete={hasOrgSources}
         />
-        {!isFederatedAuth && (
-          <OnboardingCard
-            title={USERS_TITLE}
-            testSubj="usersButton"
-            icon="user"
-            description={hasUsers ? USERS_CARD_DESCRIPTION : ONBOARDING_USERS_CARD_DESCRIPTION}
-            actionTitle={i18n.translate(
-              'xpack.enterpriseSearch.workplaceSearch.usersOnboardingCard.buttonLabel',
-              {
-                defaultMessage: 'Invite {label} users',
-                values: { label: accountsCount > 0 ? 'more' : '' },
-              }
-            )}
-            actionPath={accountsPath}
-            complete={hasUsers}
-          />
-        )}
+        <OnboardingCard
+          title={USERS_TITLE}
+          testSubj="usersButton"
+          icon="user"
+          description={hasUsers ? USERS_CARD_DESCRIPTION : ONBOARDING_USERS_CARD_DESCRIPTION}
+          actionTitle={i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.usersOnboardingCard.buttonLabel',
+            {
+              defaultMessage: 'Invite {label} users',
+              values: { label: accountsCount > 0 ? 'more' : '' },
+            }
+          )}
+          actionPath={accountsPath}
+          complete={hasUsers}
+        />
       </EuiFlexGrid>
       {name === defaultOrgName && (
         <>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.test.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { setMockValues } from './__mocks__';
 import './__mocks__/overview_logic.mock';
 
 import React from 'react';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.test.tsx
@@ -21,14 +21,6 @@ describe('OrganizationStats', () => {
   it('renders', () => {
     const wrapper = shallow(<OrganizationStats />);
 
-    expect(wrapper.find(StatisticCard)).toHaveLength(2);
-    expect(wrapper.find(EuiFlexGrid).prop('columns')).toEqual(2);
-  });
-
-  it('renders additional cards for federated auth', () => {
-    setMockValues({ isFederatedAuth: false });
-    const wrapper = shallow(<OrganizationStats />);
-
     expect(wrapper.find(StatisticCard)).toHaveLength(4);
     expect(wrapper.find(EuiFlexGrid).prop('columns')).toEqual(4);
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.tsx
@@ -13,16 +13,13 @@ import { EuiFlexGrid, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { AppLogic } from '../../app_logic';
 import { ContentSection } from '../../components/shared/content_section';
-import { SOURCES_PATH, USERS_PATH } from '../../routes';
+import { SOURCES_PATH, USERS_AND_ROLES_PATH } from '../../routes';
 
 import { OverviewLogic } from './overview_logic';
 import { StatisticCard } from './statistic_card';
 
 export const OrganizationStats: React.FC = () => {
-  const { isFederatedAuth } = useValues(AppLogic);
-
   const { sourcesCount, pendingInvitationsCount, accountsCount, personalSourcesCount } = useValues(
     OverviewLogic
   );
@@ -37,7 +34,7 @@ export const OrganizationStats: React.FC = () => {
       }
     >
       <EuiPanel color="subdued" hasShadow={false}>
-        <EuiFlexGrid columns={isFederatedAuth ? 2 : 4}>
+        <EuiFlexGrid columns={4}>
           <StatisticCard
             title={i18n.translate(
               'xpack.enterpriseSearch.workplaceSearch.organizationStats.sharedSources',
@@ -46,26 +43,22 @@ export const OrganizationStats: React.FC = () => {
             count={sourcesCount}
             actionPath={SOURCES_PATH}
           />
-          {!isFederatedAuth && (
-            <>
-              <StatisticCard
-                title={i18n.translate(
-                  'xpack.enterpriseSearch.workplaceSearch.organizationStats.invitations',
-                  { defaultMessage: 'Invitations' }
-                )}
-                count={pendingInvitationsCount}
-                actionPath={USERS_PATH}
-              />
-              <StatisticCard
-                title={i18n.translate(
-                  'xpack.enterpriseSearch.workplaceSearch.organizationStats.activeUsers',
-                  { defaultMessage: 'Active users' }
-                )}
-                count={accountsCount}
-                actionPath={USERS_PATH}
-              />
-            </>
-          )}
+          <StatisticCard
+            title={i18n.translate(
+              'xpack.enterpriseSearch.workplaceSearch.organizationStats.invitations',
+              { defaultMessage: 'Invitations' }
+            )}
+            count={pendingInvitationsCount}
+            actionPath={USERS_AND_ROLES_PATH}
+          />
+          <StatisticCard
+            title={i18n.translate(
+              'xpack.enterpriseSearch.workplaceSearch.organizationStats.activeUsers',
+              { defaultMessage: 'Active users' }
+            )}
+            count={accountsCount}
+            actionPath={USERS_AND_ROLES_PATH}
+          />
           <StatisticCard
             title={i18n.translate(
               'xpack.enterpriseSearch.workplaceSearch.organizationStats.privateSources',

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -136,7 +136,6 @@ describe('callEnterpriseSearchConfigAPI', () => {
       publicUrl: undefined,
       readOnlyMode: false,
       ilmEnabled: false,
-      isFederatedAuth: false,
       configuredLimits: {
         appSearch: {
           engine: {

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -75,7 +75,6 @@ export const callEnterpriseSearchConfigAPI = async ({
       publicUrl: stripTrailingSlash(data?.settings?.external_url),
       readOnlyMode: !!data?.settings?.read_only_mode,
       ilmEnabled: !!data?.settings?.ilm_enabled,
-      isFederatedAuth: !!data?.settings?.is_federated_auth, // i.e., not standard auth
       configuredLimits: {
         appSearch: {
           engine: {


### PR DESCRIPTION
### closes https://github.com/elastic/enterprise-search-team/issues/682

## Summary

As a part of the User management project, we are introducing the concept of a User for the first time in Kibana. This PR removes the checks that hid this functionality, mainly for the Overview page and the Groups section.

**Overview**
![image](https://user-images.githubusercontent.com/1869731/123171020-da46ca80-d440-11eb-9ce1-215f9adf72af.png)

**Groups**
![image](https://user-images.githubusercontent.com/1869731/123171173-0f531d00-d441-11eb-9cfb-db546caab97b.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
