### PR TITLE
[Enterprise Search] Add notices for deactivated users and SMTP callout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mapping.tsx
@@ -45,6 +45,7 @@ export const RoleMapping: React.FC = () => {
     selectedEngines,
     selectedAuthProviders,
     roleMappingErrors,
+    formLoading,
   } = useValues(RoleMappingsLogic);
 
   const isNew = !roleMapping;
@@ -67,6 +68,7 @@ export const RoleMapping: React.FC = () => {
   return (
     <RoleMappingFlyout
       disabled={attributeValueInvalid || !hasEngineAssignment}
+      formLoading={formLoading}
       isNew={isNew}
       closeUsersAndRolesFlyout={closeUsersAndRolesFlyout}
       handleSaveMapping={handleSaveMapping}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
@@ -58,6 +58,7 @@ describe('RoleMappingsLogic', () => {
     userCreated: false,
     userFormIsNewUser: true,
     userFormUserIsExisting: true,
+    smtpSettingsPresent: false,
   };
 
   const mappingsServerProps = {
@@ -70,6 +71,7 @@ describe('RoleMappingsLogic', () => {
     hasAdvancedRoles: false,
     singleUserRoleMappings: [asSingleUserRoleMapping],
     elasticsearchUsers,
+    smtpSettingsPresent: false,
   };
 
   beforeEach(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
@@ -59,6 +59,7 @@ describe('RoleMappingsLogic', () => {
     userFormIsNewUser: true,
     userFormUserIsExisting: true,
     smtpSettingsPresent: false,
+    formLoading: false,
   };
 
   const mappingsServerProps = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
@@ -330,6 +330,15 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         setRoleMappingsData: (_, { smtpSettingsPresent }) => smtpSettingsPresent,
       },
     ],
+    formLoading: [
+      false,
+      {
+        handleSaveMapping: () => true,
+        handleSaveUser: () => true,
+        initializeRoleMappings: () => false,
+        setRoleMappingErrors: () => false,
+      },
+    ],
   },
   selectors: ({ selectors }) => ({
     selectedOptions: [

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
@@ -7,14 +7,17 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { EuiComboBoxOptionOption } from '@elastic/eui';
-
 import {
   clearFlashMessages,
   flashAPIErrors,
   setSuccessMessage,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
+import {
+  RoleMappingsBaseServerDetails,
+  RoleMappingsBaseActions,
+  RoleMappingsBaseValues,
+} from '../../../shared/role_mapping';
 import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
 import { AttributeName, SingleUserRoleMapping, ElasticsearchUser } from '../../../shared/types';
 import { ASRoleMapping, RoleTypes } from '../../types';
@@ -29,16 +32,11 @@ import {
 
 type UserMapping = SingleUserRoleMapping<ASRoleMapping>;
 
-interface RoleMappingsServerDetails {
+interface RoleMappingsServerDetails extends RoleMappingsBaseServerDetails {
   roleMappings: ASRoleMapping[];
-  attributes: string[];
-  authProviders: string[];
   availableEngines: Engine[];
-  elasticsearchRoles: string[];
-  elasticsearchUsers: ElasticsearchUser[];
-  hasAdvancedRoles: boolean;
-  multipleAuthProvidersConfig: boolean;
   singleUserRoleMappings: UserMapping[];
+  hasAdvancedRoles: boolean;
 }
 
 const getFirstAttributeName = (roleMapping: ASRoleMapping) =>
@@ -47,24 +45,7 @@ const getFirstAttributeValue = (roleMapping: ASRoleMapping) =>
   Object.entries(roleMapping.rules)[0][1] as AttributeName;
 const emptyUser = { username: '', email: '' } as ElasticsearchUser;
 
-interface RoleMappingsActions {
-  handleAccessAllEnginesChange(selected: boolean): { selected: boolean };
-  handleAuthProviderChange(value: string[]): { value: string[] };
-  handleAttributeSelectorChange(
-    value: AttributeName,
-    firstElasticsearchRole: string
-  ): { value: AttributeName; firstElasticsearchRole: string };
-  handleAttributeValueChange(value: string): { value: string };
-  handleDeleteMapping(roleMappingId: string): { roleMappingId: string };
-  handleEngineSelectionChange(engineNames: string[]): { engineNames: string[] };
-  handleRoleChange(roleType: RoleTypes): { roleType: RoleTypes };
-  handleUsernameSelectChange(username: string): { username: string };
-  handleSaveMapping(): void;
-  handleSaveUser(): void;
-  initializeRoleMapping(roleMappingId?: string): { roleMappingId?: string };
-  initializeSingleUserRoleMapping(roleMappingId?: string): { roleMappingId?: string };
-  initializeRoleMappings(): void;
-  resetState(): void;
+interface RoleMappingsActions extends RoleMappingsBaseActions {
   setRoleMapping(roleMapping: ASRoleMapping): { roleMapping: ASRoleMapping };
   setSingleUserRoleMapping(data?: UserMapping): { singleUserRoleMapping: UserMapping };
   setRoleMappings({
@@ -73,34 +54,14 @@ interface RoleMappingsActions {
     roleMappings: ASRoleMapping[];
   }): { roleMappings: ASRoleMapping[] };
   setRoleMappingsData(data: RoleMappingsServerDetails): RoleMappingsServerDetails;
-  setElasticsearchUser(
-    elasticsearchUser?: ElasticsearchUser
-  ): { elasticsearchUser: ElasticsearchUser };
-  openRoleMappingFlyout(): void;
-  openSingleUserRoleMappingFlyout(): void;
-  closeUsersAndRolesFlyout(): void;
-  setRoleMappingErrors(errors: string[]): { errors: string[] };
-  enableRoleBasedAccess(): void;
-  setUserExistingRadioValue(userFormUserIsExisting: boolean): { userFormUserIsExisting: boolean };
-  setElasticsearchUsernameValue(username: string): { username: string };
-  setElasticsearchEmailValue(email: string): { email: string };
-  setUserCreated(): void;
-  setUserFormIsNewUser(userFormIsNewUser: boolean): { userFormIsNewUser: boolean };
+  handleAccessAllEnginesChange(selected: boolean): { selected: boolean };
+  handleEngineSelectionChange(engineNames: string[]): { engineNames: string[] };
+  handleRoleChange(roleType: RoleTypes): { roleType: RoleTypes };
 }
 
-interface RoleMappingsValues {
+interface RoleMappingsValues extends RoleMappingsBaseValues {
   accessAllEngines: boolean;
-  attributeName: AttributeName;
-  attributeValue: string;
-  attributes: string[];
-  availableAuthProviders: string[];
   availableEngines: Engine[];
-  dataLoading: boolean;
-  elasticsearchRoles: string[];
-  elasticsearchUsers: ElasticsearchUser[];
-  elasticsearchUser: ElasticsearchUser;
-  hasAdvancedRoles: boolean;
-  multipleAuthProvidersConfig: boolean;
   roleMapping: ASRoleMapping | null;
   roleMappings: ASRoleMapping[];
   singleUserRoleMapping: UserMapping | null;
@@ -108,13 +69,7 @@ interface RoleMappingsValues {
   roleType: RoleTypes;
   selectedAuthProviders: string[];
   selectedEngines: Set<string>;
-  roleMappingFlyoutOpen: boolean;
-  singleUserRoleMappingFlyoutOpen: boolean;
-  selectedOptions: EuiComboBoxOptionOption[];
-  roleMappingErrors: string[];
-  userFormUserIsExisting: boolean;
-  userCreated: boolean;
-  userFormIsNewUser: boolean;
+  hasAdvancedRoles: boolean;
 }
 
 export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappingsActions>>({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
@@ -324,6 +324,12 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         setUserFormIsNewUser: (_, { userFormIsNewUser }) => userFormIsNewUser,
       },
     ],
+    smtpSettingsPresent: [
+      false,
+      {
+        setRoleMappingsData: (_, { smtpSettingsPresent }) => smtpSettingsPresent,
+      },
+    ],
   },
   selectors: ({ selectors }) => ({
     selectedOptions: [

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.test.tsx
@@ -14,7 +14,12 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { UserFlyout, UserAddedInfo, UserInvitationCallout } from '../../../shared/role_mapping';
+import {
+  UserFlyout,
+  UserAddedInfo,
+  UserInvitationCallout,
+  DeactivatedUserCallout,
+} from '../../../shared/role_mapping';
 import { elasticsearchUsers } from '../../../shared/role_mapping/__mocks__/elasticsearch_users';
 import { wsSingleUserRoleMapping } from '../../../shared/role_mapping/__mocks__/roles';
 
@@ -89,6 +94,23 @@ describe('User', () => {
     const wrapper = shallow(<User />);
 
     expect(wrapper.find(UserAddedInfo)).toHaveLength(1);
+  });
+
+  it('renders DeactivatedUserCallout', () => {
+    setMockValues({
+      ...mockValues,
+      singleUserRoleMapping: {
+        ...wsSingleUserRoleMapping,
+        invitation: null,
+        elasticsearchUser: {
+          ...wsSingleUserRoleMapping.elasticsearchUser,
+          enabled: false,
+        },
+      },
+    });
+    const wrapper = shallow(<User />);
+
+    expect(wrapper.find(DeactivatedUserCallout)).toHaveLength(1);
   });
 
   it('disables form when username value not present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.tsx
@@ -50,6 +50,7 @@ export const User: React.FC = () => {
     userCreated,
     userFormIsNewUser,
     smtpSettingsPresent,
+    formLoading,
   } = useValues(RoleMappingsLogic);
 
   const roleTypes = hasAdvancedRoles ? [...standardRoles, ...advancedRoles] : standardRoles;
@@ -102,6 +103,7 @@ export const User: React.FC = () => {
   return (
     <UserFlyout
       disabled={flyoutDisabled}
+      formLoading={formLoading}
       isComplete={userCreated}
       isNew={userFormIsNewUser}
       closeUserFlyout={closeUsersAndRolesFlyout}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.tsx
@@ -17,6 +17,7 @@ import {
   UserSelector,
   UserAddedInfo,
   UserInvitationCallout,
+  DeactivatedUserCallout,
 } from '../../../shared/role_mapping';
 import { RoleTypes } from '../../types';
 
@@ -55,6 +56,11 @@ export const User: React.FC = () => {
   const showEngineAssignmentSelector = hasEngines && hasAdvancedRoles;
   const flyoutDisabled =
     !userFormUserIsExisting && (!elasticsearchUser.email || !elasticsearchUser.username);
+  const userIsDeactivated = !!(
+    singleUserRoleMapping &&
+    !singleUserRoleMapping.invitation &&
+    !singleUserRoleMapping.elasticsearchUser.enabled
+  );
 
   const userAddedInfo = singleUserRoleMapping && (
     <UserAddedInfo
@@ -101,6 +107,7 @@ export const User: React.FC = () => {
     >
       {userCreated ? userAddedInfo : createUserForm}
       {userInvitationCallout}
+      {userIsDeactivated && <DeactivatedUserCallout isNew={userFormIsNewUser} />}
     </UserFlyout>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/user.tsx
@@ -49,6 +49,7 @@ export const User: React.FC = () => {
     roleMappingErrors,
     userCreated,
     userFormIsNewUser,
+    smtpSettingsPresent,
   } = useValues(RoleMappingsLogic);
 
   const roleTypes = hasAdvancedRoles ? [...standardRoles, ...advancedRoles] : standardRoles;
@@ -82,6 +83,7 @@ export const User: React.FC = () => {
     <EuiForm isInvalid={roleMappingErrors.length > 0} error={roleMappingErrors}>
       <UserSelector
         isNewUser={userFormIsNewUser}
+        smtpSettingsPresent={smtpSettingsPresent}
         elasticsearchUsers={elasticsearchUsers}
         handleRoleChange={handleRoleChange}
         elasticsearchUser={elasticsearchUser}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/__mocks__/elasticsearch_users.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/__mocks__/elasticsearch_users.ts
@@ -9,5 +9,6 @@ export const elasticsearchUsers = [
   {
     email: 'user1@user.com',
     username: 'user1',
+    enabled: true,
   },
 ];

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.test.tsx
@@ -9,12 +9,12 @@ import React from 'react';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
-import { EuiComboBox, EuiFieldText } from '@elastic/eui';
+import { EuiComboBox, EuiFieldText, EuiFormRow } from '@elastic/eui';
 
 import { AttributeName } from '../types';
 
 import { AttributeSelector } from './attribute_selector';
-import { ANY_AUTH_PROVIDER, ANY_AUTH_PROVIDER_OPTION_LABEL } from './constants';
+import { ANY_AUTH_PROVIDER, ANY_AUTH_PROVIDER_OPTION_LABEL, REQUIRED_LABEL } from './constants';
 
 const handleAttributeSelectorChange = jest.fn();
 const handleAttributeValueChange = jest.fn();
@@ -165,6 +165,13 @@ describe('AttributeSelector', () => {
         'kbn_saml',
         baseProps.elasticsearchRoles[0]
       );
+    });
+
+    it('shows helpText when attributeValueInvalid', () => {
+      const wrapper = shallow(<AttributeSelector {...baseProps} attributeValueInvalid />);
+      const formRow = wrapper.find(EuiFormRow).at(2);
+
+      expect(formRow.prop('helpText')).toEqual(REQUIRED_LABEL);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
@@ -21,7 +21,7 @@ import {
   ANY_AUTH_PROVIDER,
   ANY_AUTH_PROVIDER_OPTION_LABEL,
   ATTRIBUTE_VALUE_LABEL,
-  ATTRIBUTE_VALUE_ERROR,
+  REQUIRED_LABEL,
   AUTH_ANY_PROVIDER_LABEL,
   AUTH_INDIVIDUAL_PROVIDER_LABEL,
   AUTH_PROVIDER_LABEL,
@@ -129,8 +129,7 @@ export const AttributeSelector: React.FC<Props> = ({
       <EuiFormRow
         label={ATTRIBUTE_VALUE_LABEL}
         fullWidth
-        isInvalid={attributeValueInvalid}
-        error={[ATTRIBUTE_VALUE_ERROR]}
+        helpText={attributeValueInvalid && REQUIRED_LABEL}
       >
         {attributeName === 'role' ? (
           <EuiSelect

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -444,3 +444,14 @@ export const DEACTIVATED_USER_CALLOUT_DESCRIPTION = i18n.translate(
       'This user is not currently active, and access has been temporarily revoked. Users can be re-activated via the User Management area of the Kibana console.',
   }
 );
+
+export const SMTP_CALLOUT_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.smtpCalloutLabel',
+  {
+    defaultMessage: 'Personalized invitations will be automatically sent when an Enterprise Search',
+  }
+);
+
+export const SMTP_LINK_LABEL = i18n.translate('xpack.enterpriseSearch.roleMapping.smtpLinkLabel', {
+  defaultMessage: 'SMTP configuration is provided',
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -373,6 +373,13 @@ export const UPDATE_USER_DESCRIPTION = i18n.translate(
   }
 );
 
+export const DEACTIVATED_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.deactivatedLabel',
+  {
+    defaultMessage: 'Deactivated',
+  }
+);
+
 export const INVITATION_PENDING_LABEL = i18n.translate(
   'xpack.enterpriseSearch.roleMapping.invitationPendingLabel',
   {
@@ -420,5 +427,20 @@ export const AUTH_PROVIDER_TOOLTIP = i18n.translate(
   {
     defaultMessage:
       'Provider-specific role mapping is still applied, but configuration is now deprecated.',
+  }
+);
+
+export const DEACTIVATED_USER_CALLOUT_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.deactivatedUserCalloutLabel',
+  {
+    defaultMessage: 'User deactivated',
+  }
+);
+
+export const DEACTIVATED_USER_CALLOUT_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.deactivatedUserCalloutDescription',
+  {
+    defaultMessage:
+      'This user is not currently active, and access has been temporarily revoked. Users can be re-activated via the User Management area of the Kibana console.',
   }
 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -91,13 +91,6 @@ export const ATTRIBUTE_VALUE_LABEL = i18n.translate(
   }
 );
 
-export const ATTRIBUTE_VALUE_ERROR = i18n.translate(
-  'xpack.enterpriseSearch.roleMapping.attributeValueError',
-  {
-    defaultMessage: 'Attribute value is required',
-  }
-);
-
 export const REMOVE_ROLE_MAPPING_TITLE = i18n.translate(
   'xpack.enterpriseSearch.roleMapping.removeRoleMappingTitle',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.test.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { DeactivatedUserCallout } from './';
+
+describe('DeactivatedUserCallout', () => {
+  it('renders with new', () => {
+    const wrapper = shallow(<DeactivatedUserCallout isNew />);
+
+    expect(wrapper).toMatchInlineSnapshot(`
+      <Fragment>
+        <EuiText
+          size="s"
+        >
+          <EuiIcon
+            color="warning"
+            type="alert"
+          />
+           
+          <strong>
+            User deactivated
+          </strong>
+        </EuiText>
+        <EuiSpacer
+          size="xs"
+        />
+        <EuiText
+          size="s"
+        >
+          This user is not currently active, and access has been temporarily revoked. Users can be re-activated via the User Management area of the Kibana console.
+        </EuiText>
+        <EuiSpacer />
+      </Fragment>
+    `);
+  });
+
+  it('renders with existing', () => {
+    const wrapper = shallow(<DeactivatedUserCallout isNew={false} />);
+
+    expect(wrapper).toMatchInlineSnapshot(`
+      <Fragment>
+        <EuiSpacer />
+        <EuiText
+          size="s"
+        >
+          <EuiIcon
+            color="warning"
+            type="alert"
+          />
+           
+          <strong>
+            User deactivated
+          </strong>
+        </EuiText>
+        <EuiSpacer
+          size="xs"
+        />
+        <EuiText
+          size="s"
+        >
+          This user is not currently active, and access has been temporarily revoked. Users can be re-activated via the User Management area of the Kibana console.
+        </EuiText>
+        <EuiSpacer />
+      </Fragment>
+    `);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/deactivated_user_callout.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiSpacer, EuiText, EuiIcon } from '@elastic/eui';
+
+interface Props {
+  isNew: boolean;
+}
+
+import { DEACTIVATED_USER_CALLOUT_LABEL, DEACTIVATED_USER_CALLOUT_DESCRIPTION } from './constants';
+
+export const DeactivatedUserCallout: React.FC<Props> = ({ isNew }) => (
+  <>
+    {!isNew && <EuiSpacer />}
+    <EuiText size="s">
+      <EuiIcon type="alert" color="warning" /> <strong>{DEACTIVATED_USER_CALLOUT_LABEL}</strong>
+    </EuiText>
+    <EuiSpacer size="xs" />
+    <EuiText size="s">{DEACTIVATED_USER_CALLOUT_DESCRIPTION}</EuiText>
+    <EuiSpacer />
+  </>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+export * from './types';
 export { AttributeSelector } from './attribute_selector';
 export { DeactivatedUserCallout } from './deactivated_user_callout';
 export { RolesEmptyPrompt } from './roles_empty_prompt';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { AttributeSelector } from './attribute_selector';
+export { DeactivatedUserCallout } from './deactivated_user_callout';
 export { RolesEmptyPrompt } from './roles_empty_prompt';
 export { RoleMappingsTable } from './role_mappings_table';
 export { RoleOptionLabel } from './role_option_label';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mapping_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mapping_flyout.test.tsx
@@ -26,6 +26,7 @@ describe('RoleMappingFlyout', () => {
   const props = {
     isNew: true,
     disabled: false,
+    formLoading: false,
     closeUsersAndRolesFlyout,
     handleSaveMapping,
   };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mapping_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mapping_flyout.tsx
@@ -79,7 +79,7 @@ export const RoleMappingFlyout: React.FC<Props> = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
-              disabled={disabled || formLoading}
+              disabled={disabled}
               isLoading={formLoading}
               onClick={handleSaveMapping}
               fill

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mapping_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mapping_flyout.tsx
@@ -36,6 +36,7 @@ interface Props {
   children: React.ReactNode;
   isNew: boolean;
   disabled: boolean;
+  formLoading: boolean;
   closeUsersAndRolesFlyout(): void;
   handleSaveMapping(): void;
 }
@@ -44,6 +45,7 @@ export const RoleMappingFlyout: React.FC<Props> = ({
   children,
   isNew,
   disabled,
+  formLoading,
   closeUsersAndRolesFlyout,
   handleSaveMapping,
 }) => (
@@ -77,7 +79,8 @@ export const RoleMappingFlyout: React.FC<Props> = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
-              disabled={disabled}
+              disabled={disabled || formLoading}
+              isLoading={formLoading}
               onClick={handleSaveMapping}
               fill
               data-test-subj="FlyoutButton"

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/types.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiComboBoxOptionOption } from '@elastic/eui';
+
+import { AttributeName, ElasticsearchUser } from '../../shared/types';
+
+export interface RoleMappingsBaseServerDetails {
+  attributes: string[];
+  authProviders: string[];
+  elasticsearchRoles: string[];
+  elasticsearchUsers: ElasticsearchUser[];
+  multipleAuthProvidersConfig: boolean;
+}
+
+export interface RoleMappingsBaseActions {
+  handleAuthProviderChange(value: string[]): { value: string[] };
+  handleAttributeSelectorChange(
+    value: AttributeName,
+    firstElasticsearchRole: string
+  ): { value: AttributeName; firstElasticsearchRole: string };
+  handleAttributeValueChange(value: string): { value: string };
+  handleDeleteMapping(roleMappingId: string): { roleMappingId: string };
+  handleUsernameSelectChange(username: string): { username: string };
+  handleSaveMapping(): void;
+  handleSaveUser(): void;
+  initializeRoleMapping(roleMappingId?: string): { roleMappingId?: string };
+  initializeSingleUserRoleMapping(roleMappingId?: string): { roleMappingId?: string };
+  initializeRoleMappings(): void;
+  resetState(): void;
+  setElasticsearchUser(
+    elasticsearchUser?: ElasticsearchUser
+  ): { elasticsearchUser: ElasticsearchUser };
+  openRoleMappingFlyout(): void;
+  openSingleUserRoleMappingFlyout(): void;
+  closeUsersAndRolesFlyout(): void;
+  setRoleMappingErrors(errors: string[]): { errors: string[] };
+  enableRoleBasedAccess(): void;
+  setUserExistingRadioValue(userFormUserIsExisting: boolean): { userFormUserIsExisting: boolean };
+  setElasticsearchUsernameValue(username: string): { username: string };
+  setElasticsearchEmailValue(email: string): { email: string };
+  setUserCreated(): void;
+  setUserFormIsNewUser(userFormIsNewUser: boolean): { userFormIsNewUser: boolean };
+}
+
+export interface RoleMappingsBaseValues extends RoleMappingsBaseServerDetails {
+  attributeName: AttributeName;
+  attributeValue: string;
+  availableAuthProviders: string[];
+  dataLoading: boolean;
+  elasticsearchUser: ElasticsearchUser;
+  roleMappingFlyoutOpen: boolean;
+  singleUserRoleMappingFlyoutOpen: boolean;
+  selectedOptions: EuiComboBoxOptionOption[];
+  roleMappingErrors: string[];
+  userFormUserIsExisting: boolean;
+  userCreated: boolean;
+  userFormIsNewUser: boolean;
+  accessAllEngines: boolean;
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/types.ts
@@ -15,6 +15,7 @@ export interface RoleMappingsBaseServerDetails {
   elasticsearchRoles: string[];
   elasticsearchUsers: ElasticsearchUser[];
   multipleAuthProvidersConfig: boolean;
+  smtpSettingsPresent: boolean;
 }
 
 export interface RoleMappingsBaseActions {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/types.ts
@@ -62,4 +62,5 @@ export interface RoleMappingsBaseValues extends RoleMappingsBaseServerDetails {
   userCreated: boolean;
   userFormIsNewUser: boolean;
   accessAllEngines: boolean;
+  formLoading: boolean;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.test.tsx
@@ -30,6 +30,7 @@ describe('UserFlyout', () => {
     isNew: true,
     isComplete: false,
     disabled: false,
+    formLoading: false,
     closeUserFlyout,
     handleSaveUser,
   };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.tsx
@@ -77,12 +77,7 @@ export const UserFlyout: React.FC<Props> = ({
         <EuiButtonEmpty onClick={closeUserFlyout}>{CANCEL_BUTTON_LABEL}</EuiButtonEmpty>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton
-          disabled={disabled}
-          isLoading={formLoading}
-          onClick={handleSaveUser}
-          fill
-        >
+        <EuiButton disabled={disabled} isLoading={formLoading} onClick={handleSaveUser} fill>
           {isNew ? ADD_USER_LABEL : UPDATE_USER_LABEL}
         </EuiButton>
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.tsx
@@ -28,6 +28,7 @@ interface Props {
   isNew: boolean;
   isComplete: boolean;
   disabled: boolean;
+  formLoading: boolean;
   closeUserFlyout(): void;
   handleSaveUser(): void;
 }
@@ -49,6 +50,7 @@ export const UserFlyout: React.FC<Props> = ({
   isNew,
   isComplete,
   disabled,
+  formLoading,
   closeUserFlyout,
   handleSaveUser,
 }) => {
@@ -75,7 +77,12 @@ export const UserFlyout: React.FC<Props> = ({
         <EuiButtonEmpty onClick={closeUserFlyout}>{CANCEL_BUTTON_LABEL}</EuiButtonEmpty>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton disabled={disabled} onClick={handleSaveUser} fill>
+        <EuiButton
+          disabled={disabled || formLoading}
+          isLoading={formLoading}
+          onClick={handleSaveUser}
+          fill
+        >
           {isNew ? ADD_USER_LABEL : UPDATE_USER_LABEL}
         </EuiButton>
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_flyout.tsx
@@ -78,7 +78,7 @@ export const UserFlyout: React.FC<Props> = ({
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiButton
-          disabled={disabled || formLoading}
+          disabled={disabled}
           isLoading={formLoading}
           onClick={handleSaveUser}
           fill

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_selector.test.tsx
@@ -34,6 +34,7 @@ describe('UserSelector', () => {
 
   const props = {
     isNewUser: true,
+    smtpSettingsPresent: false,
     userFormUserIsExisting: true,
     elasticsearchUsers,
     elasticsearchUser: elasticsearchUsers[0],
@@ -101,7 +102,7 @@ describe('UserSelector', () => {
         {...props}
         userFormUserIsExisting={false}
         elasticsearchUsers={[]}
-        elasticsearchUser={{ email: '', username: '' }}
+        elasticsearchUser={{ email: '', username: '', enabled: true }}
       />
     );
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/user_selector.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import {
   EuiFieldText,
+  EuiLink,
   EuiRadio,
   EuiFormRow,
   EuiSelect,
@@ -21,6 +22,9 @@ import { ElasticsearchUser } from '../../shared/types';
 import { Role as WSRole } from '../../workplace_search/types';
 
 import { USERNAME_LABEL, EMAIL_LABEL } from '../constants';
+import { docLinks } from '../doc_links';
+
+const SMTP_URL = `${docLinks.enterpriseSearchBase}/mailer-configuration.html`;
 
 import {
   NEW_USER_LABEL,
@@ -28,12 +32,15 @@ import {
   USERNAME_NO_USERS_TEXT,
   REQUIRED_LABEL,
   ROLE_LABEL,
+  SMTP_CALLOUT_LABEL,
+  SMTP_LINK_LABEL,
 } from './constants';
 
 type SharedRole = WSRole | ASRole;
 
 interface Props {
   isNewUser: boolean;
+  smtpSettingsPresent: boolean;
   userFormUserIsExisting: boolean;
   elasticsearchUsers: ElasticsearchUser[];
   elasticsearchUser: ElasticsearchUser;
@@ -48,6 +55,7 @@ interface Props {
 
 export const UserSelector: React.FC<Props> = ({
   isNewUser,
+  smtpSettingsPresent,
   userFormUserIsExisting,
   elasticsearchUsers,
   elasticsearchUser,
@@ -66,6 +74,14 @@ export const UserSelector: React.FC<Props> = ({
   }));
   const hasElasticsearchUsers = elasticsearchUsers.length > 0;
   const showNewUserExistingUserControls = userFormUserIsExisting && hasElasticsearchUsers;
+  const smptHelpText = !smtpSettingsPresent && (
+    <>
+      {SMTP_CALLOUT_LABEL}{' '}
+      <EuiLink href={SMTP_URL} target="_blank">
+        {SMTP_LINK_LABEL}
+      </EuiLink>
+    </>
+  );
 
   const roleSelect = (
     <EuiFormRow label={ROLE_LABEL}>
@@ -80,7 +96,7 @@ export const UserSelector: React.FC<Props> = ({
   );
 
   const emailInput = (
-    <EuiFormRow label={EMAIL_LABEL}>
+    <EuiFormRow label={EMAIL_LABEL} helpText={smptHelpText}>
       <EuiFieldText
         name={EMAIL_LABEL}
         data-test-subj="EmailInput"

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 
 import { shallow, mount } from 'enzyme';
 
-import { EuiInMemoryTable, EuiTextColor } from '@elastic/eui';
+import { EuiInMemoryTable, EuiTextColor, EuiBadge } from '@elastic/eui';
 
 import { engines } from '../../app_search/__mocks__/engines.mock';
 
@@ -27,6 +27,7 @@ describe('UsersTable', () => {
     singleUserRoleMappings: [wsSingleUserRoleMapping],
     initializeSingleUserRoleMapping,
     handleDeleteMapping,
+    enabled: true,
   };
 
   it('renders', () => {
@@ -55,6 +56,7 @@ describe('UsersTable', () => {
       elasticsearchUser: {
         email: null,
         username: 'foo',
+        enabled: true,
       },
     };
     const wrapper = mount(<UsersTable {...props} singleUserRoleMappings={[userWithNoEmail]} />);
@@ -96,5 +98,21 @@ describe('UsersTable', () => {
     expect(wrapper.find('[data-test-subj="AccessItems"]').prop('children')).toEqual(
       `${engines[0].name}, ${engines[1].name} + 1`
     );
+  });
+
+  it('renders deactivatedBadge', () => {
+    const disabledUser = {
+      ...wsSingleUserRoleMapping,
+      elasticsearchUser: {
+        email: 'email@user.com',
+        username: 'foo',
+        enabled: false,
+      },
+      invitation: null,
+    };
+    const wrapper = mount(<UsersTable {...props} singleUserRoleMappings={[disabledUser]} />);
+    const cell = wrapper.find('[data-test-subj="UsernameCell"]');
+
+    expect(cell.find(EuiBadge)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
@@ -15,6 +15,7 @@ import { WSRoleMapping } from '../../workplace_search/types';
 
 import {
   INVITATION_PENDING_LABEL,
+  DEACTIVATED_LABEL,
   ALL_LABEL,
   FILTER_USERS_LABEL,
   NO_USERS_LABEL,
@@ -37,6 +38,7 @@ interface SharedUser extends SingleUserRoleMapping<ASRoleMapping | WSRoleMapping
   email: string | null;
   roleType: string;
   id: string;
+  enabled: boolean;
 }
 
 interface SharedRoleMapping extends ASRoleMapping, WSRoleMapping {
@@ -52,6 +54,7 @@ interface Props {
 
 const noItemsPlaceholder = <EuiTextColor color="subdued">&mdash;</EuiTextColor>;
 const invitationBadge = <EuiBadge color="hollow">{INVITATION_PENDING_LABEL}</EuiBadge>;
+const deactivatedBadge = <EuiBadge color="hollow">{DEACTIVATED_LABEL}</EuiBadge>;
 
 export const UsersTable: React.FC<Props> = ({
   accessItemKey,
@@ -63,6 +66,7 @@ export const UsersTable: React.FC<Props> = ({
   const users = ((singleUserRoleMappings as SharedUser[]).map((user) => ({
     username: user.elasticsearchUser.username,
     email: user.elasticsearchUser.email,
+    enabled: user.elasticsearchUser.enabled,
     roleType: user.roleMapping.roleType,
     id: user.roleMapping.id,
     accessItems: (user.roleMapping as SharedRoleMapping)[accessItemKey],
@@ -73,7 +77,11 @@ export const UsersTable: React.FC<Props> = ({
     {
       field: 'username',
       name: USERNAME_LABEL,
-      render: (_, { username }: SharedUser) => username,
+      render: (_, { username, invitation, enabled }: SharedUser) => (
+        <div data-test-subj="UsernameCell">
+          {username} {!invitation && !enabled && deactivatedBadge}
+        </div>
+      ),
     },
     {
       field: 'email',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -49,10 +49,11 @@ export interface Invitation {
 export interface ElasticsearchUser {
   email: string | null;
   username: string;
+  enabled: boolean;
 }
 
 export interface SingleUserRoleMapping<T> {
-  invitation: Invitation;
+  invitation: Invitation | null;
   elasticsearchUser: ElasticsearchUser;
   roleMapping: T;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
@@ -59,6 +59,7 @@ export const RoleMapping: React.FC = () => {
     selectedAuthProviders,
     roleMapping,
     roleMappingErrors,
+    formLoading,
   } = useValues(RoleMappingsLogic);
 
   const isNew = !roleMapping;
@@ -69,6 +70,7 @@ export const RoleMapping: React.FC = () => {
   return (
     <RoleMappingFlyout
       disabled={attributeValueInvalid || !hasGroupAssignment}
+      formLoading={formLoading}
       isNew={isNew}
       closeUsersAndRolesFlyout={closeUsersAndRolesFlyout}
       handleSaveMapping={handleSaveMapping}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
@@ -58,6 +58,7 @@ describe('RoleMappingsLogic', () => {
     userFormIsNewUser: true,
     userFormUserIsExisting: true,
     smtpSettingsPresent: false,
+    formLoading: false,
   };
   const roleGroup = {
     id: '123',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
@@ -57,6 +57,7 @@ describe('RoleMappingsLogic', () => {
     userCreated: false,
     userFormIsNewUser: true,
     userFormUserIsExisting: true,
+    smtpSettingsPresent: false,
   };
   const roleGroup = {
     id: '123',
@@ -76,6 +77,7 @@ describe('RoleMappingsLogic', () => {
     elasticsearchRoles: [],
     singleUserRoleMappings: [wsSingleUserRoleMapping],
     elasticsearchUsers,
+    smtpSettingsPresent: false,
   };
 
   beforeEach(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -7,14 +7,17 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { EuiComboBoxOptionOption } from '@elastic/eui';
-
 import {
   clearFlashMessages,
   flashAPIErrors,
   setSuccessMessage,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
+import {
+  RoleMappingsBaseServerDetails,
+  RoleMappingsBaseActions,
+  RoleMappingsBaseValues,
+} from '../../../shared/role_mapping';
 import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
 import { AttributeName, SingleUserRoleMapping, ElasticsearchUser } from '../../../shared/types';
 import { RoleGroup, WSRoleMapping, Role } from '../../types';
@@ -28,14 +31,9 @@ import {
 
 type UserMapping = SingleUserRoleMapping<WSRoleMapping>;
 
-interface RoleMappingsServerDetails {
+interface RoleMappingsServerDetails extends RoleMappingsBaseServerDetails {
   roleMappings: WSRoleMapping[];
-  attributes: string[];
-  authProviders: string[];
   availableGroups: RoleGroup[];
-  elasticsearchUsers: ElasticsearchUser[];
-  elasticsearchRoles: string[];
-  multipleAuthProvidersConfig: boolean;
   singleUserRoleMappings: UserMapping[];
 }
 
@@ -45,24 +43,8 @@ const getFirstAttributeValue = (roleMapping: WSRoleMapping): string =>
   Object.entries(roleMapping.rules)[0][1] as string;
 const emptyUser = { username: '', email: '' } as ElasticsearchUser;
 
-interface RoleMappingsActions {
-  handleAllGroupsSelectionChange(selected: boolean): { selected: boolean };
-  handleAuthProviderChange(value: string[]): { value: string[] };
-  handleAttributeSelectorChange(
-    value: AttributeName,
-    firstElasticsearchRole: string
-  ): { value: AttributeName; firstElasticsearchRole: string };
-  handleAttributeValueChange(value: string): { value: string };
-  handleDeleteMapping(roleMappingId: string): { roleMappingId: string };
-  handleGroupSelectionChange(groupIds: string[]): { groupIds: string[] };
-  handleRoleChange(roleType: Role): { roleType: Role };
-  handleUsernameSelectChange(username: string): { username: string };
-  handleSaveMapping(): void;
-  handleSaveUser(): void;
-  initializeRoleMapping(roleMappingId?: string): { roleMappingId?: string };
-  initializeSingleUserRoleMapping(roleMappingId?: string): { roleMappingId?: string };
-  initializeRoleMappings(): void;
-  resetState(): void;
+interface RoleMappingsActions extends RoleMappingsBaseActions {
+  setDefaultGroup(availableGroups: RoleGroup[]): { availableGroups: RoleGroup[] };
   setRoleMapping(roleMapping: WSRoleMapping): { roleMapping: WSRoleMapping };
   setSingleUserRoleMapping(data?: UserMapping): { singleUserRoleMapping: UserMapping };
   setRoleMappings({
@@ -71,34 +53,14 @@ interface RoleMappingsActions {
     roleMappings: WSRoleMapping[];
   }): { roleMappings: WSRoleMapping[] };
   setRoleMappingsData(data: RoleMappingsServerDetails): RoleMappingsServerDetails;
-  setElasticsearchUser(
-    elasticsearchUser?: ElasticsearchUser
-  ): { elasticsearchUser: ElasticsearchUser };
-  setDefaultGroup(availableGroups: RoleGroup[]): { availableGroups: RoleGroup[] };
-  openRoleMappingFlyout(): void;
-  openSingleUserRoleMappingFlyout(): void;
-  closeUsersAndRolesFlyout(): void;
-  setRoleMappingErrors(errors: string[]): { errors: string[] };
-  enableRoleBasedAccess(): void;
-  setUserExistingRadioValue(userFormUserIsExisting: boolean): { userFormUserIsExisting: boolean };
-  setElasticsearchUsernameValue(username: string): { username: string };
-  setElasticsearchEmailValue(email: string): { email: string };
-  setUserCreated(): void;
-  setUserFormIsNewUser(userFormIsNewUser: boolean): { userFormIsNewUser: boolean };
+  handleAllGroupsSelectionChange(selected: boolean): { selected: boolean };
+  handleGroupSelectionChange(groupIds: string[]): { groupIds: string[] };
+  handleRoleChange(roleType: Role): { roleType: Role };
 }
 
-interface RoleMappingsValues {
+interface RoleMappingsValues extends RoleMappingsBaseValues {
   includeInAllGroups: boolean;
-  attributeName: AttributeName;
-  attributeValue: string;
-  attributes: string[];
-  availableAuthProviders: string[];
   availableGroups: RoleGroup[];
-  dataLoading: boolean;
-  elasticsearchRoles: string[];
-  elasticsearchUsers: ElasticsearchUser[];
-  elasticsearchUser: ElasticsearchUser;
-  multipleAuthProvidersConfig: boolean;
   roleMapping: WSRoleMapping | null;
   roleMappings: WSRoleMapping[];
   singleUserRoleMapping: UserMapping | null;
@@ -106,13 +68,6 @@ interface RoleMappingsValues {
   roleType: Role;
   selectedAuthProviders: string[];
   selectedGroups: Set<string>;
-  roleMappingFlyoutOpen: boolean;
-  singleUserRoleMappingFlyoutOpen: boolean;
-  selectedOptions: EuiComboBoxOptionOption[];
-  roleMappingErrors: string[];
-  userFormUserIsExisting: boolean;
-  userCreated: boolean;
-  userFormIsNewUser: boolean;
 }
 
 export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappingsActions>>({

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -330,6 +330,15 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         setRoleMappingsData: (_, { smtpSettingsPresent }) => smtpSettingsPresent,
       },
     ],
+    formLoading: [
+      false,
+      {
+        handleSaveMapping: () => true,
+        handleSaveUser: () => true,
+        initializeRoleMappings: () => false,
+        setRoleMappingErrors: () => false,
+      },
+    ],
   },
   selectors: ({ selectors }) => ({
     selectedOptions: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -324,6 +324,12 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
         setUserFormIsNewUser: (_, { userFormIsNewUser }) => userFormIsNewUser,
       },
     ],
+    smtpSettingsPresent: [
+      false,
+      {
+        setRoleMappingsData: (_, { smtpSettingsPresent }) => smtpSettingsPresent,
+      },
+    ],
   },
   selectors: ({ selectors }) => ({
     selectedOptions: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.test.tsx
@@ -14,7 +14,12 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { UserFlyout, UserAddedInfo, UserInvitationCallout } from '../../../shared/role_mapping';
+import {
+  UserFlyout,
+  UserAddedInfo,
+  UserInvitationCallout,
+  DeactivatedUserCallout,
+} from '../../../shared/role_mapping';
 import { elasticsearchUsers } from '../../../shared/role_mapping/__mocks__/elasticsearch_users';
 import { wsSingleUserRoleMapping } from '../../../shared/role_mapping/__mocks__/roles';
 
@@ -88,6 +93,23 @@ describe('User', () => {
     const wrapper = shallow(<User />);
 
     expect(wrapper.find(UserAddedInfo)).toHaveLength(1);
+  });
+
+  it('renders DeactivatedUserCallout', () => {
+    setMockValues({
+      ...mockValues,
+      singleUserRoleMapping: {
+        ...wsSingleUserRoleMapping,
+        invitation: null,
+        elasticsearchUser: {
+          ...wsSingleUserRoleMapping.elasticsearchUser,
+          enabled: false,
+        },
+      },
+    });
+    const wrapper = shallow(<User />);
+
+    expect(wrapper.find(DeactivatedUserCallout)).toHaveLength(1);
   });
 
   it('disables form when username value not present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.tsx
@@ -17,6 +17,7 @@ import {
   UserSelector,
   UserAddedInfo,
   UserInvitationCallout,
+  DeactivatedUserCallout,
 } from '../../../shared/role_mapping';
 import { Role } from '../../types';
 
@@ -52,6 +53,11 @@ export const User: React.FC = () => {
   const hasAvailableUsers = elasticsearchUsers.length > 0;
   const flyoutDisabled =
     (!userFormUserIsExisting || !hasAvailableUsers) && !elasticsearchUser.username;
+  const userIsDeactivated = !!(
+    singleUserRoleMapping &&
+    !singleUserRoleMapping.invitation &&
+    !singleUserRoleMapping.elasticsearchUser.enabled
+  );
 
   const userAddedInfo = singleUserRoleMapping && (
     <UserAddedInfo
@@ -98,6 +104,7 @@ export const User: React.FC = () => {
     >
       {userCreated ? userAddedInfo : createUserForm}
       {userInvitationCallout}
+      {userIsDeactivated && <DeactivatedUserCallout isNew={userFormIsNewUser} />}
     </UserFlyout>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.tsx
@@ -47,6 +47,7 @@ export const User: React.FC = () => {
     roleMappingErrors,
     userCreated,
     userFormIsNewUser,
+    smtpSettingsPresent,
   } = useValues(RoleMappingsLogic);
 
   const showGroupAssignmentSelector = availableGroups.length > 0;
@@ -79,6 +80,7 @@ export const User: React.FC = () => {
     <EuiForm isInvalid={roleMappingErrors.length > 0} error={roleMappingErrors}>
       <UserSelector
         isNewUser={userFormIsNewUser}
+        smtpSettingsPresent={smtpSettingsPresent}
         elasticsearchUsers={elasticsearchUsers}
         handleRoleChange={handleRoleChange}
         elasticsearchUser={elasticsearchUser}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/user.tsx
@@ -48,6 +48,7 @@ export const User: React.FC = () => {
     userCreated,
     userFormIsNewUser,
     smtpSettingsPresent,
+    formLoading,
   } = useValues(RoleMappingsLogic);
 
   const showGroupAssignmentSelector = availableGroups.length > 0;
@@ -99,6 +100,7 @@ export const User: React.FC = () => {
   return (
     <UserFlyout
       disabled={flyoutDisabled}
+      formLoading={formLoading}
       isComplete={userCreated}
       isNew={userFormIsNewUser}
       closeUserFlyout={closeUsersAndRolesFlyout}


### PR DESCRIPTION
### closes https://github.com/elastic/enterprise-search-team/issues/679
### closes https://github.com/elastic/enterprise-search-team/issues/671

## Summary

This PR ports 2 features from `ent-search` to `kibana` and adds another fix that was already merged in as well.

1. [Add notices for deactivated users](https://github.com/elastic/ent-search/pull/3904)
2. [Add callout to User flyout SMTP settings not present](https://github.com/elastic/ent-search/pull/3920)

As a part of this PR, DRYed out the logic interfaces for shared role mappings (https://github.com/elastic/kibana/commit/f75af5324ae8bcec3ac39f52bd3fc399c7e4bd09)

Also, as a part of this PR, changed the dirty state of the form to match the Users table where it does not look like an error (https://github.com/elastic/kibana/pull/103285/commits/96507ee979be90ffe3525e89dd155e90648cdc49):

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/1869731/123291379-aa96d180-d4d7-11eb-8d0d-121dcaa08967.png)  | ![after](https://user-images.githubusercontent.com/1869731/123291418-b2ef0c80-d4d7-11eb-9960-f66d3d560bab.png)  |

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
