### PR TITLE
[App Search] Fix Engine Overview not properly stretching to full page height

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
@@ -29,11 +29,6 @@ describe('EngineOverview', () => {
     setMockValues(values);
   });
 
-  it('renders', () => {
-    const wrapper = shallow(<EngineOverview />);
-    expect(wrapper.find('[data-test-subj="EngineOverview"]')).toHaveLength(1);
-  });
-
   describe('EmptyEngineOverview', () => {
     it('renders when the engine has no documents & the user can add documents', () => {
       const myRole = { canManageEngineDocuments: true, canViewEngineCredentials: true };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
@@ -25,9 +25,5 @@ export const EngineOverview: React.FC = () => {
   const canAddDocuments = canManageEngineDocuments && canViewEngineCredentials;
   const showEngineOverview = !isEngineEmpty || !canAddDocuments || isMetaEngine;
 
-  return (
-    <div data-test-subj="EngineOverview">
-      {showEngineOverview ? <EngineOverviewMetrics /> : <EmptyEngineOverview />}
-    </div>
-  );
+  return showEngineOverview ? <EngineOverviewMetrics /> : <EmptyEngineOverview />;
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.tsx
@@ -34,6 +34,7 @@ export const EmptyEngineOverview: React.FC = () => {
           </EuiButton>,
         ],
       }}
+      data-test-subj="EngineOverview"
     >
       <DocumentCreationButtons />
       <DocumentCreationFlyout />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_metrics.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_metrics.tsx
@@ -36,6 +36,7 @@ export const EngineOverviewMetrics: React.FC = () => {
         }),
       }}
       isLoading={dataLoading}
+      data-test-subj="EngineOverview"
     >
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>


### PR DESCRIPTION
## Summary

### Before
<img width="877" alt="" src="https://user-images.githubusercontent.com/549407/123314093-06b12400-d4df-11eb-9deb-5e591253740f.png">

### After
<img width="877" alt="" src="https://user-images.githubusercontent.com/549407/123314467-7de6b800-d4df-11eb-87a4-e1c841e20151.png">

Thanks to Davey for catching this - the issue was caused by the wrapping `<div>` around child AppSearchPageTemplate views. Removing that div and moving the `data-test-subj` hooks to the individual views fixes it

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
