### PR TITLE
[7.x] [Metrics UI] Prevent saved views from trampling URL state (#103146)

### DIFF
--- a/x-pack/plugins/infra/public/containers/saved_view/saved_view.tsx
+++ b/x-pack/plugins/infra/public/containers/saved_view/saved_view.tsx
@@ -255,12 +255,21 @@ export const useSavedView = (props: Props) => {
   }, [urlState, setUrlState, currentView, defaultViewId, data]);
 
   useEffect(() => {
-    if (!currentView && !loading && data) {
+    if (!currentView && !loading && data && shouldLoadDefault) {
       const viewToSet = views.find((v) => v.id === urlState.viewId);
       if (viewToSet) setCurrentView(viewToSet);
       else loadDefaultViewIfSet();
     }
-  }, [loading, currentView, data, views, setCurrentView, loadDefaultViewIfSet, urlState.viewId]);
+  }, [
+    loading,
+    currentView,
+    data,
+    views,
+    setCurrentView,
+    loadDefaultViewIfSet,
+    urlState.viewId,
+    shouldLoadDefault,
+  ]);
 
   return {
     views,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Prevent saved views from trampling URL state (#103146)