### PR TITLE
[Lens] Purge all incomplete columns on closing flyout

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
@@ -1467,7 +1467,7 @@ describe('IndexPattern Data Source', () => {
       ).toBeUndefined();
     });
 
-    it('should clear the incomplete column', () => {
+    it('should clear all incomplete columns', () => {
       const state = {
         indexPatternRefs: [],
         existingFields: {},
@@ -1499,7 +1499,7 @@ describe('IndexPattern Data Source', () => {
             indexPatternId: '1',
             columnOrder: [],
             columns: {},
-            incompleteColumns: { col2: { operationType: 'sum' } },
+            incompleteColumns: undefined,
           },
         },
       });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -43,7 +43,7 @@ import {
 
 import { isDraggedField, normalizeOperationDataType } from './utils';
 import { LayerPanel } from './layerpanel';
-import { IndexPatternColumn, getErrorMessages, IncompleteColumn } from './operations';
+import { IndexPatternColumn, getErrorMessages } from './operations';
 import { IndexPatternField, IndexPatternPrivateState, IndexPatternPersistedState } from './types';
 import { KibanaContextProvider } from '../../../../../src/plugins/kibana_react/public';
 import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
@@ -362,17 +362,14 @@ export function getIndexPatternDatasource({
     // Reset the temporary invalid state when closing the editor, but don't
     // update the state if it's not needed
     updateStateOnCloseDimension: ({ state, layerId, columnId }) => {
-      const layer = { ...state.layers[layerId] };
-      const current = state.layers[layerId].incompleteColumns || {};
-      if (!Object.values(current).length) {
+      const layer = state.layers[layerId];
+      if (!Object.values(layer.incompleteColumns || {}).length) {
         return;
       }
-      const newIncomplete: Record<string, IncompleteColumn> = { ...current };
-      delete newIncomplete[columnId];
       return mergeLayer({
         state,
         layerId,
-        newLayer: { ...layer, incompleteColumns: newIncomplete },
+        newLayer: { ...layer, incompleteColumns: undefined },
       });
     },
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/103103

As discussed offline, we don't need to retain certain incomplete columns - the current UI model is "do not keep incomplete transitions when closing the flyout". This PR makes sure no incomplete columns linger after close.