### PR TITLE
Update security telemetry allowlist.

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/sender.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/sender.test.ts
@@ -41,6 +41,7 @@ describe('TelemetryEventsSender', () => {
             version: '100',
           },
           file: {
+            extension: '.exe',
             size: 3,
             created: 0,
             path: 'X',
@@ -72,6 +73,7 @@ describe('TelemetryEventsSender', () => {
             name: 'foo.exe',
             nope: 'nope',
             executable: null, // null fields are never allowlisted
+            working_directory: '/some/usr/dir',
           },
           Target: {
             process: {
@@ -101,6 +103,7 @@ describe('TelemetryEventsSender', () => {
             version: '100',
           },
           file: {
+            extension: '.exe',
             size: 3,
             created: 0,
             path: 'X',
@@ -126,6 +129,7 @@ describe('TelemetryEventsSender', () => {
           },
           process: {
             name: 'foo.exe',
+            working_directory: '/some/usr/dir',
           },
           Target: {
             process: {

--- a/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts
@@ -307,6 +307,7 @@ const allowlistProcessFields: AllowlistFields = {
     },
   },
   thread: true,
+  working_directory: true,
 };
 
 // Allow list for event-related fields, which can also be nested under events[]
@@ -322,6 +323,7 @@ const allowlistBaseEventFields: AllowlistFields = {
   },
   event: true,
   file: {
+    extension: true,
     name: true,
     path: true,
     size: true,


### PR DESCRIPTION
## Summary

Security researchers (I&A) have requested additional telemetry fields to help us triage alerts and determine whether they are true/false positives.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
