### PR TITLE
[Telemetry] track event loop utilization

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_utilization/constants.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_utilization/constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Start monitoring the event loop utilization after 1 minute
+ */
+export const MONITOR_EVENT_LOOP_UTILIZATION_START = 1 * 60 * 1000;
+
+/**
+ * Check the event loop utilization every 5 seconds
+ */
+export const MONITOR_EVENT_LOOP_UTILIZATION_INTERVAL = 5 * 1000;

--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_utilization/event_loop_utilization.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_utilization/event_loop_utilization.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { EventLoopUtilization } from 'perf_hooks';
+import { performance } from 'perf_hooks';
+import { takeUntil } from 'rxjs/operators';
+import { Observable, timer } from 'rxjs';
+import type { Logger } from 'kibana/server';
+
+import { UsageCollectionSetup } from '../../../../usage_collection/server';
+
+import {
+  MONITOR_EVENT_LOOP_UTILIZATION_START,
+  MONITOR_EVENT_LOOP_UTILIZATION_INTERVAL,
+} from './constants';
+
+export class EventLoopUtlizationCollector {
+  private elu: EventLoopUtilization;
+
+  constructor() {
+    this.elu = performance.eventLoopUtilization();
+  }
+
+  public collect() {
+    const { active, idle, utilization } = performance.eventLoopUtilization(this.elu);
+
+    return {
+      active,
+      idle,
+      utilization,
+    };
+  }
+
+  public reset() {
+    this.elu = performance.eventLoopUtilization();
+  }
+}
+
+/**
+ * The monitoring of the event loop utilization starts immediately.
+ * The first collection happens after 1 minute.
+ * The utilization is collected and reset every 5 seconds.
+ * logs a warning when threshold is exceeded and increments usage counter.
+ */
+export function startTrackingEventLoopDelaysUsage(
+  usageCollection: UsageCollectionSetup,
+  logger: Logger,
+  utilizationThreshold = 0.75,
+  stopMonitoringEventLoop$: Observable<void>,
+  collectionStartDelay = MONITOR_EVENT_LOOP_UTILIZATION_START,
+  collectionInterval = MONITOR_EVENT_LOOP_UTILIZATION_INTERVAL
+) {
+  const eventLoopUtilizationCollector = new EventLoopUtlizationCollector();
+  const eventLoopUtilizationCounter = usageCollection.getUsageCounterByType('eventLoopUtilization');
+
+  timer(collectionStartDelay, collectionInterval)
+    .pipe(takeUntil(stopMonitoringEventLoop$))
+    .subscribe(async () => {
+      const { active, utilization, idle } = eventLoopUtilizationCollector.collect();
+
+      if (utilization > utilizationThreshold) {
+        logger.warn(
+          `Eventloop delay threshold exceeded. Utilization: ${
+            utilization * 100
+          }%. Idle: ${idle}ms. Active: ${active}ms.`
+        );
+        eventLoopUtilizationCounter?.incrementCounter({
+          counterName: 'utilization_threshold_exceeded',
+        });
+      }
+
+      eventLoopUtilizationCollector.reset();
+    });
+}


### PR DESCRIPTION
## Monitor event loop utilization

The `eventLoopUtilization()` method returns an object that contains the cumulative duration of time the event loop has been both idle and active as a high resolution milliseconds timer. 

The utilization value is the calculated Event Loop Utilization (ELU).

ELU is similar to CPU utilization, except that it only measures event loop statistics and not CPU usage.

It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait). No other CPU idle time is taken into consideration. The following is an example of how a mostly idle process will have a high ELU.

In some cases the CPU is mostly idle while running this script but the event loop is haulted. For example `child_process.spawnSync()` blocks the event loop from proceeding while the CPU might be idle during that time.




### How is this different from event loop delays

Event loop [delays histogram](https://github.com/elastic/kibana/pull/103615) tracks delays in the event loop. How long it takes for the event loop to flop a full cycle (check incoming requests, async functions/callbacks, timeouts, etc) to be able to jump to the next lines of code and handle more incoming requests.

So while tracking delays is crticial to check that Kibana servers are running smoothly. Tracking ELU gives another insight about the level of utilization the kibana servers run at, we can also track increasing and decreasing trends across releases and enabled feature. It is also a window for us to check how important it is adopt using multi-processes if we have high ELU

