### PR TITLE
Fix App Search crawler URL.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_landing.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_landing.test.tsx
@@ -35,6 +35,6 @@ describe('CrawlerLanding', () => {
   it('contains a link to standalone App Search', () => {
     const externalDocumentationLink = wrapper.find('[data-test-subj="CrawlerStandaloneLink"]');
 
-    expect(externalDocumentationLink.prop('href')).toBe('/as/engines/some-engine/crawler');
+    expect(externalDocumentationLink.prop('href')).toBe('/as#/engines/some-engine/crawler');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_landing.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_landing.tsx
@@ -63,7 +63,7 @@ export const CrawlerLanding: React.FC = () => (
           iconType="popout"
           fill
           color="primary"
-          href={getAppSearchUrl(generateEnginePath(ENGINE_CRAWLER_PATH))}
+          href={getAppSearchUrl(`#${generateEnginePath(ENGINE_CRAWLER_PATH)}`)}
           target="_blank"
           data-test-subj="CrawlerStandaloneLink"
         >


### PR DESCRIPTION
## Summary

When clicking on the link to configure the webcrawler we are redirected to the following URL : `http://localhost:3002/as/engines/foo/crawler` in the legacy standalone UI. This result in a routing error in App Search:

<img width="1660" alt="Capture d’écran 2021-06-28 à 15 05 48" src="https://user-images.githubusercontent.com/529238/123641557-aa257000-d822-11eb-84fe-0034f88c3ea9.png">

<img width="767" alt="Capture d’écran 2021-06-28 à 15 06 15" src="https://user-images.githubusercontent.com/529238/123641682-caedc580-d822-11eb-80dc-93395acc8c00.png">

This is because of a missing anchor in the generated URL that should be `http://localhost:3002/as#/engines/foo/crawler`

This PR is intended to fix this bug,

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
