### PR TITLE
[APM] use conventional error rate color for correlations

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
@@ -248,6 +248,7 @@ function ErrorTimeseriesChart({
           yAccessors={['y']}
           data={overallData?.overall?.timeseries ?? []}
           curve={CurveType.CURVE_MONOTONE_X}
+          color={theme.eui.euiColorVis7}
         />
 
         {correlationsData && selectedSignificantTerm ? (


### PR DESCRIPTION
Closes #97097.

Before:
![image](https://user-images.githubusercontent.com/352732/123660681-296f6f80-d834-11eb-9040-f053e20505f3.png)

After:
![image](https://user-images.githubusercontent.com/352732/123660642-22e0f800-d834-11eb-909c-bbb3aeab35e0.png)