### PR TITLE
[Enterprise Search] Update jest.sh file for more flexible pathfinding

### DIFF
--- a/x-pack/plugins/enterprise_search/jest.sh
+++ b/x-pack/plugins/enterprise_search/jest.sh
@@ -5,6 +5,8 @@
 TARGET="${1:-all}"
 if [[ $TARGET && $TARGET != "all" ]]
 then
+  # Strip any leading ./
+  TARGET=${TARGET#./}
   # If this is a file
   if [[ "$TARGET" == *".ts"* ]]; then
     PATH_WITHOUT_EXTENSION=${1%%.*}


### PR DESCRIPTION
## Summary

@JasonStoltz recently ran into some DX shenanigans where our jest.sh script wasn't working as expected due to a leading `./`, e.g. `./public/applications/etc`.

It's a pretty simple fix to strip any leading `./`s from the target path, so I opened up a quick PR for it 🍕 

### Checklist

- [x] Confirm (e.g.) `sh jest.sh ./public/applications/shared/not_found/` works as expected
- [x] Confirm `sh jest.sh public/applications/shared/not_found` (no leading `./`) also still works as expected)