### PR TITLE
[App Search] Remove analytics tracking from the entire dashboard

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -370,15 +370,12 @@ describe('RelevanceTuningLogic', () => {
         await nextTick();
 
         expect(RelevanceTuningLogic.actions.setResultsLoading).toHaveBeenCalledWith(true);
-        expect(http.post).toHaveBeenCalledWith(
-          '/api/app_search/engines/test-engine/search_settings_search',
-          {
-            body: JSON.stringify(searchSettingsWithoutNewBoostProp),
-            query: {
-              query: 'foo',
-            },
-          }
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/app_search/engines/test-engine/search', {
+          body: JSON.stringify(searchSettingsWithoutNewBoostProp),
+          query: {
+            query: 'foo',
+          },
+        });
         expect(RelevanceTuningLogic.actions.setSearchResults).toHaveBeenCalledWith(searchResults);
         expect(clearFlashMessages).toHaveBeenCalled();
       });
@@ -403,15 +400,12 @@ describe('RelevanceTuningLogic', () => {
         jest.runAllTimers();
         await nextTick();
 
-        expect(http.post).toHaveBeenCalledWith(
-          '/api/app_search/engines/test-engine/search_settings_search',
-          {
-            body: '{}',
-            query: {
-              query: 'foo',
-            },
-          }
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/app_search/engines/test-engine/search', {
+          body: '{}',
+          query: {
+            query: 'foo',
+          },
+        });
       });
 
       it('will call clearSearchResults if there is no query', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -261,7 +261,7 @@ export const RelevanceTuningLogic = kea<
       const { engineName } = EngineLogic.values;
       const { http } = HttpLogic.values;
       const { search_fields: searchFields, boosts } = removeBoostStateProps(values.searchSettings);
-      const url = `/api/app_search/engines/${engineName}/search_settings_search`;
+      const url = `/api/app_search/engines/${engineName}/search`;
 
       actions.setResultsLoading(true);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/sample_response/sample_response_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/sample_response/sample_response_logic.ts
@@ -68,12 +68,16 @@ export const SampleResponseLogic = kea<MakeLogicType<SampleResponseValues, Sampl
       const { http } = HttpLogic.values;
       const { engineName } = EngineLogic.values;
 
-      const url = `/api/app_search/engines/${engineName}/sample_response_search`;
+      const url = `/api/app_search/engines/${engineName}/search`;
 
       try {
         const response = await http.post(url, {
+          query: { query },
           body: JSON.stringify({
-            query,
+            page: {
+              size: 1,
+              current: 1,
+            },
             result_fields: resultFields,
           }),
         });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.test.ts
@@ -82,7 +82,7 @@ describe('SearchLogic', () => {
       afterAll(() => jest.useRealTimers());
 
       it('should make a GET API call with a search query', async () => {
-        http.get.mockReturnValueOnce(Promise.resolve(MOCK_SEARCH_RESPONSE));
+        http.post.mockReturnValueOnce(Promise.resolve(MOCK_SEARCH_RESPONSE));
         const logic = mountLogic();
         jest.spyOn(logic.actions, 'onSearch');
 
@@ -90,14 +90,14 @@ describe('SearchLogic', () => {
         jest.runAllTimers();
         await nextTick();
 
-        expect(http.get).toHaveBeenCalledWith('/api/app_search/engines/some-engine/search', {
+        expect(http.post).toHaveBeenCalledWith('/api/app_search/engines/some-engine/search', {
           query: { query: 'hello world' },
         });
         expect(logic.actions.onSearch).toHaveBeenCalledWith(MOCK_SEARCH_RESPONSE);
       });
 
       it('handles errors', async () => {
-        http.get.mockReturnValueOnce(Promise.reject('error'));
+        http.post.mockReturnValueOnce(Promise.reject('error'));
         const logic = mountLogic();
 
         logic.actions.search('test');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/search/search_logic.ts
@@ -61,7 +61,7 @@ export const SearchLogic = kea<MakeLogicType<SearchValues, SearchActions>>({
       const { engineName } = EngineLogic.values;
 
       try {
-        const response = await http.get(`/api/app_search/engines/${engineName}/search`, {
+        const response = await http.post(`/api/app_search/engines/${engineName}/search`, {
           query: { query },
         });
         actions.onSearch(response);

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
@@ -115,21 +115,4 @@ export function registerCurationsRoutes({
       path: '/as/engines/:engineName/curations/find_or_create',
     })
   );
-
-  router.get(
-    {
-      path: '/api/app_search/engines/{engineName}/curation_search',
-      validate: {
-        params: schema.object({
-          engineName: schema.string(),
-        }),
-        query: schema.object({
-          query: schema.string(),
-        }),
-      },
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v1/engines/:engineName/search.json',
-    })
-  );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/result_settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/result_settings.test.ts
@@ -72,32 +72,4 @@ describe('result settings routes', () => {
       });
     });
   });
-
-  describe('POST /api/app_search/engines/{name}/sample_response_search', () => {
-    const mockRouter = new MockRouter({
-      method: 'post',
-      path: '/api/app_search/engines/{engineName}/sample_response_search',
-    });
-
-    beforeEach(() => {
-      registerResultSettingsRoutes({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request to enterprise search', () => {
-      mockRouter.callRoute({
-        params: { engineName: 'some-engine' },
-        body: {
-          query: 'test',
-          result_fields: resultFields,
-        },
-      });
-
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/as/engines/:engineName/sample_response_search',
-      });
-    });
-  });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/result_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/result_settings.ts
@@ -53,7 +53,7 @@ export function registerResultSettingsRoutes({
       },
     }),
     enterpriseSearchRequestHandler.createRequest({
-      path: '/as/engines/:engineName/sample_response_search',
+      path: '/as/engines/:engineName/dashboard_search',
     })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/result_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/result_settings.ts
@@ -42,18 +42,4 @@ export function registerResultSettingsRoutes({
       path: '/as/engines/:engineName/result_settings',
     })
   );
-
-  router.post(
-    skipBodyValidation({
-      path: '/api/app_search/engines/{engineName}/sample_response_search',
-      validate: {
-        params: schema.object({
-          engineName: schema.string(),
-        }),
-      },
-    }),
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/as/engines/:engineName/dashboard_search',
-    })
-  );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search.test.ts
@@ -28,7 +28,7 @@ describe('search routes', () => {
 
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/api/as/v1/engines/:engineName/search.json',
+        path: '/as/engines/:engineName/dashboard_search',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search.ts
@@ -22,8 +22,8 @@ export function registerSearchRoutes({
   router,
   enterpriseSearchRequestHandler,
 }: RouteDependencies) {
-  router.get(
-    {
+  router.post(
+    skipBodyValidation({
       path: '/api/app_search/engines/{engineName}/search',
       validate: {
         params: schema.object({
@@ -33,19 +33,15 @@ export function registerSearchRoutes({
           query: schema.string(),
         }),
       },
-    },
+    }),
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v1/engines/:engineName/search.json',
+      path: '/as/engines/:engineName/dashboard_search',
     })
   );
 
-  // For the Search UI routes below, Search UI always uses the full API path, like:
-  // "/api/as/v1/engines/{engineName}/search.json". We only have control over the base path
-  // in Search UI, so we created a common basepath of "/api/app_search/search-ui" here that
-  // Search UI can use.
-  //
-  // Search UI *also* uses the click tracking and query suggestion endpoints, however, since the
-  // App Search plugin doesn't use that portion of Search UI, we only set up a proxy for the search endpoint below.
+  // Search UI always posts it's requests to {some_configured_base_url}/api/as/v1/engines/{engineName}/search.json
+  // For that reason, we have to create a proxy url with that same suffix below, so that we can proxy Search UI
+  // requests through Kibana's server.
   router.post(
     skipBodyValidation({
       path: '/api/app_search/search-ui/api/as/v1/engines/{engineName}/search.json',
@@ -56,7 +52,7 @@ export function registerSearchRoutes({
       },
     }),
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v1/engines/:engineName/search.json',
+      path: '/as/engines/:engineName/dashboard_search',
     })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.test.ts
@@ -132,45 +132,4 @@ describe('search settings routes', () => {
       });
     });
   });
-
-  describe('POST /api/app_search/engines/{name}/search_settings_search', () => {
-    const mockRouter = new MockRouter({
-      method: 'post',
-      path: '/api/app_search/engines/{engineName}/search_settings_search',
-    });
-
-    beforeEach(() => {
-      registerSearchSettingsRoutes({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request to enterprise search', () => {
-      mockRouter.callRoute({
-        params: { engineName: 'some-engine' },
-        body: searchSettings,
-      });
-
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/as/engines/:engineName/search_settings_search',
-      });
-    });
-
-    describe('validates query', () => {
-      it('correctly', () => {
-        const request = {
-          query: {
-            query: 'foo',
-          },
-        };
-        mockRouter.shouldValidate(request);
-      });
-
-      it('missing required fields', () => {
-        const request = { query: {} };
-        mockRouter.shouldThrow(request);
-      });
-    });
-  });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_settings.ts
@@ -56,21 +56,4 @@ export function registerSearchSettingsRoutes({
       path: '/as/engines/:engineName/search_settings',
     })
   );
-
-  router.post(
-    skipBodyValidation({
-      path: '/api/app_search/engines/{engineName}/search_settings_search',
-      validate: {
-        params: schema.object({
-          engineName: schema.string(),
-        }),
-        query: schema.object({
-          query: schema.string(),
-        }),
-      },
-    }),
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/as/engines/:engineName/search_settings_search',
-    })
-  );
 }


### PR DESCRIPTION
## Summary

In previous version of ent-search, searches origination from the ent-search FE dashboard would result in an Analytics event being logged for the search, tagged with `swiftype_` prefixed tags.

This PR removes that behavior entirely.

It primarily does so by switching all dashboard search routes to use a new ent-search endpoint, `dashboard_search`, which does NOT log analytics events.

NOTE: To test, you'll need to pull down the corresponding PR in ent-search. When you run this branch with that branch of ent-search, there should never be any search or clicks logged to the Analytics screen, with the exception of Search UI.

Things to look for when testing:
- Result Settings - Should still update the sample response dynamically as items on that screen are selected and deselected
- Relevance Tuning - Search should still work. Highlighting within the search should still work.
- Query Tester - Search should still work. Highlighting within the search should still work.
- Curations - Search should still work. Highlighting within the search should still work. 
- Documents - Search should still work. Highlighting within the search should still work. 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
