### PR TITLE
[App Search] Remove analytics tracking from the entire dashboard (curations)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
@@ -287,7 +287,10 @@ describe('CurationLogic', () => {
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith(
-          '/api/app_search/engines/some-engine/curations/cur-123456789'
+          '/api/app_search/engines/some-engine/curations/cur-123456789',
+          {
+            query: { skip_record_analytics: 'true' },
+          }
         );
         expect(CurationLogic.actions.onCurationLoad).toHaveBeenCalledWith(MOCK_CURATION_RESPONSE);
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -169,7 +169,8 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
 
       try {
         const response = await http.get(
-          `/api/app_search/engines/${engineName}/curations/${props.curationId}`
+          `/api/app_search/engines/${engineName}/curations/${props.curationId}`,
+          { query: { skip_record_analytics: 'true' } }
         );
         actions.onCurationLoad(response);
       } catch (e) {

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
@@ -67,6 +67,9 @@ export function registerCurationsRoutes({
     {
       path: '/api/app_search/engines/{engineName}/curations/{curationId}',
       validate: {
+        query: schema.object({
+          skip_record_analytics: schema.string(),
+        }),
         params: schema.object({
           engineName: schema.string(),
           curationId: schema.string(),


### PR DESCRIPTION
## Summary

This PR is a follow up to https://github.com/elastic/kibana/pull/103534

While working on that PR I realized that I had missed an analytics write event in the Dashboard, and when viewing curations, an event was being logged.

By passing a parameter on that GET route, we can avoid logging that Analytics event.

There is a corresponding PR in ent-search that adds that parameter.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
