### PR TITLE
[Security Solution] Disables loadPrebuiltRulesAndTemplatesButton 

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/load_empty_prompt.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/load_empty_prompt.test.tsx
@@ -127,4 +127,26 @@ describe('LoadPrebuiltRulesAndTemplatesButton', () => {
       );
     });
   });
+
+  it('renders disabled button if loading is true', async () => {
+    (getPrePackagedRulesStatus as jest.Mock).mockResolvedValue({
+      rules_not_installed: 0,
+      rules_installed: 0,
+      rules_not_updated: 0,
+      timelines_not_installed: 3,
+      timelines_installed: 0,
+      timelines_not_updated: 0,
+    });
+
+    const wrapper: ReactWrapper = mount(
+      <PrePackagedRulesPrompt {...{ ...props, loading: true }} />
+    );
+    await waitFor(() => {
+      wrapper.update();
+
+      expect(
+        wrapper.find('[data-test-subj="load-prebuilt-rules"] button').props().disabled
+      ).toEqual(true);
+    });
+  });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/load_empty_prompt.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/load_empty_prompt.tsx
@@ -64,12 +64,12 @@ const PrePackagedRulesPromptComponent: React.FC<PrePackagedRulesPromptProps> = (
   const loadPrebuiltRulesAndTemplatesButton = useMemo(
     () =>
       getLoadPrebuiltRulesAndTemplatesButton({
-        isDisabled: !userHasPermissions,
+        isDisabled: !userHasPermissions || loading,
         onClick: handlePreBuiltCreation,
         fill: true,
         'data-test-subj': 'load-prebuilt-rules',
       }),
-    [getLoadPrebuiltRulesAndTemplatesButton, handlePreBuiltCreation, userHasPermissions]
+    [getLoadPrebuiltRulesAndTemplatesButton, handlePreBuiltCreation, userHasPermissions, loading]
   );
 
   return (


### PR DESCRIPTION
## Summary
Disables loadPrebuiltRulesAndTemplatesButton if loading is in progress. 


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Before
<img width="600" alt="Screen Shot 2021-06-28 at 7 32 08 PM" src="https://user-images.githubusercontent.com/18617331/123716560-deac2280-d848-11eb-98ef-4839d4870224.png">

After
<img width="600" alt="Screen Shot 2021-06-28 at 7 28 11 PM" src="https://user-images.githubusercontent.com/18617331/123716558-de138c00-d848-11eb-8a0f-b38f45ac627c.png">
