### PR TITLE
Fix condition when exportCount is 0

### DIFF
--- a/src/core/server/saved_objects/routes/utils.test.ts
+++ b/src/core/server/saved_objects/routes/utils.test.ts
@@ -101,6 +101,22 @@ describe('createSavedObjectsStreamFromNdJson', () => {
       },
     ]);
   });
+
+  it('handles an ndjson stream that only contains excluded saved objects', async () => {
+    const savedObjectsStream = await createSavedObjectsStreamFromNdJson(
+      new Readable({
+        read() {
+          this.push(
+            '{"excludedObjects":[{"id":"foo","reason":"excluded","type":"foo-type"}],"excludedObjectsCount":1,"exportedCount":0,"missingRefCount":0,"missingReferences":[]}\n'
+          );
+          this.push(null);
+        },
+      })
+    );
+
+    const result = await readStreamToCompletion(savedObjectsStream);
+    expect(result).toEqual([]);
+  });
 });
 
 describe('validateTypes', () => {

--- a/src/core/server/saved_objects/routes/utils.ts
+++ b/src/core/server/saved_objects/routes/utils.ts
@@ -32,7 +32,7 @@ export async function createSavedObjectsStreamFromNdJson(ndJsonStream: Readable)
       }
     }),
     createFilterStream<SavedObject | SavedObjectsExportResultDetails>(
-      (obj) => !!obj && !(obj as SavedObjectsExportResultDetails).exportedCount
+      (obj) => !!obj && (obj as SavedObjectsExportResultDetails).exportedCount === undefined
     ),
     createConcatStream([]),
   ]);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/103517

Background:
It is possible to export an ndjson file that only contains "excluded" saved objects but we were throwing an Unhandled Promise rejection from `createFilterStream`. This PR fixes the condition.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
