### PR TITLE
[Workplace Search] Fix edge case API error

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -25,7 +25,7 @@ const pageSchema = schema.object({
   current: schema.nullable(schema.number()),
   size: schema.nullable(schema.number()),
   total_pages: schema.nullable(schema.number()),
-  total_results: schema.number(),
+  total_results: schema.nullable(schema.number()),
 });
 
 const oauthConfigSchema = schema.object({


### PR DESCRIPTION
### closes https://github.com/elastic/workplace-search-team/issues/1790

## Summary

This PR fixes an edge case where a race condition might cause the total_results from a federated content source to come back null from the server. This PR tells the server to expect null in those edge cases to prevent browser errors

![image](https://user-images.githubusercontent.com/1869731/123710303-21afcb00-d834-11eb-950d-0b2814a58c56.png)
