### PR TITLE
[TSVB] fix wrong labels, for values that are implicitly cast to false

### DIFF
--- a/src/plugins/vis_type_timeseries/common/empty_label.ts
+++ b/src/plugins/vis_type_timeseries/common/empty_label.ts
@@ -12,7 +12,7 @@ export const emptyLabel = i18n.translate('visTypeTimeseries.emptyTextValue', {
   defaultMessage: '(empty)',
 });
 
-export const getMeaningfulValueOrEmpty = (value: unknown) => {
+export const getValueOrEmpty = (value: unknown) => {
   if (value === '' || value === null || value === undefined) {
     return emptyLabel;
   }

--- a/src/plugins/vis_type_timeseries/common/empty_label.ts
+++ b/src/plugins/vis_type_timeseries/common/empty_label.ts
@@ -11,3 +11,10 @@ import { i18n } from '@kbn/i18n';
 export const emptyLabel = i18n.translate('visTypeTimeseries.emptyTextValue', {
   defaultMessage: '(empty)',
 });
+
+export const getMeaningfulValueOrEmpty = (value: unknown) => {
+  if (value === '' || value === null || value === undefined) {
+    return emptyLabel;
+  }
+  return `${value}`;
+};

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
@@ -9,7 +9,7 @@
 import { set } from '@elastic/safer-lodash-set';
 import _ from 'lodash';
 import { getLastValue } from '../../../../common/last_value_utils';
-import { emptyLabel } from '../../../../common/empty_label';
+import { getMeaningfulValueOrEmpty } from '../../../../common/empty_label';
 import { createTickFormatter } from './tick_formatter';
 import { labelDateFormatter } from './label_date_formatter';
 import moment from 'moment';
@@ -20,7 +20,7 @@ export const convertSeriesToVars = (series, model, dateFormat = 'lll', getConfig
     series
       .filter((row) => _.startsWith(row.id, seriesModel.id))
       .forEach((row) => {
-        const label = row.label ? _.snakeCase(row.label) : emptyLabel;
+        const label = getMeaningfulValueOrEmpty(row.label);
         const varName = [label, _.snakeCase(seriesModel.var_name)].filter((v) => v).join('.');
 
         const formatter = createTickFormatter(

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
@@ -9,7 +9,7 @@
 import { set } from '@elastic/safer-lodash-set';
 import _ from 'lodash';
 import { getLastValue } from '../../../../common/last_value_utils';
-import { getValueOrEmpty } from '../../../../common/empty_label';
+import { getValueOrEmpty, emptyLabel } from '../../../../common/empty_label';
 import { createTickFormatter } from './tick_formatter';
 import { labelDateFormatter } from './label_date_formatter';
 import moment from 'moment';
@@ -20,7 +20,12 @@ export const convertSeriesToVars = (series, model, dateFormat = 'lll', getConfig
     series
       .filter((row) => _.startsWith(row.id, seriesModel.id))
       .forEach((row) => {
-        const label = getValueOrEmpty(row.label);
+        let label = getValueOrEmpty(row.label);
+
+        if (label !== emptyLabel) {
+          label = _.snakeCase(label);
+        }
+
         const varName = [label, _.snakeCase(seriesModel.var_name)].filter((v) => v).join('.');
 
         const formatter = createTickFormatter(

--- a/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/lib/convert_series_to_vars.js
@@ -9,7 +9,7 @@
 import { set } from '@elastic/safer-lodash-set';
 import _ from 'lodash';
 import { getLastValue } from '../../../../common/last_value_utils';
-import { getMeaningfulValueOrEmpty } from '../../../../common/empty_label';
+import { getValueOrEmpty } from '../../../../common/empty_label';
 import { createTickFormatter } from './tick_formatter';
 import { labelDateFormatter } from './label_date_formatter';
 import moment from 'moment';
@@ -20,7 +20,7 @@ export const convertSeriesToVars = (series, model, dateFormat = 'lll', getConfig
     series
       .filter((row) => _.startsWith(row.id, seriesModel.id))
       .forEach((row) => {
-        const label = getMeaningfulValueOrEmpty(row.label);
+        const label = getValueOrEmpty(row.label);
         const varName = [label, _.snakeCase(seriesModel.var_name)].filter((v) => v).join('.');
 
         const formatter = createTickFormatter(

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/vis.js
@@ -18,7 +18,7 @@ import { replaceVars } from '../../lib/replace_vars';
 import { fieldFormats } from '../../../../../../../plugins/data/public';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { getFieldFormats, getCoreStart } from '../../../../services';
-import { getMeaningfulValueOrEmpty } from '../../../../../common/empty_label';
+import { getValueOrEmpty } from '../../../../../common/empty_label';
 
 function getColor(rules, colorKey, value) {
   let color;
@@ -98,7 +98,7 @@ class TableVis extends Component {
       });
     return (
       <tr key={row.key}>
-        <td>{getMeaningfulValueOrEmpty(rowDisplay)}</td>
+        <td>{getValueOrEmpty(rowDisplay)}</td>
         {columns}
       </tr>
     );

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/table/vis.js
@@ -18,7 +18,7 @@ import { replaceVars } from '../../lib/replace_vars';
 import { fieldFormats } from '../../../../../../../plugins/data/public';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { getFieldFormats, getCoreStart } from '../../../../services';
-import { emptyLabel } from '../../../../../common/empty_label';
+import { getMeaningfulValueOrEmpty } from '../../../../../common/empty_label';
 
 function getColor(rules, colorKey, value) {
   let color;
@@ -98,7 +98,7 @@ class TableVis extends Component {
       });
     return (
       <tr key={row.key}>
-        <td>{rowDisplay || emptyLabel}</td>
+        <td>{getMeaningfulValueOrEmpty(rowDisplay)}</td>
         {columns}
       </tr>
     );

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
@@ -10,7 +10,7 @@ import React, { useCallback } from 'react';
 import { getDisplayName } from './lib/get_display_name';
 import { labelDateFormatter } from './lib/label_date_formatter';
 import { findIndex, first } from 'lodash';
-import { getMeaningfulValueOrEmpty } from '../../../common/empty_label';
+import { getValueOrEmpty } from '../../../common/empty_label';
 import { getSplitByTermsColor } from '../lib/get_split_by_terms_color';
 
 export function visWithSplits(WrappedComponent) {
@@ -110,7 +110,7 @@ export function visWithSplits(WrappedComponent) {
             visData={newVisData}
             onBrush={props.onBrush}
             onFilterClick={props.onFilterClick}
-            additionalLabel={getMeaningfulValueOrEmpty(additionalLabel)}
+            additionalLabel={getValueOrEmpty(additionalLabel)}
             backgroundColor={props.backgroundColor}
             getConfig={props.getConfig}
           />

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
@@ -10,7 +10,7 @@ import React, { useCallback } from 'react';
 import { getDisplayName } from './lib/get_display_name';
 import { labelDateFormatter } from './lib/label_date_formatter';
 import { findIndex, first } from 'lodash';
-import { emptyLabel } from '../../../common/empty_label';
+import { getMeaningfulValueOrEmpty } from '../../../common/empty_label';
 import { getSplitByTermsColor } from '../lib/get_split_by_terms_color';
 
 export function visWithSplits(WrappedComponent) {
@@ -110,7 +110,7 @@ export function visWithSplits(WrappedComponent) {
             visData={newVisData}
             onBrush={props.onBrush}
             onFilterClick={props.onFilterClick}
-            additionalLabel={additionalLabel || emptyLabel}
+            additionalLabel={getMeaningfulValueOrEmpty(additionalLabel)}
             backgroundColor={props.backgroundColor}
             getConfig={props.getConfig}
           />

--- a/src/plugins/vis_type_timeseries/public/application/lib/get_split_by_terms_color.ts
+++ b/src/plugins/vis_type_timeseries/public/application/lib/get_split_by_terms_color.ts
@@ -10,7 +10,7 @@ import { PALETTES } from '../../../common/enums';
 import type { PanelData } from '../../../common/types';
 import { computeGradientFinalColor } from './compute_gradient_final_color';
 import { rainbowColors } from './rainbow_colors';
-import { emptyLabel } from '../../../common/empty_label';
+import { getMeaningfulValueOrEmpty } from '../../../common/empty_label';
 
 interface PaletteParams {
   colors: string[];
@@ -61,7 +61,7 @@ export const getSplitByTermsColor = ({
   const outputColor = palettesRegistry?.get(paletteName || 'default').getCategoricalColor(
     [
       {
-        name: seriesName || emptyLabel,
+        name: getMeaningfulValueOrEmpty(seriesName),
         rankAtDepth: seriesById.findIndex(({ id }) => id === seriesId),
         totalSeriesAtDepth: seriesById.length,
       },

--- a/src/plugins/vis_type_timeseries/public/application/lib/get_split_by_terms_color.ts
+++ b/src/plugins/vis_type_timeseries/public/application/lib/get_split_by_terms_color.ts
@@ -10,7 +10,7 @@ import { PALETTES } from '../../../common/enums';
 import type { PanelData } from '../../../common/types';
 import { computeGradientFinalColor } from './compute_gradient_final_color';
 import { rainbowColors } from './rainbow_colors';
-import { getMeaningfulValueOrEmpty } from '../../../common/empty_label';
+import { getValueOrEmpty } from '../../../common/empty_label';
 
 interface PaletteParams {
   colors: string[];
@@ -61,7 +61,7 @@ export const getSplitByTermsColor = ({
   const outputColor = palettesRegistry?.get(paletteName || 'default').getCategoricalColor(
     [
       {
-        name: getMeaningfulValueOrEmpty(seriesName),
+        name: getValueOrEmpty(seriesName),
         rankAtDepth: seriesById.findIndex(({ id }) => id === seriesId),
         totalSeriesAtDepth: seriesById.length,
       },

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
@@ -31,7 +31,7 @@ import { BarSeriesDecorator } from './decorators/bar_decorator';
 import { getStackAccessors } from './utils/stack_format';
 import { getBaseTheme, getChartClasses } from './utils/theme';
 import { TOOLTIP_MODES } from '../../../../../common/enums';
-import { getMeaningfulValueOrEmpty } from '../../../../../common/empty_label';
+import { getValueOrEmpty } from '../../../../../common/empty_label';
 import { getSplitByTermsColor } from '../../../lib/get_split_by_terms_color';
 import { renderEndzoneTooltip } from '../../../../../../charts/public';
 import { getAxisLabelString } from '../../../components/lib/get_axis_label_string';
@@ -237,7 +237,7 @@ export const TimeSeries = ({
                 key={key}
                 seriesId={id}
                 seriesGroupId={groupId}
-                name={getMeaningfulValueOrEmpty(seriesName)}
+                name={getValueOrEmpty(seriesName)}
                 data={data}
                 hideInLegend={hideInLegend}
                 bars={bars}
@@ -262,7 +262,7 @@ export const TimeSeries = ({
                 key={key}
                 seriesId={id}
                 seriesGroupId={groupId}
-                name={getMeaningfulValueOrEmpty(seriesName)}
+                name={getValueOrEmpty(seriesName)}
                 data={data}
                 hideInLegend={hideInLegend}
                 lines={lines}

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
@@ -31,7 +31,7 @@ import { BarSeriesDecorator } from './decorators/bar_decorator';
 import { getStackAccessors } from './utils/stack_format';
 import { getBaseTheme, getChartClasses } from './utils/theme';
 import { TOOLTIP_MODES } from '../../../../../common/enums';
-import { emptyLabel } from '../../../../../common/empty_label';
+import { getMeaningfulValueOrEmpty } from '../../../../../common/empty_label';
 import { getSplitByTermsColor } from '../../../lib/get_split_by_terms_color';
 import { renderEndzoneTooltip } from '../../../../../../charts/public';
 import { getAxisLabelString } from '../../../components/lib/get_axis_label_string';
@@ -237,7 +237,7 @@ export const TimeSeries = ({
                 key={key}
                 seriesId={id}
                 seriesGroupId={groupId}
-                name={seriesName || emptyLabel}
+                name={getMeaningfulValueOrEmpty(seriesName)}
                 data={data}
                 hideInLegend={hideInLegend}
                 bars={bars}
@@ -262,7 +262,7 @@ export const TimeSeries = ({
                 key={key}
                 seriesId={id}
                 seriesGroupId={groupId}
-                name={seriesName || emptyLabel}
+                name={getMeaningfulValueOrEmpty(seriesName)}
                 data={data}
                 hideInLegend={hideInLegend}
                 lines={lines}

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { getLastValue, isEmptyValue } from '../../../../common/last_value_utils';
 import { labelDateFormatter } from '../../components/lib/label_date_formatter';
-import { getMeaningfulValueOrEmpty } from '../../../../common/empty_label';
+import { getValueOrEmpty } from '../../../../common/empty_label';
 import reactcss from 'reactcss';
 
 const RENDER_MODES = {
@@ -131,7 +131,7 @@ export class TopN extends Component {
       return (
         <tr key={key} onClick={this.handleClick({ lastValue, ...item })} style={styles.row}>
           <td title={item.label} className="tvbVisTopN__label" style={styles.label}>
-            {getMeaningfulValueOrEmpty(label)}
+            {getValueOrEmpty(label)}
           </td>
           <td width="100%" className="tvbVisTopN__bar">
             <div className="tvbVisTopN__innerBar" style={styles.innerBar}>

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { getLastValue, isEmptyValue } from '../../../../common/last_value_utils';
 import { labelDateFormatter } from '../../components/lib/label_date_formatter';
-import { emptyLabel } from '../../../../common/empty_label';
+import { getMeaningfulValueOrEmpty } from '../../../../common/empty_label';
 import reactcss from 'reactcss';
 
 const RENDER_MODES = {
@@ -131,7 +131,7 @@ export class TopN extends Component {
       return (
         <tr key={key} onClick={this.handleClick({ lastValue, ...item })} style={styles.row}>
           <td title={item.label} className="tvbVisTopN__label" style={styles.label}>
-            {label || emptyLabel}
+            {getMeaningfulValueOrEmpty(label)}
           </td>
           <td width="100%" className="tvbVisTopN__bar">
             <div className="tvbVisTopN__innerBar" style={styles.innerBar}>


### PR DESCRIPTION
Regression of: #91838

## Summary

The aforementioned PR resulted in a regression in showing a values that could be implicitly casted to `false`. As a result instead of `0` and `false` user see `(empty)` which is not correct

## Steps to reproduce: 

1) Install sample data sets 
2) Open TSVB and set `kibana_sample_data_ecommerce` index
3) Configure aggregation as shown below:
![image](https://user-images.githubusercontent.com/20072247/123781945-78bdaa80-d8dd-11eb-89a2-532af05bb92e.png)
4) Go to `Top N` tab 

### Actual result:

![image](https://user-images.githubusercontent.com/20072247/123782110-9e4ab400-d8dd-11eb-8114-bfd38f5ee0cf.png)

 
### Expected result:
Instead of `(empty)` it should be `0`


### Additional information:
The same valid for `Boolean` fields 

![image](https://user-images.githubusercontent.com/20072247/123782719-4ceef480-d8de-11eb-9bd6-f111b01843f2.png)
