### PR TITLE
[Lens] Formula Icon, Button, Height Design Update

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula.scss
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula.scss
@@ -47,8 +47,16 @@
 }
 
 .lnsFormula__editorContent {
+  min-height: 0;
   position: relative;
-  height: 201px;
+
+  .lnsIndexPatternDimensionEditor:not(.lnsIndexPatternDimensionEditor-isFullscreen) & {
+    height: 200px;
+  }
+
+  .lnsIndexPatternDimensionEditor-isFullscreen & {
+    flex: 1;
+  }
 }
 
 .lnsFormula__editorPlaceholder {
@@ -60,11 +68,6 @@
   // Matches monaco editor
   font-family: Menlo, Monaco, 'Courier New', monospace;
   pointer-events: none;
-}
-
-.lnsIndexPatternDimensionEditor-isFullscreen .lnsFormula__editorContent {
-  flex: 1;
-  min-height: 201px;
 }
 
 .lnsFormula__warningText + .lnsFormula__warningText {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -622,7 +622,6 @@ export function FormulaEditor({
                 </EuiFlexItem>
 
                 <EuiFlexItem className="lnsFormula__editorHeaderGroup" grow={false}>
-                  {/* TODO: Replace `bolt` with `fullScreenExit` icon (after latest EUI is deployed). */}
                   <EuiButtonEmpty
                     onClick={() => {
                       toggleFullscreen();
@@ -630,7 +629,7 @@ export function FormulaEditor({
                       setIsHelpOpen(!isFullscreen);
                       trackUiEvent('toggle_formula_fullscreen');
                     }}
-                    iconType={isFullscreen ? 'bolt' : 'fullScreen'}
+                    iconType={isFullscreen ? 'fullScreenExit' : 'fullScreen'}
                     size="xs"
                     color="text"
                     flush="right"
@@ -758,7 +757,6 @@ export function FormulaEditor({
                             }}
                             iconType="documentation"
                             color="text"
-                            size="s"
                             aria-label={i18n.translate(
                               'xpack.lens.formula.editorHelpInlineShowToolTip',
                               {


### PR DESCRIPTION
## Summary

This PR addresses the following Lens formula issues:

- Replaces `bolt` icon with `fullScreenExit` icon on collapse button.
- Corrects the function reference's `EuiButtonIcon` to be the default size (i.e. `xs`).
- Fixes expanded view height styles to prevent breaking at small viewport heights.

![image](https://user-images.githubusercontent.com/3884767/123820152-59685280-d8c8-11eb-978e-0040f3468db3.png)

![image](https://user-images.githubusercontent.com/3884767/123820049-43f32880-d8c8-11eb-9646-6a8de5e9fec7.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)