### PR TITLE
[App Search] Update delete copy to indicate immediate deletion

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
@@ -101,9 +101,7 @@ describe('DocumentDetailLogic', () => {
 
         expect(http.delete).toHaveBeenCalledWith('/api/app_search/engines/engine1/documents/1');
         await nextTick();
-        expect(flashSuccessToast).toHaveBeenCalledWith('Your document was marked for deletion', {
-          text: 'It will be deleted momentarily.',
-        });
+        expect(flashSuccessToast).toHaveBeenCalledWith('Your document was deleted');
         expect(navigateToUrl).toHaveBeenCalledWith('/engines/engine1/documents');
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.ts
@@ -79,20 +79,16 @@ export const DocumentDetailLogic = kea<DocumentDetailLogicType>({
         'xpack.enterpriseSearch.appSearch.documentDetail.confirmDelete',
         { defaultMessage: 'Are you sure you want to delete this document?' }
       );
-      const DELETE_SUCCESS_TITLE = i18n.translate(
+      const DELETE_SUCCESS = i18n.translate(
         'xpack.enterpriseSearch.appSearch.documentDetail.deleteSuccess',
-        { defaultMessage: 'Your document was marked for deletion' }
-      );
-      const DELETE_SUCCESS_TEXT = i18n.translate(
-        'xpack.enterpriseSearch.appSearch.documentDetail.deleteSuccessDescription',
-        { defaultMessage: 'It will be deleted momentarily.' }
+        { defaultMessage: 'Your document was deleted' }
       );
 
       if (window.confirm(CONFIRM_DELETE)) {
         try {
           const { http } = HttpLogic.values;
           await http.delete(`/api/app_search/engines/${engineName}/documents/${documentId}`);
-          flashSuccessToast(DELETE_SUCCESS_TITLE, { text: DELETE_SUCCESS_TEXT });
+          flashSuccessToast(DELETE_SUCCESS);
           navigateToUrl(generateEnginePath(ENGINE_DOCUMENTS_PATH));
         } catch (e) {
           flashAPIErrors(e);

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -7510,7 +7510,6 @@
     "xpack.enterpriseSearch.appSearch.documentCreation.warningsTitle": "警告!",
     "xpack.enterpriseSearch.appSearch.documentDetail.confirmDelete": "このドキュメントを削除しますか？",
     "xpack.enterpriseSearch.appSearch.documentDetail.deleteSuccess": "正常にドキュメントが削除に設定されました。",
-    "xpack.enterpriseSearch.appSearch.documentDetail.deleteSuccessDescription": "すぐに削除されます。",
     "xpack.enterpriseSearch.appSearch.documentDetail.fieldHeader": "フィールド",
     "xpack.enterpriseSearch.appSearch.documentDetail.title": "ドキュメント：{documentId}",
     "xpack.enterpriseSearch.appSearch.documentDetail.valueHeader": "値",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7573,7 +7573,6 @@
     "xpack.enterpriseSearch.appSearch.documentCreation.warningsTitle": "警告！",
     "xpack.enterpriseSearch.appSearch.documentDetail.confirmDelete": "是否确定要删除此文档？",
     "xpack.enterpriseSearch.appSearch.documentDetail.deleteSuccess": "成功标记要删除的文档。",
-    "xpack.enterpriseSearch.appSearch.documentDetail.deleteSuccessDescription": "文档将被暂时删除。",
     "xpack.enterpriseSearch.appSearch.documentDetail.fieldHeader": "字段",
     "xpack.enterpriseSearch.appSearch.documentDetail.title": "文档：{documentId}",
     "xpack.enterpriseSearch.appSearch.documentDetail.valueHeader": "值",


### PR DESCRIPTION
## Summary

David [recently changed](https://github.com/elastic/ent-search/pull/3948) our dashboard action to invoke an index refresh, which means it essentially should be a synchronous action now, and we don't need copy indicating it will "soon be deleted" 🎉 

![delete](https://user-images.githubusercontent.com/549407/123830126-df2fd200-d8b7-11eb-82ac-976b6242801a.gif)

## QA

I tried deleting 6 documents and it worked each time (whereas before the deleted document would re-show up on the documents view sometimes), but would appreciate a 2nd set of eyes/QA on this!

- [x] Ensure you have latest ent-search master pulled
- [x] Delete the first document at the top of the in the Documents view
- [x] Confirm the success message says "was deleted", and confirm the deleted document actually is no longer present/at the top of the Documents view

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)