### PR TITLE
adds hasBorder to ThreatIntelPanelView

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
@@ -133,7 +133,7 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
       >
         <EuiFlexItem grow={1}>
           <InspectButtonContainer>
-            <EuiPanel>
+            <EuiPanel hasBorder>
               <HeaderSection id={CTIEventCountQueryId} subtitle={subtitle} title={panelTitle}>
                 <>{button}</>
               </HeaderSection>


### PR DESCRIPTION
## Summary

Replaces mismatched panel shadow with border (CTI dashboard link panel)

Before
<img width="643" alt="Screen Shot 2021-06-29 at 1 36 09 PM" src="https://user-images.githubusercontent.com/18617331/123842633-fc2bcb80-d8de-11eb-8bb7-f84a575f6230.png">

After
<img width="950" alt="Screen Shot 2021-06-29 at 1 34 31 PM" src="https://user-images.githubusercontent.com/18617331/123842543-e61e0b00-d8de-11eb-851f-2bd8393de941.png">
