### PR TITLE
[Canvas] Removes link from workpad breadcrumb

### DIFF
--- a/x-pack/plugins/canvas/public/lib/breadcrumbs.ts
+++ b/x-pack/plugins/canvas/public/lib/breadcrumbs.ts
@@ -7,18 +7,13 @@
 
 import { ChromeBreadcrumb } from '../../../../../src/core/public';
 
-export const getBaseBreadcrumb = () => ({
+export const getBaseBreadcrumb = (): ChromeBreadcrumb => ({
   text: 'Canvas',
   href: '#/',
 });
 
 export const getWorkpadBreadcrumb = ({
   name = 'Workpad',
-  id,
-}: { name?: string; id?: string } = {}) => {
-  const output: ChromeBreadcrumb = { text: name };
-  if (id != null) {
-    output.href = `#/workpad/${id}`;
-  }
-  return output;
-};
+}: { name?: string } = {}): ChromeBreadcrumb => ({
+  text: name,
+});

--- a/x-pack/plugins/canvas/public/routes/workpad/workpad_presentation_helper.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/workpad_presentation_helper.tsx
@@ -26,7 +26,7 @@ export const WorkpadPresentationHelper: FC = ({ children }) => {
   useEffect(() => {
     services.platform.setBreadcrumbs([
       getBaseBreadcrumb(),
-      getWorkpadBreadcrumb({ name: workpad.name, id: workpad.id }),
+      getWorkpadBreadcrumb({ name: workpad.name }),
     ]);
   }, [workpad.name, workpad.id, services.platform]);
 


### PR DESCRIPTION
## Summary

The link in the workpad breadcrumb just triggers a reload of the page. I removed the link since it's kind of a noop, and there are better ways to refresh/reload a workpad than clicking on the breadcrumb. This is also how Dashboard handles it.

#### Before
<img width="286" alt="Screen Shot 2021-06-29 at 4 17 47 PM" src="https://user-images.githubusercontent.com/1697105/123879530-ebd31b00-d8f5-11eb-8f01-1438b399fb8a.png">

#### After
<img width="291" alt="Screen Shot 2021-06-29 at 4 17 29 PM" src="https://user-images.githubusercontent.com/1697105/123879537-f1306580-d8f5-11eb-80fc-99842a28eb31.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
