### PR TITLE
Fix inaccurate Kibana status message when Kibana is in a yellow "degraded" state

### DIFF
--- a/x-pack/plugins/monitoring/public/components/cluster/overview/helpers.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/helpers.js
@@ -43,15 +43,14 @@ export function HealthLabel(props) {
     }
   }
 
-  if (product === 'kb' && status === 'red') {
+  // TODO: Use the actual service level statuses instead of converting them to colors
+  if (product === 'kb' && (status === 'yellow' || status === 'red')) {
     return (
       <EuiText>
         {i18n.translate('xpack.monitoring.cluster.health.pluginIssues', {
-          defaultMessage: 'Some plugins are experiencing issues. Check ',
+          defaultMessage: 'Some plugins may be experiencing issues. Please check ',
         })}
-        <EuiLink href="/status" target="_blank" external={true}>
-          status
-        </EuiLink>
+        <EuiLink href={`${Legacy.shims.getBasePath()}/status`}>the Kibana status page</EuiLink>.
       </EuiText>
     );
   }

--- a/x-pack/plugins/monitoring/public/components/cluster/overview/helpers.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/helpers.js
@@ -5,20 +5,21 @@
  * 2.0.
  */
 
-import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiIcon,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { get } from 'lodash';
-import { formatBytesUsage, formatPercentageUsage, formatNumber } from '../../../lib/format_number';
-import {
-  EuiSpacer,
-  EuiFlexItem,
-  EuiFlexGroup,
-  EuiTitle,
-  EuiIcon,
-  EuiHealth,
-  EuiText,
-  EuiLink,
-} from '@elastic/eui';
+import React from 'react';
+import { Legacy } from '../../../legacy_shims';
+import { formatBytesUsage, formatNumber, formatPercentageUsage } from '../../../lib/format_number';
 
 export function HealthLabel(props) {
   if (props.status === 'green') {


### PR DESCRIPTION
## Summary

This PR makes the Kibana Health Indicator display a warning message when the status value is either "yellow" or "red". Previously, it only showed this message when the status value was "red", so there would be a yellow dot but the message would say "Healthy".

This PR also fixes a bug where the link to the Kibana "/status" page was not accounting for the Kibana basePath value.

## Notes

This is a rather sad band-aid of a solution. There are at least 3 things wrong with the solution, as implemented:

1. We shouldn't be converting [the raw status values we receive from the Kibana /status API](https://github.com/elastic/kibana/blob/524401973f1d0ac5403cd0fbb3ea82a63962a45a/src/core/server/status/types.ts#L56-L103) into [color values before we store them](https://github.com/elastic/kibana/blob/1e6a024c4d09d5a66dd2f242757e1827ac6ae6cc/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.ts#L191-L217). This removes context from the information we store, and can't be re-gained. We should store the status value and then, if we want to convert to colors/levels, we can do that during retrieval. 
2. We shouldn't be collapsing all non-green [Kibana statuses](https://github.com/elastic/kibana/blob/524401973f1d0ac5403cd0fbb3ea82a63962a45a/src/core/server/status/types.ts#L56-L103) into a single message. "Degraded" is different than "Unavailable" which are both different than "Critical", and we should be able to message accordingly. (We do show a different color dot for these -- red vs. yellow -- but that's not enough.)
3. More importantly, we're the Kibana Monitoring product and when Kibana is in a non-green state, we say, "Hm, Kibana may be having some problems, go to another page to find out why". When they get to that /status page, they won't really get too much extra information, either, but we should at least be able to provide the info that the /status page has (which plugins are having problems and what those problems are, generally) in the monitoring app.

That said, this ticket fixes the immediate bug where the "yellow" status shows as "Healthy", so we should move ahead with this and log one or more separate tickets to address these problems.

## Test Plan

I'm not sure how to force Kibana into [the various non-green states](https://github.com/elastic/kibana/blob/524401973f1d0ac5403cd0fbb3ea82a63962a45a/src/core/server/status/types.ts#L56-L103), which would be ideal. For now, you can change the Kibana status value right after the data is collected from the server to verify its effect on the Kibana status indicator message.

In `x-pack/plugins/monitoring/public/views/cluster/overview/index.js`, inside of the `$scope.$watch` callback:

```diff
       this.init = () => this.renderReact(null);

       $scope.$watch(
         () => this.data,
         async (data) => {
           if (isEmpty(data)) {
             return;
           }

+          // TODO: REMOVE THIS BEFORE MERGE, THIS IS FOR TESTING ONLY
+          data.kibana.status = 'yellow';
+
           this.renderReact(
             <SetupModeRenderer
```

Then visit `/app/monitoring#/overview` in Kibana. 

- [ ] When `data.kibana.status` is set to "yellow", the Kibana section header should have a yellow dot next to it with a message that says "Some plugins may be experiencing issues. Please check the Kibana status page."
- [ ] When `data.kibana.status` is set to "red", the Kibana section header should have a red dot next to it with the same message.
- [ ] Whenever the message appears with "Please check the Kibana status page", the link should accurately link to the Kibana "/status" page
- [ ] If a dynamic base path is used for Kibana, the link should correctly open to "/{basePath}/status"
- [ ] When `data.kibana.status` is set to "green", the Kibana section header should have a green dot next to it, with a message that just says "Healthy"
- [ ] When `data.kibana.status` is set to "nonsense", the Kibana section header should have a dark grey dot next to it, with a message that says, "N/A"
- [ ] When `data.kibana.status` is deleted, set to null, or set to false, it should act the same as if the value is "nonsense"

### Still to-do

- [ ] Look into what tests we already have for these indicators and add one for this "yellow" scenario

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)