### PR TITLE
[7.x] Skip flaky cypress timeline test (#103779)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/timelines/row_renderers.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/row_renderers.spec.ts
@@ -75,7 +75,7 @@ describe('Row renderers', () => {
     });
   });
 
-  it('Selected renderer can be disabled with one click', () => {
+  it.skip('Selected renderer can be disabled with one click', () => {
     cy.get(TIMELINE_ROW_RENDERERS_DISABLE_ALL_BTN).click({ force: true });
 
     cy.intercept('PATCH', '/api/timeline').as('updateTimeline');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Skip flaky cypress timeline test (#103779)