### PR TITLE
[Security Solution][Endpoint] Allow activity log scrolling on small screens

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_activity_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_activity_log.tsx
@@ -31,6 +31,9 @@ import {
   getActivityLogRequestLoading,
 } from '../../store/selectors';
 
+const StyledEuiFlexGroup = styled(EuiFlexGroup)`
+  height: 85vh;
+`;
 const LoadMoreTrigger = styled.div`
   height: 6px;
   width: 100%;
@@ -79,7 +82,7 @@ export const EndpointActivityLog = memo(
 
     return (
       <>
-        <EuiFlexGroup direction="column" style={{ height: '85vh' }} responsive={false}>
+        <StyledEuiFlexGroup direction="column" responsive={false}>
           {(activityLogLoaded && !activityLogSize) || activityLogError ? (
             <EuiFlexItem>
               <EuiEmptyPrompt
@@ -115,7 +118,7 @@ export const EndpointActivityLog = memo(
               </EuiFlexItem>
             </>
           )}
-        </EuiFlexGroup>
+        </StyledEuiFlexGroup>
       </>
     );
   }

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_activity_log.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_activity_log.tsx
@@ -79,7 +79,7 @@ export const EndpointActivityLog = memo(
 
     return (
       <>
-        <EuiFlexGroup direction="column" style={{ height: '85vh' }}>
+        <EuiFlexGroup direction="column" style={{ height: '85vh' }} responsive={false}>
           {(activityLogLoaded && !activityLogSize) || activityLogError ? (
             <EuiFlexItem>
               <EuiEmptyPrompt


### PR DESCRIPTION
refs elastic/kibana/pull/102261

## Summary

It fixes the issue for some small screens where the **Activity Log** is not entirely scrollable, preventing the loading trigger element to come into view and thus, disabling paging.  With this change, users can paginate **Activity Log** on smaller screens same as on large screens.

**before**
![action-log-scrolling-1](https://user-images.githubusercontent.com/1849116/123939164-2097ae80-d998-11eb-8ac2-60673996522d.gif)

**after**

![action-log-scrolling-2](https://user-images.githubusercontent.com/1849116/123939567-8b48ea00-d998-11eb-9416-5fd3c6d98ffa.gif)

**large screens (no change)**
![action-log-scrolling-3](https://user-images.githubusercontent.com/1849116/123941218-3c9c4f80-d99a-11eb-9f0f-776740ff85fa.gif)
