### PR TITLE
[Security Solutions] Administration breadcrumbs shortened to be consistent with the rest

### DIFF
--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -377,12 +377,13 @@ export function updateGlobalNavigation({
   const deepLinks = getDeepLinks(undefined, capabilities);
   const updatedDeepLinks = deepLinks.map((link) => {
     switch (link.id) {
-      case 'case':
+      case SecurityPageName.case:
         return {
           ...link,
           navLinkStatus: capabilities.siem.read_cases
             ? AppNavLinkStatus.visible
             : AppNavLinkStatus.hidden,
+          searchable: capabilities.siem.read_cases === true,
         };
       default:
         return link;
@@ -390,6 +391,7 @@ export function updateGlobalNavigation({
   });
 
   updater$.next(() => ({
+    navLinkStatus: AppNavLinkStatus.hidden, // needed to prevent showing main nav link
     deepLinks: updatedDeepLinks,
   }));
 }

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -377,13 +377,12 @@ export function updateGlobalNavigation({
   const deepLinks = getDeepLinks(undefined, capabilities);
   const updatedDeepLinks = deepLinks.map((link) => {
     switch (link.id) {
-      case SecurityPageName.case:
+      case 'case':
         return {
           ...link,
           navLinkStatus: capabilities.siem.read_cases
             ? AppNavLinkStatus.visible
             : AppNavLinkStatus.hidden,
-          searchable: capabilities.siem.read_cases === true,
         };
       default:
         return link;
@@ -391,7 +390,6 @@ export function updateGlobalNavigation({
   });
 
   updater$.next(() => ({
-    navLinkStatus: AppNavLinkStatus.hidden, // needed to prevent showing main nav link
     deepLinks: updatedDeepLinks,
   }));
 }

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -13,6 +13,8 @@ import { RouteSpyState, SiemRouteType } from '../../../utils/route/types';
 import { TabNavigationProps } from '../tab_navigation/types';
 import { NetworkRouteType } from '../../../../network/pages/navigation/types';
 import { TimelineTabs } from '../../../../../common/types/timeline';
+import { AdministrationSubTab } from '../../../../management/types';
+// import { AdministrationSubTab } from '../types';
 
 const setBreadcrumbsMock = jest.fn();
 const chromeMock = {
@@ -26,6 +28,8 @@ const mockDefaultTab = (pageName: string): SiemRouteType | undefined => {
       return HostsTableType.authentications;
     case 'network':
       return NetworkRouteType.flows;
+    case 'administration':
+      return AdministrationSubTab.endpoints;
     default:
       return undefined;
   }
@@ -423,16 +427,16 @@ describe('Navigation Breadcrumbs', () => {
         },
       ]);
     });
-    test('should return Admin breadcrumbs when supplied admin pathname', () => {
+    test('should return Admin breadcrumbs when supplied endpoints pathname', () => {
       const breadcrumbs = getBreadcrumbsForRoute(
-        getMockObject('administration', '/', undefined),
+        getMockObject('administration', '/endpoints', undefined),
         getUrlForAppMock
       );
       expect(breadcrumbs).toEqual([
         { text: 'Security', href: 'securitySolution/overview' },
         {
-          text: 'Administration',
-          href: 'securitySolution/endpoints',
+          text: 'Endpoints',
+          href: '',
         },
       ]);
     });

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -14,7 +14,6 @@ import { TabNavigationProps } from '../tab_navigation/types';
 import { NetworkRouteType } from '../../../../network/pages/navigation/types';
 import { TimelineTabs } from '../../../../../common/types/timeline';
 import { AdministrationSubTab } from '../../../../management/types';
-// import { AdministrationSubTab } from '../types';
 
 const setBreadcrumbsMock = jest.fn();
 const chromeMock = {

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.ts
@@ -186,18 +186,7 @@ export const getBreadcrumbsForRoute = (
     if (spyState.tabName != null) {
       urlStateKeys = [...urlStateKeys, getOr(tempNav, spyState.tabName, object.navTabs)];
     }
-
-    return [
-      siemRootBreadcrumb,
-      ...getAdminBreadcrumbs(
-        spyState,
-        urlStateKeys.reduce(
-          (acc: string[], item: SearchNavTab) => [...acc, getSearch(item, object)],
-          []
-        ),
-        getUrlForApp
-      ),
-    ];
+    return [siemRootBreadcrumb, ...getAdminBreadcrumbs(spyState)];
   }
 
   if (

--- a/x-pack/plugins/security_solution/public/management/common/breadcrumbs.ts
+++ b/x-pack/plugins/security_solution/public/management/common/breadcrumbs.ts
@@ -6,13 +6,9 @@
  */
 
 import { ChromeBreadcrumb } from 'kibana/public';
-import { isEmpty } from 'lodash/fp';
 import { AdministrationSubTab } from '../types';
 import { ENDPOINTS_TAB, EVENT_FILTERS_TAB, POLICIES_TAB, TRUSTED_APPS_TAB } from './translations';
 import { AdministrationRouteSpyState } from '../../common/utils/route/types';
-import { GetUrlForApp } from '../../common/components/navigation/types';
-import { ADMINISTRATION } from '../../app/translations';
-import { APP_ID, SecurityPageName } from '../../../common/constants';
 
 const TabNameMappedToI18nKey: Record<AdministrationSubTab, string> = {
   [AdministrationSubTab.endpoints]: ENDPOINTS_TAB,
@@ -21,19 +17,8 @@ const TabNameMappedToI18nKey: Record<AdministrationSubTab, string> = {
   [AdministrationSubTab.eventFilters]: EVENT_FILTERS_TAB,
 };
 
-export function getBreadcrumbs(
-  params: AdministrationRouteSpyState,
-  search: string[],
-  getUrlForApp: GetUrlForApp
-): ChromeBreadcrumb[] {
+export function getBreadcrumbs(params: AdministrationRouteSpyState): ChromeBreadcrumb[] {
   return [
-    {
-      text: ADMINISTRATION,
-      href: getUrlForApp(APP_ID, {
-        deepLinkId: SecurityPageName.endpoints,
-        path: !isEmpty(search[0]) ? search[0] : '',
-      }),
-    },
     ...(params?.tabName ? [params?.tabName] : []).map((tabName) => ({
       text: TabNameMappedToI18nKey[tabName],
       href: '',


### PR DESCRIPTION
## Summary

Resolving issue #103857

"Administration" breadcrumb removed to make it consistent with the rest of the pages. It does not have a specific page assigned, it was linking to _/endpoints_ so it is not needed anymore.

![Captura de Pantalla 2021-06-30 a les 18 25 19](https://user-images.githubusercontent.com/17747913/123997293-8a33af00-d9d0-11eb-851a-e1dc1ee2ccaa.png)
![Captura de Pantalla 2021-06-30 a les 18 25 08](https://user-images.githubusercontent.com/17747913/123997382-a0da0600-d9d0-11eb-9330-21f23e30f6c4.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

