### PR TITLE
[Enterprise Search] Improve flash messages screen reader UX

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
@@ -18,7 +18,7 @@ export const FlashMessages: React.FC = ({ children }) => {
   const { messages } = useValues(FlashMessagesLogic);
 
   return (
-    <div role="alert" aria-live="polite" data-test-subj="FlashMessages">
+    <div aria-live="polite" data-test-subj="FlashMessages">
       {messages.map(({ type, message, description }, index) => (
         <Fragment key={index}>
           <EuiCallOut


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/103412 - Glen reached out on the accessibility Slack today to recommend against `role="alert"` combined with `aria-live="polite"` for the following reasons:

> - no role is needed to use `aria-live`.  i often use it on a hidden `<span>` as a "message area" when i want to announce something to the screen reader user.  anytime i want to "talk" to the SR user, i send new text into the `<span>` and the SR announces it.  no role needed.
> - when using `aria-live`, you should almost always use polite.  rarely should you use assertive.  assertive can break the normal workflow for a SR user causing messages to be read in an unexpected order.  unless the building is on fire, assertive should not be needed.
> - there are some roles that have an implicit `aria-live` associated with them.  as mentioned earlier `role="alert"` has an implicit assertive, but going by my previous bullet point, assertive should rarely be used so alert should be rarely used too.
> - if you use a role with an implicit `aria-live`, do not change the value of `aria-live`.  you will get unexpected results.  different browsers and screen readers might give different precedence over which one wins.

With the possible cross-screen-reader complications of both `role="alert"` and `aria-live="polite"` in mind, I've opted to remove `role` and simply go with `aria-live`. Thanks a ton to Glen for the knowledge - screen reader behavior in particular sometimes reminds me of the good old cross-browser-ie-6 days 😅 

### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))