### PR TITLE
Removed Search UI access for Editor role

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -292,7 +292,10 @@ describe('useEngineNav', () => {
     });
 
     it('returns a Search UI nav item', () => {
-      setMockValues({ ...values, myRole: { canManageEngineSearchUi: true } });
+      setMockValues({
+        ...values,
+        myRole: { canManageEngineSearchUi: true, canViewAccountCredentials: true },
+      });
       expect(useEngineNav()).toEqual([
         ...BASE_NAV,
         {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -50,6 +50,7 @@ export const useEngineNav = () => {
   const isEngineRoute = !!useRouteMatch(ENGINE_PATH);
   const {
     myRole: {
+      canViewAccountCredentials,
       canViewEngineAnalytics,
       canViewEngineDocuments,
       canViewEngineSchema,
@@ -275,7 +276,11 @@ export const useEngineNav = () => {
     });
   }
 
-  if (canManageEngineSearchUi) {
+  /* TODO: In 8.0, this should change to just canManageEngineSearchUi and access to Search UI should be removed from
+      the Editor role. As of 7.14, we are hiding this page from Editors this way to stay backward compatible with ent-search,
+      where Editors should still have access. Editors technically have access to this page but do not have access to
+      credentials, which are required for the page to work. */
+  if (canManageEngineSearchUi && canViewAccountCredentials) {
     navItems.push({
       id: 'searchUI',
       name: SEARCH_UI_TITLE,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -168,7 +168,10 @@ describe('EngineRouter', () => {
   });
 
   it('renders a search ui view', () => {
-    setMockValues({ ...values, myRole: { canManageEngineSearchUi: true } });
+    setMockValues({
+      ...values,
+      myRole: { canManageEngineSearchUi: true, canViewAccountCredentials: true },
+    });
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(SearchUI)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -51,6 +51,7 @@ import { EngineLogic, getEngineBreadcrumbs } from './';
 export const EngineRouter: React.FC = () => {
   const {
     myRole: {
+      canViewAccountCredentials,
       canViewEngineAnalytics,
       canViewEngineDocuments,
       canViewEngineSchema,
@@ -150,7 +151,11 @@ export const EngineRouter: React.FC = () => {
           <ResultSettings />
         </Route>
       )}
-      {canManageEngineSearchUi && (
+      {/* TODO: In 8.0, this should change to just canManageEngineSearchUi and access to Search UI should be removed from
+      the Editor role. As of 7.14, we are hiding this page from Editors this way to stay backward compatible with ent-search,
+      where Editors should still have access. Editors technically have access to this page but do not have access to
+      credentials, which are required for the page to work. */}
+      {canManageEngineSearchUi && canViewAccountCredentials && (
         <Route path={ENGINE_SEARCH_UI_PATH}>
           <SearchUI />
         </Route>


### PR DESCRIPTION
## Summary

This PR disables access for Editors to the Search UI page *in Kibana only*.

The Search UI page now requires the ability to view credentials because it [posts a Search API Key](https://github.com/elastic/kibana/pull/101320) to ent-search to generate a preview.

Editors do not have this access. For that reason Search UI does NOT work for that role in the Kibana Plugin.

Because Editors *should* still have access to this page in ent-search, I did not want to remove access for that role entirely; I only want to remove access in Kibana.

For this reason, I chose to change the Search UI permission check to check both that the role has the Manage Search UI permission AND the View Credentials permission.

All other roles should remain unaffected.

Here is a screenshot comparing 7.14 ent-search and kibana, note that Editors still have access in ent-search but not in Kibana:

<img width="2559" alt="no-search-ui" src="https://user-images.githubusercontent.com/1427475/124003603-25169400-d9a5-11eb-8e59-54cbb210e718.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
