### PR TITLE
[APM] Fix prepend form label background

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/time_comparison/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/time_comparison/index.tsx
@@ -26,7 +26,8 @@ const PrependContainer = euiStyled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${({ theme }) => theme.eui.euiGradientMiddle};
+  background-color: ${({ theme }) =>
+    theme.eui.euiFormInputGroupLabelBackground};
   padding: 0 ${px(unit)};
 `;
 


### PR DESCRIPTION
## Summary

The prepend label background for time comparison doesn't match the EUI form field background for labels.

_Before_

 
<img width="590" alt="Screenshot 2021-06-30 at 21 14 20" src="https://user-images.githubusercontent.com/4104278/124018703-68debd00-d9e8-11eb-90f3-1a6dbaa6a1bb.png">

<img width="524" alt="Screenshot 2021-06-30 at 21 13 49" src="https://user-images.githubusercontent.com/4104278/124018717-6b411700-d9e8-11eb-9571-ec54e8ef965f.png">

_After_

<img width="965" alt="Screenshot 2021-06-30 at 21 11 51" src="https://user-images.githubusercontent.com/4104278/124018730-6ed49e00-d9e8-11eb-9769-9c4df90b849c.png">

<img width="525" alt="Screenshot 2021-06-30 at 21 13 18" src="https://user-images.githubusercontent.com/4104278/124018735-7136f800-d9e8-11eb-803d-941dd6a19a6a.png">

