### PR TITLE
[7.14] [Reporting] fix too_long_frame_exception by passing scroll_id in the request body (#102972)

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.test.ts
@@ -324,6 +324,23 @@ it('uses the scrollId to page all the data', async () => {
   const csvResult = await generateCsv.generateData();
   expect(csvResult.warnings).toEqual([]);
   expect(csvResult.content).toMatchSnapshot();
+
+  expect(mockDataClient.search).toHaveBeenCalledTimes(1);
+  expect(mockDataClient.search).toBeCalledWith(
+    { params: { scroll: '30s', size: 500 } },
+    { strategy: 'es' }
+  );
+
+  // `scroll` and `clearScroll` must be called with scroll ID in the post body!
+  expect(mockEsClient.asCurrentUser.scroll).toHaveBeenCalledTimes(9);
+  expect(mockEsClient.asCurrentUser.scroll).toHaveBeenCalledWith({
+    body: { scroll: '30s', scroll_id: 'awesome-scroll-hero' },
+  });
+
+  expect(mockEsClient.asCurrentUser.clearScroll).toHaveBeenCalledTimes(1);
+  expect(mockEsClient.asCurrentUser.clearScroll).toHaveBeenCalledWith({
+    body: { scroll_id: ['awesome-scroll-hero'] },
+  });
 });
 
 describe('fields from job.searchSource.getFields() (7.12 generated)', () => {

--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -102,8 +102,10 @@ export class CsvGenerator {
     this.logger.debug(`executing scroll request`);
     const results = (
       await this.clients.es.asCurrentUser.scroll({
-        scroll: scrollSettings.duration,
-        scroll_id: scrollId,
+        body: {
+          scroll: scrollSettings.duration,
+          scroll_id: scrollId,
+        },
       })
     ).body as SearchResponse<unknown>;
     return results;
@@ -387,7 +389,7 @@ export class CsvGenerator {
       if (scrollId) {
         this.logger.debug(`executing clearScroll request`);
         try {
-          await this.clients.es.asCurrentUser.clearScroll({ scroll_id: [scrollId] });
+          await this.clients.es.asCurrentUser.clearScroll({ body: { scroll_id: [scrollId] } });
         } catch (err) {
           this.logger.error(err);
         }


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Reporting] fix too_long_frame_exception by passing scroll_id in the request body (#102972)