### PR TITLE
Override cy.exec's NODE_TLS_REJECT_UNAUTHORIZED=0

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/tasks/es_archiver.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/tasks/es_archiver.ts
@@ -9,23 +9,28 @@ import Path from 'path';
 
 const ES_ARCHIVE_DIR = './cypress/fixtures/es_archiver';
 
+// Otherwise cy.exec would inject NODE_TLS_REJECT_UNAUTHORIZED=0 and node would abort if used over https
+const NODE_TLS_REJECT_UNAUTHORIZED = '1';
+
 export const esArchiverLoad = (folder: string) => {
   const path = Path.join(ES_ARCHIVE_DIR, folder);
   cy.exec(
-    `node ../../../../scripts/es_archiver load "${path}" --config ../../../test/functional/config.js`
+    `node ../../../../scripts/es_archiver load "${path}" --config ../../../test/functional/config.js`,
+    { env: { NODE_TLS_REJECT_UNAUTHORIZED } }
   );
 };
 
 export const esArchiverUnload = (folder: string) => {
   const path = Path.join(ES_ARCHIVE_DIR, folder);
   cy.exec(
-    `node ../../../../scripts/es_archiver unload "${path}" --config ../../../test/functional/config.js`
+    `node ../../../../scripts/es_archiver unload "${path}" --config ../../../test/functional/config.js`,
+    { env: { NODE_TLS_REJECT_UNAUTHORIZED } }
   );
 };
 
 export const esArchiverResetKibana = () => {
   cy.exec(
     `node ../../../../scripts/es_archiver empty-kibana-index --config ../../../test/functional/config.js`,
-    { failOnNonZeroExit: false }
+    { env: { NODE_TLS_REJECT_UNAUTHORIZED }, failOnNonZeroExit: false }
   );
 };

--- a/x-pack/plugins/security_solution/cypress/README.md
+++ b/x-pack/plugins/security_solution/cypress/README.md
@@ -174,7 +174,7 @@ Represents all the URLs used during the tests execution.
 The data the tests need:
 
 - Is generated on the fly using our application APIs (preferred way)
-- Is ingested on the ELS instance using the `es_archive` utility
+- Is ingested on the ELS instance using the `es_archiver` utility
 
 By default, when running the tests in Jenkins mode, a base set of data is ingested on the ELS instance: an empty kibana index and a set of auditbeat data (the `empty_kibana` and `auditbeat` archives, respectively). This is usually enough to cover most of the scenarios that we are testing.
 
@@ -199,6 +199,14 @@ node ../../../scripts/es_archiver save custom_rules ".kibana",".siem-signal*"  -
 ```
 
 Note that the command will create the folder if it does not exist.
+
+### Using an archive from within the Cypress tests
+
+Task [cypress/tasks/es_archiver.ts](https://github.com/elastic/kibana/blob/master/x-pack/plugins/security_solution/cypress/tasks/es_archiver.ts) provides helpers such as `esArchiverLoad` and `esArchiverUnload` by means of `es_archiver`'s CLI.
+
+Because of `cy.exec`, used to invoke `es_archiver`, it's necessary to override its environment with `NODE_TLS_REJECT_UNAUTHORIZED=1`. It indeed would inject `NODE_TLS_REJECT_UNAUTHORIZED=0` and make `es_archive` otherwise abort with the following warning if used over https:
+
+> Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
 
 ## Development Best Practices
 

--- a/x-pack/plugins/security_solution/cypress/tasks/es_archiver.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/es_archiver.ts
@@ -12,23 +12,28 @@ const CONFIG_PATH = '../../test/functional/config.js';
 const ES_URL = Cypress.env('ELASTICSEARCH_URL');
 const KIBANA_URL = Cypress.config().baseUrl;
 
+// Otherwise cy.exec would inject NODE_TLS_REJECT_UNAUTHORIZED=0 and node would abort if used over https
+const NODE_TLS_REJECT_UNAUTHORIZED = '1';
+
 export const esArchiverLoad = (folder: string) => {
   const path = Path.join(ES_ARCHIVE_DIR, folder);
   cy.exec(
-    `node ../../../scripts/es_archiver load "${path}" --config "${CONFIG_PATH}" --es-url "${ES_URL}" --kibana-url "${KIBANA_URL}"`
+    `node ../../../scripts/es_archiver load "${path}" --config "${CONFIG_PATH}" --es-url "${ES_URL}" --kibana-url "${KIBANA_URL}"`,
+    { env: { NODE_TLS_REJECT_UNAUTHORIZED } }
   );
 };
 
 export const esArchiverUnload = (folder: string) => {
   const path = Path.join(ES_ARCHIVE_DIR, folder);
   cy.exec(
-    `node ../../../scripts/es_archiver unload "${path}" --config "${CONFIG_PATH}" --es-url "${ES_URL}" --kibana-url "${KIBANA_URL}"`
+    `node ../../../scripts/es_archiver unload "${path}" --config "${CONFIG_PATH}" --es-url "${ES_URL}" --kibana-url "${KIBANA_URL}"`,
+    { env: { NODE_TLS_REJECT_UNAUTHORIZED } }
   );
 };
 
 export const esArchiverResetKibana = () => {
   cy.exec(
     `node ../../../scripts/es_archiver empty-kibana-index --config "${CONFIG_PATH}" --es-url "${ES_URL}" --kibana-url "${KIBANA_URL}"`,
-    { failOnNonZeroExit: false }
+    { env: { NODE_TLS_REJECT_UNAUTHORIZED }, failOnNonZeroExit: false }
   );
 };


### PR DESCRIPTION
### Summary

If any of Elasticsearch or Kibana urls uses https, then `node` aborts with:

> Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes
> TLS connections and HTTPS requests insecure by disabling certificate verification.

Investigation proved that cy.exec injects `NODE_TLS_REJECT_UNAUTHORIZED=0` regardless of how `NODE_TLS_REJECT_UNAUTHORIZED` or `CYPRESS_NODE_TLS_REJECT_UNAUTHORIZED` are defined in the environment.

### Options to avoid such failure

1. Use `node --no-warnings`
   Gun too big, could hide other issues worthy of a failure

2. Explicitly pass `NODE_TLS_REJECT_UNAUTHORIZED=1`

This commit implements option 2.

### Cypress test used for the investigation

```
describe('Env checks', () => {
  it('CYPRESS_NODE_TLS_REJECT_UNAUTHORIZED is undefined', () => {
    expect(Cypress.env('NODE_TLS_REJECT_UNAUTHORIZED')).to.equal(undefined);
  });

  it('NODE_TLS_REJECT_UNAUTHORIZED is undefined', () => {
    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).to.equal(undefined);
  });

  it('cy.exec environment is sane', () => {
    const NODE_TLS_REJECT_UNAUTHORIZED =
      Cypress.env('NODE_TLS_REJECT_UNAUTHORIZED') === '0' ? '0' : '1';

    cy.exec('set', { env: { NODE_TLS_REJECT_UNAUTHORIZED } })
      .its('stdout')
      .should(($elem) => {
        expect($elem).to.not.contain('NODE_TLS_REJECT_UNAUTHORIZED=0')
      });
  });
});
```

Meta https://github.com/elastic/security-team/issues/1301.