### PR TITLE
[APM] Blank page when navigating to errors metadata

### DIFF
--- a/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
@@ -189,7 +189,6 @@ function TabContent({
   const exceptions = error.error.exception || [];
   const logStackframes = error.error.log?.stacktrace;
 
-  console.log('### caue ~ currentTab.key', currentTab.key);
   switch (currentTab.key) {
     case logStacktraceTab.key:
       return (

--- a/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
@@ -157,9 +157,9 @@ export function DetailView({ errorGroup, urlParams }: Props) {
             <EuiTab
               onClick={() => {
                 history.replace({
-                  ...location,
+                  ...history.location,
                   search: fromQuery({
-                    ...toQuery(location.search),
+                    ...toQuery(history.location.search),
                     detailTab: key,
                   }),
                 });
@@ -189,6 +189,7 @@ function TabContent({
   const exceptions = error.error.exception || [];
   const logStackframes = error.error.log?.stacktrace;
 
+  console.log('### caue ~ currentTab.key', currentTab.key);
   switch (currentTab.key) {
     case logStacktraceTab.key:
       return (

--- a/x-pack/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/index.tsx
@@ -16,6 +16,7 @@ interface Props {
 }
 
 export function ErrorMetadata({ error }: Props) {
+  console.log('### caue ~ error', error);
   const sectionsWithRows = useMemo(
     () => getSectionsWithRows(ERROR_METADATA_SECTIONS, error),
     [error]

--- a/x-pack/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/index.tsx
@@ -16,7 +16,6 @@ interface Props {
 }
 
 export function ErrorMetadata({ error }: Props) {
-  console.log('### caue ~ error', error);
   const sectionsWithRows = useMemo(
     () => getSectionsWithRows(ERROR_METADATA_SECTIONS, error),
     [error]


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/104160

![ezgif com-gif-maker(2)](https://user-images.githubusercontent.com/55978943/124492944-13f1cc80-dd83-11eb-99ea-f07b6b4ac647.gif)
