### PR TITLE
[Workplace Search] Fix bug where error was behind modal stuck in loading state

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -393,8 +393,10 @@ describe('SchemaLogic', () => {
 
         it('handles error with message', async () => {
           const onSchemaSetFormErrorsSpy = jest.spyOn(SchemaLogic.actions, 'onSchemaSetFormErrors');
-          // We expect body.message to be a string[] when it is present
-          http.post.mockReturnValue(Promise.reject({ body: { message: ['this is an error'] } }));
+          // We expect body.attributes.errors to be a string[] when it is present
+          http.post.mockReturnValue(
+            Promise.reject({ body: { attributes: { errors: ['this is an error'] } } })
+          );
           SchemaLogic.actions.setServerField(schema, ADD);
           await nextTick();
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -325,10 +325,11 @@ describe('SchemaLogic', () => {
       });
 
       it('handles duplicate', () => {
+        const onSchemaSetFormErrorsSpy = jest.spyOn(SchemaLogic.actions, 'onSchemaSetFormErrors');
         SchemaLogic.actions.onInitializeSchema(serverResponse);
         SchemaLogic.actions.addNewField('foo', SchemaType.Number);
 
-        expect(setErrorMessage).toHaveBeenCalledWith('New field already exists: foo.');
+        expect(onSchemaSetFormErrorsSpy).toHaveBeenCalledWith(['New field already exists: foo.']);
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -301,15 +301,15 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
     addNewField: ({ fieldName, newFieldType }) => {
       if (fieldName in values.activeSchema) {
         window.scrollTo(0, 0);
-        setErrorMessage(
+        actions.onSchemaSetFormErrors([
           i18n.translate(
             'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.newFieldExists.message',
             {
               defaultMessage: 'New field already exists: {fieldName}.',
               values: { fieldName },
             }
-          )
-        );
+          ),
+        ]);
       } else {
         const schema = cloneDeep(values.activeSchema);
         schema[fieldName] = newFieldType;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -350,8 +350,8 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       } catch (e) {
         window.scrollTo(0, 0);
         if (isAdding) {
-          // We expect body.message to be a string[] for actions.onSchemaSetFormErrors
-          const message: string[] = e?.body?.message || [defaultErrorMessage];
+          // We expect body.attributes.errors to be a string[] for actions.onSchemaSetFormErrors
+          const message: string[] = e?.body?.attributes?.errors || [defaultErrorMessage];
           actions.onSchemaSetFormErrors(message);
         } else {
           flashAPIErrors(e);


### PR DESCRIPTION
fixes https://github.com/elastic/workplace-search-team/issues/1831

## Summary

This PR accomplishes 2 things: 

1. It fixes a bug where the error was behind modal stuck in loading state. 

**Before**
![schema-bug](https://user-images.githubusercontent.com/1869731/124520882-621ec400-ddb3-11eb-8a6d-12a5dfa10ecb.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/124520884-66e37800-ddb3-11eb-84a1-38d3e3091642.gif)

2. It also fixes an issue from a [previous PR](https://github.com/elastic/kibana/pull/104024/files#diff-56458e080954c6ce153fa9de6107398ca7fb370e8483a236da8a8d20d2a02895R353-R355) where the wrong property was being used for the error message. 

The issue is that this is the shape of the server error response:
```JavaScript
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Fields cannot be blank.",
    "attributes": {
        "errors": ["Fields cannot be blank."]
    }
}
```
I mistakingly used the `message` prop, which is a string, when the UI expects an array of strings, which `attributes.errors` is. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
