### PR TITLE
[Workplace Search] Replace download diagnostics route with direct API route to fix button

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
@@ -16,6 +16,7 @@ import { shallow } from 'enzyme';
 
 import { EuiConfirmModal } from '@elastic/eui';
 
+import { getWorkplaceSearchUrl } from '../../../../shared/enterprise_search_url';
 import { SourceConfigFields } from '../../../components/shared/source_config_fields';
 
 import { SourceSettings } from './source_settings';
@@ -110,7 +111,7 @@ describe('SourceSettings', () => {
       const wrapper = shallow(<SourceSettings />);
 
       expect(wrapper.find('[data-test-subj="DownloadDiagnosticsButton"]').prop('href')).toEqual(
-        '/api/workplace_search/org/sources/123/download_diagnostics'
+        getWorkplaceSearchUrl('/org/sources/123/download_diagnostics')
       );
     });
 
@@ -122,7 +123,7 @@ describe('SourceSettings', () => {
       const wrapper = shallow(<SourceSettings />);
 
       expect(wrapper.find('[data-test-subj="DownloadDiagnosticsButton"]').prop('href')).toEqual(
-        '/api/workplace_search/account/sources/123/download_diagnostics'
+        getWorkplaceSearchUrl('/sources/123/download_diagnostics')
       );
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -22,6 +22,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
+import { getWorkplaceSearchUrl } from '../../../../shared/enterprise_search_url';
 import { AppLogic } from '../../../app_logic';
 import { ContentSection } from '../../../components/shared/content_section';
 import { SourceConfigFields } from '../../../components/shared/source_config_fields';
@@ -89,9 +90,8 @@ export const SourceSettings: React.FC = () => {
 
   const { clientId, clientSecret, publicKey, consumerKey, baseUrl } = configuredFields || {};
 
-  const diagnosticsPath = isOrganization
-    ? `/api/workplace_search/org/sources/${id}/download_diagnostics`
-    : `/api/workplace_search/account/sources/${id}/download_diagnostics`;
+  const pathPrefix = isOrganization ? '/org' : '';
+  const diagnosticsPath = getWorkplaceSearchUrl(`${pathPrefix}/sources/${id}/download_diagnostics`);
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value);
 

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -24,7 +24,6 @@ import {
   registerAccountSourceDisplaySettingsConfig,
   registerAccountSourceSchemasRoute,
   registerAccountSourceReindexJobRoute,
-  registerAccountSourceDownloadDiagnosticsRoute,
   registerOrgSourcesRoute,
   registerOrgSourcesStatusRoute,
   registerOrgSourceRoute,
@@ -39,7 +38,6 @@ import {
   registerOrgSourceDisplaySettingsConfig,
   registerOrgSourceSchemasRoute,
   registerOrgSourceReindexJobRoute,
-  registerOrgSourceDownloadDiagnosticsRoute,
   registerOrgSourceOauthConfigurationsRoute,
   registerOrgSourceOauthConfigurationRoute,
   registerOauthConnectorParamsRoute,
@@ -540,29 +538,6 @@ describe('sources routes', () => {
     });
   });
 
-  describe('GET /api/workplace_search/account/sources/{sourceId}/download_diagnostics', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'get',
-        path: '/api/workplace_search/account/sources/{sourceId}/download_diagnostics',
-      });
-
-      registerAccountSourceDownloadDiagnosticsRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/:sourceId/download_diagnostics',
-      });
-    });
-  });
-
   describe('GET /api/workplace_search/org/sources', () => {
     let mockRouter: MockRouter;
 
@@ -1034,29 +1009,6 @@ describe('sources routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/sources/:sourceId/reindex_job/:jobId',
-      });
-    });
-  });
-
-  describe('GET /api/workplace_search/org/sources/{sourceId}/download_diagnostics', () => {
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockRouter = new MockRouter({
-        method: 'get',
-        path: '/api/workplace_search/org/sources/{sourceId}/download_diagnostics',
-      });
-
-      registerOrgSourceDownloadDiagnosticsRoute({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('creates a request handler', () => {
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/:sourceId/download_diagnostics',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -385,25 +385,6 @@ export function registerAccountSourceReindexJobRoute({
   );
 }
 
-export function registerAccountSourceDownloadDiagnosticsRoute({
-  router,
-  enterpriseSearchRequestHandler,
-}: RouteDependencies) {
-  router.get(
-    {
-      path: '/api/workplace_search/account/sources/{sourceId}/download_diagnostics',
-      validate: {
-        params: schema.object({
-          sourceId: schema.string(),
-        }),
-      },
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/ws/sources/:sourceId/download_diagnostics',
-    })
-  );
-}
-
 // Org routes
 export function registerOrgSourcesRoute({
   router,
@@ -733,25 +714,6 @@ export function registerOrgSourceReindexJobRoute({
   );
 }
 
-export function registerOrgSourceDownloadDiagnosticsRoute({
-  router,
-  enterpriseSearchRequestHandler,
-}: RouteDependencies) {
-  router.get(
-    {
-      path: '/api/workplace_search/org/sources/{sourceId}/download_diagnostics',
-      validate: {
-        params: schema.object({
-          sourceId: schema.string(),
-        }),
-      },
-    },
-    enterpriseSearchRequestHandler.createRequest({
-      path: '/ws/org/sources/:sourceId/download_diagnostics',
-    })
-  );
-}
-
 export function registerOrgSourceOauthConfigurationsRoute({
   router,
   enterpriseSearchRequestHandler,
@@ -901,7 +863,6 @@ export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
   registerAccountSourceDisplaySettingsConfig(dependencies);
   registerAccountSourceSchemasRoute(dependencies);
   registerAccountSourceReindexJobRoute(dependencies);
-  registerAccountSourceDownloadDiagnosticsRoute(dependencies);
   registerOrgSourcesRoute(dependencies);
   registerOrgSourcesStatusRoute(dependencies);
   registerOrgSourceRoute(dependencies);
@@ -916,7 +877,6 @@ export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
   registerOrgSourceDisplaySettingsConfig(dependencies);
   registerOrgSourceSchemasRoute(dependencies);
   registerOrgSourceReindexJobRoute(dependencies);
-  registerOrgSourceDownloadDiagnosticsRoute(dependencies);
   registerOrgSourceOauthConfigurationsRoute(dependencies);
   registerOrgSourceOauthConfigurationRoute(dependencies);
   registerOauthConnectorParamsRoute(dependencies);


### PR DESCRIPTION
fixes https://github.com/elastic/workplace-search-team/issues/1758

## Summary

This PR removes the Kibana server proxy for downloading source diagnostics. Since we don't have an API body we are passing to the UI, there is no need for the proxy and the download button now works as expected.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
