### PR TITLE
[ftr] add contextual locator for relocating within an element

### DIFF
--- a/test/functional/services/common/find.ts
+++ b/test/functional/services/common/find.ts
@@ -11,6 +11,7 @@ import { WebDriver, WebElement, By, until } from 'selenium-webdriver';
 import { Browsers } from '../remote/browsers';
 import { FtrService, FtrProviderContext } from '../../ftr_provider_context';
 import { WebElementWrapper } from '../lib/web_element_wrapper';
+import { ContextualLocator } from '../lib/contextual_locator';
 
 export class FindService extends FtrService {
   private readonly log = this.ctx.getService('log');
@@ -138,8 +139,9 @@ export class FindService extends FtrService {
     parentElement: WebElementWrapper
   ): Promise<WebElementWrapper | never> {
     this.log.debug(`Find.descendantDisplayedByCssSelector('${selector}')`);
-    const element = await parentElement._webElement.findElement(By.css(selector));
-    const descendant = this.wrap(element, By.css(selector));
+    const locator = By.css(selector);
+    const element = await parentElement._webElement.findElement(locator);
+    const descendant = this.wrap(element, new ContextualLocator(parentElement, locator));
     const isDisplayed = await descendant.isDisplayed();
     if (isDisplayed) {
       return descendant;
@@ -452,7 +454,10 @@ export class FindService extends FtrService {
     }
   }
 
-  private wrap(webElement: WebElement | WebElementWrapper, locator: By | null = null) {
+  private wrap(
+    webElement: WebElement | WebElementWrapper,
+    locator: By | ContextualLocator | null = null
+  ) {
     return WebElementWrapper.create(
       webElement,
       locator,

--- a/test/functional/services/lib/contextual_locator.ts
+++ b/test/functional/services/lib/contextual_locator.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { By } from 'selenium-webdriver';
+import { WebElementWrapper } from './web_element_wrapper';
+
+export class ContextualLocator {
+  constructor(private readonly context: WebElementWrapper, private readonly locator: By) {}
+
+  async relocate() {
+    return this.context._webElement.findElement(this.locator);
+  }
+}

--- a/test/functional/services/lib/web_element_wrapper/web_element_wrapper.ts
+++ b/test/functional/services/lib/web_element_wrapper/web_element_wrapper.ts
@@ -16,6 +16,7 @@ import { CustomCheerio, CustomCheerioStatic } from './custom_cheerio_api';
 // @ts-ignore not supported yet
 import { scrollIntoViewIfNecessary } from './scroll_into_view_if_necessary';
 import { Browsers } from '../../remote/browsers';
+import { ContextualLocator } from '../contextual_locator';
 
 interface TypeOptions {
   charByChar: boolean;
@@ -39,7 +40,7 @@ export class WebElementWrapper {
 
   public static create(
     webElement: WebElement | WebElementWrapper,
-    locator: By | null,
+    locator: By | ContextualLocator | null,
     driver: WebDriver,
     timeout: number,
     fixedHeaderHeight: number,
@@ -63,7 +64,7 @@ export class WebElementWrapper {
 
   constructor(
     public _webElement: WebElement,
-    private locator: By | null,
+    private locator: By | ContextualLocator | null,
     private driver: WebDriver,
     private timeout: number,
     private fixedHeaderHeight: number,
@@ -122,7 +123,10 @@ export class WebElementWrapper {
       );
 
       await delay(200);
-      this._webElement = await this.driver.findElement(this.locator);
+      this._webElement = await (this.locator instanceof ContextualLocator
+        ? this.locator.relocate()
+        : this.driver.findElement(this.locator));
+
       return await this.retryCall(fn, attemptsRemaining - 1);
     }
   }


### PR DESCRIPTION
We currently support relocating an element if it can't be clicked, which works by passing a `locator` to the `WebElementWrapper` and then reevaluating the locator in specific error conditions. This locator describes the CSS selector which was used to find an element, but not the context that selector was executed in (if a descendant selector function was used).

The `ContextualLocator` class wraps both an instance of `By` and `WebElementWrapper` so that we can call `async relocate()` and have the locator re-evaluated against the `WebElementWrapper` and find the right element in the right context.