### PR TITLE
Tweak solution nav to feedback

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/collapsible_nav.test.tsx.snap
@@ -371,7 +371,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
     isOpen={true}
     onClose={[Function]}
     ownFocus={false}
-    size={240}
+    size={248}
   >
     <button
       aria-controls="collapsibe-nav"
@@ -395,7 +395,7 @@ exports[`CollapsibleNav renders links grouped by category 1`] = `
       pushMinBreakpoint="l"
       role={null}
       side="left"
-      size={240}
+      size={248}
       type="overlay"
     >
       <nav
@@ -2158,7 +2158,7 @@ exports[`CollapsibleNav renders the default nav 1`] = `
     isOpen={false}
     onClose={[Function]}
     ownFocus={false}
-    size={240}
+    size={248}
   >
     <button
       aria-controls="collapsibe-nav"
@@ -2407,7 +2407,7 @@ exports[`CollapsibleNav renders the default nav 2`] = `
     isOpen={false}
     onClose={[Function]}
     ownFocus={false}
-    size={240}
+    size={248}
   >
     <button
       aria-controls="collapsibe-nav"

--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -4553,7 +4553,7 @@ exports[`Header renders 1`] = `
                       isOpen={false}
                       onClose={[Function]}
                       ownFocus={false}
-                      size={240}
+                      size={248}
                     >
                       <EuiHeaderSectionItemButton
                         aria-controls="mockId"

--- a/src/core/public/chrome/ui/header/collapsible_nav.tsx
+++ b/src/core/public/chrome/ui/header/collapsible_nav.tsx
@@ -126,7 +126,7 @@ export function CollapsibleNav({
       onClose={closeNav}
       button={button}
       ownFocus={false}
-      size={240}
+      size={248}
     >
       {customNavLink && (
         <Fragment>

--- a/src/plugins/kibana_react/public/page_template/page_template.scss
+++ b/src/plugins/kibana_react/public/page_template/page_template.scss
@@ -1,5 +1,7 @@
 .kbnPageTemplate__pageSideBar {
   overflow: hidden;
+  // Temporary hack till the sizing is changed directly in EUI
+  min-width: 248px;
 
   @include euiCanAnimate {
     transition: min-width $euiAnimSpeedFast $euiAnimSlightResistance;

--- a/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav.scss
+++ b/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav.scss
@@ -3,13 +3,8 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
 .kbnPageTemplateSolutionNav {
   @include euiYScroll;
 
-  @include euiBreakpoint('m') {
-    width: $euiPageSidebarMinWidth + ($euiSizeL * 2);
-    padding: $euiSizeL;
-  }
-
-  @include euiBreakpoint('l', 'xl') {
-    width: $euiPageSidebarMinWidth + ($euiSizeL * 2);
+  @include euiBreakpoint('m' ,'l', 'xl') {
+    width: 248px;
     padding: $euiSizeL;
   }
 }

--- a/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav.tsx
+++ b/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav.tsx
@@ -138,7 +138,7 @@ export const KibanaPageTemplateSolutionNav: FunctionComponent<KibanaPageTemplate
               outsideClickCloses
               onClose={() => setIsSideNavOpenOnMobile(false)}
               side="left"
-              size={240}
+              size={248}
               closeButtonPosition="outside"
             >
               {sideNav}

--- a/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav_collapse_button.scss
+++ b/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav_collapse_button.scss
@@ -1,8 +1,8 @@
 .kbnPageTemplateSolutionNavCollapseButton {
   position: absolute;
   opacity: 0;
-  left: 240px - $euiSize;
-  top: $euiSize;
+  left: 248px - $euiSize;
+  top: $euiSizeL;
   z-index: 2;
 
   @include euiCanAnimate {
@@ -18,11 +18,11 @@
   &:hover,
   &:focus {
     opacity: 1;
-    left: 240px - $euiSizeL;
+    left: 248px - $euiSizeL;
   }
 
   .kbnPageTemplate__pageSideBar:hover & {
-    transition-delay: $euiAnimSpeedSlow;
+    transition-delay: $euiAnimSpeedSlow * 2;
   }
 }
 

--- a/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav_collapse_button.tsx
+++ b/src/plugins/kibana_react/public/page_template/solution_nav/solution_nav_collapse_button.tsx
@@ -49,7 +49,6 @@ export const KibanaPageTemplateSolutionNavCollapseButton: FunctionComponent<Kiba
       className={classes}
       iconType={isCollapsed ? 'menuRight' : 'menuLeft'}
       size="s"
-      display="fill"
       color="text"
       aria-label={isCollapsed ? openLabel : collapseLabel}
       title={isCollapsed ? openLabel : collapseLabel}


### PR DESCRIPTION
## Summary

Makes some tweaks to the Solution Side nav (and corresponding global nav) due to feedback since merged.

* De-emphasizes the collapse button to make it the text style both on peek and collapse
* Adjusts the size of the solution an additional 8px to account for our longest solution name: "Workplace Search"
* Adjusts the global nav to match the same size
* Adjusts the delay on the hover for the nav to be longer

![](https://snid.es/2021JUL/sBniZ7tdheciHl9g.gif)

### TODO later

* This PR (like the one before it) relies on some pretty specific pixel values spread across a variety of files. This will need to be consolidated at the EUI level in a PR there. Captured in https://github.com/elastic/eui/issues/4939


### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
