### PR TITLE
[7.x] Align test with non-CCS version

### DIFF
--- a/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
@@ -55,7 +55,7 @@ describe('Alert details with unmapped fields', () => {
 
   it('Displays the unmapped field on the table', () => {
     const expectedUnmmappedField = {
-      row: 55,
+      row: 56,
       field: 'unmapped',
       text: 'This is the unmapped field',
     };


### PR DESCRIPTION
The spec [ccs_integration/detection_alerts/alerts_details.spec.ts](https://github.com/elastic/kibana/blob/master/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts) was copied from [integration/detection_alerts/alerts_details.spec.ts](https://github.com/elastic/kibana/blob/master/x-pack/plugins/security_solution/cypress/integration/detection_alerts/alerts_details.spec.ts) and then modified for CCS purposes.

When backported to 7.x, the spec lost the alignment with the corresponding non-CCS version and the test started to fail ([log](https://internal-ci.elastic.co/job/elastic+integration-test+7.x/554/consoleText)):

```
proc [cypress]   1) Alert details with unmapped fields
 proc [cypress]        Displays the unmapped field on the table:
 proc [cypress] 
 proc [cypress]       Timed out retrying after 60000ms
 proc [cypress]       + expected - actual
 proc [cypress] 
 proc [cypress]       -'signal.status'
 proc [cypress]       +'unmapped'
 proc [cypress]       
 proc [cypress]       at Context.eval (https://localhost:5601/__cypress/tests?p=cypress/ccs_integration/detection_alerts/alerts_details.spec.ts:19050:54)
```

This PR restores the alignment and the test passing.

Meta https://github.com/elastic/security-team/issues/1301.