### PR TITLE
[DOCS] Fixes typo in Spaces doc

### DIFF
--- a/docs/spaces/index.asciidoc
+++ b/docs/spaces/index.asciidoc
@@ -28,7 +28,7 @@ Kibana supports spaces in several ways.  You can:
 [float]
 ==== Required permissions
 
-The `kibana_admin` role or equivilent is required to manage **Spaces**.
+The `kibana_admin` role or equivalent is required to manage **Spaces**.
 
 TIP: Looking to support multiple tenants? See <<xpack-security-multiple-tenants, the Security documentation>> for more information.
 


### PR DESCRIPTION
## Summary

This PR corrects the spelling of "equivalent".