### PR TITLE
[ML] Transforms: Fix wizard page layout on resize and link button widths

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/clone_transform/clone_transform_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/clone_transform/clone_transform_section.tsx
@@ -131,7 +131,10 @@ export const CloneTransformSection: FC<Props> = ({ match, location }) => {
 
       <EuiSpacer size="l" />
 
-      <EuiPageContentBody data-test-subj="transformPageCloneTransform">
+      <EuiPageContentBody
+        data-test-subj="transformPageCloneTransform"
+        className="transform__wizardBody"
+      >
         {typeof errorMessage !== 'undefined' && (
           <>
             <EuiCallOut

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
@@ -12,7 +12,6 @@ import {
   EuiButton,
   EuiCard,
   EuiCopy,
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -480,8 +479,8 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
           {created && (
             <Fragment>
               <EuiHorizontalRule />
-              <EuiFlexGrid gutterSize="l">
-                <EuiFlexItem style={PANEL_ITEM_STYLE}>
+              <EuiFlexGroup gutterSize="l">
+                <EuiFlexItem style={PANEL_ITEM_STYLE} grow={false}>
                   <EuiCard
                     icon={<EuiIcon size="xxl" type="list" />}
                     title={i18n.translate('xpack.transform.stepCreateForm.transformListCardTitle', {
@@ -498,7 +497,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
                   />
                 </EuiFlexItem>
                 {started === true && createIndexPattern === true && indexPatternId === undefined && (
-                  <EuiFlexItem style={PANEL_ITEM_STYLE}>
+                  <EuiFlexItem style={PANEL_ITEM_STYLE} grow={false}>
                     <EuiPanel style={{ position: 'relative' }}>
                       <EuiProgress size="xs" color="primary" position="absolute" />
                       <EuiText color="subdued" size="s">
@@ -515,7 +514,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
                   </EuiFlexItem>
                 )}
                 {isDiscoverAvailable && discoverLink !== undefined && (
-                  <EuiFlexItem style={PANEL_ITEM_STYLE}>
+                  <EuiFlexItem style={PANEL_ITEM_STYLE} grow={false}>
                     <EuiCard
                       icon={<EuiIcon size="xxl" type="discoverApp" />}
                       title={i18n.translate('xpack.transform.stepCreateForm.discoverCardTitle', {
@@ -532,7 +531,7 @@ export const StepCreateForm: FC<StepCreateFormProps> = React.memo(
                     />
                   </EuiFlexItem>
                 )}
-              </EuiFlexGrid>
+              </EuiFlexGroup>
             </Fragment>
           )}
         </EuiForm>

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/_wizard.scss
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/_wizard.scss
@@ -8,22 +8,11 @@
   }
 }
 
-.transform__stepDefineForm {
-  align-items: flex-start;
-}
-
-.transform__stepDefineFormLeftColumn {
-  min-width: 420px;
-  border-right: 1px solid $euiColorLightShade;
-}
-
 /*
-This is an override to replicate the previous full-page-width of the transforms creation wizard
-when it was in use within the ML plugin. The Kibana management section limits a max-width to 1200px
-which is a bit narrow for the two column layout of the transform wizard. We might revisit this for
-future versions to blend in more with the overall design of the Kibana management section.
-The management section's navigation width is 192px + 24px right margin
+This ensures the wizard goes full page width, and that the data grid in the page does not
+cause the body of the wizard page to overflow into the side navigation of the Kibana
+Stack Management page on resize.
 */
-.mgtPage__body--transformWizard {
-  max-width: calc(100% - 216px);
+.transform__wizardBody {
+  max-width: calc(100% - 16px);
 }

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/wizard.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/wizard.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { Fragment, FC, useEffect, useRef, useState, createContext, useMemo } from 'react';
+import React, { Fragment, FC, useRef, useState, createContext, useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 
@@ -33,11 +33,6 @@ import {
 import { WizardNav } from '../wizard_nav';
 import { IndexPattern } from '../../../../../../../../../src/plugins/data/public';
 import type { RuntimeMappings } from '../step_define/common/types';
-
-enum KBN_MANAGEMENT_PAGE_CLASSNAME {
-  DEFAULT_BODY = 'mgtPage__body',
-  TRANSFORM_BODY_MODIFIER = 'mgtPage__body--transformWizard',
-}
 
 enum WIZARD_STEPS {
   DEFINE,
@@ -120,34 +115,6 @@ export const Wizard: FC<WizardProps> = React.memo(({ cloneConfig, searchItems })
 
   // The CREATE state
   const [stepCreateState, setStepCreateState] = useState(getDefaultStepCreateState);
-
-  useEffect(() => {
-    // The transform plugin doesn't control the wrapping management page via React
-    // so we use plain JS to add and remove a custom CSS class to set the full
-    // page width to 100% for the transform wizard. It's done to replicate the layout
-    // as it was when transforms were part of the ML plugin. This will be revisited
-    // to come up with an approach that's more in line with the overall layout
-    // of the Kibana management section.
-    let managementBody = document.getElementsByClassName(
-      KBN_MANAGEMENT_PAGE_CLASSNAME.DEFAULT_BODY
-    );
-
-    if (managementBody.length > 0) {
-      managementBody[0].classList.replace(
-        KBN_MANAGEMENT_PAGE_CLASSNAME.DEFAULT_BODY,
-        KBN_MANAGEMENT_PAGE_CLASSNAME.TRANSFORM_BODY_MODIFIER
-      );
-      return () => {
-        managementBody = document.getElementsByClassName(
-          KBN_MANAGEMENT_PAGE_CLASSNAME.TRANSFORM_BODY_MODIFIER
-        );
-        managementBody[0].classList.replace(
-          KBN_MANAGEMENT_PAGE_CLASSNAME.TRANSFORM_BODY_MODIFIER,
-          KBN_MANAGEMENT_PAGE_CLASSNAME.DEFAULT_BODY
-        );
-      };
-    }
-  }, []);
 
   const transformConfig = getCreateTransformRequestBody(
     indexPattern.title,

--- a/x-pack/plugins/transform/public/app/sections/create_transform/create_transform_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/create_transform_section.tsx
@@ -68,7 +68,10 @@ export const CreateTransformSection: FC<Props> = ({ match }) => {
 
       <EuiSpacer size="l" />
 
-      <EuiPageContentBody data-test-subj="transformPageCreateTransform">
+      <EuiPageContentBody
+        data-test-subj="transformPageCreateTransform"
+        className="transform__wizardBody"
+      >
         {searchItemsError !== undefined && (
           <>
             <EuiCallOut title={searchItemsError} color="danger" iconType="alert" />


### PR DESCRIPTION
## Summary

Fixes the layout of the create / clone transform wizard page, so that it no longer overflows the content the side navigation bar when the width of browser is reduced, as shown in #103882.

Also fixes the width of the cards at the end of the wizard which link to the Transform Management page and Discover, so that the cards all have equal width.

Before:

![image](https://user-images.githubusercontent.com/7405507/124785036-69260d80-df3e-11eb-86ce-44491b4dda35.png)


After:
 
![image](https://user-images.githubusercontent.com/7405507/124784892-4693f480-df3e-11eb-899f-00c8be7f3830.png)


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixes #103882

