### PR TITLE
[App Search] Disable crawler nav link & route for sample & meta engines

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -53,6 +53,7 @@ describe('EngineLogic', () => {
     isEngineSchemaEmpty: true,
     isMetaEngine: false,
     isSampleEngine: false,
+    canCrawl: true,
     hasSchemaErrors: false,
     hasSchemaConflicts: false,
     hasUnconfirmedSchemaFields: false,
@@ -356,7 +357,7 @@ describe('EngineLogic', () => {
       });
     });
 
-    describe('isSampleEngine', () => {
+    describe('isSampleEngine & canCrawl', () => {
       it('should be set based on engine.sample', () => {
         const engine = { ...mockEngineData, sample: true };
         mount({ engine });
@@ -365,11 +366,12 @@ describe('EngineLogic', () => {
           ...DEFAULT_VALUES_WITH_ENGINE,
           engine,
           isSampleEngine: true,
+          canCrawl: false,
         });
       });
     });
 
-    describe('isMetaEngine', () => {
+    describe('isMetaEngine & canCrawl', () => {
       it('should be set based on engine.type', () => {
         const engine = { ...mockEngineData, type: EngineTypes.meta };
         mount({ engine });
@@ -378,6 +380,7 @@ describe('EngineLogic', () => {
           ...DEFAULT_VALUES_WITH_ENGINE,
           engine,
           isMetaEngine: true,
+          canCrawl: false,
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -23,6 +23,7 @@ interface EngineValues {
   isEngineSchemaEmpty: boolean;
   isMetaEngine: boolean;
   isSampleEngine: boolean;
+  canCrawl: boolean;
   hasSchemaErrors: boolean;
   hasSchemaConflicts: boolean;
   hasUnconfirmedSchemaFields: boolean;
@@ -101,6 +102,10 @@ export const EngineLogic = kea<MakeLogicType<EngineValues, EngineActions>>({
     ],
     isMetaEngine: [() => [selectors.engine], (engine) => engine?.type === EngineTypes.meta],
     isSampleEngine: [() => [selectors.engine], (engine) => !!engine?.sample],
+    canCrawl: [
+      () => [selectors.isMetaEngine, selectors.isSampleEngine],
+      (isMetaEngine, isSampleEngine) => !isMetaEngine && !isSampleEngine,
+    ],
     // Indexed engines
     hasSchemaErrors: [
       () => [selectors.engine],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -167,7 +167,7 @@ describe('useEngineNav', () => {
       const myRole = { canViewEngineCrawler: true };
 
       it('returns a crawler nav item', () => {
-        setMockValues({ ...values, myRole });
+        setMockValues({ ...values, myRole, canCrawl: true });
         expect(useEngineNav()).toEqual([
           ...BASE_NAV,
           {
@@ -179,8 +179,8 @@ describe('useEngineNav', () => {
         ]);
       });
 
-      it('does not return a crawler nav item for meta engines', () => {
-        setMockValues({ ...values, myRole, isMetaEngine: true });
+      it('does not return a crawler nav item for engines that cannot crawl (e.g. meta engines, sample engine)', () => {
+        setMockValues({ ...values, myRole, canCrawl: false });
         expect(useEngineNav()).toEqual(BASE_NAV);
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -68,6 +68,7 @@ export const useEngineNav = () => {
     dataLoading,
     isSampleEngine,
     isMetaEngine,
+    canCrawl,
     hasSchemaErrors,
     hasSchemaConflicts,
     hasUnconfirmedSchemaFields,
@@ -185,7 +186,7 @@ export const useEngineNav = () => {
     });
   }
 
-  if (canViewEngineCrawler && !isMetaEngine) {
+  if (canViewEngineCrawler && canCrawl) {
     navItems.push({
       id: 'crawler',
       name: CRAWLER_TITLE,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -39,6 +39,7 @@ describe('EngineRouter', () => {
     ...mockEngineValues,
     dataLoading: false,
     engineNotFound: false,
+    isMetaEngine: false,
     canCrawl: false,
     myRole: {},
   };
@@ -176,7 +177,11 @@ describe('EngineRouter', () => {
   });
 
   it('renders a source engines view', () => {
-    setMockValues({ ...values, myRole: { canViewMetaEngineSourceEngines: true } });
+    setMockValues({
+      ...values,
+      myRole: { canViewMetaEngineSourceEngines: true },
+      isMetaEngine: true,
+    });
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(SourceEngines)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -39,6 +39,7 @@ describe('EngineRouter', () => {
     ...mockEngineValues,
     dataLoading: false,
     engineNotFound: false,
+    canCrawl: false,
     myRole: {},
   };
   const actions = {
@@ -182,7 +183,7 @@ describe('EngineRouter', () => {
   });
 
   it('renders a crawler view', () => {
-    setMockValues({ ...values, myRole: { canViewEngineCrawler: true } });
+    setMockValues({ ...values, myRole: { canViewEngineCrawler: true }, canCrawl: true });
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(CrawlerRouter)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -66,7 +66,7 @@ export const EngineRouter: React.FC = () => {
   } = useValues(AppLogic);
 
   const { engineName: engineNameFromUrl } = useParams() as { engineName: string };
-  const { engineName, dataLoading, engineNotFound } = useValues(EngineLogic);
+  const { engineName, dataLoading, engineNotFound, canCrawl } = useValues(EngineLogic);
   const { setEngineName, initializeEngine, pollEmptyEngine, stopPolling, clearEngine } = useActions(
     EngineLogic
   );
@@ -125,7 +125,7 @@ export const EngineRouter: React.FC = () => {
           <SourceEngines />
         </Route>
       )}
-      {canViewEngineCrawler && (
+      {canViewEngineCrawler && canCrawl && (
         <Route path={ENGINE_CRAWLER_PATH}>
           <CrawlerRouter />
         </Route>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -66,7 +66,9 @@ export const EngineRouter: React.FC = () => {
   } = useValues(AppLogic);
 
   const { engineName: engineNameFromUrl } = useParams() as { engineName: string };
-  const { engineName, dataLoading, engineNotFound, canCrawl } = useValues(EngineLogic);
+  const { engineName, dataLoading, engineNotFound, isMetaEngine, canCrawl } = useValues(
+    EngineLogic
+  );
   const { setEngineName, initializeEngine, pollEmptyEngine, stopPolling, clearEngine } = useActions(
     EngineLogic
   );
@@ -120,7 +122,7 @@ export const EngineRouter: React.FC = () => {
           <SchemaRouter />
         </Route>
       )}
-      {canViewMetaEngineSourceEngines && (
+      {canViewMetaEngineSourceEngines && isMetaEngine && (
         <Route path={META_ENGINE_SOURCE_ENGINES_PATH}>
           <SourceEngines />
         </Route>


### PR DESCRIPTION
## Summary

Per product, the Crawler link/route should not available for the `national-parks-demo` sample engine.

<img width="259" alt="" src="https://user-images.githubusercontent.com/549407/124798164-e8e4b580-df07-11eb-86e5-c0741cf71aac.png">

Also while I was here, I noticed the source engines route didn't have an `isMetaEngine` check like its nav link did, so I updated that as well.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios