### PR TITLE
[Fleet] Fix policy revision number getting bumped for no reason

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
@@ -14,7 +14,10 @@ import type { AgentPolicy, NewPackagePolicy, Output } from '../types';
 
 import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 
-import { ensurePreconfiguredPackagesAndPolicies } from './preconfiguration';
+import {
+  ensurePreconfiguredPackagesAndPolicies,
+  comparePreconfiguredPolicyToCurrent,
+} from './preconfiguration';
 
 jest.mock('./agent_policy_update');
 
@@ -277,5 +280,77 @@ describe('policy preconfiguration', () => {
     expect(policiesB.length).toEqual(1);
     expect(policiesB[0].id).toBe('mocked-test-id');
     expect(policiesB[0].updated_at).toEqual(policiesA[0].updated_at);
+  });
+});
+
+describe('comparePreconfiguredPolicyToCurrent', () => {
+  const baseConfig = {
+    name: 'Test policy',
+    namespace: 'default',
+    description: 'This is a test policy',
+    id: 'test-id',
+    unenroll_timeout: 60,
+    package_policies: [
+      {
+        package: { name: 'test_package' },
+        name: 'Test package',
+      },
+    ],
+  };
+
+  const basePackagePolicy: AgentPolicy = {
+    id: 'test-id',
+    namespace: 'default',
+    monitoring_enabled: ['logs', 'metrics'],
+    name: 'Test policy',
+    description: 'This is a test policy',
+    unenroll_timeout: 60,
+    is_preconfigured: true,
+    status: 'active',
+    is_managed: true,
+    revision: 1,
+    updated_at: '2021-07-07T16:29:55.144Z',
+    updated_by: 'system',
+    package_policies: [
+      {
+        package: { name: 'test_package', title: 'Test package', version: '1.0.0' },
+        name: 'Test package',
+        namespace: 'default',
+        enabled: true,
+        id: 'test-package-id',
+        revision: 1,
+        updated_at: '2021-07-07T16:29:55.144Z',
+        updated_by: 'system',
+        created_at: '2021-07-07T16:29:55.144Z',
+        created_by: 'system',
+        inputs: [],
+        policy_id: 'abc123',
+        output_id: 'default',
+      },
+    ],
+  };
+
+  it('should return hasChanged when a top-level policy field changes', () => {
+    const { hasChanged } = comparePreconfiguredPolicyToCurrent(
+      { ...baseConfig, unenroll_timeout: 120 },
+      basePackagePolicy
+    );
+    expect(hasChanged).toBe(true);
+  });
+
+  it('should not return hasChanged when no top-level fields change', () => {
+    const { hasChanged } = comparePreconfiguredPolicyToCurrent(
+      {
+        ...baseConfig,
+        package_policies: [
+          {
+            package: { name: 'different_package' },
+            name: 'Different package',
+          },
+        ],
+      },
+      basePackagePolicy
+    );
+    expect(hasChanged).toBe(false);
   });
 });

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -7,7 +7,7 @@
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from 'src/core/server';
 import { i18n } from '@kbn/i18n';
-import { groupBy, omit, isEqual } from 'lodash';
+import { groupBy, omit, pick, isEqual } from 'lodash';
 
 import type {
   NewPackagePolicy,
@@ -143,7 +143,8 @@ export async function ensurePreconfiguredPackagesAndPolicies(
       if (!created) {
         if (!policy?.is_managed) return { created, policy };
         const configTopLevelFields = omit(preconfiguredAgentPolicy, 'package_policies', 'id');
-        const currentTopLevelFields = omit(policy, 'package_policies');
+        const currentTopLevelFields = pick(policy, ...Object.keys(configTopLevelFields));
+
         if (!isEqual(configTopLevelFields, currentTopLevelFields)) {
           const updatedPolicy = await agentPolicyService.update(
             soClient,


### PR DESCRIPTION
## Summary

Fixes #104584 

The check to see if any top-level fields on `is_managed` policies had changed was broken, and wasn't correctly filtering the current agent policy down to only the diff-checked fields. This fixes the issue.