### PR TITLE
[Metrics UI] Move from extended_bounds to hard_bounds for date_histogram aggregations

### DIFF
--- a/x-pack/plugins/infra/server/lib/metrics/lib/__snapshots__/create_aggregations.test.ts.snap
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/__snapshots__/create_aggregations.test.ts.snap
@@ -11,7 +11,7 @@ Object {
       },
     },
     "date_histogram": Object {
-      "extended_bounds": Object {
+      "hard_bounds": Object {
         "max": 1577838720000,
         "min": 1577835120000,
       },
@@ -36,7 +36,7 @@ Object {
           },
         },
         "date_histogram": Object {
-          "extended_bounds": Object {
+          "hard_bounds": Object {
             "max": 1577840400000,
             "min": 1577836800000,
           },
@@ -73,7 +73,7 @@ Object {
       },
     },
     "date_histogram": Object {
-      "extended_bounds": Object {
+      "hard_bounds": Object {
         "max": 1577840400000,
         "min": 1577836800000,
       },

--- a/x-pack/plugins/infra/server/lib/metrics/lib/calculate_date_histogram_offset.test.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/calculate_date_histogram_offset.test.ts
@@ -17,6 +17,36 @@ describe('calculateDateHistogramOffset(timerange)', () => {
       field: '@timestamp',
     };
     const offset = calculateDateHistogramOffset(timerange);
-    expect(offset).toBe('-28s');
+    expect(offset).toBe('-28000ms');
+  });
+  it('should work with un-even timeranges (60s buckets)', () => {
+    const timerange = {
+      from: 1625057349373,
+      to: 1625057649373,
+      interval: '60s',
+      field: '@timestamp',
+    };
+    const offset = calculateDateHistogramOffset(timerange);
+    expect(offset).toBe('-51373ms');
+  });
+  it('should work with un-even timeranges (5m buckets)', () => {
+    const timerange = {
+      from: 1625516185059,
+      to: 1625602885059,
+      interval: '5m',
+      field: '@timestamp',
+    };
+    const offset = calculateDateHistogramOffset(timerange);
+    expect(offset).toBe('-215059ms');
+  });
+  it('should work with un-even timeranges (>=10s buckets)', () => {
+    const timerange = {
+      from: 1625516185059,
+      to: 1625602885059,
+      interval: '>=10s',
+      field: '@timestamp',
+    };
+    const offset = calculateDateHistogramOffset(timerange);
+    expect(offset).toBe('-215059ms');
   });
 });

--- a/x-pack/plugins/infra/server/lib/metrics/lib/calculate_date_histogram_offset.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/calculate_date_histogram_offset.ts
@@ -14,5 +14,10 @@ export const calculateDateHistogramOffset = (timerange: MetricsAPITimerange): st
 
   // negative offset to align buckets with full intervals (e.g. minutes)
   const offset = (fromInSeconds % bucketSize) - bucketSize;
-  return `${offset}s`;
+
+  // Because everything is being rounded to the nearest second, except the timerange,
+  // we need to adjust the buckets to account for the millisecond offset otherwise
+  // the last bucket will be only contain the difference.
+  const millisOffset = timerange.to % 1000;
+  return `${offset * 1000 - millisOffset}ms`;
 };

--- a/x-pack/plugins/infra/server/lib/metrics/lib/create_aggregations.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/create_aggregations.ts
@@ -18,7 +18,7 @@ export const createAggregations = (options: MetricsAPIRequest) => {
         field: options.timerange.field,
         fixed_interval: intervalString,
         offset: options.alignDataToEnd ? calculateDateHistogramOffset(options.timerange) : '0s',
-        extended_bounds: {
+        hard_bounds: {
           min: options.timerange.from,
           max: options.timerange.to,
         },


### PR DESCRIPTION
## Summary

This PR fixes #104699 by converting all our `date_histograms` from `extended_bounds` to `hard_bounds` in an effort to reduce the partial buckets that `extended_bounds` creates. I've also added millisecond resolution the the `offset` option so we are creating buckets that end exactly on the data queried. So when we say "last 5 minutes" it's not the last five minutes rounded to the nearest minute but actually the last 5 minutes relative to the `to` part of the time range.

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios