### PR TITLE
[7.14] [Alerting][Docs] Fixed formatting issues for alerting documentation. Added docs about rules statuses. (#103725)

### DIFF
--- a/docs/user/alerting/alerting-getting-started.asciidoc
+++ b/docs/user/alerting/alerting-getting-started.asciidoc
@@ -24,13 +24,16 @@ This section describes all of these elements and how they operate together.
 [float]
 === Rules
 
-A rule specifies a background task that runs on the {kib} server to check for specific conditions. It consists of three main parts: 
+A rule specifies a background task that runs on the {kib} server to check for specific conditions. {kib} provides two types of rules: stack rules that are built into {kib} and domain rules that are registered by Kibana apps. Refer to <<rule-types,Rule types>> for more information.
+
+A rule consists of three main parts: 
 
 * *Conditions*: what needs to be detected?
 * *Schedule*: when/how often should detection checks run?
 * *Actions*: what happens when a condition is detected?
 
-For example, when monitoring a set of servers, a rule might: 
+For example, when monitoring a set of servers, a rule might:
+
 * Check for average CPU usage > 0.9 on each server for the last two minutes (condition).
 * Check every minute (schedule).
 * Send a warning email message via SMTP with subject `CPU on {{server}} is high` (action).

--- a/docs/user/alerting/create-and-manage-rules.asciidoc
+++ b/docs/user/alerting/create-and-manage-rules.asciidoc
@@ -153,6 +153,17 @@ You can perform these operations in bulk by multi-selecting rules, and then clic
 image:images/bulk-mute-disable.png[The Manage rules button lets you mute/unmute, enable/disable, and delete in bulk,width=75%]
 
 [float]
+=== Rule status
+
+A rule can have one of the following statuses:
+
+`active`:: The conditions for the rule have been met, and the associated actions should be invoked.
+`ok`:: The conditions for the rule were previously met, but no longer. Changed to `recovered` in the 7.14 release.
+`error`:: An error was encountered during rule execution.
+`pending`:: The rule has not yet executed.  The rule was either just created, or enabled after being disabled.
+`unknown`:: A problem occurred when calculating the status. Most likely, something went wrong with the alerting code.
+
+[float]
 [[importing-and-exporting-rules]]
 === Import and export rules
 

--- a/docs/user/alerting/troubleshooting/testing-connectors.asciidoc
+++ b/docs/user/alerting/troubleshooting/testing-connectors.asciidoc
@@ -19,7 +19,7 @@ image::user/alerting/images/teams-connector-test.png[Five clauses define the con
 
 Executing an Email action via https://github.com/pmuellr/kbn-action[kbn-action]. In this example, is using a cloud deployment of the stack:
 
-[source]
+[source, txt]
 --------------------------------------------------
 $ npm -g install pmuellr/kbn-action
 
@@ -45,7 +45,7 @@ $ kbn-action ls
 --------------------------------------------------
 and then execute this:
 
-[source]
+[source, txt]
 --------------------------------------------------
 $ kbn-action execute a692dc89-15b9-4a3c-9e47-9fb6872e49ce '{subject: "hallo", message: "hallo!", to:["test@yahoo.com"]}'
 {


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Alerting][Docs] Fixed formatting issues for alerting documentation. Added docs about rules statuses. (#103725)