### PR TITLE
[Fleet] Fix add agent in the package policy table

### DIFF
--- a/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
@@ -28,6 +28,7 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   const { getHref } = useLink();
   const hasWriteCapabilities = useCapabilities().write;
   const refreshAgentPolicy = useAgentPolicyRefresh();
+  const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
 
   const onEnrollmentFlyoutClose = useMemo(() => {
     return () => setIsEnrollmentFlyoutOpen(false);
@@ -48,7 +49,10 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
     // </EuiContextMenuItem>,
     <EuiContextMenuItem
       icon="plusInCircle"
-      onClick={() => setIsEnrollmentFlyoutOpen(true)}
+      onClick={() => {
+        setIsActionsMenuOpen(false);
+        setIsEnrollmentFlyoutOpen(true);
+      }}
       key="addAgent"
     >
       <FormattedMessage
@@ -112,7 +116,11 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
           />
         </EuiPortal>
       )}
-      <ContextMenuActions items={menuItems} />
+      <ContextMenuActions
+        isOpen={isActionsMenuOpen}
+        items={menuItems}
+        onChange={(isOpen) => setIsActionsMenuOpen(isOpen)}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary


The actions context menu stay open when clicking on add agent from the agent policy package policy table.
That PR fix that by making the actions menu managed and closing it when opening the add agent flyout.


## UI changes

### Before

<img width="1663" alt="Screen Shot 2021-07-07 at 2 22 51 PM" src="https://user-images.githubusercontent.com/1336873/124810914-e1d19d80-df2f-11eb-841e-6b146d8147bb.png">


### After

<img width="1642" alt="Screen Shot 2021-07-07 at 2 27 59 PM" src="https://user-images.githubusercontent.com/1336873/124810912-e1390700-df2f-11eb-8405-3299100d3b5d.png">
