### PR TITLE
[App Search] Result Settings: Max size input fixes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.test.tsx
@@ -90,10 +90,10 @@ describe('FieldNumber', () => {
     expect(props.updateAction).toHaveBeenCalledWith('foo', 21);
   });
 
-  it('will call updateAction on blur using the minimum possible value if the current value is something other than a number', () => {
+  it('will call clearAction on blur if the current value is something other than a number', () => {
     const wrapper = shallow(<FieldNumber {...props} />);
     wrapper.simulate('blur', { target: { value: '' } });
-    expect(props.updateAction).toHaveBeenCalledWith('foo', 20);
+    expect(props.clearAction).toHaveBeenCalledWith('foo');
   });
 
   it('will call updateAction on blur using the minimum possible value if the value is something lower than the minimum', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.test.tsx
@@ -54,7 +54,7 @@ describe('FieldNumber', () => {
         }}
       />
     );
-    expect(wrapper.find(EuiFieldNumber).prop('value')).toEqual('');
+    expect(wrapper.find(EuiFieldNumber).prop('value')).toEqual(' ');
   });
 
   it('is disabled if the [fieldEnabledProperty] in fieldSettings is false', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.tsx
@@ -73,7 +73,7 @@ export const FieldNumber: React.FC<Props> = ({
       value={
         typeof fieldSettings[fieldSizeProperty] === 'number'
           ? (fieldSettings[fieldSizeProperty] as number)
-          : ''
+          : ' ' // Without the space, invalid non-numbers don't get cleared for some reason
       }
       placeholder={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.resultSettings.numberFieldPlaceholder',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/field_number.tsx
@@ -43,11 +43,10 @@ const handleFieldNumberBlur = (
   clearAction: (fieldName: string) => void
 ) => {
   return (e: FocusEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value, 10);
-    const fieldValue = Math.min(
-      SIZE_FIELD_MAXIMUM,
-      Math.max(SIZE_FIELD_MINIMUM, isNaN(value) ? 0 : value)
-    );
+    let fieldValue = parseInt(e.target.value, 10);
+    if (!isNaN(fieldValue)) {
+      fieldValue = Math.min(SIZE_FIELD_MAXIMUM, Math.max(SIZE_FIELD_MINIMUM, fieldValue));
+    }
     updateOrClearSizeForField(fieldName, fieldValue, updateAction, clearAction);
   };
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/text_fields_body.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/text_fields_body.tsx
@@ -56,7 +56,7 @@ export const TextFieldsBody: React.FC = () => {
               }}
             />
           </EuiTableRowCellCheckbox>
-          <EuiTableRowCell align="center">
+          <EuiTableRowCell align="center" textOnly={false}>
             <FieldNumber
               fieldName={fieldName}
               fieldEnabledProperty="raw"
@@ -95,7 +95,7 @@ export const TextFieldsBody: React.FC = () => {
               }}
             />
           </EuiTableRowCellCheckbox>
-          <EuiTableRowCell align="center">
+          <EuiTableRowCell align="center" textOnly={false}>
             <FieldNumber
               fieldName={fieldName}
               fieldEnabledProperty="snippet"

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/text_fields_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_table/text_fields_header.tsx
@@ -30,7 +30,7 @@ export const TextFieldsHeader: React.FC = () => {
             { defaultMessage: 'Raw' }
           )}
         </EuiTableHeaderCell>
-        <EuiTableHeaderCell align="center">
+        <EuiTableHeaderCell align="center" width="115">
           {i18n.translate(
             'xpack.enterpriseSearch.appSearch.engine.resultSettings.table.column.maxSizeTitle',
             { defaultMessage: 'Max size' }
@@ -48,7 +48,7 @@ export const TextFieldsHeader: React.FC = () => {
             { defaultMessage: 'Fallback' }
           )}
         </EuiTableHeaderCell>
-        <EuiTableHeaderCell align="center">
+        <EuiTableHeaderCell align="center" width="115">
           {i18n.translate(
             'xpack.enterpriseSearch.appSearch.engine.resultSettings.table.column.maxSizeTitle',
             { defaultMessage: 'Max size' }


### PR DESCRIPTION
## Summary

This PR contains 2 separate fixes for the "Max size" field number input in the Result Settings view.

### Placeholder cutoff fix in Chrome (https://github.com/elastic/kibana/commit/0f6372b65fb01b79a9429f8cf4ce49784bcb5436)

#### Before:

<img src="https://user-images.githubusercontent.com/549407/124816528-767ed000-df1d-11eb-82ed-b419e47d914d.png" width="400" alt="">

#### After:

<img width="442" alt="" src="https://user-images.githubusercontent.com/549407/124816605-8dbdbd80-df1d-11eb-9c20-d60cc1e0e5ea.png">

Also tested on Edge & Safari. It's possible Windows might have custom chrome that throws this off, but seems unlikely 🤔

### Unable to reset input to blank/no limit (https://github.com/elastic/kibana/commit/5b4fa88b9bb28c50752d2a45c4d15bb70154ef0d)

#### Before:

![cant_reset](https://user-images.githubusercontent.com/549407/124816759-bd6cc580-df1d-11eb-92d1-32da081a2d69.gif)

#### After:

![resets](https://user-images.githubusercontent.com/549407/124816872-dffede80-df1d-11eb-8fb4-11f0fe7e15ac.gif)

Note that with https://github.com/elastic/kibana/commit/4642e1d644b1fb3b1c02712d6ec7fde74e843ee0, users simply cannot enter non-numeric characters now

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)