### PR TITLE
[App Search] Fix engine routes that are meta engine or non-meta-engine specific

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -39,6 +39,7 @@ describe('EngineRouter', () => {
     ...mockEngineValues,
     dataLoading: false,
     engineNotFound: false,
+    isMetaEngine: false,
     myRole: {},
   };
   const actions = {
@@ -175,14 +176,18 @@ describe('EngineRouter', () => {
   });
 
   it('renders a source engines view', () => {
-    setMockValues({ ...values, myRole: { canViewMetaEngineSourceEngines: true } });
+    setMockValues({
+      ...values,
+      myRole: { canViewMetaEngineSourceEngines: true },
+      isMetaEngine: true,
+    });
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(SourceEngines)).toHaveLength(1);
   });
 
   it('renders a crawler view', () => {
-    setMockValues({ ...values, myRole: { canViewEngineCrawler: true } });
+    setMockValues({ ...values, myRole: { canViewEngineCrawler: true }, isMetaEngine: false });
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(CrawlerRouter)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -66,7 +66,7 @@ export const EngineRouter: React.FC = () => {
   } = useValues(AppLogic);
 
   const { engineName: engineNameFromUrl } = useParams() as { engineName: string };
-  const { engineName, dataLoading, engineNotFound } = useValues(EngineLogic);
+  const { engineName, dataLoading, engineNotFound, isMetaEngine } = useValues(EngineLogic);
   const { setEngineName, initializeEngine, pollEmptyEngine, stopPolling, clearEngine } = useActions(
     EngineLogic
   );
@@ -120,12 +120,12 @@ export const EngineRouter: React.FC = () => {
           <SchemaRouter />
         </Route>
       )}
-      {canViewMetaEngineSourceEngines && (
+      {canViewMetaEngineSourceEngines && isMetaEngine && (
         <Route path={META_ENGINE_SOURCE_ENGINES_PATH}>
           <SourceEngines />
         </Route>
       )}
-      {canViewEngineCrawler && (
+      {canViewEngineCrawler && !isMetaEngine && (
         <Route path={ENGINE_CRAWLER_PATH}>
           <CrawlerRouter />
         </Route>


### PR DESCRIPTION
## Summary

Update meta/non-meta engine routes to include their respective `isMetaEngine` conditional. This matches their nav link behavior, and is basically an extra safety check for inquisitive users or wonky link issues.

I noticed this in https://github.com/elastic/kibana/pull/104693 (which we're no longer fully using) and pulled it out to its own separate PR

### Before

<img width="1220" alt="" src="https://user-images.githubusercontent.com/549407/124819573-433e4000-df21-11eb-94e2-959afead2e3d.png">

<img width="1223" alt="" src="https://user-images.githubusercontent.com/549407/124819578-446f6d00-df21-11eb-8f74-cfc67f8801b3.png">

### After

<img width="1225" alt="" src="https://user-images.githubusercontent.com/549407/124819586-46d1c700-df21-11eb-9a6e-ec07e4c3194d.png">

<img width="1218" alt="" src="https://user-images.githubusercontent.com/549407/124819593-4802f400-df21-11eb-9cb5-6d6eeb32f642.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios