### PR TITLE
[Lens] Fix dashboard error when localstorage is empty

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
@@ -497,6 +497,57 @@ describe('loader', () => {
       });
     });
 
+    it('should initialize all the embeddable references without local storage', async () => {
+      const savedState: IndexPatternPersistedState = {
+        layers: {
+          layerb: {
+            columnOrder: ['col1', 'col2'],
+            columns: {
+              col1: {
+                dataType: 'date',
+                isBucketed: true,
+                label: 'My date',
+                operationType: 'date_histogram',
+                params: {
+                  interval: 'm',
+                },
+                sourceField: 'timestamp',
+              },
+              col2: {
+                dataType: 'number',
+                isBucketed: false,
+                label: 'Sum of bytes',
+                operationType: 'sum',
+                sourceField: 'bytes',
+              },
+            },
+          },
+        },
+      };
+      const storage = createMockStorage({});
+      const state = await loadInitialState({
+        persistedState: savedState,
+        references: [
+          { name: 'indexpattern-datasource-current-indexpattern', id: '2', type: 'index-pattern' },
+          { name: 'indexpattern-datasource-layer-layerb', id: '2', type: 'index-pattern' },
+          { name: 'another-reference', id: 'c', type: 'index-pattern' },
+        ],
+        indexPatternsService: mockIndexPatternsService(),
+        storage,
+        options: { isFullEditor: false },
+      });
+
+      expect(state).toMatchObject({
+        currentIndexPatternId: undefined,
+        indexPatternRefs: [],
+        indexPatterns: {
+          '2': sampleIndexPatterns['2'],
+        },
+        layers: { layerb: { ...savedState.layers.layerb, indexPatternId: '2' } },
+      });
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
     it('should initialize from saved state', async () => {
       const savedState: IndexPatternPersistedState = {
         layers: {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/104776

The steps for this are a bit tricky to reproduce, but essentially they are:

1. Create a dashboard, then create a visualization from the dashboard and save it back to the dashboard. I think you can save to the library as well, the cause is the same.
2. Save the dashboard
3. Go to your dev tools and clear the `lens-settings` localstorage key.
4. Refresh the dashboard

The error is caused by attempting to load an `undefined` index pattern ID, which is because the `currentIndexPatternId` is undefined when there is no localstorage entry.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
