### PR TITLE
[Workplace Search] Fix download diagnostics button

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
@@ -125,5 +125,15 @@ describe('SourceSettings', () => {
         '/api/workplace_search/account/sources/123/download_diagnostics'
       );
     });
+
+    it('renders with the correct download file name', () => {
+      jest.spyOn(global.Date, 'now').mockImplementationOnce(() => new Date('1970-01-01').valueOf());
+
+      const wrapper = shallow(<SourceSettings />);
+
+      expect(wrapper.find('[data-test-subj="DownloadDiagnosticsButton"]').prop('download')).toEqual(
+        '123_custom_0_diagnostics.json'
+      );
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -184,7 +184,7 @@ export const SourceSettings: React.FC = () => {
           href={diagnosticsPath}
           isLoading={buttonLoading}
           data-test-subj="DownloadDiagnosticsButton"
-          download
+          download={`${id}_${serviceType}_${Date.now()}_diagnostics.json`}
         >
           {SYNC_DIAGNOSTICS_BUTTON}
         </EuiButton>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -6,14 +6,12 @@
  */
 
 import React, { useEffect, useState, ChangeEvent, FormEvent } from 'react';
-import { Link } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 import { isEmpty } from 'lodash';
 
 import {
   EuiButton,
-  EuiButtonEmpty,
   EuiConfirmModal,
   EuiFieldText,
   EuiFlexGroup,
@@ -22,6 +20,8 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
+import { HttpLogic } from '../../../../shared/http';
+import { EuiButtonEmptyTo } from '../../../../shared/react_router_helpers';
 import { AppLogic } from '../../../app_logic';
 import { ContentSection } from '../../../components/shared/content_section';
 import { SourceConfigFields } from '../../../components/shared/source_config_fields';
@@ -57,6 +57,8 @@ import { SourceLogic } from '../source_logic';
 import { SourceLayout } from './source_layout';
 
 export const SourceSettings: React.FC = () => {
+  const { http } = useValues(HttpLogic);
+
   const { updateContentSource, removeContentSource } = useActions(SourceLogic);
   const { getSourceConfigData } = useActions(AddSourceLogic);
 
@@ -90,8 +92,8 @@ export const SourceSettings: React.FC = () => {
   const { clientId, clientSecret, publicKey, consumerKey, baseUrl } = configuredFields || {};
 
   const diagnosticsPath = isOrganization
-    ? `/api/workplace_search/org/sources/${id}/download_diagnostics`
-    : `/api/workplace_search/account/sources/${id}/download_diagnostics`;
+    ? http.basePath.prepend(`/api/workplace_search/org/sources/${id}/download_diagnostics`)
+    : http.basePath.prepend(`/api/workplace_search/account/sources/${id}/download_diagnostics`);
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value);
 
@@ -172,9 +174,9 @@ export const SourceSettings: React.FC = () => {
             baseUrl={baseUrl}
           />
           <EuiFormRow>
-            <Link to={editPath}>
-              <EuiButtonEmpty flush="left">{SOURCE_CONFIG_LINK}</EuiButtonEmpty>
-            </Link>
+            <EuiButtonEmptyTo to={editPath} flush="left">
+              {SOURCE_CONFIG_LINK}
+            </EuiButtonEmptyTo>
           </EuiFormRow>
         </ContentSection>
       )}

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -209,17 +209,23 @@ describe('EnterpriseSearchRequestHandler', () => {
           headers: mockExpectedResponseHeaders,
         });
       });
-    });
 
-    it('works if response contains no json data', async () => {
-      EnterpriseSearchAPI.mockReturn();
+      it('passes back the response body as-is if hasJsonResponse is false', async () => {
+        const mockFile = new File(['mockFile'], 'mockFile.json');
+        EnterpriseSearchAPI.mockReturn(mockFile);
 
-      const requestHandler = enterpriseSearchRequestHandler.createRequest({ path: '/api/prep' });
-      await makeAPICall(requestHandler);
+        const requestHandler = enterpriseSearchRequestHandler.createRequest({
+          path: '/api/file',
+          hasJsonResponse: false,
+        });
+        await makeAPICall(requestHandler);
 
-      expect(responseMock.custom).toHaveBeenCalledWith({
-        statusCode: 200,
-        headers: mockExpectedResponseHeaders,
+        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/file');
+        expect(responseMock.custom).toHaveBeenCalledWith({
+          body: expect.any(Buffer), // Unfortunately Response() buffers the body so we can't actually inspect/equality assert on it
+          statusCode: 200,
+          headers: mockExpectedResponseHeaders,
+        });
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -34,6 +34,7 @@ interface ConstructorDependencies {
 interface RequestParams {
   path: string;
   params?: object;
+  hasJsonResponse?: boolean;
   hasValidData?: Function;
 }
 interface ErrorResponse {
@@ -64,7 +65,12 @@ export class EnterpriseSearchRequestHandler {
     this.enterpriseSearchUrl = config.host as string;
   }
 
-  createRequest({ path, params = {}, hasValidData = () => true }: RequestParams) {
+  createRequest({
+    path,
+    params = {},
+    hasJsonResponse = true,
+    hasValidData = () => true,
+  }: RequestParams) {
     return async (
       _context: RequestHandlerContext,
       request: KibanaRequest<unknown, unknown, unknown>,
@@ -119,7 +125,7 @@ export class EnterpriseSearchRequestHandler {
         // Check returned data
         let responseBody;
 
-        try {
+        if (hasJsonResponse) {
           const json = await apiResponse.json();
 
           if (!hasValidData(json)) {
@@ -134,8 +140,8 @@ export class EnterpriseSearchRequestHandler {
           } else {
             responseBody = json;
           }
-        } catch (e) {
-          responseBody = undefined;
+        } else {
+          responseBody = apiResponse.body;
         }
 
         // Pass successful responses back to the front-end

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/onboarding.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/onboarding.test.ts
@@ -30,6 +30,7 @@ describe('engine routes', () => {
       mockRouter.callRoute({ body: {} });
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/as/onboarding/complete',
+        hasJsonResponse: false,
       });
     });
 

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/onboarding.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/onboarding.ts
@@ -24,6 +24,7 @@ export function registerOnboardingRoutes({
     },
     enterpriseSearchRequestHandler.createRequest({
       path: '/as/onboarding/complete',
+      hasJsonResponse: false,
     })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -559,6 +559,7 @@ describe('sources routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/sources/:sourceId/download_diagnostics',
+        hasJsonResponse: false,
       });
     });
   });
@@ -1057,6 +1058,7 @@ describe('sources routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/sources/:sourceId/download_diagnostics',
+        hasJsonResponse: false,
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -400,6 +400,7 @@ export function registerAccountSourceDownloadDiagnosticsRoute({
     },
     enterpriseSearchRequestHandler.createRequest({
       path: '/ws/sources/:sourceId/download_diagnostics',
+      hasJsonResponse: false,
     })
   );
 }
@@ -748,6 +749,7 @@ export function registerOrgSourceDownloadDiagnosticsRoute({
     },
     enterpriseSearchRequestHandler.createRequest({
       path: '/ws/org/sources/:sourceId/download_diagnostics',
+      hasJsonResponse: false,
     })
   );
 }


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1758

## Summary

The main goal of this PR is to fix the download diagnostics button in Workplace Search. It wasn't working previously due to the `apiResponse.json()` line in our `EnterpriseSearchRequestHandler` helper. Updating the helper to accept a `hasJsonResponse` param and skipping all `.json()` conversion/parsing for non-JSON responses from ent-search (e.g. files or empty responses) fixes the issue.

![ws-download](https://user-images.githubusercontent.com/549407/124851206-f07f7b00-df56-11eb-98c5-2b77709728f0.gif)

As always, please follow along by commit and read the commit messages 🙏 

## QA

- Workplace Search
  - [x] "Download diagnostics" button works as expected
  - [x] "Edit content source connector settings" button SPA link works as expected on dev mode
- App Search
  - [x] "Try a sample engine" button works as before and does not throw any errors in the dev console
  - [x] General cross-app XHR pass checking for any other non-JSON responses

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios