### PR TITLE
[7.13] [load testing] adjust ES heap size (#101906)

### DIFF
--- a/x-pack/test/load/config.ts
+++ b/x-pack/test/load/config.ts
@@ -34,6 +34,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     esTestCluster: {
       ...xpackFunctionalTestsConfig.get('esTestCluster'),
       serverArgs: [...xpackFunctionalTestsConfig.get('esTestCluster.serverArgs')],
+      esJavaOpts: '-Xms8g -Xmx8g',
     },
 
     kbnTestServer: {

--- a/x-pack/test/load/runner.ts
+++ b/x-pack/test/load/runner.ts
@@ -18,7 +18,7 @@ const simulationPackage = 'org.kibanaLoadTest.simulation';
 const simulationFIleExtension = '.scala';
 const gatlingProjectRootPath: string =
   process.env.GATLING_PROJECT_PATH || resolve(REPO_ROOT, '../kibana-load-testing');
-const simulationEntry: string = process.env.GATLING_SIMULATIONS || 'DemoJourney';
+const simulationEntry: string = process.env.GATLING_SIMULATIONS || 'branch.DemoJourney';
 
 if (!Fs.existsSync(gatlingProjectRootPath)) {
   throw createFlagError(


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [load testing] adjust ES heap size (#101906)