### PR TITLE
[7.x] Lower Kibana app bundle limits (#104688)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -5,7 +5,7 @@ pageLoadAssetSize:
   apmOss: 18996
   bfetch: 51874
   canvas: 1066647
-  charts: 195358
+  charts: 95000
   cloud: 21076
   console: 46235
   core: 432925
@@ -16,7 +16,7 @@ pageLoadAssetSize:
   data: 900000
   dataEnhanced: 50420
   devTools: 38781
-  discover: 105147
+  discover: 99999
   discoverEnhanced: 42730
   embeddable: 242753
   embeddableEnhanced: 41145


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Lower Kibana app bundle limits (#104688)