### PR TITLE
[Lens] Fix lens embeddable initial render

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable_component.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable_component.tsx
@@ -9,6 +9,7 @@ import React, { FC, useEffect } from 'react';
 import { CoreStart } from 'kibana/public';
 import { UiActionsStart } from 'src/plugins/ui_actions/public';
 import type { Start as InspectorStartContract } from 'src/plugins/inspector/public';
+import { EuiLoadingChart } from '@elastic/eui';
 import {
   EmbeddableInput,
   EmbeddableOutput,
@@ -68,6 +69,10 @@ export function getEmbeddableComponent(core: CoreStart, plugins: PluginsStartDep
     const input = { ...props };
     const [embeddable, loading, error] = useEmbeddableFactory({ factory, input });
     const hasActions = props.withActions === true;
+
+    if (loading) {
+      return <EuiLoadingChart />;
+    }
 
     if (embeddable && hasActions) {
       return (


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/104067

Apparently whenever lens embeddable  wasn't rendering, this loading remains true forever. This fix makes sure it properly waits for loading embeddable before loading EmbeddableRender 
