### PR TITLE
[Lens] Remove previous time shift mode

### DIFF
--- a/docs/user/dashboard/lens-advanced.asciidoc
+++ b/docs/user/dashboard/lens-advanced.asciidoc
@@ -301,9 +301,6 @@ image::images/lens_advanced_5_2.png[Line chart with cumulative sum of orders mad
 *Lens* allows you to compare the currently selected time range with historical data using the *Time shift* option. To calculate the percent
 change, use *Formula*.
 
-Time shifts can be used on any metric. The special shift *previous* will show the time window preceding the currently selected one, spanning the same duration.
-For example, if *Last 7 days* is selected in the time filter, *previous* will show data from 14 days ago to 7 days ago.
-
 If multiple time shifts are used in a single chart, a multiple of the date histogram interval should be chosen - otherwise data points might not line up in the chart and empty spots can occur.
 For example, if a daily interval is used, shifting one series by *36h*, and another one by *1d*, is not recommended. In this scenario, either reduce the interval to *12h*, or create two separate charts.
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/time_shift_utils.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/time_shift_utils.tsx
@@ -81,12 +81,6 @@ export const timeShiftOptions = [
     }),
     value: '1y',
   },
-  {
-    label: i18n.translate('xpack.lens.indexPattern.timeShift.previous', {
-      defaultMessage: 'Previous time range',
-    }),
-    value: 'previous',
-  },
 ];
 
 export const timeShiftOptionOrder = timeShiftOptions.reduce<{ [key: string]: number }>(


### PR DESCRIPTION
This PR removes all user-visible mentions of the "previous" time shift mode. The logic is still in place ready to be exposed once we decided on an approach, but the feature is not documented in any way.