### PR TITLE
[TSVB] fix include/exclude fields appear to migrated TSVB visualization when using Group by Terms

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/cumulative_sum.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/cumulative_sum.js
@@ -23,6 +23,7 @@ import {
   EuiFormRow,
   EuiSpacer,
 } from '@elastic/eui';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 export function CumulativeSumAgg(props) {
   const { model, siblings, fields, indexPattern } = props;
@@ -70,7 +71,7 @@ export function CumulativeSumAgg(props) {
               onChange={handleSelectChange('field')}
               metrics={siblings}
               metric={model}
-              fields={fields[indexPattern]}
+              fields={fields[getIndexPatternKey(indexPattern)]}
               value={model.field}
               exclude={[METRIC_TYPES.TOP_HIT]}
             />

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/derivative.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/derivative.js
@@ -25,6 +25,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 export const DerivativeAgg = (props) => {
   const { siblings, fields, indexPattern } = props;
@@ -80,7 +81,7 @@ export const DerivativeAgg = (props) => {
               onChange={handleSelectChange('field')}
               metrics={siblings}
               metric={model}
-              fields={fields[indexPattern]}
+              fields={fields[getIndexPatternKey(indexPattern)]}
               value={model.field}
               exclude={[METRIC_TYPES.TOP_HIT]}
               fullWidth

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/moving_average.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/moving_average.js
@@ -26,6 +26,7 @@ import {
   EuiFieldNumber,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 const DEFAULTS = {
   model_type: MODEL_TYPES.UNWEIGHTED,
@@ -141,7 +142,7 @@ export const MovingAverageAgg = (props) => {
               onChange={handleSelectChange('field')}
               metrics={siblings}
               metric={model}
-              fields={fields[indexPattern]}
+              fields={fields[getIndexPatternKey(indexPattern)]}
               value={model.field}
               exclude={[METRIC_TYPES.TOP_HIT]}
             />

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_only.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_only.js
@@ -23,6 +23,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 export const PositiveOnlyAgg = (props) => {
   const { siblings, fields, indexPattern } = props;
@@ -74,7 +75,7 @@ export const PositiveOnlyAgg = (props) => {
               onChange={handleSelectChange('field')}
               metrics={siblings}
               metric={model}
-              fields={fields[indexPattern]}
+              fields={fields[getIndexPatternKey(indexPattern)]}
               value={model.field}
               exclude={[METRIC_TYPES.TOP_HIT]}
             />

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/serial_diff.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/serial_diff.js
@@ -24,6 +24,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 export const SerialDiffAgg = (props) => {
   const { siblings, fields, indexPattern, model } = props;
@@ -74,7 +75,7 @@ export const SerialDiffAgg = (props) => {
               onChange={handleSelectChange('field')}
               metrics={siblings}
               metric={model}
-              fields={fields[indexPattern]}
+              fields={fields[getIndexPatternKey(indexPattern)]}
               value={model.field}
               exclude={[METRIC_TYPES.TOP_HIT]}
             />

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/std_sibling.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/std_sibling.js
@@ -27,6 +27,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 const StandardSiblingAggUi = (props) => {
   const { siblings, intl, fields, indexPattern } = props;
@@ -147,7 +148,7 @@ const StandardSiblingAggUi = (props) => {
               onChange={handleSelectChange('field')}
               exclude={[METRIC_TYPES.PERCENTILE, METRIC_TYPES.TOP_HIT]}
               metrics={siblings}
-              fields={fields[indexPattern]}
+              fields={fields[getIndexPatternKey(indexPattern)]}
               metric={model}
               value={model.field}
             />

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/vars.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/vars.js
@@ -15,6 +15,7 @@ import { AddDeleteButtons } from '../add_delete_buttons';
 import { collectionActions } from '../lib/collection_actions';
 import { MetricSelect } from './metric_select';
 import { EuiFlexGroup, EuiFlexItem, EuiFieldText } from '@elastic/eui';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 export const newVariable = (opts) => ({ id: uuid.v1(), name: '', field: '', ...opts });
 
@@ -59,7 +60,7 @@ export class CalculationVars extends Component {
               metrics={this.props.metrics}
               metric={this.props.model}
               value={row.field}
-              fields={this.props.fields[this.props.indexPattern]}
+              fields={this.props.fields[getIndexPatternKey(this.props.indexPattern)]}
               includeSiblings={this.props.includeSiblings}
               exclude={this.props.exclude}
             />

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/__snapshots__/terms.test.js.snap
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/__snapshots__/terms.test.js.snap
@@ -78,6 +78,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
         labelType="label"
       >
         <EuiFieldText
+          data-test-subj="groupByInclude"
           onChange={[Function]}
         />
       </EuiFormRow>
@@ -100,6 +101,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
         labelType="label"
       >
         <EuiFieldText
+          data-test-subj="groupByExclude"
           onChange={[Function]}
         />
       </EuiFormRow>

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/terms.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/terms.js
@@ -27,6 +27,7 @@ import {
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 import { KBN_FIELD_TYPES } from '../../../../../data/public';
 import { STACKED_OPTIONS } from '../../visualizations/constants';
+import { getIndexPatternKey } from '../../../../common/index_patterns_utils';
 
 const DEFAULTS = { terms_direction: 'desc', terms_size: 10, terms_order_by: '_count' };
 
@@ -75,10 +76,11 @@ export const SplitByTermsUI = ({
       }),
     },
   ];
+  const fieldsSelector = getIndexPatternKey(indexPattern);
   const selectedDirectionOption = dirOptions.find((option) => {
     return model.terms_direction === option.value;
   });
-  const selectedField = find(fields[indexPattern], ({ name }) => name === model.terms_field);
+  const selectedField = find(fields[fieldsSelector], ({ name }) => name === model.terms_field);
   const selectedFieldType = get(selectedField, 'type');
 
   if (
@@ -198,7 +200,7 @@ export const SplitByTermsUI = ({
               metrics={metrics}
               clearable={false}
               additionalOptions={[defaultCount, terms]}
-              fields={fields[indexPattern]}
+              fields={fields[fieldsSelector]}
               onChange={handleSelectChange('terms_order_by')}
               restrict="basic"
               value={model.terms_order_by}

--- a/src/plugins/vis_type_timeseries/public/application/components/splits/terms.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/terms.js
@@ -146,6 +146,7 @@ export const SplitByTermsUI = ({
               <EuiFieldText
                 value={model.terms_include}
                 onChange={handleTextChange('terms_include')}
+                data-test-subj="groupByInclude"
               />
             </EuiFormRow>
           </EuiFlexItem>
@@ -162,6 +163,7 @@ export const SplitByTermsUI = ({
               <EuiFieldText
                 value={model.terms_exclude}
                 onChange={handleTextChange('terms_exclude')}
+                data-test-subj="groupByExclude"
               />
             </EuiFormRow>
           </EuiFlexItem>

--- a/test/functional/apps/visualize/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/_tsvb_time_series.ts
@@ -155,7 +155,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       describe('Clicking on the chart', () => {
         it(`should create a filter`, async () => {
-          await visualBuilder.setMetricsGroupByTerms('machine.os.raw');
+          await visualBuilder.setMetricsGroupByTerms('machine.os.raw', {
+            include: 'win 7',
+            exclude: 'ios',
+          });
           await visualBuilder.clickSeriesOption();
           await testSubjects.click('visualizeSaveButton');
 

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -628,7 +628,10 @@ export class VisualBuilderPageObject extends FtrService {
     return await this.find.allByCssSelector('.tvbSeriesEditor');
   }
 
-  public async setMetricsGroupByTerms(field: string) {
+  public async setMetricsGroupByTerms(
+    field: string,
+    filtering: { include?: string; exclude?: string } = {}
+  ) {
     const groupBy = await this.find.byCssSelector(
       '.tvbAggRow--split [data-test-subj="comboBoxInput"]'
     );
@@ -636,6 +639,22 @@ export class VisualBuilderPageObject extends FtrService {
     await this.common.sleep(1000);
     const byField = await this.testSubjects.find('groupByField');
     await this.comboBox.setElement(byField, field);
+
+    await this.setMetricsGroupByFiltering(filtering.include, filtering.exclude);
+  }
+
+  public async setMetricsGroupByFiltering(include?: string, exclude?: string) {
+    const setFilterValue = async (value: string | undefined, subjectKey: string) => {
+      if (typeof value === 'string') {
+        const valueSubject = await this.testSubjects.find(subjectKey);
+
+        await valueSubject.clearValue();
+        await valueSubject.type(value);
+      }
+    };
+
+    await setFilterValue(include, 'groupByInclude');
+    await setFilterValue(exclude, 'groupByExclude');
   }
 
   public async checkSelectedMetricsGroupByValue(value: string) {


### PR DESCRIPTION
Closes: #104829

## Summary

**Describe the bug:**

Migrated the `[Logs] Response Codes Over Time + Annotations` from 7.12 to 7.14-BC and the Include/Exclude fields are now showing up in the Group by section of the configuration.

Migrated TSVB chart from 7.12 to 7.14:

<img width="1252" alt="Screenshot 2021-07-08 at 11 00 17" src="https://user-images.githubusercontent.com/924948/124898752-c3c37600-dfdf-11eb-8358-0c52c9da56a5.png">

Same visualization in 7.14 "clean":

<img width="1266" alt="Screenshot 2021-07-08 at 11 01 25" src="https://user-images.githubusercontent.com/924948/124898859-dc339080-dfdf-11eb-91cc-8433311a88db.png">


**Steps to reproduce:**
1. Bootstrap a 7.12 instance and load the sample logs dataset
2. Shutdown the 7.12 instance and bootstrap a 7.14 instance
3. Open the `[Logs] Response Codes Over Time + Annotations` visualization