### PR TITLE
[Fleet] Fix background color on view assets button

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -151,7 +151,10 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
             />
           </EuiText>
           <EuiSpacer size="l" />
-          <EuiButton href={getHref('integration_details_assets', { pkgkey: `${name}-${version}` })}>
+          <EuiButton
+            fill
+            href={getHref('integration_details_assets', { pkgkey: `${name}-${version}` })}
+          >
             {i18n.translate('xpack.fleet.epm.agentEnrollment.viewDataAssetsLabel', {
               defaultMessage: 'View assets',
             })}


### PR DESCRIPTION
## Summary 

Fix button background color in agent enrollment flyout.

![Screen Shot 2021-07-08 at 10 45 00 AM](https://user-images.githubusercontent.com/6766512/124942367-91af1580-dfd9-11eb-8ab2-60ce10ddb453.png)

Fixes #104813