### PR TITLE
[APM] Fleet migration - Set APM Server URL from Cloud plugin

### DIFF
--- a/x-pack/plugins/apm/server/lib/fleet/create_cloud_apm_package_policy.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/create_cloud_apm_package_policy.ts
@@ -14,15 +14,20 @@ import {
   APM_SERVER_SCHEMA_SAVED_OBJECT_TYPE,
   APM_SERVER_SCHEMA_SAVED_OBJECT_ID,
 } from '../../../common/apm_saved_object_constants';
-import { APMPluginStartDependencies } from '../../types';
+import {
+  APMPluginSetupDependencies,
+  APMPluginStartDependencies,
+} from '../../types';
 import { getApmPackagePolicyDefinition } from './get_apm_package_policy_definition';
 
 export async function createCloudApmPackgePolicy({
+  cloudPluginSetup,
   fleetPluginStart,
   savedObjectsClient,
   esClient,
   logger,
 }: {
+  cloudPluginSetup: APMPluginSetupDependencies['cloud'];
   fleetPluginStart: NonNullable<APMPluginStartDependencies['fleet']>;
   savedObjectsClient: SavedObjectsClientContract;
   esClient: ElasticsearchClient;
@@ -35,9 +40,10 @@ export async function createCloudApmPackgePolicy({
   const apmServerSchema: Record<string, any> = JSON.parse(
     (attributes as { schemaJson: string }).schemaJson
   );
-  const apmPackagePolicyDefinition = getApmPackagePolicyDefinition(
-    apmServerSchema
-  );
+  const apmPackagePolicyDefinition = getApmPackagePolicyDefinition({
+    apmServerSchema,
+    cloudPluginSetup,
+  });
   logger.info(`Fleet migration on Cloud - apmPackagePolicy create start`);
   const apmPackagePolicy = await fleetPluginStart.packagePolicyService.create(
     savedObjectsClient,

--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
@@ -5,16 +5,21 @@
  * 2.0.
  */
 
+import { APMPluginSetupDependencies } from '../../types';
 import {
   POLICY_ELASTIC_AGENT_ON_CLOUD,
   APM_PACKAGE_NAME,
 } from './get_cloud_apm_package_policy';
 
+interface GetApmPackagePolicyDefinitionOptions {
+  apmServerSchema: Record<string, any>;
+  cloudPluginSetup: APMPluginSetupDependencies['cloud'];
+}
 export function getApmPackagePolicyDefinition(
-  apmServerSchema: Record<string, any>
+  options: GetApmPackagePolicyDefinitionOptions
 ) {
   return {
-    name: 'apm',
+    name: 'Elastic APM',
     namespace: 'default',
     enabled: true,
     policy_id: POLICY_ELASTIC_AGENT_ON_CLOUD,
@@ -24,7 +29,7 @@ export function getApmPackagePolicyDefinition(
         type: 'apm',
         enabled: true,
         streams: [],
-        vars: getApmPackageInputVars(apmServerSchema),
+        vars: getApmPackageInputVars(options),
       },
     ],
     package: {
@@ -35,16 +40,17 @@ export function getApmPackagePolicyDefinition(
   };
 }
 
-function getApmPackageInputVars(apmServerSchema: Record<string, any>) {
+function getApmPackageInputVars(options: GetApmPackagePolicyDefinitionOptions) {
+  const { apmServerSchema } = options;
   const apmServerConfigs = Object.entries(
     apmConfigMapping
-  ).map(([key, { name, type }]) => ({ key, name, type }));
+  ).map(([key, { name, type, getValue }]) => ({ key, name, type, getValue }));
 
   const inputVars: Record<
     string,
     { type: string; value: any }
-  > = apmServerConfigs.reduce((acc, { key, name, type }) => {
-    const value = apmServerSchema[key] ?? ''; // defaults to an empty string to be edited in Fleet UI
+  > = apmServerConfigs.reduce((acc, { key, name, type, getValue }) => {
+    const value = (getValue ? getValue(options) : apmServerSchema[key]) ?? ''; // defaults to an empty string to be edited in Fleet UI
     return {
       ...acc,
       [name]: { type, value },
@@ -55,7 +61,11 @@ function getApmPackageInputVars(apmServerSchema: Record<string, any>) {
 
 export const apmConfigMapping: Record<
   string,
-  { name: string; type: string }
+  {
+    name: string;
+    type: string;
+    getValue?: (options: GetApmPackagePolicyDefinitionOptions) => any;
+  }
 > = {
   'apm-server.host': {
     name: 'host',
@@ -64,6 +74,7 @@ export const apmConfigMapping: Record<
   'apm-server.url': {
     name: 'url',
     type: 'text',
+    getValue: ({ cloudPluginSetup }) => cloudPluginSetup?.apm?.url,
   },
   'apm-server.secret_token': {
     name: 'secret_token',

--- a/x-pack/plugins/apm/server/routes/fleet.ts
+++ b/x-pack/plugins/apm/server/routes/fleet.ts
@@ -164,8 +164,6 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
     const esClient = coreStart.elasticsearch.client.asScoped(resources.request)
       .asCurrentUser;
     const cloudPluginSetup = plugins.cloud?.setup;
-    console.log('cloudPluginSetup:');
-    console.log(cloudPluginSetup);
     const fleetPluginStart = await plugins.fleet.start();
     const securityPluginStart = await plugins.security.start();
     const hasRequiredRole = isSuperuser({ securityPluginStart, request });

--- a/x-pack/plugins/apm/server/routes/fleet.ts
+++ b/x-pack/plugins/apm/server/routes/fleet.ts
@@ -163,6 +163,9 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
     const coreStart = await resources.core.start();
     const esClient = coreStart.elasticsearch.client.asScoped(resources.request)
       .asCurrentUser;
+    const cloudPluginSetup = plugins.cloud?.setup;
+    console.log('cloudPluginSetup:');
+    console.log(cloudPluginSetup);
     const fleetPluginStart = await plugins.fleet.start();
     const securityPluginStart = await plugins.security.start();
     const hasRequiredRole = isSuperuser({ securityPluginStart, request });
@@ -171,6 +174,7 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
     }
     return {
       cloud_apm_package_policy: await createCloudApmPackgePolicy({
+        cloudPluginSetup,
         fleetPluginStart,
         savedObjectsClient,
         esClient,


### PR DESCRIPTION
Fixes #104907 by setting the `url` input var for the apm package policy to whatever is defined in the cloud plugin setup `apm.url` property. This will result in the field being correctly populated in the integration edit page and the APM Tutorial will show the correct server url configuraiton for agent setup.