### PR TITLE
[App Search] Relevance Tuning: Fix unsaved changes bug

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.test.tsx
@@ -10,7 +10,7 @@ import '../../../__mocks__/shallow_useeffect.mock';
 
 import React from 'react';
 
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 
 import { rerender } from '../../../test_helpers';
 
@@ -162,10 +162,18 @@ describe('MultiInputRows', () => {
   });
 
   describe('onChange', () => {
+    let wrapper: ShallowWrapper;
     const onChange = jest.fn();
 
+    beforeEach(() => {
+      wrapper = shallow(<MultiInputRows {...props} onChange={onChange} />);
+    });
+
+    it('does not call on change on mount', () => {
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('returns the current values dynamically on change', () => {
-      const wrapper = shallow(<MultiInputRows {...props} onChange={onChange} />);
       setMockValues({ ...values, values: ['updated'] });
       rerender(wrapper);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/multi_input_rows/multi_input_rows.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { useValues, useActions } from 'kea';
+import useUpdateEffect from 'react-use/lib/useUpdateEffect';
 
 import { EuiForm, EuiButton, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 
@@ -49,7 +50,7 @@ export const MultiInputRows: React.FC<Props> = ({
   const { values, addedNewRow, hasEmptyValues, hasOnlyOneValue } = useValues(logic);
   const { addValue, editValue, deleteValue } = useActions(logic);
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     if (onChange) {
       onChange(filterEmptyValues(values));
     }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -229,7 +229,7 @@ describe('RelevanceTuningLogic', () => {
     });
 
     describe('updatePrecision', () => {
-      it('should set precision inside search settings', () => {
+      it('should set precision inside search settings and set unsavedChanges to true', () => {
         mount();
         RelevanceTuningLogic.actions.updatePrecision(9);
 
@@ -239,6 +239,7 @@ describe('RelevanceTuningLogic', () => {
             ...DEFAULT_VALUES.searchSettings,
             precision: 9,
           },
+          unsavedChanges: true,
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -191,6 +191,7 @@ export const RelevanceTuningLogic = kea<
     unsavedChanges: [
       false,
       {
+        updatePrecision: () => true,
         setSearchSettings: () => true,
         setSearchSettingsResponse: () => false,
       },


### PR DESCRIPTION
## Summary

This PR fixes 2 separate unsaved changes bugs. closes https://github.com/elastic/app-search-team/issues/1881

### Bug 1: MultiInputRows causes an unsaved changes false positive (ddcc251)

AKA, the ghost of https://github.com/elastic/kibana/pull/96881#discussion_r613391348 past 👻 

MultiInputRows was causing an unsaved change false positive because its `onChange` fn (`updateBoostValue`) was firing on mount.

I did a quick search for more elegant ways to mimic the `componentDidUpdate` (i.e., sans `componentDidMount`) lifecycle with React hooks, and as it turns out, the `react-use` library does exactly what we want, is used in Kibana, and is maintained by an Elastician (the awesome Vadim Dalecky). 🎉 Docs here: https://github.com/streamich/react-use/blob/master/docs/useUpdateEffect.md

### Bug 2: Precision Tuner not triggering unsaved changes (d51216a)

This is a super small/quick fix for precision tuner changes not triggering the unsaved changes prompt. 

## QA

- Go to any engine with documents
- Go to the Relevance Tuning view
- Create a value boost, enter any text. Save
- Refresh the page (prompt should not appear)
- [x] Refresh the page again, a prompt should not appear
- [x] Navigate away from the page, a prompt should not appear
- Go back to the Relevance Tuning view and change the precision slider setting
- [x] Navigate away from the page and confirm a prompt does appear

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

NB: I was pleasantly surprised `useUpdateEffect` worked as-is without any mocking required - huge kudos to the awesome folks & Elasticians writing/maintaining that library