### PR TITLE
[ML] Fix Single Metric Viewer & Explorer annotation table actions overflow and annotations count not matching

### DIFF
--- a/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
+++ b/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
@@ -542,12 +542,7 @@ class AnnotationsTableUI extends Component {
         enabled: (annotation) => isTimeSeriesViewJob(this.getJob(annotation.job_id)),
         icon: 'visLine',
         type: 'icon',
-        onClick: (annotation) => {
-          this.setState({
-            datafeedFlyoutVisible: true,
-            datafeedEnd: annotation.end_timestamp,
-          });
-        },
+        onClick: (annotation) => this.openSingleMetricView(annotation),
       });
     }
 

--- a/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
+++ b/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
@@ -18,7 +18,6 @@ import React, { Component, Fragment, useContext } from 'react';
 import memoizeOne from 'memoize-one';
 import {
   EuiBadge,
-  EuiButtonEmpty,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -687,7 +686,7 @@ class AnnotationsTableUI extends Component {
     columns.push(
       {
         align: RIGHT_ALIGNMENT,
-        // width: '60px',
+        width: '60px',
         name: i18n.translate('xpack.ml.annotationsTable.actionsColumnName', {
           defaultMessage: 'Actions',
         }),

--- a/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
+++ b/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
@@ -25,6 +25,7 @@ import {
   EuiInMemoryTable,
   EuiLink,
   EuiLoadingSpinner,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -51,6 +52,19 @@ import { ML_APP_LOCATOR, ML_PAGES } from '../../../../../common/constants/locato
 import { timeFormatter } from '../../../../../common/util/date_utils';
 import { MlAnnotationUpdatesContext } from '../../../contexts/ml/ml_annotation_updates_context';
 import { DatafeedChartFlyout } from '../../../jobs/jobs_list/components/datafeed_chart_flyout';
+
+const editAnnotationsText = (
+  <FormattedMessage
+    id="xpack.ml.annotationsTable.editAnnotationsTooltip"
+    defaultMessage="Edit annotation"
+  />
+);
+const viewDataFeedText = (
+  <FormattedMessage
+    id="xpack.ml.annotationsTable.datafeedChartTooltip"
+    defaultMessage="Datafeed chart"
+  />
+);
 
 const CURRENT_SERIES = 'current_series';
 /**
@@ -457,82 +471,67 @@ class AnnotationsTableUI extends Component {
     const actions = [];
 
     actions.push({
-      render: (annotation) => {
-        // find the original annotation because the table might not show everything
+      name: editAnnotationsText,
+      description: editAnnotationsText,
+      icon: 'pencil',
+      type: 'icon',
+      onClick: (annotation) => {
         const annotationId = annotation._id;
         const originalAnnotation = annotations.find((d) => d._id === annotationId);
-        const editAnnotationsText = (
-          <FormattedMessage
-            id="xpack.ml.annotationsTable.editAnnotationsTooltip"
-            defaultMessage="Edit annotation"
-          />
-        );
-        const editAnnotationsAriaLabelText = i18n.translate(
-          'xpack.ml.annotationsTable.editAnnotationsTooltipAriaLabel',
-          { defaultMessage: 'Edit annotation' }
-        );
-        return (
-          <EuiButtonEmpty
-            size="xs"
-            aria-label={editAnnotationsAriaLabelText}
-            iconType="pencil"
-            onClick={() => annotationUpdatesService.setValue(originalAnnotation ?? annotation)}
-          >
-            {editAnnotationsText}
-          </EuiButtonEmpty>
-        );
+
+        annotationUpdatesService.setValue(originalAnnotation ?? annotation);
       },
     });
 
     if (this.state.jobId && this.props.jobs[0].analysis_config.bucket_span) {
       // add datafeed modal action
       actions.push({
-        render: (annotation) => {
-          const viewDataFeedText = (
-            <FormattedMessage
-              id="xpack.ml.annotationsTable.datafeedChartTooltip"
-              defaultMessage="Datafeed chart"
-            />
-          );
-          const viewDataFeedTooltipAriaLabelText = i18n.translate(
-            'xpack.ml.annotationsTable.datafeedChartTooltipAriaLabel',
-            { defaultMessage: 'Datafeed chart' }
-          );
-          return (
-            <EuiButtonEmpty
-              size="xs"
-              aria-label={viewDataFeedTooltipAriaLabelText}
-              iconType="visAreaStacked"
-              onClick={() =>
-                this.setState({
-                  datafeedFlyoutVisible: true,
-                  datafeedEnd: annotation.end_timestamp,
-                })
-              }
-            >
-              {viewDataFeedText}
-            </EuiButtonEmpty>
-          );
+        name: viewDataFeedText,
+        description: viewDataFeedText,
+        icon: 'visAreaStacked',
+        type: 'icon',
+        onClick: (annotation) => {
+          this.setState({
+            datafeedFlyoutVisible: true,
+            datafeedEnd: annotation.end_timestamp,
+          });
         },
       });
     }
 
     if (isSingleMetricViewerLinkVisible) {
       actions.push({
-        render: (annotation) => {
+        name: (annotation) => {
           const isDrillDownAvailable = isTimeSeriesViewJob(this.getJob(annotation.job_id));
-          const openInSingleMetricViewerTooltipText = isDrillDownAvailable ? (
-            <FormattedMessage
-              id="xpack.ml.annotationsTable.openInSingleMetricViewerTooltip"
-              defaultMessage="Open in Single Metric Viewer"
-            />
-          ) : (
-            <FormattedMessage
-              id="xpack.ml.annotationsTable.jobConfigurationNotSupportedInSingleMetricViewerTooltip"
-              defaultMessage="Job configuration not supported in Single Metric Viewer"
-            />
+
+          if (isDrillDownAvailable) {
+            return (
+              <FormattedMessage
+                id="xpack.ml.annotationsTable.openInSingleMetricViewerTooltip"
+                defaultMessage="Open in Single Metric Viewer"
+              />
+            );
+          }
+          return (
+            <EuiToolTip
+              content={
+                <FormattedMessage
+                  id="xpack.ml.annotationsTable.jobConfigurationNotSupportedInSingleMetricViewerTooltip"
+                  defaultMessage="Job configuration not supported in Single Metric Viewer"
+                />
+              }
+            >
+              <FormattedMessage
+                id="xpack.ml.annotationsTable.openInSingleMetricViewerTooltip"
+                defaultMessage="Open in Single Metric Viewer"
+              />
+            </EuiToolTip>
           );
-          const openInSingleMetricViewerAriaLabelText = isDrillDownAvailable
+        },
+        description: (annotation) => {
+          const isDrillDownAvailable = isTimeSeriesViewJob(this.getJob(annotation.job_id));
+
+          return isDrillDownAvailable
             ? i18n.translate('xpack.ml.annotationsTable.openInSingleMetricViewerAriaLabel', {
                 defaultMessage: 'Open in Single Metric Viewer',
               })
@@ -540,18 +539,15 @@ class AnnotationsTableUI extends Component {
                 'xpack.ml.annotationsTable.jobConfigurationNotSupportedInSingleMetricViewerAriaLabel',
                 { defaultMessage: 'Job configuration not supported in Single Metric Viewer' }
               );
-
-          return (
-            <EuiButtonEmpty
-              size="xs"
-              disabled={!isDrillDownAvailable}
-              aria-label={openInSingleMetricViewerAriaLabelText}
-              iconType="visLine"
-              onClick={() => this.openSingleMetricView(annotation)}
-            >
-              {openInSingleMetricViewerTooltipText}
-            </EuiButtonEmpty>
-          );
+        },
+        enabled: (annotation) => isTimeSeriesViewJob(this.getJob(annotation.job_id)),
+        icon: 'visLine',
+        type: 'icon',
+        onClick: (annotation) => {
+          this.setState({
+            datafeedFlyoutVisible: true,
+            datafeedEnd: annotation.end_timestamp,
+          });
         },
       });
     }
@@ -691,7 +687,7 @@ class AnnotationsTableUI extends Component {
     columns.push(
       {
         align: RIGHT_ALIGNMENT,
-        width: '60px',
+        // width: '60px',
         name: i18n.translate('xpack.ml.annotationsTable.actionsColumnName', {
           defaultMessage: 'Actions',
         }),

--- a/x-pack/plugins/ml/public/application/explorer/explorer.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.js
@@ -261,6 +261,30 @@ export class ExplorerUI extends React.Component {
     } = this.props.explorerState;
     const { annotationsData, aggregations, error: annotationsError } = annotations;
 
+    const annotationsCnt = Array.isArray(annotationsData) ? annotationsData.length : 0;
+    const allAnnotationsCnt = Array.isArray(aggregations?.event?.buckets)
+      ? aggregations.event.buckets.reduce((acc, v) => acc + v.doc_count, 0)
+      : annotationsCnt;
+
+    const badge =
+      allAnnotationsCnt > annotationsCnt ? (
+        <EuiBadge color={'hollow'}>
+          <FormattedMessage
+            id="xpack.ml.explorer.annotationsTitleTotalCount"
+            defaultMessage="First {visibleCount} out of a total of {totalCount}"
+            values={{ visibleCount: annotationsCnt, totalCount: allAnnotationsCnt }}
+          />
+        </EuiBadge>
+      ) : (
+        <EuiBadge color={'hollow'}>
+          <FormattedMessage
+            id="xpack.ml.explorer.annotationsTitleTotalCount"
+            defaultMessage="Total: {count}"
+            values={{ count: annotationsCnt }}
+          />
+        </EuiBadge>
+      );
+
     const jobSelectorProps = {
       dateFormatTz: getDateFormatTz(),
     };
@@ -404,7 +428,7 @@ export class ExplorerUI extends React.Component {
             {loading === false && tableData.anomalies?.length ? (
               <AnomaliesMap anomalies={tableData.anomalies} jobIds={selectedJobIds} />
             ) : null}
-            {annotationsData.length > 0 && (
+            {annotationsCnt > 0 && (
               <>
                 <EuiPanel data-test-subj="mlAnomalyExplorerAnnotationsPanel loaded">
                   <EuiAccordion
@@ -416,15 +440,7 @@ export class ExplorerUI extends React.Component {
                             id="xpack.ml.explorer.annotationsTitle"
                             defaultMessage="Annotations {badge}"
                             values={{
-                              badge: (
-                                <EuiBadge color={'hollow'}>
-                                  <FormattedMessage
-                                    id="xpack.ml.explorer.annotationsTitleTotalCount"
-                                    defaultMessage="Total: {count}"
-                                    values={{ count: annotationsData.length }}
-                                  />
-                                </EuiBadge>
-                              ),
+                              badge,
                             }}
                           />
                         </h2>

--- a/x-pack/plugins/ml/public/application/explorer/explorer.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.js
@@ -270,7 +270,7 @@ export class ExplorerUI extends React.Component {
       allAnnotationsCnt > annotationsCnt ? (
         <EuiBadge color={'hollow'}>
           <FormattedMessage
-            id="xpack.ml.explorer.annotationsTitleTotalCount"
+            id="xpack.ml.explorer.annotationsOutOfTotalCountTitle"
             defaultMessage="First {visibleCount} out of a total of {totalCount}"
             values={{ visibleCount: annotationsCnt, totalCount: allAnnotationsCnt }}
           />

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -13642,7 +13642,6 @@
     "xpack.ml.annotationsTable.byColumnSMVName": "グループ基準",
     "xpack.ml.annotationsTable.detectorColumnName": "検知器",
     "xpack.ml.annotationsTable.editAnnotationsTooltip": "注釈を編集します",
-    "xpack.ml.annotationsTable.editAnnotationsTooltipAriaLabel": "注釈を編集します",
     "xpack.ml.annotationsTable.eventColumnName": "イベント",
     "xpack.ml.annotationsTable.fromColumnName": "開始：",
     "xpack.ml.annotationsTable.howToCreateAnnotationDescription": "注釈を作成するには、{linkToSingleMetricView} を開きます",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13821,7 +13821,6 @@
     "xpack.ml.annotationsTable.byColumnSMVName": "依据",
     "xpack.ml.annotationsTable.detectorColumnName": "检测工具",
     "xpack.ml.annotationsTable.editAnnotationsTooltip": "编辑注释",
-    "xpack.ml.annotationsTable.editAnnotationsTooltipAriaLabel": "编辑注释",
     "xpack.ml.annotationsTable.eventColumnName": "事件",
     "xpack.ml.annotationsTable.fromColumnName": "自",
     "xpack.ml.annotationsTable.howToCreateAnnotationDescription": "要创建注释，请打开 {linkToSingleMetricView}",


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced by #101236 which causes the labels to overlap in the Explorer/Single Metric View. The disabled option was also still clickable, which leads to an unsupported page.

**Before**
<img width="1763" alt="Screen Shot 2021-07-07 at 16 57 48" src="https://user-images.githubusercontent.com/43350163/124969430-4e11d700-dfec-11eb-9472-6bc4bb508908.png">

**After**

Annotations table in the Explorer view
<img width="1441" alt="Screen Shot 2021-07-08 at 11 42 12" src="https://user-images.githubusercontent.com/43350163/124969381-3c303400-dfec-11eb-9322-2975d9c51284.png">


Annotations table in the job list
<img width="1222" alt="Screen Shot 2021-07-08 at 13 00 38" src="https://user-images.githubusercontent.com/43350163/124969617-887b7400-dfec-11eb-9e71-b48083a51995.png">

When Single Metric Viewer view is disabled
<img width="351" alt="Screen Shot 2021-07-08 at 11 41 39" src="https://user-images.githubusercontent.com/43350163/124969310-27ec3700-dfec-11eb-991a-fc84ec5b9589.png">
 
Also fixes https://github.com/elastic/kibana/issues/98074 by indicating more clearly that we are only showing 500 annotations.

<img width="968" alt="Screen Shot 2021-07-09 at 09 47 02" src="https://user-images.githubusercontent.com/43350163/125097889-2c702880-e09c-11eb-87be-51262efe0ef0.png">
 

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
