### PR TITLE
[CTI] makes dashboard links external

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_disabled_module.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_disabled_module.tsx
@@ -25,7 +25,7 @@ export const CtiDisabledModuleComponent = () => {
         title={i18n.DANGER_TITLE}
         body={i18n.DANGER_BODY}
         button={
-          <EuiButton href={threatIntelDocLink} color={'danger'} fill>
+          <EuiButton href={threatIntelDocLink} color={'danger'} fill target="_blank">
             {i18n.DANGER_BUTTON}
           </EuiButton>
         }

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
@@ -35,7 +35,7 @@ const DashboardLinkItems = styled(EuiFlexGroup)`
 `;
 
 const Title = styled(EuiFlexItem)`
-  min-width: 140px;
+  min-width: 110px;
 `;
 
 const List = styled.ul`
@@ -44,7 +44,6 @@ const List = styled.ul`
 
 const DashboardRightSideElement = styled(EuiFlexItem)`
   align-items: flex-end;
-  max-width: 200px;
 `;
 
 const RightSideLink = styled(EuiLink)`
@@ -152,9 +151,7 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
                         gutterSize="l"
                         justifyContent="spaceBetween"
                       >
-                        <Title key={`${title}-link`} grow={3}>
-                          {title}
-                        </Title>
+                        <Title key={`${title}-link`}>{title}</Title>
                         <EuiFlexGroup
                           gutterSize="s"
                           key={`${title}-divider`}
@@ -162,10 +159,10 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
                           alignItems="center"
                           justifyContent="flexEnd"
                         >
-                          <DashboardRightSideElement key={`${title}-count`} grow={1}>
+                          <DashboardRightSideElement key={`${title}-count`}>
                             {count}
                           </DashboardRightSideElement>
-                          <DashboardRightSideElement key={`${title}-source`} grow={3}>
+                          <DashboardRightSideElement key={`${title}-source`}>
                             {path ? (
                               <RightSideLink href={path} target="_blank">
                                 {linkCopy}

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
@@ -22,7 +22,6 @@ import { InspectButtonContainer } from '../../../common/components/inspect';
 import { HeaderSection } from '../../../common/components/header_section';
 import { ID as CTIEventCountQueryId } from '../../containers/overview_cti_links/use_cti_event_counts';
 import { CtiListItem } from '../../containers/overview_cti_links/helpers';
-import { LinkButton } from '../../../common/components/links';
 import { useKibana } from '../../../common/lib/kibana';
 import { CtiInnerPanel } from './cti_inner_panel';
 import * as i18n from './translations';
@@ -45,12 +44,12 @@ const List = styled.ul`
 
 const DashboardRightSideElement = styled(EuiFlexItem)`
   align-items: flex-end;
-  max-width: 160px;
+  max-width: 200px;
 `;
 
 const RightSideLink = styled(EuiLink)`
   text-align: right;
-  min-width: 140px;
+  min-width: 180px;
 `;
 
 interface ThreatIntelPanelViewProps {
@@ -96,12 +95,12 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
 
   const button = useMemo(
     () => (
-      <LinkButton href={buttonHref} disabled={!buttonHref}>
+      <EuiButton href={buttonHref} isDisabled={!buttonHref} target="_blank">
         <FormattedMessage
           id="xpack.securitySolution.overview.ctiViewDasboard"
           defaultMessage="View dashboard"
         />
-      </LinkButton>
+      </EuiButton>
     ),
     [buttonHref]
   );
@@ -117,7 +116,11 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
           color={'primary'}
           title={i18n.INFO_TITLE}
           body={i18n.INFO_BODY}
-          button={<EuiButton href={threatIntelDashboardDocLink}>{i18n.INFO_BUTTON}</EuiButton>}
+          button={
+            <EuiButton href={threatIntelDashboardDocLink} target="_blank">
+              {i18n.INFO_BUTTON}
+            </EuiButton>
+          }
         />
       ) : null,
     [isDashboardPluginDisabled, threatIntelDashboardDocLink]
@@ -164,7 +167,9 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
                           </DashboardRightSideElement>
                           <DashboardRightSideElement key={`${title}-source`} grow={3}>
                             {path ? (
-                              <RightSideLink href={path}>{linkCopy}</RightSideLink>
+                              <RightSideLink href={path} target="_blank">
+                                {linkCopy}
+                              </RightSideLink>
                             ) : (
                               <EuiText color={'subdued'} size={'s'}>
                                 {linkCopy}


### PR DESCRIPTION
external links
<img width="493" alt="Screen Shot 2021-07-08 at 4 31 14 PM" src="https://user-images.githubusercontent.com/18617331/124986840-1b76d700-e00a-11eb-9898-ae4550185dd0.png">


## Summary

Makes all links external in the CTI Dashboard Link Panel.
- Documentation buttons
- Overview Dashboard button
- Dashboard links
  - Dashboard links now have the external link icon (placed by EUI)

