### PR TITLE
[RFC] Experiment: split Canvas Expression Definitions from async Expression logic

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/esdocs.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/esdocs.ts
@@ -10,13 +10,8 @@ import {
   ExpressionValueFilter,
 } from 'src/plugins/expressions/common';
 
-// @ts-expect-error untyped local
-import { buildESRequest } from '../../../common/lib/request/build_es_request';
-
-import { searchService } from '../../../public/services';
-import { ESSQL_SEARCH_STRATEGY } from '../../../common/lib/constants';
-import { EssqlSearchStrategyRequest, EssqlSearchStrategyResponse } from '../../../types';
-import { getFunctionHelp } from '../../../i18n';
+import { i18n } from '@kbn/i18n';
+import { ELASTICSEARCH, LUCENE } from '../../../i18n/constants';
 
 interface Arguments {
   index: string;
@@ -27,14 +22,58 @@ interface Arguments {
   count: number;
 }
 
+const help = i18n.translate('xpack.canvas.functions.esdocsHelpText', {
+  defaultMessage:
+    'Query {ELASTICSEARCH} for raw documents. Specify the fields you want to retrieve, ' +
+    'especially if you are asking for a lot of rows.',
+  values: {
+    ELASTICSEARCH,
+  },
+});
+
+const argHelp = {
+  query: i18n.translate('xpack.canvas.functions.esdocs.args.queryHelpText', {
+    defaultMessage: 'A {LUCENE} query string.',
+    values: {
+      LUCENE,
+    },
+  }),
+  count: i18n.translate('xpack.canvas.functions.esdocs.args.countHelpText', {
+    defaultMessage:
+      'The number of documents to retrieve. For better performance, use a smaller data set.',
+  }),
+  fields: i18n.translate('xpack.canvas.functions.esdocs.args.fieldsHelpText', {
+    defaultMessage: 'A comma-separated list of fields. For better performance, use fewer fields.',
+  }),
+  index: i18n.translate('xpack.canvas.functions.esdocs.args.indexHelpText', {
+    defaultMessage: 'An index or index pattern. For example, {example}.',
+    values: {
+      example: '`"logstash-*"`',
+    },
+  }),
+  metaFields: i18n.translate('xpack.canvas.functions.esdocs.args.metaFieldsHelpText', {
+    defaultMessage: 'Comma separated list of meta fields. For example, {example}.',
+    values: {
+      example: '`"_index,_type"`',
+    },
+  }),
+  sort: i18n.translate('xpack.canvas.functions.esdocs.args.sortHelpText', {
+    defaultMessage:
+      'The sort direction formatted as {directions}. For example, {example1} or {example2}.',
+    values: {
+      directions: `\`"${['field', 'direction'].join(', ')}"\``,
+      example1: `\`"${['@timestamp', 'desc'].join(', ')}"\``,
+      example2: `\`"${['bytes', 'asc'].join(', ')}"\``,
+    },
+  }),
+};
+
 export function esdocs(): ExpressionFunctionDefinition<
   'esdocs',
   ExpressionValueFilter,
   Arguments,
   any
 > {
-  const { help, args: argHelp } = getFunctionHelp().esdocs;
-
   return {
     name: 'esdocs',
     type: 'datatable',
@@ -74,68 +113,9 @@ export function esdocs(): ExpressionFunctionDefinition<
         help: argHelp.sort,
       },
     },
-    fn: async (input, args, handlers) => {
-      const { count, index, fields, sort } = args;
-
-      input.and = input.and.concat([
-        {
-          type: 'filter',
-          filterType: 'luceneQueryString',
-          query: args.query,
-          and: [],
-        },
-      ]);
-
-      // Load ad-hoc to avoid adding to the page load bundle size
-      const squel = await import('safe-squel');
-
-      let query = squel.select({
-        autoQuoteTableNames: true,
-        autoQuoteFieldNames: true,
-        autoQuoteAliasNames: true,
-        nameQuoteCharacter: '"',
-      });
-
-      if (index) {
-        query.from(index);
-      }
-
-      if (fields) {
-        const allFields = fields.split(',').map((field) => field.trim());
-        allFields.forEach((field) => (query = query.field(field)));
-      }
-
-      if (sort) {
-        const [sortField, sortOrder] = sort.split(',').map((str) => str.trim());
-        if (sortField) {
-          query.order(`"${sortField}"`, sortOrder === 'asc');
-        }
-      }
-
-      const search = searchService.getService().search;
-
-      const req = {
-        count,
-        query: query.toString(),
-        filter: input.and,
-      };
-
-      // We're requesting the data using the ESSQL strategy because
-      // the SQL routes return type information with the result set
-      return search
-        .search<EssqlSearchStrategyRequest, EssqlSearchStrategyResponse>(req, {
-          strategy: ESSQL_SEARCH_STRATEGY,
-        })
-        .toPromise()
-        .then((resp: EssqlSearchStrategyResponse) => {
-          return {
-            type: 'datatable',
-            meta: {
-              type: 'essql',
-            },
-            ...resp,
-          };
-        });
+    fn: async (input, args, context) => {
+      const { esdocsFn } = await import('./fns');
+      return await esdocsFn(input, args, context);
     },
   };
 }

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/escount.fn.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/escount.fn.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// @ts-expect-error untyped local
+import { buildESRequest } from '../../../../common/lib/request/build_es_request';
+import { searchService } from '../../../../public/services';
+
+import { escount } from '../escount';
+
+export const escountFn: ReturnType<typeof escount>['fn'] = async (input, args, _context) => {
+  input.and = input.and.concat([
+    {
+      type: 'filter',
+      filterType: 'luceneQueryString',
+      query: args.query,
+      and: [],
+    },
+  ]);
+
+  const esRequest = buildESRequest(
+    {
+      index: args.index,
+      body: {
+        track_total_hits: true,
+        size: 0,
+        query: {
+          bool: {
+            must: [{ match_all: {} }],
+          },
+        },
+      },
+    },
+    input
+  );
+
+  const search = searchService.getService().search;
+  const req = {
+    params: {
+      ...esRequest,
+    },
+  };
+
+  const resp = await search.search(req).toPromise();
+  return resp.rawResponse.hits.total;
+};

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/esdocs.fn.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/esdocs.fn.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// @ts-expect-error untyped local
+import { buildESRequest } from '../../../../common/lib/request/build_es_request';
+
+import { searchService } from '../../../../public/services';
+import { ESSQL_SEARCH_STRATEGY } from '../../../../common/lib/constants';
+import { EssqlSearchStrategyRequest, EssqlSearchStrategyResponse } from '../../../../types';
+
+import { esdocs } from '../esdocs';
+
+export const esdocsFn: ReturnType<typeof esdocs>['fn'] = async (input, args, context) => {
+  const { count, index, fields, sort } = args;
+
+  input.and = input.and.concat([
+    {
+      type: 'filter',
+      filterType: 'luceneQueryString',
+      query: args.query,
+      and: [],
+    },
+  ]);
+
+  // Load ad-hoc to avoid adding to the page load bundle size
+  const squel = await import('safe-squel');
+
+  let query = squel.select({
+    autoQuoteTableNames: true,
+    autoQuoteFieldNames: true,
+    autoQuoteAliasNames: true,
+    nameQuoteCharacter: '"',
+  });
+
+  if (index) {
+    query.from(index);
+  }
+
+  if (fields) {
+    const allFields = fields.split(',').map((field) => field.trim());
+    allFields.forEach((field) => (query = query.field(field)));
+  }
+
+  if (sort) {
+    const [sortField, sortOrder] = sort.split(',').map((str) => str.trim());
+    if (sortField) {
+      query.order(`"${sortField}"`, sortOrder === 'asc');
+    }
+  }
+
+  const search = searchService.getService().search;
+
+  const req = {
+    count,
+    query: query.toString(),
+    filter: input.and,
+  };
+
+  // We're requesting the data using the ESSQL strategy because
+  // the SQL routes return type information with the result set
+  return search
+    .search<EssqlSearchStrategyRequest, EssqlSearchStrategyResponse>(req, {
+      strategy: ESSQL_SEARCH_STRATEGY,
+    })
+    .toPromise()
+    .then((resp: EssqlSearchStrategyResponse) => {
+      return {
+        type: 'datatable',
+        meta: {
+          type: 'essql',
+        },
+        ...resp,
+      };
+    });
+};

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/essql.fn.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/essql.fn.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { searchService } from '../../../../public/services';
+import { ESSQL_SEARCH_STRATEGY } from '../../../../common/lib/constants';
+import { EssqlSearchStrategyRequest, EssqlSearchStrategyResponse } from '../../../../types';
+
+import { essql } from '../essql';
+
+export const essqlFn: ReturnType<typeof essql>['fn'] = async (input, args, handlers) => {
+  const search = searchService.getService().search;
+  const { parameter, ...restOfArgs } = args;
+  const req = {
+    ...restOfArgs,
+    params: parameter,
+    filter: input.and,
+  };
+
+  try {
+    const resp = await search
+      .search<EssqlSearchStrategyRequest, EssqlSearchStrategyResponse>(req, {
+        strategy: ESSQL_SEARCH_STRATEGY,
+      })
+      .toPromise();
+    return {
+      type: 'datatable',
+      meta: {
+        type: 'essql',
+      },
+      ...resp,
+    };
+  } catch (e) {
+    let message = `Unexpected error from Elasticsearch: ${e.message}`;
+    if (e.err) {
+      const { type, reason } = e.err.attributes;
+      if (type === 'parsing_exception') {
+        message = `Couldn't parse Elasticsearch SQL query. You may need to add double quotes to names containing special characters. Check your query and try again. Error: ${reason}`;
+      } else {
+        message = `Unexpected error from Elasticsearch: ${type} - ${reason}`;
+      }
+    }
+
+    // Re-write the error message before surfacing it up
+    e.message = message;
+    throw e;
+  }
+};

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/index.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { escountFn } from './escount.fn';
+export { esdocsFn } from './esdocs.fn';
+export { essqlFn } from './essql.fn';
+export { locationFn } from './location.fn';
+export { markdownFn } from './markdown.fn';

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/location.fn.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/location.fn.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const noop = () => {};
+
+import { location } from '../location';
+
+export const locationFn: ReturnType<typeof location>['fn'] = async () => {
+  return new Promise((resolve) => {
+    function createLocation(geoposition: GeolocationPosition) {
+      const { latitude, longitude } = geoposition.coords;
+      return resolve({
+        type: 'datatable',
+        columns: [
+          { id: 'latitude', name: 'latitude', meta: { type: 'number' } },
+          { id: 'longitude', name: 'longitude', meta: { type: 'number' } },
+        ],
+        rows: [{ latitude, longitude }],
+      });
+    }
+
+    return navigator.geolocation.getCurrentPosition(createLocation, noop, {
+      maximumAge: 5000,
+    });
+  });
+};

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/markdown.fn.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/fns/markdown.fn.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { markdown } from '../markdown';
+
+export const markdownFn: ReturnType<typeof markdown>['fn'] = async (input, args) => {
+  // @ts-expect-error untyped local
+  const { Handlebars } = await import('../../../../common/lib/handlebars');
+  const compileFunctions = args.content.map((str) =>
+    Handlebars.compile(String(str), { knownHelpersOnly: true })
+  );
+  const ctx = {
+    columns: [],
+    rows: [],
+    type: null,
+    ...input,
+  };
+
+  return {
+    type: 'render',
+    as: 'markdown',
+    value: {
+      content: compileFunctions.map((fn) => fn(ctx)).join(''),
+      font: args.font,
+      openLinksInNewTab: args.openLinksInNewTab,
+    },
+  };
+};

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/functions.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/functions.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { location } from './location';
+import { markdown } from './markdown';
+import { urlparam } from './urlparam';
+import { escount } from './escount';
+import { esdocs } from './esdocs';
+import { essql } from './essql';
+
+export const functions = [location, markdown, urlparam, escount, esdocs, essql];

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/index.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/index.ts
@@ -7,20 +7,6 @@
 
 import { functions as commonFunctions } from '../common';
 import { functions as externalFunctions } from '../external';
-import { location } from './location';
-import { markdown } from './markdown';
-import { urlparam } from './urlparam';
-import { escount } from './escount';
-import { esdocs } from './esdocs';
-import { essql } from './essql';
+import { functions as browserFunctions } from './functions';
 
-export const functions = [
-  location,
-  markdown,
-  urlparam,
-  escount,
-  esdocs,
-  essql,
-  ...commonFunctions,
-  ...externalFunctions,
-];
+export const functions = [...browserFunctions, ...commonFunctions, ...externalFunctions];

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/location.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/location.ts
@@ -5,10 +5,8 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
 import { Datatable, ExpressionFunctionDefinition } from '../../../types';
-import { getFunctionHelp } from '../../../i18n';
-
-const noop = () => {};
 
 interface Return extends Datatable {
   columns: [
@@ -18,32 +16,28 @@ interface Return extends Datatable {
   rows: [{ latitude: number; longitude: number }];
 }
 
-export function location(): ExpressionFunctionDefinition<'location', null, {}, Promise<Return>> {
-  const { help } = getFunctionHelp().location;
+const help = i18n.translate('xpack.canvas.functions.locationHelpText', {
+  defaultMessage:
+    'Find your current location using the {geolocationAPI} of the browser. ' +
+    'Performance can vary, but is fairly accurate. ' +
+    'See {url}. Don’t use {locationFn} if you plan to generate PDFs as this function requires user input.',
+  values: {
+    geolocationAPI: 'Geolocation API',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/Navigator/geolocation',
+    locationFn: '`location`',
+  },
+});
 
+export function location(): ExpressionFunctionDefinition<'location', null, {}, Promise<Return>> {
   return {
     name: 'location',
     type: 'datatable',
     inputTypes: ['null'],
     args: {},
     help,
-    fn: () => {
-      return new Promise((resolve) => {
-        function createLocation(geoposition: GeolocationPosition) {
-          const { latitude, longitude } = geoposition.coords;
-          return resolve({
-            type: 'datatable',
-            columns: [
-              { id: 'latitude', name: 'latitude', meta: { type: 'number' } },
-              { id: 'longitude', name: 'longitude', meta: { type: 'number' } },
-            ],
-            rows: [{ latitude, longitude }],
-          });
-        }
-        return navigator.geolocation.getCurrentPosition(createLocation, noop, {
-          maximumAge: 5000,
-        });
-      });
+    fn: async (input, args, context) => {
+      const { locationFn } = await import('./fns');
+      return await locationFn(input, args, context);
     },
   };
 }

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/urlparam.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/browser/urlparam.ts
@@ -6,12 +6,44 @@
  */
 
 import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
-import { getFunctionHelp } from '../../../i18n';
+
+import { i18n } from '@kbn/i18n';
+import { TYPE_STRING, URL as URLConstant } from '../../../i18n/constants';
 
 interface Arguments {
   param: string;
   default: string;
 }
+
+const help = i18n.translate('xpack.canvas.functions.urlparamHelpText', {
+  defaultMessage:
+    'Retrieves a {URLConstant} parameter to use in an expression. ' +
+    'The {urlparamFn} function always returns a {TYPE_STRING}. ' +
+    'For example, you can retrieve the value {value} from the parameter {myVar} from the {URL} {example}.',
+  values: {
+    example: '`https://localhost:5601/app/canvas?myVar=20`',
+    myVar: '`myVar`',
+    TYPE_STRING,
+    URLConstant,
+    urlparamFn: '`urlparam`',
+    value: '`"20"`',
+  },
+});
+
+const argHelp = {
+  param: i18n.translate('xpack.canvas.functions.urlparam.args.paramHelpText', {
+    defaultMessage: 'The {URLConstant} hash parameter to retrieve.',
+    values: {
+      URLConstant,
+    },
+  }),
+  default: i18n.translate('xpack.canvas.functions.urlparam.args.defaultHelpText', {
+    defaultMessage: 'The string returned when the {URLConstant} parameter is unspecified.',
+    values: {
+      URLConstant,
+    },
+  }),
+};
 
 export function urlparam(): ExpressionFunctionDefinition<
   'urlparam',
@@ -19,8 +51,6 @@ export function urlparam(): ExpressionFunctionDefinition<
   Arguments,
   string | string[]
 > {
-  const { help, args: argHelp } = getFunctionHelp().urlparam;
-
   return {
     name: 'urlparam',
     aliases: [],
@@ -41,7 +71,7 @@ export function urlparam(): ExpressionFunctionDefinition<
         help: argHelp.default,
       },
     },
-    fn: (input, args) => {
+    fn: (_input, args) => {
       const url = new URL(window.location.href);
       const query = url.searchParams;
       return query.get(args.param) || args.default;

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -32,6 +32,8 @@ import { PresentationUtilPluginStart } from '../../../../src/plugins/presentatio
 import { getPluginApi, CanvasApi } from './plugin_api';
 import { pluginServiceRegistry } from './services/kibana';
 
+import { functions } from '../canvas_plugin_src/functions/browser/functions';
+
 export { CoreStart, CoreSetup };
 
 /**
@@ -86,6 +88,8 @@ export class CanvasPlugin
         defaultPath: `#${lastPath}`,
       }));
     }
+
+    functions.map((fn) => setupPlugins.expressions.registerFunction(fn));
 
     coreSetup.application.register({
       category: DEFAULT_APP_CATEGORIES.kibana,


### PR DESCRIPTION
> This is a WIP, to evaluate the impact of splitting the Expression logic from the definition.

Related: https://github.com/elastic/kibana/pull/104264

I took six browser functions and:

- Split the expression logic from the definition;
- Registered the definitions with the Expressions plugin on setup;
- Co-located the strings;
- Added an index to allow for grouped async import, (otherwise each function body was a separate module)

Side-effects:

- More code in the page bundle.
- Strong typing for help dictionaries will break.

## Before 23.5k

<img width="702" alt="Screen Shot 2021-07-08 at 6 07 59 PM" src="https://user-images.githubusercontent.com/297604/124996771-84188080-e017-11eb-82a1-990c869ce74e.png">

## After 36.9k

<img width="709" alt="Screen Shot 2021-07-08 at 6 08 06 PM" src="https://user-images.githubusercontent.com/297604/124996777-8a0e6180-e017-11eb-8c9d-87033695e1ba.png">
