### PR TITLE
[Reporting] Add `handleSIGHUP: false` to puppeteer LaunchOptions

### DIFF
--- a/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
@@ -26,6 +26,18 @@ import { HeadlessChromiumDriver } from '../driver';
 import { args } from './args';
 import { Metrics, getMetrics } from './metrics';
 
+// Puppeteer type definitions do not match the documentation.
+// See https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerlaunchoptions
+interface ReportingLaunchOptions extends puppeteer.LaunchOptions {
+  userDataDir?: string;
+  ignoreHTTPSErrors?: boolean;
+  args?: string[];
+}
+
+declare module 'puppeteer' {
+  function launch(options: ReportingLaunchOptions): Promise<puppeteer.Browser>;
+}
+
 type BrowserConfig = CaptureConfig['browser']['chromium'];
 type ViewportConfig = CaptureConfig['viewport'];
 
@@ -85,11 +97,12 @@ export class HeadlessChromiumDriverFactory {
           userDataDir: this.userDataDir,
           executablePath: this.binaryPath,
           ignoreHTTPSErrors: true,
+          handleSIGHUP: false,
           args: chromiumArgs,
           env: {
             TZ: browserTimezone,
           },
-        } as puppeteer.LaunchOptions);
+        });
 
         page = await browser.newPage();
         devTools = await page.target().createCDPSession();


### PR DESCRIPTION
## Summary

Resolves: https://github.com/elastic/kibana/issues/104988

Puppeteer controls the headless browser for PNG/PDF report jobs that are executed on a background context on the server.

The default behavior of Puppeteer is to forward signals that are sent to the script to Chromium. This means that when Kibana receives a SIGHUP signal and a report job is running, the report attempt will fail.

SIGINT and SIGTERM signals are still forwarded to Chromium to handle.

See https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerlaunchoptions

## Testing
See https://github.com/elastic/kibana/issues/104568

## Release note
Fixed a bug where a PNG or PDF report would fail if the Kibana process receives a SIGHUP signal.