### PR TITLE
 [APM] Support for data streams index patterns for cloud migration

### DIFF
--- a/x-pack/plugins/apm/server/index.test.ts
+++ b/x-pack/plugins/apm/server/index.test.ts
@@ -30,7 +30,7 @@ describe('mergeConfigs', () => {
 
     expect(mergeConfigs(apmOssConfig, apmConfig)).toEqual({
       'apm_oss.errorIndices': 'logs-apm*,apm-*-error-*',
-      'apm_oss.indexPattern': 'apm-*',
+      'apm_oss.indexPattern': 'traces-apm*,logs-apm*,metrics-apm*,apm-*',
       'apm_oss.metricsIndices': 'metrics-apm*,apm-*-metric-*',
       'apm_oss.spanIndices': 'traces-apm*,apm-*-span-*',
       'apm_oss.transactionIndices': 'traces-apm*,apm-*-transaction-*',

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -74,7 +74,7 @@ export function mergeConfigs(
     'apm_oss.metricsIndices': apmOssConfig.metricsIndices,
     'apm_oss.sourcemapIndices': apmOssConfig.sourcemapIndices,
     'apm_oss.onboardingIndices': apmOssConfig.onboardingIndices,
-    'apm_oss.indexPattern': apmOssConfig.indexPattern, // TODO: add data stream indices: traces-apm*,logs-apm*,metrics-apm*. Blocked by https://github.com/elastic/kibana/issues/87851
+    'apm_oss.indexPattern': apmOssConfig.indexPattern,
     /* eslint-enable @typescript-eslint/naming-convention */
     'xpack.apm.serviceMapEnabled': apmConfig.serviceMapEnabled,
     'xpack.apm.serviceMapFingerprintBucketSize':
@@ -118,6 +118,10 @@ export function mergeConfigs(
   mergedConfig[
     'apm_oss.metricsIndices'
   ] = `metrics-apm*,${mergedConfig['apm_oss.metricsIndices']}`;
+
+  mergedConfig[
+    'apm_oss.indexPattern'
+  ] = `traces-apm*,logs-apm*,metrics-apm*,${mergedConfig['apm_oss.indexPattern']}`;
 
   return mergedConfig;
 }

--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
@@ -34,7 +34,7 @@ export function getApmPackagePolicyDefinition(
     ],
     package: {
       name: APM_PACKAGE_NAME,
-      version: '0.3.0-dev.1',
+      version: '0.3.0',
       title: 'Elastic APM',
     },
   };

--- a/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.ts
+++ b/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.ts
@@ -19,7 +19,8 @@ export async function createStaticIndexPattern(
   setup: Setup,
   config: APMRouteHandlerResources['config'],
   savedObjectsClient: InternalSavedObjectsClient,
-  spaceId: string | undefined
+  spaceId: string | undefined,
+  overwrite = false
 ): Promise<boolean> {
   return withApmSpan('create_static_index_pattern', async () => {
     // don't autocreate APM index pattern if it's been disabled via the config
@@ -45,7 +46,7 @@ export async function createStaticIndexPattern(
           },
           {
             id: APM_STATIC_INDEX_PATTERN_ID,
-            overwrite: false,
+            overwrite,
             namespace: spaceId,
           }
         )

--- a/x-pack/plugins/apm/server/routes/fleet.ts
+++ b/x-pack/plugins/apm/server/routes/fleet.ts
@@ -25,6 +25,8 @@ import { createCloudApmPackgePolicy } from '../lib/fleet/create_cloud_apm_packag
 import { getUnsupportedApmServerSchema } from '../lib/fleet/get_unsupported_apm_server_schema';
 import { isSuperuser } from '../lib/fleet/is_superuser';
 import { getInternalSavedObjectsClient } from '../lib/helpers/get_internal_saved_objects_client';
+import { setupRequest } from '../lib/helpers/setup_request';
+import { createStaticIndexPattern } from '../lib/index_pattern/create_static_index_pattern';
 
 const hasFleetDataRoute = createApmServerRoute({
   endpoint: 'GET /api/apm/fleet/has_data',
@@ -153,7 +155,7 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
   endpoint: 'POST /api/apm/fleet/cloud_apm_package_policy',
   options: { tags: ['access:apm', 'access:apm_write'] },
   handler: async (resources) => {
-    const { plugins, context, config, request, logger } = resources;
+    const { plugins, context, config, request, logger, core } = resources;
     const cloudApmMigrationEnabled =
       config['xpack.apm.agent.migrations.enabled'];
     if (!plugins.fleet || !plugins.security) {
@@ -170,15 +172,34 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
     if (!hasRequiredRole || !cloudApmMigrationEnabled) {
       throw Boom.forbidden(CLOUD_SUPERUSER_REQUIRED_MESSAGE);
     }
-    return {
-      cloud_apm_package_policy: await createCloudApmPackgePolicy({
-        cloudPluginSetup,
-        fleetPluginStart,
-        savedObjectsClient,
-        esClient,
-        logger,
-      }),
-    };
+
+    const cloudApmAackagePolicy = await createCloudApmPackgePolicy({
+      cloudPluginSetup,
+      fleetPluginStart,
+      savedObjectsClient,
+      esClient,
+      logger,
+    });
+
+    const [setup, internalSavedObjectsClient] = await Promise.all([
+      setupRequest(resources),
+      core
+        .start()
+        .then((coreStart) => coreStart.savedObjects.createInternalRepository()),
+    ]);
+
+    const spaceId = plugins.spaces?.setup.spacesService.getSpaceId(request);
+
+    // force update the index pattern title with data streams
+    await createStaticIndexPattern(
+      setup,
+      config,
+      internalSavedObjectsClient,
+      spaceId,
+      true
+    );
+
+    return { cloud_apm_package_policy: cloudApmAackagePolicy };
   },
 });
 

--- a/x-pack/plugins/apm/server/routes/fleet.ts
+++ b/x-pack/plugins/apm/server/routes/fleet.ts
@@ -185,7 +185,7 @@ const createCloudApmPackagePolicyRoute = createApmServerRoute({
       setupRequest(resources),
       core
         .start()
-        .then((coreStart) => coreStart.savedObjects.createInternalRepository()),
+        .then(({ savedObjects }) => savedObjects.createInternalRepository()),
     ]);
 
     const spaceId = plugins.spaces?.setup.spacesService.getSpaceId(request);


### PR DESCRIPTION
Fixes #101095 and elastic/apm-server#5579.

Adds Support for data streams in the index pattern title for the static APM index pattern. This index pattern is forced to be updated when the Fleet migration for cloud is initiated by the user. Also updates the APM integration package version to 0.3.0 the most recently released version in the package registry.

