### PR TITLE
Fix of the `ja-JP.json not found` error.

### DIFF
--- a/src/plugins/expression_reveal_image/.i18nrc.json
+++ b/src/plugins/expression_reveal_image/.i18nrc.json
@@ -1,7 +1,0 @@
-{
-  "prefix": "expressionRevealImage",
-  "paths": {
-    "expressionRevealImage": "."
-  },
-  "translations": ["translations/ja-JP.json"]
-}

--- a/src/plugins/screenshot_mode/.i18nrc.json
+++ b/src/plugins/screenshot_mode/.i18nrc.json
@@ -1,7 +1,0 @@
-{
-  "prefix": "screenshotMode",
-  "paths": {
-    "screenshotMode": "."
-  },
-  "translations": ["translations/ja-JP.json"]
-}

--- a/x-pack/plugins/timelines/.i18nrc.json
+++ b/x-pack/plugins/timelines/.i18nrc.json
@@ -1,7 +1,0 @@
-{
-  "prefix": "timelines",
-  "paths": {
-    "timelines": "."
-  },
-  "translations": ["translations/ja-JP.json"]
-}


### PR DESCRIPTION
## Fixes the error of starting a project with Japan localization.
To reproduce the problem, need to run: 
```bash
yarn start --i18n.locale=ja-JP
```
## Removes:
- .i18nrc.json file at `screenshotMode`
- .i18nrc.json file at `expressionRevealImage`
- .i18nrc.json file at `x-pack/plugins/timelines`