### PR TITLE
[Lens] Add more Lens QA doc

### DIFF
--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -319,7 +319,12 @@ You can also change the index pattern for a single *Layer*.
 [[why-my-field-x-is-missing-from-the-fields-list]]
 ===== Why is my field X missing from the fields list?
 
-*Lens* does not support the visualization of full-text fields, therefore it is not showing them in the data summary.
+If your field is not in the `Available fields` list in *Lens* there may be multiple reasons, here described:
+* the field is a full-text field, therefore it is not showing in the data summary.
+* the field is a Geo field, therefore it is not showing in the data summary prior to v.7.14.0
+* the mapping is not supported by index-patterns, for instance for fields in `flattened` objects
+
+If your field does not fall into one of the cases above, check if that is available into the `Empty fields` group: *Lens* uses an heuristic to determine whether the fields have available values or not and for sparse datasets it can be less precise.
 
 [float]
 [[how-to-handle-gaps-in-time-series-visualizations]]
@@ -370,3 +375,9 @@ Here's a short list of few different aspects to check:
 ** If a custom `Number` configuration is used, check that the color stop values are covering the current data range.
 
 ** If a `Percent` configuration is used, and the data range changes, the colors displayed are affected.
+
+[float]
+[[is-it-possible-to-show-icons-in-datatable]]
+===== Is it possible to show icons in datatable?
+
+It is possible to show icons <<../managing-index-patterns#string-field-formatters, via field formatter>>.

--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -316,13 +316,14 @@ Each *Layer* in a visualization is associated with an index pattern and mutiple 
 You can also change the index pattern for a single *Layer*.
 
 [float]
-[[why-my-field-x-is-missing-from-the-fields-list]]
-===== Why is my field X missing from the fields list?
+[[why-my-field-is-missing-from-the-fields-list]]
+===== Why is my field missing from the fields list?
 
 Fields do not appear in the *Available fields* in the following scenarios:
-* The field is a full-text field, therefore it is not showing in the data summary.
-* the field is a Geo field, therefore it is not showing in the data summary prior to v.7.14.0
-* the mapping is not supported by index-patterns, for instance for fields in `flattened` objects
+* The field is a full-text field.
+* The field is a `geo_point` field
+* The field is a `flattened` field.
+* The field is a `object` field.
 
 Verify if the field appears in the *Empty fields* list. *Lens* uses heuristics to determine if the fields contain values. For sparse data sets, the heuristics are less precise.
 

--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -380,4 +380,4 @@ Here's a short list of few different aspects to check:
 [[is-it-possible-to-show-icons-in-datatable]]
 ===== Is it possible to show icons in datatable?
 
-It is possible to show icons <<../managing-index-patterns#string-field-formatters, via field formatter>>.
+It is possible to show icons <<managing-index-patterns#string-field-formatters, via field formatter>>.

--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -380,4 +380,4 @@ Here's a short list of few different aspects to check:
 [[is-it-possible-to-show-icons-in-datatable]]
 ===== Is it possible to show icons in datatable?
 
-It is possible to show icons <<managing-index-patterns#string-field-formatters, via field formatter>>.
+It is possible to show icons <<managing-index-patterns, via field formatter>>.

--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -319,12 +319,12 @@ You can also change the index pattern for a single *Layer*.
 [[why-my-field-x-is-missing-from-the-fields-list]]
 ===== Why is my field X missing from the fields list?
 
-If your field is not in the `Available fields` list in *Lens* there may be multiple reasons, here described:
-* the field is a full-text field, therefore it is not showing in the data summary.
+Fields do not appear in the *Available fields* in the following scenarios:
+* The field is a full-text field, therefore it is not showing in the data summary.
 * the field is a Geo field, therefore it is not showing in the data summary prior to v.7.14.0
 * the mapping is not supported by index-patterns, for instance for fields in `flattened` objects
 
-If your field does not fall into one of the cases above, check if that is available into the `Empty fields` group: *Lens* uses an heuristic to determine whether the fields have available values or not and for sparse datasets it can be less precise.
+Verify if the field appears in the *Empty fields* list. *Lens* uses heuristics to determine if the fields contain values. For sparse data sets, the heuristics are less precise.
 
 [float]
 [[how-to-handle-gaps-in-time-series-visualizations]]
@@ -378,6 +378,6 @@ Here's a short list of few different aspects to check:
 
 [float]
 [[is-it-possible-to-show-icons-in-datatable]]
-===== Is it possible to show icons in datatable?
+===== Is it possible to display icons in data tables?
 
-It is possible to show icons <<managing-index-patterns, via field formatter>>.
+You can display icons with <<managing-index-patterns, field formatter>> in data tables.


### PR DESCRIPTION
## Summary

More on #81780 

Expanded the `missing field` answer based on previous PR, and added new question about datatable text styling.

Not sure about releasing with 7.14. You think it's ok @KOTungseth ?


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
