### PR TITLE
Replace cmd with bash as EuiCodeBlock language

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
@@ -44,7 +44,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({ details }) => {
   const infoPopover = (
     <EuiPopover button={tooltipPopoverTrigger} isOpen={isPopoverOpen} closePopover={closePopover}>
       <EuiCodeBlock
-        language="cmd"
+        language="bash"
         fontSize="m"
         paddingSize="m"
         style={{ maxWidth: 300 }}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/workplace-search-team/issues/1844

Replaced cmd with bash as EuiCodeBlock language.
`cmd` is no longer supported by 3rd party library used by EuiCodeBlock.

Before:

https://user-images.githubusercontent.com/11838280/125088583-f0d95c80-e0a3-11eb-9968-675bf1694737.mp4

After:

https://user-images.githubusercontent.com/11838280/125088122-80cad680-e0a3-11eb-8faa-246480911828.mp4

I don't think we need a test for this in our plugin since the correct language prop should be verified in EUI. There's already an issue for that: https://github.com/elastic/eui/issues/4849