### PR TITLE
[7.x] [Reporting] Add `handleSIGHUP: false` to puppeteer LaunchOptions (#104992)

### DIFF
--- a/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
@@ -26,6 +26,18 @@ import { HeadlessChromiumDriver } from '../driver';
 import { args } from './args';
 import { Metrics, getMetrics } from './metrics';
 
+// Puppeteer type definitions do not match the documentation.
+// See https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerlaunchoptions
+interface ReportingLaunchOptions extends puppeteer.LaunchOptions {
+  userDataDir?: string;
+  ignoreHTTPSErrors?: boolean;
+  args?: string[];
+}
+
+declare module 'puppeteer' {
+  function launch(options: ReportingLaunchOptions): Promise<puppeteer.Browser>;
+}
+
 type BrowserConfig = CaptureConfig['browser']['chromium'];
 type ViewportConfig = CaptureConfig['viewport'];
 
@@ -85,11 +97,12 @@ export class HeadlessChromiumDriverFactory {
           userDataDir: this.userDataDir,
           executablePath: this.binaryPath,
           ignoreHTTPSErrors: true,
+          handleSIGHUP: false,
           args: chromiumArgs,
           env: {
             TZ: browserTimezone,
           },
-        } as puppeteer.LaunchOptions);
+        });
 
         page = await browser.newPage();
         devTools = await page.target().createCDPSession();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Reporting] Add `handleSIGHUP: false` to puppeteer LaunchOptions (#104992)