### PR TITLE
[Workplace Search] Remove users from groups views

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -117,7 +117,7 @@ export const GroupOverview: React.FC = () => {
     onGroupNameInputChange,
   } = useActions(GroupLogic);
   const {
-    group: { name, contentSources, users, canDeleteGroup },
+    group: { name, contentSources, canDeleteGroup },
     groupNameInputValue,
     dataLoading,
     confirmDeleteModalVisible,
@@ -157,7 +157,6 @@ export const GroupOverview: React.FC = () => {
   );
 
   const hasContentSources = contentSources?.length > 0;
-  const hasUsers = users?.length > 0;
 
   const manageSourcesButton = (
     <EuiButton color="primary" onClick={showSharedSourcesModal}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -33,24 +33,23 @@ import { NAV, CANCEL_BUTTON } from '../../../constants';
 import { USERS_AND_ROLES_PATH } from '../../../routes';
 import { GroupLogic, MAX_NAME_LENGTH } from '../group_logic';
 
-import { GroupUsersTable } from './group_users_table';
-
 export const EMPTY_SOURCES_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.groups.overview.emptySourcesDescription',
   {
     defaultMessage: 'No content sources are shared with this group.',
   }
 );
+const USERS_SECTION_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.groups.overview.usersSectionTitle',
+  {
+    defaultMessage: 'Group users',
+  }
+);
 const GROUP_USERS_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.groups.overview.groupUsersDescription',
   {
-    defaultMessage: 'Members will be able to search over the group’s sources.',
-  }
-);
-export const EMPTY_USERS_DESCRIPTION = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.groups.overview.emptyUsersDescription',
-  {
-    defaultMessage: 'There are no users in this group.',
+    defaultMessage:
+      "Users assigned to this group gain access to the sources' data and content defined above. User assignments for this group can be managed in the Users and Roles area.",
   }
 );
 const MANAGE_SOURCES_BUTTON_TEXT = i18n.translate(
@@ -199,12 +198,11 @@ export const GroupOverview: React.FC = () => {
 
   const usersSection = (
     <ContentSection
-      title="Group users"
-      description={hasUsers ? GROUP_USERS_DESCRIPTION : EMPTY_USERS_DESCRIPTION}
-      action={manageUsersButton}
+      title={USERS_SECTION_TITLE}
+      description={GROUP_USERS_DESCRIPTION}
       data-test-subj="GroupUsersSection"
     >
-      {hasUsers && <GroupUsersTable />}
+      {manageUsersButton}
     </ContentSection>
   );
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
@@ -14,20 +14,13 @@ import moment from 'moment';
 
 import { EuiTableRow } from '@elastic/eui';
 
-import { GroupRow, NO_USERS_MESSAGE, NO_SOURCES_MESSAGE } from './group_row';
-import { GroupUsers } from './group_users';
+import { GroupRow, NO_SOURCES_MESSAGE } from './group_row';
 
 describe('GroupRow', () => {
   it('renders', () => {
     const wrapper = shallow(<GroupRow {...groups[0]} />);
 
     expect(wrapper.find(EuiTableRow)).toHaveLength(1);
-  });
-
-  it('renders group users', () => {
-    const wrapper = shallow(<GroupRow {...groups[0]} />);
-
-    expect(wrapper.find(GroupUsers)).toHaveLength(1);
   });
 
   it('renders fromNow date string when in range', () => {
@@ -42,12 +35,6 @@ describe('GroupRow', () => {
     const wrapper = shallow(<GroupRow {...groups[0]} updatedAt={'2020-01-01'} />);
 
     expect(wrapper.find('small').text()).toEqual('Last updated January 1, 2020.');
-  });
-
-  it('renders empty users message when no users present', () => {
-    const wrapper = shallow(<GroupRow {...groups[0]} usersCount={0} />);
-
-    expect(wrapper.find('.user-group__accounts').text()).toEqual(NO_USERS_MESSAGE);
   });
 
   it('renders empty sources message when no sources present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
@@ -19,7 +19,6 @@ import { Group } from '../../../types';
 import { MAX_NAME_LENGTH } from '../group_logic';
 
 import { GroupSources } from './group_sources';
-import { GroupUsers } from './group_users';
 
 const DAYS_CUTOFF = 8;
 export const NO_SOURCES_MESSAGE = i18n.translate(
@@ -40,14 +39,7 @@ const dateDisplay = (date: string) =>
     ? moment(date).fromNow()
     : moment(date).format('MMMM D, YYYY');
 
-export const GroupRow: React.FC<Group> = ({
-  id,
-  name,
-  updatedAt,
-  contentSources,
-  users,
-  usersCount,
-}) => {
+export const GroupRow: React.FC<Group> = ({ id, name, updatedAt, contentSources }) => {
   const GROUP_UPDATED_TEXT = i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.groups.groupUpdatedText',
     {
@@ -73,15 +65,6 @@ export const GroupRow: React.FC<Group> = ({
             <GroupSources groupSources={contentSources} />
           ) : (
             NO_SOURCES_MESSAGE
-          )}
-        </div>
-      </EuiTableRowCell>
-      <EuiTableRowCell>
-        <div className="user-group__accounts">
-          {usersCount > 0 ? (
-            <GroupUsers groupUsers={users} usersCount={usersCount} groupId={id} />
-          ) : (
-            NO_USERS_MESSAGE
           )}
         </div>
       </EuiTableRowCell>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
@@ -36,12 +36,6 @@ const SOURCES_TABLE_HEADER = i18n.translate(
     defaultMessage: 'Content sources',
   }
 );
-const USERS_TABLE_HEADER = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.usersTableHeader',
-  {
-    defaultMessage: 'Users',
-  }
-);
 
 export const GroupsTable: React.FC<{}> = () => {
   const { setActivePage } = useActions(GroupsLogic);
@@ -77,7 +71,6 @@ export const GroupsTable: React.FC<{}> = () => {
         <EuiTableHeader>
           <EuiTableHeaderCell>{GROUP_TABLE_HEADER}</EuiTableHeaderCell>
           <EuiTableHeaderCell>{SOURCES_TABLE_HEADER}</EuiTableHeaderCell>
-          <EuiTableHeaderCell>{USERS_TABLE_HEADER}</EuiTableHeaderCell>
           <EuiTableHeaderCell />
         </EuiTableHeader>
         <EuiTableBody>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -8117,7 +8117,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveDescription": "グループはWorkplace Searchから削除されます。{name}を削除してよろしいですか？",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmTitleText": "確認",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.emptySourcesDescription": "コンテンツソースはこのグループと共有されていません。",
-    "xpack.enterpriseSearch.workplaceSearch.groups.overview.emptyUsersDescription": "このグループにはユーザーがありません。",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.groupSourcesDescription": "「{name}」グループのすべてのユーザーによって検索可能です。",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.groupSourcesTitle": "グループコンテンツソース",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.groupUsersDescription": "メンバーはグループのソースを検索できます。",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -8105,7 +8105,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.groupSourcesUpdated": "共有コンテンツソースが正常に更新されました。",
     "xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.groupTableHeader": "グループ",
     "xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.sourcesTableHeader": "コンテンツソース",
-    "xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.usersTableHeader": "ユーザー",
     "xpack.enterpriseSearch.workplaceSearch.groups.groupUpdatedText": "前回更新日時{updatedAt}。",
     "xpack.enterpriseSearch.workplaceSearch.groups.heading": "グループを管理",
     "xpack.enterpriseSearch.workplaceSearch.groups.inviteUsers.action": "ユーザーを招待",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -8185,7 +8185,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmRemoveDescription": "您的组将从 Workplace Search 中删除。确定要移除 {name}？",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.confirmTitleText": "确认",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.emptySourcesDescription": "未与此组共享任何内容源。",
-    "xpack.enterpriseSearch.workplaceSearch.groups.overview.emptyUsersDescription": "此组中没有用户。",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.groupSourcesDescription": "可按“{name}”组中的所有用户搜索。",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.groupSourcesTitle": "组内容源",
     "xpack.enterpriseSearch.workplaceSearch.groups.overview.groupUsersDescription": "成员将可以对该组的源进行搜索。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -8173,7 +8173,6 @@
     "xpack.enterpriseSearch.workplaceSearch.groups.groupSourcesUpdated": "已成功更新共享内容源。",
     "xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.groupTableHeader": "组",
     "xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.sourcesTableHeader": "内容源",
-    "xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.usersTableHeader": "用户",
     "xpack.enterpriseSearch.workplaceSearch.groups.groupUpdatedText": "上次更新于 {updatedAt}。",
     "xpack.enterpriseSearch.workplaceSearch.groups.heading": "管理组",
     "xpack.enterpriseSearch.workplaceSearch.groups.inviteUsers.action": "邀请用户",


### PR DESCRIPTION
fixes https://github.com/elastic/enterprise-search-team/issues/700

## Summary

After some [discussion](https://github.com/elastic/enterprise-search-team/issues/700#issuecomment-877323547), edge cases were found that prohibit shipping 7.14 with any concept of Users on the groups views. This PR removes the users from the groups table and also the users table from the group overview page. 

**Before**
![gs-before](https://user-images.githubusercontent.com/1869731/125115426-ed989d80-e0b0-11eb-97b8-208d2447b20c.png)
![g-before](https://user-images.githubusercontent.com/1869731/125115429-eec9ca80-e0b0-11eb-8efe-7de83d167bb8.png)

**After**
![gs-after](https://user-images.githubusercontent.com/1869731/125115440-f2f5e800-e0b0-11eb-97c8-f64943dce5f1.png)
![g-after](https://user-images.githubusercontent.com/1869731/125115446-f4271500-e0b0-11eb-867b-e2070e95d17e.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
