### PR TITLE
[Enterprise Search] Fixed description contrast on Enterprise Search Home

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
@@ -19,6 +19,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiTitle,
+  EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -59,14 +60,15 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({ access }) => {
         <EuiPageHeader>
           <EuiPageHeaderSection className="enterpriseSearchOverview__header">
             <EuiTitle size="l">
-              <h1 className="enterpriseSearchOverview__heading">
+              <h1>
                 {i18n.translate('xpack.enterpriseSearch.overview.heading', {
                   defaultMessage: 'Welcome to Elastic Enterprise Search',
                 })}
               </h1>
             </EuiTitle>
-            <EuiTitle size="s">
-              <p className="enterpriseSearchOverview__subheading">
+            <EuiSpacer />
+            <EuiText>
+              <p>
                 {config.host
                   ? i18n.translate('xpack.enterpriseSearch.overview.subheading', {
                       defaultMessage: 'Select a product to get started.',
@@ -75,7 +77,7 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({ access }) => {
                       defaultMessage: 'Choose a product to set up and get started.',
                     })}
               </p>
-            </EuiTitle>
+            </EuiText>
           </EuiPageHeaderSection>
         </EuiPageHeader>
         <EuiPageContentBody>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.scss
@@ -21,21 +21,7 @@
   &__header {
     text-align: center;
     margin: auto;
-  }
-
-  &__heading {
-    @include euiBreakpoint('xs', 's') {
-      font-size: $euiFontSizeXL;
-      line-height: map-get(map-get($euiTitles, 'm'), 'line-height');
-    }
-  }
-
-  &__subheading {
-    color: $euiColorMediumShade;
-    font-size: $euiFontSize;
-
     @include euiBreakpoint('m', 'l', 'xl') {
-      font-size: $euiFontSizeL;
       margin-bottom: $euiSizeL;
     }
   }


### PR DESCRIPTION
## Summary

The contrast in Dark Mode on the Enterprise Search Home page description was not great.

I updated it to use the default color.

Additionally, I thought I'd take a moment to clean that section up so it uses the same title / description sizes, colors, and spacing as all of our other pages, and remove a bunch of custom styles.

Since this isn't a major bug for 7.14 I'm targeting 7.15 for this change.

Before:
![screencapture-localhost-5601-bil-app-enterprise-search-overview-2021-07-09-15_03_45](https://user-images.githubusercontent.com/1427475/125125090-1f1c6380-e0c7-11eb-97f4-195233fde8ca.png)

After:
![screencapture-localhost-5601-bil-app-enterprise-search-overview-2021-07-09-15_03_24](https://user-images.githubusercontent.com/1427475/125125102-23e11780-e0c7-11eb-8972-161d0ec5892d.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
