### PR TITLE
[Enterprise Search] Fix Error Connecting view not displaying for auth issues

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -403,7 +403,7 @@ describe('EnterpriseSearchRequestHandler', () => {
         expect(responseMock.customError).toHaveBeenCalledWith({
           statusCode: 502,
           body: 'Cannot authenticate Enterprise Search user',
-          headers: mockExpectedResponseHeaders,
+          headers: { ...mockExpectedResponseHeaders, [ERROR_CONNECTING_HEADER]: 'true' },
         });
         expect(mockLogger.error).toHaveBeenCalled();
       });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -298,9 +298,10 @@ export class EnterpriseSearchRequestHandler {
    */
   handleAuthenticationError(response: KibanaResponseFactory) {
     const errorMessage = 'Cannot authenticate Enterprise Search user';
+    const headers = { ...this.headers, [ERROR_CONNECTING_HEADER]: 'true' };
 
     this.log.error(errorMessage);
-    return response.customError({ statusCode: 502, headers: this.headers, body: errorMessage });
+    return response.customError({ statusCode: 502, headers, body: errorMessage });
   }
 
   /**

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -283,11 +283,10 @@ export class EnterpriseSearchRequestHandler {
 
   handleConnectionError(response: KibanaResponseFactory, e: Error) {
     const errorMessage = `Error connecting to Enterprise Search: ${e?.message || e.toString()}`;
+    const headers = { ...this.headers, [ERROR_CONNECTING_HEADER]: 'true' };
 
     this.log.error(errorMessage);
     if (e instanceof Error) this.log.debug(e.stack as string);
-
-    const headers = { ...this.headers, [ERROR_CONNECTING_HEADER]: 'true' };
 
     return response.customError({ statusCode: 502, headers, body: errorMessage });
   }


### PR DESCRIPTION
## Summary

I forgot to add the error connecting header to user authentication error responses in https://github.com/elastic/kibana/pull/103555. My reasoning behind showing "Error connecting" for auth issues is due to the following reasons:

1. Security: if the user actually shouldn't be able to access the app, we should reveal as little of it as possible
2. Troubleshooting: the error connecting page has more troubleshooting steps than just a generic error, and additionally links to the setup guide which can potentially help with auth (e.g. SAML) issues

For clarity, if a user simply doesn't have access to AS or WS normally, then the respective plugin should simply be disabled (not visible in the nav, etc). So the only times a user should actually run into this error/screen due to auth is:

- If the user attempts to access a specific feature/API endpoint they should not have access to - this primarily occurs around features that require platinum licenses; ent-search will throw a 401 in that scenario
- If the user's ent-search role mapping gets deleted in the middle of their session
- On standard auth prior to 7.14 (should no longer be an issue w/ the user/roles refactor)
- SAML auth issues (not totally sure about the details, but probably related to incorrect configuration)

### Before

![before](https://user-images.githubusercontent.com/549407/125126393-e3c26a80-e0af-11eb-8144-a57e682bb20b.gif)

### After

![after](https://user-images.githubusercontent.com/549407/125126413-ec1aa580-e0af-11eb-92c7-8dfa7196b9b2.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios