### PR TITLE
Removing async from file upload and data visualizer plugins start lifecycle

### DIFF
--- a/x-pack/plugins/data_visualizer/server/plugin.ts
+++ b/x-pack/plugins/data_visualizer/server/plugin.ts
@@ -12,7 +12,7 @@ import { dataVisualizerRoutes } from './routes';
 export class DataVisualizerPlugin implements Plugin {
   constructor() {}
 
-  async setup(coreSetup: CoreSetup<StartDeps, unknown>, plugins: SetupDeps) {
+  setup(coreSetup: CoreSetup<StartDeps, unknown>, plugins: SetupDeps) {
     dataVisualizerRoutes(coreSetup);
   }
 

--- a/x-pack/plugins/file_upload/server/plugin.ts
+++ b/x-pack/plugins/file_upload/server/plugin.ts
@@ -21,7 +21,7 @@ export class FileUploadPlugin implements Plugin {
     this._logger = initializerContext.logger.get();
   }
 
-  async setup(coreSetup: CoreSetup<StartDeps, unknown>, plugins: SetupDeps) {
+  setup(coreSetup: CoreSetup<StartDeps, unknown>, plugins: SetupDeps) {
     fileUploadRoutes(coreSetup, this._logger);
 
     setupCapabilities(coreSetup);


### PR DESCRIPTION
Setup functions in each plugin are `async` but do not need to be. 
Removing them stops these warnings when kibana starts up:
```
server    log   [11:25:39.623] [warning][plugins-system] Plugin fileUpload is using asynchronous setup lifecycle. Asynchronous plugins support will be removed in a later version.
server    log   [11:25:39.640] [warning][plugins-system] Plugin dataVisualizer is using asynchronous setup lifecycle. Asynchronous plugins support will be removed in a later version.
```

