### PR TITLE
[7.x] [DOCS] Adds how to create dashboard drilldowns for Top N and Table TSVB panels (#104548)

### DIFF
--- a/docs/user/dashboard/tsvb.asciidoc
+++ b/docs/user/dashboard/tsvb.asciidoc
@@ -146,6 +146,27 @@ The *Markdown* visualization supports Markdown with Handlebar (mustache) syntax 
 For answers to frequently asked *TSVB* question, review the following. 
 
 [float]
+===== How do I create dashboard drilldowns for Top N and Table visualizations?
+
+You can create dashboard drilldowns that include the specified time range for *Top N* and *Table* visualizations.
+
+. Open the dashboard that you want to link to, then copy the URL.
+
+. Open the dashboard with the *Top N* and *Table* visualization panel, then click *Edit* in the toolbar. 
+
+. Open the *Top N* or *Table* panel menu, then select *Edit visualization*.
+
+. Click *Panel options*. 
+
+. In the *Item URL* field, enter the URL. 
++
+For example `dashboards#/view/f193ca90-c9f4-11eb-b038-dd3270053a27`.
+
+. Click *Save and return*.
+
+. In the toolbar, cick *Save as*, then make sure *Store time with dashboard* is deselected. 
+
+[float]
 ===== Why is my TSVB visualization missing data?
 
 It depends, but most often there are two causes:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds how to create dashboard drilldowns for Top N and Table TSVB panels (#104548)