### PR TITLE
[Workplace Search] Hide heading when page loading

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.test.tsx
@@ -58,6 +58,13 @@ describe('AddSourceList', () => {
     expect(wrapper.find(AvailableSourcesList)).toHaveLength(1);
   });
 
+  it('does not render header when loading', () => {
+    setMockValues({ ...mockValues, dataLoading: true });
+    const wrapper = shallow(<AddSourceList />);
+
+    expect(wrapper.prop('pageHeader')).toBe(undefined);
+  });
+
   describe('layout', () => {
     it('renders the default workplace search layout when on an organization view', () => {
       setMockValues({ ...mockValues, isOrganization: true });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
@@ -104,7 +104,9 @@ export const AddSourceList: React.FC = () => {
     <Layout
       pageChrome={[NAV.SOURCES, NAV.ADD_SOURCE]}
       pageViewTelemetry="add_source"
-      pageHeader={{ pageTitle: PAGE_TITLE, description: PAGE_DESCRIPTION }}
+      pageHeader={
+        dataLoading ? undefined : { pageTitle: PAGE_TITLE, description: PAGE_DESCRIPTION }
+      }
       isLoading={dataLoading}
     >
       {!isOrganization && (


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1866

## Summary

This PR fixes a bug where the UI would flash a conditional heading before the page loaded.

**Before**
![before](https://user-images.githubusercontent.com/1869731/125323171-19f82800-e304-11eb-9b68-a314e8631caf.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/125323180-1cf31880-e304-11eb-8535-ea82a04ee47c.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
