### PR TITLE
[Cases][Observability][Bug] Exclude registering the cases feature if feature flag is disabled

### DIFF
--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -38,47 +38,49 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
   }
 
   public setup(core: CoreSetup, plugins: PluginSetup) {
-    plugins.features.registerKibanaFeature({
-      id: casesFeatureId,
-      name: i18n.translate('xpack.observability.featureRegistry.linkObservabilityTitle', {
-        defaultMessage: 'Cases',
-      }),
-      order: 1100,
-      category: DEFAULT_APP_CATEGORIES.observability,
-      app: [casesFeatureId, 'kibana'],
-      catalogue: [observabilityFeatureId],
-      cases: [observabilityFeatureId],
-      privileges: {
-        all: {
-          app: [casesFeatureId, 'kibana'],
-          catalogue: [observabilityFeatureId],
-          cases: {
-            all: [observabilityFeatureId],
-          },
-          api: [],
-          savedObject: {
-            all: [],
-            read: [],
-          },
-          ui: ['crud_cases', 'read_cases'], // uiCapabilities[casesFeatureId].crud_cases or read_cases
-        },
-        read: {
-          app: [casesFeatureId, 'kibana'],
-          catalogue: [observabilityFeatureId],
-          cases: {
-            read: [observabilityFeatureId],
-          },
-          api: [],
-          savedObject: {
-            all: [],
-            read: [],
-          },
-          ui: ['read_cases'], // uiCapabilities[uiCapabilities[casesFeatureId]].read_cases
-        },
-      },
-    });
-
     const config = this.initContext.config.get<ObservabilityConfig>();
+
+    if (config.unsafe.cases.enabled) {
+      plugins.features.registerKibanaFeature({
+        id: casesFeatureId,
+        name: i18n.translate('xpack.observability.featureRegistry.linkObservabilityTitle', {
+          defaultMessage: 'Cases',
+        }),
+        order: 1100,
+        category: DEFAULT_APP_CATEGORIES.observability,
+        app: [casesFeatureId, 'kibana'],
+        catalogue: [observabilityFeatureId],
+        cases: [observabilityFeatureId],
+        privileges: {
+          all: {
+            app: [casesFeatureId, 'kibana'],
+            catalogue: [observabilityFeatureId],
+            cases: {
+              all: [observabilityFeatureId],
+            },
+            api: [],
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['crud_cases', 'read_cases'], // uiCapabilities[casesFeatureId].crud_cases or read_cases
+          },
+          read: {
+            app: [casesFeatureId, 'kibana'],
+            catalogue: [observabilityFeatureId],
+            cases: {
+              read: [observabilityFeatureId],
+            },
+            api: [],
+            savedObject: {
+              all: [],
+              read: [],
+            },
+            ui: ['read_cases'], // uiCapabilities[uiCapabilities[casesFeatureId]].read_cases
+          },
+        },
+      });
+    }
 
     let annotationsApiPromise: Promise<AnnotationsAPI> | undefined;
 


### PR DESCRIPTION
This PR addresses: https://github.com/elastic/kibana/issues/104964 

The issue is that the Cases privileges was selected through the Observability section even when the feature flag was disabling the Cases UI. This fix does not register the cases feature within observability when the feature flag is marked as disabled.

<details><summary>Cases disabled via the kibana.dev.yml feature flag:</summary>

![image](https://user-images.githubusercontent.com/56361221/125340310-533e9100-e320-11eb-91d9-0401e16370fb.png)

</details>

<details><summary>Cases enabled via the kibana.dev.yml feature flag:</summary>

![image](https://user-images.githubusercontent.com/56361221/125340973-14f5a180-e321-11eb-9139-df068baa2aae.png)

</details>