### PR TITLE
[CTI] adds Recorded Future link

### DIFF
--- a/x-pack/plugins/security_solution/common/cti/constants.ts
+++ b/x-pack/plugins/security_solution/common/cti/constants.ts
@@ -65,9 +65,9 @@ export const CTI_DEFAULT_SOURCES = [
   'Abuse Malware',
   'AlienVault OTX',
   'Anomali',
-  'Anomali ThreatStream',
   'Malware Bazaar',
   'MISP',
+  'Recorded Future',
 ];
 
 export const DEFAULT_CTI_SOURCE_INDEX = ['filebeat-*'];

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
@@ -159,10 +159,10 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
                           alignItems="center"
                           justifyContent="flexEnd"
                         >
-                          <DashboardRightSideElement key={`${title}-count`}>
+                          <DashboardRightSideElement key={`${title}-count`} grow={false}>
                             {count}
                           </DashboardRightSideElement>
-                          <DashboardRightSideElement key={`${title}-source`}>
+                          <DashboardRightSideElement key={`${title}-source`} grow={false}>
                             {path ? (
                               <RightSideLink href={path} target="_blank">
                                 {linkCopy}

--- a/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/index.tsx
@@ -74,8 +74,8 @@ export const useCtiDashboardLinks = (
                   })
                 )
               );
-              const items = DashboardsSO.savedObjects?.reduce(
-                (acc: CtiListItem[], dashboardSO, i) => {
+              const items = DashboardsSO.savedObjects
+                ?.reduce((acc: CtiListItem[], dashboardSO, i) => {
                   const item = createLinkFromDashboardSO(
                     dashboardSO,
                     eventCountsByDataset,
@@ -87,9 +87,8 @@ export const useCtiDashboardLinks = (
                     acc.push(item);
                   }
                   return acc;
-                },
-                []
-              );
+                }, [])
+                .sort((a, b) => (a.title > b.title ? 1 : -1));
               setListItems(items);
             } else {
               handleDisabledPlugin();


### PR DESCRIPTION
## Summary

 - adds Recorded Future dashboard link to CTI Dashboard Link Panel on Overview Page
 - fixes minor styling issue on the Dashboard Link Panel
 - sorts panel links in alphabetical order

## Notes
- was unable to create the Recorded Future dashboard by following the steps outlined in [here](https://github.com/elastic/kibana/pull/100423#issue-649464731). Until there is a Dashboard Saved Object with a 'threat intel' tag and 'Recorded Future' title, the link will be dormant.
- Removed Anomali ThreatStream link (which was also dormant) as there seems to be a single dashboard link for Anomali in general. 