### PR TITLE
[Workplace Search] Handle edge case for GitHub oAuth URL mismatch

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -27,6 +27,7 @@ import {
   getSourcesPath,
 } from '../../../../routes';
 import { CustomSource } from '../../../../types';
+import { PERSONAL_DASHBOARD_SOURCE_ERROR } from '../../constants';
 import { SourcesLogic } from '../../sources_logic';
 
 import {
@@ -378,7 +379,9 @@ describe('AddSourceLogic', () => {
 
           expect(navigateToUrl).toHaveBeenCalledWith(PERSONAL_SOURCES_PATH);
           expect(setErrorMessage).toHaveBeenCalledWith(
-            'The redirect_uri MUST match the registered callback URL for this application.'
+            PERSONAL_DASHBOARD_SOURCE_ERROR(
+              'The redirect_uri MUST match the registered callback URL for this application.'
+            )
           );
         });
       });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -359,9 +359,11 @@ describe('AddSourceLogic', () => {
       });
 
       describe('Github error edge case', () => {
+        const getGithubQueryString = (context: 'organization' | 'account') =>
+          `?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22${context}%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TOKEN%3D%3D%22%2C%22index_permissions%22%3Afalse%7D`;
+
         it('handles "organization" redirect and displays error', () => {
-          const githubQueryString =
-            '?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22organization%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TTAyYktJSkU5Um9PQ0p5clNEbGk0MnM0cXhqMXZXaDBxdG8zeXQ3YkRnYkIyempWaUMwMGpuZmpLR25pcHRKT0RxUXFvbTJGM20vZE5RcUpEcVhWNEE9PQ%3D%3D%22%2C%22index_permissions%22%3Afalse%7D';
+          const githubQueryString = getGithubQueryString('organization');
           AddSourceLogic.actions.saveSourceParams(githubQueryString);
 
           expect(navigateToUrl).toHaveBeenCalledWith('/');
@@ -371,8 +373,7 @@ describe('AddSourceLogic', () => {
         });
 
         it('handles "account" redirect and displays error', () => {
-          const githubQueryString =
-            '?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22account%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TTAyYktJSkU5Um9PQ0p5clNEbGk0MnM0cXhqMXZXaDBxdG8zeXQ3YkRnYkIyempWaUMwMGpuZmpLR25pcHRKT0RxUXFvbTJGM20vZE5RcUpEcVhWNEE9PQ%3D%3D%22%2C%22index_permissions%22%3Afalse%7D';
+          const githubQueryString = getGithubQueryString('account');
           AddSourceLogic.actions.saveSourceParams(githubQueryString);
 
           expect(navigateToUrl).toHaveBeenCalledWith(PERSONAL_SOURCES_PATH);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -20,7 +20,12 @@ jest.mock('../../../../app_logic', () => ({
 }));
 import { AppLogic } from '../../../../app_logic';
 
-import { ADD_GITHUB_PATH, SOURCES_PATH, getSourcesPath } from '../../../../routes';
+import {
+  ADD_GITHUB_PATH,
+  SOURCES_PATH,
+  PERSONAL_SOURCES_PATH,
+  getSourcesPath,
+} from '../../../../routes';
 import { CustomSource } from '../../../../types';
 import { SourcesLogic } from '../../sources_logic';
 
@@ -36,7 +41,7 @@ describe('AddSourceLogic', () => {
   const { mount } = new LogicMounter(AddSourceLogic);
   const { http } = mockHttpValues;
   const { navigateToUrl } = mockKibanaValues;
-  const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
+  const { clearFlashMessages, flashAPIErrors, setErrorMessage } = mockFlashMessageHelpers;
 
   const defaultValues = {
     addSourceCurrentStep: AddSourceSteps.ConfigIntroStep,
@@ -351,6 +356,30 @@ describe('AddSourceLogic', () => {
 
         expect(setPreContentSourceIdSpy).toHaveBeenCalledWith(preContentSourceId);
         expect(navigateToUrl).toHaveBeenCalledWith(`${ADD_GITHUB_PATH}/configure${queryString}`);
+      });
+
+      describe('Github error edge case', () => {
+        it('handles "organization" redirect and displays error', () => {
+          const githubQueryString =
+            '?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22organization%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TTAyYktJSkU5Um9PQ0p5clNEbGk0MnM0cXhqMXZXaDBxdG8zeXQ3YkRnYkIyempWaUMwMGpuZmpLR25pcHRKT0RxUXFvbTJGM20vZE5RcUpEcVhWNEE9PQ%3D%3D%22%2C%22index_permissions%22%3Afalse%7D';
+          AddSourceLogic.actions.saveSourceParams(githubQueryString);
+
+          expect(navigateToUrl).toHaveBeenCalledWith('/');
+          expect(setErrorMessage).toHaveBeenCalledWith(
+            'The redirect_uri MUST match the registered callback URL for this application.'
+          );
+        });
+
+        it('handles "account" redirect and displays error', () => {
+          const githubQueryString =
+            '?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22account%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TTAyYktJSkU5Um9PQ0p5clNEbGk0MnM0cXhqMXZXaDBxdG8zeXQ3YkRnYkIyempWaUMwMGpuZmpLR25pcHRKT0RxUXFvbTJGM20vZE5RcUpEcVhWNEE9PQ%3D%3D%22%2C%22index_permissions%22%3Afalse%7D';
+          AddSourceLogic.actions.saveSourceParams(githubQueryString);
+
+          expect(navigateToUrl).toHaveBeenCalledWith(PERSONAL_SOURCES_PATH);
+          expect(setErrorMessage).toHaveBeenCalledWith(
+            'The redirect_uri MUST match the registered callback URL for this application.'
+          );
+        });
       });
 
       it('handles error', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -30,6 +30,7 @@ import {
   getSourcesPath,
 } from '../../../../routes';
 import { CustomSource } from '../../../../types';
+import { PERSONAL_DASHBOARD_SOURCE_ERROR } from '../../constants';
 import { staticSourceData } from '../../source_data';
 import { SourcesLogic } from '../../sources_logic';
 
@@ -517,7 +518,11 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       */
       if (params.error_description) {
         navigateToUrl(isOrganization ? '/' : PERSONAL_SOURCES_PATH);
-        setErrorMessage(params.error_description);
+        setErrorMessage(
+          isOrganization
+            ? params.error_description
+            : PERSONAL_DASHBOARD_SOURCE_ERROR(params.error_description)
+        );
         return;
       }
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -510,8 +510,8 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       const isOrganization = state.context !== 'account';
 
       /**
-        There is an extreme edge case where the user is trying to connect Github as source ent-search,
-        after configuring it in Kibana. When this happens Github redirects the user from ent-search to Kibana
+        There is an extreme edge case where the user is trying to connect Github as source from ent-search,
+        after configuring it in Kibana. When this happens, Github redirects the user from ent-search to Kibana
         with special error properties in the query params. In this case we need to redirect the user to the
         app home page and display the error message, and not persist the other query params to the server.
       */

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -16,13 +16,19 @@ import {
   flashAPIErrors,
   setSuccessMessage,
   clearFlashMessages,
+  setErrorMessage,
 } from '../../../../../shared/flash_messages';
 import { HttpLogic } from '../../../../../shared/http';
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { parseQueryParams } from '../../../../../shared/query_params';
 import { AppLogic } from '../../../../app_logic';
 import { CUSTOM_SERVICE_TYPE, WORKPLACE_SEARCH_URL_PREFIX } from '../../../../constants';
-import { SOURCES_PATH, ADD_GITHUB_PATH, getSourcesPath } from '../../../../routes';
+import {
+  SOURCES_PATH,
+  ADD_GITHUB_PATH,
+  PERSONAL_SOURCES_PATH,
+  getSourcesPath,
+} from '../../../../routes';
 import { CustomSource } from '../../../../types';
 import { staticSourceData } from '../../source_data';
 import { SourcesLogic } from '../../sources_logic';
@@ -50,6 +56,8 @@ export interface OauthParams {
   state: string;
   session_state: string;
   oauth_verifier?: string;
+  error?: string;
+  error_description?: string;
 }
 
 export interface AddSourceActions {
@@ -500,6 +508,18 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       const route = '/api/workplace_search/sources/create';
       const state = JSON.parse(params.state);
       const isOrganization = state.context !== 'account';
+
+      /**
+        There is an extreme edge case where the user is trying to connect Github as source ent-search,
+        after configuring it in Kibana. When this happens Github redirects the user from ent-search to Kibana
+        with special error properties in the query params. In this case we need to redirect the user to the
+        app home page and display the error message, and not persist the other query params to the server.
+      */
+      if (params.error_description) {
+        navigateToUrl(isOrganization ? '/' : PERSONAL_SOURCES_PATH);
+        setErrorMessage(params.error_description);
+        return;
+      }
 
       try {
         const response = await http.get(route, { query });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/constants.ts
@@ -470,3 +470,10 @@ export const PRIVATE_DASHBOARD_READ_ONLY_MODE_WARNING = i18n.translate(
       'Workplace Search is currently available for search only, due to regular maintenance. Contact your system administrator for more information.',
   }
 );
+
+export const PERSONAL_DASHBOARD_SOURCE_ERROR = (error: string) =>
+  i18n.translate('xpack.enterpriseSearch.workplaceSearch.personalDashboardSourceError', {
+    defaultMessage:
+      'Could not connect the source, reach out to your admin for help. Error message: {error}',
+    values: { error },
+  });


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1850

## Summary

This PR addresses a rare bug when a user configures Github in Kibana and then tries to connect it in ent-search. The issue is that all other connectors such as Google Drive handle this gracefully by showing an error such as this:

![image](https://user-images.githubusercontent.com/1869731/125344033-68b1bc00-e31c-11eb-964e-94f8da1c7921.png)

Github, however, redirects the user to the oAuth redirect URL on file with error params that otherwise do not exist. The fix it to look for those errors in the logic file and break out of the flow, redirect the user the Kibana Enterprise Search landing page, and show the error.

**Organization**
![org](https://user-images.githubusercontent.com/1869731/125344232-a9a9d080-e31c-11eb-8f34-004e31d87692.png)

**Note:** The overview page was selected here because the redirects that occur for users with no sources vs users with sources were causing the flash messages not to be displayed. This is such an edge case that I decided it was ok to drop the user on the main Workplace Search page since they did not intend to come here anyway. 

**Personal**
![image](https://user-images.githubusercontent.com/1869731/125498055-73a93573-7b99-4e12-86b6-565a13a321e1.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
