### PR TITLE
[project-assigner] Add entry for Platform Security Team

### DIFF
--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -17,6 +17,7 @@ jobs:
               {"label": "Feature:Canvas", "projectNumber": 38, "columnName": "Inbox"},
               {"label": "Feature:Dashboard", "projectNumber": 68, "columnName": "Inbox"},
               {"label": "Feature:Drilldowns", "projectNumber": 68, "columnName": "Inbox"},
-              {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"}
+              {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"},
+              {"label": "Team:Security", "projectNumber": 320, "columnName": "Awaiting triage", "projectScope": "org"}
             ]
           ghToken: ${{ secrets.PROJECT_ASSIGNER_TOKEN }}

--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -11,5 +11,12 @@ jobs:
         uses: elastic/github-actions/project-assigner@v2.0.0
         id: project_assigner
         with:
-          issue-mappings: '[{"label": "Feature:Lens", "projectNumber": 32, "columnName": "Long-term goals"}, {"label": "Feature:Canvas", "projectNumber": 38, "columnName": "Inbox"}, {"label": "Feature:Dashboard", "projectNumber": 68, "columnName": "Inbox"}, {"label": "Feature:Drilldowns", "projectNumber": 68, "columnName": "Inbox"}, {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"}]'
+          issue-mappings: |
+            [
+              {"label": "Feature:Lens", "projectNumber": 32, "columnName": "Long-term goals"},
+              {"label": "Feature:Canvas", "projectNumber": 38, "columnName": "Inbox"},
+              {"label": "Feature:Dashboard", "projectNumber": 68, "columnName": "Inbox"},
+              {"label": "Feature:Drilldowns", "projectNumber": 68, "columnName": "Inbox"},
+              {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"}
+            ]
           ghToken: ${{ secrets.PROJECT_ASSIGNER_TOKEN }}


### PR DESCRIPTION
## Summary

Add auto-assigner entry for `Team:Security` GH label to appropriate org-level project for the Platform Security Team.