### PR TITLE
[Security Solution][Endpoint][Host Isolation] Fixes bug to remove excess host metadata status toasts on non user initiated errors

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -400,6 +400,11 @@ export enum HostStatus {
    * Host is inactive as indicated by its checkin status during the last checkin window
    */
   INACTIVE = 'inactive',
+
+  /**
+   * Host is unenrolled
+   */
+  UNENROLLED = 'unenrolled',
 }
 
 export type PolicyInfo = Immutable<{

--- a/x-pack/plugins/security_solution/public/common/components/endpoint/agent_status.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/agent_status.tsx
@@ -20,7 +20,7 @@ export const AgentStatus = React.memo(({ hostStatus }: { hostStatus: HostStatus 
     >
       <FormattedMessage
         id="xpack.securitySolution.endpoint.list.hostStatusValue"
-        defaultMessage="{hostStatus, select, healthy {Healthy} unhealthy {Unhealthy} updating {Updating} offline {Offline} inactive {Inactive} other {Unhealthy}}"
+        defaultMessage="{hostStatus, select, healthy {Healthy} unhealthy {Unhealthy} updating {Updating} offline {Offline} inactive {Inactive} unenrolled {Unenrolled} other {Unhealthy}}"
         values={{ hostStatus }}
       />
     </EuiBadge>

--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/take_action_dropdown.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/take_action_dropdown.tsx
@@ -10,6 +10,7 @@ import { EuiContextMenuItem, EuiContextMenuPanel, EuiButton, EuiPopover } from '
 import { ISOLATE_HOST, UNISOLATE_HOST } from './translations';
 import { TAKE_ACTION } from '../alerts_table/alerts_utility_bar/translations';
 import { useHostIsolationStatus } from '../../containers/detection_engine/alerts/use_host_isolation_status';
+import { HostStatus } from '../../../../common/endpoint/types';
 
 export const TakeActionDropdown = React.memo(
   ({
@@ -19,7 +20,9 @@ export const TakeActionDropdown = React.memo(
     onChange: (action: 'isolateHost' | 'unisolateHost') => void;
     agentId: string;
   }) => {
-    const { loading, isIsolated: isolationStatus } = useHostIsolationStatus({ agentId });
+    const { loading, isIsolated: isolationStatus, agentStatus } = useHostIsolationStatus({
+      agentId,
+    });
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
     const closePopoverHandler = useCallback(() => {
@@ -41,7 +44,7 @@ export const TakeActionDropdown = React.memo(
           iconSide="right"
           fill
           iconType="arrowDown"
-          disabled={loading}
+          disabled={loading || agentStatus === HostStatus.UNENROLLED}
           onClick={() => {
             setIsPopoverOpen(!isPopoverOpen);
           }}
@@ -49,7 +52,7 @@ export const TakeActionDropdown = React.memo(
           {TAKE_ACTION}
         </EuiButton>
       );
-    }, [isPopoverOpen, loading]);
+    }, [isPopoverOpen, loading, agentStatus]);
 
     return (
       <EuiPopover

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/translations.ts
@@ -37,13 +37,3 @@ export const CASES_FROM_ALERTS_FAILURE = i18n.translate(
   'xpack.securitySolution.endpoint.hostIsolation.casesFromAlerts.title',
   { defaultMessage: 'Failed to find associated cases' }
 );
-
-export const ISOLATION_STATUS_FAILURE = i18n.translate(
-  'xpack.securitySolution.endpoint.hostIsolation.isolationStatus.title',
-  { defaultMessage: 'Failed to retrieve current isolation status' }
-);
-
-export const ISOLATION_PENDING_FAILURE = i18n.translate(
-  'xpack.securitySolution.endpoint.hostIsolation.isolationPending.title',
-  { defaultMessage: 'Failed to retrieve isolation pending statuses' }
-);

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/host_constants.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/host_constants.ts
@@ -18,6 +18,7 @@ export const HOST_STATUS_TO_BADGE_COLOR = Object.freeze<
   [HostStatus.UPDATING]: 'primary',
   [HostStatus.OFFLINE]: 'default',
   [HostStatus.INACTIVE]: 'default',
+  [HostStatus.UNENROLLED]: 'default',
 });
 
 export const POLICY_STATUS_TO_HEALTH_COLOR = Object.freeze<

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/agent_statuses.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/agent_statuses.tsx
@@ -6,11 +6,12 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { DefaultDraggable } from '../../../../../common/components/draggables';
 import { EndpointHostIsolationStatus } from '../../../../../common/components/endpoint/host_isolation';
 import { useHostIsolationStatus } from '../../../../../detections/containers/detection_engine/alerts/use_host_isolation_status';
 import { AgentStatus } from '../../../../../common/components/endpoint/agent_status';
+import { EMPTY_STATUS } from './translations';
 
 export const AgentStatuses = React.memo(
   ({
@@ -31,18 +32,25 @@ export const AgentStatuses = React.memo(
       pendingUnisolation,
     } = useHostIsolationStatus({ agentId: value });
     const isolationFieldName = 'host.isolation';
+    console.log(agentStatus);
     return (
       <EuiFlexGroup gutterSize="none">
-        <EuiFlexItem grow={false}>
-          <DefaultDraggable
-            field={fieldName}
-            id={`event-details-value-default-draggable-${contextId}-${eventId}-${fieldName}-${value}`}
-            tooltipContent={fieldName}
-            value={`${agentStatus}`}
-          >
-            <AgentStatus hostStatus={agentStatus} />
-          </DefaultDraggable>
-        </EuiFlexItem>
+        {agentStatus !== undefined ? (
+          <EuiFlexItem grow={false}>
+            <DefaultDraggable
+              field={fieldName}
+              id={`event-details-value-default-draggable-${contextId}-${eventId}-${fieldName}-${value}`}
+              tooltipContent={fieldName}
+              value={`${agentStatus}`}
+            >
+              <AgentStatus hostStatus={agentStatus} />
+            </DefaultDraggable>
+          </EuiFlexItem>
+        ) : (
+          <EuiText>
+            <p>{EMPTY_STATUS}</p>
+          </EuiText>
+        )}
         <EuiFlexItem grow={false}>
           <DefaultDraggable
             field={isolationFieldName}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/agent_statuses.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/agent_statuses.tsx
@@ -32,7 +32,6 @@ export const AgentStatuses = React.memo(
       pendingUnisolation,
     } = useHostIsolationStatus({ agentId: value });
     const isolationFieldName = 'host.isolation';
-    console.log(agentStatus);
     return (
       <EuiFlexGroup gutterSize="none">
         {agentStatus !== undefined ? (

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/translations.ts
@@ -44,3 +44,10 @@ export const LINK_ELASTIC_ENDPOINT_SECURITY = i18n.translate(
     defaultMessage: 'Open in Endpoint Security',
   }
 );
+
+export const EMPTY_STATUS = i18n.translate(
+  'xpack.securitySolution.hostIsolation.agentStatuses.empty',
+  {
+    defaultMessage: '-',
+  }
+);


### PR DESCRIPTION
## Summary

- [x] This PR silently catches api calls to the endpoint host metadata api and isolation pending apis to prevent showing the user error toasts when the user has no control over the call
- [x] If the error code status from the host metadata api is 404, the agent status will show an "unenrolled" badge only on the alert details flyout + Take Action dropdown is disabled
- [x] Fixes a separate bug where an `Unhealthy` badge flashes right before the actual agent status badge finally loads. The default during the loading state is now replaced with a text `-`. 

## Screenshots 
A dash shows right before the actual agent status is loaded
![quikdash](https://user-images.githubusercontent.com/56409205/125354969-72461e80-e332-11eb-8d4d-ef4dfad75616.gif)

Unenrolled badge for 404 error, Take Action button is disabled
![image](https://user-images.githubusercontent.com/56409205/125359698-b3413180-e338-11eb-8b8b-25b3e0257853.png)
