### PR TITLE
[APM] Fixes support for APM data streams in Security and Timelines UIs

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -110,6 +110,7 @@ export const APP_EVENT_FILTERS_PATH = `${APP_PATH}${EVENT_FILTERS_PATH}`;
 /** The comma-delimited list of Elasticsearch indices from which the SIEM app collects events */
 export const DEFAULT_INDEX_PATTERN = [
   'apm-*-transaction*',
+  'traces-apm*',
   'auditbeat-*',
   'endgame-*',
   'filebeat-*',

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -98,6 +98,7 @@ export interface MachineLearningRule {
 
 export const getIndexPatterns = (): string[] => [
   'apm-*-transaction*',
+  'traces-apm*',
   'auditbeat-*',
   'endgame-*',
   'filebeat-*',

--- a/x-pack/plugins/security_solution/public/common/components/drag_and_drop/__snapshots__/drag_drop_context_wrapper.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/drag_and_drop/__snapshots__/drag_drop_context_wrapper.test.tsx.snap
@@ -366,6 +366,7 @@ exports[`DragDropContextWrapper rendering it renders against the snapshot 1`] = 
             "format": "",
             "indexes": Array [
               "apm-*-transaction*",
+              "traces-apm*",
               "auditbeat-*",
               "endgame-*",
               "filebeat-*",

--- a/x-pack/plugins/security_solution/public/common/components/event_details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/__mocks__/index.ts
@@ -406,6 +406,7 @@ export const mockAlertDetailsData = [
     field: 'signal.rule.index',
     values: [
       'apm-*-transaction*',
+      'traces-apm*',
       'auditbeat-*',
       'endgame-*',
       'filebeat-*',
@@ -415,6 +416,7 @@ export const mockAlertDetailsData = [
     ],
     originalValue: [
       'apm-*-transaction*',
+      'traces-apm*',
       'auditbeat-*',
       'endgame-*',
       'filebeat-*',

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
@@ -34,12 +34,12 @@ jest.mock('react-redux', () => {
 
 const mockOptions = [
   { label: 'apm-*-transaction*', value: 'apm-*-transaction*' },
-  { label: 'traces-apm*', value: 'traces-apm*' },
   { label: 'auditbeat-*', value: 'auditbeat-*' },
   { label: 'endgame-*', value: 'endgame-*' },
   { label: 'filebeat-*', value: 'filebeat-*' },
   { label: 'logs-*', value: 'logs-*' },
   { label: 'packetbeat-*', value: 'packetbeat-*' },
+  { label: 'traces-apm*', value: 'traces-apm*' },
   { label: 'winlogbeat-*', value: 'winlogbeat-*' },
 ];
 

--- a/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/sourcerer/index.test.tsx
@@ -34,6 +34,7 @@ jest.mock('react-redux', () => {
 
 const mockOptions = [
   { label: 'apm-*-transaction*', value: 'apm-*-transaction*' },
+  { label: 'traces-apm*', value: 'traces-apm*' },
   { label: 'auditbeat-*', value: 'auditbeat-*' },
   { label: 'endgame-*', value: 'endgame-*' },
   { label: 'filebeat-*', value: 'filebeat-*' },

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/selectors.test.ts
@@ -18,12 +18,12 @@ describe('Sourcerer selectors', () => {
         mapStateToProps(mockGlobalState, SourcererScopeName.default).selectedPatterns
       ).toEqual([
         'apm-*-transaction*',
-        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',
         'logs-*',
         'packetbeat-*',
+        'traces-apm*',
         'winlogbeat-*',
         '-*elastic-cloud-logs-*',
       ]);
@@ -39,11 +39,11 @@ describe('Sourcerer selectors', () => {
         mapStateToProps(myMockGlobalState, SourcererScopeName.default).selectedPatterns
       ).toEqual([
         'apm-*-transaction*',
-        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',
         'packetbeat-*',
+        'traces-apm*',
         'winlogbeat-*',
       ]);
     });
@@ -61,12 +61,12 @@ describe('Sourcerer selectors', () => {
         mapStateToProps(myMockGlobalState, SourcererScopeName.default).selectedPatterns
       ).toEqual([
         'apm-*-transaction*',
-        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',
         'logs-endpoint.event-*',
         'packetbeat-*',
+        'traces-apm*',
         'winlogbeat-*',
       ]);
     });

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/selectors.test.ts
@@ -18,6 +18,7 @@ describe('Sourcerer selectors', () => {
         mapStateToProps(mockGlobalState, SourcererScopeName.default).selectedPatterns
       ).toEqual([
         'apm-*-transaction*',
+        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',
@@ -38,6 +39,7 @@ describe('Sourcerer selectors', () => {
         mapStateToProps(myMockGlobalState, SourcererScopeName.default).selectedPatterns
       ).toEqual([
         'apm-*-transaction*',
+        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',
@@ -59,6 +61,7 @@ describe('Sourcerer selectors', () => {
         mapStateToProps(myMockGlobalState, SourcererScopeName.default).selectedPatterns
       ).toEqual([
         'apm-*-transaction*',
+        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
@@ -175,6 +175,7 @@ export const alertsMock: AlertSearchResponse<unknown, unknown> = {
               immutable: false,
               index: [
                 'apm-*-transaction*',
+                'traces-apm*',
                 'auditbeat-*',
                 'endgame-*',
                 'filebeat-*',
@@ -414,6 +415,7 @@ export const alertsMock: AlertSearchResponse<unknown, unknown> = {
               immutable: false,
               index: [
                 'apm-*-transaction*',
+                'traces-apm*',
                 'auditbeat-*',
                 'endgame-*',
                 'filebeat-*',
@@ -619,6 +621,7 @@ export const alertsMock: AlertSearchResponse<unknown, unknown> = {
               immutable: false,
               index: [
                 'apm-*-transaction*',
+                'traces-apm*',
                 'auditbeat-*',
                 'endgame-*',
                 'filebeat-*',
@@ -822,6 +825,7 @@ export const alertsMock: AlertSearchResponse<unknown, unknown> = {
               immutable: false,
               index: [
                 'apm-*-transaction*',
+                'traces-apm*',
                 'auditbeat-*',
                 'endgame-*',
                 'filebeat-*',

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/mock.ts
@@ -20,6 +20,7 @@ export const savedRuleMock: Rule = {
   id: '12345678987654321',
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule.test.tsx
@@ -54,6 +54,7 @@ describe('useRule', () => {
           immutable: false,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_status.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_status.test.tsx
@@ -43,6 +43,7 @@ const testRule: Rule = {
   immutable: false,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_with_fallback.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_with_fallback.test.tsx
@@ -62,6 +62,7 @@ describe('useRuleWithFallback', () => {
             "immutable": false,
             "index": Array [
               "apm-*-transaction*",
+              "traces-apm*",
               "auditbeat-*",
               "endgame-*",
               "filebeat-*",
@@ -125,6 +126,7 @@ describe('useRuleWithFallback', () => {
             "immutable": false,
             "index": Array [
               "apm-*-transaction*",
+              "traces-apm*",
               "auditbeat-*",
               "endgame-*",
               "filebeat-*",

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/__mocks__/mock.ts
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/__mocks__/mock.ts
@@ -14,6 +14,7 @@ export const mockIndexPatternIds: IndexPatternMapping[] = [
 
 export const mockAPMIndexPatternIds: IndexPatternMapping[] = [
   { title: 'apm-*', id: '8c7323ac-97ad-4b53-ac0a-40f8f691a918' },
+  { title: 'traces-apm*,logs-apm*,metrics-apm*,apm-*', id: '8c7323ac-97ad-4b53-ac0a-40f8f691a918' },
 ];
 
 export const mockSourceLayer = {
@@ -465,6 +466,15 @@ export const mockAPMTransactionIndexPattern: IndexPatternSavedObject = {
   _version: 'abc',
   attributes: {
     title: 'apm-*-transaction*',
+  },
+};
+
+export const mockAPMTracesDataStreamIndexPattern: IndexPatternSavedObject = {
+  id: 'traces-apm*',
+  type: 'index-pattern',
+  _version: 'abc',
+  attributes: {
+    title: 'traces-apm*',
   },
 };
 

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/__mocks__/mock.ts
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/__mocks__/mock.ts
@@ -184,6 +184,11 @@ export const mockClientLayer = {
   joins: [],
 };
 
+const mockApmDataStreamClientLayer = {
+  ...mockClientLayer,
+  label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Client Point',
+};
+
 export const mockServerLayer = {
   sourceDescriptor: {
     id: 'uuid.v4()',
@@ -237,6 +242,11 @@ export const mockServerLayer = {
   visible: true,
   type: 'VECTOR',
   query: { query: '', language: 'kuery' },
+};
+
+const mockApmDataStreamServerLayer = {
+  ...mockServerLayer,
+  label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Server Point',
 };
 
 export const mockLineLayer = {
@@ -366,6 +376,10 @@ export const mockClientServerLineLayer = {
   type: 'VECTOR',
   query: { query: '', language: 'kuery' },
 };
+const mockApmDataStreamClientServerLineLayer = {
+  ...mockClientServerLineLayer,
+  label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Line',
+};
 
 export const mockLayerList = [
   {
@@ -422,6 +436,9 @@ export const mockLayerListMixed = [
   mockClientServerLineLayer,
   mockServerLayer,
   mockClientLayer,
+  mockApmDataStreamClientServerLineLayer,
+  mockApmDataStreamServerLayer,
+  mockApmDataStreamClientLayer,
 ];
 
 export const mockAPMIndexPattern: IndexPatternSavedObject = {

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.test.tsx
@@ -12,6 +12,7 @@ import {
   mockAPMIndexPattern,
   mockAPMRegexIndexPattern,
   mockAPMTransactionIndexPattern,
+  mockAPMTracesDataStreamIndexPattern,
   mockAuditbeatIndexPattern,
   mockCCSGlobIndexPattern,
   mockCommaFilebeatAuditbeatCCSGlobIndexPattern,
@@ -69,6 +70,7 @@ describe('embedded_map_helpers', () => {
   describe('findMatchingIndexPatterns', () => {
     const siemDefaultIndices = [
       'apm-*-transaction*',
+      'traces-apm*',
       'auditbeat-*',
       'endgame-*',
       'filebeat-*',
@@ -102,11 +104,16 @@ describe('embedded_map_helpers', () => {
 
     test('finds exact glob-matched index patterns ', () => {
       const matchingIndexPatterns = findMatchingIndexPatterns({
-        kibanaIndexPatterns: [mockAPMTransactionIndexPattern, mockFilebeatIndexPattern],
+        kibanaIndexPatterns: [
+          mockAPMTransactionIndexPattern,
+          mockAPMTracesDataStreamIndexPattern,
+          mockFilebeatIndexPattern,
+        ],
         siemDefaultIndices,
       });
       expect(matchingIndexPatterns).toEqual([
         mockAPMTransactionIndexPattern,
+        mockAPMTracesDataStreamIndexPattern,
         mockFilebeatIndexPattern,
       ]);
     });

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/map_config.ts
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/map_config.ts
@@ -61,6 +61,21 @@ export const SUM_OF_DESTINATION_BYTES = 'sum_of_destination.bytes';
 export const SUM_OF_CLIENT_BYTES = 'sum_of_client.bytes';
 export const SUM_OF_SERVER_BYTES = 'sum_of_server.bytes';
 
+const APM_LAYER_FIELD_MAPPING = {
+  source: {
+    metricField: 'client.bytes',
+    geoField: 'client.geo.location',
+    tooltipProperties: Object.keys(clientFieldMappings),
+    label: i18n.CLIENT_LAYER,
+  },
+  destination: {
+    metricField: 'server.bytes',
+    geoField: 'server.geo.location',
+    tooltipProperties: Object.keys(serverFieldMappings),
+    label: i18n.SERVER_LAYER,
+  },
+};
+
 // Mapping to fields for creating specific layers for a given index pattern
 // e.g. The apm-* index pattern needs layers for client/server instead of source/destination
 export const lmc: LayerMappingCollection = {
@@ -78,20 +93,8 @@ export const lmc: LayerMappingCollection = {
       label: i18n.DESTINATION_LAYER,
     },
   },
-  'apm-*': {
-    source: {
-      metricField: 'client.bytes',
-      geoField: 'client.geo.location',
-      tooltipProperties: Object.keys(clientFieldMappings),
-      label: i18n.CLIENT_LAYER,
-    },
-    destination: {
-      metricField: 'server.bytes',
-      geoField: 'server.geo.location',
-      tooltipProperties: Object.keys(serverFieldMappings),
-      label: i18n.SERVER_LAYER,
-    },
-  },
+  'apm-*': APM_LAYER_FIELD_MAPPING,
+  'traces-apm*,logs-apm*,metrics-apm*,apm-*': APM_LAYER_FIELD_MAPPING,
 };
 
 /**

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/column_headers/__snapshots__/index.test.tsx.snap
@@ -367,6 +367,7 @@ exports[`ColumnHeaders rendering renders correctly against snapshot 1`] = `
             "format": "",
             "indexes": Array [
               "apm-*-transaction*",
+              "traces-apm*",
               "auditbeat-*",
               "endgame-*",
               "filebeat-*",

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/__snapshots__/suricata_row_renderer.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/__snapshots__/suricata_row_renderer.test.tsx.snap
@@ -368,6 +368,7 @@ exports[`suricata_row_renderer renders correctly against snapshot 1`] = `
                 "format": "",
                 "indexes": Array [
                   "apm-*-transaction*",
+                  "traces-apm*",
                   "auditbeat-*",
                   "endgame-*",
                   "filebeat-*",

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/__snapshots__/zeek_details.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/__snapshots__/zeek_details.test.tsx.snap
@@ -366,6 +366,7 @@ exports[`ZeekDetails rendering it renders the default ZeekDetails 1`] = `
             "format": "",
             "indexes": Array [
               "apm-*-transaction*",
+              "traces-apm*",
               "auditbeat-*",
               "endgame-*",
               "filebeat-*",

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/__snapshots__/zeek_row_renderer.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/__snapshots__/zeek_row_renderer.test.tsx.snap
@@ -368,6 +368,7 @@ exports[`zeek_row_renderer renders correctly against snapshot 1`] = `
                 "format": "",
                 "indexes": Array [
                   "apm-*-transaction*",
+                  "traces-apm*",
                   "auditbeat-*",
                   "endgame-*",
                   "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_403_response_to_a_post.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_403_response_to_a_post.json
@@ -7,8 +7,7 @@
     "Security scans and tests may result in these errors. Misconfigured or buggy applications may produce large numbers of these errors. If the source is unexpected, the user unauthorized, or the request unusual, these may indicate suspicious or malicious activity."
   ],
   "index": [
-    "apm-*-transaction*",
-    "traces-apm*"
+    "apm-*-transaction*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_403_response_to_a_post.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_403_response_to_a_post.json
@@ -7,7 +7,8 @@
     "Security scans and tests may result in these errors. Misconfigured or buggy applications may produce large numbers of these errors. If the source is unexpected, the user unauthorized, or the request unusual, these may indicate suspicious or malicious activity."
   ],
   "index": [
-    "apm-*-transaction*"
+    "apm-*-transaction*",
+    "traces-apm*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_405_response_method_not_allowed.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_405_response_method_not_allowed.json
@@ -7,8 +7,7 @@
     "Security scans and tests may result in these errors. Misconfigured or buggy applications may produce large numbers of these errors. If the source is unexpected, the user unauthorized, or the request unusual, these may indicate suspicious or malicious activity."
   ],
   "index": [
-    "apm-*-transaction*",
-    "traces-apm*"
+    "apm-*-transaction*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_405_response_method_not_allowed.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_405_response_method_not_allowed.json
@@ -7,7 +7,8 @@
     "Security scans and tests may result in these errors. Misconfigured or buggy applications may produce large numbers of these errors. If the source is unexpected, the user unauthorized, or the request unusual, these may indicate suspicious or malicious activity."
   ],
   "index": [
-    "apm-*-transaction*"
+    "apm-*-transaction*",
+    "traces-apm*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_null_user_agent.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_null_user_agent.json
@@ -25,8 +25,7 @@
     }
   ],
   "index": [
-    "apm-*-transaction*",
-    "traces-apm*"
+    "apm-*-transaction*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_null_user_agent.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_null_user_agent.json
@@ -25,7 +25,8 @@
     }
   ],
   "index": [
-    "apm-*-transaction*"
+    "apm-*-transaction*",
+    "traces-apm*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_sqlmap_user_agent.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_sqlmap_user_agent.json
@@ -7,8 +7,7 @@
     "This rule does not indicate that a SQL injection attack occurred, only that the `sqlmap` tool was used. Security scans and tests may result in these errors. If the source is not an authorized security tester, this is generally suspicious or malicious activity."
   ],
   "index": [
-    "apm-*-transaction*",
-    "traces-apm*"
+    "apm-*-transaction*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_sqlmap_user_agent.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/apm_sqlmap_user_agent.json
@@ -7,7 +7,8 @@
     "This rule does not indicate that a SQL injection attack occurred, only that the `sqlmap` tool was used. Security scans and tests may result in these errors. If the source is not an authorized security tester, this is generally suspicious or malicious activity."
   ],
   "index": [
-    "apm-*-transaction*"
+    "apm-*-transaction*",
+    "traces-apm*"
   ],
   "language": "kuery",
   "license": "Elastic License v2",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/external_alerts.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/external_alerts.json
@@ -5,6 +5,7 @@
   "description": "Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to immediately begin investigating external alerts in the app.",
   "index": [
     "apm-*-transaction*",
+    "traces-apm*",
     "auditbeat-*",
     "filebeat-*",
     "logs-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/external_alerts.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/external_alerts.json
@@ -5,7 +5,6 @@
   "description": "Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to immediately begin investigating external alerts in the app.",
   "index": [
     "apm-*-transaction*",
-    "traces-apm*",
     "auditbeat-*",
     "filebeat-*",
     "logs-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/detections_admin/detections_role.json
@@ -8,6 +8,7 @@
           ".lists*",
           ".items*",
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/hunter/detections_role.json
@@ -5,6 +5,7 @@
       {
         "names": [
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/platform_engineer/detections_role.json
@@ -9,6 +9,7 @@
       {
         "names": [
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/rule_author/detections_role.json
@@ -5,6 +5,7 @@
       {
         "names": [
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/soc_manager/detections_role.json
@@ -5,6 +5,7 @@
       {
         "names": [
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t1_analyst/detections_role.json
@@ -6,6 +6,7 @@
       {
         "names": [
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/roles_users/t2_analyst/detections_role.json
@@ -8,6 +8,7 @@
           ".lists*",
           ".items*",
           "apm-*-transaction*",
+          "traces-apm*",
           "auditbeat-*",
           "endgame-*",
           "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/rules/patches/simplest_updated_name.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/rules/patches/simplest_updated_name.json
@@ -8,6 +8,7 @@
   "from": "now-360s",
   "index": [
     "apm-*-transaction*",
+    "traces-apm*",
     "auditbeat-*",
     "endgame-*",
     "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/rules/queries/query_with_mappings.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/rules/queries/query_with_mappings.json
@@ -3,6 +3,7 @@
   "enabled": false,
   "index": [
     "apm-*-transaction*",
+    "traces-apm*",
     "auditbeat-*",
     "endgame-*",
     "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/rules/test_cases/queries/action_without_meta.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/scripts/rules/test_cases/queries/action_without_meta.json
@@ -2,6 +2,7 @@
   "type": "query",
   "index": [
     "apm-*-transaction*",
+    "traces-apm*",
     "auditbeat-*",
     "endgame-*",
     "filebeat-*",

--- a/x-pack/plugins/security_solution/server/lib/source_status/elasticsearch_adapter.ts
+++ b/x-pack/plugins/security_solution/server/lib/source_status/elasticsearch_adapter.ts
@@ -12,6 +12,7 @@ import { ApmServiceNameAgg } from './types';
 import { ENDPOINT_METADATA_INDEX } from '../../../common/constants';
 
 const APM_INDEX_NAME = 'apm-*-transaction*';
+const APM_DATA_STREAM = 'traces-apm*';
 
 export class ElasticsearchSourceStatusAdapter implements SourceStatusAdapter {
   constructor(private readonly framework: FrameworkAdapter) {}
@@ -23,7 +24,9 @@ export class ElasticsearchSourceStatusAdapter implements SourceStatusAdapter {
       // Add endpoint metadata index to indices to check
       indexNames.push(ENDPOINT_METADATA_INDEX);
       // Remove APM index if exists, and only query if length > 0 in case it's the only index provided
-      const nonApmIndexNames = indexNames.filter((name) => name !== APM_INDEX_NAME);
+      const nonApmIndexNames = indexNames.filter(
+        (name) => name !== APM_INDEX_NAME && name !== APM_DATA_STREAM
+      );
       const indexCheckResponse = await (nonApmIndexNames.length > 0
         ? this.framework.callWithRequest(request, 'search', {
             index: nonApmIndexNames,
@@ -39,7 +42,8 @@ export class ElasticsearchSourceStatusAdapter implements SourceStatusAdapter {
 
       // Note: Additional check necessary for APM-specific index. For details see: https://github.com/elastic/kibana/issues/56363
       // Only verify if APM data exists if indexNames includes `apm-*-transaction*` (default included apm index)
-      const includesApmIndex = indexNames.includes(APM_INDEX_NAME);
+      const includesApmIndex =
+        indexNames.includes(APM_INDEX_NAME) || indexNames.includes(APM_DATA_STREAM);
       const hasApmDataResponse = await (includesApmIndex
         ? this.framework.callWithRequest<{}, ApmServiceNameAgg>(
             request,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
@@ -18,6 +18,7 @@ import {
 export const mockOptions: HostsRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -613,6 +614,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -822,6 +824,7 @@ export const expectedDsl = {
   ignoreUnavailable: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/__mocks__/index.ts
@@ -17,6 +17,7 @@ import {
 export const mockOptions: HostAuthenticationsRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -2151,6 +2152,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -2372,6 +2374,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
@@ -17,6 +17,7 @@ import {
 export const mockOptions: HostDetailsRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -1303,6 +1304,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -1416,6 +1418,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/__mocks__/index.ts
@@ -14,6 +14,7 @@ import {
 export const mockOptions: HostFirstLastSeenRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -126,6 +127,7 @@ export const formattedSearchStrategyFirstResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -191,6 +193,7 @@ export const formattedSearchStrategyLastResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -225,6 +228,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/__mocks__/index.ts
@@ -15,6 +15,7 @@ import {
 export const mockOptions: HostOverviewRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -119,6 +120,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -331,6 +333,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/__mocks__/index.ts
@@ -10,6 +10,7 @@ import { HostsQueries, SortField } from '../../../../../../../common/search_stra
 export const mockOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -4302,6 +4303,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -4436,6 +4438,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
@@ -33,6 +33,7 @@ export const formattedAlertsSearchStrategyResponse: MatrixHistogramStrategyRespo
         {
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -166,6 +167,7 @@ export const expectedDsl = {
   ignoreUnavailable: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -199,6 +201,7 @@ export const formattedAnomaliesSearchStrategyResponse: MatrixHistogramStrategyRe
         {
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -381,6 +384,7 @@ export const formattedAuthenticationsSearchStrategyResponse: MatrixHistogramStra
         {
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -947,6 +951,7 @@ export const formattedEventsSearchStrategyResponse: MatrixHistogramStrategyRespo
         {
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -1925,6 +1930,7 @@ export const formattedDnsSearchStrategyResponse: MatrixHistogramStrategyResponse
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/__mocks__/index.ts
@@ -10,6 +10,7 @@ import { MatrixHistogramType } from '../../../../../../../common/search_strategy
 export const mockOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -27,6 +28,7 @@ export const mockOptions = {
 export const expectedDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/__mocks__/index.ts
@@ -10,6 +10,7 @@ import { MatrixHistogramType } from '../../../../../../../common/search_strategy
 export const mockOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -27,6 +28,7 @@ export const mockOptions = {
 export const expectedDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/__mocks__/index.ts
@@ -10,6 +10,7 @@ import { MatrixHistogramType } from '../../../../../../../common/search_strategy
 export const mockOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -26,6 +27,7 @@ export const mockOptions = {
 export const expectedDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/__mocks__/index.ts
@@ -10,6 +10,7 @@ import { MatrixHistogramType } from '../../../../../../../common/search_strategy
 export const mockOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -28,6 +29,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/__mocks__/index.ts
@@ -14,6 +14,7 @@ import {
 export const mockOptions: MatrixHistogramRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -31,6 +32,7 @@ export const mockOptions: MatrixHistogramRequestOptions = {
 export const expectedDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -85,6 +87,7 @@ export const expectedDsl = {
 export const expectedThresholdDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -141,6 +144,7 @@ export const expectedThresholdDsl = {
 export const expectedThresholdMissingFieldDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -243,6 +247,7 @@ export const expectedThresholdWithCardinalityDsl = {
   ignoreUnavailable: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -256,6 +261,7 @@ export const expectedThresholdWithCardinalityDsl = {
 export const expectedThresholdWithGroupFieldsAndCardinalityDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -362,6 +368,7 @@ export const expectedThresholdGroupWithCardinalityDsl = {
   ignoreUnavailable: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -375,6 +382,7 @@ export const expectedThresholdGroupWithCardinalityDsl = {
 export const expectedIpIncludingMissingDataDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -437,6 +445,7 @@ export const expectedIpIncludingMissingDataDsl = {
 export const expectedIpNotIncludingMissingDataDsl = {
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/__mocks__/index.ts
@@ -15,6 +15,7 @@ import {
 export const mockOptions: NetworkDetailsRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -306,6 +307,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -447,6 +449,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/__mocks__/index.ts
@@ -17,6 +17,7 @@ import {
 export const mockOptions: NetworkDnsRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -133,6 +134,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -204,6 +206,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/__mocks__/index.ts
@@ -18,6 +18,7 @@ import {
 export const mockOptions: NetworkHttpRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -621,6 +622,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -678,6 +680,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/__mocks__/index.ts
@@ -15,6 +15,7 @@ import {
 export const mockOptions: NetworkOverviewRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -103,6 +104,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -208,6 +210,7 @@ export const expectedDsl = {
   ignoreUnavailable: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/__mocks__/index.ts
@@ -18,6 +18,7 @@ import {
 export const mockOptions: NetworkTlsRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -61,6 +62,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -115,6 +117,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/__mocks__/index.ts
@@ -18,6 +18,7 @@ import {
 export const mockOptions: NetworkTopCountriesRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -60,6 +61,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -119,6 +121,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/__mocks__/index.ts
@@ -19,6 +19,7 @@ import {
 export const mockOptions: NetworkTopNFlowRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -812,6 +813,7 @@ export const formattedSearchStrategyResponse: NetworkTopNFlowStrategyResponse = 
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -879,6 +881,7 @@ export const expectedDsl = {
   allowNoIndices: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/__mocks__/index.ts
@@ -18,6 +18,7 @@ import {
 export const mockOptions: NetworkUsersRequestOptions = {
   defaultIndex: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',
@@ -121,6 +122,7 @@ export const formattedSearchStrategyResponse = {
           allowNoIndices: true,
           index: [
             'apm-*-transaction*',
+            'traces-apm*',
             'auditbeat-*',
             'endgame-*',
             'filebeat-*',
@@ -210,6 +212,7 @@ export const expectedDsl = {
   ignoreUnavailable: true,
   index: [
     'apm-*-transaction*',
+    'traces-apm*',
     'auditbeat-*',
     'endgame-*',
     'filebeat-*',

--- a/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/column_headers/__snapshots__/index.test.tsx.snap
@@ -367,6 +367,7 @@ exports[`ColumnHeaders rendering renders correctly against snapshot 1`] = `
             "format": "",
             "indexes": Array [
               "apm-*-transaction*",
+              "traces-apm*",
               "auditbeat-*",
               "endgame-*",
               "filebeat-*",

--- a/x-pack/plugins/timelines/public/mock/browser_fields.ts
+++ b/x-pack/plugins/timelines/public/mock/browser_fields.ts
@@ -10,6 +10,7 @@ import type { BrowserFields } from '../../common/search_strategy/index_fields';
 
 const DEFAULT_INDEX_PATTERN = [
   'apm-*-transaction*',
+  'traces-apm*',
   'auditbeat-*',
   'endgame-*',
   'filebeat-*',

--- a/x-pack/plugins/timelines/public/mock/global_state.ts
+++ b/x-pack/plugins/timelines/public/mock/global_state.ts
@@ -24,6 +24,7 @@ export const mockGlobalState: TimelineState = {
       id: 'test',
       indexNames: [
         'apm-*-transaction*',
+        'traces-apm*',
         'auditbeat-*',
         'endgame-*',
         'filebeat-*',

--- a/x-pack/plugins/timelines/server/search_strategy/index_fields/index.test.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/index_fields/index.test.ts
@@ -845,7 +845,7 @@ describe('Fields Provider', () => {
     });
 
     it('should search apm index fields', async () => {
-      const indices = ['apm-*-transaction*'];
+      const indices = ['apm-*-transaction*', 'traces-apm*'];
       const request = {
         indices,
         onlyCheckIfIndicesExist: false,
@@ -861,7 +861,7 @@ describe('Fields Provider', () => {
     });
 
     it('should check apm index exists with data', async () => {
-      const indices = ['apm-*-transaction*'];
+      const indices = ['apm-*-transaction*', 'traces-apm*'];
       const request = {
         indices,
         onlyCheckIfIndicesExist: true,
@@ -883,7 +883,7 @@ describe('Fields Provider', () => {
     });
 
     it('should check apm index exists with no data', async () => {
-      const indices = ['apm-*-transaction*'];
+      const indices = ['apm-*-transaction*', 'traces-apm*'];
       const request = {
         indices,
         onlyCheckIfIndicesExist: true,

--- a/x-pack/plugins/timelines/server/search_strategy/index_fields/index.test.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/index_fields/index.test.ts
@@ -867,13 +867,17 @@ describe('Fields Provider', () => {
         onlyCheckIfIndicesExist: true,
       };
 
-      esClientSearchMock.mockResolvedValueOnce({
+      esClientSearchMock.mockResolvedValue({
         body: { hits: { total: { value: 1 } } },
       });
       const response = await requestIndexFieldSearch(request, deps, beatFields);
 
       expect(esClientSearchMock).toHaveBeenCalledWith({
         index: indices[0],
+        body: { query: { match_all: {} }, size: 0 },
+      });
+      expect(esClientSearchMock).toHaveBeenCalledWith({
+        index: indices[1],
         body: { query: { match_all: {} }, size: 0 },
       });
       expect(getFieldsForWildcardMock).not.toHaveBeenCalled();
@@ -889,7 +893,7 @@ describe('Fields Provider', () => {
         onlyCheckIfIndicesExist: true,
       };
 
-      esClientSearchMock.mockResolvedValueOnce({
+      esClientSearchMock.mockResolvedValue({
         body: { hits: { total: { value: 0 } } },
       });
 
@@ -897,6 +901,10 @@ describe('Fields Provider', () => {
 
       expect(esClientSearchMock).toHaveBeenCalledWith({
         index: indices[0],
+        body: { query: { match_all: {} }, size: 0 },
+      });
+      expect(esClientSearchMock).toHaveBeenCalledWith({
+        index: indices[1],
         body: { query: { match_all: {} }, size: 0 },
       });
       expect(getFieldsForWildcardMock).not.toHaveBeenCalled();

--- a/x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../common/search_strategy/index_fields';
 
 const apmIndexPattern = 'apm-*-transaction*';
+const apmDataStreamsPattern = 'traces-apm*';
 
 export const indexFieldsProvider = (): ISearchStrategy<
   IndexFieldsStrategyRequest,
@@ -51,7 +52,10 @@ export const requestIndexFieldSearch = async (
   const responsesIndexFields = await Promise.all(
     dedupeIndices
       .map(async (index) => {
-        if (request.onlyCheckIfIndicesExist && index.includes(apmIndexPattern)) {
+        if (
+          request.onlyCheckIfIndicesExist &&
+          (index.includes(apmIndexPattern) || index.includes(apmDataStreamsPattern))
+        ) {
           // for apm index pattern check also if there's data https://github.com/elastic/kibana/issues/90661
           const searchResponse = await esClient.asCurrentUser.search({
             index,

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/all/helpers.test.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/all/helpers.test.ts
@@ -141,7 +141,7 @@ describe('#formatTimelineData', () => {
           parent: {
             depth: 0,
             index:
-              'apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*',
+              'apm-*-transaction*,traces-apm*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*',
             id: '0268af90-d8da-576a-9747-2a191519416a',
             type: 'event',
           },
@@ -180,6 +180,7 @@ describe('#formatTimelineData', () => {
             query: '_id :*',
             index: [
               'apm-*-transaction*',
+              'traces-apm*',
               'auditbeat-*',
               'endgame-*',
               'filebeat-*',
@@ -246,7 +247,7 @@ describe('#formatTimelineData', () => {
             {
               depth: 0,
               index:
-                'apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*',
+                'apm-*-transaction*,traces-apm*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*',
               id: '0268af90-d8da-576a-9747-2a191519416a',
               type: 'event',
             },
@@ -255,7 +256,7 @@ describe('#formatTimelineData', () => {
             {
               depth: 0,
               index:
-                'apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*',
+                'apm-*-transaction*,traces-apm*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,winlogbeat-*',
               id: '0268af90-d8da-576a-9747-2a191519416a',
               type: 'event',
             },
@@ -279,6 +280,7 @@ describe('#formatTimelineData', () => {
         'signal.rule.version': ['1'],
         'signal.rule.index': [
           'apm-*-transaction*',
+          'traces-apm*',
           'auditbeat-*',
           'endgame-*',
           'filebeat-*',
@@ -332,6 +334,7 @@ describe('#formatTimelineData', () => {
               id: ['696c24e0-526d-11eb-836c-e1620268b945'],
               index: [
                 'apm-*-transaction*',
+                'traces-apm*',
                 'auditbeat-*',
                 'endgame-*',
                 'filebeat-*',


### PR DESCRIPTION
Addresses #94702.

With the new APM migration to data streams (#102682, #105015), all instances where indices depended on only `apm-*` or `apm-*-transaction*`, must also include support for new data streams for traces `traces-apm*` and index pattern title `traces-apm*,logs-apm*,metrics-apm*,apm-*`.