### PR TITLE
[Lens] Fix field stats when multiple runtime fields are used

### DIFF
--- a/x-pack/test/api_integration/apis/lens/field_stats.ts
+++ b/x-pack/test/api_integration/apis/lens/field_stats.ts
@@ -427,6 +427,38 @@ export default ({ getService }: FtrProviderContext) => {
 
         expect(body.totalDocuments).to.eql(425);
       });
+
+      it('should allow filtering on a runtime field other than the field in use', async () => {
+        const { body } = await supertest
+          .post('/api/lens/index_stats/logstash-2015.09.22/field')
+          .set(COMMON_HEADERS)
+          .send({
+            dslQuery: {
+              bool: {
+                filter: [{ exists: { field: 'runtime_string_field' } }],
+              },
+            },
+            fromDate: TEST_START_TIME,
+            toDate: TEST_END_TIME,
+            fieldName: 'runtime_number_field',
+          })
+          .expect(200);
+
+        expect(body).to.eql({
+          totalDocuments: 4634,
+          sampledDocuments: 4634,
+          sampledValues: 4634,
+          topValues: {
+            buckets: [
+              {
+                count: 4634,
+                key: 5,
+              },
+            ],
+          },
+          histogram: { buckets: [] },
+        });
+      });
     });
 
     describe('histogram', () => {

--- a/x-pack/test/functional/es_archives/visualize/default/data.json
+++ b/x-pack/test/functional/es_archives/visualize/default/data.json
@@ -157,7 +157,7 @@
         "timeFieldName": "@timestamp",
         "title": "logstash-2015.09.22",
         "fields":"[{\"name\":\"scripted_date\",\"type\":\"date\",\"count\":0,\"scripted\":true,\"script\":\"1234\",\"lang\":\"painless\",\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"scripted_string\",\"type\":\"string\",\"count\":0,\"scripted\":true,\"script\":\"return 'hello'\",\"lang\":\"painless\",\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false}]",
-        "runtimeFieldMap":"{\"runtime_string_field\":{\"type\":\"keyword\",\"script\":{\"source\":\"emit('hello world!')\"}}}"
+        "runtimeFieldMap":"{\"runtime_string_field\":{\"type\":\"keyword\",\"script\":{\"source\":\"emit('hello world!')\"}},\"runtime_number_field\":{\"type\":\"double\",\"script\":{\"source\":\"emit(5)\"}}}"
       },
       "migrationVersion": {
         "index-pattern": "7.11.0"


### PR DESCRIPTION
Instead of only using one runtime field per stats request, all fields are potentially being used.

Fixes https://github.com/elastic/kibana/issues/105303

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
