### PR TITLE
[APM] Fixes support for APM index pattern with data streams

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/solution_layers/observability/create_layer_descriptor.test.ts
+++ b/x-pack/plugins/maps/public/classes/layers/solution_layers/observability/create_layer_descriptor.test.ts
@@ -54,7 +54,7 @@ describe('createLayerDescriptor', () => {
             applyGlobalTime: true,
             id: '12345',
             indexPatternId: 'apm_static_index_pattern_id',
-            indexPatternTitle: 'apm-*',
+            indexPatternTitle: 'traces-apm*,logs-apm*,metrics-apm*,apm-*',
             metrics: [
               {
                 field: 'transaction.duration.us',

--- a/x-pack/plugins/maps/public/classes/layers/solution_layers/observability/create_layer_descriptor.ts
+++ b/x-pack/plugins/maps/public/classes/layers/solution_layers/observability/create_layer_descriptor.ts
@@ -39,7 +39,7 @@ import { getDefaultDynamicProperties } from '../../../styles/vector/vector_style
 
 // redefining APM constant to avoid making maps app depend on APM plugin
 export const APM_INDEX_PATTERN_ID = 'apm_static_index_pattern_id';
-export const APM_INDEX_PATTERN_TITLE = 'apm-*';
+export const APM_INDEX_PATTERN_TITLE = 'traces-apm*,logs-apm*,metrics-apm*,apm-*';
 
 const defaultDynamicProperties = getDefaultDynamicProperties();
 

--- a/x-pack/plugins/maps/public/classes/layers/solution_layers/security/create_layer_descriptors.test.ts
+++ b/x-pack/plugins/maps/public/classes/layers/solution_layers/security/create_layer_descriptors.test.ts
@@ -30,16 +30,14 @@ import { createSecurityLayerDescriptors } from './create_layer_descriptors';
 
 describe('createLayerDescriptor', () => {
   test('apm index', () => {
-    expect(
-      createSecurityLayerDescriptors('id', 'traces-apm*,logs-apm*,metrics-apm*,apm-*')
-    ).toEqual([
+    expect(createSecurityLayerDescriptors('id', 'apm-*-transaction*')).toEqual([
       {
         __dataRequests: [],
         alpha: 0.75,
         id: '12345',
         includeInFitToBounds: true,
         joins: [],
-        label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Source Point',
+        label: 'apm-*-transaction* | Source Point',
         maxZoom: 24,
         minZoom: 0,
         sourceDescriptor: {
@@ -148,7 +146,7 @@ describe('createLayerDescriptor', () => {
         id: '12345',
         includeInFitToBounds: true,
         joins: [],
-        label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Destination point',
+        label: 'apm-*-transaction* | Destination point',
         maxZoom: 24,
         minZoom: 0,
         sourceDescriptor: {
@@ -257,7 +255,7 @@ describe('createLayerDescriptor', () => {
         id: '12345',
         includeInFitToBounds: true,
         joins: [],
-        label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Line',
+        label: 'apm-*-transaction* | Line',
         maxZoom: 24,
         minZoom: 0,
         sourceDescriptor: {
@@ -616,6 +614,345 @@ describe('createLayerDescriptor', () => {
             },
           ],
           sourceGeoField: 'source.geo.location',
+          type: 'ES_PEW_PEW',
+        },
+        style: {
+          isTimeAware: true,
+          properties: {
+            fillColor: {
+              options: {
+                color: '#54B399',
+              },
+              type: 'STATIC',
+            },
+            icon: {
+              options: {
+                value: 'marker',
+              },
+              type: 'STATIC',
+            },
+            iconOrientation: {
+              options: {
+                orientation: 0,
+              },
+              type: 'STATIC',
+            },
+            iconSize: {
+              options: {
+                size: 6,
+              },
+              type: 'STATIC',
+            },
+            labelBorderColor: {
+              options: {
+                color: '#FFFFFF',
+              },
+              type: 'STATIC',
+            },
+            labelBorderSize: {
+              options: {
+                size: 'SMALL',
+              },
+            },
+            labelColor: {
+              options: {
+                color: '#000000',
+              },
+              type: 'STATIC',
+            },
+            labelSize: {
+              options: {
+                size: 14,
+              },
+              type: 'STATIC',
+            },
+            labelText: {
+              options: {
+                value: '',
+              },
+              type: 'STATIC',
+            },
+            lineColor: {
+              options: {
+                color: '#6092C0',
+              },
+              type: 'STATIC',
+            },
+            lineWidth: {
+              options: {
+                field: {
+                  name: 'doc_count',
+                  origin: 'source',
+                },
+                fieldMetaOptions: {
+                  isEnabled: true,
+                  sigma: 3,
+                },
+                maxSize: 8,
+                minSize: 1,
+              },
+              type: 'DYNAMIC',
+            },
+            symbolizeAs: {
+              options: {
+                value: 'circle',
+              },
+            },
+          },
+          type: 'VECTOR',
+        },
+        type: 'VECTOR',
+        visible: true,
+      },
+    ]);
+  });
+
+  test('apm data stream', () => {
+    expect(createSecurityLayerDescriptors('id', 'traces-apm-opbean-node')).toEqual([
+      {
+        __dataRequests: [],
+        alpha: 0.75,
+        id: '12345',
+        includeInFitToBounds: true,
+        joins: [],
+        label: 'traces-apm-opbean-node | Source Point',
+        maxZoom: 24,
+        minZoom: 0,
+        sourceDescriptor: {
+          applyGlobalQuery: true,
+          applyGlobalTime: true,
+          filterByMapBounds: true,
+          geoField: 'client.geo.location',
+          id: '12345',
+          indexPatternId: 'id',
+          scalingType: 'TOP_HITS',
+          sortField: '',
+          sortOrder: 'desc',
+          tooltipProperties: [
+            'host.name',
+            'client.ip',
+            'client.domain',
+            'client.geo.country_iso_code',
+            'client.as.organization.name',
+          ],
+          topHitsSize: 1,
+          topHitsSplitField: 'client.ip',
+          type: 'ES_SEARCH',
+        },
+        style: {
+          isTimeAware: true,
+          properties: {
+            fillColor: {
+              options: {
+                color: '#6092C0',
+              },
+              type: 'STATIC',
+            },
+            icon: {
+              options: {
+                value: 'home',
+              },
+              type: 'STATIC',
+            },
+            iconOrientation: {
+              options: {
+                orientation: 0,
+              },
+              type: 'STATIC',
+            },
+            iconSize: {
+              options: {
+                size: 8,
+              },
+              type: 'STATIC',
+            },
+            labelBorderColor: {
+              options: {
+                color: '#FFFFFF',
+              },
+              type: 'STATIC',
+            },
+            labelBorderSize: {
+              options: {
+                size: 'SMALL',
+              },
+            },
+            labelColor: {
+              options: {
+                color: '#000000',
+              },
+              type: 'STATIC',
+            },
+            labelSize: {
+              options: {
+                size: 14,
+              },
+              type: 'STATIC',
+            },
+            labelText: {
+              options: {
+                value: '',
+              },
+              type: 'STATIC',
+            },
+            lineColor: {
+              options: {
+                color: '#FFFFFF',
+              },
+              type: 'STATIC',
+            },
+            lineWidth: {
+              options: {
+                size: 2,
+              },
+              type: 'STATIC',
+            },
+            symbolizeAs: {
+              options: {
+                value: 'icon',
+              },
+            },
+          },
+          type: 'VECTOR',
+        },
+        type: 'VECTOR',
+        visible: true,
+      },
+      {
+        __dataRequests: [],
+        alpha: 0.75,
+        id: '12345',
+        includeInFitToBounds: true,
+        joins: [],
+        label: 'traces-apm-opbean-node | Destination point',
+        maxZoom: 24,
+        minZoom: 0,
+        sourceDescriptor: {
+          applyGlobalQuery: true,
+          applyGlobalTime: true,
+          filterByMapBounds: true,
+          geoField: 'server.geo.location',
+          id: '12345',
+          indexPatternId: 'id',
+          scalingType: 'TOP_HITS',
+          sortField: '',
+          sortOrder: 'desc',
+          tooltipProperties: [
+            'host.name',
+            'server.ip',
+            'server.domain',
+            'server.geo.country_iso_code',
+            'server.as.organization.name',
+          ],
+          topHitsSize: 1,
+          topHitsSplitField: 'server.ip',
+          type: 'ES_SEARCH',
+        },
+        style: {
+          isTimeAware: true,
+          properties: {
+            fillColor: {
+              options: {
+                color: '#D36086',
+              },
+              type: 'STATIC',
+            },
+            icon: {
+              options: {
+                value: 'marker',
+              },
+              type: 'STATIC',
+            },
+            iconOrientation: {
+              options: {
+                orientation: 0,
+              },
+              type: 'STATIC',
+            },
+            iconSize: {
+              options: {
+                size: 8,
+              },
+              type: 'STATIC',
+            },
+            labelBorderColor: {
+              options: {
+                color: '#FFFFFF',
+              },
+              type: 'STATIC',
+            },
+            labelBorderSize: {
+              options: {
+                size: 'SMALL',
+              },
+            },
+            labelColor: {
+              options: {
+                color: '#000000',
+              },
+              type: 'STATIC',
+            },
+            labelSize: {
+              options: {
+                size: 14,
+              },
+              type: 'STATIC',
+            },
+            labelText: {
+              options: {
+                value: '',
+              },
+              type: 'STATIC',
+            },
+            lineColor: {
+              options: {
+                color: '#FFFFFF',
+              },
+              type: 'STATIC',
+            },
+            lineWidth: {
+              options: {
+                size: 2,
+              },
+              type: 'STATIC',
+            },
+            symbolizeAs: {
+              options: {
+                value: 'icon',
+              },
+            },
+          },
+          type: 'VECTOR',
+        },
+        type: 'VECTOR',
+        visible: true,
+      },
+      {
+        __dataRequests: [],
+        alpha: 0.75,
+        id: '12345',
+        includeInFitToBounds: true,
+        joins: [],
+        label: 'traces-apm-opbean-node | Line',
+        maxZoom: 24,
+        minZoom: 0,
+        sourceDescriptor: {
+          applyGlobalQuery: true,
+          applyGlobalTime: true,
+          destGeoField: 'server.geo.location',
+          id: '12345',
+          indexPatternId: 'id',
+          metrics: [
+            {
+              field: 'client.bytes',
+              type: 'sum',
+            },
+            {
+              field: 'server.bytes',
+              type: 'sum',
+            },
+          ],
+          sourceGeoField: 'client.geo.location',
           type: 'ES_PEW_PEW',
         },
         style: {

--- a/x-pack/plugins/maps/public/classes/layers/solution_layers/security/create_layer_descriptors.test.ts
+++ b/x-pack/plugins/maps/public/classes/layers/solution_layers/security/create_layer_descriptors.test.ts
@@ -30,14 +30,16 @@ import { createSecurityLayerDescriptors } from './create_layer_descriptors';
 
 describe('createLayerDescriptor', () => {
   test('apm index', () => {
-    expect(createSecurityLayerDescriptors('id', 'apm-*-transaction*')).toEqual([
+    expect(
+      createSecurityLayerDescriptors('id', 'traces-apm*,logs-apm*,metrics-apm*,apm-*')
+    ).toEqual([
       {
         __dataRequests: [],
         alpha: 0.75,
         id: '12345',
         includeInFitToBounds: true,
         joins: [],
-        label: 'apm-*-transaction* | Source Point',
+        label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Source Point',
         maxZoom: 24,
         minZoom: 0,
         sourceDescriptor: {
@@ -146,7 +148,7 @@ describe('createLayerDescriptor', () => {
         id: '12345',
         includeInFitToBounds: true,
         joins: [],
-        label: 'apm-*-transaction* | Destination point',
+        label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Destination point',
         maxZoom: 24,
         minZoom: 0,
         sourceDescriptor: {
@@ -255,7 +257,7 @@ describe('createLayerDescriptor', () => {
         id: '12345',
         includeInFitToBounds: true,
         joins: [],
-        label: 'apm-*-transaction* | Line',
+        label: 'traces-apm*,logs-apm*,metrics-apm*,apm-* | Line',
         maxZoom: 24,
         minZoom: 0,
         sourceDescriptor: {

--- a/x-pack/plugins/maps/public/classes/layers/solution_layers/security/create_layer_descriptors.ts
+++ b/x-pack/plugins/maps/public/classes/layers/solution_layers/security/create_layer_descriptors.ts
@@ -35,7 +35,11 @@ const defaultDynamicProperties = getDefaultDynamicProperties();
 const euiVisColorPalette = euiPaletteColorBlind();
 
 function isApmIndex(indexPatternTitle: string) {
-  return minimatch(indexPatternTitle, APM_INDEX_PATTERN_TITLE);
+  return APM_INDEX_PATTERN_TITLE.split(',')
+    .map((pattern) => {
+      return minimatch(indexPatternTitle, pattern);
+    })
+    .some(Boolean);
 }
 
 function getSourceField(indexPatternTitle: string) {


### PR DESCRIPTION
Addresses #94702.

Fixes maps support for the APM data streams, which would contain geo data of traces if a user migrates in the APM settings (#102682, #105015).