### PR TITLE
[7.x] [Security Solution][Endpoint][Host Isolation] Fixes bug to remove excess host metadata status toasts on non user initiated errors (#105331)

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -400,6 +400,11 @@ export enum HostStatus {
    * Host is inactive as indicated by its checkin status during the last checkin window
    */
   INACTIVE = 'inactive',
+
+  /**
+   * Host is unenrolled
+   */
+  UNENROLLED = 'unenrolled',
 }
 
 export type PolicyInfo = Immutable<{

--- a/x-pack/plugins/security_solution/public/common/components/endpoint/agent_status.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/agent_status.tsx
@@ -20,7 +20,7 @@ export const AgentStatus = React.memo(({ hostStatus }: { hostStatus: HostStatus 
     >
       <FormattedMessage
         id="xpack.securitySolution.endpoint.list.hostStatusValue"
-        defaultMessage="{hostStatus, select, healthy {Healthy} unhealthy {Unhealthy} updating {Updating} offline {Offline} inactive {Inactive} other {Unhealthy}}"
+        defaultMessage="{hostStatus, select, healthy {Healthy} unhealthy {Unhealthy} updating {Updating} offline {Offline} inactive {Inactive} unenrolled {Unenrolled} other {Unhealthy}}"
         values={{ hostStatus }}
       />
     </EuiBadge>

--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/take_action_dropdown.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/take_action_dropdown.tsx
@@ -10,6 +10,7 @@ import { EuiContextMenuItem, EuiContextMenuPanel, EuiButton, EuiPopover } from '
 import { ISOLATE_HOST, UNISOLATE_HOST } from './translations';
 import { TAKE_ACTION } from '../alerts_table/alerts_utility_bar/translations';
 import { useHostIsolationStatus } from '../../containers/detection_engine/alerts/use_host_isolation_status';
+import { HostStatus } from '../../../../common/endpoint/types';
 
 export const TakeActionDropdown = React.memo(
   ({
@@ -19,7 +20,9 @@ export const TakeActionDropdown = React.memo(
     onChange: (action: 'isolateHost' | 'unisolateHost') => void;
     agentId: string;
   }) => {
-    const { loading, isIsolated: isolationStatus } = useHostIsolationStatus({ agentId });
+    const { loading, isIsolated: isolationStatus, agentStatus } = useHostIsolationStatus({
+      agentId,
+    });
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
     const closePopoverHandler = useCallback(() => {
@@ -41,7 +44,7 @@ export const TakeActionDropdown = React.memo(
           iconSide="right"
           fill
           iconType="arrowDown"
-          disabled={loading}
+          disabled={loading || agentStatus === HostStatus.UNENROLLED}
           onClick={() => {
             setIsPopoverOpen(!isPopoverOpen);
           }}
@@ -49,7 +52,7 @@ export const TakeActionDropdown = React.memo(
           {TAKE_ACTION}
         </EuiButton>
       );
-    }, [isPopoverOpen, loading]);
+    }, [isPopoverOpen, loading, agentStatus]);
 
     return (
       <EuiPopover

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/translations.ts
@@ -37,13 +37,3 @@ export const CASES_FROM_ALERTS_FAILURE = i18n.translate(
   'xpack.securitySolution.endpoint.hostIsolation.casesFromAlerts.title',
   { defaultMessage: 'Failed to find associated cases' }
 );
-
-export const ISOLATION_STATUS_FAILURE = i18n.translate(
-  'xpack.securitySolution.endpoint.hostIsolation.isolationStatus.title',
-  { defaultMessage: 'Failed to retrieve current isolation status' }
-);
-
-export const ISOLATION_PENDING_FAILURE = i18n.translate(
-  'xpack.securitySolution.endpoint.hostIsolation.isolationPending.title',
-  { defaultMessage: 'Failed to retrieve isolation pending statuses' }
-);

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/host_constants.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/host_constants.ts
@@ -18,6 +18,7 @@ export const HOST_STATUS_TO_BADGE_COLOR = Object.freeze<
   [HostStatus.UPDATING]: 'primary',
   [HostStatus.OFFLINE]: 'default',
   [HostStatus.INACTIVE]: 'default',
+  [HostStatus.UNENROLLED]: 'default',
 });
 
 export const POLICY_STATUS_TO_HEALTH_COLOR = Object.freeze<

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/agent_statuses.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/agent_statuses.tsx
@@ -6,11 +6,12 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { DefaultDraggable } from '../../../../../common/components/draggables';
 import { EndpointHostIsolationStatus } from '../../../../../common/components/endpoint/host_isolation';
 import { useHostIsolationStatus } from '../../../../../detections/containers/detection_engine/alerts/use_host_isolation_status';
 import { AgentStatus } from '../../../../../common/components/endpoint/agent_status';
+import { EMPTY_STATUS } from './translations';
 
 export const AgentStatuses = React.memo(
   ({
@@ -33,16 +34,22 @@ export const AgentStatuses = React.memo(
     const isolationFieldName = 'host.isolation';
     return (
       <EuiFlexGroup gutterSize="none">
-        <EuiFlexItem grow={false}>
-          <DefaultDraggable
-            field={fieldName}
-            id={`event-details-value-default-draggable-${contextId}-${eventId}-${fieldName}-${value}`}
-            tooltipContent={fieldName}
-            value={`${agentStatus}`}
-          >
-            <AgentStatus hostStatus={agentStatus} />
-          </DefaultDraggable>
-        </EuiFlexItem>
+        {agentStatus !== undefined ? (
+          <EuiFlexItem grow={false}>
+            <DefaultDraggable
+              field={fieldName}
+              id={`event-details-value-default-draggable-${contextId}-${eventId}-${fieldName}-${value}`}
+              tooltipContent={fieldName}
+              value={`${agentStatus}`}
+            >
+              <AgentStatus hostStatus={agentStatus} />
+            </DefaultDraggable>
+          </EuiFlexItem>
+        ) : (
+          <EuiText>
+            <p>{EMPTY_STATUS}</p>
+          </EuiText>
+        )}
         <EuiFlexItem grow={false}>
           <DefaultDraggable
             field={isolationFieldName}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/translations.ts
@@ -44,3 +44,10 @@ export const LINK_ELASTIC_ENDPOINT_SECURITY = i18n.translate(
     defaultMessage: 'Open in Endpoint Security',
   }
 );
+
+export const EMPTY_STATUS = i18n.translate(
+  'xpack.securitySolution.hostIsolation.agentStatuses.empty',
+  {
+    defaultMessage: '-',
+  }
+);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution][Endpoint][Host Isolation] Fixes bug to remove excess host metadata status toasts on non user initiated errors (#105331)