### PR TITLE
[SECURITY SOLUTUONS] Bugs bring back KQL autocomplete in timeline + fix last updated

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.tsx
@@ -26,7 +26,7 @@ interface FlyoutPaneComponentProps {
 const StyledEuiFlyout = styled(EuiFlyout)<EuiFlyoutProps>`
   animation: none;
   min-width: 150px;
-  z-index: ${({ theme }) => theme.eui.euiZLevel6};
+  z-index: ${({ theme }) => theme.eui.euiZLevel4};
 `;
 
 const FlyoutPaneComponent: React.FC<FlyoutPaneComponentProps> = ({

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.test.tsx
@@ -161,6 +161,50 @@ describe('Footer Timeline Component', () => {
       wrapper.find('[data-test-subj="timelineSizeRowPopover"] button').first().simulate('click');
       expect(wrapper.find('[data-test-subj="timelinePickSizeRow"]').exists()).toBeTruthy();
     });
+
+    test('it renders last updated when updated at is > 0', () => {
+      const wrapper = mount(
+        <TestProviders>
+          <FooterComponent
+            activePage={0}
+            updatedAt={updatedAt}
+            height={100}
+            id={'timeline-id'}
+            isLive={false}
+            isLoading={false}
+            itemsCount={itemsCount}
+            itemsPerPage={2}
+            itemsPerPageOptions={[1, 5, 10, 20]}
+            onChangePage={loadMore}
+            totalCount={serverSideEventCount}
+          />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="fixed-width-last-updated"]').exists()).toBeTruthy();
+    });
+
+    test('it does NOT render last updated when updated at is 0', () => {
+      const wrapper = mount(
+        <TestProviders>
+          <FooterComponent
+            activePage={0}
+            updatedAt={0}
+            height={100}
+            id={'timeline-id'}
+            isLive={false}
+            isLoading={false}
+            itemsCount={itemsCount}
+            itemsPerPage={2}
+            itemsPerPageOptions={[1, 5, 10, 20]}
+            onChangePage={loadMore}
+            totalCount={serverSideEventCount}
+          />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="fixed-width-last-updated"]').exists()).toBeFalsy();
+    });
   });
 
   describe('Events', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.tsx
@@ -45,11 +45,11 @@ const FixedWidthLastUpdatedContainer = React.memo<FixedWidthLastUpdatedContainer
     const width = useEventDetailsWidthContext();
     const compact = useMemo(() => isCompactFooter(width), [width]);
 
-    return (
+    return updatedAt > 0 ? (
       <FixedWidthLastUpdated data-test-subj="fixed-width-last-updated" compact={compact}>
         {timelines.getLastUpdated({ updatedAt, compact })}
       </FixedWidthLastUpdated>
-    );
+    ) : null;
   }
 );
 


### PR DESCRIPTION
## Summary

1. KQL autocomplete was hidden behind the the timeline fly-out
![image](https://user-images.githubusercontent.com/189600/125377472-0af09480-e35b-11eb-9f56-341160ba7ba9.png)

2. Fixed https://github.com/elastic/kibana/issues/99611 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
