### PR TITLE
[SecuritySolution] disable edit and create from rules breadcrumb

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -324,7 +324,7 @@ describe('Navigation Breadcrumbs', () => {
         {
           text: 'Create',
           href:
-            "securitySolution/rules/create?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
+            "",
         },
       ]);
     });
@@ -382,7 +382,7 @@ describe('Navigation Breadcrumbs', () => {
         },
         {
           text: 'Edit',
-          href: `securitySolution/rules/id/${mockDetailName}/edit?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))`,
+          href: '',
         },
       ]);
     });

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -323,8 +323,7 @@ describe('Navigation Breadcrumbs', () => {
         },
         {
           text: 'Create',
-          href:
-            "",
+          href: '',
         },
       ]);
     });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -77,7 +77,7 @@ export const getBreadcrumbs = (
       ...breadcrumb,
       {
         text: i18nRules.ADD_PAGE_TITLE,
-        href: ''
+        href: '',
       },
     ];
   }
@@ -87,7 +87,7 @@ export const getBreadcrumbs = (
       ...breadcrumb,
       {
         text: i18nRules.EDIT_PAGE_TITLE,
-        href: ''
+        href: '',
       },
     ];
   }

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -77,10 +77,7 @@ export const getBreadcrumbs = (
       ...breadcrumb,
       {
         text: i18nRules.ADD_PAGE_TITLE,
-        href: getUrlForApp(APP_ID, {
-          deepLinkId: SecurityPageName.rules,
-          path: '',
-        }),
+        href: ''
       },
     ];
   }
@@ -90,10 +87,7 @@ export const getBreadcrumbs = (
       ...breadcrumb,
       {
         text: i18nRules.EDIT_PAGE_TITLE,
-        href: getUrlForApp(APP_ID, {
-          deepLinkId: SecurityPageName.rules,
-          path: '',
-        }),
+        href: ''
       },
     ];
   }

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -11,8 +11,6 @@ import { ChromeBreadcrumb } from '../../../../../../../../src/core/public';
 import {
   getRulesUrl,
   getRuleDetailsUrl,
-  getCreateRuleUrl,
-  getEditRuleUrl,
 } from '../../../../common/components/link_to/redirect_to_detection_engine';
 import * as i18nRules from './translations';
 import { RouteSpyState } from '../../../../common/utils/route/types';
@@ -81,7 +79,7 @@ export const getBreadcrumbs = (
         text: i18nRules.ADD_PAGE_TITLE,
         href: getUrlForApp(APP_ID, {
           deepLinkId: SecurityPageName.rules,
-          path: getCreateRuleUrl(!isEmpty(search[0]) ? search[0] : ''),
+          path: '',
         }),
       },
     ];
@@ -94,7 +92,7 @@ export const getBreadcrumbs = (
         text: i18nRules.EDIT_PAGE_TITLE,
         href: getUrlForApp(APP_ID, {
           deepLinkId: SecurityPageName.rules,
-          path: getEditRuleUrl(params.detailName, !isEmpty(search[0]) ? search[0] : ''),
+          path: '',
         }),
       },
     ];


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/103866

Steps to Verify:

1. Navigate to Rules tab of security.
2. Click on create a new rule.
3. That breadcrumb "Create" should be disabled
4. Go ahead and create the rule, back to the rule details page, and click Edit rule
5. That breadcrumb "Edit" should be disabled


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


