### PR TITLE
[7.14] Log a warning when documents of unknown types are detected during migration (#105213)

### DIFF
--- a/src/core/server/saved_objects/migrations/core/migrate_raw_docs.test.ts
+++ b/src/core/server/saved_objects/migrations/core/migrate_raw_docs.test.ts
@@ -137,14 +137,15 @@ describe('migrateRawDocsSafely', () => {
     const transform = jest.fn<any, any>((doc: any) => [
       set(_.cloneDeep(doc), 'attributes.name', 'HOI!'),
     ]);
-    const task = migrateRawDocsSafely(
-      new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
-      transform,
-      [
+    const task = migrateRawDocsSafely({
+      serializer: new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
+      knownTypes: new Set(['a', 'c']),
+      migrateDoc: transform,
+      rawDocs: [
         { _id: 'a:b', _source: { type: 'a', a: { name: 'AAA' } } },
         { _id: 'c:d', _source: { type: 'c', c: { name: 'DDD' } } },
-      ]
-    );
+      ],
+    });
     const result = (await task()) as Either.Right<DocumentsTransformSuccess>;
     expect(result._tag).toEqual('Right');
     expect(result.right.processedDocs).toEqual([
@@ -181,14 +182,15 @@ describe('migrateRawDocsSafely', () => {
     const transform = jest.fn<any, any>((doc: any) => [
       set(_.cloneDeep(doc), 'attributes.name', 'TADA'),
     ]);
-    const task = migrateRawDocsSafely(
-      new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
-      transform,
-      [
+    const task = migrateRawDocsSafely({
+      serializer: new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
+      knownTypes: new Set(['a', 'c']),
+      migrateDoc: transform,
+      rawDocs: [
         { _id: 'foo:b', _source: { type: 'a', a: { name: 'AAA' } } },
         { _id: 'c:d', _source: { type: 'c', c: { name: 'DDD' } } },
-      ]
-    );
+      ],
+    });
     const result = (await task()) as Either.Left<DocumentsTransformFailed>;
     expect(transform).toHaveBeenCalledTimes(1);
     expect(result._tag).toEqual('Left');
@@ -202,11 +204,12 @@ describe('migrateRawDocsSafely', () => {
       set(_.cloneDeep(doc), 'attributes.name', 'HOI!'),
       { id: 'bar', type: 'foo', attributes: { name: 'baz' } },
     ]);
-    const task = migrateRawDocsSafely(
-      new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
-      transform,
-      [{ _id: 'a:b', _source: { type: 'a', a: { name: 'AAA' } } }]
-    );
+    const task = migrateRawDocsSafely({
+      serializer: new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
+      knownTypes: new Set(['a', 'c']),
+      migrateDoc: transform,
+      rawDocs: [{ _id: 'a:b', _source: { type: 'a', a: { name: 'AAA' } } }],
+    });
     const result = (await task()) as Either.Right<DocumentsTransformSuccess>;
     expect(result._tag).toEqual('Right');
     expect(result.right.processedDocs).toEqual([
@@ -235,11 +238,12 @@ describe('migrateRawDocsSafely', () => {
     const transform = jest.fn<any, any>((doc: any) => {
       throw new TransformSavedObjectDocumentError(new Error('error during transform'), '8.0.0');
     });
-    const task = migrateRawDocsSafely(
-      new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
-      transform,
-      [{ _id: 'a:b', _source: { type: 'a', a: { name: 'AAA' } } }] // this is the raw doc
-    );
+    const task = migrateRawDocsSafely({
+      serializer: new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
+      knownTypes: new Set(['a', 'c']),
+      migrateDoc: transform,
+      rawDocs: [{ _id: 'a:b', _source: { type: 'a', a: { name: 'AAA' } } }], // this is the raw doc
+    });
     const result = (await task()) as Either.Left<DocumentsTransformFailed>;
     expect(transform).toHaveBeenCalledTimes(1);
     expect(result._tag).toEqual('Left');
@@ -251,5 +255,44 @@ describe('migrateRawDocsSafely', () => {
         "rawId": "a:b",
       }
     `);
+  });
+
+  test('skips documents of unknown types', async () => {
+    const transform = jest.fn<any, any>((doc: any) => [
+      set(_.cloneDeep(doc), 'attributes.name', 'HOI!'),
+    ]);
+    const task = migrateRawDocsSafely({
+      serializer: new SavedObjectsSerializer(new SavedObjectTypeRegistry()),
+      knownTypes: new Set(['a']),
+      migrateDoc: transform,
+      rawDocs: [
+        { _id: 'a:b', _source: { type: 'a', a: { name: 'AAA' } } },
+        { _id: 'c:d', _source: { type: 'c', c: { name: 'DDD' } } },
+      ],
+    });
+
+    const result = (await task()) as Either.Right<DocumentsTransformSuccess>;
+    expect(result._tag).toEqual('Right');
+    expect(result.right.processedDocs).toEqual([
+      {
+        _id: 'a:b',
+        _source: { type: 'a', a: { name: 'HOI!' }, migrationVersion: {}, references: [] },
+      },
+      {
+        _id: 'c:d',
+        // name field is not migrated on unknown type
+        _source: { type: 'c', c: { name: 'DDD' } },
+      },
+    ]);
+
+    const obj1 = {
+      id: 'b',
+      type: 'a',
+      attributes: { name: 'AAA' },
+      migrationVersion: {},
+      references: [],
+    };
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(transform).toHaveBeenNthCalledWith(1, obj1);
   });
 });

--- a/src/core/server/saved_objects/migrations/kibana/kibana_migrator.ts
+++ b/src/core/server/saved_objects/migrations/kibana/kibana_migrator.ts
@@ -184,11 +184,12 @@ export class KibanaMigrator {
               logger: this.log,
               preMigrationScript: indexMap[index].script,
               transformRawDocs: (rawDocs: SavedObjectsRawDoc[]) =>
-                migrateRawDocsSafely(
-                  this.serializer,
-                  this.documentMigrator.migrateAndConvert,
-                  rawDocs
-                ),
+                migrateRawDocsSafely({
+                  serializer: this.serializer,
+                  knownTypes: new Set(this.typeRegistry.getAllTypes().map((t) => t.name)),
+                  migrateDoc: this.documentMigrator.migrateAndConvert,
+                  rawDocs,
+                }),
               migrationVersionPerType: this.documentMigrator.migrationVersion,
               indexPrefix: index,
               migrationsConfig: this.soMigrationsConfig,

--- a/src/core/server/saved_objects/migrationsv2/actions/check_for_unknown_docs.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/check_for_unknown_docs.test.ts
@@ -97,9 +97,12 @@ describe('checkForUnknownDocs', () => {
     const result = await task();
 
     expect(Either.isRight(result)).toBe(true);
+    expect((result as Either.Right<any>).right).toEqual({
+      unknownDocs: [],
+    });
   });
 
-  it('resolves with `Either.left` when unknown docs are found', async () => {
+  it('resolves with `Either.right` when unknown docs are found', async () => {
     const client = elasticsearchClientMock.createInternalClient(
       elasticsearchClientMock.createSuccessTransportRequestPromise({
         hits: {
@@ -120,9 +123,8 @@ describe('checkForUnknownDocs', () => {
 
     const result = await task();
 
-    expect(Either.isLeft(result)).toBe(true);
-    expect((result as Either.Left<any>).left).toEqual({
-      type: 'unknown_docs_found',
+    expect(Either.isRight(result)).toBe(true);
+    expect((result as Either.Right<any>).right).toEqual({
       unknownDocs: [
         { id: '12', type: 'foo' },
         { id: '14', type: 'bar' },
@@ -148,9 +150,8 @@ describe('checkForUnknownDocs', () => {
 
     const result = await task();
 
-    expect(Either.isLeft(result)).toBe(true);
-    expect((result as Either.Left<any>).left).toEqual({
-      type: 'unknown_docs_found',
+    expect(Either.isRight(result)).toBe(true);
+    expect((result as Either.Right<any>).right).toEqual({
       unknownDocs: [{ id: '12', type: 'unknown' }],
     });
   });

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -80,7 +80,6 @@ export type {
 } from './update_and_pickup_mappings';
 export { updateAndPickupMappings } from './update_and_pickup_mappings';
 
-import type { UnknownDocsFound } from './check_for_unknown_docs';
 export type {
   CheckForUnknownDocsParams,
   UnknownDocsFound,
@@ -131,7 +130,6 @@ export interface ActionErrorTypeMap {
   alias_not_found_exception: AliasNotFound;
   remove_index_not_a_concrete_index: RemoveIndexNotAConcreteIndex;
   documents_transform_failed: DocumentsTransformFailed;
-  unknown_docs_found: UnknownDocsFound;
 }
 
 /**

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7_13_0_unknown_types.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7_13_0_unknown_types.test.ts
@@ -7,42 +7,31 @@
  */
 
 import Path from 'path';
-import Fs from 'fs';
-import Util from 'util';
+import fs from 'fs/promises';
 import { estypes } from '@elastic/elasticsearch';
 import * as kbnTestServer from '../../../../test_helpers/kbn_server';
 import { Root } from '../../../root';
+import JSON5 from 'json5';
+import { ElasticsearchClient } from '../../../elasticsearch';
 
 const logFilePath = Path.join(__dirname, '7_13_unknown_types_test.log');
 
-const asyncUnlink = Util.promisify(Fs.unlink);
-
 async function removeLogFile() {
   // ignore errors if it doesn't exist
-  await asyncUnlink(logFilePath).catch(() => void 0);
+  await fs.unlink(logFilePath).catch(() => void 0);
 }
 
 describe('migration v2', () => {
   let esServer: kbnTestServer.TestElasticsearchUtils;
   let root: Root;
+  let startES: () => Promise<kbnTestServer.TestElasticsearchUtils>;
 
   beforeAll(async () => {
     await removeLogFile();
   });
 
-  afterAll(async () => {
-    if (root) {
-      await root.shutdown();
-    }
-    if (esServer) {
-      await esServer.stop();
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
-  });
-
-  it('migrates the documents to the highest version', async () => {
-    const { startES } = kbnTestServer.createTestServers({
+  beforeEach(() => {
+    ({ startES } = kbnTestServer.createTestServers({
       adjustTimeout: (t: number) => jest.setTimeout(t),
       settings: {
         es: {
@@ -53,50 +42,155 @@ describe('migration v2', () => {
           dataArchive: Path.join(__dirname, 'archives', '7.13.0_with_unknown_so.zip'),
         },
       },
-    });
+    }));
+  });
 
+  afterEach(async () => {
+    if (root) {
+      await root.shutdown();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+  });
+
+  it('logs a warning and completes the migration with unknown docs retained', async () => {
     root = createRoot();
-
     esServer = await startES();
     await root.setup();
+    await root.start();
 
-    try {
-      await root.start();
-    } catch (err) {
-      const errorMessage = err.message;
+    const logFileContent = await fs.readFile(logFilePath, 'utf-8');
+    const records = logFileContent
+      .split('\n')
+      .filter(Boolean)
+      .map((str) => JSON5.parse(str));
 
-      expect(
-        errorMessage.startsWith(
-          'Unable to complete saved object migrations for the [.kibana] index: Migration failed because documents ' +
-            'were found for unknown saved object types. To proceed with the migration, please delete these documents from the ' +
-            '".kibana_7.13.0_001" index.'
-        )
-      ).toBeTruthy();
+    const unknownDocsWarningLog = records.find((rec) =>
+      rec.message.startsWith(`[.kibana] CHECK_UNKNOWN_DOCUMENTS`)
+    );
 
-      const unknownDocs = [
-        { type: 'space', id: 'space:default' },
-        { type: 'space', id: 'space:first' },
-        { type: 'space', id: 'space:second' },
-        { type: 'space', id: 'space:third' },
-        { type: 'space', id: 'space:forth' },
-        { type: 'space', id: 'space:fifth' },
-        { type: 'space', id: 'space:sixth' },
-        { type: 'foo', id: 'P2SQfHkBs3dBRGh--No5' },
-        { type: 'foo', id: 'QGSZfHkBs3dBRGh-ANoD' },
-        { type: 'foo', id: 'QWSZfHkBs3dBRGh-hNob' },
-      ];
+    expect(
+      unknownDocsWarningLog.message.startsWith(
+        '[.kibana] CHECK_UNKNOWN_DOCUMENTS Upgrades will fail for 8.0+ because documents were found for unknown saved ' +
+          'object types. To ensure that upgrades will succeed in the future, either re-enable plugins or delete ' +
+          'these documents from the ".kibana_8.0.0_001" index after the current upgrade completes.'
+      )
+    ).toBeTruthy();
 
-      unknownDocs.forEach(({ id, type }) => {
-        expect(errorMessage).toEqual(expect.stringContaining(`- "${id}" (type: "${type}")`));
-      });
+    const unknownDocs = [
+      { type: 'space', id: 'space:default' },
+      { type: 'space', id: 'space:first' },
+      { type: 'space', id: 'space:second' },
+      { type: 'space', id: 'space:third' },
+      { type: 'space', id: 'space:forth' },
+      { type: 'space', id: 'space:fifth' },
+      { type: 'space', id: 'space:sixth' },
+      { type: 'foo', id: 'P2SQfHkBs3dBRGh--No5' },
+      { type: 'foo', id: 'QGSZfHkBs3dBRGh-ANoD' },
+      { type: 'foo', id: 'QWSZfHkBs3dBRGh-hNob' },
+    ];
 
-      const client = esServer.es.getClient();
-      const { body: response } = await client.indices.getSettings({ index: '.kibana_7.13.0_001' });
-      const settings = response['.kibana_7.13.0_001']
-        .settings as estypes.IndicesIndexStatePrefixedSettings;
-      expect(settings.index).not.toBeUndefined();
-      expect(settings.index!.blocks?.write).not.toEqual('true');
-    }
+    unknownDocs.forEach(({ id, type }) => {
+      expect(unknownDocsWarningLog.message).toEqual(
+        expect.stringContaining(`- "${id}" (type: "${type}")`)
+      );
+    });
+
+    const client: ElasticsearchClient = esServer.es.getClient();
+    const { body: response } = await client.indices.getSettings({ index: '.kibana_8.0.0_001' });
+    const settings = response['.kibana_8.0.0_001']
+      .settings as estypes.IndicesIndexStatePrefixedSettings;
+    expect(settings.index).not.toBeUndefined();
+    expect(settings.index!.blocks?.write).not.toEqual('true');
+
+    // Ensure that documents for unknown types were preserved in target index in an unmigrated state
+    const spaceDocs = await fetchDocs(client, '.kibana_8.0.0_001', 'space');
+    expect(spaceDocs.map((s) => s.id)).toEqual(
+      expect.arrayContaining([
+        'space:default',
+        'space:first',
+        'space:second',
+        'space:third',
+        'space:forth',
+        'space:fifth',
+        'space:sixth',
+      ])
+    );
+    spaceDocs.forEach((d) => {
+      expect(d.migrationVersion.space).toEqual('6.6.0');
+      expect(d.coreMigrationVersion).toEqual('7.13.0');
+    });
+    const fooDocs = await fetchDocs(client, '.kibana_8.0.0_001', 'foo');
+    expect(fooDocs.map((f) => f.id)).toEqual(
+      expect.arrayContaining([
+        'P2SQfHkBs3dBRGh--No5',
+        'QGSZfHkBs3dBRGh-ANoD',
+        'QWSZfHkBs3dBRGh-hNob',
+      ])
+    );
+    fooDocs.forEach((d) => {
+      expect(d.migrationVersion.foo).toEqual('7.13.0');
+      expect(d.coreMigrationVersion).toEqual('7.13.0');
+    });
+  });
+
+  it('migrates outdated documents when types are re-enabled', async () => {
+    // Start kibana with foo and space types disabled
+    root = createRoot();
+    esServer = await startES();
+    await root.setup();
+    await root.start();
+
+    // Shutdown and start Kibana again with space type registered to ensure space docs get migrated
+    await root.shutdown();
+    root = createRoot();
+    const coreSetup = await root.setup();
+    coreSetup.savedObjects.registerType({
+      name: 'space',
+      hidden: false,
+      mappings: { properties: {} },
+      namespaceType: 'agnostic',
+      migrations: {
+        '6.6.0': (d) => d,
+        '8.0.0': (d) => d,
+      },
+    });
+    await root.start();
+
+    const client: ElasticsearchClient = esServer.es.getClient();
+    const spacesDocsMigrated = await fetchDocs(client, '.kibana_8.0.0_001', 'space');
+    expect(spacesDocsMigrated.map((s) => s.id)).toEqual(
+      expect.arrayContaining([
+        'space:default',
+        'space:first',
+        'space:second',
+        'space:third',
+        'space:forth',
+        'space:fifth',
+        'space:sixth',
+      ])
+    );
+    spacesDocsMigrated.forEach((d) => {
+      expect(d.migrationVersion.space).toEqual('8.0.0'); // should be migrated
+      expect(d.coreMigrationVersion).toEqual('8.0.0');
+    });
+
+    // Make sure unmigrated foo docs are also still there in an unmigrated state
+    const fooDocsUnmigrated = await fetchDocs(client, '.kibana_8.0.0_001', 'foo');
+    expect(fooDocsUnmigrated.map((f) => f.id)).toEqual(
+      expect.arrayContaining([
+        'P2SQfHkBs3dBRGh--No5',
+        'QGSZfHkBs3dBRGh-ANoD',
+        'QWSZfHkBs3dBRGh-hNob',
+      ])
+    );
+    fooDocsUnmigrated.forEach((d) => {
+      expect(d.migrationVersion.foo).toEqual('7.13.0'); // should still not be migrated
+      expect(d.coreMigrationVersion).toEqual('7.13.0');
+    });
   });
 });
 
@@ -130,4 +224,27 @@ function createRoot() {
       oss: true,
     }
   );
+}
+
+async function fetchDocs(esClient: ElasticsearchClient, index: string, type: string) {
+  const { body } = await esClient.search<any>({
+    index,
+    size: 10000,
+    body: {
+      query: {
+        bool: {
+          should: [
+            {
+              term: { type },
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  return body.hits.hits.map((h) => ({
+    ...h._source,
+    id: h._id,
+  }));
 }

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7_13_0_unknown_types.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7_13_0_unknown_types.test.ts
@@ -13,7 +13,11 @@ import * as kbnTestServer from '../../../../test_helpers/kbn_server';
 import { Root } from '../../../root';
 import JSON5 from 'json5';
 import { ElasticsearchClient } from '../../../elasticsearch';
+import { Env } from '@kbn/config';
+import { REPO_ROOT } from '@kbn/utils';
+import { getEnvOptions } from '@kbn/config/target/mocks';
 
+const kibanaVersion = Env.createDefault(REPO_ROOT, getEnvOptions()).packageInfo.version;
 const logFilePath = Path.join(__dirname, '7_13_unknown_types_test.log');
 
 async function removeLogFile() {
@@ -76,7 +80,7 @@ describe('migration v2', () => {
       unknownDocsWarningLog.message.startsWith(
         '[.kibana] CHECK_UNKNOWN_DOCUMENTS Upgrades will fail for 8.0+ because documents were found for unknown saved ' +
           'object types. To ensure that upgrades will succeed in the future, either re-enable plugins or delete ' +
-          'these documents from the ".kibana_8.0.0_001" index after the current upgrade completes.'
+          `these documents from the ".kibana_${kibanaVersion}_001" index after the current upgrade completes.`
       )
     ).toBeTruthy();
 
@@ -100,14 +104,16 @@ describe('migration v2', () => {
     });
 
     const client: ElasticsearchClient = esServer.es.getClient();
-    const { body: response } = await client.indices.getSettings({ index: '.kibana_8.0.0_001' });
-    const settings = response['.kibana_8.0.0_001']
+    const { body: response } = await client.indices.getSettings({
+      index: `.kibana_${kibanaVersion}_001`,
+    });
+    const settings = response[`.kibana_${kibanaVersion}_001`]
       .settings as estypes.IndicesIndexStatePrefixedSettings;
     expect(settings.index).not.toBeUndefined();
     expect(settings.index!.blocks?.write).not.toEqual('true');
 
     // Ensure that documents for unknown types were preserved in target index in an unmigrated state
-    const spaceDocs = await fetchDocs(client, '.kibana_8.0.0_001', 'space');
+    const spaceDocs = await fetchDocs(client, `.kibana_${kibanaVersion}_001`, 'space');
     expect(spaceDocs.map((s) => s.id)).toEqual(
       expect.arrayContaining([
         'space:default',
@@ -123,7 +129,7 @@ describe('migration v2', () => {
       expect(d.migrationVersion.space).toEqual('6.6.0');
       expect(d.coreMigrationVersion).toEqual('7.13.0');
     });
-    const fooDocs = await fetchDocs(client, '.kibana_8.0.0_001', 'foo');
+    const fooDocs = await fetchDocs(client, `.kibana_${kibanaVersion}_001`, 'foo');
     expect(fooDocs.map((f) => f.id)).toEqual(
       expect.arrayContaining([
         'P2SQfHkBs3dBRGh--No5',
@@ -155,13 +161,13 @@ describe('migration v2', () => {
       namespaceType: 'agnostic',
       migrations: {
         '6.6.0': (d) => d,
-        '8.0.0': (d) => d,
+        [kibanaVersion]: (d) => d,
       },
     });
     await root.start();
 
     const client: ElasticsearchClient = esServer.es.getClient();
-    const spacesDocsMigrated = await fetchDocs(client, '.kibana_8.0.0_001', 'space');
+    const spacesDocsMigrated = await fetchDocs(client, `.kibana_${kibanaVersion}_001`, 'space');
     expect(spacesDocsMigrated.map((s) => s.id)).toEqual(
       expect.arrayContaining([
         'space:default',
@@ -174,12 +180,12 @@ describe('migration v2', () => {
       ])
     );
     spacesDocsMigrated.forEach((d) => {
-      expect(d.migrationVersion.space).toEqual('8.0.0'); // should be migrated
-      expect(d.coreMigrationVersion).toEqual('8.0.0');
+      expect(d.migrationVersion.space).toEqual(kibanaVersion); // should be migrated
+      expect(d.coreMigrationVersion).toEqual(kibanaVersion);
     });
 
     // Make sure unmigrated foo docs are also still there in an unmigrated state
-    const fooDocsUnmigrated = await fetchDocs(client, '.kibana_8.0.0_001', 'foo');
+    const fooDocsUnmigrated = await fetchDocs(client, `.kibana_${kibanaVersion}_001`, 'foo');
     expect(fooDocsUnmigrated.map((f) => f.id)).toEqual(
       expect.arrayContaining([
         'P2SQfHkBs3dBRGh--No5',

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.ts
@@ -52,6 +52,8 @@ const logStateTransition = (
       switch (level) {
         case 'error':
           return logger.error(logMessagePrefix + message);
+        case 'warning':
+          return logger.warn(logMessagePrefix + message);
         case 'info':
           return logger.info(logMessagePrefix + message);
         default:

--- a/src/core/server/saved_objects/migrationsv2/model/extract_errors.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/extract_errors.test.ts
@@ -25,7 +25,7 @@ describe('extractUnknownDocFailureReason', () => {
         '.kibana_15'
       )
     ).toMatchInlineSnapshot(`
-      "Migration failed because documents were found for unknown saved object types. To proceed with the migration, please delete these documents from the \\".kibana_15\\" index.
+      "Upgrades will fail for 8.0+ because documents were found for unknown saved object types. To ensure that upgrades will succeed in the future, either re-enable plugins or delete these documents from the \\".kibana_15\\" index after the current upgrade completes.
       The documents with unknown types are:
       - \\"unknownType:12\\" (type: \\"unknownType\\")
       - \\"anotherUnknownType:42\\" (type: \\"anotherUnknownType\\")

--- a/src/core/server/saved_objects/migrationsv2/model/extract_errors.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/extract_errors.ts
@@ -38,15 +38,16 @@ export function extractTransformFailuresReason(
 
 export function extractUnknownDocFailureReason(
   unknownDocs: CheckForUnknownDocsFoundDoc[],
-  sourceIndex: string
+  targetIndex: string
 ): string {
   return (
-    `Migration failed because documents were found for unknown saved object types. ` +
-    `To proceed with the migration, please delete these documents from the "${sourceIndex}" index.\n` +
+    `Upgrades will fail for 8.0+ because documents were found for unknown saved object types. ` +
+    `To ensure that upgrades will succeed in the future, either re-enable plugins or delete these documents from the ` +
+    `"${targetIndex}" index after the current upgrade completes.\n` +
     `The documents with unknown types are:\n` +
     unknownDocs.map((doc) => `- "${doc.id}" (type: "${doc.type}")\n`).join('') +
     `You can delete them using the following command:\n` +
-    `curl -X POST "{elasticsearch}/${sourceIndex}/_bulk?pretty" -H 'Content-Type: application/json' -d'\n` +
+    `curl -X POST "{elasticsearch}/${targetIndex}/_bulk?pretty" -H 'Content-Type: application/json' -d'\n` +
     unknownDocs.map((doc) => `{ "delete" : { "_id" : "${doc.id}" } }\n`).join('') +
     `'`
   );

--- a/src/core/server/saved_objects/migrationsv2/model/model.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/model.test.ts
@@ -715,7 +715,7 @@ describe('migrations v2 model', () => {
         },
       } as const;
 
-      test('CHECK_UNKNOWN_DOCUMENTS -> SET_SOURCE_WRITE_BLOCK if action succeeds', () => {
+      test('CHECK_UNKNOWN_DOCUMENTS -> SET_SOURCE_WRITE_BLOCK if action succeeds and no unknown docs are found', () => {
         const checkUnknownDocumentsSourceState: CheckUnknownDocumentsState = {
           ...baseState,
           controlState: 'CHECK_UNKNOWN_DOCUMENTS',
@@ -723,7 +723,7 @@ describe('migrations v2 model', () => {
           sourceIndexMappings: mappingsWithUnknownType,
         };
 
-        const res: ResponseType<'CHECK_UNKNOWN_DOCUMENTS'> = Either.right({});
+        const res: ResponseType<'CHECK_UNKNOWN_DOCUMENTS'> = Either.right({ unknownDocs: [] });
         const newState = model(checkUnknownDocumentsSourceState, res);
         expect(newState.controlState).toEqual('SET_SOURCE_WRITE_BLOCK');
 
@@ -758,9 +758,12 @@ describe('migrations v2 model', () => {
             },
           }
         `);
+
+        // No log message gets appended
+        expect(newState.logs).toEqual([]);
       });
 
-      test('CHECK_UNKNOWN_DOCUMENTS -> FATAL if action fails and unknown docs were found', () => {
+      test('CHECK_UNKNOWN_DOCUMENTS -> SET_SOURCE_WRITE_BLOCK and adds log if action succeeds and unknown docs were found', () => {
         const checkUnknownDocumentsSourceState: CheckUnknownDocumentsState = {
           ...baseState,
           controlState: 'CHECK_UNKNOWN_DOCUMENTS',
@@ -768,20 +771,51 @@ describe('migrations v2 model', () => {
           sourceIndexMappings: mappingsWithUnknownType,
         };
 
-        const res: ResponseType<'CHECK_UNKNOWN_DOCUMENTS'> = Either.left({
-          type: 'unknown_docs_found',
+        const res: ResponseType<'CHECK_UNKNOWN_DOCUMENTS'> = Either.right({
           unknownDocs: [
             { id: 'dashboard:12', type: 'dashboard' },
             { id: 'foo:17', type: 'foo' },
           ],
         });
         const newState = model(checkUnknownDocumentsSourceState, res);
-        expect(newState.controlState).toEqual('FATAL');
+        expect(newState.controlState).toEqual('SET_SOURCE_WRITE_BLOCK');
 
         expect(newState).toMatchObject({
-          controlState: 'FATAL',
-          reason: expect.stringContaining(
-            'Migration failed because documents were found for unknown saved object types'
+          controlState: 'SET_SOURCE_WRITE_BLOCK',
+          sourceIndex: Option.some('.kibana_3'),
+          targetIndex: '.kibana_7.11.0_001',
+        });
+
+        // This snapshot asserts that we disable the unknown saved object
+        // type. Because it's mappings are disabled, we also don't copy the
+        // `_meta.migrationMappingPropertyHashes` for the disabled type.
+        expect(newState.targetIndexMappings).toMatchInlineSnapshot(`
+          Object {
+            "_meta": Object {
+              "migrationMappingPropertyHashes": Object {
+                "new_saved_object_type": "4a11183eee21e6fbad864f7a30b39ad0",
+              },
+            },
+            "properties": Object {
+              "disabled_saved_object_type": Object {
+                "dynamic": false,
+                "properties": Object {},
+              },
+              "new_saved_object_type": Object {
+                "properties": Object {
+                  "value": Object {
+                    "type": "text",
+                  },
+                },
+              },
+            },
+          }
+        `);
+
+        expect(newState.logs[0]).toMatchObject({
+          level: 'warning',
+          message: expect.stringContaining(
+            'Upgrades will fail for 8.0+ because documents were found for unknown saved object types'
           ),
         });
       });

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -19,7 +19,7 @@ import {
   DocumentsTransformSuccess,
 } from '../migrations/core/migrate_raw_docs';
 
-export type MigrationLogLevel = 'error' | 'info';
+export type MigrationLogLevel = 'error' | 'info' | 'warning';
 
 export interface MigrationLog {
   level: MigrationLogLevel;


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Log a warning when documents of unknown types are detected during migration (#105213)