### PR TITLE
[ML] Fix calendar creation during model snapshot restore

### DIFF
--- a/x-pack/plugins/ml/public/application/components/model_snapshots/revert_model_snapshot_flyout/revert_model_snapshot_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/components/model_snapshots/revert_model_snapshot_flyout/revert_model_snapshot_flyout.tsx
@@ -42,6 +42,7 @@ import { Anomaly } from '../../../jobs/new_job/common/results_loader/results_loa
 import { parseInterval } from '../../../../../common/util/parse_interval';
 import { CreateCalendar, CalendarEvent } from './create_calendar';
 import { timeFormatter } from '../../../../../common/util/date_utils';
+import { toastNotificationServiceProvider } from '../../../services/toast_notification_service';
 
 interface Props {
   snapshot: ModelSnapshot;
@@ -139,6 +140,10 @@ export const RevertModelSnapshotFlyout: FC<Props> = ({
             })
           );
           refresh();
+        })
+        .catch((error) => {
+          const { displayErrorToast } = toastNotificationServiceProvider(toasts);
+          displayErrorToast(error);
         });
       hideRevertModal();
       closeFlyout();

--- a/x-pack/plugins/ml/server/models/job_service/model_snapshots.ts
+++ b/x-pack/plugins/ml/server/models/job_service/model_snapshots.ts
@@ -85,7 +85,6 @@ export function modelSnapshotProvider(client: IScopedClusterClient, mlClient: Ml
           ),
           events: calendarEvents.map((s) => ({
             calendar_id: calendarId,
-            event_id: '',
             description: s.description,
             start_time: `${s.start}`,
             end_time: `${s.end}`,


### PR DESCRIPTION
An empty `event_id` is being added to the events being created when adding calendars during a snapshot restore.

Bug introduced here https://github.com/elastic/kibana/pull/83808
Looks like the empty id was added to work around incorrect esclient types.

Also adds a catch for any other unexpected errors when applying a snapshot
