### PR TITLE
[7.x] [Maps] Move new vector layer wizard card down (#104797)

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/load_layer_wizards.ts
+++ b/x-pack/plugins/maps/public/classes/layers/load_layer_wizards.ts
@@ -38,7 +38,6 @@ export function registerLayerWizards() {
 
   // Registration order determines display order
   registerLayerWizard(uploadLayerWizardConfig);
-  registerLayerWizard(newVectorLayerWizardConfig);
   registerLayerWizard(esDocumentsLayerWizardConfig);
   // @ts-ignore
   registerLayerWizard(choroplethLayerWizardConfig);
@@ -51,6 +50,7 @@ export function registerLayerWizards() {
   registerLayerWizard(point2PointLayerWizardConfig);
   // @ts-ignore
   registerLayerWizard(emsBoundariesLayerWizardConfig);
+  registerLayerWizard(newVectorLayerWizardConfig);
   // @ts-ignore
   registerLayerWizard(emsBaseMapLayerWizardConfig);
   // @ts-ignore

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
@@ -535,6 +535,17 @@ exports[`TOCEntryActionsPopover should not show edit actions in read only mode 1
               "onClick": [Function],
               "toolTipContent": null,
             },
+            Object {
+              "data-test-subj": "layerSettingsButton",
+              "disabled": false,
+              "icon": <EuiIcon
+                size="m"
+                type="pencil"
+              />,
+              "name": "Edit layer settings",
+              "onClick": [Function],
+              "toolTipContent": null,
+            },
           ],
           "title": "Layer actions",
         },

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
@@ -158,6 +158,17 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
         },
       },
     ];
+    actionItems.push({
+      disabled: this.props.isEditButtonDisabled,
+      name: EDIT_LAYER_SETTINGS_LABEL,
+      icon: <EuiIcon type="pencil" size="m" />,
+      'data-test-subj': 'layerSettingsButton',
+      toolTipContent: null,
+      onClick: () => {
+        this._closePopover();
+        this.props.openLayerSettings();
+      },
+    });
 
     if (!this.props.isReadOnly) {
       if (this.state.supportsFeatureEditing) {
@@ -186,17 +197,6 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
           },
         });
       }
-      actionItems.push({
-        disabled: this.props.isEditButtonDisabled,
-        name: EDIT_LAYER_SETTINGS_LABEL,
-        icon: <EuiIcon type="pencil" size="m" />,
-        'data-test-subj': 'layerSettingsButton',
-        toolTipContent: null,
-        onClick: () => {
-          this._closePopover();
-          this.props.openLayerSettings();
-        },
-      });
       actionItems.push({
         name: i18n.translate('xpack.maps.layerTocActions.cloneLayerTitle', {
           defaultMessage: 'Clone layer',


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Maps] Move new vector layer wizard card down (#104797)