### PR TITLE
[Search Sessions] Expire empty sessions after a minute

### DIFF
--- a/x-pack/plugins/data_enhanced/server/search/session/check_non_persiseted_sessions.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/check_non_persiseted_sessions.ts
@@ -59,7 +59,11 @@ function checkNonPersistedSessionsPage(
         `${SEARCH_SESSIONS_CLEANUP_TASK_TYPE} Found ${nonPersistedSearchSessions.total} sessions, processing ${nonPersistedSearchSessions.saved_objects.length}`
       );
 
-      const updatedSessions = await getAllSessionsStatusUpdates(deps, nonPersistedSearchSessions);
+      const updatedSessions = await getAllSessionsStatusUpdates(
+        deps,
+        config,
+        nonPersistedSearchSessions
+      );
       const deletedSessionIds: string[] = [];
 
       await Promise.all(

--- a/x-pack/plugins/data_enhanced/server/search/session/check_persisted_sessions.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/check_persisted_sessions.ts
@@ -36,7 +36,11 @@ function checkPersistedSessionsPage(
         `${SEARCH_SESSIONS_TASK_TYPE} Found ${persistedSearchSessions.total} sessions, processing ${persistedSearchSessions.saved_objects.length}`
       );
 
-      const updatedSessions = await getAllSessionsStatusUpdates(deps, persistedSearchSessions);
+      const updatedSessions = await getAllSessionsStatusUpdates(
+        deps,
+        config,
+        persistedSearchSessions
+      );
       await bulkUpdateSessions(deps, updatedSessions);
 
       return persistedSearchSessions;

--- a/x-pack/plugins/data_enhanced/server/search/session/expire_persisted_sessions.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/expire_persisted_sessions.ts
@@ -36,7 +36,7 @@ function checkSessionExpirationPage(
         `${SEARCH_SESSIONS_EXPIRE_TASK_TYPE} Found ${searchSessions.total} sessions, processing ${searchSessions.saved_objects.length}`
       );
 
-      const updatedSessions = await getAllSessionsStatusUpdates(deps, searchSessions);
+      const updatedSessions = await getAllSessionsStatusUpdates(deps, config, searchSessions);
       await bulkUpdateSessions(deps, updatedSessions);
 
       return searchSessions;

--- a/x-pack/plugins/data_enhanced/server/search/session/get_session_status.test.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/get_session_status.test.ts
@@ -5,18 +5,21 @@
  * 2.0.
  */
 
-import { SearchStatus } from './types';
+import { SearchSessionsConfig, SearchStatus } from './types';
 import { getSessionStatus } from './get_session_status';
 import { SearchSessionStatus } from '../../../../../../src/plugins/data/common';
 import moment from 'moment';
 
 describe('getSessionStatus', () => {
+  const mockConfig = ({
+    notTouchedInProgressTimeout: moment.duration(1, 'm'),
+  } as unknown) as SearchSessionsConfig;
   test("returns an in_progress status if there's nothing inside the session", () => {
     const session: any = {
       idMapping: {},
       touched: moment(),
     };
-    expect(getSessionStatus(session)).toBe(SearchSessionStatus.IN_PROGRESS);
+    expect(getSessionStatus(session, mockConfig)).toBe(SearchSessionStatus.IN_PROGRESS);
   });
 
   test("returns an error status if there's at least one error", () => {
@@ -27,7 +30,7 @@ describe('getSessionStatus', () => {
         c: { status: SearchStatus.COMPLETE },
       },
     };
-    expect(getSessionStatus(session)).toBe(SearchSessionStatus.ERROR);
+    expect(getSessionStatus(session, mockConfig)).toBe(SearchSessionStatus.ERROR);
   });
 
   test('expires a empty session after a minute', () => {
@@ -35,7 +38,17 @@ describe('getSessionStatus', () => {
       idMapping: {},
       touched: moment().subtract(2, 'm'),
     };
-    expect(getSessionStatus(session)).toBe(SearchSessionStatus.EXPIRED);
+    expect(getSessionStatus(session, mockConfig)).toBe(SearchSessionStatus.EXPIRED);
+  });
+
+  test('doesnt expire a full session after a minute', () => {
+    const session: any = {
+      idMapping: {
+        a: { status: SearchStatus.IN_PROGRESS },
+      },
+      touched: moment().subtract(2, 'm'),
+    };
+    expect(getSessionStatus(session, mockConfig)).toBe(SearchSessionStatus.IN_PROGRESS);
   });
 
   test('returns a complete status if all are complete', () => {
@@ -46,7 +59,7 @@ describe('getSessionStatus', () => {
         c: { status: SearchStatus.COMPLETE },
       },
     };
-    expect(getSessionStatus(session)).toBe(SearchSessionStatus.COMPLETE);
+    expect(getSessionStatus(session, mockConfig)).toBe(SearchSessionStatus.COMPLETE);
   });
 
   test('returns a running status if some are still running', () => {
@@ -57,6 +70,6 @@ describe('getSessionStatus', () => {
         c: { status: SearchStatus.IN_PROGRESS },
       },
     };
-    expect(getSessionStatus(session)).toBe(SearchSessionStatus.IN_PROGRESS);
+    expect(getSessionStatus(session, mockConfig)).toBe(SearchSessionStatus.IN_PROGRESS);
   });
 });

--- a/x-pack/plugins/data_enhanced/server/search/session/get_session_status.test.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/get_session_status.test.ts
@@ -8,11 +8,13 @@
 import { SearchStatus } from './types';
 import { getSessionStatus } from './get_session_status';
 import { SearchSessionStatus } from '../../../../../../src/plugins/data/common';
+import moment from 'moment';
 
 describe('getSessionStatus', () => {
   test("returns an in_progress status if there's nothing inside the session", () => {
     const session: any = {
       idMapping: {},
+      touched: moment(),
     };
     expect(getSessionStatus(session)).toBe(SearchSessionStatus.IN_PROGRESS);
   });
@@ -26,6 +28,14 @@ describe('getSessionStatus', () => {
       },
     };
     expect(getSessionStatus(session)).toBe(SearchSessionStatus.ERROR);
+  });
+
+  test('expires a empty session after a minute', () => {
+    const session: any = {
+      idMapping: {},
+      touched: moment().subtract(2, 'm'),
+    };
+    expect(getSessionStatus(session)).toBe(SearchSessionStatus.EXPIRED);
   });
 
   test('returns a complete status if all are complete', () => {

--- a/x-pack/plugins/data_enhanced/server/search/session/get_session_status.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/get_session_status.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import moment from 'moment';
 import {
   SearchSessionSavedObjectAttributes,
   SearchSessionStatus,
@@ -13,8 +14,12 @@ import { SearchStatus } from './types';
 
 export function getSessionStatus(session: SearchSessionSavedObjectAttributes): SearchSessionStatus {
   const searchStatuses = Object.values(session.idMapping);
+  const curTime = moment();
   if (searchStatuses.some((item) => item.status === SearchStatus.ERROR)) {
     return SearchSessionStatus.ERROR;
+  } else if (curTime.diff(moment(session.touched), 'ms') > 60000) {
+    // Expire empty sessions that weren't touched for a minute
+    return SearchSessionStatus.EXPIRED;
   } else if (
     searchStatuses.length > 0 &&
     searchStatuses.every((item) => item.status === SearchStatus.COMPLETE)

--- a/x-pack/plugins/data_enhanced/server/search/session/update_session_status.test.ts
+++ b/x-pack/plugins/data_enhanced/server/search/session/update_session_status.test.ts
@@ -21,6 +21,7 @@ import {
 
 describe('bulkUpdateSessions', () => {
   let mockClient: any;
+  const mockConfig: any = {};
   let savedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
   const mockLogger: any = {
     debug: jest.fn(),
@@ -66,6 +67,7 @@ describe('bulkUpdateSessions', () => {
           client: mockClient,
           logger: mockLogger,
         },
+        mockConfig,
         so
       );
 
@@ -105,6 +107,7 @@ describe('bulkUpdateSessions', () => {
           client: mockClient,
           logger: mockLogger,
         },
+        mockConfig,
         so
       );
 
@@ -139,6 +142,7 @@ describe('bulkUpdateSessions', () => {
           client: mockClient,
           logger: mockLogger,
         },
+        mockConfig,
         so
       );
 
@@ -176,6 +180,7 @@ describe('bulkUpdateSessions', () => {
           client: mockClient,
           logger: mockLogger,
         },
+        mockConfig,
         so
       );
 
@@ -219,6 +224,7 @@ describe('bulkUpdateSessions', () => {
           client: mockClient,
           logger: mockLogger,
         },
+        mockConfig,
         so
       );
 


### PR DESCRIPTION
## Summary

Resolves #104689 by expiring empty sessions after 1 minute (configurable).

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
