### PR TITLE
[7.x] [Maps] Change TOC pop-up wording to reflect filter change, not search bar change (#105163)

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_button/toc_entry_button.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_button/toc_entry_button.tsx
@@ -116,7 +116,7 @@ export class TOCEntryButton extends Component<Props, State> {
         footnotes.push({
           icon: <EuiIcon color="subdued" type="filter" size="s" />,
           message: i18n.translate('xpack.maps.layer.isUsingSearchMsg', {
-            defaultMessage: 'Results narrowed by search bar',
+            defaultMessage: 'Results narrowed by query and filters',
           }),
         });
       }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Maps] Change TOC pop-up wording to reflect filter change, not search bar change (#105163)