### PR TITLE
[7.x] Format numbers in TOC pop-up and add layer menu to locale (#105165)

### DIFF
--- a/docs/maps/vector-layer.asciidoc
+++ b/docs/maps/vector-layer.asciidoc
@@ -20,10 +20,10 @@ The index must contain at least one field mapped as {ref}/geo-point.html[geo_poi
 Results are limited to the `index.max_result_window` index setting, which defaults to 10000.
 Select the appropriate *Scaling* option for your use case.
 +
-* *Limit results to 10000.* The layer displays features from the first `index.max_result_window` documents.
+* *Limit results to 10,000* The layer displays features from the first `index.max_result_window` documents.
 Results exceeding `index.max_result_window` are not displayed.
 
-* *Show clusters when results exceed 10000.* When results exceed `index.max_result_window`, the layer uses {ref}/search-aggregations-bucket-geotilegrid-aggregation.html[GeoTile grid aggregation] to group your documents into clusters and displays metrics for each cluster. When results are less then `index.max_result_window`, the layer displays features from individual documents.
+* *Show clusters when results exceed 10,000* When results exceed `index.max_result_window`, the layer uses {ref}/search-aggregations-bucket-geotilegrid-aggregation.html[GeoTile grid aggregation] to group your documents into clusters and displays metrics for each cluster. When results are less then `index.max_result_window`, the layer displays features from individual documents.
 
 * *Use vector tiles.* Vector tiles partition your map into 6 to 8 tiles.
 Each tile request is limited to the `index.max_result_window` index setting.

--- a/x-pack/plugins/maps/public/classes/layers/file_upload_wizard/wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/file_upload_wizard/wizard.tsx
@@ -106,7 +106,7 @@ export class ClientFileCreateSourceEditor extends Component<RenderWizardArgument
         ? i18n.translate('xpack.maps.fileUpload.trimmedResultsMsg', {
             defaultMessage: `Results limited to {numFeatures} features, {previewCoverage}% of file.`,
             values: {
-              numFeatures: geojsonFile.features.length,
+              numFeatures: geojsonFile.features.length.toLocaleString(),
               previewCoverage,
             },
           })

--- a/x-pack/plugins/maps/public/classes/layers/tiled_vector_layer/tiled_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/tiled_vector_layer/tiled_vector_layer.tsx
@@ -95,13 +95,13 @@ export class TiledVectorLayer extends VectorLayer {
         ? i18n.translate('xpack.maps.tiles.resultsTrimmedMsg', {
             defaultMessage: `Results limited to {count} documents.`,
             values: {
-              count: totalFeaturesCount,
+              count: totalFeaturesCount.toLocaleString(),
             },
           })
         : i18n.translate('xpack.maps.tiles.resultsCompleteMsg', {
             defaultMessage: `Found {count} documents.`,
             values: {
-              count: totalFeaturesCount,
+              count: totalFeaturesCount.toLocaleString(),
             },
           }),
       areResultsTrimmed: isIncomplete,

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.test.ts
@@ -51,7 +51,7 @@ describe('getSourceTooltipContent', () => {
       sourceDataRequest
     );
     expect(areResultsTrimmed).toBe(true);
-    expect(tooltipContent).toBe('Results limited to first 1000 tracks of ~5000.');
+    expect(tooltipContent).toBe('Results limited to first 1,000 tracks of ~5,000.');
   });
 
   it('Should show results trimmed icon and message when tracks are trimmed', () => {
@@ -90,7 +90,7 @@ describe('getSourceTooltipContent', () => {
     );
     expect(areResultsTrimmed).toBe(true);
     expect(tooltipContent).toBe(
-      'Results limited to first 1000 tracks of ~5000. 10 of 1000 tracks are incomplete.'
+      'Results limited to first 1,000 tracks of ~5,000. 10 of 1,000 tracks are incomplete.'
     );
   });
 });

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_line_source/es_geo_line_source.tsx
@@ -326,21 +326,21 @@ export class ESGeoLineSource extends AbstractESAggSource {
       ? i18n.translate('xpack.maps.esGeoLine.areEntitiesTrimmedMsg', {
           defaultMessage: `Results limited to first {entityCount} tracks of ~{totalEntities}.`,
           values: {
-            entityCount: meta.entityCount,
-            totalEntities: meta.totalEntities,
+            entityCount: meta.entityCount.toLocaleString(),
+            totalEntities: meta.totalEntities.toLocaleString(),
           },
         })
       : i18n.translate('xpack.maps.esGeoLine.tracksCountMsg', {
           defaultMessage: `Found {entityCount} tracks.`,
-          values: { entityCount: meta.entityCount },
+          values: { entityCount: meta.entityCount.toLocaleString() },
         });
     const tracksTrimmedMsg =
       meta.numTrimmedTracks > 0
         ? i18n.translate('xpack.maps.esGeoLine.tracksTrimmedMsg', {
             defaultMessage: `{numTrimmedTracks} of {entityCount} tracks are incomplete.`,
             values: {
-              entityCount: meta.entityCount,
-              numTrimmedTracks: meta.numTrimmedTracks,
+              entityCount: meta.entityCount.toLocaleString(),
+              numTrimmedTracks: meta.numTrimmedTracks.toLocaleString(),
             },
           })
         : undefined;

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx
@@ -620,17 +620,17 @@ export class ESSearchSource extends AbstractESSource implements ITiledSingleLaye
         ? i18n.translate('xpack.maps.esSearch.topHitsResultsTrimmedMsg', {
             defaultMessage: `Results limited to first {entityCount} entities of ~{totalEntities}.`,
             values: {
-              entityCount: meta.entityCount,
-              totalEntities: meta.totalEntities,
+              entityCount: meta.entityCount?.toLocaleString(),
+              totalEntities: meta.totalEntities?.toLocaleString(),
             },
           })
         : i18n.translate('xpack.maps.esSearch.topHitsEntitiesCountMsg', {
             defaultMessage: `Found {entityCount} entities.`,
-            values: { entityCount: meta.entityCount },
+            values: { entityCount: meta.entityCount?.toLocaleString() },
           });
       const docsPerEntityMsg = i18n.translate('xpack.maps.esSearch.topHitsSizeMsg', {
         defaultMessage: `Showing top {topHitsSize} documents per entity.`,
-        values: { topHitsSize: this._descriptor.topHitsSize },
+        values: { topHitsSize: this._descriptor.topHitsSize?.toLocaleString() },
       });
 
       return {
@@ -645,7 +645,7 @@ export class ESSearchSource extends AbstractESSource implements ITiledSingleLaye
       return {
         tooltipContent: i18n.translate('xpack.maps.esSearch.resultsTrimmedMsg', {
           defaultMessage: `Results limited to first {count} documents.`,
-          values: { count: meta.resultsCount },
+          values: { count: meta.resultsCount?.toLocaleString() },
         }),
         areResultsTrimmed: true,
       };
@@ -654,7 +654,7 @@ export class ESSearchSource extends AbstractESSource implements ITiledSingleLaye
     return {
       tooltipContent: i18n.translate('xpack.maps.esSearch.featureCountMsg', {
         defaultMessage: `Found {count} documents.`,
-        values: { count: meta.resultsCount },
+        values: { count: meta.resultsCount?.toLocaleString() },
       }),
       areResultsTrimmed: false,
     };

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/__snapshots__/scaling_form.test.tsx.snap
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/__snapshots__/scaling_form.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`scaling form should disable clusters option when clustering is not supp
       <EuiRadio
         checked={true}
         id="LIMIT"
-        label="Limit results to 10000."
+        label="Limit results to 10,000"
         onChange={[Function]}
       />
       <EuiToolTip
@@ -40,7 +40,7 @@ exports[`scaling form should disable clusters option when clustering is not supp
           checked={false}
           disabled={true}
           id="CLUSTERS"
-          label="Show clusters when results exceed 10000."
+          label="Show clusters when results exceed 10,000"
           onChange={[Function]}
         />
       </EuiToolTip>
@@ -114,14 +114,14 @@ exports[`scaling form should render 1`] = `
       <EuiRadio
         checked={true}
         id="LIMIT"
-        label="Limit results to 10000."
+        label="Limit results to 10,000"
         onChange={[Function]}
       />
       <EuiRadio
         checked={false}
         disabled={false}
         id="CLUSTERS"
-        label="Show clusters when results exceed 10000."
+        label="Show clusters when results exceed 10,000"
         onChange={[Function]}
       />
       <EuiToolTip

--- a/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_form.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_search_source/util/scaling_form.tsx
@@ -38,12 +38,12 @@ interface Props {
 }
 
 interface State {
-  maxResultWindow: number;
+  maxResultWindow: string;
 }
 
 export class ScalingForm extends Component<Props, State> {
   state = {
-    maxResultWindow: DEFAULT_MAX_RESULT_WINDOW,
+    maxResultWindow: DEFAULT_MAX_RESULT_WINDOW.toLocaleString(),
   };
   _isMounted = false;
 
@@ -61,7 +61,7 @@ export class ScalingForm extends Component<Props, State> {
       const indexPattern = await getIndexPatternService().get(this.props.indexPatternId);
       const { maxResultWindow } = await loadIndexSettings(indexPattern!.title);
       if (this._isMounted) {
-        this.setState({ maxResultWindow });
+        this.setState({ maxResultWindow: maxResultWindow.toLocaleString() });
       }
     } catch (err) {
       return;
@@ -90,7 +90,7 @@ export class ScalingForm extends Component<Props, State> {
       <EuiRadio
         id={SCALING_TYPES.CLUSTERS}
         label={i18n.translate('xpack.maps.source.esSearch.clusterScalingLabel', {
-          defaultMessage: 'Show clusters when results exceed {maxResultWindow}.',
+          defaultMessage: 'Show clusters when results exceed {maxResultWindow}',
           values: { maxResultWindow: this.state.maxResultWindow },
         })}
         checked={this.props.scalingType === SCALING_TYPES.CLUSTERS}
@@ -170,7 +170,7 @@ export class ScalingForm extends Component<Props, State> {
             <EuiRadio
               id={SCALING_TYPES.LIMIT}
               label={i18n.translate('xpack.maps.source.esSearch.limitScalingLabel', {
-                defaultMessage: 'Limit results to {maxResultWindow}.',
+                defaultMessage: 'Limit results to {maxResultWindow}',
                 values: { maxResultWindow: this.state.maxResultWindow },
               })}
               checked={this.props.scalingType === SCALING_TYPES.LIMIT}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Format numbers in TOC pop-up and add layer menu to locale (#105165)