### PR TITLE
[ML] Fix warning level of bucket span estimator toast

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span_estimator/estimate_bucket_span.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/bucket_span_estimator/estimate_bucket_span.ts
@@ -6,7 +6,7 @@
  */
 
 import { useContext, useState } from 'react';
-
+import { i18n } from '@kbn/i18n';
 import { JobCreatorContext } from '../../../job_creator_context';
 import { EVENT_RATE_FIELD_ID } from '../../../../../../../../../common/types/fields';
 import { BucketSpanEstimatorData } from '../../../../../../../../../common/types/job_service';
@@ -76,10 +76,16 @@ export function useEstimateBucketSpan() {
 
   async function estimateBucketSpan() {
     setStatus(ESTIMATE_STATUS.RUNNING);
-    const { name, error, message } = await ml.estimateBucketSpan(data);
+    const { name, error, message: text } = await ml.estimateBucketSpan(data);
     setStatus(ESTIMATE_STATUS.NOT_RUNNING);
     if (error === true) {
-      getToastNotificationService().displayErrorToast(message);
+      const title = i18n.translate(
+        'xpack.ml.newJob.wizard.pickFieldsStep.bucketSpanEstimator.errorTitle',
+        {
+          defaultMessage: 'Bucket span could not be estimated',
+        }
+      );
+      getToastNotificationService().displayWarningToast({ title, text });
     } else {
       jobCreator.bucketSpan = name;
       jobCreatorUpdate();


### PR DESCRIPTION
When the bucket span estimator fails to estimate, the results should be shown in a nicer warning toast, rather than the severe looking error toast.

![image](https://user-images.githubusercontent.com/22172091/125483142-16eb8670-51d3-43ff-896a-5c3fe974fb8f.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
