### PR TITLE
[Snapshots + Restore] Fix no snapshots prompt

### DIFF
--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/home.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/home.test.ts
@@ -13,7 +13,6 @@ import {
   setupEnvironment,
   pageHelpers,
   nextTick,
-  delay,
   getRandomString,
   findTestSubject,
 } from './helpers';
@@ -409,9 +408,9 @@ describe('<SnapshotRestoreHome />', () => {
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
-          await delay(100);
-          testBed.component.update();
         });
+
+        testBed.component.update();
       });
 
       test('should display an empty prompt', () => {
@@ -438,9 +437,8 @@ describe('<SnapshotRestoreHome />', () => {
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
-          await delay(2000);
-          testBed.component.update();
         });
+        testBed.component.update();
       });
 
       test('should display an empty prompt', () => {
@@ -477,9 +475,9 @@ describe('<SnapshotRestoreHome />', () => {
 
         await act(async () => {
           testBed.actions.selectTab('snapshots');
-          await delay(2000);
-          testBed.component.update();
         });
+
+        testBed.component.update();
       });
 
       test('should list them in the table', async () => {

--- a/x-pack/plugins/snapshot_restore/server/routes/api/snapshots.ts
+++ b/x-pack/plugins/snapshot_restore/server/routes/api/snapshots.ts
@@ -37,6 +37,25 @@ export function registerSnapshotsRoutes({
         // Silently swallow error as policy names aren't required in UI
       }
 
+      let repositories: string[] = [];
+
+      try {
+        const {
+          body: repositoriesByName,
+        } = await clusterClient.asCurrentUser.snapshot.getRepository({
+          repository: '_all',
+        });
+        repositories = Object.keys(repositoriesByName);
+
+        if (repositories.length === 0) {
+          return res.ok({
+            body: { snapshots: [], repositories: [], policies },
+          });
+        }
+      } catch (e) {
+        return handleEsError({ error: e, response: res });
+      }
+
       try {
         // If any of these repositories 504 they will cost the request significant time.
         const { body: fetchedSnapshots } = await clusterClient.asCurrentUser.snapshot.get({
@@ -51,24 +70,16 @@ export function registerSnapshotsRoutes({
           size: SNAPSHOT_LIST_MAX_SIZE,
         });
 
-        const allRepos: string[] = [];
-
         // Decorate each snapshot with the repository with which it's associated.
         const snapshots = fetchedSnapshots?.snapshots?.map((snapshot) => {
-          // @ts-expect-error @elastic/elasticsearch "repository" is a new field in the response
-          allRepos.push(snapshot.repository);
           return deserializeSnapshotDetails(snapshot as SnapshotDetailsEs, managedRepository);
-        });
-
-        const uniqueRepos = allRepos.filter((repo, index) => {
-          return allRepos.indexOf(repo) === index;
         });
 
         return res.ok({
           body: {
             snapshots: snapshots || [],
             policies,
-            repositories: uniqueRepos,
+            repositories,
             // @ts-expect-error @elastic/elasticsearch "failures" is a new field in the response
             errors: fetchedSnapshots?.failures,
           },


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/105385

Steps to test are outlined in the issue^.

Caused by a regression of https://github.com/elastic/kibana/pull/103331.

The repository associated with a snapshot is returned from the ES snapshots API. However, we weren't accounting for the possibility that a user could have a repository with no snapshots yet. In order to account for this, we still need to fetch all repositories on the server.

Note: This is a bit tricky to add test coverage for. It's not possible to create a successful repository via the integration tests, so the tests are using mocked data. There is a CIT to test the prompt, however, the data was mocked correctly so nothing was failing. I have added an additional test to the `snapshots.test.ts` file.

<img width="745" alt="Screen Shot 2021-07-13 at 12 19 30 PM" src="https://user-images.githubusercontent.com/5226211/125488742-bc9421dd-df6f-469a-8538-0b58f0eba00f.png">



