### PR TITLE
[APM] Updates the APM static index pattern regardless of fleet migration status

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Settings/schema/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/schema/index.tsx
@@ -142,9 +142,7 @@ async function createCloudApmPackagePolicy(
 ) {
   updateLocalStorage(FETCH_STATUS.LOADING);
   try {
-    const {
-      cloud_apm_package_policy: cloudApmPackagePolicy,
-    } = await callApmApi({
+    const { cloudApmPackagePolicy } = await callApmApi({
       endpoint: 'POST /api/apm/fleet/cloud_apm_package_policy',
       signal: null,
     });

--- a/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.test.ts
+++ b/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.test.ts
@@ -22,14 +22,12 @@ describe('createStaticIndexPattern', () => {
     const setup = {} as Setup;
 
     const savedObjectsClient = getMockSavedObjectsClient();
-    await createStaticIndexPattern(
+    await createStaticIndexPattern({
       setup,
-      {
-        'xpack.apm.autocreateApmIndexPattern': false,
-      } as APMConfig,
+      config: { 'xpack.apm.autocreateApmIndexPattern': false } as APMConfig,
       savedObjectsClient,
-      'default'
-    );
+      spaceId: 'default',
+    });
     expect(savedObjectsClient.create).not.toHaveBeenCalled();
   });
 
@@ -43,14 +41,12 @@ describe('createStaticIndexPattern', () => {
 
     const savedObjectsClient = getMockSavedObjectsClient();
 
-    await createStaticIndexPattern(
+    await createStaticIndexPattern({
       setup,
-      {
-        'xpack.apm.autocreateApmIndexPattern': true,
-      } as APMConfig,
+      config: { 'xpack.apm.autocreateApmIndexPattern': true } as APMConfig,
       savedObjectsClient,
-      'default'
-    );
+      spaceId: 'default',
+    });
     expect(savedObjectsClient.create).not.toHaveBeenCalled();
   });
 
@@ -64,14 +60,12 @@ describe('createStaticIndexPattern', () => {
 
     const savedObjectsClient = getMockSavedObjectsClient();
 
-    await createStaticIndexPattern(
+    await createStaticIndexPattern({
       setup,
-      {
-        'xpack.apm.autocreateApmIndexPattern': true,
-      } as APMConfig,
+      config: { 'xpack.apm.autocreateApmIndexPattern': true } as APMConfig,
       savedObjectsClient,
-      'default'
-    );
+      spaceId: 'default',
+    });
 
     expect(savedObjectsClient.create).toHaveBeenCalled();
   });

--- a/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.test.ts
+++ b/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.test.ts
@@ -90,6 +90,7 @@ describe('createStaticIndexPattern', () => {
       setup,
       config: {
         'xpack.apm.autocreateApmIndexPattern': true,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         'apm_oss.indexPattern': apmIndexPatternTitle,
       } as APMConfig,
       savedObjectsClient,
@@ -121,6 +122,7 @@ describe('createStaticIndexPattern', () => {
       setup,
       config: {
         'xpack.apm.autocreateApmIndexPattern': true,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         'apm_oss.indexPattern': apmIndexPatternTitle,
       } as APMConfig,
       savedObjectsClient,

--- a/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.ts
+++ b/x-pack/plugins/apm/server/lib/index_pattern/create_static_index_pattern.ts
@@ -15,13 +15,23 @@ import { InternalSavedObjectsClient } from '../helpers/get_internal_saved_object
 import { withApmSpan } from '../../utils/with_apm_span';
 import { getApmIndexPatternTitle } from './get_apm_index_pattern_title';
 
-export async function createStaticIndexPattern(
-  setup: Setup,
-  config: APMRouteHandlerResources['config'],
-  savedObjectsClient: InternalSavedObjectsClient,
-  spaceId: string | undefined,
-  overwrite = false
-): Promise<boolean> {
+type ApmIndexPatternAttributes = typeof apmIndexPattern.attributes & {
+  title: string;
+};
+
+export async function createStaticIndexPattern({
+  setup,
+  config,
+  savedObjectsClient,
+  spaceId,
+  overwrite = false,
+}: {
+  setup: Setup;
+  config: APMRouteHandlerResources['config'];
+  savedObjectsClient: InternalSavedObjectsClient;
+  spaceId?: string;
+  overwrite?: boolean;
+}): Promise<boolean> {
   return withApmSpan('create_static_index_pattern', async () => {
     // don't autocreate APM index pattern if it's been disabled via the config
     if (!config['xpack.apm.autocreateApmIndexPattern']) {
@@ -35,8 +45,31 @@ export async function createStaticIndexPattern(
       return false;
     }
 
+    const apmIndexPatternTitle = getApmIndexPatternTitle(config);
+
+    if (!overwrite) {
+      try {
+        const {
+          attributes: { title: existingApmIndexPatternTitle },
+        }: {
+          attributes: ApmIndexPatternAttributes;
+        } = await savedObjectsClient.get(
+          'index-pattern',
+          APM_STATIC_INDEX_PATTERN_ID
+        );
+        // if the existing index pattern does not matches the new one, force an update
+        if (existingApmIndexPatternTitle !== apmIndexPatternTitle) {
+          overwrite = true;
+        }
+      } catch (e) {
+        // if the index pattern (saved object) is not found, then we can continue with creation
+        if (!SavedObjectsErrorHelpers.isNotFoundError(e)) {
+          throw e;
+        }
+      }
+    }
+
     try {
-      const apmIndexPatternTitle = getApmIndexPatternTitle(config);
       await withApmSpan('create_index_pattern_saved_object', () =>
         savedObjectsClient.create(
           'index-pattern',

--- a/x-pack/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/index_pattern.ts
@@ -32,12 +32,12 @@ const staticIndexPatternRoute = createApmServerRoute({
 
     const spaceId = spaces?.setup.spacesService.getSpaceId(request);
 
-    const didCreateIndexPattern = await createStaticIndexPattern(
+    const didCreateIndexPattern = await createStaticIndexPattern({
       setup,
       config,
       savedObjectsClient,
-      spaceId
-    );
+      spaceId,
+    });
 
     return { created: didCreateIndexPattern };
   },


### PR DESCRIPTION
Fixes #105469.

Removes the update of the index pattern from the fleet migration API, and instead does a check when the index pattern is normally created, to see if it needs to be updated, if so, then the existing index pattern is overwritten with one with the new title that supports data streams in addition to classic APM indices.