### PR TITLE
[7.14] [ML] Fix APM latency order of sticky header properties, add help popover (#103759)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -104,16 +104,7 @@ export function Correlations() {
         width: '20%',
       });
     }
-    if (urlParams.transactionName) {
-      properties.push({
-        label: i18n.translate('xpack.apm.correlations.transactionLabel', {
-          defaultMessage: 'Transaction',
-        }),
-        fieldName: TRANSACTION_NAME,
-        val: urlParams.transactionName,
-        width: '20%',
-      });
-    }
+
     if (urlParams.environment) {
       properties.push({
         label: i18n.translate('xpack.apm.correlations.environmentLabel', {
@@ -121,6 +112,17 @@ export function Correlations() {
         }),
         fieldName: SERVICE_ENVIRONMENT,
         val: getEnvironmentLabel(urlParams.environment),
+        width: '20%',
+      });
+    }
+
+    if (urlParams.transactionName) {
+      properties.push({
+        label: i18n.translate('xpack.apm.correlations.transactionLabel', {
+          defaultMessage: 'Transaction',
+        }),
+        fieldName: TRANSACTION_NAME,
+        val: urlParams.transactionName,
         width: '20%',
       });
     }

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
@@ -36,6 +36,7 @@ import { useCorrelations } from './use_correlations';
 import { push } from '../../shared/Links/url_helpers';
 import { useUiTracker } from '../../../../../observability/public';
 import { asPreciseDecimal } from '../../../../common/utils/formatters';
+import { LatencyCorrelationsHelpPopover } from './ml_latency_correlations_help_popover';
 
 const DEFAULT_PERCENTILE_THRESHOLD = 95;
 const isErrorMessage = (arg: unknown): arg is Error => {
@@ -151,7 +152,7 @@ export function MlLatencyCorrelations({ onClose }: Props) {
               'xpack.apm.correlations.latencyCorrelations.correlationsTable.correlationColumnDescription',
               {
                 defaultMessage:
-                  'The impact of a field on the latency of the service, ranging from 0 to 1.',
+                  'The correlation score [0-1] of an attribute; the greater the score, the more an attribute increases latency.',
               }
             )}
           >
@@ -263,20 +264,6 @@ export function MlLatencyCorrelations({ onClose }: Props) {
 
   return (
     <>
-      <EuiText size="s" color="subdued">
-        <p>
-          {i18n.translate(
-            'xpack.apm.correlations.latencyCorrelations.description',
-            {
-              defaultMessage:
-                'What is slowing down my service? Correlations will help discover a slower performance in a particular cohort of your data.',
-            }
-          )}
-        </p>
-      </EuiText>
-
-      <EuiSpacer size="m" />
-
       <EuiFlexGroup>
         <EuiFlexItem grow={false}>
           {!isRunning && (
@@ -319,6 +306,9 @@ export function MlLatencyCorrelations({ onClose }: Props) {
               />
             </EuiFlexItem>
           </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <LatencyCorrelationsHelpPopover />
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { HelpPopover, HelpPopoverButton } from '../help_popover/help_popover';
+
+export function LatencyCorrelationsHelpPopover() {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  return (
+    <HelpPopover
+      anchorPosition="leftUp"
+      button={
+        <HelpPopoverButton
+          onClick={() => {
+            setIsPopoverOpen(!isPopoverOpen);
+          }}
+        />
+      }
+      closePopover={() => setIsPopoverOpen(false)}
+      isOpen={isPopoverOpen}
+      title={i18n.translate('xpack.apm.correlations.latencyPopoverTitle', {
+        defaultMessage: 'Latency correlations',
+      })}
+    >
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverBasicExplanation"
+          defaultMessage="Correlations help you discover which attributes are contributing to increased transaction response times or latency."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverChartExplanation"
+          defaultMessage="The latency distribution chart visualizes the overall latency of the transactions in the service. When you hover over attributes in the table, their latency distribution is added to the chart."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverTableExplanation"
+          defaultMessage="The table is sorted by correlation coefficients that range from 0 to 1. Attributes with higher correlation values are more likely to contribute to high latency transactions."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverPerformanceExplanation"
+          defaultMessage="This analysis performs statistical searches across a large number of attributes. For large time ranges and services with high transaction throughput, this might take some time. Reduce the time range to improve performance."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverFilterExplanation"
+          defaultMessage="You can also add or remove filters to affect the queries in the APM app."
+        />
+      </p>
+    </HelpPopover>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/help_popover/help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/help_popover/help_popover.tsx
@@ -15,23 +15,32 @@ import {
   EuiPopoverTitle,
   EuiText,
 } from '@elastic/eui';
-import './help_popover.scss';
+import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
 
-export const HelpPopoverButton = ({ onClick }: { onClick: EuiLinkButtonProps['onClick'] }) => {
+const PopoverContent = euiStyled(EuiText)`
+  max-width: 480px;
+  max-height: 40vh;
+`;
+
+export function HelpPopoverButton({
+  onClick,
+}: {
+  onClick: EuiLinkButtonProps['onClick'];
+}) {
   return (
     <EuiButtonIcon
-      className="mlHelpPopover__buttonIcon"
+      className="apmHelpPopover__buttonIcon"
       size="s"
       iconType="help"
-      aria-label={i18n.translate('xpack.ml.helpPopover.ariaLabel', {
+      aria-label={i18n.translate('xpack.apm.helpPopover.ariaLabel', {
         defaultMessage: 'Help',
       })}
       onClick={onClick}
     />
   );
-};
+}
 
-export const HelpPopover = ({
+export function HelpPopover({
   anchorPosition,
   button,
   children,
@@ -45,23 +54,19 @@ export const HelpPopover = ({
   closePopover: EuiPopoverProps['closePopover'];
   isOpen: EuiPopoverProps['isOpen'];
   title?: string;
-}) => {
+}) {
   return (
     <EuiPopover
       anchorPosition={anchorPosition}
       button={button}
-      className="mlHelpPopover"
       closePopover={closePopover}
       isOpen={isOpen}
+      panelPaddingSize="s"
       ownFocus
-      panelClassName="mlHelpPopover__panel"
-      panelPaddingSize="none"
     >
       {title && <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>}
 
-      <EuiText className="mlHelpPopover__content" size="s">
-        {children}
-      </EuiText>
+      <PopoverContent size="s">{children}</PopoverContent>
     </EuiPopover>
   );
-};
+}

--- a/x-pack/plugins/apm/public/components/app/help_popover/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/help_popover/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { HelpPopoverButton, HelpPopover } from './help_popover';


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [ML] Fix APM latency order of sticky header properties, add help popover (#103759)