### PR TITLE
[Workplace Search] Fix rendering bug where line on logo in v7 theme

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
@@ -66,7 +66,7 @@ export const AccountHeader: React.FC = () => {
   );
 
   return (
-    <EuiHeader>
+    <EuiHeader className="personalDashboardHeader">
       <EuiHeaderSection grow={false}>
         <EuiHeaderSectionItem>
           <EuiHeaderLogo iconType="logoWorkplaceSearch" />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/account_header/account_header.tsx
@@ -66,13 +66,13 @@ export const AccountHeader: React.FC = () => {
   );
 
   return (
-    <EuiHeader className="personalDashboardHeader">
+    <EuiHeader>
       <EuiHeaderSection grow={false}>
-        <EuiHeaderSectionItem>
+        <EuiHeaderSectionItem border="none">
           <EuiHeaderLogo iconType="logoWorkplaceSearch" />
           <EuiText>{WORKPLACE_SEARCH_TITLE}</EuiText>
         </EuiHeaderSectionItem>
-        <EuiHeaderSectionItem>
+        <EuiHeaderSectionItem border="none">
           <EuiHeaderLinks>
             <EuiButtonEmptyTo to={PERSONAL_SOURCES_PATH}>{ACCOUNT_NAV.SOURCES}</EuiButtonEmptyTo>
           </EuiHeaderLinks>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_layout/personal_dashboard_layout.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_layout/personal_dashboard_layout.scss
@@ -23,3 +23,10 @@
     height: 100%;
   }
 }
+
+.personalDashboardHeader {
+  // Fixes a bug in Kibana v7 theme where logo has extra line visible
+  .euiHeaderSectionItem:after {
+    background: none;
+  }
+}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_layout/personal_dashboard_layout.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_layout/personal_dashboard_layout.scss
@@ -23,10 +23,3 @@
     height: 100%;
   }
 }
-
-.personalDashboardHeader {
-  // Fixes a bug in Kibana v7 theme where logo has extra line visible
-  .euiHeaderSectionItem:after {
-    background: none;
-  }
-}


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1868

## Summary

Fixes rendering bug where a line appeared next to the Workplace Search logo in v7 theme on the Personal dashboard.

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/1869731/125501678-6f7e488f-3e84-4fa7-8488-f5a018fe790a.png)  | ![after](https://user-images.githubusercontent.com/1869731/125501682-23d670aa-f048-49fa-a04d-e2e13d675b23.png)