### PR TITLE
[Uptime] Exclude all documents missing hash from TLS query

### DIFF
--- a/x-pack/plugins/uptime/server/lib/requests/get_certs.test.ts
+++ b/x-pack/plugins/uptime/server/lib/requests/get_certs.test.ts
@@ -173,7 +173,7 @@ describe('getCerts', () => {
                   "filter": Array [
                     Object {
                       "exists": Object {
-                        "field": "tls.server",
+                        "field": "tls.server.hash.sha256",
                       },
                     },
                     Object {

--- a/x-pack/plugins/uptime/server/lib/requests/get_certs.ts
+++ b/x-pack/plugins/uptime/server/lib/requests/get_certs.ts
@@ -68,6 +68,11 @@ export const getCerts: UMElasticsearchQueryFn<GetCertsParams, CertResult> = asyn
             },
           },
           {
+            exists: {
+              field: 'tls.server.hash.sha256',
+            },
+          },
+          {
             range: {
               'monitor.timespan': {
                 gte: from,

--- a/x-pack/plugins/uptime/server/lib/requests/get_certs.ts
+++ b/x-pack/plugins/uptime/server/lib/requests/get_certs.ts
@@ -64,11 +64,6 @@ export const getCerts: UMElasticsearchQueryFn<GetCertsParams, CertResult> = asyn
         filter: [
           {
             exists: {
-              field: 'tls.server',
-            },
-          },
-          {
-            exists: {
               field: 'tls.server.hash.sha256',
             },
           },


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/104208.

We noticed that when browser monitors cycle through pages, they pick up TLS data and populate relevant ECS fields with it. Unfortunately, we don't get a SHA256 indexed; we collapse on this field for all our TLS check-related UIs and rules. In light of this, we're adding a clause to exclude any documents that are missing the field `tls.server.hash.sha256` from our TLS query.

Monitors specifically defined to watch endpoints that are using TLS will continue to function as they always have.

## Testing

1. In `master`, define a browser monitor that will pick up TLS data. (I was able to pick up data by monitoring sites like CNN).
2. Define an `http` monitor for a website using TLS.
3. Navigate to certs page; you should see at least two entries, one for each of your monitors.
4. Checkout this branch and reload the page, you should only see an entry for your `http` monitor.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
