### PR TITLE
[Exploratory view] Fixed bug in series storage hook

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.test.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+
+import { UrlStorageContextProvider, useSeriesStorage } from './use_series_storage';
+import { render } from '@testing-library/react';
+
+const mockSingleSeries = {
+  'performance-distribution': {
+    reportType: 'data-distribution',
+    dataType: 'ux',
+    breakdown: 'user_agent.name',
+    time: { from: 'now-15m', to: 'now' },
+  },
+};
+
+const mockMultipleSeries = {
+  'performance-distribution': {
+    reportType: 'data-distribution',
+    dataType: 'ux',
+    breakdown: 'user_agent.name',
+    time: { from: 'now-15m', to: 'now' },
+  },
+  'kpi-over-time': {
+    reportType: 'kpi-over-time',
+    dataType: 'synthetics',
+    breakdown: 'user_agent.name',
+    time: { from: 'now-15m', to: 'now' },
+  },
+};
+
+describe('userSeries', function () {
+  function setupTestComponent(seriesData: any) {
+    const setData = jest.fn();
+    function TestComponent() {
+      const data = useSeriesStorage();
+
+      useEffect(() => {
+        setData(data);
+      }, [data]);
+
+      return <span>Test</span>;
+    }
+
+    render(
+      <UrlStorageContextProvider
+        storage={{ get: jest.fn().mockReturnValue(seriesData), set: jest.fn() }}
+      >
+        <TestComponent />
+      </UrlStorageContextProvider>
+    );
+
+    return setData;
+  }
+  it('should return expected result when there is one series', function () {
+    const setData = setupTestComponent(mockSingleSeries);
+
+    expect(setData).toHaveBeenCalledTimes(2);
+    expect(setData).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        allSeries: {
+          'performance-distribution': {
+            breakdown: 'user_agent.name',
+            dataType: 'ux',
+            reportType: 'data-distribution',
+            time: { from: 'now-15m', to: 'now' },
+          },
+        },
+        allSeriesIds: ['performance-distribution'],
+        firstSeries: {
+          breakdown: 'user_agent.name',
+          dataType: 'ux',
+          reportType: 'data-distribution',
+          time: { from: 'now-15m', to: 'now' },
+        },
+        firstSeriesId: 'performance-distribution',
+      })
+    );
+  });
+
+  it('should return expected result when there are multiple series series', function () {
+    const setData = setupTestComponent(mockMultipleSeries);
+
+    expect(setData).toHaveBeenCalledTimes(2);
+    expect(setData).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        allSeries: {
+          'performance-distribution': {
+            breakdown: 'user_agent.name',
+            dataType: 'ux',
+            reportType: 'data-distribution',
+            time: { from: 'now-15m', to: 'now' },
+          },
+          'kpi-over-time': {
+            reportType: 'kpi-over-time',
+            dataType: 'synthetics',
+            breakdown: 'user_agent.name',
+            time: { from: 'now-15m', to: 'now' },
+          },
+        },
+        allSeriesIds: ['performance-distribution', 'kpi-over-time'],
+        firstSeries: {
+          breakdown: 'user_agent.name',
+          dataType: 'ux',
+          reportType: 'data-distribution',
+          time: { from: 'now-15m', to: 'now' },
+        },
+        firstSeriesId: 'performance-distribution',
+      })
+    );
+  });
+
+  it('should return expected result when there are no series', function () {
+    const setData = setupTestComponent({});
+
+    expect(setData).toHaveBeenCalledTimes(2);
+    expect(setData).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        allSeries: {},
+        allSeriesIds: [],
+        firstSeries: undefined,
+        firstSeriesId: undefined,
+      })
+    );
+  });
+});

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
@@ -67,7 +67,7 @@ export function UrlStorageContextProvider({
 
     setAllSeries(allSeriesN);
     setFirstSeriesId(allSeriesIds?.[0]);
-    setFirstSeries(allSeriesN?.[0]);
+    setFirstSeries(allSeriesN?.[allSeriesIds?.[0]]);
     (storage as IKbnUrlStateStorage).set(allSeriesKey, allShortSeries);
   }, [allShortSeries, storage]);
 


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/105459

Fixed a bug in series storage hook, where it wasn't returning the first series properly 

Also added relevant unit tests to cover this hook

This was also the cause of brushing breaking while Performance distribution report type is selected,
