### PR TITLE
[Integrations UI] Handle deprecated `$yml` code block language in integration READMEs

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/markdown_renderers.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/markdown_renderers.tsx
@@ -24,6 +24,12 @@ const REL_NOFOLLOW = 'nofollow';
 /** prevents the browser from sending the current address as referrer via the Referer HTTP header */
 const REL_NOREFERRER = 'noreferrer';
 
+// Maps deprecated code block languages to supported ones in prism.js
+const CODE_LANGUAGE_OVERRIDES: Record<string, string> = {
+  $json: 'json',
+  $yml: 'yml',
+};
+
 export const markdownRenderers = {
   root: ({ children }: { children: React.ReactNode[] }) => (
     <EuiText grow={true}>{children}</EuiText>
@@ -60,8 +66,17 @@ export const markdownRenderers = {
     </EuiLink>
   ),
   code: ({ language, value }: { language: string; value: string }) => {
-    // Old packages are using `$json`, which is not valid any more with the move to prism.js
-    const parsedLang = language === '$json' ? 'json' : language;
+    let parsedLang = language;
+
+    // Some integrations export code block content that includes language tags that have since
+    // been removed or deprecated in `prism.js`, the upstream depedency that handles syntax highlighting
+    // in EuiCodeBlock components
+    const languageOverride = CODE_LANGUAGE_OVERRIDES[language];
+
+    if (languageOverride) {
+      parsedLang = languageOverride;
+    }
+
     return (
       <EuiCodeBlock language={parsedLang} isCopyable>
         {value}


### PR DESCRIPTION
## Summary

Fixes `$yml not registered` error coming from Prism.js when rendering some integration README content, e.g. Prometheus. 

## Screenshots

Before (on QA Cloud)
![Screen Shot 2021-07-13 at 3 34 45 PM](https://user-images.githubusercontent.com/6766512/125514196-6f236113-98a1-4d15-8a2a-962ca0b5dba0.png)

After (fixed on localhost)
![Screen Shot 2021-07-13 at 3 34 59 PM](https://user-images.githubusercontent.com/6766512/125514197-b8114f83-13e1-43e5-a5d3-b6d8fd201cd7.png)
