### PR TITLE
Depanel Fleet setup pages

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_cloud_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_cloud_instructions.tsx
@@ -8,7 +8,6 @@
 import React, { useEffect } from 'react';
 import {
   EuiButton,
-  EuiPanel,
   EuiLink,
   EuiEmptyPrompt,
   EuiFlexItem,
@@ -39,62 +38,54 @@ export const CloudInstructions: React.FC<{ deploymentUrl: string }> = ({ deploym
 
   return (
     <>
-      <EuiPanel
-        paddingSize="none"
-        grow={false}
-        hasShadow={false}
-        hasBorder={true}
-        className="eui-textCenter"
-      >
-        <EuiEmptyPrompt
-          title={
-            <h2>
-              <FormattedMessage
-                id="xpack.fleet.fleetServerSetup.cloudSetupTitle"
-                defaultMessage="Enable APM & Fleet"
-              />
-            </h2>
-          }
-          body={
+      <EuiEmptyPrompt
+        title={
+          <h2>
             <FormattedMessage
-              id="xpack.fleet.fleetServerSetup.cloudSetupText"
-              defaultMessage="A Fleet Server is required before you can enroll agents with Fleet. You can add one to your deployment by enabling APM & Fleet. For more information see the {link}"
-              values={{
-                link: (
-                  <EuiLink
-                    href={docLinks.links.fleet.fleetServerAddFleetServer}
-                    target="_blank"
-                    external
-                  >
-                    <FormattedMessage
-                      id="xpack.fleet.settings.userGuideLink"
-                      defaultMessage="Fleet User Guide"
-                    />
-                  </EuiLink>
-                ),
-              }}
+              id="xpack.fleet.fleetServerSetup.cloudSetupTitle"
+              defaultMessage="Enable APM & Fleet"
             />
-          }
-          actions={
-            <>
-              <EuiButton
-                iconSide="right"
-                iconType="popout"
-                fill
-                isLoading={false}
-                type="submit"
-                href={`${deploymentUrl}/edit`}
-                target="_blank"
-              >
-                <FormattedMessage
-                  id="xpack.fleet.fleetServerSetup.cloudDeploymentLink"
-                  defaultMessage="Edit deployment"
-                />
-              </EuiButton>
-            </>
-          }
-        />
-      </EuiPanel>
+          </h2>
+        }
+        body={
+          <FormattedMessage
+            id="xpack.fleet.fleetServerSetup.cloudSetupText"
+            defaultMessage="A Fleet Server is required before you can enroll agents with Fleet. You can add one to your deployment by enabling APM & Fleet. For more information see the {link}"
+            values={{
+              link: (
+                <EuiLink
+                  href={docLinks.links.fleet.fleetServerAddFleetServer}
+                  target="_blank"
+                  external
+                >
+                  <FormattedMessage
+                    id="xpack.fleet.settings.userGuideLink"
+                    defaultMessage="Fleet User Guide"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        }
+        actions={
+          <>
+            <EuiButton
+              iconSide="right"
+              iconType="popout"
+              fill
+              isLoading={false}
+              type="submit"
+              href={`${deploymentUrl}/edit`}
+              target="_blank"
+            >
+              <FormattedMessage
+                id="xpack.fleet.fleetServerSetup.cloudDeploymentLink"
+                defaultMessage="Edit deployment"
+              />
+            </EuiButton>
+          </>
+        }
+      />
       <EuiSpacer size="m" />
       <EuiFlexItem>
         <EuiFlexGroup justifyContent="center" gutterSize="s">

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
@@ -10,7 +10,6 @@ import {
   EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPanel,
   EuiSpacer,
   EuiText,
   EuiLink,
@@ -737,9 +736,8 @@ export const OnPremInstructions: React.FC = () => {
   }, [notifications.toasts]);
 
   return (
-    <EuiPanel paddingSize="l" grow={false} hasShadow={false} hasBorder={true}>
-      <EuiSpacer size="s" />
-      <EuiText className="eui-textCenter">
+    <>
+      <EuiText>
         <h2>
           <FormattedMessage
             id="xpack.fleet.fleetServerSetup.setupTitle"
@@ -788,6 +786,6 @@ export const OnPremInstructions: React.FC = () => {
             : CompleteStep(),
         ]}
       />
-    </EuiPanel>
+    </>
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/fleet_server_requirement_page.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/fleet_server_requirement_page.tsx
@@ -21,7 +21,6 @@ const FlexItemWithMinWidth = styled(EuiFlexItem)`
 const ContentWrapper = styled(EuiFlexGroup)`
   height: 100%;
   margin: 0 auto;
-  max-width: 800px;
 `;
 
 export const FleetServerRequirementPage = () => {


### PR DESCRIPTION
## Summary

Just some small visual cleanup while I was looking at the page. Removes all the paneling and gets it closer to our other page layouts.

### BEFORE

![image](https://user-images.githubusercontent.com/324519/125514496-22b9519b-23fd-488a-9feb-dd3bc7214b24.png)

### AFTER

![image](https://user-images.githubusercontent.com/324519/125514570-27eabd83-1ecd-4e8e-bfa0-b78e65035f39.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)