### PR TITLE
[Security Solution][Alerts] - Add alerts subfeature UI

### DIFF
--- a/x-pack/plugins/security_solution/server/features.ts
+++ b/x-pack/plugins/security_solution/server/features.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+import { KibanaFeatureConfig, SubFeatureConfig } from '../../features/common';
+import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/server';
+import { APP_ID, SERVER_APP_ID } from '../common/constants';
+import { savedObjectTypes } from './saved_objects';
+
+const CASES_SUB_FEATURE: SubFeatureConfig = {
+  name: 'Cases',
+  privilegeGroups: [
+    {
+      groupType: 'mutually_exclusive',
+      privileges: [
+        {
+          id: 'cases_all',
+          includeIn: 'all',
+          name: 'All',
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          // using variables with underscores here otherwise when we retrieve them from the kibana
+          // capabilities in a hook I get type errors regarding boolean | ReadOnly<{[x: string]: boolean}>
+          ui: ['crud_cases', 'read_cases'], // uiCapabilities.siem.crud_cases
+          cases: {
+            all: [APP_ID],
+          },
+        },
+        {
+          id: 'cases_read',
+          includeIn: 'read',
+          name: 'Read',
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          // using variables with underscores here otherwise when we retrieve them from the kibana
+          // capabilities in a hook I get type errors regarding boolean | ReadOnly<{[x: string]: boolean}>
+          ui: ['read_cases'], // uiCapabilities.siem.read_cases
+          cases: {
+            read: [APP_ID],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export const getAlertsSubFeature = (ruleTypes: string[]): SubFeatureConfig => ({
+  name: i18n.translate('xpack.securitySolution.featureRegistry.manageAlertsName', {
+    defaultMessage: 'Alerts',
+  }),
+  privilegeGroups: [
+    {
+      groupType: 'mutually_exclusive',
+      privileges: [
+        {
+          id: 'alerts_all',
+          name: i18n.translate('xpack.securitySolution.featureRegistry.subfeature.alertsAllName', {
+            defaultMessage: 'All',
+          }),
+          includeIn: 'all' as 'all',
+          alerting: {
+            alert: {
+              all: ruleTypes,
+            },
+          },
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: [],
+        },
+        {
+          id: 'alerts_read',
+          name: i18n.translate('xpack.securitySolution.featureRegistry.subfeature.alertsReadName', {
+            defaultMessage: 'Read',
+          }),
+          includeIn: 'read' as 'read',
+          alerting: {
+            alert: {
+              read: ruleTypes,
+            },
+          },
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: [],
+        },
+      ],
+    },
+  ],
+});
+
+export const getKibanaPrivilegesFeaturePrivileges = (
+  ruleTypes: string[],
+  isRuleRegistryEnabled: boolean
+): KibanaFeatureConfig => ({
+  id: SERVER_APP_ID,
+  name: i18n.translate('xpack.securitySolution.featureRegistry.linkSecuritySolutionTitle', {
+    defaultMessage: 'Security',
+  }),
+  order: 1100,
+  category: DEFAULT_APP_CATEGORIES.security,
+  app: [APP_ID, 'kibana'],
+  catalogue: ['securitySolution'],
+  management: {
+    insightsAndAlerting: ['triggersActions'],
+  },
+  alerting: ruleTypes,
+  cases: [APP_ID],
+  subFeatures: isRuleRegistryEnabled
+    ? [{ ...CASES_SUB_FEATURE }, { ...getAlertsSubFeature(ruleTypes) }]
+    : [{ ...CASES_SUB_FEATURE }],
+  privileges: {
+    all: {
+      app: [APP_ID, 'kibana'],
+      catalogue: ['securitySolution'],
+      api: ['securitySolution', 'lists-all', 'lists-read', 'rac'],
+      savedObject: {
+        all: ['alert', 'exception-list', 'exception-list-agnostic', ...savedObjectTypes],
+        read: [],
+      },
+      alerting: {
+        rule: {
+          all: ruleTypes,
+        },
+        alert: {
+          all: ruleTypes,
+        },
+      },
+      management: {
+        insightsAndAlerting: ['triggersActions'],
+      },
+      ui: ['show', 'crud'],
+    },
+    read: {
+      app: [APP_ID, 'kibana'],
+      catalogue: ['securitySolution'],
+      api: ['securitySolution', 'lists-read', 'rac'],
+      savedObject: {
+        all: [],
+        read: ['exception-list', 'exception-list-agnostic', ...savedObjectTypes],
+      },
+      alerting: {
+        rule: {
+          read: ruleTypes,
+        },
+        alert: {
+          read: ruleTypes,
+        },
+      },
+      management: {
+        insightsAndAlerting: ['triggersActions'],
+      },
+      ui: ['show'],
+    },
+  },
+});

--- a/x-pack/plugins/security_solution/server/features.ts
+++ b/x-pack/plugins/security_solution/server/features.ts
@@ -133,9 +133,6 @@ export const getKibanaPrivilegesFeaturePrivileges = (
         rule: {
           all: ruleTypes,
         },
-        alert: {
-          all: ruleTypes,
-        },
       },
       management: {
         insightsAndAlerting: ['triggersActions'],
@@ -152,9 +149,6 @@ export const getKibanaPrivilegesFeaturePrivileges = (
       },
       alerting: {
         rule: {
-          read: ruleTypes,
-        },
-        alert: {
           read: ruleTypes,
         },
       },

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -7,7 +7,6 @@
 
 import { once } from 'lodash';
 import { Observable } from 'rxjs';
-import { i18n } from '@kbn/i18n';
 import LRU from 'lru-cache';
 
 import {
@@ -17,7 +16,6 @@ import {
   Plugin as IPlugin,
   PluginInitializerContext,
   SavedObjectsClient,
-  DEFAULT_APP_CATEGORIES,
 } from '../../../../src/core/server';
 import {
   PluginSetup as DataPluginSetup,
@@ -58,7 +56,7 @@ import { signalRulesAlertType } from './lib/detection_engine/signals/signal_rule
 import { rulesNotificationAlertType } from './lib/detection_engine/notifications/rules_notification_alert_type';
 import { isNotificationAlertExecutor } from './lib/detection_engine/notifications/types';
 import { ManifestTask } from './endpoint/lib/artifacts';
-import { initSavedObjects, savedObjectTypes } from './saved_objects';
+import { initSavedObjects } from './saved_objects';
 import { AppClientFactory } from './client';
 import { createConfig, ConfigType } from './config';
 import { initUiSettings } from './ui_settings';
@@ -91,6 +89,7 @@ import { licenseService } from './lib/license';
 import { PolicyWatcher } from './endpoint/lib/policy/license_watch';
 import { parseExperimentalConfigValue } from '../common/experimental_features';
 import { migrateArtifactsToFleet } from './endpoint/lib/artifacts/migrate_artifacts_to_fleet';
+import { getKibanaPrivilegesFeaturePrivileges } from './features';
 
 export interface SetupPlugins {
   alerting: AlertingSetup;
@@ -279,107 +278,9 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       ...(isRuleRegistryEnabled ? referenceRuleTypes : []),
     ];
 
-    plugins.features.registerKibanaFeature({
-      id: SERVER_APP_ID,
-      name: i18n.translate('xpack.securitySolution.featureRegistry.linkSecuritySolutionTitle', {
-        defaultMessage: 'Security',
-      }),
-      order: 1100,
-      category: DEFAULT_APP_CATEGORIES.security,
-      app: [APP_ID, 'kibana'],
-      catalogue: ['securitySolution'],
-      management: {
-        insightsAndAlerting: ['triggersActions'],
-      },
-      alerting: ruleTypes,
-      cases: [APP_ID],
-      subFeatures: [
-        {
-          name: 'Cases',
-          privilegeGroups: [
-            {
-              groupType: 'mutually_exclusive',
-              privileges: [
-                {
-                  id: 'cases_all',
-                  includeIn: 'all',
-                  name: 'All',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  // using variables with underscores here otherwise when we retrieve them from the kibana
-                  // capabilities in a hook I get type errors regarding boolean | ReadOnly<{[x: string]: boolean}>
-                  ui: ['crud_cases', 'read_cases'], // uiCapabilities.siem.crud_cases
-                  cases: {
-                    all: [APP_ID],
-                  },
-                },
-                {
-                  id: 'cases_read',
-                  includeIn: 'read',
-                  name: 'Read',
-                  savedObject: {
-                    all: [],
-                    read: [],
-                  },
-                  // using variables with underscores here otherwise when we retrieve them from the kibana
-                  // capabilities in a hook I get type errors regarding boolean | ReadOnly<{[x: string]: boolean}>
-                  ui: ['read_cases'], // uiCapabilities.siem.read_cases
-                  cases: {
-                    read: [APP_ID],
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      privileges: {
-        all: {
-          app: [APP_ID, 'kibana'],
-          catalogue: ['securitySolution'],
-          api: ['securitySolution', 'lists-all', 'lists-read', 'rac'],
-          savedObject: {
-            all: ['alert', 'exception-list', 'exception-list-agnostic', ...savedObjectTypes],
-            read: [],
-          },
-          alerting: {
-            rule: {
-              all: ruleTypes,
-            },
-            alert: {
-              all: ruleTypes,
-            },
-          },
-          management: {
-            insightsAndAlerting: ['triggersActions'],
-          },
-          ui: ['show', 'crud'],
-        },
-        read: {
-          app: [APP_ID, 'kibana'],
-          catalogue: ['securitySolution'],
-          api: ['securitySolution', 'lists-read', 'rac'],
-          savedObject: {
-            all: [],
-            read: ['exception-list', 'exception-list-agnostic', ...savedObjectTypes],
-          },
-          alerting: {
-            rule: {
-              read: ruleTypes,
-            },
-            alert: {
-              read: ruleTypes,
-            },
-          },
-          management: {
-            insightsAndAlerting: ['triggersActions'],
-          },
-          ui: ['show'],
-        },
-      },
-    });
+    plugins.features.registerKibanaFeature(
+      getKibanaPrivilegesFeaturePrivileges(ruleTypes, isRuleRegistryEnabled)
+    );
 
     // Continue to register legacy rules against alerting client exposed through rule-registry
     if (this.setupPlugins.alerting != null) {

--- a/x-pack/test/rule_registry/common/config.ts
+++ b/x-pack/test/rule_registry/common/config.ts
@@ -80,6 +80,9 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
           `--xpack.actions.enabledActionTypes=${JSON.stringify(enabledActionTypes)}`,
           '--xpack.eventLog.logEntries=true',
           ...disabledPlugins.map((key) => `--xpack.${key}.enabled=false`),
+          // TO DO: Remove feature flags once we're good to go
+          '--xpack.securitySolution.enableExperimental=["ruleRegistryEnabled"]',
+          '--xpack.ruleRegistry.write.enabled=true',
           `--server.xsrf.whitelist=${JSON.stringify(getAllExternalServiceSimulatorPaths())}`,
           ...(ssl
             ? [

--- a/x-pack/test/rule_registry/common/lib/authentication/roles.ts
+++ b/x-pack/test/rule_registry/common/lib/authentication/roles.ts
@@ -24,10 +24,7 @@ export const globalRead: Role = {
     },
     kibana: [
       {
-        feature: {
-          siem: ['read'],
-          apm: ['read'],
-        },
+        base: ['read'],
         spaces: ['*'],
       },
     ],


### PR DESCRIPTION
## Summary

This PR adds the subfeature UI for alerts to security solution. Note that the ability to customize subfeatures is still a gold feature. How will this map with existing users? The feature and subfeature are tied. So if a user was previously assinged `All` for security solution - they would get `all` for alerts, etc. 

It still remains behind a feature flag, so to see the change you'll need to have the following in your `kibana.dev.yml`
```
xpack.securitySolution.enableExperimental: ['ruleRegistryEnabled']
xpack.ruleRegistry.write.enabled: true
```

![Screen Shot 2021-07-13 at 12 08 19 PM](https://user-images.githubusercontent.com/10927944/125510907-444f205e-c18d-4d0a-9249-50dc2251ab8f.png)

Otherwise you'll just see:

![Screen Shot 2021-07-13 at 1 37 17 PM](https://user-images.githubusercontent.com/10927944/125521471-c3afd9ec-c03d-4c8d-99d7-d287dea817e3.png)


Allows for the following combos, some of these combos may not make much sense, however we are not restricting it:
![Screen Shot 2021-07-13 at 12 10 43 PM](https://user-images.githubusercontent.com/10927944/125511211-61505964-05db-4544-9c12-d1b95287ff43.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
