### PR TITLE
[Fleet] Tweak copy for elasticsearch configuration

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/es_requirements_page.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/es_requirements_page.tsx
@@ -72,7 +72,8 @@ export const MissingESRequirementsPage: React.FunctionComponent<{
           <EuiSpacer size="m" />
           <FormattedMessage
             id="xpack.fleet.setupPage.missingRequirementsElasticsearchTitle"
-            defaultMessage="In your Elasticsearch policy, enable:"
+            defaultMessage="In your Elasticsearch configuration ({esConfigFile}), enable:"
+            values={{ esConfigFile: <EuiCode>elasticsearch.yml</EuiCode> }}
           />
           <EuiSpacer size="l" />
           <RequirementItem isMissing={false}>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -9207,7 +9207,6 @@
     "xpack.fleet.setupPage.gettingStartedText": "詳細については、{link}ガイドをお読みください。",
     "xpack.fleet.setupPage.missingRequirementsCalloutDescription": "Elasticエージェントの集中管理を使用するには、次のElasticsearchのセキュリティ機能を有効にする必要があります。",
     "xpack.fleet.setupPage.missingRequirementsCalloutTitle": "不足しているセキュリティ要件",
-    "xpack.fleet.setupPage.missingRequirementsElasticsearchTitle": "Elasticsearchポリシーでは、次のことができます。",
     "xpack.fleet.unenrollAgents.cancelButtonLabel": "キャンセル",
     "xpack.fleet.unenrollAgents.confirmMultipleButtonLabel": "{count}個のエージェントを登録解除",
     "xpack.fleet.unenrollAgents.confirmSingleButtonLabel": "エージェントの登録解除",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -9293,7 +9293,6 @@
     "xpack.fleet.setupPage.gettingStartedText": "有关更多信息，请阅读我们的{link}指南。",
     "xpack.fleet.setupPage.missingRequirementsCalloutDescription": "要对 Elastic 代理使用集中管理，请启用下面的 Elasticsearch 安全功能。",
     "xpack.fleet.setupPage.missingRequirementsCalloutTitle": "缺失安全性要求",
-    "xpack.fleet.setupPage.missingRequirementsElasticsearchTitle": "在 Elasticsearch 策略中，启用：",
     "xpack.fleet.unenrollAgents.cancelButtonLabel": "取消",
     "xpack.fleet.unenrollAgents.confirmMultipleButtonLabel": "取消注册 {count} 个代理",
     "xpack.fleet.unenrollAgents.confirmSingleButtonLabel": "取消注册代理",


### PR DESCRIPTION
## Summary

Closes #105532 

On the setup page with an incorrect elasticsearch configuration the copy was confusing. This PR adds a clearer copy.

<img width="875" alt="Screenshot 2021-07-14 at 10 34 00" src="https://user-images.githubusercontent.com/57448/125590715-85e4dbc8-b3d5-413a-a3ce-0ac4717a0354.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)


