### PR TITLE
[7.14] [SecuritySolution] disable edit and create from rules breadcrumb (#105412)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -323,8 +323,7 @@ describe('Navigation Breadcrumbs', () => {
         },
         {
           text: 'Create',
-          href:
-            "securitySolution/rules/create?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))",
+          href: '',
         },
       ]);
     });
@@ -382,7 +381,7 @@ describe('Navigation Breadcrumbs', () => {
         },
         {
           text: 'Edit',
-          href: `securitySolution/rules/id/${mockDetailName}/edit?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))`,
+          href: '',
         },
       ]);
     });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -11,8 +11,6 @@ import { ChromeBreadcrumb } from '../../../../../../../../src/core/public';
 import {
   getRulesUrl,
   getRuleDetailsUrl,
-  getCreateRuleUrl,
-  getEditRuleUrl,
 } from '../../../../common/components/link_to/redirect_to_detection_engine';
 import * as i18nRules from './translations';
 import { RouteSpyState } from '../../../../common/utils/route/types';
@@ -79,10 +77,7 @@ export const getBreadcrumbs = (
       ...breadcrumb,
       {
         text: i18nRules.ADD_PAGE_TITLE,
-        href: getUrlForApp(APP_ID, {
-          deepLinkId: SecurityPageName.rules,
-          path: getCreateRuleUrl(!isEmpty(search[0]) ? search[0] : ''),
-        }),
+        href: '',
       },
     ];
   }
@@ -92,10 +87,7 @@ export const getBreadcrumbs = (
       ...breadcrumb,
       {
         text: i18nRules.EDIT_PAGE_TITLE,
-        href: getUrlForApp(APP_ID, {
-          deepLinkId: SecurityPageName.rules,
-          path: getEditRuleUrl(params.detailName, !isEmpty(search[0]) ? search[0] : ''),
-        }),
+        href: '',
       },
     ];
   }


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [SecuritySolution] disable edit and create from rules breadcrumb (#105412)