### PR TITLE
[7.14] [Actions] Swimlane: Change API Token field to a password textfield (#105475)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/swimlane/steps/swimlane_connection.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/swimlane/steps/swimlane_connection.tsx
@@ -4,7 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiCallOut, EuiFieldText, EuiFormRow, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiFieldText,
+  EuiFormRow,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+  EuiFieldPassword,
+} from '@elastic/eui';
 import React, { useCallback } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
 import * as i18n from '../translations';
@@ -141,7 +149,7 @@ const SwimlaneConnectionComponent: React.FunctionComponent<Props> = ({
               <EuiSpacer size="m" />
             </>
           )}
-          <EuiFieldText
+          <EuiFieldPassword
             fullWidth
             isInvalid={isApiTokenInvalid}
             readOnly={readOnly}


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Actions] Swimlane: Change API Token field to a password textfield (#105475)