### PR TITLE
[7.14] Align test with non-CCS version (#104667)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
@@ -55,7 +55,7 @@ describe('Alert details with unmapped fields', () => {
 
   it('Displays the unmapped field on the table', () => {
     const expectedUnmmappedField = {
-      row: 55,
+      row: 56,
       field: 'unmapped',
       text: 'This is the unmapped field',
     };


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [7.x] Align test with non-CCS version (#104667)