### PR TITLE
[7.14] [Discover][Main] Fix missing error message when building search query throws exceptions (#103923)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/services/use_saved_search.ts
+++ b/src/plugins/discover/public/application/apps/main/services/use_saved_search.ts
@@ -279,13 +279,21 @@ export const useSavedSearch = ({
     ).pipe(debounceTime(100));
 
     const subscription = fetch$.subscribe((val) => {
-      fetchAll(val === 'reset');
+      try {
+        fetchAll(val === 'reset');
+      } catch (error) {
+        data$.next({
+          state: FetchStatus.ERROR,
+          fetchError: error,
+        });
+      }
     });
 
     return () => {
       subscription.unsubscribe();
     };
   }, [
+    data$,
     data.query.queryString,
     filterManager,
     refetch$,

--- a/test/functional/apps/discover/_date_nested.ts
+++ b/test/functional/apps/discover/_date_nested.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const testSubjects = getService('testSubjects');
+  const PageObjects = getPageObjects(['common', 'timePicker', 'discover']);
+  const security = getService('security');
+
+  describe('timefield is a date in a nested field', function () {
+    before(async function () {
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/date_nested');
+      await security.testUser.setRoles(['kibana_admin', 'kibana_date_nested']);
+      await PageObjects.common.navigateToApp('discover');
+    });
+
+    after(async function unloadMakelogs() {
+      await security.testUser.restoreDefaults();
+      await esArchiver.unload('test/functional/fixtures/es_archiver/date_nested');
+    });
+
+    it('should show an error message', async function () {
+      await PageObjects.discover.selectIndexPattern('date-nested');
+      await PageObjects.discover.waitUntilSearchingHasFinished();
+      await testSubjects.existOrFail('discoverNoResultsError');
+    });
+  });
+}

--- a/test/functional/apps/discover/index.ts
+++ b/test/functional/apps/discover/index.ts
@@ -50,5 +50,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./_indexpattern_with_unmapped_fields'));
     loadTestFile(require.resolve('./_runtime_fields_editor'));
     loadTestFile(require.resolve('./_huge_fields'));
+    loadTestFile(require.resolve('./_date_nested'));
   });
 }

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -247,6 +247,21 @@ export default async function ({ readConfigFile }) {
           },
           kibana: [],
         },
+
+        kibana_date_nested: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['date-nested'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
         kibana_message_with_newline: {
           elasticsearch: {
             cluster: [],

--- a/test/functional/fixtures/es_archiver/date_nested/data.json
+++ b/test/functional/fixtures/es_archiver/date_nested/data.json
@@ -1,0 +1,30 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "index-pattern:date-nested",
+    "index": ".kibana",
+    "source": {
+      "index-pattern": {
+       "fields":"[]",
+        "timeFieldName": "@timestamp",
+        "title": "date-nested"
+      },
+      "type": "index-pattern"
+    }
+  }
+}
+
+
+{
+  "type": "doc",
+  "value": {
+    "id": "date-nested-1",
+    "index": "date-nested",
+    "source": {
+      "message" : "test",
+      "nested": {
+        "timestamp": "2021-06-30T12:00:00.123Z"
+      }
+    }
+  }
+}

--- a/test/functional/fixtures/es_archiver/date_nested/mappings.json
+++ b/test/functional/fixtures/es_archiver/date_nested/mappings.json
@@ -1,0 +1,22 @@
+{
+  "type": "index",
+  "value": {
+    "index": "date-nested",
+    "mappings": {
+      "properties": {
+        "message": {
+          "type": "text"
+        },
+        "nested": {
+          "type": "nested"
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Discover][Main] Fix missing error message when building search query throws exceptions (#103923)