### PR TITLE
[ML] Fixing job wizard with missing description

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
@@ -222,12 +222,11 @@ export class JobCreator {
   }
 
   public get description(): string {
-    return this._job_config.description;
+    return this._job_config.description ?? '';
   }
 
   public get groups(): string[] {
-    // @ts-expect-error @elastic-elasticsearch FIXME groups is optional
-    return this._job_config.groups;
+    return this._job_config.groups ?? [];
   }
 
   public set groups(groups: string[]) {


### PR DESCRIPTION
Fixes bug mentioned [here](https://github.com/elastic/kibana/issues/101344) where a job with a missing `description` property will cause the wizard to crash.
This can be achieved either by editing the JSON in the advanced wizard and removing the description or by cloning a job which does not contain a description.

Also updates the `group` getter which has a similar issue but we were suppressing the ts error.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

