### PR TITLE
[7.x] fix flaky file_hash unit test (#105447)

### DIFF
--- a/src/core/server/core_app/bundle_routes/file_hash.test.ts
+++ b/src/core/server/core_app/bundle_routes/file_hash.test.ts
@@ -19,8 +19,7 @@ const mockedCache = (): jest.Mocked<IFileHashCache> => ({
   set: jest.fn(),
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/105174
-describe.skip('getFileHash', () => {
+describe('getFileHash', () => {
   const sampleFilePath = resolve(__dirname, 'foo.js');
   const fd = 42;
   const stats: Stats = { ino: 42, size: 9000 } as any;
@@ -68,6 +67,8 @@ describe.skip('getFileHash', () => {
     await getFileHash(cache, sampleFilePath, stats, fd);
 
     expect(cache.set).toHaveBeenCalledTimes(1);
-    expect(cache.set).toHaveBeenCalledWith(`${sampleFilePath}-${stats.ino}`, computedHashPromise);
+    expect(cache.set).toHaveBeenCalledWith(`${sampleFilePath}-${stats.ino}`, expect.any(Promise));
+    const promiseValue = await cache.set.mock.calls[0][1];
+    expect(promiseValue).toEqual('computed-hash');
   });
 });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix flaky file_hash unit test (#105447)