### PR TITLE
[Remote Clusters] Fixed remote clusters details flyout for long strings

### DIFF
--- a/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/detail_panel/detail_panel.js
+++ b/x-pack/plugins/remote_clusters/public/application/sections/remote_cluster_list/detail_panel/detail_panel.js
@@ -494,6 +494,7 @@ export class DetailPanel extends Component {
         aria-labelledby="remoteClusterDetailsFlyoutTitle"
         size="m"
         maxWidth={550}
+        className="eui-textBreakAll"
       >
         <EuiFlyoutHeader>
           <EuiFlexGroup alignItems="center" gutterSize="s">


### PR DESCRIPTION
## Summary

This PR fixes the display of long strings in the remote clusters flyout. Previously, if a remote cluster is created with a very long string for its name, proxy address, server name or seed, the long string would either push the second column of description off the screen or the long string itself would go off the screen. This fix forces long strings to break and display on several lines. 

### Screenshots 
#### Before 
Long name
![Screenshot 2021-07-14 at 14 36 28](https://user-images.githubusercontent.com/6585477/125623604-6ffa14f9-ea19-4703-93d3-38028bceb208.png)


Proxy mode
![Screenshot 2021-07-14 at 14 14 52](https://user-images.githubusercontent.com/6585477/125623667-9271cff2-7758-4d0c-94b2-6a01cf26f512.png)


Sniff mode
![Screenshot 2021-07-14 at 14 14 42](https://user-images.githubusercontent.com/6585477/125622207-408d3dc9-caef-4da1-8a41-5a4e96468425.png)


#### After
Long name
![Screenshot 2021-07-14 at 14 35 48](https://user-images.githubusercontent.com/6585477/125623756-67e73732-3fee-4ce3-b446-09c67a84d632.png)


Proxy mode
![Screenshot 2021-07-14 at 14 07 57](https://user-images.githubusercontent.com/6585477/125623823-d0a9df59-1a87-4263-b5d6-e1578d7659f2.png)



Sniff mode
![Screenshot 2021-07-14 at 14 08 03](https://user-images.githubusercontent.com/6585477/125623795-5e58f622-fc35-4141-8c74-d486d15375e9.png)

## Release Note
Remote Clusters UI now better displays long values in the details flyout. 