### PR TITLE
[Security Solution] Alert flyout overview

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBasicTableColumn, EuiSpacer, EuiHorizontalRule, EuiTitle } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSpacer, EuiHorizontalRule, EuiTitle, EuiText } from '@elastic/eui';
 import { get, getOr, find } from 'lodash/fp';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
@@ -246,14 +246,16 @@ const AlertSummaryViewComponent: React.FC<{
       {maybeRule?.note && (
         <>
           <EuiHorizontalRule />
-          <EuiTitle size="xxs" data-test-subj="summary-view-guide">
-            <h6>{i18n.INVESTIGATION_GUIDE}</h6>
+          <EuiTitle size="xxxs" data-test-subj="summary-view-guide">
+            <h5>{i18n.INVESTIGATION_GUIDE}</h5>
           </EuiTitle>
           <EuiSpacer size="s" />
           <Indent>
-            <LineClamp>
-              <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
-            </LineClamp>
+            <EuiText size="xs">
+              <LineClamp lineClampHeight={4.5}>
+                <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
+              </LineClamp>
+            </EuiText>
           </Indent>
         </>
       )}

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -11,6 +11,7 @@ import {
   EuiDescriptionListDescription,
   EuiDescriptionListTitle,
   EuiSpacer,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import { get, getOr, find } from 'lodash/fp';
 import React, { useMemo } from 'react';
@@ -220,14 +221,17 @@ const AlertSummaryViewComponent: React.FC<{
         title={title}
       />
       {maybeRule?.note && (
-        <StyledEuiDescriptionList data-test-subj={`summary-view-guide`} compressed>
-          <EuiDescriptionListTitle>{i18n.INVESTIGATION_GUIDE}</EuiDescriptionListTitle>
-          <EuiDescriptionListDescription>
-            <LineClamp>
-              <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
-            </LineClamp>
-          </EuiDescriptionListDescription>
-        </StyledEuiDescriptionList>
+        <>
+          <EuiHorizontalRule />
+          <StyledEuiDescriptionList data-test-subj={`summary-view-guide`} compressed>
+            <EuiDescriptionListTitle>{i18n.INVESTIGATION_GUIDE}</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              <LineClamp>
+                <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
+              </LineClamp>
+            </EuiDescriptionListDescription>
+          </StyledEuiDescriptionList>
+        </>
       )}
     </>
   );

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -21,6 +21,8 @@ import {
   ALERTS_HEADERS_THRESHOLD_CARDINALITY,
   ALERTS_HEADERS_THRESHOLD_COUNT,
   ALERTS_HEADERS_THRESHOLD_TERMS,
+  SIGNAL_STATUS,
+  TIMESTAMP,
 } from '../../../detections/components/alerts_table/translations';
 import {
   IP_FIELD_TYPE,
@@ -40,8 +42,8 @@ const StyledText = styled.div`
 `;
 
 const fields = [
-  { id: 'signal.status' },
-  { id: '@timestamp' },
+  { id: 'signal.status', label: SIGNAL_STATUS },
+  { id: '@timestamp', label: TIMESTAMP },
   {
     id: SIGNAL_RULE_NAME_FIELD_NAME,
     linkField: 'signal.rule.id',
@@ -57,6 +59,20 @@ const fields = [
   { id: 'signal.threshold_result.count', label: ALERTS_HEADERS_THRESHOLD_COUNT },
   { id: 'signal.threshold_result.terms', label: ALERTS_HEADERS_THRESHOLD_TERMS },
   { id: 'signal.threshold_result.cardinality', label: ALERTS_HEADERS_THRESHOLD_CARDINALITY },
+];
+
+const processFields = [
+  ...fields,
+  { id: 'process.name' },
+  { id: 'process.parent.name' },
+  { id: 'process.args' },
+];
+
+const networkFields = [
+  ...fields,
+  { id: 'destination.address' },
+  { id: 'destination.port' },
+  { id: 'process.name' },
 ];
 
 const getDescription = ({
@@ -88,8 +104,22 @@ const getSummaryRows = ({
   timelineId: string;
   eventId: string;
 }) => {
+  const categoryField = find({ category: 'event', field: 'event.category' }, data) as
+    | TimelineEventsDetailsItem
+    | undefined;
+  const eventCategory = Array.isArray(categoryField?.originalValue)
+    ? categoryField?.originalValue[0]
+    : categoryField?.originalValue;
+
+  const tableFields =
+    eventCategory === 'network'
+      ? networkFields
+      : eventCategory === 'process'
+      ? processFields
+      : fields;
+
   return data != null
-    ? fields.reduce<SummaryRow[]>((acc, item) => {
+    ? tableFields.reduce<SummaryRow[]>((acc, item) => {
         const field = data.find((d) => d.field === item.id);
         if (!field) {
           return acc;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -5,14 +5,7 @@
  * 2.0.
  */
 
-import {
-  EuiBasicTableColumn,
-  EuiDescriptionList,
-  EuiDescriptionListDescription,
-  EuiDescriptionListTitle,
-  EuiSpacer,
-  EuiHorizontalRule,
-} from '@elastic/eui';
+import { EuiBasicTableColumn, EuiSpacer, EuiHorizontalRule, EuiTitle } from '@elastic/eui';
 import { get, getOr, find } from 'lodash/fp';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
@@ -41,8 +34,8 @@ import { MarkdownRenderer } from '../markdown_editor';
 import { LineClamp } from '../line_clamp';
 import { endpointAlertCheck } from '../../utils/endpoint_alert_check';
 
-const StyledEuiDescriptionList = styled(EuiDescriptionList)`
-  padding: 24px 4px 4px;
+const StyledText = styled.div`
+  padding: 0 4px;
   word-break: break-word;
 `;
 
@@ -223,14 +216,15 @@ const AlertSummaryViewComponent: React.FC<{
       {maybeRule?.note && (
         <>
           <EuiHorizontalRule />
-          <StyledEuiDescriptionList data-test-subj={`summary-view-guide`} compressed>
-            <EuiDescriptionListTitle>{i18n.INVESTIGATION_GUIDE}</EuiDescriptionListTitle>
-            <EuiDescriptionListDescription>
-              <LineClamp>
-                <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
-              </LineClamp>
-            </EuiDescriptionListDescription>
-          </StyledEuiDescriptionList>
+          <EuiTitle size="xxs" data-test-subj="summary-view-guide">
+            <h6>{i18n.INVESTIGATION_GUIDE}</h6>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <StyledText>
+            <LineClamp>
+              <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
+            </LineClamp>
+          </StyledText>
         </>
       )}
     </>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -36,8 +36,8 @@ import { MarkdownRenderer } from '../markdown_editor';
 import { LineClamp } from '../line_clamp';
 import { endpointAlertCheck } from '../../utils/endpoint_alert_check';
 
-const StyledText = styled.div`
-  padding: 0 4px;
+export const Indent = styled.div`
+  padding: 0 8px;
   word-break: break-word;
 `;
 
@@ -237,7 +237,7 @@ const AlertSummaryViewComponent: React.FC<{
 
   return (
     <>
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       <SummaryView
         summaryColumns={summaryColumns}
         summaryRows={isEndpointAlert ? summaryRowsWithAgentStatus : summaryRows}
@@ -250,11 +250,11 @@ const AlertSummaryViewComponent: React.FC<{
             <h6>{i18n.INVESTIGATION_GUIDE}</h6>
           </EuiTitle>
           <EuiSpacer size="s" />
-          <StyledText>
+          <Indent>
             <LineClamp>
               <MarkdownRenderer>{maybeRule.note}</MarkdownRenderer>
             </LineClamp>
-          </StyledText>
+          </Indent>
         </>
       )}
     </>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -38,7 +38,7 @@ const RightMargin = styled.span`
 const EnrichmentTitle: React.FC<ThreatSummaryItem['title']> = ({ title, type }) => (
   <>
     <RightMargin>
-      <EuiTitle size="xxs">
+      <EuiTitle size="xxxs">
         <h5>{title}</h5>
       </EuiTitle>
     </RightMargin>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.test.tsx
@@ -82,7 +82,7 @@ describe('EventDetails', () => {
   });
 
   describe('alerts tabs', () => {
-    ['Summary', 'Threat Intel', 'Table', 'JSON View'].forEach((tab) => {
+    ['Overview', 'Threat Intel', 'Table', 'JSON View'].forEach((tab) => {
       test(`it renders the ${tab} tab`, () => {
         const expectedCopy = tab === 'Threat Intel' ? `${tab} (1)` : tab;
         expect(
@@ -94,14 +94,14 @@ describe('EventDetails', () => {
       });
     });
 
-    test('the Summary tab is selected by default', () => {
+    test('the Overview tab is selected by default', () => {
       expect(
         alertsWrapper
           .find('[data-test-subj="eventDetails"]')
           .find('.euiTab-isSelected')
           .first()
           .text()
-      ).toEqual('Summary');
+      ).toEqual('Overview');
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -128,7 +128,7 @@ const EventDetailsComponent: React.FC<Props> = ({
       isAlert
         ? {
             id: EventsViewType.summaryView,
-            name: i18n.SUMMARY,
+            name: i18n.OVERVIEW,
             content: (
               <>
                 <AlertSummaryView
@@ -137,6 +137,7 @@ const EventDetailsComponent: React.FC<Props> = ({
                     eventId: id,
                     browserFields,
                     timelineId,
+                    title: i18n.DUCOMENT_SUMMARY,
                   }}
                 />
                 {enrichmentCount > 0 && (

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -197,7 +197,7 @@ export const onEventDetailsTabKeyPressed = ({
 };
 
 const getTitle = (title: string) => (
-  <EuiTitle size="xxs">
+  <EuiTitle size="xxxs">
     <h5>{title}</h5>
   </EuiTitle>
 );

--- a/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiInMemoryTable, EuiBasicTableColumn, EuiTitle, EuiHorizontalRule } from '@elastic/eui';
+import { EuiInMemoryTable, EuiBasicTableColumn, EuiTitle, EuiText } from '@elastic/eui';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -16,28 +16,13 @@ export const StyledEuiInMemoryTable = styled(EuiInMemoryTable as any)`
   .euiTableHeaderCell,
   .euiTableRowCell {
     border: none;
+    .euiTitle--xxsmall {
+      font-size: 12px;
+    }
   }
   .euiTableHeaderCell .euiTableCellContent {
     padding: 0;
   }
-`;
-
-const StyledEuiTitle = styled(EuiTitle)`
-  color: ${({ theme }) => theme.eui.euiColorDarkShade};
-  text-transform: lowercase;
-  padding-top: ${({ theme }) => theme.eui.paddingSizes.s};
-  h2 {
-    min-width: 120px;
-  }
-  hr {
-    max-width: 75%;
-  }
-`;
-
-const FlexDiv = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
 `;
 
 export const SummaryViewComponent: React.FC<{
@@ -45,22 +30,19 @@ export const SummaryViewComponent: React.FC<{
   summaryColumns: Array<EuiBasicTableColumn<SummaryRow>>;
   summaryRows: SummaryRow[];
   dataTestSubj?: string;
-}> = ({ summaryColumns, summaryRows, dataTestSubj = 'summary-view', title }) => {
+}> = ({ summaryColumns, summaryRows, dataTestSubj = 'summary-view', title, subTitle }) => {
   return (
     <>
       {title && (
-        <StyledEuiTitle size="xxs">
-          <FlexDiv>
-            <h2>{title}</h2>
-            <EuiHorizontalRule margin="none" />
-          </FlexDiv>
-        </StyledEuiTitle>
+        <EuiTitle size="xxxs">
+          <h6>{title}</h6>
+        </EuiTitle>
       )}
       <StyledEuiInMemoryTable
         data-test-subj={dataTestSubj}
         items={summaryRows}
         columns={summaryColumns}
-        compressed
+        compressed={true}
       />
     </>
   );

--- a/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
@@ -35,8 +35,8 @@ export const SummaryViewComponent: React.FC<{
   return (
     <>
       {title && (
-        <EuiTitle size="xxs">
-          <h6>{title}</h6>
+        <EuiTitle size="xxxs">
+          <h5>{title}</h5>
         </EuiTitle>
       )}
       <Indent>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
@@ -11,6 +11,10 @@ import styled from 'styled-components';
 
 import { SummaryRow } from './helpers';
 
+export const Indent = styled.div`
+  padding: 0 4px;
+`;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const StyledEuiInMemoryTable = styled(EuiInMemoryTable as any)`
   .euiTableHeaderCell,
@@ -35,12 +39,14 @@ export const SummaryViewComponent: React.FC<{
           <h6>{title}</h6>
         </EuiTitle>
       )}
-      <StyledEuiInMemoryTable
-        data-test-subj={dataTestSubj}
-        items={summaryRows}
-        columns={summaryColumns}
-        compressed
-      />
+      <Indent>
+        <StyledEuiInMemoryTable
+          data-test-subj={dataTestSubj}
+          items={summaryRows}
+          columns={summaryColumns}
+          compressed
+        />
+      </Indent>
     </>
   );
 };

--- a/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
@@ -39,7 +39,7 @@ export const SummaryViewComponent: React.FC<{
         data-test-subj={dataTestSubj}
         items={summaryRows}
         columns={summaryColumns}
-        compressed={true}
+        compressed
       />
     </>
   );

--- a/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiInMemoryTable, EuiBasicTableColumn, EuiTitle, EuiText } from '@elastic/eui';
+import { EuiInMemoryTable, EuiBasicTableColumn, EuiTitle } from '@elastic/eui';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -16,9 +16,6 @@ export const StyledEuiInMemoryTable = styled(EuiInMemoryTable as any)`
   .euiTableHeaderCell,
   .euiTableRowCell {
     border: none;
-    .euiTitle--xxsmall {
-      font-size: 12px;
-    }
   }
   .euiTableHeaderCell .euiTableCellContent {
     padding: 0;
@@ -30,11 +27,11 @@ export const SummaryViewComponent: React.FC<{
   summaryColumns: Array<EuiBasicTableColumn<SummaryRow>>;
   summaryRows: SummaryRow[];
   dataTestSubj?: string;
-}> = ({ summaryColumns, summaryRows, dataTestSubj = 'summary-view', title, subTitle }) => {
+}> = ({ summaryColumns, summaryRows, dataTestSubj = 'summary-view', title }) => {
   return (
     <>
       {title && (
-        <EuiTitle size="xxxs">
+        <EuiTitle size="xxs">
           <h6>{title}</h6>
         </EuiTitle>
       )}

--- a/x-pack/plugins/security_solution/public/common/components/event_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/translations.ts
@@ -7,27 +7,23 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const SUMMARY = i18n.translate('xpack.securitySolution.alertDetails.summary', {
-  defaultMessage: 'Summary',
-});
-
 export const THREAT_INTEL = i18n.translate('xpack.securitySolution.alertDetails.threatIntel', {
   defaultMessage: 'Threat Intel',
 });
 
 export const INVESTIGATION_GUIDE = i18n.translate(
-  'xpack.securitySolution.alertDetails.summary.investigationGuide',
+  'xpack.securitySolution.alertDetails.overview.investigationGuide',
   {
     defaultMessage: 'Investigation guide',
   }
 );
 
-export const OVERVIEW = i18n.translate('xpack.securitySolution.alertDetails.summary.overview', {
+export const OVERVIEW = i18n.translate('xpack.securitySolution.alertDetails.overview', {
   defaultMessage: 'Overview',
 });
 
 export const DUCOMENT_SUMMARY = i18n.translate(
-  'xpack.securitySolution.alertDetails.summary.documentSummary',
+  'xpack.securitySolution.alertDetails.overview.documentSummary',
   {
     defaultMessage: 'Document Summary',
   }

--- a/x-pack/plugins/security_solution/public/common/components/event_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/translations.ts
@@ -22,6 +22,17 @@ export const INVESTIGATION_GUIDE = i18n.translate(
   }
 );
 
+export const OVERVIEW = i18n.translate('xpack.securitySolution.alertDetails.summary.overview', {
+  defaultMessage: 'Overview',
+});
+
+export const DUCOMENT_SUMMARY = i18n.translate(
+  'xpack.securitySolution.alertDetails.summary.documentSummary',
+  {
+    defaultMessage: 'Document Summary',
+  }
+);
+
 export const TABLE = i18n.translate('xpack.securitySolution.eventDetails.table', {
   defaultMessage: 'Table',
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
@@ -245,9 +245,23 @@ export const STATUS = i18n.translate(
   }
 );
 
+export const SIGNAL_STATUS = i18n.translate(
+  'xpack.securitySolution.eventsViewer.alerts.overviewTable.signalStatusTitle',
+  {
+    defaultMessage: 'Status',
+  }
+);
+
 export const TRIGGERED = i18n.translate(
   'xpack.securitySolution.eventsViewer.alerts.defaultHeaders.triggeredTitle',
   {
     defaultMessage: 'Triggered',
+  }
+);
+
+export const TIMESTAMP = i18n.translate(
+  'xpack.securitySolution.eventsViewer.alerts.overviewTable.timestampTitle',
+  {
+    defaultMessage: 'Timestamp',
   }
 );

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
@@ -77,11 +77,7 @@ exports[`Details Panel Component DetailsPanel:EventDetails: rendering it should 
             >
               <div
                 className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <EuiTitle
-                  size="s"
-                />
-              </div>
+              />
             </EuiFlexItem>
             <EuiFlexItem
               grow={false}
@@ -328,11 +324,7 @@ Array [
                     >
                       <div
                         className="euiFlexItem euiFlexItem--flexGrowZero"
-                      >
-                        <EuiTitle
-                          size="s"
-                        />
-                      </div>
+                      />
                     </EuiFlexItem>
                   </div>
                 </EuiFlexGroup>
@@ -545,11 +537,7 @@ Array [
                   >
                     <div
                       className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiTitle
-                        size="s"
-                      />
-                    </div>
+                    />
                   </EuiFlexItem>
                 </div>
               </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`Details Panel Component DetailsPanel:EventDetails: rendering it should 
       handleOnEventClosed={[Function]}
       isAlert={false}
       loading={true}
+      ruleName=""
     >
       <Styled(EuiFlexGroup)
         gutterSize="none"
@@ -306,6 +307,7 @@ Array [
             <ExpandableEventTitle
               isAlert={false}
               loading={true}
+              ruleName=""
             >
               <Styled(EuiFlexGroup)
                 gutterSize="none"
@@ -522,6 +524,7 @@ Array [
           <ExpandableEventTitle
             isAlert={false}
             loading={true}
+            ruleName=""
           >
             <Styled(EuiFlexGroup)
               gutterSize="none"

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
@@ -5,33 +5,23 @@
  * 2.0.
  */
 
-import { find, isEmpty } from 'lodash/fp';
+import { isEmpty } from 'lodash/fp';
 import {
   EuiButtonIcon,
   EuiTextColor,
   EuiLoadingContent,
   EuiTitle,
-  EuiSpacer,
-  EuiDescriptionList,
-  EuiDescriptionListTitle,
-  EuiDescriptionListDescription,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHorizontalRule,
 } from '@elastic/eui';
-import React, { useMemo } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { TimelineTabs } from '../../../../../common/types/timeline';
 import { BrowserFields } from '../../../../common/containers/source';
 import { EventDetails } from '../../../../common/components/event_details/event_details';
 import { TimelineEventsDetailsItem } from '../../../../../common/search_strategy/timeline';
-import { LineClamp } from '../../../../common/components/line_clamp';
 import * as i18n from './translations';
-import { LinkAnchor } from '../../../../common/components/links';
-import { APP_ID, SecurityPageName } from '../../../../../common/constants';
-import { getRuleDetailsUrl, useFormatUrl } from '../../../../common/components/link_to';
-import { useKibana } from '../../../../common/lib/kibana';
 
 export type HandleOnEventClosed = () => void;
 interface Props {
@@ -93,29 +83,6 @@ ExpandableEventTitle.displayName = 'ExpandableEventTitle';
 
 export const ExpandableEvent = React.memo<Props>(
   ({ browserFields, event, timelineId, timelineTabType, isAlert, loading, detailsData }) => {
-    const { navigateToApp } = useKibana().services.application;
-    const { formatUrl } = useFormatUrl(SecurityPageName.rules);
-
-    const reason = useMemo(() => {
-      if (detailsData) {
-        const reasonField = find({ category: 'event', field: 'reason' }, detailsData) as
-          | TimelineEventsDetailsItem
-          | undefined;
-
-        if (reasonField?.originalValue) {
-          return Array.isArray(reasonField?.originalValue)
-            ? reasonField?.originalValue.join()
-            : reasonField?.originalValue;
-        }
-      }
-      return null;
-    }, [detailsData]);
-
-    const ruleId = useMemo(() => {
-      const findRuleId = find({ category: 'signal', field: 'signal.rule.id' }, detailsData)?.values;
-      return findRuleId ? findRuleId[0] : '';
-    }, [detailsData]);
-
     if (!event.eventId) {
       return <EuiTextColor color="subdued">{i18n.EVENT_DETAILS_PLACEHOLDER}</EuiTextColor>;
     }
@@ -126,32 +93,6 @@ export const ExpandableEvent = React.memo<Props>(
 
     return (
       <StyledFlexGroup direction="column" gutterSize="none">
-        {reason && (
-          <EuiFlexItem grow={false}>
-            <EuiDescriptionList data-test-subj="event-reason" compressed>
-              <EuiDescriptionListTitle>{i18n.REASON}</EuiDescriptionListTitle>
-              <EuiDescriptionListDescription>
-                <LineClamp>{reason}</LineClamp>
-              </EuiDescriptionListDescription>
-            </EuiDescriptionList>
-            <EuiSpacer size="m" />
-            <LinkAnchor
-              data-test-subj="ruleName"
-              onClick={(ev: { preventDefault: () => void }) => {
-                ev.preventDefault();
-                navigateToApp(APP_ID, {
-                  deepLinkId: SecurityPageName.rules,
-                  path: getRuleDetailsUrl(ruleId),
-                });
-              }}
-              href={formatUrl(getRuleDetailsUrl(ruleId))}
-            >
-              {i18n.VIEW_RULE_DETAILS_PAGE}
-            </LinkAnchor>
-            <EuiHorizontalRule />
-          </EuiFlexItem>
-        )}
-
         <StyledEuiFlexItem grow={true}>
           <EventDetails
             browserFields={browserFields}

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
@@ -62,13 +62,11 @@ export const ExpandableEventTitle = React.memo<ExpandableEventTitleProps>(
   ({ isAlert, loading, handleOnEventClosed, ruleName }) => (
     <StyledEuiFlexGroup gutterSize="none" justifyContent="spaceBetween" wrap={true}>
       <EuiFlexItem grow={false}>
-        <EuiTitle size="s">
-          {!loading ? (
+        {!loading && (
+          <EuiTitle size="s">
             <h4>{isAlert && !isEmpty(ruleName) ? ruleName : i18n.EVENT_DETAILS}</h4>
-          ) : (
-            <></>
-          )}
-        </EuiTitle>
+          </EuiTitle>
+        )}
       </EuiFlexItem>
       {handleOnEventClosed && (
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -106,6 +106,12 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
     return endpointAlertCheck({ data: detailsData || [] });
   }, [detailsData]);
 
+  const ruleName = useMemo(() => {
+    const findRuleName = find({ category: 'signal', field: 'signal.rule.name' }, detailsData)
+      ?.values;
+    return findRuleName ? findRuleName[0] : '';
+  }, [detailsData]);
+
   const agentId = useMemo(() => {
     const findAgentId = find({ category: 'agent', field: 'agent.id' }, detailsData)?.values;
     return findAgentId ? findAgentId[0] : '';
@@ -177,7 +183,7 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
         {isHostIsolationPanelOpen ? (
           backToAlertDetailsLink
         ) : (
-          <ExpandableEventTitle isAlert={isAlert} loading={loading} />
+          <ExpandableEventTitle isAlert={isAlert} loading={loading} ruleName={ruleName} />
         )}
       </EuiFlyoutHeader>
       {isIsolateActionSuccessBannerVisible && (
@@ -225,6 +231,7 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
       <ExpandableEventTitle
         isAlert={isAlert}
         loading={loading}
+        ruleName={ruleName}
         handleOnEventClosed={handleOnEventClosed}
       />
       <EuiSpacer size="m" />

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.tsx
@@ -36,6 +36,7 @@ import { useIsolationPrivileges } from '../../../../common/hooks/endpoint/use_is
 import { isIsolationSupported } from '../../../../../common/endpoint/service/host_isolation/utils';
 import { endpointAlertCheck } from '../../../../common/utils/endpoint_alert_check';
 import { useWithCaseDetailsRefresh } from '../../../../common/components/endpoint/host_isolation/endpoint_host_isolation_cases_context';
+import { TimelineEventsDetailsItem } from '../../../../../common';
 
 const StyledEuiFlyoutBody = styled(EuiFlyoutBody)`
   .euiFlyoutBody__overflow {
@@ -50,6 +51,20 @@ const StyledEuiFlyoutBody = styled(EuiFlyoutBody)`
     }
   }
 `;
+
+const getFieldValue = (
+  {
+    category,
+    field,
+  }: {
+    category: string;
+    field: string;
+  },
+  data: TimelineEventsDetailsItem[] | null
+) => {
+  const currentField = find({ category, field }, data)?.values;
+  return currentField && currentField.length > 0 ? currentField[0] : '';
+};
 
 interface EventDetailsPanelProps {
   browserFields: BrowserFields;
@@ -106,37 +121,34 @@ const EventDetailsPanelComponent: React.FC<EventDetailsPanelProps> = ({
     return endpointAlertCheck({ data: detailsData || [] });
   }, [detailsData]);
 
-  const ruleName = useMemo(() => {
-    const findRuleName = find({ category: 'signal', field: 'signal.rule.name' }, detailsData)
-      ?.values;
-    return findRuleName ? findRuleName[0] : '';
-  }, [detailsData]);
+  const ruleName = useMemo(
+    () => getFieldValue({ category: 'signal', field: 'signal.rule.name' }, detailsData),
+    [detailsData]
+  );
 
-  const agentId = useMemo(() => {
-    const findAgentId = find({ category: 'agent', field: 'agent.id' }, detailsData)?.values;
-    return findAgentId ? findAgentId[0] : '';
-  }, [detailsData]);
+  const agentId = useMemo(
+    () => getFieldValue({ category: 'agent', field: 'agent.id' }, detailsData),
+    [detailsData]
+  );
 
-  const hostOsFamily = useMemo(() => {
-    const findOsName = find({ category: 'host', field: 'host.os.name' }, detailsData)?.values;
-    return findOsName ? findOsName[0] : '';
-  }, [detailsData]);
+  const hostOsFamily = useMemo(
+    () => getFieldValue({ category: 'host', field: 'host.os.name' }, detailsData),
+    [detailsData]
+  );
 
-  const agentVersion = useMemo(() => {
-    const findAgentVersion = find({ category: 'agent', field: 'agent.version' }, detailsData)
-      ?.values;
-    return findAgentVersion ? findAgentVersion[0] : '';
-  }, [detailsData]);
+  const agentVersion = useMemo(
+    () => getFieldValue({ category: 'agent', field: 'agent.version' }, detailsData),
+    [detailsData]
+  );
 
-  const alertId = useMemo(() => {
-    const findAlertId = find({ category: '_id', field: '_id' }, detailsData)?.values;
-    return findAlertId ? findAlertId[0] : '';
-  }, [detailsData]);
+  const alertId = useMemo(() => getFieldValue({ category: '_id', field: '_id' }, detailsData), [
+    detailsData,
+  ]);
 
-  const hostName = useMemo(() => {
-    const findHostName = find({ category: 'host', field: 'host.name' }, detailsData)?.values;
-    return findHostName ? findHostName[0] : '';
-  }, [detailsData]);
+  const hostName = useMemo(
+    () => getFieldValue({ category: 'host', field: 'host.name' }, detailsData),
+    [detailsData]
+  );
 
   const isolationSupported = isIsolationSupported({
     osName: hostOsFamily,

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/translations.ts
@@ -14,6 +14,13 @@ export const MESSAGE = i18n.translate(
   }
 );
 
+export const REASON = i18n.translate(
+  'xpack.securitySolution.timeline.expandableEvent.reasonTitle',
+  {
+    defaultMessage: 'Reason',
+  }
+);
+
 export const CLOSE = i18n.translate(
   'xpack.securitySolution.timeline.expandableEvent.closeEventDetailsLabel',
   {
@@ -39,5 +46,12 @@ export const ALERT_DETAILS = i18n.translate(
   'xpack.securitySolution.timeline.expandableEvent.alertTitleLabel',
   {
     defaultMessage: 'Alert details',
+  }
+);
+
+export const VIEW_RULE_DETAILS_PAGE = i18n.translate(
+  'xpack.securitySolution.timeline.expandableEvent.viewRuleDetailsTitleLabel',
+  {
+    defaultMessage: 'View rule detail page',
   }
 );

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/translations.ts
@@ -14,13 +14,6 @@ export const MESSAGE = i18n.translate(
   }
 );
 
-export const REASON = i18n.translate(
-  'xpack.securitySolution.timeline.expandableEvent.reasonTitle',
-  {
-    defaultMessage: 'Reason',
-  }
-);
-
 export const CLOSE = i18n.translate(
   'xpack.securitySolution.timeline.expandableEvent.closeEventDetailsLabel',
   {
@@ -46,12 +39,5 @@ export const ALERT_DETAILS = i18n.translate(
   'xpack.securitySolution.timeline.expandableEvent.alertTitleLabel',
   {
     defaultMessage: 'Alert details',
-  }
-);
-
-export const VIEW_RULE_DETAILS_PAGE = i18n.translate(
-  'xpack.securitySolution.timeline.expandableEvent.viewRuleDetailsTitleLabel',
-  {
-    defaultMessage: 'View rule detail page',
   }
 );

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -18540,8 +18540,6 @@
     "xpack.securitySolution.administration.os.windows": "Windows",
     "xpack.securitySolution.alertDetails.checkDocs": "マニュアルをご確認ください。",
     "xpack.securitySolution.alertDetails.ifCtiNotEnabled": "脅威インテリジェンスソースを有効にしていない場合で、この機能について関心がある場合は、",
-    "xpack.securitySolution.alertDetails.summary": "まとめ",
-    "xpack.securitySolution.alertDetails.summary.investigationGuide": "調査ガイド",
     "xpack.securitySolution.alertDetails.summary.readLess": "表示を減らす",
     "xpack.securitySolution.alertDetails.summary.readMore": "続きを読む",
     "xpack.securitySolution.alertDetails.threatIntel": "Threat Intel",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -18804,8 +18804,6 @@
     "xpack.securitySolution.administration.os.windows": "Windows",
     "xpack.securitySolution.alertDetails.checkDocs": "请查看我们的文档。",
     "xpack.securitySolution.alertDetails.ifCtiNotEnabled": "如果尚未启用任何威胁情报来源，并希望更多了解此功能，",
-    "xpack.securitySolution.alertDetails.summary": "摘要",
-    "xpack.securitySolution.alertDetails.summary.investigationGuide": "调查指南",
     "xpack.securitySolution.alertDetails.summary.readLess": "阅读更少内容",
     "xpack.securitySolution.alertDetails.summary.readMore": "阅读更多内容",
     "xpack.securitySolution.alertDetails.threatIntel": "威胁情报",


### PR DESCRIPTION
## Summary

https://github.com/elastic/security-team/issues/1271
https://github.com/elastic/security-team/issues/1394

- Change the flyout title from `Alert details` to rule name
- Change the tab name from summary to overview

- If event.category is network, show extra fields: process.name, destination.address, destination.port

<img width="1676" alt="Screenshot 2021-07-19 at 17 29 12" src="https://user-images.githubusercontent.com/6295984/126194635-a6567dca-7f36-4d3b-bdde-baef1180a442.png">



- If event.category is process, show extra fields: process.name, process.parent.name, process.args
<img width="1678" alt="Screenshot 2021-07-19 at 17 34 22" src="https://user-images.githubusercontent.com/6295984/126195189-5bb50431-a2b5-40a4-9409-f6bf165df85a.png">




