### PR TITLE
[packages/rule-data-utils] Remove legacy build and watchs cripts

### DIFF
--- a/packages/kbn-rule-data-utils/package.json
+++ b/packages/kbn-rule-data-utils/package.json
@@ -4,10 +4,5 @@
   "types": "./target/index.d.ts",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "private": true,
-  "scripts": {
-    "build": "../../node_modules/.bin/tsc",
-    "kbn:bootstrap": "yarn build",
-    "kbn:watch": "yarn build --watch"
-  }
+  "private": true
 }


### PR DESCRIPTION
This package was migrated to bazel, but the legacy style script commands
still exist in `package.json`.  This removes these scripts to avoid
incorrectly building the package.