### PR TITLE
[CTI] Adds validation to Indicator index pattern

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
@@ -86,7 +86,6 @@ import {
   getCustomQueryInvalidationText,
   getDefineContinueButton,
   getIndexPatternClearButton,
-  getIndexPatternForbiddenText,
   getIndexPatternInvalidationText,
   getIndicatorAndButton,
   getIndicatorAtLeastOneInvalidationText,
@@ -168,11 +167,6 @@ describe('indicator match', () => {
         it('Shows invalidation text if you try to continue without filling it out', () => {
           getDefineContinueButton().click();
           getIndexPatternInvalidationText().should('exist');
-        });
-
-        it('Shows invalidation text if you try to create invalid index pattern', () => {
-          getIndicatorIndicatorIndex().type(`*{enter}`);
-          getIndexPatternForbiddenText().should('exist');
         });
       });
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/indicator_match_rule.spec.ts
@@ -86,6 +86,7 @@ import {
   getCustomQueryInvalidationText,
   getDefineContinueButton,
   getIndexPatternClearButton,
+  getIndexPatternForbiddenText,
   getIndexPatternInvalidationText,
   getIndicatorAndButton,
   getIndicatorAtLeastOneInvalidationText,
@@ -167,6 +168,11 @@ describe('indicator match', () => {
         it('Shows invalidation text if you try to continue without filling it out', () => {
           getDefineContinueButton().click();
           getIndexPatternInvalidationText().should('exist');
+        });
+
+        it('Shows invalidation text if you try to create invalid index pattern', () => {
+          getIndicatorIndicatorIndex().type(`*{enter}`);
+          getIndexPatternForbiddenText().should('exist');
         });
       });
 

--- a/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
@@ -94,9 +94,6 @@ export const AT_LEAST_ONE_VALID_MATCH = 'At least one indicator match is require
 
 export const AT_LEAST_ONE_INDEX_PATTERN = 'A minimum of one index pattern is required.';
 
-export const FORBIDDEN_INDEX_PATTERN =
-  'The index pattern can not be *. Please create a different index pattern.';
-
 export const CUSTOM_QUERY_REQUIRED = 'A custom query is required.';
 
 export const DEFINE_CONTINUE_BUTTON = '[data-test-subj="define-continue"]';

--- a/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
@@ -94,6 +94,9 @@ export const AT_LEAST_ONE_VALID_MATCH = 'At least one indicator match is require
 
 export const AT_LEAST_ONE_INDEX_PATTERN = 'A minimum of one index pattern is required.';
 
+export const FORBIDDEN_INDEX_PATTERN =
+  'The index pattern can not be *. Please create a different index pattern.';
+
 export const CUSTOM_QUERY_REQUIRED = 'A custom query is required.';
 
 export const DEFINE_CONTINUE_BUTTON = '[data-test-subj="define-continue"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -92,7 +92,6 @@ import {
   EMAIL_CONNECTOR_PORT_INPUT,
   EMAIL_CONNECTOR_USER_INPUT,
   EMAIL_CONNECTOR_PASSWORD_INPUT,
-  FORBIDDEN_INDEX_PATTERN,
 } from '../screens/create_new_rule';
 import { TOAST_ERROR } from '../screens/shared';
 import { SERVER_SIDE_EVENT_COUNT } from '../screens/timeline';
@@ -433,8 +432,6 @@ export const getIndicatorAtLeastOneInvalidationText = () => cy.contains(AT_LEAST
 
 /** Returns that at least one index pattern is required content */
 export const getIndexPatternInvalidationText = () => cy.contains(AT_LEAST_ONE_INDEX_PATTERN);
-
-export const getIndexPatternForbiddenText = () => cy.contains(FORBIDDEN_INDEX_PATTERN);
 
 /** Returns the continue button on the step of about */
 export const getAboutContinueButton = () => cy.get(ABOUT_CONTINUE_BTN);

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -92,6 +92,7 @@ import {
   EMAIL_CONNECTOR_PORT_INPUT,
   EMAIL_CONNECTOR_USER_INPUT,
   EMAIL_CONNECTOR_PASSWORD_INPUT,
+  FORBIDDEN_INDEX_PATTERN,
 } from '../screens/create_new_rule';
 import { TOAST_ERROR } from '../screens/shared';
 import { SERVER_SIDE_EVENT_COUNT } from '../screens/timeline';
@@ -432,6 +433,8 @@ export const getIndicatorAtLeastOneInvalidationText = () => cy.contains(AT_LEAST
 
 /** Returns that at least one index pattern is required content */
 export const getIndexPatternInvalidationText = () => cy.contains(AT_LEAST_ONE_INDEX_PATTERN);
+
+export const getIndexPatternForbiddenText = () => cy.contains(FORBIDDEN_INDEX_PATTERN);
 
 /** Returns the continue button on the step of about */
 export const getAboutContinueButton = () => cy.get(ABOUT_CONTINUE_BTN);

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.test.tsx
@@ -19,6 +19,7 @@ import {
   getFormattedEntries,
   getFormattedEntry,
   getUpdatedEntriesOnDelete,
+  customValidators,
 } from './helpers';
 import { ThreatMapEntry } from '@kbn/securitysolution-io-ts-alerting-types';
 
@@ -292,6 +293,21 @@ describe('Helpers', () => {
         },
       ]);
       expect(items).toEqual([{ entries: [entry] }]);
+    });
+  });
+
+  describe('customValidators.forbiddenField', () => {
+    const FORBIDDEN = '*';
+
+    test('it returns expected value when a forbidden value is passed in', () => {
+      expect(customValidators.forbiddenField('*', FORBIDDEN)).toEqual({
+        code: 'ERR_FIELD_FORMAT',
+        message: 'The index pattern cannot be *. Please choose a more specific index pattern.',
+      });
+    });
+
+    test('it returns undefined when a non-forbidden value is passed in', () => {
+      expect(customValidators.forbiddenField('.test-index', FORBIDDEN)).not.toBeDefined();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
@@ -204,7 +204,7 @@ export const customValidators = {
           'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.threatMatchIndexForbiddenError',
           {
             defaultMessage:
-              'The index pattern can not be { forbiddenString }. Please create a different index pattern.',
+              'The index pattern cannot be { forbiddenString }. Please choose a more specific index pattern.',
             values: {
               forbiddenString,
             },

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
@@ -186,7 +186,7 @@ export const customValidators = {
   forbiddenField: (
     value: unknown,
     forbiddenString: string
-  ): ReturnType<ValidationFunc<unknown, ERROR_CODE>> => {
+  ): ReturnType<ValidationFunc<{}, ERROR_CODE>> => {
     let match: boolean;
 
     if (typeof value === 'string') {

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
@@ -6,11 +6,14 @@
  */
 
 import uuid from 'uuid';
+import { i18n } from '@kbn/i18n';
 import { addIdToItem } from '@kbn/securitysolution-utils';
 import { ThreatMap, threatMap, ThreatMapping } from '@kbn/securitysolution-io-ts-alerting-types';
 
 import { IndexPattern, IFieldType } from '../../../../../../../src/plugins/data/common';
 import { Entry, FormattedEntry, ThreatMapEntries, EmptyEntry } from './types';
+import { ValidationFunc } from '../../../../../../../src/plugins/es_ui_shared/static/forms/hook_form_lib';
+import { ERROR_CODE } from '../../../../../../../src/plugins/es_ui_shared/static/forms/helpers/field_validators/types';
 
 /**
  * Formats the entry into one that is easily usable for the UI.
@@ -177,4 +180,37 @@ export const singleEntryThreat = (items: ThreatMapEntries[]): boolean => {
     items[0].entries[0].field === '' &&
     items[0].entries[0].value === ''
   );
+};
+
+export const customValidators = {
+  forbiddenField: (
+    value: unknown,
+    forbiddenString: string
+  ): ReturnType<ValidationFunc<unknown, ERROR_CODE>> => {
+    let match: boolean;
+
+    if (typeof value === 'string') {
+      match = value === forbiddenString;
+    } else if (Array.isArray(value)) {
+      match = !!value.find((item) => item === forbiddenString);
+    } else {
+      match = false;
+    }
+
+    if (match) {
+      return {
+        code: 'ERR_FIELD_FORMAT',
+        message: i18n.translate(
+          'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.threatMatchIndexForbiddenError',
+          {
+            defaultMessage:
+              'The index pattern can not be { forbiddenString }. Please create a different index pattern.',
+            values: {
+              forbiddenString,
+            },
+          }
+        ),
+      };
+    }
+  },
 };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import {
   singleEntryThreat,
   containsInvalidItems,
+  customValidators,
 } from '../../../../common/components/threat_match/helpers';
 import { isThreatMatchRule, isThresholdRule } from '../../../../../common/detection_engine/utils';
 import { isMlRule } from '../../../../../common/machine_learning/helpers';
@@ -369,6 +370,19 @@ export const schema: FormSchema<DefineStepRule> = {
               }
             )
           )(...args);
+        },
+      },
+      {
+        validator: (
+          ...args: Parameters<ValidationFunc>
+        ): ReturnType<ValidationFunc<{}, ERROR_CODE>> | undefined => {
+          const [{ formData, value }] = args;
+          const needsValidation = isThreatMatchRule(formData.ruleType);
+          if (!needsValidation) {
+            return;
+          }
+
+          return customValidators.forbiddenField(value, '*');
         },
       },
     ],


### PR DESCRIPTION
## Summary

Ensures that users can not use `*` as a valid indicator index pattern while creating an Indicator Match Rule.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

