### PR TITLE
[ML] Anomaly Detection explorer: ensure geo points show up in embeddable map chart area

### DIFF
--- a/x-pack/plugins/ml/public/application/services/anomaly_explorer_charts_service.ts
+++ b/x-pack/plugins/ml/public/application/services/anomaly_explorer_charts_service.ts
@@ -504,8 +504,9 @@ export class AnomalyExplorerChartsService {
         const config = seriesConfigs[i];
         let records;
         if (
-          config.detectorLabel !== undefined &&
-          config.detectorLabel.includes(ML_JOB_AGGREGATION.LAT_LONG)
+          (config.detectorLabel !== undefined &&
+            config.detectorLabel.includes(ML_JOB_AGGREGATION.LAT_LONG)) ||
+          config?.metricFunction === ML_JOB_AGGREGATION.LAT_LONG
         ) {
           if (config.entityFields.length) {
             records = [


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/101344

No longer relies solely on the detector label to determine if a job has relevant geo data for charts.




### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))




