### PR TITLE
[Workplace Search] Fix Chrome issues with GitHub sources

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -289,6 +289,7 @@ describe('AddSourceLogic', () => {
     describe('saveSourceParams', () => {
       const params = {
         code: 'code123',
+        session_state: 'session_state123',
         state:
           '{"action":"create","context":"organization","service_type":"gmail","csrf_token":"token==","index_permissions":false}',
       };
@@ -306,7 +307,7 @@ describe('AddSourceLogic', () => {
         const setAddedSourceSpy = jest.spyOn(SourcesLogic.actions, 'setAddedSource');
         const { serviceName, indexPermissions, serviceType } = response;
         http.get.mockReturnValue(Promise.resolve(response));
-        AddSourceLogic.actions.saveSourceParams(queryString);
+        AddSourceLogic.actions.saveSourceParams(queryString, params, true);
         expect(http.get).toHaveBeenCalledWith('/api/workplace_search/sources/create', {
           query: {
             ...params,
@@ -324,7 +325,7 @@ describe('AddSourceLogic', () => {
         const accountQueryString =
           '?state=%7B%22action%22:%22create%22,%22context%22:%22account%22,%22service_type%22:%22gmail%22,%22csrf_token%22:%22token%3D%3D%22,%22index_permissions%22:false%7D&code=code';
 
-        AddSourceLogic.actions.saveSourceParams(accountQueryString);
+        AddSourceLogic.actions.saveSourceParams(accountQueryString, params, false);
 
         await nextTick();
 
@@ -345,7 +346,7 @@ describe('AddSourceLogic', () => {
             preContentSourceId,
           })
         );
-        AddSourceLogic.actions.saveSourceParams(queryString);
+        AddSourceLogic.actions.saveSourceParams(queryString, params, true);
         expect(http.get).toHaveBeenCalledWith('/api/workplace_search/sources/create', {
           query: {
             ...params,
@@ -389,7 +390,7 @@ describe('AddSourceLogic', () => {
       it('handles error', async () => {
         http.get.mockReturnValue(Promise.reject('this is an error'));
 
-        AddSourceLogic.actions.saveSourceParams(queryString);
+        AddSourceLogic.actions.saveSourceParams(queryString, params, true);
         await nextTick();
 
         expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -361,28 +361,27 @@ describe('AddSourceLogic', () => {
       });
 
       describe('Github error edge case', () => {
+        const GITHUB_ERROR =
+          'The redirect_uri MUST match the registered callback URL for this application.';
+        const errorParams = { ...params, error_description: GITHUB_ERROR };
         const getGithubQueryString = (context: 'organization' | 'account') =>
           `?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22${context}%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TOKEN%3D%3D%22%2C%22index_permissions%22%3Afalse%7D`;
 
         it('handles "organization" redirect and displays error', () => {
           const githubQueryString = getGithubQueryString('organization');
-          AddSourceLogic.actions.saveSourceParams(githubQueryString);
+          AddSourceLogic.actions.saveSourceParams(githubQueryString, errorParams, true);
 
           expect(navigateToUrl).toHaveBeenCalledWith('/');
-          expect(setErrorMessage).toHaveBeenCalledWith(
-            'The redirect_uri MUST match the registered callback URL for this application.'
-          );
+          expect(setErrorMessage).toHaveBeenCalledWith(GITHUB_ERROR);
         });
 
         it('handles "account" redirect and displays error', () => {
           const githubQueryString = getGithubQueryString('account');
-          AddSourceLogic.actions.saveSourceParams(githubQueryString);
+          AddSourceLogic.actions.saveSourceParams(githubQueryString, errorParams, false);
 
           expect(navigateToUrl).toHaveBeenCalledWith(PERSONAL_SOURCES_PATH);
           expect(setErrorMessage).toHaveBeenCalledWith(
-            PERSONAL_DASHBOARD_SOURCE_ERROR(
-              'The redirect_uri MUST match the registered callback URL for this application.'
-            )
+            PERSONAL_DASHBOARD_SOURCE_ERROR(GITHUB_ERROR)
           );
         });
       });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -20,7 +20,6 @@ import {
 } from '../../../../../shared/flash_messages';
 import { HttpLogic } from '../../../../../shared/http';
 import { KibanaLogic } from '../../../../../shared/kibana';
-import { parseQueryParams } from '../../../../../shared/query_params';
 import { AppLogic } from '../../../../app_logic';
 import { CUSTOM_SERVICE_TYPE, WORKPLACE_SEARCH_URL_PREFIX } from '../../../../constants';
 import {
@@ -95,7 +94,11 @@ export interface AddSourceActions {
     isUpdating: boolean,
     successCallback?: () => void
   ): { isUpdating: boolean; successCallback?(): void };
-  saveSourceParams(search: Search): { search: Search };
+  saveSourceParams(
+    search: Search,
+    params: OauthParams,
+    isOrganization: boolean
+  ): { search: Search; params: OauthParams; isOrganization: boolean };
   getSourceConfigData(serviceType: string): { serviceType: string };
   getSourceConnectData(
     serviceType: string,
@@ -206,7 +209,11 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       isUpdating,
       successCallback,
     }),
-    saveSourceParams: (search: Search) => ({ search }),
+    saveSourceParams: (search: Search, params: OauthParams, isOrganization: boolean) => ({
+      search,
+      params,
+      isOrganization,
+    }),
     createContentSource: (
       serviceType: string,
       successCallback: () => void,
@@ -500,15 +507,12 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         actions.setButtonNotLoading();
       }
     },
-    saveSourceParams: async ({ search }) => {
+    saveSourceParams: async ({ search, params, isOrganization }) => {
       const { http } = HttpLogic.values;
       const { navigateToUrl } = KibanaLogic.values;
       const { setAddedSource } = SourcesLogic.actions;
-      const params = (parseQueryParams(search) as unknown) as OauthParams;
       const query = { ...params, kibana_host: kibanaHost };
       const route = '/api/workplace_search/sources/create';
-      const state = JSON.parse(params.state);
-      const isOrganization = state.context !== 'account';
 
       /**
         There is an extreme edge case where the user is trying to connect Github as source from ent-search,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -539,7 +539,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         // GitHub requires an intermediate configuration step, where we collect the repos to index.
         if (hasConfigureStep && !values.oauthConfigCompleted) {
           actions.setPreContentSourceId(preContentSourceId);
-          navigateToUrl(`${ADD_GITHUB_PATH}/configure${search}`);
+          navigateToUrl(getSourcesPath(`${ADD_GITHUB_PATH}/configure${search}`, isOrganization));
         } else {
           setAddedSource(serviceName, indexPermissions, serviceType);
           navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
@@ -28,7 +28,8 @@ describe('SourceAdded', () => {
   });
 
   it('renders', () => {
-    const search = '?name=foo&serviceType=custom&indexPermissions=false';
+    const search =
+      '?code=1234&state=%7B%22action%22%3A%22create%22%2C%22context%22%3A%22account%22%2C%22service_type%22%3A%22github%22%2C%22csrf_token%22%3A%22TOKEN123%3D%3D%22%2C%22index_permissions%22%3Afalse%7D';
     (useLocation as jest.Mock).mockImplementationOnce(() => ({ search }));
     const wrapper = shallow(<SourceAdded />);
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -15,8 +15,9 @@ import { EuiPage, EuiPageBody } from '@elastic/eui';
 
 import { KibanaLogic } from '../../../../shared/kibana';
 import { Loading } from '../../../../shared/loading';
+import { parseQueryParams } from '../../../../shared/query_params';
 
-import { AddSourceLogic } from './add_source/add_source_logic';
+import { AddSourceLogic, OauthParams } from './add_source/add_source_logic';
 
 /**
  * This component merely triggers catchs the redirect from the oauth application and initializes the saving
@@ -25,14 +26,17 @@ import { AddSourceLogic } from './add_source/add_source_logic';
  */
 export const SourceAdded: React.FC = () => {
   const { search } = useLocation() as Location;
+  const params = (parseQueryParams(search) as unknown) as OauthParams;
+  const state = JSON.parse(params.state);
+  const isOrganization = state.context !== 'account';
   const { setChromeIsVisible } = useValues(KibanaLogic);
   const { saveSourceParams } = useActions(AddSourceLogic);
 
   // We don't want the personal dashboard to flash the Kibana chrome, so we hide it.
-  setChromeIsVisible(false);
+  setChromeIsVisible(isOrganization);
 
   useEffect(() => {
-    saveSourceParams(search);
+    saveSourceParams(search, params, isOrganization);
   }, []);
 
   return (

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -135,7 +135,7 @@ export function registerAccountCreateSourceRoute({
           login: schema.maybe(schema.string()),
           password: schema.maybe(schema.string()),
           organizations: schema.maybe(schema.arrayOf(schema.string())),
-          indexPermissions: schema.boolean(),
+          indexPermissions: schema.maybe(schema.boolean()),
         }),
       },
     },


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1882

## Summary

This PR addresses an edge case bug that occurs in the connection of Github sources. There were 3 issues that were fixed in this PR.

1. We could not actually connect Github because the route had a required param that was not present. This had already been [fixed](https://github.com/elastic/kibana/pull/84164/commits/30d8b1dfa861fc5c6ce027b7831362e023767bee#diff-07f094b2a4719e8511f003d8e278a77cd6b808d11b14d1c528705f9b259c328fR373) for the organization source, but because the personal dashboard came later, it was not done at the same time and was missed. (https://github.com/elastic/kibana/commit/27778fb624c5c9f6861911429d5380e05f21fb7d)
2. Connecting a private Github source redirected to the org repo selector page. This was, again, an oversight that came as a result of converting the org dashboard months before the private dashboard and not testing Github thoroughly in the personal dashboard migration (this was my bad). (https://github.com/elastic/kibana/commit/0ad332f58694be8f6cb0d724bcbdf49f67c537b5)
3. Chrome was hidden on the org Github repo selector page. The issue here is a bit complicated but will explain it again. The personal dashboard requires that we hide the chrome. This is typically done by [checking the URL](https://github.com/elastic/kibana/blob/master/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx#L64-L69) to see if it is a personal dashboard route. However, we use the same route for ALL content sources and pass the context in a `state` param from the Rails server. Because the Kibana chrome fires before the `useEffect` call is made, there was a flash of Kibana chrome that was initially fixed by just hiding the chrome altogether and letting the app show the chrome where needed. Unfortunately, Github requires an extra redirect and that was throwing everything off. The solution was to move the logic of parsing the state from the query params to the template and hiding the chrome only where `account` was set in the state. (https://github.com/elastic/kibana/commit/805711d9200265e4e5465f7baf7973bdc2bb6043)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
