### PR TITLE
[Security Solution][CTI] Enrichment Details Final Copy/UI 

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/enrichment_icon.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/enrichment_icon.tsx
@@ -24,7 +24,7 @@ export const getTooltipContent = (type: string | undefined) =>
 export const EnrichmentIcon: React.FC<{ type: string | undefined }> = ({ type }) => {
   return (
     <EuiToolTip title={getTooltipTitle(type)} content={getTooltipContent(type)}>
-      <EuiIcon type="logoSecurity" size="s" />
+      <EuiIcon type="iInCircle" size="m" />
     </EuiToolTip>
   );
 };

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/no_enrichments_panel.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/no_enrichments_panel.tsx
@@ -41,7 +41,7 @@ export const NoEnrichmentsPanel: React.FC<{
   const threatIntelDocsUrl = `${
     useKibana().services.docLinks.links.filebeat.base
   }/filebeat-module-threatintel.html`;
-  const noIndicatorEnrichmentsDescription = (
+  const noIntelligenceCTA = (
     <>
       {i18n.IF_CTI_NOT_ENABLED}
       <EuiLink href={threatIntelDocsUrl} target="_blank">
@@ -55,10 +55,9 @@ export const NoEnrichmentsPanel: React.FC<{
       <NoEnrichmentsPanelView
         title={<h2>{i18n.NO_ENRICHMENTS_FOUND_TITLE}</h2>}
         description={
-          <>
-            <p>{noIndicatorEnrichmentsDescription}</p>
-            <p>{i18n.NO_INVESTIGATION_ENRICHMENTS_DESCRIPTION}</p>
-          </>
+          <p>
+            {i18n.NO_ENRICHMENTS_FOUND_DESCRIPTION} {noIntelligenceCTA}
+          </p>
         }
       />
     );
@@ -68,7 +67,11 @@ export const NoEnrichmentsPanel: React.FC<{
         <EuiHorizontalRule margin="s" />
         <NoEnrichmentsPanelView
           title={<h2>{i18n.NO_INDICATOR_ENRICHMENTS_TITLE}</h2>}
-          description={noIndicatorEnrichmentsDescription}
+          description={
+            <p>
+              {i18n.NO_INDICATOR_ENRICHMENTS_DESCRIPTION} {noIntelligenceCTA}
+            </p>
+          }
         />
       </>
     );
@@ -78,7 +81,11 @@ export const NoEnrichmentsPanel: React.FC<{
         <EuiHorizontalRule margin="s" />
         <NoEnrichmentsPanelView
           title={<h2>{i18n.NO_INVESTIGATION_ENRICHMENTS_TITLE}</h2>}
-          description={i18n.NO_INVESTIGATION_ENRICHMENTS_DESCRIPTION}
+          description={
+            <p>
+              {i18n.NO_INVESTIGATION_ENRICHMENTS_DESCRIPTION} {noIntelligenceCTA}
+            </p>
+          }
         />
       </>
     );

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_details_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_details_view.tsx
@@ -48,10 +48,10 @@ const ThreatDetailsHeader: React.FC<{
 }> = ({ field, value, provider, type }) => (
   <>
     <EuiTextColor color="subdued">
-      <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="xs">
+      <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="xs" wrap>
         <EuiFlexItem grow={false}>
           <EuiText size="s">
-            {field} {value}
+            <span>{field}</span> <span>{value}</span>
           </EuiText>
         </EuiFlexItem>
         {provider && (

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_details_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_details_view.tsx
@@ -48,10 +48,7 @@ const ThreatDetailsHeader: React.FC<{
 }> = ({ field, value, provider, type }) => (
   <>
     <EuiTextColor color="subdued">
-      <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="s">
-        <EuiFlexItem grow={false}>
-          <EnrichmentIcon type={type} />
-        </EuiFlexItem>
+      <EuiFlexGroup justifyContent="flexStart" alignItems="center" gutterSize="xs">
         <EuiFlexItem grow={false}>
           <EuiText size="s">
             {field} {value}
@@ -66,6 +63,9 @@ const ThreatDetailsHeader: React.FC<{
             </EuiFlexItem>
           </>
         )}
+        <EuiFlexItem grow={false}>
+          <EnrichmentIcon type={type} />
+        </EuiFlexItem>
         <EuiFlexItem>
           <EuiHorizontalRule margin="none" />
         </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -32,17 +32,17 @@ export interface ThreatSummaryItem {
 }
 
 const RightMargin = styled.span`
-  margin-right: ${({ theme }) => theme.eui.paddingSizes.s};
+  margin-right: ${({ theme }) => theme.eui.paddingSizes.xs};
 `;
 
 const EnrichmentTitle: React.FC<ThreatSummaryItem['title']> = ({ title, type }) => (
   <>
     <RightMargin>
-      <EnrichmentIcon type={type} />
+      <EuiTitle size="xxs">
+        <h5>{title}</h5>
+      </EuiTitle>
     </RightMargin>
-    <EuiTitle size="xxs">
-      <h5>{title}</h5>
-    </EuiTitle>
+    <EnrichmentIcon type={type} />
   </>
 );
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/translations.ts
@@ -47,28 +47,44 @@ export const INVESTIGATION_TOOLTIP_CONTENT = i18n.translate(
 export const NO_INDICATOR_ENRICHMENTS_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.noIndicatorEnrichmentsTitle',
   {
-    defaultMessage: 'No Threat Matches Detected',
+    defaultMessage: 'No Indicator Matches Found',
+  }
+);
+
+export const NO_INDICATOR_ENRICHMENTS_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.alertDetails.noIndicatorEnrichmentsDescription',
+  {
+    defaultMessage:
+      'We did not find any threat intelligence indicators with any of the indicator match rules.',
   }
 );
 
 export const NO_INVESTIGATION_ENRICHMENTS_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.noInvestigationEnrichmentsTitle',
   {
-    defaultMessage: 'No Enrichment with Threat Intelligence Found',
+    defaultMessage: 'No Threat Intelligence Enrichment Found',
   }
 );
 
 export const NO_INVESTIGATION_ENRICHMENTS_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.alertDetails.noInvestigationEnrichmentsDescription',
   {
-    defaultMessage: "We haven't found any threat intelligence from the last 30 days.",
+    defaultMessage: 'We did not find any threat intelligence in last 30 days to enrich this alert.',
   }
 );
 
 export const NO_ENRICHMENTS_FOUND_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.noEnrichmentsFoundTitle',
   {
-    defaultMessage: 'No Threat Intelligence Found',
+    defaultMessage: 'No Indicator Match or Threat Intel Enrichment Found',
+  }
+);
+
+export const NO_ENRICHMENTS_FOUND_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.alertDetails.noEnrichmentsFoundDescription',
+  {
+    defaultMessage:
+      'We did not find threat intelligence that matches any of the indicator match rules, or any enrichment for this alert.',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/translations.ts
@@ -17,14 +17,14 @@ export const PROVIDER_PREPOSITION = i18n.translate(
 export const INDICATOR_TOOLTIP_TITLE = i18n.translate(
   'xpack.securitySolution.eventDetails.ctiSummary.indicatorEnrichmentTooltipTitle',
   {
-    defaultMessage: 'Indicator rule enrichment',
+    defaultMessage: 'Threat Match Detected',
   }
 );
 
 export const INVESTIGATION_TOOLTIP_TITLE = i18n.translate(
   'xpack.securitySolution.eventDetails.ctiSummary.investigationEnrichmentTooltipTitle',
   {
-    defaultMessage: 'Investigation time enrichment',
+    defaultMessage: 'Enriched with Threat Intelligence',
   }
 );
 
@@ -32,7 +32,7 @@ export const INDICATOR_TOOLTIP_CONTENT = i18n.translate(
   'xpack.securitySolution.eventDetails.ctiSummary.indicatorEnrichmentTooltipContent',
   {
     defaultMessage:
-      'This field matched a known indicator, and was enriched by an indicator match rule. See more details on the Threat Intel tab.',
+      'This field value matched a threat intelligence indicator with a rule you created.',
   }
 );
 
@@ -40,42 +40,35 @@ export const INVESTIGATION_TOOLTIP_CONTENT = i18n.translate(
   'xpack.securitySolution.eventDetails.ctiSummary.investigationEnrichmentTooltipContent',
   {
     defaultMessage:
-      'This field matched a known indicator; see more details on the Threat Intel tab.',
+      'This field value has additional information available from threat intelligence sources.',
   }
 );
 
 export const NO_INDICATOR_ENRICHMENTS_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.noIndicatorEnrichmentsTitle',
   {
-    defaultMessage: 'No indicator match rule enrichments found',
+    defaultMessage: 'No Threat Matches Detected',
   }
 );
 
 export const NO_INVESTIGATION_ENRICHMENTS_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.noInvestigationEnrichmentsTitle',
   {
-    defaultMessage: 'No investigation time enrichments found',
+    defaultMessage: 'No Enrichment with Threat Intelligence Found',
   }
 );
 
 export const NO_INVESTIGATION_ENRICHMENTS_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.alertDetails.noInvestigationEnrichmentsDescription',
   {
-    defaultMessage: "We haven't found any indicator matches from the last 30 days.",
+    defaultMessage: "We haven't found any threat intelligence from the last 30 days.",
   }
 );
 
 export const NO_ENRICHMENTS_FOUND_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.noEnrichmentsFoundTitle',
   {
-    defaultMessage: 'No indicator match rule or investigation time enrichments found',
-  }
-);
-
-export const NO_ENRICHMENTS_FOUND_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.alertDetails.noEnrichmentFoundDescription',
-  {
-    defaultMessage: 'No indicator match rule or investigation time enrichments found',
+    defaultMessage: 'No Threat Intelligence Found',
   }
 );
 
@@ -94,6 +87,6 @@ export const CHECK_DOCS = i18n.translate('xpack.securitySolution.alertDetails.ch
 export const INVESTIGATION_QUERY_TITLE = i18n.translate(
   'xpack.securitySolution.alertDetails.investigationTimeQueryTitle',
   {
-    defaultMessage: 'Investigation time enrichment',
+    defaultMessage: 'Enrichment with Threat Intelligence',
   }
 );


### PR DESCRIPTION
## Summary

Some final copy changes and minor UI updates to reflect feedback from build candidates. 

### Summary of changes

* Icon tooltip converted from security shield to an `( i )`, and moved to the right
    <kbd><img width="499" alt="Alerts_-_Kibana" src="https://user-images.githubusercontent.com/657252/125710318-ec02eed1-51de-4d09-8bdc-8a4e06147d95.png"></kbd>
    <kbd><img width="530" alt="Alerts_-_Kibana" src="https://user-images.githubusercontent.com/657252/125710353-fea519fd-7600-4991-acc0-3e9205835c58.png"></kbd>
* Allows header to wrap to multiple lines on long content
    <kbd><img width="539" alt="Alerts_-_Kibana" src="https://user-images.githubusercontent.com/657252/125710447-73514cf5-3193-4bb5-b3d8-48df82353198.png"></kbd>
* Copy updates (_note_: I've updated these with the latest from the below comment from @shimonmodi; these screenshots are slightly out of date)
  * No CTI (at all)
      <kbd><img width="526" alt="Alerts_-_Kibana" src="https://user-images.githubusercontent.com/657252/125710564-611f1c97-20e5-4e22-9ddf-73f70cf7abc4.png"></kbd> 
  * No Threat Match enrichments
      <kbd><img width="534" alt="Alerts_-_Kibana" src="https://user-images.githubusercontent.com/657252/125710488-7ed419f0-f56e-4942-94a2-94ae859a9c3f.png"></kbd> 
  * No Threat Intelligence enrichments
      <kbd><img width="517" alt="Alerts_-_Kibana" src="https://user-images.githubusercontent.com/657252/125710731-0e8d8f0d-6f66-4bbf-bc3d-5e022d58ee3a.png"></kbd> 

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
