### PR TITLE
[7.14] [ML] Functional tests - re-activate a11y tests (#105198)

### DIFF
--- a/x-pack/test/accessibility/apps/ml.ts
+++ b/x-pack/test/accessibility/apps/ml.ts
@@ -59,8 +59,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/103538
-      describe.skip('with data loaded', function () {
+      describe('with data loaded', function () {
         const adJobId = 'fq_single_a11y';
         const dfaOutlierJobId = 'iph_outlier_a11y';
         const calendarId = 'calendar_a11y';


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [ML] Functional tests - re-activate a11y tests (#105198)