### PR TITLE
[Security Solution] [RAC] Add alerts count table to Security Solutions alerts page

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/schemas/request/query_signals_index_schema.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/schemas/request/query_signals_index_schema.ts
@@ -6,13 +6,13 @@
  */
 
 import * as t from 'io-ts';
-import { PositiveIntegerGreaterThanZero } from '@kbn/securitysolution-io-ts-types';
+import { PositiveInteger } from '@kbn/securitysolution-io-ts-types';
 
 export const querySignalsSchema = t.exact(
   t.partial({
     query: t.object,
     aggs: t.object,
-    size: PositiveIntegerGreaterThanZero,
+    size: PositiveInteger,
     track_total_hits: t.boolean,
     _source: t.array(t.string),
   })

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/alerts_count.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/alerts_count.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import '../../../common/mock/match_media';
+import { AlertsCount } from './alerts_count';
+import { alertsMock } from '../../containers/detection_engine/alerts/mock';
+import { AlertSearchResponse } from '../../containers/detection_engine/alerts/types';
+import { AlertsAggregation } from './types';
+import { TestProviders } from '../../../common/mock';
+import { DragDropContextWrapper } from '../../../common/components/drag_and_drop/drag_drop_context_wrapper';
+import { mockBrowserFields } from '../../../common/containers/source/mock';
+
+jest.mock('../../../common/lib/kibana');
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+  return {
+    ...original,
+    useDispatch: () => mockDispatch,
+  };
+});
+
+describe('AlertsCount', () => {
+  it('renders correctly', () => {
+    const wrapper = shallow(
+      <AlertsCount
+        data={alertsMock as AlertSearchResponse<unknown, AlertsAggregation>}
+        loading={false}
+        selectedStackByOption={'test_selected_field'}
+      />
+    );
+
+    expect(wrapper.find('[data-test-subj="alertsCountTable"]').exists()).toBeTruthy();
+  });
+
+  it('renders the given alert item', () => {
+    const alertFiedlKey = 'test_stack_by_test_key';
+    const alertFiedlCount = 999;
+    const alertData = {
+      ...alertsMock,
+      aggregations: {
+        alertsByGroupingCount: {
+          buckets: [
+            {
+              key: alertFiedlKey,
+              doc_count: alertFiedlCount,
+            },
+          ],
+        },
+        alertsByGrouping: { buckets: [] },
+      },
+    } as AlertSearchResponse<unknown, AlertsAggregation>;
+
+    const wrapper = mount(
+      <TestProviders>
+        <DragDropContextWrapper browserFields={mockBrowserFields}>
+          <AlertsCount
+            data={alertData}
+            loading={false}
+            selectedStackByOption={'test_selected_field'}
+          />
+        </DragDropContextWrapper>
+      </TestProviders>
+    );
+
+    expect(wrapper.text()).toContain(alertFiedlKey);
+    expect(wrapper.text()).toContain(alertFiedlCount);
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/alerts_count.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/alerts_count.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiBasicTableColumn, EuiInMemoryTable } from '@elastic/eui';
+import React, { memo, useMemo } from 'react';
+import styled from 'styled-components';
+import numeral from '@elastic/numeral';
+import { useUiSetting$ } from '../../../common/lib/kibana';
+import { DEFAULT_NUMBER_FORMAT } from '../../../../common/constants';
+import { AlertSearchResponse } from '../../containers/detection_engine/alerts/types';
+import { AlertsAggregation } from './types';
+import * as i18n from './translations';
+import { DefaultDraggable } from '../../../common/components/draggables';
+import { GenericBuckets } from '../../../../common';
+
+interface AlertsCountProps {
+  loading: boolean;
+  data: AlertSearchResponse<unknown, AlertsAggregation> | null;
+  selectedStackByOption: string;
+}
+
+const Wrapper = styled.div`
+  overflow: scroll;
+  margin-top: ${({ theme }) => theme.eui.euiSizeXS};
+`;
+
+const getAlertsCountTableColumns = (
+  selectedStackByOption: string,
+  defaultNumberFormat: string
+): Array<EuiBasicTableColumn<GenericBuckets>> => {
+  return [
+    {
+      field: 'key',
+      name: selectedStackByOption,
+      truncateText: true,
+      render: function DraggableStackOptionField(item: string) {
+        return (
+          <DefaultDraggable
+            field={selectedStackByOption}
+            id={`alert-count-draggable-${selectedStackByOption}-${item}`}
+            value={item}
+          >
+            {item}
+          </DefaultDraggable>
+        );
+      },
+    },
+    {
+      field: 'doc_count',
+      name: i18n.COUNT_TABLE_COLUMN_TITLE,
+      sortable: true,
+      textOnly: true,
+      render: (item: string) => numeral(item).format(defaultNumberFormat),
+    },
+  ];
+};
+
+export const AlertsCount = memo<AlertsCountProps>(({ data, loading, selectedStackByOption }) => {
+  const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
+  const listItems = data?.aggregations?.alertsByGroupingCount?.buckets ?? [];
+  const tableColumns = useMemo(
+    () => getAlertsCountTableColumns(selectedStackByOption, defaultNumberFormat),
+    [selectedStackByOption, defaultNumberFormat]
+  );
+
+  return (
+    <Wrapper data-test-subj="alertsCountTable">
+      <EuiInMemoryTable
+        isSelectable={false}
+        columns={tableColumns}
+        items={listItems}
+        loading={loading}
+        sorting={true}
+      />
+    </Wrapper>
+  );
+});
+
+AlertsCount.displayName = 'AlertsCount';

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/alerts_histogram.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/alerts_histogram.test.tsx
@@ -26,6 +26,6 @@ describe('AlertsHistogram', () => {
       />
     );
 
-    expect(wrapper.find('Chart')).toBeTruthy();
+    expect(wrapper.find('Chart').exists()).toBeTruthy();
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { shallow, mount } from 'enzyme';
 
 import '../../../common/mock/match_media';
@@ -69,7 +69,7 @@ describe('AlertsHistogramPanel', () => {
   it('renders correctly', () => {
     const wrapper = shallow(<AlertsHistogramPanel {...defaultProps} />);
 
-    expect(wrapper.find('[id="detections-histogram"]')).toBeTruthy();
+    expect(wrapper.find('[data-test-subj="alerts-histogram-panel"]').exists()).toBeTruthy();
   });
 
   describe('Button view alerts', () => {
@@ -78,7 +78,7 @@ describe('AlertsHistogramPanel', () => {
       const wrapper = shallow(<AlertsHistogramPanel {...props} />);
 
       expect(
-        wrapper.find('[data-test-subj="alerts-histogram-panel-go-to-alerts-page"]')
+        wrapper.find('[data-test-subj="alerts-histogram-panel-go-to-alerts-page"]').exists()
       ).toBeTruthy();
     });
 
@@ -99,6 +99,45 @@ describe('AlertsHistogramPanel', () => {
     });
   });
 
+  describe('Count table', () => {
+    it('renders Graph and Count tabs', async () => {
+      const props = { ...defaultProps, showLinkToAlerts: true };
+      const wrapper = mount(
+        <TestProviders>
+          <AlertsHistogramPanel {...props} showCountTable />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        expect(wrapper.find('TabTitle').exists()).toBeTruthy();
+        expect(
+          wrapper.find('[data-test-subj="stepAboutDetailsToggleGraph"]').exists()
+        ).toBeTruthy();
+        expect(
+          wrapper.find('[data-test-subj="stepAboutDetailsToggleCount"]').exists()
+        ).toBeTruthy();
+      });
+    });
+
+    it('renders alert count table when count tab is clicked', async () => {
+      const props = { ...defaultProps, showLinkToAlerts: true };
+
+      await act(async () => {
+        const wrapper = mount(
+          <TestProviders>
+            <AlertsHistogramPanel {...props} showCountTable />
+          </TestProviders>
+        );
+        wrapper.find('button[data-test-subj="stepAboutDetailsToggleCount"]').simulate('click');
+
+        await waitFor(() => {
+          wrapper.update();
+          expect(wrapper.find('AlertsCount').exists()).toBeTruthy();
+        });
+      });
+    });
+  });
+
   describe('Query', () => {
     it('it render with a illegal KQL', async () => {
       const spyOnBuildEsQuery = jest.spyOn(esQuery, 'buildEsQuery');
@@ -113,7 +152,7 @@ describe('AlertsHistogramPanel', () => {
       );
 
       await waitFor(() => {
-        expect(wrapper.find('[id="detections-histogram"]')).toBeTruthy();
+        expect(wrapper.find('[data-test-subj="alerts-histogram-panel"]').exists()).toBeTruthy();
       });
     });
   });
@@ -140,6 +179,7 @@ describe('AlertsHistogramPanel', () => {
       await waitFor(() => {
         expect(mockGetAlertsHistogramQuery.mock.calls[0]).toEqual([
           'signal.rule.name',
+          false,
           '2020-07-07T08:20:18.966Z',
           '2020-07-08T08:20:18.966Z',
           [

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/translations.ts
@@ -111,6 +111,13 @@ export const VIEW_ALERTS = i18n.translate(
   }
 );
 
+export const COUNT_TAB = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.histogram.countTabTitle',
+  {
+    defaultMessage: 'Count',
+  }
+);
+
 export const SHOWING_ALERTS = (
   totalAlertsFormatted: string,
   totalAlerts: number,
@@ -121,3 +128,10 @@ export const SHOWING_ALERTS = (
     defaultMessage:
       'Showing: {modifier}{totalAlertsFormatted} {totalAlerts, plural, =1 {alert} other {alerts}}',
   });
+
+export const COUNT_TABLE_COLUMN_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.histogram.countTableColumnTitle',
+  {
+    defaultMessage: 'Count',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { GenericBuckets } from '../../../../common';
 import { inputsModel } from '../../../common/store';
 
 export interface AlertsHistogramOption {
@@ -22,8 +23,10 @@ export interface AlertsAggregation {
   alertsByGrouping: {
     buckets: AlertsGroupBucket[];
   };
+  alertsByGroupingCount: {
+    buckets: GenericBuckets[];
+  };
 }
-
 export interface AlertsBucket {
   key_as_string: string;
   key: number;
@@ -32,6 +35,7 @@ export interface AlertsBucket {
 
 export interface AlertsGroupBucket {
   key: string;
+  doc_count: number;
   alerts: {
     buckets: AlertsBucket[];
   };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -261,6 +261,7 @@ const DetectionEnginePageComponent = () => {
                 stackByOptions={alertsHistogramOptions}
                 to={to}
                 updateDateRange={updateDateRangeCallback}
+                showCountTable
               />
               <EuiSpacer size="l" />
             </Display>


### PR DESCRIPTION
## Summary
issue: https://github.com/elastic/security-team/issues/1273

Add a table that shows the count of alerts for each stacked by field. The table is hidden under the "Count" Tab.

Changes:
* Add tabs to the panel
* Add a new term aggregation to alerts query that fetches 10.000 items
* Create `AlertsCount` component

<img width="500" alt="Screenshot 2021-07-16 at 16 20 36" src="https://user-images.githubusercontent.com/1490444/125962627-d1d64dcb-473b-43cd-b0ce-3970d6d84120.png">

<img width="500" alt="Screenshot 2021-07-16 at 16 20 49" src="https://user-images.githubusercontent.com/1490444/125962623-99812bb4-a0c7-4e41-81e8-de0a4c08707d.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

