### PR TITLE
[7.x] check metric function as well as label to determine geo (#105671)

### DIFF
--- a/x-pack/plugins/ml/public/application/services/anomaly_explorer_charts_service.ts
+++ b/x-pack/plugins/ml/public/application/services/anomaly_explorer_charts_service.ts
@@ -504,8 +504,9 @@ export class AnomalyExplorerChartsService {
         const config = seriesConfigs[i];
         let records;
         if (
-          config.detectorLabel !== undefined &&
-          config.detectorLabel.includes(ML_JOB_AGGREGATION.LAT_LONG)
+          (config.detectorLabel !== undefined &&
+            config.detectorLabel.includes(ML_JOB_AGGREGATION.LAT_LONG)) ||
+          config?.metricFunction === ML_JOB_AGGREGATION.LAT_LONG
         ) {
           if (config.entityFields.length) {
             records = [


### PR DESCRIPTION
Backports the following commits to 7.x:
 - check metric function as well as label to determine geo (#105671)