### PR TITLE
[UX] make route match optional in EnvironmentFilter

### DIFF
--- a/packages/kbn-typed-react-router-config/src/create_router.test.tsx
+++ b/packages/kbn-typed-react-router-config/src/create_router.test.tsx
@@ -158,6 +158,12 @@ describe('createRouter', () => {
         router.getParams('/service-map', history.location);
       }).toThrowError('No matching route found for /service-map');
     });
+
+    it('does not throw an error if the given path does not match any routes but is marked as optional', () => {
+      expect(() => {
+        router.getParams('/service-map', history.location, true);
+      }).not.toThrowError();
+    });
   });
 
   describe('matchRoutes', () => {

--- a/packages/kbn-typed-react-router-config/src/types/index.ts
+++ b/packages/kbn-typed-react-router-config/src/types/index.ts
@@ -125,6 +125,11 @@ export interface Router<TRoutes extends Route[]> {
     path: TPath,
     location: Location
   ): OutputOf<TRoutes, TPath>;
+  getParams<TPath extends PathsOf<TRoutes>, TOptional extends boolean>(
+    path: TPath,
+    location: Location,
+    optional: TOptional
+  ): TOptional extends true ? OutputOf<TRoutes, TPath> | undefined : OutputOf<TRoutes, TPath>;
   link<TPath extends PathsOf<TRoutes>>(
     path: TPath,
     ...args: TypeAsArgs<TypeOf<TRoutes, TPath>>

--- a/packages/kbn-typed-react-router-config/src/use_params.ts
+++ b/packages/kbn-typed-react-router-config/src/use_params.ts
@@ -9,9 +9,9 @@
 import { useLocation } from 'react-router-dom';
 import { useRouter } from './use_router';
 
-export function useParams(path: string) {
+export function useParams(path: string, optional: boolean = false) {
   const router = useRouter();
   const location = useLocation();
 
-  return router.getParams(path as never, location);
+  return router.getParams(path as never, location, optional);
 }

--- a/x-pack/plugins/apm/public/application/uxApp.tsx
+++ b/x-pack/plugins/apm/public/application/uxApp.tsx
@@ -10,7 +10,8 @@ import euiLightVars from '@elastic/eui/dist/eui_theme_light.json';
 import { AppMountParameters, CoreStart } from 'kibana/public';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Route, Router } from 'react-router-dom';
+import { Route as ReactRouterRoute } from 'react-router-dom';
+import { RouterProvider, createRouter } from '@kbn/typed-react-router-config';
 import { DefaultTheme, ThemeProvider } from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import type { ObservabilityRuleTypeRegistry } from '../../../observability/public';
@@ -66,12 +67,14 @@ function UxApp() {
       })}
     >
       <div data-test-subj="csmMainContainer" role="main">
-        <Route component={ScrollToTopOnPathChange} />
+        <ReactRouterRoute component={ScrollToTopOnPathChange} />
         <RumHome />
       </div>
     </ThemeProvider>
   );
 }
+
+const uxRouter = createRouter([]);
 
 export function UXAppRoot({
   appMountParameters,
@@ -107,12 +110,12 @@ export function UXAppRoot({
           services={{ ...core, ...plugins, embeddable, data }}
         >
           <i18nCore.Context>
-            <Router history={history}>
+            <RouterProvider history={history} router={uxRouter}>
               <UrlParamsProvider>
                 <UxApp />
                 <UXActionMenu appMountParameters={appMountParameters} />
               </UrlParamsProvider>
-            </Router>
+            </RouterProvider>
           </i18nCore.Context>
         </KibanaContextProvider>
       </ApmPluginContext.Provider>

--- a/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -64,12 +64,15 @@ function getOptions(environments: string[]) {
 export function EnvironmentFilter() {
   const history = useHistory();
   const location = useLocation();
-  const { path } = useApmParams('/*');
+  const apmParams = useApmParams('/*', true);
   const { urlParams } = useUrlParams();
 
   const { environment, start, end } = urlParams;
   const { environments, status = 'loading' } = useEnvironmentsFetcher({
-    serviceName: 'serviceName' in path ? path.serviceName : undefined,
+    serviceName:
+      apmParams && 'serviceName' in apmParams.path
+        ? apmParams.path.serviceName
+        : undefined,
     start,
     end,
   });

--- a/x-pack/plugins/apm/public/hooks/use_apm_params.ts
+++ b/x-pack/plugins/apm/public/hooks/use_apm_params.ts
@@ -9,7 +9,17 @@ import { OutputOf, PathsOf, useParams } from '@kbn/typed-react-router-config';
 import { ApmRoutes } from '../components/routing/apm_route_config';
 
 export function useApmParams<TPath extends PathsOf<ApmRoutes>>(
+  path: TPath,
+  optional: true
+): OutputOf<ApmRoutes, TPath> | undefined;
+
+export function useApmParams<TPath extends PathsOf<ApmRoutes>>(
   path: TPath
-): OutputOf<ApmRoutes, TPath> {
-  return useParams(path as never);
+): OutputOf<ApmRoutes, TPath>;
+
+export function useApmParams(
+  path: string,
+  optional?: true
+): OutputOf<ApmRoutes, PathsOf<ApmRoutes>> | undefined {
+  return useParams(path, optional);
 }


### PR DESCRIPTION
Closes #105757.

The UX app uses the EnvironmentFilter component to display an environment selector. The EnvironmentFilter component uses `useApmParams` which was introduced in https://github.com/elastic/kibana/pull/104274. However, APM routes are not used for the UX app, so useApmParams() cannot match any routes and return route parameters. 

This change makes a route match for useApmParams optional.