### PR TITLE
[Fleet] Move namespace description text to namespace input

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_define_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_define_package_policy.tsx
@@ -163,22 +163,6 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                   defaultMessage="Description"
                 />
               }
-              helpText={
-                <FormattedMessage
-                  id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceHelpLabel"
-                  defaultMessage="Change the default namespace inherited from the selected Agent policy. This setting changes the name of the integration's data stream. {learnMore}."
-                  values={{
-                    learnMore: (
-                      <EuiLink href={docLinks.links.fleet.datastreamsNamingScheme} target="_blank">
-                        {i18n.translate(
-                          'xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceHelpLearnMoreLabel',
-                          { defaultMessage: 'Learn more' }
-                        )}
-                      </EuiLink>
-                    ),
-                  }}
-                />
-              }
               labelAppend={
                 <EuiText size="xs" color="subdued">
                   <FormattedMessage
@@ -273,6 +257,25 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                       <FormattedMessage
                         id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceInputLabel"
                         defaultMessage="Namespace"
+                      />
+                    }
+                    helpText={
+                      <FormattedMessage
+                        id="xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceHelpLabel"
+                        defaultMessage="Change the default namespace inherited from the selected Agent policy. This setting changes the name of the integration's data stream. {learnMore}."
+                        values={{
+                          learnMore: (
+                            <EuiLink
+                              href={docLinks.links.fleet.datastreamsNamingScheme}
+                              target="_blank"
+                            >
+                              {i18n.translate(
+                                'xpack.fleet.createPackagePolicy.stepConfigure.packagePolicyNamespaceHelpLearnMoreLabel',
+                                { defaultMessage: 'Learn more' }
+                              )}
+                            </EuiLink>
+                          ),
+                        }}
                       />
                     }
                   >


### PR DESCRIPTION
## Summary

Issue #105648 

Move the namespace description text to be below the name input.


Before:
<img width="913" alt="Screenshot 2021-07-16 at 11 15 47" src="https://user-images.githubusercontent.com/3315046/125933796-fce4dcfc-e54f-4851-8a1c-69886adb4266.png">
After:
<img width="913" alt="Screenshot 2021-07-16 at 11 13 56" src="https://user-images.githubusercontent.com/3315046/125933781-c59cbc84-20dc-4b19-8224-14c186436df4.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

N/A


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
