### PR TITLE
[Security Solution] Skips flakey test from Cypress

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/prebuilt_rules.spec.ts
@@ -39,7 +39,8 @@ import { ALERTS_URL } from '../../urls/navigation';
 import { totalNumberOfPrebuiltRules } from '../../objects/rule';
 import { cleanKibana } from '../../tasks/common';
 
-describe('Alerts rules, prebuilt rules', () => {
+// FLAKY: https://github.com/elastic/kibana/issues/105791
+describe.skip('Alerts rules, prebuilt rules', () => {
   beforeEach(() => {
     cleanKibana();
   });


### PR DESCRIPTION
## Summary

This syncs up with the test we skipped on a backport to 7.x where we couldn't get 7.x builds to pass. This should go to (master) and (7.14) to avoid us having issues with builds from CI showing up there and keeping things consistent. 

See this blocker created:
https://github.com/elastic/kibana/issues/105791

See this backport we did the skip on:
https://github.com/elastic/kibana/pull/105700

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
