### PR TITLE
Improve painless validation handling in monaco

### DIFF
--- a/packages/kbn-monaco/src/painless/diagnostics_adapter.ts
+++ b/packages/kbn-monaco/src/painless/diagnostics_adapter.ts
@@ -35,6 +35,11 @@ export class DiagnosticsAdapter {
             return;
           }
 
+          // Reset the model markers if an empty string is provided on change
+          if (model.getValue().trim() === '') {
+            return monaco.editor.setModelMarkers(model, ID, []);
+          }
+
           // Every time a new change is made, wait 500ms before validating
           clearTimeout(handle);
           handle = setTimeout(() => this.validate(model.uri), 500);
@@ -42,8 +47,11 @@ export class DiagnosticsAdapter {
 
         model.onDidChangeLanguage(({ newLanguage }) => {
           // Reset the model markers if the language ID has changed and is no longer "painless"
+          // Otherwise, re-validate
           if (newLanguage !== ID) {
             return monaco.editor.setModelMarkers(model, ID, []);
+          } else {
+            this.validate(model.uri);
           }
         });
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/105759, specifically, points 2 and 3 in https://github.com/elastic/kibana/issues/105759#issuecomment-880787935.

Note: The testing of monaco is currently manual, so no tests were added as part of this PR.

### How to test:
The editor changes can be tested by creating a `script` processor via the Ingest Node Pipelines UI.

**Test scenario: Error markers removed when script is cleared**
1. Add an invalid script, for example:

```
// missing closing ;
boolean myBoolean = true
return myBoolean;
```
2. Verify error marker displays
3. Delete entire script (clear editor)
4. Verify no error marker displays

**Test scenario: Error markers appear on language change**
1. Add an invalid script, for example:

```
// missing closing ;
boolean myBoolean = true
return myBoolean;
```
2. Verify error marker displays
3. Change the "Language" field to something other than Painless, e.g., "java"
4. Verify no error marker displays and text highlighting is removed
5. Change the "Language" field back to Painless (either clear the field or type "painless")
6. Verify error markers display again as well as text highlighting