### PR TITLE
[Synthetics] Define color for XHR timings in waterfall chart

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor/synthetics/step_detail/waterfall/data_formatting.test.ts
+++ b/x-pack/plugins/uptime/public/components/monitor/synthetics/step_detail/waterfall/data_formatting.test.ts
@@ -206,6 +206,7 @@ describe('Palettes', () => {
       ssl: '#edc5a2',
       stylesheet: '#ca8eae',
       wait: '#b0c9e0',
+      xhr: '#e7664c',
     });
   });
 });

--- a/x-pack/plugins/uptime/public/components/monitor/synthetics/step_detail/waterfall/data_formatting.ts
+++ b/x-pack/plugins/uptime/public/components/monitor/synthetics/step_detail/waterfall/data_formatting.ts
@@ -435,6 +435,7 @@ const buildMimeTypePalette = (): MimeTypeColourPalette => {
       case MimeType.Font:
         acc[value] = SAFE_PALETTE[8];
         break;
+      case MimeType.XHR:
       case MimeType.Other:
         acc[value] = SAFE_PALETTE[9];
         break;


### PR DESCRIPTION
## Summary

Resolves #105529 

We noticed that the colors being generated for XHR timings in the Synthetics waterfall chart were incorrect and confusing.

This is happening because one of the values in the enumerable set of `mime_types` we support has no color defined. This change will make the `XHR` type use the same color we already use for `Other`.

## Testing

Make sure that an `XHR` timing has the same color as `Other`.