### PR TITLE
[i18n] EUI token use `FormattedMessage` instead of `i18n.translate`

### DIFF
--- a/src/core/public/i18n/i18n_eui_mapping.tsx
+++ b/src/core/public/i18n/i18n_eui_mapping.tsx
@@ -712,11 +712,13 @@ export const getEuiContextMapping = () => {
         defaultMessage: 'Next page, {page}',
         values: { page },
       }),
-    'euiPagination.pageOfTotalCompressed': ({ page, total }: EuiValues) =>
-      i18n.translate('core.euiPagination.pageOfTotalCompressed', {
-        defaultMessage: '{page} of {total}',
-        values: { page, total },
-      }),
+    'euiPagination.pageOfTotalCompressed': ({ page, total }: EuiValues) => (
+      <FormattedMessage
+        id="core.euiPagination.pageOfTotalCompressed"
+        defaultMessage="{page} of {total}"
+        values={{ page, total }}
+      />
+    ),
     'euiPagination.previousPage': ({ page }: EuiValues) =>
       i18n.translate('core.euiPagination.previousPage', {
         defaultMessage: 'Previous page, {page}',


### PR DESCRIPTION
## Summary

Updates an i18n token added in #105127 to use `FormattedMessage` instead of `i18n.translate`. The pagination numbers are React components, not strings, and were therefore rendering as `[object Object]`.
