### PR TITLE
[Security Solutions] Make Cypress tests work independent of on-disk rules vs cloud rules

### DIFF
--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
+/* eslint-disable @kbn/eslint/no-restricted-paths */
+import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_rules/index';
 import { getMockThreatData } from '../../public/detections/mitre/mitre_tactics_techniques';
 import { getTimeline, CompleteTimeline, getIndicatorMatchTimelineTemplate } from './timeline';
+
+export const totalNumberOfPrebuiltRules = rawRules.length;
 
 const ccsRemoteName: string = Cypress.env('CCS_REMOTE_NAME');
 

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -5,16 +5,8 @@
  * 2.0.
  */
 
-/* eslint-disable @kbn/eslint/no-restricted-paths */
-import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_rules/index';
 import { getMockThreatData } from '../../public/detections/mitre/mitre_tactics_techniques';
 import { getTimeline, CompleteTimeline, getIndicatorMatchTimelineTemplate } from './timeline';
-
-export const totalNumberOfPrebuiltRules = rawRules.length;
-
-export const totalNumberOfPrebuiltRulesInEsArchive = 127;
-
-export const totalNumberOfPrebuiltRulesInEsArchiveCustomRule = 145;
 
 const ccsRemoteName: string = Cypress.env('CCS_REMOTE_NAME');
 

--- a/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts_detection_rules.ts
@@ -217,9 +217,10 @@ export const waitForRulesTableToBeAutoRefreshed = () => {
 };
 
 export const waitForPrebuiltDetectionRulesToBeLoaded = () => {
-  cy.get(LOAD_PREBUILT_RULES_BTN).should('not.exist');
-  cy.get(RULES_TABLE).should('exist');
-  cy.get(RULES_TABLE_REFRESH_INDICATOR).should('not.exist');
+  // Wait up to 5 minutes for the rules to load as in CI containers this can be very slow
+  cy.get(LOAD_PREBUILT_RULES_BTN, { timeout: 300000 }).should('not.exist');
+  cy.get(RULES_TABLE, { timeout: 300000 }).should('exist');
+  cy.get(RULES_TABLE_REFRESH_INDICATOR, { timeout: 300000 }).should('not.exist');
 };
 
 export const waitForRuleToChangeStatus = () => {


### PR DESCRIPTION
## Summary

Whenever we forget to mirror a rule on disk on-disk compared to a fleet server being updated, the pre-packaged rules will activate and prefer to grab the rules from the online service which can and will cause issues with our tests. This PR decouples that logic so that the total count of rules comes from the pre-packaged rule endpoint instead of relying on-disk rules.

* Increases our timeouts around waiting for pre-packaged rules to happen since we saw timeouts when the online rules were taking over.  
* Uses a `>=` check instead of strict equals and splits out the regex of numbers from their text in the tests.
* Changes the `prebuild_rules.spec.ts` 

One important CON to mention is that you're losing a bit of test safety that all the rules were installed correctly since we use a `>=` even when checking strings around deleting rules.

**How to manual testing this situation:**
Run the cypress tests and delete one of the rules from 

```
x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/index.ts
```

And you should see Cypress still passing tests.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
