### PR TITLE
[Security Solution][Exceptions] Adds error catch to Exceptions toString method

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
@@ -26,8 +26,9 @@ import {
   getProcessCodeSignature,
   retrieveAlertOsTypes,
   filterIndexPatterns,
+  getCodeSignatureValue,
 } from './helpers';
-import { AlertData } from './types';
+import { AlertData, Flattened } from './types';
 import {
   ListOperatorTypeEnum as OperatorTypeEnum,
   EntriesArray,
@@ -41,6 +42,7 @@ import { getCommentsArrayMock } from '../../../../../lists/common/schemas/types/
 import { fields } from '../../../../../../../src/plugins/data/common/index_patterns/fields/fields.mocks';
 import { ENTRIES, OLD_DATE_RELATIVE_TO_DATE_NOW } from '../../../../../lists/common/constants.mock';
 import { IFieldType, IIndexPattern } from 'src/plugins/data/common';
+import { CodeSignature } from '../../../../common/ecs/file';
 
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('123'),
@@ -337,6 +339,17 @@ describe('Exception helpers', () => {
       ];
       const result = entryHasListType(payload);
       expect(result).toEqual(true);
+    });
+  });
+
+  describe('#getCodeSignatureValue', () => {
+    test('it should return empty string if code_signature nested value are undefined', () => {
+      // Using the unsafe casting because with our types this shouldn't be possible but there have been issues with old data having undefined values in these fields
+      const payload = ([{ trusted: undefined, subject_name: undefined }] as unknown) as Flattened<
+        CodeSignature[]
+      >;
+      const result = getCodeSignatureValue(payload);
+      expect(result).toEqual([{ trusted: '', subjectName: '' }]);
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
@@ -325,8 +325,8 @@ export const getCodeSignatureValue = (
   if (Array.isArray(codeSignature) && codeSignature.length > 0) {
     return codeSignature.map((signature) => {
       return {
-        subjectName: signature.subject_name ?? '',
-        trusted: signature?.trusted.toString() ?? '',
+        subjectName: signature?.subject_name ?? '',
+        trusted: signature?.trusted?.toString() ?? '',
       };
     });
   } else {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
@@ -326,7 +326,7 @@ export const getCodeSignatureValue = (
     return codeSignature.map((signature) => {
       return {
         subjectName: signature.subject_name ?? '',
-        trusted: signature.trusted.toString() ?? '',
+        trusted: signature?.trusted.toString() ?? '',
       };
     });
   } else {


### PR DESCRIPTION
## Summary

Addresses #104442

Fixes bug where if the `trusted` value within the `code_signature` field was undefined, an error would throw crashing the app

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
