### PR TITLE
[7.14] Fixes  "servers.elasticsearch.auth" must be a string error (#105095)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/tasks/login.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/login.ts
@@ -205,6 +205,11 @@ const credentialsProvidedByEnvironment = (): boolean =>
  * Kibana's `/internal/security/login` endpoint, bypassing the login page (for speed).
  */
 const loginViaEnvironmentCredentials = () => {
+  const providerName =
+    Cypress.env('protocol') === 'http' || Cypress.config().baseUrl!.includes('staging')
+      ? 'basic'
+      : 'cloud-basic';
+
   cy.log(
     `Authenticating via environment credentials from the \`CYPRESS_${ELASTICSEARCH_USERNAME}\` and \`CYPRESS_${ELASTICSEARCH_PASSWORD}\` environment variables`
   );
@@ -213,7 +218,7 @@ const loginViaEnvironmentCredentials = () => {
   cy.request({
     body: {
       providerType: 'basic',
-      providerName: 'basic',
+      providerName,
       currentURL: '/',
       params: {
         username: Cypress.env(ELASTICSEARCH_USERNAME),

--- a/x-pack/test/security_solution_cypress/upgrade_config.ts
+++ b/x-pack/test/security_solution_cypress/upgrade_config.ts
@@ -5,15 +5,10 @@
  * 2.0.
  */
 
-import { FtrConfigProviderContext } from '@kbn/test';
-
 import { SecuritySolutionCypressUpgradeCliTestRunner } from './runner';
 
-export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const securitySolutionCypressConfig = await readConfigFile(require.resolve('./config.ts'));
+export default async function () {
   return {
-    ...securitySolutionCypressConfig.getAll(),
-
     testRunner: SecuritySolutionCypressUpgradeCliTestRunner,
   };
 }


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Fixes  "servers.elasticsearch.auth" must be a string error (#105095)