### PR TITLE
Remove beta admonitions for Fleet docs

### DIFF
--- a/docs/fleet/fleet.asciidoc
+++ b/docs/fleet/fleet.asciidoc
@@ -3,8 +3,6 @@
 [[fleet]]
 = {fleet}
 
-beta[]
-
 {fleet} in {kib} enables you to add and manage integrations for popular
 services and platforms, as well as manage {elastic-agent} installations in
 standalone or {fleet} mode.

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>{fleet} settings</titleabbrev>
 ++++
 
-experimental[]
-
 You can configure `xpack.fleet` settings in your `kibana.yml`. 
 By default, {fleet} is enabled. To use {fleet}, you also need to configure {kib} and {es} hosts.
 

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -27,7 +27,7 @@ image::images/add-data-tutorials.png[Add Data tutorials]
 [discrete]
 === Add Elastic Agent
 
-beta[] *Elastic Agent* is a sneak peek at the next generation of
+*Elastic Agent* is the next generation of
 data integration modules, offering
 a centralized way to set up your integrations.
 With *Fleet*, you can add


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/observability-docs/pull/871

Removes beta admonitions from the Fleet docs.

Note that Fleet is going GA (meaning it will be officially supported), but the dev team is still working on adding integrations, so Fleet is not yet the recommended way to manage ingest for all use cases.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
