### PR TITLE
[CTI] dedupes repeating threat intel

### DIFF
--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/cti/index.mock.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/cti/index.mock.ts
@@ -149,6 +149,7 @@ export const buildEventEnrichmentMock = (
   'threatintel.indicator.file.type': ['html'],
   'threatintel.indicator.first_seen': ['2021-05-28T18:33:29.000Z'],
   'threatintel.indicator.type': ['file'],
+  'threatintel.indicator.provider': ['abuseurl'],
   ...overrides,
 });
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.test.tsx
@@ -24,12 +24,11 @@ describe('ThreatSummaryView', () => {
     jest.clearAllMocks();
   });
 
-  const enrichments = [
-    buildEventEnrichmentMock(),
-    buildEventEnrichmentMock({ 'matched.id': ['other.id'], 'matched.field': ['other.field'] }),
-  ];
-
   it('renders a row for each enrichment', () => {
+    const enrichments = [
+      buildEventEnrichmentMock(),
+      buildEventEnrichmentMock({ 'matched.id': ['other.id'], 'matched.field': ['other.field'] }),
+    ];
     const wrapper = mount(
       <TestProviders>
         <ThreatSummaryView enrichments={enrichments} eventId={eventId} timelineId={timelineId} />


### PR DESCRIPTION
## Summary

-  Dedupes repeating key-value-provider (threat intel) items on Alert Details tab of the Alert Summary Flyout.
- sorts items by provider

before
<img width="526" alt="Screen Shot 2021-07-16 at 3 31 47 PM" src="https://user-images.githubusercontent.com/18617331/125999574-92461dd3-0c80-40dd-9751-c1852ebf67d9.png">

after
<img width="605" alt="Screen Shot 2021-07-16 at 3 30 48 PM" src="https://user-images.githubusercontent.com/18617331/125999599-e4735f49-cb07-4cf2-9803-ae4755590dcf.png">
