### PR TITLE
[CTI] updates NoEnrichmentPanel props

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/no_enrichments_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/no_enrichments_panel.test.tsx
@@ -16,21 +16,30 @@ jest.mock('../../../lib/kibana');
 describe('NoEnrichmentsPanelView', () => {
   it('renders a qualified container', () => {
     const wrapper = mount(
-      <NoEnrichmentsPanel existingEnrichmentsCount={1} investigationEnrichmentsCount={0} />
+      <NoEnrichmentsPanel
+        isIndicatorMatchesPresent={true}
+        isInvestigationTimeEnrichmentsPresent={false}
+      />
     );
     expect(wrapper.find('[data-test-subj="no-enrichments-panel"]').exists()).toEqual(true);
   });
 
   it('renders nothing when all enrichments are present', () => {
     const wrapper = mount(
-      <NoEnrichmentsPanel existingEnrichmentsCount={1} investigationEnrichmentsCount={1} />
+      <NoEnrichmentsPanel
+        isIndicatorMatchesPresent={true}
+        isInvestigationTimeEnrichmentsPresent={true}
+      />
     );
     expect(wrapper.find('[data-test-subj="no-enrichments-panel"]').exists()).toEqual(false);
   });
 
   it('renders expected text when no enrichments are present', () => {
     const wrapper = mount(
-      <NoEnrichmentsPanel existingEnrichmentsCount={0} investigationEnrichmentsCount={0} />
+      <NoEnrichmentsPanel
+        isIndicatorMatchesPresent={false}
+        isInvestigationTimeEnrichmentsPresent={false}
+      />
     );
     expect(wrapper.find('[data-test-subj="no-enrichments-panel"]').hostNodes().text()).toContain(
       i18n.NO_ENRICHMENTS_FOUND_TITLE
@@ -39,7 +48,10 @@ describe('NoEnrichmentsPanelView', () => {
 
   it('renders expected text when existing enrichments are absent', () => {
     const wrapper = mount(
-      <NoEnrichmentsPanel existingEnrichmentsCount={0} investigationEnrichmentsCount={1} />
+      <NoEnrichmentsPanel
+        isIndicatorMatchesPresent={false}
+        isInvestigationTimeEnrichmentsPresent={true}
+      />
     );
     expect(wrapper.find('[data-test-subj="no-enrichments-panel"]').hostNodes().text()).toContain(
       i18n.NO_INDICATOR_ENRICHMENTS_TITLE
@@ -48,7 +60,10 @@ describe('NoEnrichmentsPanelView', () => {
 
   it('renders expected text when investigation enrichments are absent', () => {
     const wrapper = mount(
-      <NoEnrichmentsPanel existingEnrichmentsCount={1} investigationEnrichmentsCount={0} />
+      <NoEnrichmentsPanel
+        isIndicatorMatchesPresent={true}
+        isInvestigationTimeEnrichmentsPresent={false}
+      />
     );
     expect(wrapper.find('[data-test-subj="no-enrichments-panel"]').hostNodes().text()).toContain(
       i18n.NO_INVESTIGATION_ENRICHMENTS_TITLE

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/no_enrichments_panel.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/no_enrichments_panel.tsx
@@ -35,9 +35,9 @@ const NoEnrichmentsPanelView: React.FC<{
 NoEnrichmentsPanelView.displayName = 'NoEnrichmentsPanelView';
 
 export const NoEnrichmentsPanel: React.FC<{
-  existingEnrichmentsCount: number;
-  investigationEnrichmentsCount: number;
-}> = ({ existingEnrichmentsCount, investigationEnrichmentsCount }) => {
+  isIndicatorMatchesPresent: boolean;
+  isInvestigationTimeEnrichmentsPresent: boolean;
+}> = ({ isIndicatorMatchesPresent, isInvestigationTimeEnrichmentsPresent }) => {
   const threatIntelDocsUrl = `${
     useKibana().services.docLinks.links.filebeat.base
   }/filebeat-module-threatintel.html`;
@@ -50,7 +50,7 @@ export const NoEnrichmentsPanel: React.FC<{
     </>
   );
 
-  if (existingEnrichmentsCount === 0 && investigationEnrichmentsCount === 0) {
+  if (!isIndicatorMatchesPresent && !isInvestigationTimeEnrichmentsPresent) {
     return (
       <NoEnrichmentsPanelView
         title={<h2>{i18n.NO_ENRICHMENTS_FOUND_TITLE}</h2>}
@@ -61,7 +61,7 @@ export const NoEnrichmentsPanel: React.FC<{
         }
       />
     );
-  } else if (existingEnrichmentsCount === 0) {
+  } else if (!isIndicatorMatchesPresent) {
     return (
       <>
         <EuiHorizontalRule margin="s" />
@@ -75,7 +75,7 @@ export const NoEnrichmentsPanel: React.FC<{
         />
       </>
     );
-  } else if (investigationEnrichmentsCount === 0) {
+  } else if (!isInvestigationTimeEnrichmentsPresent) {
     return (
       <>
         <EuiHorizontalRule margin="s" />

--- a/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/event_details.tsx
@@ -113,15 +113,14 @@ const EventDetailsComponent: React.FC<Props> = ({
     loading: enrichmentsLoading,
     result: enrichmentsResponse,
   } = useInvestigationTimeEnrichment(eventFields);
-  const investigationEnrichments = useMemo(() => enrichmentsResponse?.enrichments ?? [], [
-    enrichmentsResponse?.enrichments,
-  ]);
+
   const allEnrichments = useMemo(() => {
     if (enrichmentsLoading || !enrichmentsResponse?.enrichments) {
       return existingEnrichments;
     }
     return filterDuplicateEnrichments([...existingEnrichments, ...enrichmentsResponse.enrichments]);
   }, [enrichmentsLoading, enrichmentsResponse, existingEnrichments]);
+
   const enrichmentCount = allEnrichments.length;
 
   const summaryTab: EventViewTab | undefined = useMemo(
@@ -184,21 +183,16 @@ const EventDetailsComponent: React.FC<Props> = ({
               <>
                 <ThreatDetailsView enrichments={allEnrichments} />
                 <NoEnrichmentsPanel
-                  investigationEnrichmentsCount={investigationEnrichments.length}
-                  existingEnrichmentsCount={existingEnrichments.length}
+                  isInvestigationTimeEnrichmentsPresent={
+                    enrichmentCount > existingEnrichments.length
+                  }
+                  isIndicatorMatchesPresent={existingEnrichments.length > 0}
                 />
               </>
             ),
           }
         : undefined,
-    [
-      allEnrichments,
-      enrichmentCount,
-      enrichmentsLoading,
-      existingEnrichments.length,
-      investigationEnrichments.length,
-      isAlert,
-    ]
+    [allEnrichments, enrichmentCount, enrichmentsLoading, existingEnrichments.length, isAlert]
   );
 
   const tableTab = useMemo(


### PR DESCRIPTION
## Summary

Previously when all of the investigation time enrichments were deduped, `No Threat Intelligence Enrichment Found` copy didn't show up as expected. This change ensures that when all of the investigation time enrichments are deduped, the expected message shows up.

expected view when all investigation time enrichments are deduped (as they are the same as the indicator matches that already exist on the alert)
<img width="588" alt="Screen Shot 2021-07-16 at 4 16 04 PM" src="https://user-images.githubusercontent.com/18617331/126003886-f7f99535-80c5-4931-bf02-eea9bc86ea09.png">
