### PR TITLE
[7.x] [RAC] [RBAC] add space ids array to each alert document (#105173)

### DIFF
--- a/packages/kbn-rule-data-utils/src/technical_field_names.ts
+++ b/packages/kbn-rule-data-utils/src/technical_field_names.ts
@@ -8,7 +8,7 @@
 
 import { ValuesType } from 'utility-types';
 
-const ALERT_NAMESPACE = 'kibana.rac.alert';
+const ALERT_NAMESPACE = 'kibana.rac.alert' as const;
 
 const TIMESTAMP = '@timestamp' as const;
 const EVENT_KIND = 'event.kind' as const;
@@ -28,6 +28,7 @@ const ALERT_DURATION = `${ALERT_NAMESPACE}.duration.us` as const;
 const ALERT_SEVERITY_LEVEL = `${ALERT_NAMESPACE}.severity.level` as const;
 const ALERT_SEVERITY_VALUE = `${ALERT_NAMESPACE}.severity.value` as const;
 const ALERT_STATUS = `${ALERT_NAMESPACE}.status` as const;
+const SPACE_IDS = 'kibana.space_ids' as const;
 const ALERT_EVALUATION_THRESHOLD = `${ALERT_NAMESPACE}.evaluation.threshold` as const;
 const ALERT_EVALUATION_VALUE = `${ALERT_NAMESPACE}.evaluation.value` as const;
 
@@ -52,6 +53,7 @@ const fields = {
   ALERT_STATUS,
   ALERT_EVALUATION_THRESHOLD,
   ALERT_EVALUATION_VALUE,
+  SPACE_IDS,
 };
 
 export {
@@ -75,6 +77,7 @@ export {
   ALERT_STATUS,
   ALERT_EVALUATION_THRESHOLD,
   ALERT_EVALUATION_VALUE,
+  SPACE_IDS,
 };
 
 export type TechnicalRuleDataFieldName = ValuesType<typeof fields>;

--- a/x-pack/plugins/alerting/server/authorization/alerting_authorization.mock.ts
+++ b/x-pack/plugins/alerting/server/authorization/alerting_authorization.mock.ts
@@ -17,6 +17,7 @@ const createAlertingAuthorizationMock = () => {
     filterByRuleTypeAuthorization: jest.fn(),
     getFindAuthorizationFilter: jest.fn(),
     getAugmentedRuleTypesWithAuthorization: jest.fn(),
+    getSpaceId: jest.fn(),
   };
   return mocked;
 };

--- a/x-pack/plugins/alerting/server/authorization/alerting_authorization.ts
+++ b/x-pack/plugins/alerting/server/authorization/alerting_authorization.ts
@@ -81,6 +81,7 @@ export class AlertingAuthorization {
   private readonly featuresIds: Promise<Set<string>>;
   private readonly allPossibleConsumers: Promise<AuthorizedConsumers>;
   private readonly exemptConsumerIds: string[];
+  private readonly spaceId: Promise<string | undefined>;
 
   constructor({
     alertTypeRegistry,
@@ -100,6 +101,8 @@ export class AlertingAuthorization {
     // An example of this is the Rules Management `consumer` as we don't want to have to
     // manually authorize each rule type in the management UI.
     this.exemptConsumerIds = exemptConsumerIds;
+
+    this.spaceId = getSpace(request).then((maybeSpace) => maybeSpace?.id);
 
     this.featuresIds = getSpace(request)
       .then((maybeSpace) => new Set(maybeSpace?.disabledFeatures ?? []))
@@ -136,6 +139,10 @@ export class AlertingAuthorization {
 
   private shouldCheckAuthorization(): boolean {
     return this.authorization?.mode?.useRbacForRequest(this.request) ?? false;
+  }
+
+  public async getSpaceId(): Promise<string | undefined> {
+    return this.spaceId;
   }
 
   /*

--- a/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts
@@ -26,6 +26,7 @@ import {
   RULE_UUID,
   TAGS,
   TIMESTAMP,
+  SPACE_IDS,
 } from '../../../common/technical_rule_data_field_names';
 import { ecsFieldMap } from './ecs_field_map';
 
@@ -43,6 +44,7 @@ export const technicalRuleFieldMap = {
   ),
   [OWNER]: { type: 'keyword' },
   [PRODUCER]: { type: 'keyword' },
+  [SPACE_IDS]: { type: 'keyword', array: true },
   [ALERT_UUID]: { type: 'keyword' },
   [ALERT_ID]: { type: 'keyword' },
   [ALERT_START]: { type: 'date' },

--- a/x-pack/plugins/rule_registry/docs/alerts_client/classes/alertsclient.md
+++ b/x-pack/plugins/rule_registry/docs/alerts_client/classes/alertsclient.md
@@ -18,6 +18,7 @@ on alerts as data.
 - [authorization](alertsclient.md#authorization)
 - [esClient](alertsclient.md#esclient)
 - [logger](alertsclient.md#logger)
+- [spaceId](alertsclient.md#spaceid)
 
 ### Methods
 
@@ -41,7 +42,7 @@ on alerts as data.
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:59](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L59)
+[rule_registry/server/alert_data_client/alerts_client.ts:66](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L66)
 
 ## Properties
 
@@ -51,7 +52,7 @@ on alerts as data.
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:57](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L57)
+[rule_registry/server/alert_data_client/alerts_client.ts:63](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L63)
 
 ___
 
@@ -61,7 +62,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:58](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L58)
+[rule_registry/server/alert_data_client/alerts_client.ts:64](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L64)
 
 ___
 
@@ -71,7 +72,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:59](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L59)
+[rule_registry/server/alert_data_client/alerts_client.ts:65](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L65)
 
 ___
 
@@ -81,7 +82,17 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:56](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L56)
+[rule_registry/server/alert_data_client/alerts_client.ts:62](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L62)
+
+___
+
+### spaceId
+
+• `Private` `Readonly` **spaceId**: `Promise`<undefined \| string\>
+
+#### Defined in
+
+[rule_registry/server/alert_data_client/alerts_client.ts:66](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L66)
 
 ## Methods
 
@@ -101,7 +112,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:79](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L79)
+[rule_registry/server/alert_data_client/alerts_client.ts:87](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L87)
 
 ___
 
@@ -121,7 +132,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:115](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L115)
+[rule_registry/server/alert_data_client/alerts_client.ts:134](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L134)
 
 ___
 
@@ -142,7 +153,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:68](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L68)
+[rule_registry/server/alert_data_client/alerts_client.ts:76](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L76)
 
 ___
 
@@ -162,7 +173,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:219](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L219)
+[rule_registry/server/alert_data_client/alerts_client.ts:238](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L238)
 
 ___
 
@@ -188,4 +199,4 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:160](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L160)
+[rule_registry/server/alert_data_client/alerts_client.ts:179](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L179)

--- a/x-pack/plugins/rule_registry/docs/alerts_client/interfaces/constructoroptions.md
+++ b/x-pack/plugins/rule_registry/docs/alerts_client/interfaces/constructoroptions.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:34](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L34)
+[rule_registry/server/alert_data_client/alerts_client.ts:40](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L40)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:33](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L33)
+[rule_registry/server/alert_data_client/alerts_client.ts:39](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L39)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:35](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L35)
+[rule_registry/server/alert_data_client/alerts_client.ts:41](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L41)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:32](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L32)
+[rule_registry/server/alert_data_client/alerts_client.ts:38](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L38)

--- a/x-pack/plugins/rule_registry/docs/alerts_client/interfaces/updateoptions.md
+++ b/x-pack/plugins/rule_registry/docs/alerts_client/interfaces/updateoptions.md
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:41](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L41)
+[rule_registry/server/alert_data_client/alerts_client.ts:47](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L47)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:39](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L39)
+[rule_registry/server/alert_data_client/alerts_client.ts:45](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L45)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:42](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L42)
+[rule_registry/server/alert_data_client/alerts_client.ts:48](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L48)
 
 ___
 
@@ -55,4 +55,4 @@ ___
 
 #### Defined in
 
-[rule_registry/server/alert_data_client/alerts_client.ts:40](https://github.com/elastic/kibana/blob/f2a94addc85/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L40)
+[rule_registry/server/alert_data_client/alerts_client.ts:46](https://github.com/elastic/kibana/blob/48e1b91d751/x-pack/plugins/rule_registry/server/alert_data_client/alerts_client.ts#L46)

--- a/x-pack/plugins/rule_registry/server/alert_data_client/tests/get.test.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/tests/get.test.ts
@@ -27,6 +27,7 @@ const alertsClientParams: jest.Mocked<ConstructorOptions> = {
 
 beforeEach(() => {
   jest.resetAllMocks();
+  alertingAuthMock.getSpaceId.mockImplementation(() => Promise.resolve('test_default_space_id'));
 });
 
 describe('get()', () => {
@@ -60,6 +61,7 @@ describe('get()', () => {
                   message: 'hello world 1',
                   'kibana.rac.alert.owner': 'apm',
                   'kibana.rac.alert.status': 'open',
+                  'kibana.rac.alert.space_ids': ['test_default_space_id'],
                 },
               },
             ],
@@ -72,6 +74,9 @@ describe('get()', () => {
       Object {
         "_version": "WzM2MiwyXQ==",
         "kibana.rac.alert.owner": "apm",
+        "kibana.rac.alert.space_ids": Array [
+          "test_default_space_id",
+        ],
         "kibana.rac.alert.status": "open",
         "message": "hello world 1",
         "rule.id": "apm.error_rate",
@@ -83,8 +88,19 @@ describe('get()', () => {
         Object {
           "body": Object {
             "query": Object {
-              "term": Object {
-                "_id": "1",
+              "bool": Object {
+                "filter": Array [
+                  Object {
+                    "term": Object {
+                      "_id": "1",
+                    },
+                  },
+                  Object {
+                    "term": Object {
+                      "kibana.space_ids": "test_default_space_id",
+                    },
+                  },
+                ],
               },
             },
           },
@@ -126,6 +142,7 @@ describe('get()', () => {
                   message: 'hello world 1',
                   'kibana.rac.alert.owner': 'apm',
                   'kibana.rac.alert.status': 'open',
+                  'kibana.rac.alert.space_ids': ['test_default_space_id'],
                 },
               },
             ],
@@ -187,6 +204,7 @@ describe('get()', () => {
                     message: 'hello world 1',
                     'kibana.rac.alert.owner': 'apm',
                     'kibana.rac.alert.status': 'open',
+                    'kibana.rac.alert.space_ids': ['test_default_space_id'],
                   },
                 },
               ],
@@ -210,6 +228,9 @@ describe('get()', () => {
         Object {
           "_version": "WzM2MiwyXQ==",
           "kibana.rac.alert.owner": "apm",
+          "kibana.rac.alert.space_ids": Array [
+            "test_default_space_id",
+          ],
           "kibana.rac.alert.status": "open",
           "message": "hello world 1",
           "rule.id": "apm.error_rate",

--- a/x-pack/plugins/rule_registry/server/alert_data_client/tests/update.test.ts
+++ b/x-pack/plugins/rule_registry/server/alert_data_client/tests/update.test.ts
@@ -27,6 +27,7 @@ const alertsClientParams: jest.Mocked<ConstructorOptions> = {
 
 beforeEach(() => {
   jest.resetAllMocks();
+  alertingAuthMock.getSpaceId.mockImplementation(() => Promise.resolve('test_default_space_id'));
 });
 
 describe('update()', () => {
@@ -57,6 +58,7 @@ describe('update()', () => {
                   message: 'hello world 1',
                   'kibana.rac.alert.owner': 'apm',
                   'kibana.rac.alert.status': 'open',
+                  'kibana.rac.alert.space_ids': ['test_default_space_id'],
                 },
               },
             ],
@@ -142,6 +144,7 @@ describe('update()', () => {
                   message: 'hello world 1',
                   'kibana.rac.alert.owner': 'apm',
                   'kibana.rac.alert.status': 'open',
+                  'kibana.rac.alert.space_ids': ['test_default_space_id'],
                 },
               },
             ],
@@ -234,6 +237,7 @@ describe('update()', () => {
                   message: 'hello world 1',
                   'kibana.rac.alert.owner': 'apm',
                   'kibana.rac.alert.status': 'open',
+                  'kibana.rac.alert.space_ids': ['test_default_space_id'],
                 },
               },
             ],
@@ -293,6 +297,7 @@ describe('update()', () => {
                     message: 'hello world 1',
                     'kibana.rac.alert.owner': 'apm',
                     'kibana.rac.alert.status': 'open',
+                    'kibana.rac.alert.space_ids': ['test_default_space_id'],
                   },
                 },
               ],

--- a/x-pack/plugins/rule_registry/server/scripts/observer/detections_role.json
+++ b/x-pack/plugins/rule_registry/server/scripts/observer/detections_role.json
@@ -6,13 +6,7 @@
   "kibana": [
     {
       "feature": {
-        "ml": ["read"],
-        "monitoring": ["all"],
-        "apm": ["minimal_read", "alerts_all"],
-        "ruleRegistry": ["all"],
-        "actions": ["read"],
-        "builtInAlerts": ["all"],
-        "alerting": ["all"]
+        "apm": ["read", "alerts_all"]
       },
       "spaces": ["*"]
     }

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -31,6 +31,7 @@ import {
   OWNER,
   RULE_UUID,
   TIMESTAMP,
+  SPACE_IDS,
 } from '../../common/technical_rule_data_field_names';
 import { RuleDataClient } from '../rule_data_client';
 import { AlertExecutorOptionsWithExtraServices } from '../types';
@@ -124,6 +125,7 @@ export const createLifecycleExecutor = (logger: Logger, ruleDataClient: RuleData
     rule,
     services: { alertInstanceFactory },
     state: previousState,
+    spaceId,
   } = options;
 
   const ruleExecutorData = getRuleData(options);
@@ -257,6 +259,15 @@ export const createLifecycleExecutor = (logger: Logger, ruleDataClient: RuleData
 
     event[ALERT_START] = started;
     event[ALERT_UUID] = alertUuid;
+
+    // not sure why typescript needs the non-null assertion here
+    // we already assert the value is not undefined with the ternary
+    // still getting an error with the ternary.. strange.
+
+    event[SPACE_IDS] =
+      event[SPACE_IDS] == null
+        ? [spaceId]
+        : [spaceId, ...event[SPACE_IDS]!.filter((sid) => sid !== spaceId)];
 
     if (isNew) {
       event[EVENT_ACTION] = 'open';

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
@@ -198,6 +198,9 @@ describe('createLifecycleRuleTypeFactory', () => {
               "kibana.rac.alert.producer": "producer",
               "kibana.rac.alert.start": "2021-06-16T09:01:00.000Z",
               "kibana.rac.alert.status": "open",
+              "kibana.space_ids": Array [
+                "spaceId",
+              ],
               "rule.category": "ruleTypeName",
               "rule.id": "ruleTypeId",
               "rule.name": "name",
@@ -217,6 +220,9 @@ describe('createLifecycleRuleTypeFactory', () => {
               "kibana.rac.alert.producer": "producer",
               "kibana.rac.alert.start": "2021-06-16T09:01:00.000Z",
               "kibana.rac.alert.status": "open",
+              "kibana.space_ids": Array [
+                "spaceId",
+              ],
               "rule.category": "ruleTypeName",
               "rule.id": "ruleTypeId",
               "rule.name": "name",
@@ -236,6 +242,9 @@ describe('createLifecycleRuleTypeFactory', () => {
               "kibana.rac.alert.producer": "producer",
               "kibana.rac.alert.start": "2021-06-16T09:01:00.000Z",
               "kibana.rac.alert.status": "open",
+              "kibana.space_ids": Array [
+                "spaceId",
+              ],
               "rule.category": "ruleTypeName",
               "rule.id": "ruleTypeId",
               "rule.name": "name",
@@ -255,6 +264,9 @@ describe('createLifecycleRuleTypeFactory', () => {
               "kibana.rac.alert.producer": "producer",
               "kibana.rac.alert.start": "2021-06-16T09:01:00.000Z",
               "kibana.rac.alert.status": "open",
+              "kibana.space_ids": Array [
+                "spaceId",
+              ],
               "rule.category": "ruleTypeName",
               "rule.id": "ruleTypeId",
               "rule.name": "name",

--- a/x-pack/test/apm_api_integration/tests/alerts/rule_registry.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/rule_registry.ts
@@ -376,6 +376,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             "kibana.rac.alert.status": Array [
               "open",
             ],
+            "kibana.space_ids": Array [
+              "default",
+            ],
             "processor.event": Array [
               "transaction",
             ],
@@ -448,6 +451,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             ],
             "kibana.rac.alert.status": Array [
               "open",
+            ],
+            "kibana.space_ids": Array [
+              "default",
             ],
             "processor.event": Array [
               "transaction",
@@ -555,6 +561,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             ],
             "kibana.rac.alert.status": Array [
               "closed",
+            ],
+            "kibana.space_ids": Array [
+              "default",
             ],
             "processor.event": Array [
               "transaction",

--- a/x-pack/test/functional/es_archives/rule_registry/alerts/data.json
+++ b/x-pack/test/functional/es_archives/rule_registry/alerts/data.json
@@ -8,7 +8,40 @@
       "rule.id": "apm.error_rate",
       "message": "hello world 1",
       "kibana.rac.alert.owner": "apm",
-      "kibana.rac.alert.status": "open"
+      "kibana.rac.alert.status": "open",
+      "kibana.space_ids": ["space1", "space2"]
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "index": ".alerts-observability-apm",
+    "id": "space1alert",
+    "source": {
+      "@timestamp": "2020-12-16T15:16:18.570Z",
+      "rule.id": "apm.error_rate",
+      "message": "hello world 1",
+      "kibana.rac.alert.owner": "apm",
+      "kibana.rac.alert.status": "open",
+      "kibana.space_ids": ["space1"]
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "index": ".alerts-observability-apm",
+    "id": "space2alert",
+    "source": {
+      "@timestamp": "2020-12-16T15:16:18.570Z",
+      "rule.id": "apm.error_rate",
+      "message": "hello world 1",
+      "kibana.rac.alert.owner": "apm",
+      "kibana.rac.alert.status": "open",
+      "kibana.space_ids": ["space2"]
     }
   }
 }
@@ -23,7 +56,8 @@
       "rule.id": "siem.signals",
       "message": "hello world security",
       "kibana.rac.alert.owner": "siem",
-      "kibana.rac.alert.status": "open"
+      "kibana.rac.alert.status": "open",
+      "kibana.space_ids": ["space1", "space2"]
     }
   }
 }

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alert_by_id.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alert_by_id.ts
@@ -98,6 +98,30 @@ export default ({ getService }: FtrProviderContext) => {
       await esArchiver.unload('x-pack/test/functional/es_archives/rule_registry/alerts');
     });
 
+    it('superuser should be able to access an alert in a given space', async () => {
+      await supertestWithoutAuth
+        .get(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}?id=space1alert&index=${APM_ALERT_INDEX}`)
+        .auth(superUser.username, superUser.password)
+        .set('kbn-xsrf', 'true')
+        .expect(200);
+    });
+
+    it('superuser should NOT be able to access an alert in a space which the alert does not exist in', async () => {
+      await supertestWithoutAuth
+        .get(`${getSpaceUrlPrefix(SPACE2)}${TEST_URL}?id=space1alert&index=${APM_ALERT_INDEX}`)
+        .auth(superUser.username, superUser.password)
+        .set('kbn-xsrf', 'true')
+        .expect(404);
+    });
+
+    it('obs only space 1 user should NOT be able to access an alert in a space which the user does not have access to', async () => {
+      await supertestWithoutAuth
+        .get(`${getSpaceUrlPrefix(SPACE1)}${TEST_URL}?id=space2alert&index=${APM_ALERT_INDEX}`)
+        .auth(superUser.username, superUser.password)
+        .set('kbn-xsrf', 'true')
+        .expect(404);
+    });
+
     function addTests({ space, authorizedUsers, unauthorizedUsers, alertId, index }: TestCase) {
       authorizedUsers.forEach(({ username, password }) => {
         it(`${username} should be able to access alert ${alertId} in ${space}/${index}`, async () => {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/trial/update_alert.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/trial/update_alert.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import expect from '@kbn/expect';
+import { omit } from 'lodash/fp';
 
 import {
   superUser,
@@ -104,15 +105,13 @@ export default ({ getService }: FtrProviderContext) => {
             _version: Buffer.from(JSON.stringify([0, 1]), 'utf8').toString('base64'),
           })
           .expect(200);
-        expect(res.body).to.eql({
+        expect(omit(['_version', '_seq_no'], res.body)).to.eql({
           success: true,
           _index: '.alerts-observability-apm',
           _id: 'NoxgpHkBqbdrfX07MqXV',
           result: 'updated',
           _shards: { total: 2, successful: 1, failed: 0 },
           _type: '_doc',
-          _version: 'WzEsMV0=',
-          _seq_no: 1,
           _primary_term: 1,
         });
       });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [RAC] [RBAC] add space ids array to each alert document (#105173)