### PR TITLE
Provide sensible defaults for `xpack.security.session.{lifespan|idleTimeout}`.

### DIFF
--- a/docs/settings/security-settings.asciidoc
+++ b/docs/settings/security-settings.asciidoc
@@ -271,7 +271,7 @@ You can configure the following settings in the `kibana.yml` file.
 
 |[[xpack-session-idleTimeout]] `xpack.security.session.idleTimeout` {ess-icon}
   | Ensures that user sessions will expire after a period of inactivity. This and <<xpack-session-lifespan,`xpack.security.session.lifespan`>> are both
-highly recommended. You can also specify this setting for <<xpack-security-provider-session-idleTimeout, every provider separately>>. If this is _not_ set or set to `0`, then sessions will never expire due to inactivity. By default, this setting is not set.
+highly recommended. You can also specify this setting for <<xpack-security-provider-session-idleTimeout, every provider separately>>. If this is set to `0`, then sessions will never expire due to inactivity. By default, this value is 1 hour.
 
 2+a|
 [TIP]
@@ -281,8 +281,8 @@ Use a string of `<count>[ms\|s\|m\|h\|d\|w\|M\|Y]` (e.g. '20m', '24h', '7d', '1w
 
 |[[xpack-session-lifespan]] `xpack.security.session.lifespan` {ess-icon}
   | Ensures that user sessions will expire after the defined time period. This behavior is also known as an "absolute timeout". If
-this is _not_ set or set to `0`, user sessions could stay active indefinitely. This and <<xpack-session-idleTimeout, `xpack.security.session.idleTimeout`>> are both highly
-recommended. You can also specify this setting for <<xpack-security-provider-session-lifespan, every provider separately>>. By default, this setting is not set.
+this is set to `0`, user sessions could stay active indefinitely. This and <<xpack-session-idleTimeout, `xpack.security.session.idleTimeout`>> are both highly
+recommended. You can also specify this setting for <<xpack-security-provider-session-lifespan, every provider separately>>. By default, this value is 30 days.
 
 2+a|
 [TIP]

--- a/docs/user/security/session-management.asciidoc
+++ b/docs/user/security/session-management.asciidoc
@@ -12,24 +12,24 @@ To manage user sessions programmatically, {kib} exposes <<session-management-api
 ==== Session idle timeout
 
 You can use `xpack.security.session.idleTimeout` to expire sessions after a period of inactivity. This and `xpack.security.session.lifespan` are both highly recommended.
-By default, sessions don't expire because of inactivity. To define a sliding session expiration, set the  property in the `kibana.yml` configuration file. The idle timeout is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, set the idle timeout to expire sessions after 1 hour of inactivity:
+By default, sessions expire after 1 hour of inactivity. To define another value for a sliding session expiration, set the  property in the `kibana.yml` configuration file. The idle timeout is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, set the idle timeout to expire sessions after 30 minutes of inactivity:
 
 --
 [source,yaml]
 --------------------------------------------------------------------------------
-xpack.security.session.idleTimeout: "1h"
+xpack.security.session.idleTimeout: "30m"
 --------------------------------------------------------------------------------
 --
 
 [[session-lifespan]]
 ==== Session lifespan
 
-You can use `xpack.security.session.lifespan` to configure the maximum session duration or "lifespan" -- also known as the "absolute timeout". This and `xpack.security.session.idleTimeout` are both highly recommended. By default, sessions don't have a fixed lifespan, and if an idle timeout is defined, a session can still be extended indefinitely. To define a maximum session lifespan, set the property in the `kibana.yml` configuration file. The lifespan is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, set the lifespan to expire sessions after 30 days:
+You can use `xpack.security.session.lifespan` to configure the maximum session duration or "lifespan" -- also known as the "absolute timeout". This and `xpack.security.session.idleTimeout` are both highly recommended. By default, a maximum session lifespan is 30 days. To define another lifespan, set the property in the `kibana.yml` configuration file. The lifespan is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, set the lifespan to expire sessions after 7 days:
 
 --
 [source,yaml]
 --------------------------------------------------------------------------------
-xpack.security.session.lifespan: "30d"
+xpack.security.session.lifespan: "7d"
 --------------------------------------------------------------------------------
 --
 

--- a/docs/user/security/session-management.asciidoc
+++ b/docs/user/security/session-management.asciidoc
@@ -38,7 +38,7 @@ xpack.security.session.lifespan: "7d"
 
 [IMPORTANT]
 ============================================================================
-If you specify neither session idle timeout nor lifespan, then {kib} will not automatically remove session information from the index unless you explicitly log out. This might lead to an infinitely growing session index. Configure the idle timeout and lifespan settings for the {kib} sessions so that they can be cleaned up even if you don't explicitly log out.
+If you disable session idle timeout and lifespan, then Kibana will not automatically remove session information from the index unless you explicitly log out. This might lead to an infinitely growing session index. As long as either idle timeout or lifespan is configured, Kibana sessions will be cleaned up even if you don't explicitly log out.
 ============================================================================
 
 You can configure the interval at which {kib} tries to remove expired and invalid sessions from the session index. By default, this value is 1 hour and cannot be less than 10 seconds. To define another interval, set the `xpack.security.session.cleanupInterval` property in the `kibana.yml` configuration file. The interval is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, schedule the session index cleanup to perform once a day:

--- a/x-pack/plugins/security/server/config.test.ts
+++ b/x-pack/plugins/security/server/config.test.ts
@@ -61,6 +61,8 @@ describe('config schema', () => {
         "secureCookies": false,
         "session": Object {
           "cleanupInterval": "PT1H",
+          "idleTimeout": "PT1H",
+          "lifespan": "P30D",
         },
       }
     `);
@@ -110,6 +112,8 @@ describe('config schema', () => {
         "secureCookies": false,
         "session": Object {
           "cleanupInterval": "PT1H",
+          "idleTimeout": "PT1H",
+          "lifespan": "P30D",
         },
       }
     `);
@@ -158,6 +162,8 @@ describe('config schema', () => {
         "secureCookies": false,
         "session": Object {
           "cleanupInterval": "PT1H",
+          "idleTimeout": "PT1H",
+          "lifespan": "P30D",
         },
       }
     `);
@@ -1615,11 +1621,11 @@ describe('createConfig()', () => {
     it('returns default values if neither global nor provider specific settings are set', async () => {
       expect(createMockConfig().session.getExpirationTimeouts({ type: 'basic', name: 'basic1' }))
         .toMatchInlineSnapshot(`
-          Object {
-            "idleTimeout": null,
-            "lifespan": null,
-          }
-        `);
+        Object {
+          "idleTimeout": "PT1H",
+          "lifespan": "P30D",
+        }
+      `);
     });
 
     it('correctly handles explicitly disabled global settings', async () => {
@@ -1653,11 +1659,11 @@ describe('createConfig()', () => {
           name: 'basic1',
         })
       ).toMatchInlineSnapshot(`
-          Object {
-            "idleTimeout": "PT0.123S",
-            "lifespan": null,
-          }
-        `);
+        Object {
+          "idleTimeout": "PT0.123S",
+          "lifespan": "P30D",
+        }
+      `);
 
       expect(
         createMockConfig({ session: { lifespan: 456 } }).session.getExpirationTimeouts({
@@ -1665,11 +1671,11 @@ describe('createConfig()', () => {
           name: 'basic1',
         })
       ).toMatchInlineSnapshot(`
-          Object {
-            "idleTimeout": null,
-            "lifespan": "PT0.456S",
-          }
-        `);
+        Object {
+          "idleTimeout": "PT1H",
+          "lifespan": "PT0.456S",
+        }
+      `);
 
       expect(
         createMockConfig({
@@ -1692,7 +1698,7 @@ describe('createConfig()', () => {
       ).toMatchInlineSnapshot(`
         Object {
           "idleTimeout": "PT0.123S",
-          "lifespan": null,
+          "lifespan": "P30D",
         }
       `);
 
@@ -1703,7 +1709,7 @@ describe('createConfig()', () => {
         })
       ).toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": null,
+          "idleTimeout": "PT1H",
           "lifespan": "PT0.456S",
         }
       `);
@@ -1734,14 +1740,14 @@ describe('createConfig()', () => {
         .toMatchInlineSnapshot(`
         Object {
           "idleTimeout": "PT0.321S",
-          "lifespan": null,
+          "lifespan": "P30D",
         }
       `);
       expect(configWithoutGlobal.session.getExpirationTimeouts({ type: 'saml', name: 'saml1' }))
         .toMatchInlineSnapshot(`
         Object {
           "idleTimeout": "PT5M32.211S",
-          "lifespan": null,
+          "lifespan": "P30D",
         }
       `);
 
@@ -1758,14 +1764,14 @@ describe('createConfig()', () => {
         .toMatchInlineSnapshot(`
         Object {
           "idleTimeout": "PT0.321S",
-          "lifespan": null,
+          "lifespan": "P30D",
         }
       `);
       expect(configWithGlobal.session.getExpirationTimeouts({ type: 'saml', name: 'saml1' }))
         .toMatchInlineSnapshot(`
         Object {
           "idleTimeout": "PT5M32.211S",
-          "lifespan": null,
+          "lifespan": "P30D",
         }
       `);
     });
@@ -1783,14 +1789,14 @@ describe('createConfig()', () => {
       expect(configWithoutGlobal.session.getExpirationTimeouts({ type: 'basic', name: 'basic1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": null,
+          "idleTimeout": "PT1H",
           "lifespan": "PT0.654S",
         }
       `);
       expect(configWithoutGlobal.session.getExpirationTimeouts({ type: 'saml', name: 'saml1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": null,
+          "idleTimeout": "PT1H",
           "lifespan": "PT11M5.544S",
         }
       `);
@@ -1807,7 +1813,7 @@ describe('createConfig()', () => {
       expect(configWithGlobal.session.getExpirationTimeouts({ type: 'basic', name: 'basic1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": null,
+          "idleTimeout": "PT1H",
           "lifespan": "PT0.654S",
         }
       `);

--- a/x-pack/plugins/security/server/session_management/session.test.ts
+++ b/x-pack/plugins/security/server/session_management/session.test.ts
@@ -358,7 +358,7 @@ describe('Session', () => {
       session = new Session({
         logger: loggingSystemMock.createLogger(),
         config: createConfig(
-          ConfigSchema.validate({ session: { idleTimeout: 123 } }),
+          ConfigSchema.validate({ session: { idleTimeout: 123, lifespan: null } }),
           loggingSystemMock.createLogger(),
           { isTLSEnabled: false }
         ),
@@ -398,7 +398,7 @@ describe('Session', () => {
         session = new Session({
           logger: loggingSystemMock.createLogger(),
           config: createConfig(
-            ConfigSchema.validate({ session: { lifespan } }),
+            ConfigSchema.validate({ session: { idleTimeout: null, lifespan } }),
             loggingSystemMock.createLogger(),
             { isTLSEnabled: false }
           ),
@@ -472,9 +472,11 @@ describe('Session', () => {
 
       session = new Session({
         logger: loggingSystemMock.createLogger(),
-        config: createConfig(ConfigSchema.validate({}), loggingSystemMock.createLogger(), {
-          isTLSEnabled: false,
-        }),
+        config: createConfig(
+          ConfigSchema.validate({ session: { idleTimeout: null, lifespan: null } }),
+          loggingSystemMock.createLogger(),
+          { isTLSEnabled: false }
+        ),
         sessionCookie: mockSessionCookie,
         sessionIndex: mockSessionIndex,
       });
@@ -527,7 +529,7 @@ describe('Session', () => {
         session = new Session({
           logger: loggingSystemMock.createLogger(),
           config: createConfig(
-            ConfigSchema.validate({ session: { idleTimeout: 123 } }),
+            ConfigSchema.validate({ session: { idleTimeout: 123, lifespan: null } }),
             loggingSystemMock.createLogger(),
             { isTLSEnabled: false }
           ),
@@ -718,7 +720,7 @@ describe('Session', () => {
         session = new Session({
           logger: loggingSystemMock.createLogger(),
           config: createConfig(
-            ConfigSchema.validate({ session: { lifespan } }),
+            ConfigSchema.validate({ session: { idleTimeout: null, lifespan } }),
             loggingSystemMock.createLogger(),
             { isTLSEnabled: false }
           ),

--- a/x-pack/plugins/security/server/session_management/session_index.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.test.ts
@@ -26,9 +26,11 @@ describe('Session index', () => {
     const sessionIndexOptions = {
       logger: loggingSystemMock.createLogger(),
       kibanaIndexName: '.kibana_some_tenant',
-      config: createConfig(ConfigSchema.validate({}), loggingSystemMock.createLogger(), {
-        isTLSEnabled: false,
-      }),
+      config: createConfig(
+        ConfigSchema.validate({ session: { idleTimeout: null, lifespan: null } }),
+        loggingSystemMock.createLogger(),
+        { isTLSEnabled: false }
+      ),
       elasticsearchClient: mockElasticsearchClient,
     };
 
@@ -239,7 +241,7 @@ describe('Session index', () => {
         logger: loggingSystemMock.createLogger(),
         kibanaIndexName: '.kibana_some_tenant',
         config: createConfig(
-          ConfigSchema.validate({ session: { lifespan: 456 } }),
+          ConfigSchema.validate({ session: { idleTimeout: null, lifespan: 456 } }),
           loggingSystemMock.createLogger(),
           { isTLSEnabled: false }
         ),
@@ -315,7 +317,7 @@ describe('Session index', () => {
         logger: loggingSystemMock.createLogger(),
         kibanaIndexName: '.kibana_some_tenant',
         config: createConfig(
-          ConfigSchema.validate({ session: { idleTimeout } }),
+          ConfigSchema.validate({ session: { idleTimeout, lifespan: null } }),
           loggingSystemMock.createLogger(),
           { isTLSEnabled: false }
         ),


### PR DESCRIPTION
## Summary

This PR changes default values for the session timeout settings. You can find more details on the decision in https://github.com/elastic/kibana/issues/68885

**New defaults:**
* `xpack.security.session.idleTimeout: 8h` (we initially picked `1h`, but bumped it to `8h` in the follow-up https://github.com/elastic/kibana/pull/115565)
* `xpack.security.session.lifespan: 30d`

Docs preview link: https://kibana_106061.docs-preview.app.elstc.co/diff

__Fixes: https://github.com/elastic/kibana/issues/68885__

### Release note

We are enabling session expiration timeouts by default in Kibana: session idle or inactivity timeout is set to 8 hours, and session maximum lifespan is set to 30 days. Refer to [`Session management` documentation](https://www.elastic.co/guide/en/kibana/current/xpack-security-session-management.html) for more info.