### PR TITLE
[7.x] [Canvas] Fixes messed up form layout on custom interval form (#101967)

### DIFF
--- a/x-pack/plugins/canvas/public/components/workpad_header/view_menu/custom_interval.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/view_menu/custom_interval.tsx
@@ -75,12 +75,7 @@ export const CustomInterval = ({ gutterSize, buttonSize, onSubmit, defaultValue 
 
         <EuiFlexItem grow={false}>
           <EuiFormRow hasEmptyLabelSpace={true} display="rowCompressed">
-            <EuiButton
-              disabled={isInvalid}
-              size={buttonSize}
-              type="submit"
-              style={{ minWidth: 'auto' }}
-            >
+            <EuiButton disabled={isInvalid} size={buttonSize} type="submit" minWidth="auto">
               {strings.getButtonLabel()}
             </EuiButton>
           </EuiFormRow>

--- a/x-pack/plugins/canvas/shareable_runtime/components/footer/settings/__snapshots__/settings.test.tsx.snap
+++ b/x-pack/plugins/canvas/shareable_runtime/components/footer/settings/__snapshots__/settings.test.tsx.snap
@@ -324,6 +324,7 @@ exports[`<Settings /> can navigate Autoplay Settings 2`] = `
                             <button
                               class="euiButton euiButton--primary euiButton--small"
                               id="generated-id"
+                              style="min-width: auto;"
                               type="submit"
                             >
                               <span

--- a/x-pack/plugins/canvas/shareable_runtime/components/footer/settings/__stories__/__snapshots__/autoplay_settings.stories.storyshot
+++ b/x-pack/plugins/canvas/shareable_runtime/components/footer/settings/__stories__/__snapshots__/autoplay_settings.stories.storyshot
@@ -139,7 +139,7 @@ exports[`Storyshots shareables/Footer/Settings/AutoplaySettings component: off, 
                 onFocus={[Function]}
                 style={
                   Object {
-                    "minWidth": undefined,
+                    "minWidth": "auto",
                   }
                 }
                 type="submit"
@@ -302,7 +302,7 @@ exports[`Storyshots shareables/Footer/Settings/AutoplaySettings component: on, 5
                 onFocus={[Function]}
                 style={
                   Object {
-                    "minWidth": undefined,
+                    "minWidth": "auto",
                   }
                 }
                 type="submit"
@@ -465,7 +465,7 @@ exports[`Storyshots shareables/Footer/Settings/AutoplaySettings contextual 1`] =
                 onFocus={[Function]}
                 style={
                   Object {
-                    "minWidth": undefined,
+                    "minWidth": "auto",
                   }
                 }
                 type="submit"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Canvas] Fixes messed up form layout on custom interval form (#101967)