### PR TITLE
[ML] Transforms: Fixes overflow of data grid into side navigation

### DIFF
--- a/x-pack/plugins/transform/public/app/app.tsx
+++ b/x-pack/plugins/transform/public/app/app.tsx
@@ -43,9 +43,12 @@ export const App: FC<{ history: ScopedHistory }> = ({ history }) => {
     );
   }
 
+  // min-width: 0 is needed to ensure the source index and preview data grids do not
+  // overflow into the management page side nav when the page width is reduced
+  // see https://github.com/elastic/eui/issues/4941
   return (
     <EuiFlexGroup justifyContent="spaceAround" data-test-subj="transformApp">
-      <EuiFlexItem grow={true}>
+      <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
         <Router history={history}>
           <Switch>
             <Route

--- a/x-pack/plugins/transform/public/app/app.tsx
+++ b/x-pack/plugins/transform/public/app/app.tsx
@@ -10,7 +10,7 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { Router, Route, Switch } from 'react-router-dom';
 import { ScopedHistory } from 'kibana/public';
 
-import { EuiErrorBoundary, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiErrorBoundary } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -43,27 +43,20 @@ export const App: FC<{ history: ScopedHistory }> = ({ history }) => {
     );
   }
 
-  // min-width: 0 is needed to ensure the source index and preview data grids do not
-  // overflow into the management page side nav when the page width is reduced
-  // see https://github.com/elastic/eui/issues/4941
   return (
-    <EuiFlexGroup justifyContent="spaceAround" data-test-subj="transformApp">
-      <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
-        <Router history={history}>
-          <Switch>
-            <Route
-              path={`/${SECTION_SLUG.CLONE_TRANSFORM}/:transformId`}
-              component={CloneTransformSection}
-            />
-            <Route
-              path={`/${SECTION_SLUG.CREATE_TRANSFORM}/:savedObjectId`}
-              component={CreateTransformSection}
-            />
-            <Route path={`/`} component={TransformManagementSection} />
-          </Switch>
-        </Router>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <Router history={history}>
+      <Switch>
+        <Route
+          path={`/${SECTION_SLUG.CLONE_TRANSFORM}/:transformId`}
+          component={CloneTransformSection}
+        />
+        <Route
+          path={`/${SECTION_SLUG.CREATE_TRANSFORM}/:savedObjectId`}
+          component={CreateTransformSection}
+        />
+        <Route path={`/`} component={TransformManagementSection} />
+      </Switch>
+    </Router>
   );
 };
 

--- a/x-pack/plugins/transform/public/app/sections/clone_transform/clone_transform_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/clone_transform/clone_transform_section.tsx
@@ -131,10 +131,7 @@ export const CloneTransformSection: FC<Props> = ({ match, location }) => {
 
       <EuiSpacer size="l" />
 
-      <EuiPageContentBody
-        data-test-subj="transformPageCloneTransform"
-        className="transform__wizardBody"
-      >
+      <EuiPageContentBody data-test-subj="transformPageCloneTransform">
         {typeof errorMessage !== 'undefined' && (
           <>
             <EuiCallOut

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/_wizard.scss
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/_wizard.scss
@@ -8,11 +8,3 @@
   }
 }
 
-/*
-This ensures the wizard goes full page width, and that the data grid in the page does not
-cause the body of the wizard page to overflow into the side navigation of the Kibana
-Stack Management page on resize.
-*/
-.transform__wizardBody {
-  max-width: calc(100% - 16px);
-}

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/_wizard.scss
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/wizard/_wizard.scss
@@ -7,4 +7,3 @@
     padding-right: 0;
   }
 }
-

--- a/x-pack/plugins/transform/public/app/sections/create_transform/create_transform_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/create_transform_section.tsx
@@ -68,10 +68,7 @@ export const CreateTransformSection: FC<Props> = ({ match }) => {
 
       <EuiSpacer size="l" />
 
-      <EuiPageContentBody
-        data-test-subj="transformPageCreateTransform"
-        className="transform__wizardBody"
-      >
+      <EuiPageContentBody data-test-subj="transformPageCreateTransform">
         {searchItemsError !== undefined && (
           <>
             <EuiCallOut title={searchItemsError} color="danger" iconType="alert" />


### PR DESCRIPTION
## Summary

Follow-up to #104680, fixing the resize behavior of the data grid, as used for the source index and preview, so that it adjusts size smoothly when the page is increased in width.

Uses the approach suggested in https://github.com/elastic/eui/issues/4941#issuecomment-881705351, adding `min-width: 0` to the flex item containing the grid,

Before:
![grid_resize](https://user-images.githubusercontent.com/7405507/126163565-20d8f791-949b-4b57-9c71-80382bf593d3.gif)

After:
![grid_resize_after2](https://user-images.githubusercontent.com/7405507/126163592-2489239d-8766-46d9-bada-83b17151f32b.gif)


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
