### PR TITLE
[Fleet] Prevent monitoring values flickering on load

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_details/agent_details_overview.tsx
@@ -133,33 +133,37 @@ export const AgentDetailsOverviewSection: React.FunctionComponent<{
             title: i18n.translate('xpack.fleet.agentDetails.monitorLogsLabel', {
               defaultMessage: 'Monitor logs',
             }),
-            description: agentPolicy?.monitoring_enabled?.includes('logs') ? (
-              <FormattedMessage
-                id="xpack.fleet.agentList.monitorLogsEnabledText"
-                defaultMessage="True"
-              />
-            ) : (
-              <FormattedMessage
-                id="xpack.fleet.agentList.monitorLogsDisabledText"
-                defaultMessage="False"
-              />
-            ),
+            description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
+              agentPolicy?.monitoring_enabled?.includes('logs') ? (
+                <FormattedMessage
+                  id="xpack.fleet.agentList.monitorLogsEnabledText"
+                  defaultMessage="True"
+                />
+              ) : (
+                <FormattedMessage
+                  id="xpack.fleet.agentList.monitorLogsDisabledText"
+                  defaultMessage="False"
+                />
+              )
+            ) : null,
           },
           {
             title: i18n.translate('xpack.fleet.agentDetails.monitorMetricsLabel', {
               defaultMessage: 'Monitor metrics',
             }),
-            description: agentPolicy?.monitoring_enabled?.includes('metrics') ? (
-              <FormattedMessage
-                id="xpack.fleet.agentList.monitorMetricsEnabledText"
-                defaultMessage="True"
-              />
-            ) : (
-              <FormattedMessage
-                id="xpack.fleet.agentList.monitorMetricsDisabledText"
-                defaultMessage="False"
-              />
-            ),
+            description: Array.isArray(agentPolicy?.monitoring_enabled) ? (
+              agentPolicy?.monitoring_enabled?.includes('metrics') ? (
+                <FormattedMessage
+                  id="xpack.fleet.agentList.monitorMetricsEnabledText"
+                  defaultMessage="True"
+                />
+              ) : (
+                <FormattedMessage
+                  id="xpack.fleet.agentList.monitorMetricsDisabledText"
+                  defaultMessage="False"
+                />
+              )
+            ) : null,
           },
         ].map(({ title, description }) => {
           return (


### PR DESCRIPTION
## Summary

fixes #105927 

On first render of `AgentDetailsOverviewSection`, `agentPolicy` is `undefined`. 

This lead to the "Monitor Logs" and "Monitor Metrics" values to default to false, until the second render when `agentPolicy` is defined. 

I have opted to default to empty if agentPolicy is undefined the same way we do with the integrations pills.

While loading:

<img width="1016" alt="Screenshot 2021-07-19 at 14 29 25" src="https://user-images.githubusercontent.com/3315046/126167600-624e4218-a9dc-4da6-89a9-0c07789bbdab.png">


Once loaded:

<img width="1016" alt="Screenshot 2021-07-19 at 14 29 49" src="https://user-images.githubusercontent.com/3315046/126167637-1f43608c-3e68-4126-bf30-227470fce2a2.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
