### PR TITLE
[7.13] [DOCS] Removes coming tags from 7.13.4 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -60,8 +60,6 @@ Review important information about the {kib} 7.13.x releases.
 [[release-notes-7.13.4]]
 == {kib} 7.13.4
 
-coming::[7.13.4]
-
 For information about the {kib} 7.13.4 release, review the following information.
 
 [float]


### PR DESCRIPTION
Removes the coming tags from the 7.13.4 release notes.