### PR TITLE
[Synthetics] Fix mobile synthetics image clipping

### DIFF
--- a/x-pack/plugins/uptime/public/components/synthetics/step_screenshot_display.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/step_screenshot_display.tsx
@@ -16,7 +16,7 @@ import {
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import React, { useContext, useEffect, useRef, useState, FC } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState, FC } from 'react';
 import useIntersection from 'react-use/lib/useIntersection';
 import {
   isScreenshotRef as isAScreenshotRef,
@@ -36,7 +36,7 @@ interface StepScreenshotDisplayProps {
   lazyLoad?: boolean;
 }
 
-const IMAGE_MAX_WIDTH = 450;
+const IMAGE_MAX_WIDTH = 640;
 
 const StepImage = styled(EuiImage)`
   &&& {
@@ -136,9 +136,23 @@ export const StepScreenshotDisplay: FC<StepScreenshotDisplayProps> = ({
     }
   }, [basePath, checkGroup, stepIndex, isScreenshotRef]);
 
+  const refDimensions = useMemo(() => {
+    if (isAScreenshotRef(screenshotRef)) {
+      const { height, width } = screenshotRef.ref.screenshotRef.screenshot_ref;
+      return { height, width };
+    }
+  }, [screenshotRef]);
+
   const shouldRenderImage = hasIntersected || !lazyLoad;
   return (
-    <div ref={containerRef} style={{ backgroundColor: pageBackground, maxWidth: IMAGE_MAX_WIDTH }}>
+    <div
+      ref={containerRef}
+      style={{
+        backgroundColor: pageBackground,
+        maxWidth: Math.min(IMAGE_MAX_WIDTH, refDimensions?.width ?? Number.MAX_VALUE),
+        maxHeight: refDimensions?.height ?? undefined,
+      }}
+    >
       {shouldRenderImage && isScreenshotBlob && (
         <BaseStepImage stepName={stepName} stepIndex={stepIndex} url={url} />
       )}

--- a/x-pack/plugins/uptime/public/components/synthetics/step_screenshot_display.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/step_screenshot_display.tsx
@@ -36,16 +36,13 @@ interface StepScreenshotDisplayProps {
   lazyLoad?: boolean;
 }
 
-const IMAGE_WIDTH = 640;
-const IMAGE_HEIGHT = 360;
+const IMAGE_MAX_WIDTH = 450;
 
 const StepImage = styled(EuiImage)`
   &&& {
     figcaption {
       display: none;
     }
-    width: ${IMAGE_WIDTH},
-    height: ${IMAGE_HEIGHT},
     objectFit: 'cover',
     objectPosition: 'center top',
   }
@@ -141,10 +138,7 @@ export const StepScreenshotDisplay: FC<StepScreenshotDisplayProps> = ({
 
   const shouldRenderImage = hasIntersected || !lazyLoad;
   return (
-    <div
-      ref={containerRef}
-      style={{ backgroundColor: pageBackground, height: IMAGE_HEIGHT, width: IMAGE_WIDTH }}
-    >
+    <div ref={containerRef} style={{ backgroundColor: pageBackground, maxWidth: IMAGE_MAX_WIDTH }}>
       {shouldRenderImage && isScreenshotBlob && (
         <BaseStepImage stepName={stepName} stepIndex={stepIndex} url={url} />
       )}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/uptime/issues/339.

The default sizes we use for images are hardcoded. They work well for landscape-shaped images; portrait-shaped images like the ones produced by mobile emulation are getting clipped by the hardcoded value.

We can limit the width to a `max-size` and allow height to match. The plus side of this solution is it's very simple, and it works for both image sizes. The drawback is it will reduce the size of the image we show for desktop-style images, but it will not clip anything. Users will also still have the ability to expand the screenshot to see it in the full-screen viewer mode.

This is a minimum-viable fix. I am open to suggestions on how to make this better, especially if it means the existing experience won't change.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
