### PR TITLE
[7.x] [ML] Fix Index data visualizer sometimes shows wrong doc count for saved searches (#106007)

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
@@ -65,20 +65,16 @@ export const DataVisualizerUrlStateContextProvider: FC<DataVisualizerUrlStateCon
     const parsedQueryString = parse(prevSearchString, { sort: false });
 
     const getIndexPattern = async () => {
-      if (typeof parsedQueryString?.index === 'string') {
-        const indexPattern = await indexPatterns.get(parsedQueryString.index);
-        setCurrentIndexPattern(indexPattern);
-      }
-
       if (typeof parsedQueryString?.savedSearchId === 'string') {
         const savedSearchId = parsedQueryString.savedSearchId;
         try {
           const savedSearch = await savedObjectsClient.get('search', savedSearchId);
           const indexPatternId = savedSearch.references.find((ref) => ref.type === 'index-pattern')
             ?.id;
-          if (indexPatternId !== undefined) {
+          if (indexPatternId !== undefined && savedSearch) {
             try {
               const indexPattern = await indexPatterns.get(indexPatternId);
+              setCurrentSavedSearch(savedSearch);
               setCurrentIndexPattern(indexPattern);
             } catch (e) {
               toasts.addError(e, {
@@ -88,7 +84,6 @@ export const DataVisualizerUrlStateContextProvider: FC<DataVisualizerUrlStateCon
               });
             }
           }
-          setCurrentSavedSearch(savedSearch);
         } catch (e) {
           toasts.addError(e, {
             title: i18n.translate('xpack.dataVisualizer.index.savedSearchErrorMessage', {
@@ -97,6 +92,11 @@ export const DataVisualizerUrlStateContextProvider: FC<DataVisualizerUrlStateCon
             }),
           });
         }
+      }
+
+      if (typeof parsedQueryString?.index === 'string') {
+        const indexPattern = await indexPatterns.get(parsedQueryString.index);
+        setCurrentIndexPattern(indexPattern);
       }
     };
     getIndexPattern();

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -496,8 +496,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/105087
-  describe.skip('index based', function () {
+  describe('index based', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Fix Index data visualizer sometimes shows wrong doc count for saved searches (#106007)