### PR TITLE
[7.14] Remove beta admonitions for Fleet docs (#106010)

### DIFF
--- a/docs/fleet/fleet.asciidoc
+++ b/docs/fleet/fleet.asciidoc
@@ -3,8 +3,6 @@
 [[fleet]]
 = {fleet}
 
-beta[]
-
 {fleet} in {kib} enables you to add and manage integrations for popular
 services and platforms, as well as manage {elastic-agent} installations in
 standalone or {fleet} mode.

--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>{fleet} settings</titleabbrev>
 ++++
 
-experimental[]
-
 You can configure `xpack.fleet` settings in your `kibana.yml`. 
 By default, {fleet} is enabled. To use {fleet}, you also need to configure {kib} and {es} hosts.
 

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -27,7 +27,7 @@ image::images/add-data-tutorials.png[Add Data tutorials]
 [discrete]
 === Add Elastic Agent
 
-beta[] *Elastic Agent* is a sneak peek at the next generation of
+*Elastic Agent* is the next generation of
 data integration modules, offering
 a centralized way to set up your integrations.
 With *Fleet*, you can add


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Remove beta admonitions for Fleet docs (#106010)