### PR TITLE
[Enterprise Search] Fix Users copy to account for built-in users

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -318,7 +318,7 @@ export const USERS_HEADING_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.roleMapping.usersHeadingDescription',
   {
     defaultMessage:
-      'User management provides granular access for individual or special permission needs. Users from federated sources such as SAML are managed by role mappings, and excluded from this list.',
+      'User management provides granular access for individual or special permission needs. Some users may be excluded from this list. These include users from federated sources such as SAML, which are managed by role mappings, and built-in user accounts such as the “elastic” or “enterprise_search” users.',
   }
 );
 


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1888

## Summary

Currently, there is a case where a new user sees 2 users when they first log into Enterprise Search (or Kibana) and have not created any users. There is no way for a user to see what these are, as the users are hidden from the list. This PR fixes the copy to account for that. 

![2021-07-19_15-25-30 (2)](https://user-images.githubusercontent.com/1869731/126228675-0bd4ced8-53ed-49a5-a945-f00d2f8bac38.gif)

**Before**
![image](https://user-images.githubusercontent.com/1869731/126228666-908662dd-f972-4865-8c41-b765a0ef4fc6.png)

**After**
![image](https://user-images.githubusercontent.com/1869731/126228315-95684745-87f0-460f-82f8-e1580bc4b299.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
