### PR TITLE
[7.x] [Metrics UI] Inventory layout issues - interval language to tooltip (#105687)

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/filter_bar.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/filter_bar.tsx
@@ -12,12 +12,7 @@ import { WaffleTimeControls } from './waffle/waffle_time_controls';
 import { SearchBar } from './search_bar';
 
 export const FilterBar = () => (
-  <EuiFlexGroup
-    alignItems="center"
-    justifyContent="spaceBetween"
-    gutterSize="m"
-    style={{ flexGrow: 0 }}
-  >
+  <EuiFlexGroup justifyContent="spaceBetween" gutterSize="m" style={{ flexGrow: 0 }}>
     <EuiFlexItem>
       <SearchBar />
     </EuiFlexItem>

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
@@ -152,7 +152,7 @@ export const Layout = React.memo(
                           gutterSize="m"
                         >
                           <Toolbar nodeType={nodeType} currentTime={currentTime} />
-                          <EuiFlexItem grow={false}>
+                          <EuiFlexItem grow={false} className="eui-hideFor--s eui-hideFor--xs">
                             <IntervalLabel intervalAsString={intervalAsString} />
                           </EuiFlexItem>
                           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/interval_label.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/interval_label.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiText } from '@elastic/eui';
+import { EuiIconTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 interface Props {
@@ -19,14 +19,16 @@ export const IntervalLabel = ({ intervalAsString }: Props) => {
   }
 
   return (
-    <EuiText color="subdued" size="s">
-      <p>
+    <EuiIconTip
+      size="m"
+      type="clock"
+      content={
         <FormattedMessage
           id="xpack.infra.homePage.toolbar.showingLastOneMinuteDataText"
           defaultMessage="Last {duration} of data for the selected time"
           values={{ duration: intervalAsString }}
         />
-      </p>
-    </EuiText>
+      }
+    />
   );
 };

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_time_controls.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_time_controls.tsx
@@ -53,7 +53,7 @@ export const WaffleTimeControls = withTheme(({ theme }: Props) => {
   );
 
   return (
-    <EuiFlexGroup alignItems="center" gutterSize="m">
+    <EuiFlexGroup gutterSize="m">
       <EuiFlexItem grow={false} data-test-subj="waffleDatePicker">
         <EuiDatePicker
           dateFormat="L LTS"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Inventory layout issues - interval language to tooltip (#105687)