### PR TITLE
[kbn/optimizer] store references to bazel target for all package files

### DIFF
--- a/packages/kbn-optimizer/src/__fixtures__/mock_repo/packages/kbn-ui-shared-deps/src/public_path_module_creator.ts
+++ b/packages/kbn-optimizer/src/__fixtures__/mock_repo/packages/kbn-ui-shared-deps/src/public_path_module_creator.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
-// stub

--- a/packages/kbn-optimizer/src/integration_tests/basic_optimization.test.ts
+++ b/packages/kbn-optimizer/src/integration_tests/basic_optimization.test.ts
@@ -15,7 +15,7 @@ import cpy from 'cpy';
 import del from 'del';
 import { tap, filter } from 'rxjs/operators';
 import { REPO_ROOT } from '@kbn/utils';
-import { ToolingLog } from '@kbn/dev-utils';
+import { ToolingLog, createReplaceSerializer } from '@kbn/dev-utils';
 import { runOptimizer, OptimizerConfig, OptimizerUpdate, logOptimizerState } from '../index';
 
 import { allValuesFrom } from '../common';
@@ -28,6 +28,8 @@ expect.addSnapshotSerializer({
   serialize: (value: string) => value.split(REPO_ROOT).join('<absolute path>').replace(/\\/g, '/'),
   test: (value: any) => typeof value === 'string' && value.includes(REPO_ROOT),
 });
+
+expect.addSnapshotSerializer(createReplaceSerializer(/\w+-fastbuild/, '<platform>-fastbuild'));
 
 const log = new ToolingLog({
   level: 'error',
@@ -130,7 +132,7 @@ it('builds expected bundles, saves bundle counts to metadata', async () => {
   expect(foo.cache.getModuleCount()).toBe(6);
   expect(foo.cache.getReferencedFiles()).toMatchInlineSnapshot(`
     Array [
-      <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/packages/kbn-ui-shared-deps/src/public_path_module_creator.ts,
+      <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/bazel-out/<platform>-fastbuild/bin/packages/kbn-ui-shared-deps/target/public_path_module_creator.js,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/foo/kibana.json,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/foo/public/async_import.ts,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/foo/public/ext.ts,
@@ -153,7 +155,7 @@ it('builds expected bundles, saves bundle counts to metadata', async () => {
       <absolute path>/node_modules/@kbn/optimizer/postcss.config.js,
       <absolute path>/node_modules/css-loader/package.json,
       <absolute path>/node_modules/style-loader/package.json,
-      <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/packages/kbn-ui-shared-deps/src/public_path_module_creator.ts,
+      <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/bazel-out/<platform>-fastbuild/bin/packages/kbn-ui-shared-deps/target/public_path_module_creator.js,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/bar/kibana.json,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/bar/public/index.scss,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/plugins/bar/public/index.ts,
@@ -173,7 +175,7 @@ it('builds expected bundles, saves bundle counts to metadata', async () => {
 
   expect(baz.cache.getReferencedFiles()).toMatchInlineSnapshot(`
     Array [
-      <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/packages/kbn-ui-shared-deps/src/public_path_module_creator.ts,
+      <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/bazel-out/<platform>-fastbuild/bin/packages/kbn-ui-shared-deps/target/public_path_module_creator.js,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/x-pack/baz/kibana.json,
       <absolute path>/packages/kbn-optimizer/src/__fixtures__/__tmp__/mock_repo/x-pack/baz/public/index.ts,
       <absolute path>/packages/kbn-optimizer/src/worker/entry_point_creator.ts,

--- a/packages/kbn-optimizer/src/optimizer/watcher.ts
+++ b/packages/kbn-optimizer/src/optimizer/watcher.ts
@@ -38,7 +38,6 @@ export class Watcher {
 
   private readonly watchpack = new Watchpack({
     aggregateTimeout: 0,
-    ignored: /node_modules\/([^\/]+[\/])*(?!package.json)([^\/]+)$/,
   });
 
   private readonly change$ = Rx.fromEvent<[string]>(this.watchpack, 'change').pipe(share());

--- a/src/dev/precommit_hook/casing_check_config.js
+++ b/src/dev/precommit_hook/casing_check_config.js
@@ -78,11 +78,7 @@ export const IGNORE_FILE_GLOBS = [
  *
  * @type {Array}
  */
-export const KEBAB_CASE_DIRECTORY_GLOBS = [
-  'packages/*',
-  'x-pack',
-  'packages/kbn-optimizer/src/__fixtures__/mock_repo/packages/kbn-ui-shared-deps',
-];
+export const KEBAB_CASE_DIRECTORY_GLOBS = ['packages/*', 'x-pack'];
 
 /**
  * These patterns are matched against directories and indicate


### PR DESCRIPTION
Reverts part of https://github.com/elastic/kibana/pull/105154 because we can't rely on the target file matching the source file, so we need to maintain a reference to the target file and instead put in work to rebuild the target files less often, which we've got plans to start working on soon.

Additionally, this fixes a bug caused by the movement of package files into the `node_modules` directory and the use of `--preserve-symlinks` which leads to the outputs of packages being treated the same as node modules from NPM, where all references are flattened to a reference to the `package.json`. This obviously doesn't work for packages as the `package.json` file is rarely updated. To fix this we're calling `realpath` on the relevant `package.json` file and seeing if it's actually found in a `bazel-out/*-fastbuild/bin/packages` dir. If the package.json file is within a matching directory then we maintain a reference to the actual file rather than replacing it with a reference to the package.json file.

This ensures that the `@kbn/optimizer` watches the bazel build output of each file included in the bundle and rebuilds the bundle as necessary.

To validate that this works:
 1. checkout the pr
 2. run `yarn kbn watch-bazel`, wait all builds are complete
 3. run `node scripts/build_kibana_platform_plugins` to ensure that all bundles are cached
 4. validate that `src/plugins/expressions/target/public/.kbn-optimizer-cache` includes many references to `node_modules/@kbn/tinymath/src/functions`, indicating that we're caching refs to the actual files in the packages. Other node modules should still be referencing the package.json, like `node_modules/fast-shallow-equal/package.json`
 5. run `node scripts/build_kibana_platform_plugins --watch`, all bundles should be cached
 6. modify something in `packages/kbn-tinymath/src/functions/clamp.js` and you should see bazel kick off a build, and once it's done you should see the optimizer start 3 workers to build bundles referencing the `@kbn/tinymath` package. 