### PR TITLE
[7.x] [CTI] removes inspect button (#105988)

### DIFF
--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_disabled_module.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/cti_disabled_module.tsx
@@ -36,7 +36,12 @@ export const CtiDisabledModuleComponent = () => {
   );
 
   return (
-    <ThreatIntelPanelView totalEventCount={0} splitPanel={danger} listItems={EMPTY_LIST_ITEMS} />
+    <ThreatIntelPanelView
+      totalEventCount={0}
+      splitPanel={danger}
+      listItems={EMPTY_LIST_ITEMS}
+      isInspectEnabled={false}
+    />
   );
 };
 

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.test.tsx
@@ -144,4 +144,32 @@ describe('ThreatIntelPanelView', () => {
       `Showing: ${mockThreatIntelPanelViewProps.totalEventCount} events`
     );
   });
+
+  it('renders inspect button by default', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider theme={mockTheme}>
+            <ThreatIntelPanelView {...mockThreatIntelPanelViewProps} />
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
+    );
+
+    expect(wrapper.exists('[data-test-subj="inspect-icon-button"]')).toBe(true);
+  });
+
+  it('does not render inspect button if isInspectEnabled is false', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <I18nProvider>
+          <ThemeProvider theme={mockTheme}>
+            <ThreatIntelPanelView {...mockThreatIntelPanelViewProps} isInspectEnabled={false} />
+          </ThemeProvider>
+        </I18nProvider>
+      </Provider>
+    );
+
+    expect(wrapper.exists('[data-test-subj="inspect-icon-button"]')).toBe(false);
+  });
 });

--- a/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/overview_cti_links/threat_intel_panel_view.tsx
@@ -56,6 +56,7 @@ const RightSideLink = styled(EuiLink)`
 interface ThreatIntelPanelViewProps {
   buttonHref?: string;
   isDashboardPluginDisabled?: boolean;
+  isInspectEnabled?: boolean;
   listItems: CtiListItem[];
   splitPanel?: JSX.Element;
   totalEventCount: number;
@@ -78,6 +79,7 @@ const panelTitle = (
 export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
   buttonHref = '',
   isDashboardPluginDisabled,
+  isInspectEnabled = true,
   listItems,
   splitPanel,
   totalEventCount,
@@ -134,7 +136,11 @@ export const ThreatIntelPanelView: React.FC<ThreatIntelPanelViewProps> = ({
         <EuiFlexItem grow={1}>
           <InspectButtonContainer>
             <EuiPanel hasBorder>
-              <HeaderSection id={CTIEventCountQueryId} subtitle={subtitle} title={panelTitle}>
+              <HeaderSection
+                id={isInspectEnabled ? CTIEventCountQueryId : undefined}
+                subtitle={subtitle}
+                title={panelTitle}
+              >
                 <>{button}</>
               </HeaderSection>
               {splitPanel}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CTI] removes inspect button (#105988)