### PR TITLE
[Security Solution][Detection Rules] Fixes import rules modal text

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -17,7 +17,7 @@ export const BACK_TO_DETECTIONS = i18n.translate(
 export const IMPORT_RULE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.importRuleTitle',
   {
-    defaultMessage: 'Import rule',
+    defaultMessage: 'Import rules',
   }
 );
 
@@ -532,7 +532,7 @@ export const IMPORT_RULE_BTN_TITLE = i18n.translate(
 export const SELECT_RULE = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.importRuleModal.selectRuleDescription',
   {
-    defaultMessage: 'Select a Security rule (as exported from the Detection Engine view) to import',
+    defaultMessage: 'Select Security rules (as exported from the Detection Engine view) to import',
   }
 );
 
@@ -546,7 +546,7 @@ export const INITIAL_PROMPT_TEXT = i18n.translate(
 export const OVERWRITE_WITH_SAME_NAME = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.importRuleModal.overwriteDescription',
   {
-    defaultMessage: 'Automatically overwrite saved objects with the same rule ID',
+    defaultMessage: 'Overwrite existing Rules with conflicting Rule ID',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -532,7 +532,7 @@ export const IMPORT_RULE_BTN_TITLE = i18n.translate(
 export const SELECT_RULE = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.importRuleModal.selectRuleDescription',
   {
-    defaultMessage: 'Select Security rules (as exported from the Detection Engine view) to import',
+    defaultMessage: 'Select Security rules (as exported from the Detection Rules page) to import',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -546,7 +546,7 @@ export const INITIAL_PROMPT_TEXT = i18n.translate(
 export const OVERWRITE_WITH_SAME_NAME = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.importRuleModal.overwriteDescription',
   {
-    defaultMessage: 'Overwrite existing Rules with conflicting Rule ID',
+    defaultMessage: 'Overwrite existing detection rules with conflicting Rule ID',
   }
 );
 


### PR DESCRIPTION
## Summary

Addresses #104376

Changes the text in the import rule modal to be plural

#### Screenshots 
![Screen Shot 2021-07-19 at 5 32 00 PM](https://user-images.githubusercontent.com/56367316/126240567-9601bce3-67b5-44be-b2fe-75da8715b7dd.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
