### PR TITLE
[APM] fix correlation chart tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@elastic/apm-rum": "^5.8.0",
     "@elastic/apm-rum-react": "^1.2.11",
-    "@elastic/charts": "32.0.0",
+    "@elastic/charts": "32.0.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@7.14.0-canary.6",
     "@elastic/ems-client": "7.14.0",

--- a/x-pack/plugins/apm/public/components/app/correlations/correlations_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/correlations_chart.tsx
@@ -190,6 +190,7 @@ export function CorrelationsChart({
           yAccessors={['doc_count']}
           color={euiTheme.eui.euiColorVis1}
           fit="lookahead"
+          tickFormat={(d) => d}
         />
         {Array.isArray(histogram) &&
           field !== undefined &&
@@ -212,6 +213,7 @@ export function CorrelationsChart({
               xAccessor="key"
               yAccessors={['doc_count']}
               color={euiTheme.eui.euiColorVis2}
+              tickFormat={(d) => d}
             />
           )}
       </Chart>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@32.0.0":
-  version "32.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-32.0.0.tgz#f747b8fa931027ba7476a6284be03383cd6a6dab"
-  integrity sha512-3cvX0Clezocd6/T2R5h3+nilPdIgWrO+it043giyW5U0pAtFC5P+5VyNEjn22LlD3zzbndxAbXHSj0QDvHXOBw==
+"@elastic/charts@32.0.1":
+  version "32.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-32.0.1.tgz#cad81c83ab55b418d42fdbfdf500304f0cda7fd8"
+  integrity sha512-ov7Fu0nn2sBiZRU7bxKtHfN7B8Ppqh1zAORzb5+5ep23xXWv4voDzSGx/kW9n5In5RK9OVplRUQGstjJ4to8zA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

The APM correlation chart uses a logarithmic x scale. [The bug was fixed and solved](https://github.com/elastic/elastic-charts/pull/1258) in `@elastic/charts` and released in version 32.0.1, updated in this PR.

It was a one-line change in elastic-charts (plus test/example)

~@walterra Do you want to fix also the missing Y value on the tooltip in this PR? as described in chat it depends on the `formatter` used on the Y axis here~
https://github.com/elastic/kibana/blob/1f5be1e1e1b677b6014b635085313e098153fd4f/x-pack/plugins/apm/public/components/app/correlations/correlations_chart.tsx#L185-L187

~I'm not sure about the proposed logic there and why you want to hide every non-integer values. Probably is better to truncate the value to the integral part only~

I've also fixed the missing tooltip value, the mentioned `tickFormat` function was used to show a nice set of Y axis ticks.
I've added the `tickFormat` to the series to overwrite the axis one. 

**Note**
For 7.x and 8.x a different elastic-chart version will be released containing this fix. 

https://user-images.githubusercontent.com/1421091/126301778-16533145-791b-478b-b97c-388cda493612.mp4

