### PR TITLE
[bug] don't convert KbnServerErrors again

### DIFF
--- a/src/plugins/data/server/autocomplete/value_suggestions_route.ts
+++ b/src/plugins/data/server/autocomplete/value_suggestions_route.ts
@@ -11,7 +11,7 @@ import { IRouter } from 'kibana/server';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { getRequestAbortedSignal } from '../lib';
-import { getKbnServerError } from '../../../kibana_utils/server';
+import { getKbnServerError, reportServerError } from '../../../kibana_utils/server';
 import type { ConfigSchema } from '../../config';
 import { termsEnumSuggestions } from './terms_enum';
 import { termsAggSuggestions } from './terms_agg';
@@ -65,7 +65,8 @@ export function registerValueSuggestionsRoute(router: IRouter, config$: Observab
         );
         return response.ok({ body });
       } catch (e) {
-        throw getKbnServerError(e);
+        const kbnErr = getKbnServerError(e);
+        return reportServerError(response, kbnErr);
       }
     }
   );

--- a/src/plugins/kibana_utils/server/report_server_error.ts
+++ b/src/plugins/kibana_utils/server/report_server_error.ts
@@ -24,6 +24,7 @@ export class KbnServerError extends KbnError {
  * @returns `KbnServerError`
  */
 export function getKbnServerError(e: Error) {
+  if (e instanceof KbnServerError) return e;
   return new KbnServerError(
     e.message ?? 'Unknown error',
     e instanceof ResponseError ? e.statusCode : 500,

--- a/test/api_integration/apis/suggestions/suggestions.js
+++ b/test/api_integration/apis/suggestions/suggestions.js
@@ -44,5 +44,14 @@ export default function ({ getService }) {
           query: 'nes',
         })
         .expect(200, ['nestedValue']));
+
+    it('should return 404 if index is not found', () =>
+      supertest
+        .post('/api/kibana/suggestions/values/not_found')
+        .send({
+          field: 'baz.keyword',
+          query: '1',
+        })
+        .expect(404));
   });
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/104974

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
