### PR TITLE
[Lens] Improve network error message

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/error_helper.test.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/error_helper.test.ts
@@ -141,6 +141,17 @@ const scriptedFieldError = {
   },
 };
 
+const networkError = {
+  stack: 'Error: Batch request failed with status 0',
+  message: '[lens_merge_tables] > [esaggs] > Batch request failed with status 0',
+  name: 'Error',
+  original: {
+    name: 'Error',
+    message: 'Batch request failed with status 0',
+    stack: 'Error: Batch request failed with status 0',
+  },
+};
+
 // EsAggs will report an internal error when user attempts to use a runtime field on an indexpattern he has no access to
 const indexpatternAccessError = {
   stack: "TypeError: Cannot read property 'values' of undefined\n",
@@ -173,6 +184,12 @@ describe('lens_error_helpers', () => {
     it('should report the original es aggs error for runtime fields for indexpattern not accessible', () => {
       expect(getOriginalRequestErrorMessages(indexpatternAccessError as Error)).toEqual([
         indexpatternAccessError.message,
+      ]);
+    });
+
+    it("should report a network custom message when there's a network/connection problem", () => {
+      expect(getOriginalRequestErrorMessages(networkError as Error)).toEqual([
+        'Network error, try again later or contact your administrator.',
       ]);
     });
   });


### PR DESCRIPTION
## Summary

Fixes #105987 

Network errors have a specific message with specific status code.
This PR detects the specific message and shows to the user a more friendly explanation of the problem.

<img width="764" alt="Screenshot 2021-07-20 at 15 16 17" src="https://user-images.githubusercontent.com/924948/126331858-d1263e60-30fe-4063-8429-f229d5eba957.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
