### PR TITLE
[Search session][Discover] Clear refresh interval when restoring search session

### DIFF
--- a/src/plugins/discover/public/application/apps/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/apps/main/services/discover_state.test.ts
@@ -202,5 +202,16 @@ describe('createSearchSessionRestorationDataProvider', () => {
       expect(initialState.timeRange).toBe(relativeTime);
       expect(restoreState.timeRange).toBe(absoluteTime);
     });
+
+    test('restoreState clears refreshInterval', async () => {
+      const { initialState, restoreState } = await searchSessionInfoProvider.getUrlGeneratorData();
+      expect(initialState.refreshInterval).toBeUndefined();
+      expect(restoreState.refreshInterval).toMatchInlineSnapshot(`
+        Object {
+          "pause": true,
+          "value": 0,
+        }
+      `);
+    });
   });
 });

--- a/src/plugins/discover/public/application/apps/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/apps/main/services/discover_state.ts
@@ -393,5 +393,11 @@ function createUrlGeneratorState({
     savedQuery: appState.savedQuery,
     interval: appState.interval,
     useHash: false,
+    refreshInterval: shouldRestoreSearchSession
+      ? {
+          pause: true, // force pause refresh interval when restoring a session
+          value: 0,
+        }
+      : undefined,
   };
 }


### PR DESCRIPTION
## Summary

Per title

Closes https://github.com/elastic/kibana/issues/104449

### Screenshot after restoring a search session

<img width="1029" alt="Screenshot 2021-07-20 at 15 27 39" src="https://user-images.githubusercontent.com/8155004/126333312-4989725e-831a-4b2e-ac12-cc1096ed8cf0.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios