### PR TITLE
[7.x] Update dependency @elastic/charts to v33 (master) (#105633)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@elastic/apm-rum": "^5.8.0",
     "@elastic/apm-rum-react": "^1.2.11",
-    "@elastic/charts": "32.0.0",
+    "@elastic/charts": "33.0.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@7.14.0-canary.6",
     "@elastic/ems-client": "7.14.0",

--- a/src/plugins/vis_type_xy/public/utils/render_all_series.tsx
+++ b/src/plugins/vis_type_xy/public/utils/render_all_series.tsx
@@ -18,6 +18,7 @@ import {
   Accessor,
   AccessorFn,
   ColorVariant,
+  LabelOverflowConstraint,
 } from '@elastic/charts';
 
 import { DatatableRow } from '../../../expressions/public';
@@ -130,7 +131,7 @@ export const renderAllSeries = (
               minBarHeight={2}
               displayValueSettings={{
                 showValueLabel,
-                hideClippedValue: true,
+                overflowConstraints: [LabelOverflowConstraint.ChartEdges],
               }}
             />
           );
@@ -161,7 +162,7 @@ export const renderAllSeries = (
               stackAccessors={isStacked ? ['__any_value__'] : undefined}
               displayValueSettings={{
                 showValueLabel,
-                hideClippedValue: true,
+                overflowConstraints: [LabelOverflowConstraint.ChartEdges],
               }}
               timeZone={timeZone}
               stackMode={stackMode}

--- a/x-pack/plugins/lens/public/xy_visualization/__snapshots__/expression.test.tsx.snap
+++ b/x-pack/plugins/lens/public/xy_visualization/__snapshots__/expression.test.tsx.snap
@@ -335,9 +335,11 @@ exports[`xy_expression XYChart component it renders bar 1`] = `
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -399,9 +401,11 @@ exports[`xy_expression XYChart component it renders bar 1`] = `
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -558,9 +562,11 @@ exports[`xy_expression XYChart component it renders horizontal bar 1`] = `
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -622,9 +628,11 @@ exports[`xy_expression XYChart component it renders horizontal bar 1`] = `
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -1219,9 +1227,11 @@ exports[`xy_expression XYChart component it renders stacked bar 1`] = `
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -1287,9 +1297,11 @@ exports[`xy_expression XYChart component it renders stacked bar 1`] = `
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -1450,9 +1462,11 @@ exports[`xy_expression XYChart component it renders stacked horizontal bar 1`] =
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }
@@ -1518,9 +1532,11 @@ exports[`xy_expression XYChart component it renders stacked horizontal bar 1`] =
     }
     displayValueSettings={
       Object {
-        "hideClippedValue": true,
         "isAlternatingValueLabel": false,
         "isValueContainedInElement": true,
+        "overflowConstraints": Array [
+          "chartEdges",
+        ],
         "showValueLabel": false,
         "valueFormatter": [Function],
       }

--- a/x-pack/plugins/lens/public/xy_visualization/expression.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/expression.tsx
@@ -25,6 +25,7 @@ import {
   ElementClickListener,
   BrushEndListener,
   CurveType,
+  LabelOverflowConstraint,
 } from '@elastic/charts';
 import { I18nProvider } from '@kbn/i18n/react';
 import {
@@ -909,7 +910,7 @@ export function XYChart({
                   showValueLabel: shouldShowValueLabels && valueLabels !== 'hide',
                   isAlternatingValueLabel: false,
                   isValueContainedInElement: true,
-                  hideClippedValue: true,
+                  overflowConstraints: [LabelOverflowConstraint.ChartEdges],
                 },
               };
               return <BarSeries key={index} {...seriesProps} {...valueLabelsSettings} />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,10 +1389,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@32.0.0":
-  version "32.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-32.0.0.tgz#f747b8fa931027ba7476a6284be03383cd6a6dab"
-  integrity sha512-3cvX0Clezocd6/T2R5h3+nilPdIgWrO+it043giyW5U0pAtFC5P+5VyNEjn22LlD3zzbndxAbXHSj0QDvHXOBw==
+"@elastic/charts@33.0.0":
+  version "33.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-33.0.0.tgz#45428b792300e363ecd3454465be49d42788a1fd"
+  integrity sha512-HUt0oBaO/PSRZcYHmdLL1lzFWMBtP/9umGIAQgW785qv+y/Hv2cjjfYNckGfnr5RUDtx0KCc3v2UBkRq6n93EA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update dependency @elastic/charts to v33 (master) (#105633)