### PR TITLE
[7.14] [TSVB] fix No longer possible to define intervals like >=1m or >=12h (#105954)

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/index_pattern.js
@@ -323,7 +323,7 @@ export const IndexPattern = ({
                     content={
                       <FormattedMessage
                         id="visTypeTimeseries.indexPattern.detailLevelHelpText"
-                        defaultMessage="Controls the auto interval based on the time range. The default interval is affected by the advanced settings {histogramTargetBars} and {histogramMaxBars}."
+                        defaultMessage="Controls the auto and gte intervals based on the time range. The default interval is affected by the advanced settings {histogramTargetBars} and {histogramMaxBars}."
                         values={{
                           histogramTargetBars: UI_SETTINGS.HISTOGRAM_MAX_BARS,
                           histogramMaxBars: UI_SETTINGS.HISTOGRAM_BAR_TARGET,
@@ -352,7 +352,7 @@ export const IndexPattern = ({
                     disabled={
                       disabled ||
                       isEntireTimeRangeActive(model, isTimeSeries) ||
-                      !(model[intervalName] === AUTO_INTERVAL || !model[intervalName])
+                      !(isAutoInterval(model[intervalName]) || isGteInterval(model[intervalName]))
                     }
                     min={0}
                     max={maxBarsUiSettings}

--- a/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_bucket_size.test.js
+++ b/src/plugins/vis_type_timeseries/server/lib/vis_data/helpers/get_bucket_size.test.js
@@ -13,7 +13,7 @@ describe('getBucketSize', () => {
     body: {
       timerange: {
         min: '2017-01-01T00:00:00.000Z',
-        max: '2017-01-01T01:00:00.000Z',
+        max: '2017-07-01T01:00:00.000Z',
       },
     },
   };
@@ -26,9 +26,10 @@ describe('getBucketSize', () => {
 
   test('returns auto calculated buckets', () => {
     const result = getBucketSize(req, 'auto', capabilities, 100);
+    const expectedValue = 86400; // 24h
 
-    expect(result).toHaveProperty('bucketSize', 30);
-    expect(result).toHaveProperty('intervalString', '30s');
+    expect(result).toHaveProperty('bucketSize', expectedValue);
+    expect(result).toHaveProperty('intervalString', `${expectedValue}s`);
   });
 
   test('returns overridden buckets (1s)', () => {
@@ -53,16 +54,23 @@ describe('getBucketSize', () => {
   });
 
   test('returns overridden buckets (>=2d)', () => {
-    const result = getBucketSize(req, '>=2d', capabilities, 100);
+    const result = getBucketSize(req, '>=2d', capabilities, 1000);
 
     expect(result).toHaveProperty('bucketSize', 86400 * 2);
     expect(result).toHaveProperty('intervalString', '2d');
   });
 
-  test('returns overridden buckets (>=10s)', () => {
-    const result = getBucketSize(req, '>=10s', capabilities, 100);
+  test('returns overridden buckets (>=5d)', () => {
+    const result = getBucketSize(req, '>=5d', capabilities, 100);
 
-    expect(result).toHaveProperty('bucketSize', 30);
-    expect(result).toHaveProperty('intervalString', '30s');
+    expect(result).toHaveProperty('bucketSize', 432000);
+    expect(result).toHaveProperty('intervalString', '5d');
+  });
+
+  test('returns overridden buckets for 1 bar and >=1d interval', () => {
+    const result = getBucketSize(req, '>=1d', capabilities, 1);
+
+    expect(result).toHaveProperty('bucketSize', 2592000);
+    expect(result).toHaveProperty('intervalString', '2592000s');
   });
 });

--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -162,6 +162,39 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
+    describe('switch panel interval test', () => {
+      beforeEach(async () => {
+        await PageObjects.visualBuilder.resetPage();
+        await PageObjects.visualBuilder.clickMetric();
+        await PageObjects.visualBuilder.checkMetricTabIsPresent();
+        await PageObjects.visualBuilder.clickPanelOptions('metric');
+        await PageObjects.visualBuilder.setMetricsDataTimerangeMode('Last value');
+        await PageObjects.visualBuilder.setDropLastBucket(true);
+        await PageObjects.timePicker.setAbsoluteRange(
+          'Sep 19, 2015 @ 06:31:44.000',
+          'Sep 22, 2015 @ 18:31:44.000'
+        );
+      });
+
+      it('should be able to switch to gte interval (>=2d)', async () => {
+        await PageObjects.visualBuilder.setIntervalValue('>=2d');
+        const newValue = await PageObjects.visualBuilder.getMetricValue();
+        expect(newValue).to.eql('9,371');
+      });
+
+      it('should be able to switch to fixed interval (1d)', async () => {
+        await PageObjects.visualBuilder.setIntervalValue('1d');
+        const newValue = await PageObjects.visualBuilder.getMetricValue();
+        expect(newValue).to.eql('4,614');
+      });
+
+      it('should be able to switch to auto interval', async () => {
+        await PageObjects.visualBuilder.setIntervalValue('auto');
+        const newValue = await PageObjects.visualBuilder.getMetricValue();
+        expect(newValue).to.eql('156');
+      });
+    });
+
     describe('browser history changes', () => {
       it('should activate previous/next chart tab and panel config', async () => {
         await PageObjects.visualBuilder.resetPage();

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4449,7 +4449,6 @@
     "visTypeTimeseries.iconSelect.tagLabel": "タグ",
     "visTypeTimeseries.indexPattern.detailLevel": "詳細レベル",
     "visTypeTimeseries.indexPattern.detailLevelAriaLabel": "詳細レベル",
-    "visTypeTimeseries.indexPattern.detailLevelHelpText": "時間範囲に基づき自動間隔を制御します。デフォルトの間隔は詳細設定の{histogramTargetBars}と{histogramMaxBars}の影響を受けます。",
     "visTypeTimeseries.indexPattern.dropLastBucketLabel": "最後のバケットをドロップしますか？",
     "visTypeTimeseries.indexPattern.finest": "最も細かい",
     "visTypeTimeseries.indexPattern.intervalHelpText": "例：auto、1m、1d、7d、1y、>=1m",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4475,7 +4475,6 @@
     "visTypeTimeseries.iconSelect.tagLabel": "标签",
     "visTypeTimeseries.indexPattern.detailLevel": "详细程度",
     "visTypeTimeseries.indexPattern.detailLevelAriaLabel": "详细程度",
-    "visTypeTimeseries.indexPattern.detailLevelHelpText": "根据时间范围控制自动时间间隔。默认时间间隔受高级设置 {histogramTargetBars} 和 {histogramMaxBars} 影响。",
     "visTypeTimeseries.indexPattern.dropLastBucketLabel": "丢弃上一存储桶？",
     "visTypeTimeseries.indexPattern.finest": "最精细",
     "visTypeTimeseries.indexPattern.intervalHelpText": "示例：auto、1m、1d、7d、1y、>=1m",


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [TSVB] fix No longer possible to define intervals like >=1m or >=12h (#105954)