### PR TITLE
[7.x] [Canvas] String ui argument refactor. (#105742)

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/uis/arguments/string.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/uis/arguments/string.js
@@ -5,55 +5,48 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { compose, withProps } from 'recompose';
 import { EuiFlexItem, EuiFlexGroup, EuiFieldText, EuiButton } from '@elastic/eui';
-import { get } from 'lodash';
-import { createStatefulPropHoc } from '../../../public/components/enhance/stateful_prop';
 import { templateFromReactComponent } from '../../../public/lib/template_from_react_component';
 import { ArgumentStrings } from '../../../i18n';
 
 const { String: strings } = ArgumentStrings;
 
-const StringArgInput = ({ updateValue, value, confirm, commit, argId }) => (
-  <EuiFlexGroup gutterSize="s">
-    <EuiFlexItem>
-      <EuiFieldText
-        compressed
-        id={argId}
-        value={value}
-        onChange={confirm ? updateValue : (ev) => commit(ev.target.value)}
-      />
-    </EuiFlexItem>
-    {confirm && (
-      <EuiFlexItem grow={false} className="canvasSidebar__panel-noMinWidth">
-        <EuiButton size="s" onClick={() => commit(value)}>
-          {confirm}
-        </EuiButton>
-      </EuiFlexItem>
-    )}
-  </EuiFlexGroup>
-);
+const StringArgInput = ({ argValue, typeInstance, onValueChange, argId }) => {
+  const [value, setValue] = useState(argValue);
+  const confirm = typeInstance?.options?.confirm;
 
-StringArgInput.propTypes = {
-  updateValue: PropTypes.func.isRequired,
-  value: PropTypes.string.isRequired,
-  confirm: PropTypes.string,
-  commit: PropTypes.func.isRequired,
-  argId: PropTypes.string.isRequired,
+  useEffect(() => {
+    setValue(argValue);
+  }, [argValue]);
+
+  const onChange = useCallback(
+    (ev) => {
+      const onChangeFn = confirm ? setValue : onValueChange;
+      onChangeFn(ev.target.value);
+    },
+    [confirm, onValueChange]
+  );
+
+  return (
+    <EuiFlexGroup gutterSize="s">
+      <EuiFlexItem>
+        <EuiFieldText compressed id={argId} value={value} onChange={onChange} />
+      </EuiFlexItem>
+      {confirm && (
+        <EuiFlexItem grow={false} className="canvasSidebar__panel-noMinWidth">
+          <EuiButton size="s" onClick={() => onValueChange(value)}>
+            {confirm}
+          </EuiButton>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
 };
 
-const EnhancedStringArgInput = compose(
-  withProps(({ onValueChange, typeInstance, argValue }) => ({
-    confirm: get(typeInstance, 'options.confirm'),
-    commit: onValueChange,
-    value: argValue,
-  })),
-  createStatefulPropHoc('value')
-)(StringArgInput);
-
-EnhancedStringArgInput.propTypes = {
+StringArgInput.propTypes = {
+  argId: PropTypes.string.isRequired,
   argValue: PropTypes.any.isRequired,
   onValueChange: PropTypes.func.isRequired,
   typeInstance: PropTypes.object.isRequired,
@@ -63,5 +56,5 @@ export const string = () => ({
   name: 'string',
   displayName: strings.getDisplayName(),
   help: strings.getHelp(),
-  simpleTemplate: templateFromReactComponent(EnhancedStringArgInput),
+  simpleTemplate: templateFromReactComponent(StringArgInput),
 });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Canvas] String ui argument refactor. (#105742)