### PR TITLE
Fix up undefined handling in EP Meta telem task

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/endpoint_task.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/endpoint_task.test.ts
@@ -74,6 +74,33 @@ describe('test', () => {
         .createTaskRunner;
     const taskRunner = createTaskRunner({ taskInstance: mockTaskInstance });
     await taskRunner.run();
-    expect(mockSender.fetchDiagnosticAlerts).not.toHaveBeenCalled();
+    expect(mockSender.fetchEndpointMetrics).not.toHaveBeenCalled();
+    expect(mockSender.fetchEndpointPolicyResponses).not.toHaveBeenCalled();
+  });
+
+  test('endpoint task should run when opted in', async () => {
+    const mockSender = createMockTelemetryEventsSender(true);
+    const mockTaskManager = taskManagerMock.createSetup();
+    const telemetryEpMetaTask = new MockTelemetryEndpointTask(logger, mockTaskManager, mockSender);
+
+    const mockTaskInstance = {
+      id: TelemetryEndpointTaskConstants.TYPE,
+      runAt: new Date(),
+      attempts: 0,
+      ownerId: '',
+      status: TaskStatus.Running,
+      startedAt: new Date(),
+      scheduledAt: new Date(),
+      retryAt: new Date(),
+      params: {},
+      state: {},
+      taskType: TelemetryEndpointTaskConstants.TYPE,
+    };
+    const createTaskRunner =
+      mockTaskManager.registerTaskDefinitions.mock.calls[0][0][TelemetryEndpointTaskConstants.TYPE]
+        .createTaskRunner;
+    const taskRunner = createTaskRunner({ taskInstance: mockTaskInstance });
+    await taskRunner.run();
+    expect(telemetryEpMetaTask.runTask).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/telemetry/endpoint_task.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/endpoint_task.ts
@@ -250,18 +250,16 @@ export class TelemetryEndpointTask {
     };
 
     // If there is no policy responses in the 24h > now then we will continue
-    const policyResponses =
-      failedPolicyResponses.aggregations === undefined ||
-      failedPolicyResponses.aggregations === null
-        ? new Map<string, EndpointPolicyResponseDocument>()
-        : failedPolicyResponses.aggregations.policy_responses.buckets.reduce(
-            (cache, endpointAgentId) => {
-              const doc = endpointAgentId.latest_response.hits.hits[0];
-              cache.set(endpointAgentId.key, doc);
-              return cache;
-            },
-            new Map<string, EndpointPolicyResponseDocument>()
-          );
+    const policyResponses = failedPolicyResponses.aggregations
+      ? failedPolicyResponses.aggregations.policy_responses.buckets.reduce(
+          (cache, endpointAgentId) => {
+            const doc = endpointAgentId.latest_response.hits.hits[0];
+            cache.set(endpointAgentId.key, doc);
+            return cache;
+          },
+          new Map<string, EndpointPolicyResponseDocument>()
+        )
+      : new Map<string, EndpointPolicyResponseDocument>();
 
     /** STAGE 4 - Create the telemetry log records
      *

--- a/x-pack/plugins/security_solution/server/lib/telemetry/endpoint_task.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/endpoint_task.ts
@@ -251,7 +251,8 @@ export class TelemetryEndpointTask {
 
     // If there is no policy responses in the 24h > now then we will continue
     const policyResponses =
-      failedPolicyResponses.aggregations === undefined
+      failedPolicyResponses.aggregations === undefined ||
+      failedPolicyResponses.aggregations === null
         ? new Map<string, EndpointPolicyResponseDocument>()
         : failedPolicyResponses.aggregations.policy_responses.buckets.reduce(
             (cache, endpointAgentId) => {

--- a/x-pack/plugins/security_solution/server/lib/telemetry/mocks.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/mocks.ts
@@ -22,6 +22,8 @@ export const createMockTelemetryEventsSender = (
     start: jest.fn(),
     stop: jest.fn(),
     fetchDiagnosticAlerts: jest.fn(),
+    fetchEndpointMetrics: jest.fn(),
+    fetchEndpointPolicyResponses: jest.fn(),
     queueTelemetryEvents: jest.fn(),
     processEvents: jest.fn(),
     isTelemetryOptedIn: jest.fn().mockReturnValue(enableTelemtry ?? jest.fn()),


### PR DESCRIPTION
## Summary

QA reported an error log in the snapshot release.

```
{"type":"log","@timestamp":"2021-07-20T09:29:45+00:00","tags":["error","plugins","taskManager"],"pid":3606,"message":"Task security:endpoint-meta-telemetry \"security:endpoint-meta-telemetry:1.0.0\" failed: TypeError: Cannot read property 'endpoint_agents' of undefined"}
```

I was able to reproduce. The task manager fires a task run on startup, and this happens where there are no active Endpoint Agents. This is not a new bug and was patched in the [initial commit](https://github.com/elastic/kibana/pull/102171). However, a [follow-up PR](https://github.com/elastic/kibana/pull/104396) that made performance improvements regretfully introduced a regression in the guarding case. This PR adds additional safety to the task run.

Asides from the automated testing, I performed the following manual actions:

  1. I started a kibana with the security solution enabled, but no endpoints or fleet agents - (task ran fine)
  1. I started a kibana with the security solution and enrolled an agent - (task ran fine)
  1. I started a kibana with the security solution, enrolled an agent, and applied a policy with endpoint (task ran fine with metrics returned)
  1. I started a kibana with the security solution, enrolled an agent, and applied a policy with endpoint, emptied the data policy response cahce (task ran fine with metrics returned)
  1. I started a kibana with the security solution, enrolled an agent, and applied a policy with endpoint, emptied the data policy response cache + emptid the policy config cache (task ran fine with metrics returned)

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
