### PR TITLE
[6.8] Fix glob parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -438,7 +438,7 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-microsoft-contrib": "^6.0.0",
     "tslint-plugin-prettier": "^2.0.0",
-    "typescript": "^3.0.3",
+    "typescript": "~3.4.0",
     "vinyl-fs": "^3.0.2",
     "xml2js": "^0.4.19",
     "xmlbuilder": "9.0.4",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "getos": "^3.1.0",
     "glob": "^7.1.2",
     "glob-all": "^3.1.0",
-    "globby": "^8.0.1",
+    "globby": "^11.0.4",
     "handlebars": "4.7.7",
     "hjson": "3.1.0",
     "http-proxy-agent": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -315,7 +315,6 @@
     "@types/fetch-mock": "7.2.1",
     "@types/getopts": "^2.0.0",
     "@types/glob": "^5.0.35",
-    "@types/globby": "^8.0.0",
     "@types/graphql": "^0.13.1",
     "@types/has-ansi": "^3.0.0",
     "@types/humps": "^1.1.2",

--- a/packages/kbn-config-schema/package.json
+++ b/packages/kbn-config-schema/package.json
@@ -10,7 +10,7 @@
     "kbn:bootstrap": "yarn build"
   },
   "devDependencies": {
-    "typescript": "^3.0.3"
+    "typescript": "~3.4.0"
   },
   "peerDependencies": {
     "joi": "^13.5.2",

--- a/packages/kbn-i18n/package.json
+++ b/packages/kbn-i18n/package.json
@@ -25,7 +25,7 @@
     "del": "^3.0.0",
     "getopts": "^2.2.3",
     "supports-color": "^6.1.0",
-    "typescript": "^3.0.3"
+    "typescript": "~3.4.0"
   },
   "dependencies": {
     "intl-format-cache": "^2.1.0",

--- a/packages/kbn-plugin-helpers/package.json
+++ b/packages/kbn-plugin-helpers/package.json
@@ -14,7 +14,7 @@
     "del": "^2.2.2",
     "execa": "^1.0.0",
     "gulp-rename": "1.2.2",
-    "globby": "^8.0.1",
+    "globby": "^11.0.4",
     "gulp-zip": "^4.1.0",
     "inquirer": "^1.2.2",
     "minimatch": "^3.0.4",

--- a/packages/kbn-pm/package.json
+++ b/packages/kbn-pm/package.json
@@ -45,7 +45,7 @@
     "execa": "^1.0.0",
     "getopts": "^2.0.0",
     "glob": "^7.1.2",
-    "globby": "^8.0.1",
+    "globby": "^11.0.4",
     "has-ansi": "^3.0.0",
     "indent-string": "^3.2.0",
     "lodash.clonedeepwith": "^4.5.0",

--- a/packages/kbn-pm/package.json
+++ b/packages/kbn-pm/package.json
@@ -61,7 +61,7 @@
     "strong-log-transformer": "^2.1.0",
     "tempy": "^0.2.1",
     "ts-loader": "^5.2.2",
-    "typescript": "^3.0.3",
+    "typescript": "~3.4.0",
     "unlazy-loader": "^0.1.3",
     "webpack": "4.26.1",
     "webpack-cli": "^3.3.5",

--- a/packages/kbn-pm/package.json
+++ b/packages/kbn-pm/package.json
@@ -17,7 +17,6 @@
     "@types/execa": "^0.9.0",
     "@types/getopts": "^2.0.0",
     "@types/glob": "^5.0.35",
-    "@types/globby": "^6.1.0",
     "@types/has-ansi": "^3.0.0",
     "@types/indent-string": "^3.0.0",
     "@types/jest": "^23.3.1",

--- a/src/core/public/injected_metadata/deep_freeze.test.ts
+++ b/src/core/public/injected_metadata/deep_freeze.test.ts
@@ -82,8 +82,8 @@ it('types return values to prevent mutations in typescript', async () => {
   ).rejects.toThrowErrorMatchingInlineSnapshot(`
 "Command failed: tsc --noEmit
 
-index.ts(30,11): error TS2540: Cannot assign to 'baz' because it is a constant or a read-only property.
-index.ts(40,10): error TS2540: Cannot assign to 'bar' because it is a constant or a read-only property.
+index.ts(30,11): error TS2540: Cannot assign to 'baz' because it is a read-only property.
+index.ts(40,10): error TS2540: Cannot assign to 'bar' because it is a read-only property.
 "
 `);
 });

--- a/src/dev/build/tasks/nodejs_modules/webpack_dll.js
+++ b/src/dev/build/tasks/nodejs_modules/webpack_dll.js
@@ -21,6 +21,7 @@ import { deleteAll, read, write } from '../../lib';
 import { dirname, sep, relative } from 'path';
 import pkgUp from 'pkg-up';
 import globby from 'globby';
+import normalizePosixPath from 'normalize-path';
 
 export async function getDllEntries(manifestPath, whiteListedModules) {
   const manifest = JSON.parse(await read(manifestPath));
@@ -53,7 +54,7 @@ export async function getDllEntries(manifestPath, whiteListedModules) {
 export async function cleanDllModuleFromEntryPath(logger, entryPath) {
   const modulePkgPath = await pkgUp(entryPath);
   const modulePkg = JSON.parse(await read(modulePkgPath));
-  const moduleDir = dirname(modulePkgPath);
+  const moduleDir = normalizePosixPath(dirname(modulePkgPath));
 
   // Cancel the cleanup for this module as it
   // was already done.

--- a/src/ui/public/chrome/directives/header_global_nav/components/header_app_menu.tsx
+++ b/src/ui/public/chrome/directives/header_global_nav/components/header_app_menu.tsx
@@ -72,12 +72,12 @@ class HeaderAppMenuUI extends Component<Props, State> {
     );
 
     return (
+      // @ts-ignore
       <EuiPopover
         id="headerAppMenu"
         button={button}
         isOpen={this.state.isOpen}
         anchorPosition="downRight"
-        // @ts-ignore
         repositionOnScroll
         closePopover={this.closeMenu}
       >

--- a/src/ui/public/vis/update_status.ts
+++ b/src/ui/public/vis/update_status.ts
@@ -55,12 +55,12 @@ function hasSizeChanged(size: Size, oldSize?: Size): boolean {
   return oldSize.width !== size.width || oldSize.height !== size.height;
 }
 
-function getUpdateStatus<T extends Status>(
-  requiresUpdateStatus: T[] = [],
+function getUpdateStatus(
+  requiresUpdateStatus: Status[] = [],
   obj: any,
   param: { vis: Vis; visData: any; uiState: PersistedState }
-): { [reqStats in T]: boolean } {
-  const status = {} as { [reqStats in T]: boolean };
+): { [reqStats in Status]: boolean } {
+  const status = {} as { [reqStats in Status]: boolean };
 
   // If the vis type doesn't need update status, skip all calculations
   if (requiresUpdateStatus.length === 0) {

--- a/src/utils/binder.ts
+++ b/src/utils/binder.ts
@@ -18,8 +18,8 @@
  */
 
 export interface Emitter {
-  on: (args: any[]) => void;
-  off: (args: any[]) => void;
+  on: (...args: any[]) => void;
+  off: (...args: any[]) => void;
   addListener: Emitter['on'];
   removeListener: Emitter['off'];
 }
@@ -31,8 +31,8 @@ export class BinderBase {
     const on = emitter.on || emitter.addListener;
     const off = emitter.off || emitter.removeListener;
 
-    on.call(emitter, args[0]);
-    this.disposal.push(() => off.call(emitter, args[0]));
+    on.apply(emitter, args);
+    this.disposal.push(() => off.apply(emitter, args));
   }
 
   public destroy() {

--- a/src/utils/binder.ts
+++ b/src/utils/binder.ts
@@ -31,8 +31,8 @@ export class BinderBase {
     const on = emitter.on || emitter.addListener;
     const off = emitter.off || emitter.removeListener;
 
-    on.apply(emitter, args);
-    this.disposal.push(() => off.apply(emitter, args));
+    on.call(emitter, args[0]);
+    this.disposal.push(() => off.call(emitter, args[0]));
   }
 
   public destroy() {

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -107,7 +107,7 @@
     "tmp": "0.0.31",
     "tree-kill": "^1.2.2",
     "ts-loader": "^5.2.2",
-    "typescript": "^3.0.3",
+    "typescript": "~3.4.0",
     "vinyl-fs": "^3.0.2",
     "xml-crypto": "^0.10.1",
     "xml2js": "^0.4.19",

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
@@ -253,6 +253,7 @@ export class WatcherFlyout extends Component<
               }
             }
           )}{' '}
+          // @ts-ignore
           <UnconnectedKibanaLink
             location={this.props.location}
             pathname={'/app/kibana'}

--- a/x-pack/plugins/apm/public/components/shared/Links/KibanaLink.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/KibanaLink.test.tsx
@@ -23,6 +23,7 @@ function getUnconnectedKibanLink() {
   };
 
   return shallow(
+    // @ts-ignore
     <UnconnectedKibanaLink
       location={{ search: '' } as Location}
       pathname={'/app/kibana'}
@@ -94,6 +95,7 @@ describe('UnconnectedKibanaLink', () => {
     };
 
     const wrapper = shallow(
+      // @ts-ignore
       <UnconnectedKibanaLink
         location={{ search: '' } as Location}
         pathname={'/app/kibana'}

--- a/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
+++ b/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
@@ -28,7 +28,7 @@ import {
 import { IUrlParams } from '../urlParams';
 
 export const getEmptySerie = memoize(
-  (start = Date.now() - 3600000, end = Date.now()) => {
+  (start: number = Date.now() - 3600000, end: number = Date.now()) => {
     const dates = d3.time
       .scale()
       .domain([new Date(start), new Date(end)])

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.test.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.test.ts
@@ -291,9 +291,11 @@ function getESResponse(buckets: ESBucket[]): ESResponse {
         buckets: buckets.map(bucket => {
           return {
             ...bucket,
-            lower: { value: oc(bucket).lower.value(null) },
-            upper: { value: oc(bucket).upper.value(null) },
-            anomaly_score: { value: oc(bucket).anomaly_score.value(null) }
+            lower: { value: oc(bucket).lower.value(null) || null },
+            upper: { value: oc(bucket).upper.value(null) || null },
+            anomaly_score: {
+              value: oc(bucket).anomaly_score.value(null) || null
+            }
           };
         })
       }

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.test.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.test.ts
@@ -291,11 +291,9 @@ function getESResponse(buckets: ESBucket[]): ESResponse {
         buckets: buckets.map(bucket => {
           return {
             ...bucket,
-            lower: { value: oc(bucket).lower.value(null) || null },
-            upper: { value: oc(bucket).upper.value(null) || null },
-            anomaly_score: {
-              value: oc(bucket).anomaly_score.value(null) || null
-            }
+            lower: { value: oc(bucket).lower.value(null)! },
+            upper: { value: oc(bucket).upper.value(null)! },
+            anomaly_score: { value: oc(bucket).anomaly_score.value(null)! }
           };
         })
       }

--- a/x-pack/plugins/beats_management/public/lib/elasticsearch.ts
+++ b/x-pack/plugins/beats_management/public/lib/elasticsearch.ts
@@ -48,7 +48,7 @@ export class ElasticsearchLib {
         });
       }
 
-      return hiddenFieldsCheck.reduce((isvalid, field) => {
+      return hiddenFieldsCheck.reduce((isvalid: boolean, field) => {
         if (!isvalid) {
           return false;
         }

--- a/x-pack/plugins/infra/public/components/range_date_picker/index.tsx
+++ b/x-pack/plugins/infra/public/components/range_date_picker/index.tsx
@@ -346,7 +346,7 @@ export const RangeDatePicker = injectI18n(
       });
     };
 
-    private closePopover = (type: string, from?: string, to?: string) => {
+    private closePopover = (type?: string, from?: string, to?: string) => {
       const { startDate, endDate, recentlyUsed } = this.managedStartEndDateFromType(type, from, to);
       this.setState(
         {
@@ -364,7 +364,7 @@ export const RangeDatePicker = injectI18n(
       );
     };
 
-    private managedStartEndDateFromType(type: string, from?: string, to?: string) {
+    private managedStartEndDateFromType(type?: string, from?: string, to?: string) {
       const { intl } = this.props;
       let { startDate, endDate } = this.state;
       let recentlyUsed: RecentlyUsed[] = this.state.recentlyUsed;
@@ -433,7 +433,7 @@ export const RangeDatePicker = injectI18n(
         type === 'date-range' || !type ? type : get(find(commonDates, { id: type }), 'label');
 
       if (textJustUsed !== undefined && !find(recentlyUsed, ['text', textJustUsed])) {
-        recentlyUsed.unshift({ type, text: textJustUsed });
+        recentlyUsed.unshift({ type: type as string, text: textJustUsed });
         recentlyUsed = recentlyUsed.slice(0, 5);
       }
 

--- a/x-pack/plugins/infra/public/containers/with_state_from_location.tsx
+++ b/x-pack/plugins/infra/public/containers/with_state_from_location.tsx
@@ -50,6 +50,7 @@ export const withStateFromLocation = <StateInLocation extends {}>({
         const stateFromLocation = mapLocationToState(location);
 
         return (
+          // @ts-ignore
           <WrappedComponent
             {...otherProps}
             {...stateFromLocation}

--- a/x-pack/plugins/infra/public/utils/typed_redux.ts
+++ b/x-pack/plugins/infra/public/utils/typed_redux.ts
@@ -65,6 +65,6 @@ type PlainActionCreator<WrappedActionCreator> = WrappedActionCreator extends () 
 export const bindPlainActionCreators = <WrappedActionCreators extends ActionCreators>(
   actionCreators: WrappedActionCreators
 ) => (dispatch: Dispatch) =>
-  bindActionCreators(actionCreators, dispatch) as {
+  (bindActionCreators(actionCreators, dispatch) as unknown) as {
     [P in keyof WrappedActionCreators]: PlainActionCreator<WrappedActionCreators[P]>
   };

--- a/x-pack/plugins/security/public/views/management/edit_role/components/privileges/es/__snapshots__/index_privilege_form.test.tsx.snap
+++ b/x-pack/plugins/security/public/views/management/edit_role/components/privileges/es/__snapshots__/index_privilege_form.test.tsx.snap
@@ -207,6 +207,7 @@ exports[`it renders without crashing 1`] = `
           component="div"
           grow={true}
         >
+          // @ts-ignore
           <EuiSwitch
             checked={false}
             compressed={true}

--- a/x-pack/plugins/security/public/views/management/edit_role/components/privileges/es/index_privilege_form.tsx
+++ b/x-pack/plugins/security/public/views/management/edit_role/components/privileges/es/index_privilege_form.tsx
@@ -196,6 +196,7 @@ export class IndexPrivilegeForm extends Component<Props, State> {
       <EuiFlexGroup direction="column">
         {!this.props.isReservedRole && (
           <EuiFlexItem>
+            // @ts-ignore
             <EuiSwitch
               data-test-subj={`restrictDocumentsQuery${this.props.formIndex}`}
               label={
@@ -204,7 +205,6 @@ export class IndexPrivilegeForm extends Component<Props, State> {
                   defaultMessage="Grant read privileges to specific documents"
                 />
               }
-              // @ts-ignore
               compressed={true}
               checked={this.state.queryExpanded}
               onChange={this.toggleDocumentQuery}

--- a/x-pack/plugins/spaces/public/views/nav_control/components/spaces_menu.tsx
+++ b/x-pack/plugins/spaces/public/views/nav_control/components/spaces_menu.tsx
@@ -106,14 +106,13 @@ class SpacesMenuUI extends Component<Props, State> {
     const { intl } = this.props;
     return (
       <div key="manageSpacesSearchField" className="spcMenu__searchFieldWrapper">
+        // @ts-ignore FIXME needs updated typedef
         <EuiFieldSearch
           placeholder={intl.formatMessage({
             id: 'xpack.spaces.navControl.spacesMenu.findSpacePlaceholder',
             defaultMessage: 'Find a space',
           })}
           incremental={true}
-          // FIXME needs updated typedef
-          // @ts-ignore
           onSearch={this.onSearch}
           onKeyDown={this.onSearchKeyDown}
           onFocus={this.onSearchFocus}

--- a/x-pack/plugins/spaces/public/views/nav_control/nav_control_popover.tsx
+++ b/x-pack/plugins/spaces/public/views/nav_control/nav_control_popover.tsx
@@ -80,6 +80,7 @@ export class NavControlPopover extends Component<Props, State> {
     }
 
     return (
+      // @ts-ignore
       <EuiPopover
         id={'spcMenuPopover'}
         data-test-subj={`spacesNavSelector`}
@@ -88,7 +89,6 @@ export class NavControlPopover extends Component<Props, State> {
         closePopover={this.closeSpaceSelector}
         anchorPosition={this.props.anchorPosition}
         panelPaddingSize="none"
-        // @ts-ignore
         repositionOnScroll={true}
         withTitle={this.props.anchorPosition.includes('down')}
         ownFocus

--- a/x-pack/plugins/spaces/public/views/space_selector/space_selector.tsx
+++ b/x-pack/plugins/spaces/public/views/space_selector/space_selector.tsx
@@ -160,6 +160,7 @@ class SpaceSelectorUI extends Component<Props, State> {
     }
     return (
       <EuiFlexItem className="spcSpaceSelector__searchHolder">
+        // @ts-ignore
         <EuiFieldSearch
           className="spcSpaceSelector__searchField"
           placeholder={intl.formatMessage({
@@ -167,7 +168,6 @@ class SpaceSelectorUI extends Component<Props, State> {
             defaultMessage: 'Find a space',
           })}
           incremental={true}
-          // @ts-ignore
           onSearch={this.onSearch}
         />
       </EuiFlexItem>

--- a/x-pack/plugins/spaces/server/lib/space_request_interceptors.test.ts
+++ b/x-pack/plugins/spaces/server/lib/space_request_interceptors.test.ts
@@ -18,6 +18,9 @@ describe('interceptors', () => {
   };
   let server: any;
   let request: any;
+  interface Config {
+    [key: string]: any;
+  }
 
   beforeEach(() => {
     teardowns.push(() => sandbox.restore());
@@ -26,13 +29,10 @@ describe('interceptors', () => {
       setupFn: (ser: any) => void = () => {
         return;
       },
-      testConfig = {}
+      testConfig: Config = {}
     ) => {
       server = new Server();
 
-      interface Config {
-        [key: string]: any;
-      }
       const config: Config = {
         'server.basePath': '/foo',
         ...testConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,14 +2854,6 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
-
 anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
@@ -5417,7 +5409,7 @@ chokidar@^2.0.0, chokidar@^2.0.3, chokidar@^2.0.4, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.4.1:
+chokidar@^3.4.1, chokidar@^3.4.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -5431,21 +5423,6 @@ chokidar@^3.4.1:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
-chokidar@^3.4.2:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
-  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.5.0"
-  optionalDependencies:
-    fsevents "~2.3.1"
 
 chownr@^1.0.1, chownr@^1.1.1:
   version "1.1.1"
@@ -9636,11 +9613,6 @@ fsevents@^1.0.0, fsevents@^1.2.3, fsevents@^1.2.7:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fsevents@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
-  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
-
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
@@ -9947,7 +9919,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob-parent@^5.1.0, glob-parent@~5.1.0, glob-parent@~5.1.2:
+glob-parent@^5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -18172,13 +18144,6 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-readdirp@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
-  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
-  dependencies:
-    picomatch "^2.2.1"
 
 readdirp@~3.6.0:
   version "3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,21 +1776,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/globby@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@types/globby/-/globby-6.1.0.tgz#7c25b975512a89effea2a656ca8cf6db7fb29d11"
-  integrity sha512-j3XSDNoK4LO5T+ZviQD6PqfEjm07QFEacOTbJR3hnLWuWX0ZMLJl9oRPgj1PyrfGbXhfHFkksC9QZ9HFltJyrw==
-  dependencies:
-    "@types/glob" "*"
-
-"@types/globby@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@types/globby/-/globby-8.0.0.tgz#7bd10eaf802e1e11afdb1e5436cf472ddf4c0dd2"
-  integrity sha512-xDtsX5tlctxJzvg29r/LN12z30oJpoFP9cE8eJ8nY5cbSvN0c0RdRHrVlEq4LRh362Sd+JsqxJ3QWw0Wnyto8w==
-  dependencies:
-    "@types/glob" "*"
-    fast-glob "^2.0.2"
-
 "@types/graphql@^0.13.1":
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.13.4.tgz#55ae9c29f0fd6b85ee536f5c72b4769d5c5e06b1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,6 +2862,14 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 apollo-cache-control@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.1.1.tgz#173d14ceb3eb9e7cb53de7eb8b61bee6159d4171"
@@ -5390,7 +5398,7 @@ chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.0.4, chokidar@^2.1.8:
+chokidar@^2.0.0, chokidar@^2.0.3, chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -5408,6 +5416,21 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.0.4, chokidar@^2.
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.4.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chokidar@^3.4.2:
   version "3.5.0"
@@ -9618,6 +9641,11 @@ fsevents@~2.3.1:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
   integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
 
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fstream@^1.0.0, fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
@@ -9919,7 +9947,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -18164,6 +18192,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 readline2@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
@@ -22738,14 +22773,23 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
-  integrity sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
+watchpack-chokidar2@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz#38500072ee6ece66f3769936950ea1771be1c957"
+  integrity sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==
   dependencies:
-    chokidar "^2.0.2"
+    chokidar "^2.1.8"
+
+watchpack@^1.5.0:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
+  integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
+  dependencies:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+  optionalDependencies:
+    chokidar "^3.4.1"
+    watchpack-chokidar2 "^2.0.1"
 
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10153,6 +10153,18 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-4.1.0.tgz#080f54549ec1b82a6c60e631fc82e1211dbe95f8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10154,19 +10154,7 @@ globals@^9.18.0, globals@^9.2.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-globby@^11.0.1:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
-  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
-
-globby@^11.0.4:
+globby@^11.0.1, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -21696,15 +21696,15 @@ typescript-fsa@^2.0.0, typescript-fsa@^2.5.0:
   resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-2.5.0.tgz#1baec01b5e8f5f34c322679d1327016e9e294faf"
   integrity sha1-G67AG16PXzTDImedEycBbp4pT68=
 
-typescript@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
-  integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
-
 typescript@^3.2.2:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
+
+typescript@~3.4.0:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.23, ua-parser-js@^0.7.9:
   version "0.7.24"


### PR DESCRIPTION
This PR upgrades `glob-parent` for prod-dependencies.

It also ensures that all paths given to `globby` are normalized (for details see PR #96476).

For the tests to pass, I had to also upgrade `typescript` to v3.4.5. This is as far as I can tell because the `globby` dependency includes types that makes use of features not support by our old `typescript` version (v3.0.3). This meant fixing/upgrading part of our TypeScript syntax to align with the new version, which makes this PR a bit messy. I've left a bunch of review comments showing the original TypeScript error message for context.