### PR TITLE
Remove recursive plugin status in meta field

### DIFF
--- a/src/core/server/status/get_summary_status.test.ts
+++ b/src/core/server/status/get_summary_status.test.ts
@@ -101,15 +101,7 @@ describe('getSummaryStatus', () => {
           summary: '[s2]: Lorem ipsum',
           detail: 'See the status page for more information',
           meta: {
-            affectedServices: {
-              s2: {
-                level: ServiceStatusLevels.unavailable,
-                summary: 'Lorem ipsum',
-                meta: {
-                  custom: { data: 'here' },
-                },
-              },
-            },
+            affectedServices: ['s2'],
           },
         });
       });
@@ -136,17 +128,7 @@ describe('getSummaryStatus', () => {
           detail: 'Vivamus pulvinar sem ac luctus ultrices.',
           documentationUrl: 'http://helpmenow.com/problem1',
           meta: {
-            affectedServices: {
-              s2: {
-                level: ServiceStatusLevels.unavailable,
-                summary: 'Lorem ipsum',
-                detail: 'Vivamus pulvinar sem ac luctus ultrices.',
-                documentationUrl: 'http://helpmenow.com/problem1',
-                meta: {
-                  custom: { data: 'here' },
-                },
-              },
-            },
+            affectedServices: ['s2'],
           },
         });
       });
@@ -183,26 +165,7 @@ describe('getSummaryStatus', () => {
           summary: '[2] services are unavailable',
           detail: 'See the status page for more information',
           meta: {
-            affectedServices: {
-              s2: {
-                level: ServiceStatusLevels.unavailable,
-                summary: 'Lorem ipsum',
-                detail: 'Vivamus pulvinar sem ac luctus ultrices.',
-                documentationUrl: 'http://helpmenow.com/problem1',
-                meta: {
-                  custom: { data: 'here' },
-                },
-              },
-              s3: {
-                level: ServiceStatusLevels.unavailable,
-                summary: 'Proin mattis',
-                detail: 'Nunc quis nulla at mi lobortis pretium.',
-                documentationUrl: 'http://helpmenow.com/problem2',
-                meta: {
-                  other: { data: 'over there' },
-                },
-              },
-            },
+            affectedServices: ['s2', 's3'],
           },
         });
       });

--- a/src/core/server/status/get_summary_status.ts
+++ b/src/core/server/status/get_summary_status.ts
@@ -31,7 +31,7 @@ export const getSummaryStatus = (
       // TODO: include URL to status page
       detail: status.detail ?? `See the status page for more information`,
       meta: {
-        affectedServices: { [serviceName]: status },
+        affectedServices: [serviceName],
       },
     };
   } else {
@@ -41,7 +41,7 @@ export const getSummaryStatus = (
       // TODO: include URL to status page
       detail: `See the status page for more information`,
       meta: {
-        affectedServices: Object.fromEntries(highestStatuses),
+        affectedServices: highestStatuses.map(([serviceName]) => serviceName),
       },
     };
   }

--- a/src/core/server/status/plugins_status.test.ts
+++ b/src/core/server/status/plugins_status.test.ts
@@ -303,12 +303,7 @@ describe('PluginStatusService', () => {
           summary: '[a]: Status check timed out after 30s',
           detail: 'See the status page for more information',
           meta: {
-            affectedServices: {
-              a: {
-                level: ServiceStatusLevels.unavailable,
-                summary: 'Status check timed out after 30s',
-              },
-            },
+            affectedServices: ['a'],
           },
         },
       });

--- a/src/core/server/status/status_service.test.ts
+++ b/src/core/server/status/status_service.test.ts
@@ -254,12 +254,9 @@ describe('StatusService', () => {
               "detail": "See the status page for more information",
               "level": degraded,
               "meta": Object {
-                "affectedServices": Object {
-                  "savedObjects": Object {
-                    "level": degraded,
-                    "summary": "This is degraded!",
-                  },
-                },
+                "affectedServices": Array [
+                  "savedObjects",
+                ],
               },
               "summary": "[savedObjects]: This is degraded!",
             },
@@ -307,12 +304,9 @@ describe('StatusService', () => {
               "detail": "See the status page for more information",
               "level": degraded,
               "meta": Object {
-                "affectedServices": Object {
-                  "savedObjects": Object {
-                    "level": degraded,
-                    "summary": "This is degraded!",
-                  },
-                },
+                "affectedServices": Array [
+                  "savedObjects",
+                ],
               },
               "summary": "[savedObjects]: This is degraded!",
             },


### PR DESCRIPTION
## Summary

Fixes #100202

Depending on how a plugin implements their custom status check, it's possible for our status log messages to explode in size due to how the default status summaries rollup all of their dependencies' statuses in a recursive, cascading manner. This PR changes the default status summary to only include the names of the affected dependencies, rather than their entire status check which is already available in the full status object.

Here's the change for an individual plugin's default status object:

#### Before

```json5
{
  "level": "unavailable",
  "summary": "[2] services are unavailable",
  "detail": "See the status page for more information",
  "meta": {
    "affectedServices": {
      "dependencyA": {
        "level": "unavailable",
        "summary": "dependencyB is unavailable",
        "meta": {
          "affectedServices": {
            "dependencyB": {
              "level": "unavailable",
              "summary": "Something isn't working"
            }
          }
        }
      },
      "dependencyB": {
        "level": "unavailable",
        "summary": "Something isn't working"
      }
    }
  }
}
```

#### After

```json5
{
  "level": "unavailable",
  "summary": "[2] services are unavailable",
  "detail": "See the status page for more information",
  "meta": {
    "affectedServices": ["dependencyA", "dependencyB"]
  }
}
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
