### PR TITLE
[data.search.autocomplete] Remove usage of ES client transport.request

### DIFF
--- a/src/plugins/data/server/autocomplete/terms_enum.test.ts
+++ b/src/plugins/data/server/autocomplete/terms_enum.test.ts
@@ -12,6 +12,7 @@ import { ElasticsearchClient, SavedObjectsClientContract } from 'kibana/server';
 import { ConfigSchema } from '../../config';
 import type { DeeplyMockedKeys } from '@kbn/utility-types/jest';
 import type { ApiResponse } from '@elastic/elasticsearch';
+import { TermsEnumResponse } from '@elastic/elasticsearch/api/types';
 
 let savedObjectsClientMock: jest.Mocked<SavedObjectsClientContract>;
 let esClientMock: DeeplyMockedKeys<ElasticsearchClient>;
@@ -29,7 +30,9 @@ describe('_terms_enum suggestions', () => {
     const requestHandlerContext = coreMock.createRequestHandlerContext();
     savedObjectsClientMock = requestHandlerContext.savedObjects.client;
     esClientMock = requestHandlerContext.elasticsearch.client.asCurrentUser;
-    esClientMock.transport.request.mockResolvedValue((mockResponse as unknown) as ApiResponse);
+    esClientMock.termsEnum.mockResolvedValue(
+      (mockResponse as unknown) as ApiResponse<TermsEnumResponse>
+    );
   });
 
   it('calls the _terms_enum API with the field, query, filters, and config tiers', async () => {
@@ -44,7 +47,7 @@ describe('_terms_enum suggestions', () => {
       { name: 'field_name', type: 'string' }
     );
 
-    const [[args]] = esClientMock.transport.request.mock.calls;
+    const [[args]] = esClientMock.termsEnum.mock.calls;
 
     expect(args).toMatchInlineSnapshot(`
       Object {
@@ -67,8 +70,7 @@ describe('_terms_enum suggestions', () => {
           },
           "string": "query",
         },
-        "method": "POST",
-        "path": "/index/_terms_enum",
+        "index": "index",
       }
     `);
     expect(result).toEqual(mockResponse.body.terms);
@@ -85,7 +87,7 @@ describe('_terms_enum suggestions', () => {
       []
     );
 
-    const [[args]] = esClientMock.transport.request.mock.calls;
+    const [[args]] = esClientMock.termsEnum.mock.calls;
 
     expect(args).toMatchInlineSnapshot(`
       Object {
@@ -108,8 +110,7 @@ describe('_terms_enum suggestions', () => {
           },
           "string": "query",
         },
-        "method": "POST",
-        "path": "/index/_terms_enum",
+        "index": "index",
       }
     `);
     expect(result).toEqual(mockResponse.body.terms);

--- a/src/plugins/data/server/autocomplete/terms_enum.ts
+++ b/src/plugins/data/server/autocomplete/terms_enum.ts
@@ -11,7 +11,6 @@ import { estypes } from '@elastic/elasticsearch';
 import { IFieldType } from '../../common';
 import { findIndexPatternById, getFieldByName } from '../index_patterns';
 import { shimAbortSignal } from '../search';
-import { getKbnServerError } from '../../../kibana_utils/server';
 import { ConfigSchema } from '../../config';
 
 export async function termsEnumSuggestions(
@@ -31,32 +30,26 @@ export async function termsEnumSuggestions(
     field = indexPattern && getFieldByName(fieldName, indexPattern);
   }
 
-  try {
-    const promise = esClient.transport.request({
-      method: 'POST',
-      path: encodeURI(`/${index}/_terms_enum`),
-      body: {
-        field: field?.name ?? fieldName,
-        string: query,
-        index_filter: {
-          bool: {
-            must: [
-              ...(filters ?? []),
-              {
-                terms: {
-                  _tier: tiers,
-                },
+  const promise = esClient.termsEnum({
+    index,
+    body: {
+      field: field?.name ?? fieldName,
+      string: query,
+      index_filter: {
+        bool: {
+          must: [
+            ...(filters ?? []),
+            {
+              terms: {
+                _tier: tiers,
               },
-            ],
-          },
+            },
+          ],
         },
       },
-    });
+    },
+  });
 
-    const result = await shimAbortSignal(promise, abortSignal);
-
-    return result.body.terms;
-  } catch (e) {
-    throw getKbnServerError(e);
-  }
+  const result = await shimAbortSignal(promise, abortSignal);
+  return result.body.terms;
 }


### PR DESCRIPTION
## Summary

Just changes over from using `transport.request` to using the `termsEnum` method on the ES client (it wasn't originally available when implementing the feature).

Also doesn't wrap errors in `getKbnServerError` (to have parody with how the `terms_agg` implementation works).

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
