### PR TITLE
[Uptime] Step Details Page navigation - handle unequal steps between check groups

### DIFF
--- a/x-pack/plugins/uptime/public/components/synthetics/check_steps/use_expanded_row.tsx
+++ b/x-pack/plugins/uptime/public/components/synthetics/check_steps/use_expanded_row.tsx
@@ -40,17 +40,18 @@ export const useExpandedRow = ({ loading, steps, allSteps }: HookProps) => {
     for (const expandedRowKeyStr in expandedRows) {
       if (expandedRows.hasOwnProperty(expandedRowKeyStr)) {
         const expandedRowKey = Number(expandedRowKeyStr);
+        const step = steps.find((stepF) => stepF.synthetics?.step?.index !== expandedRowKey);
 
-        const step = steps.find((stepF) => stepF.synthetics?.step?.index !== expandedRowKey)!;
-
-        expandedRowsN[expandedRowKey] = (
-          <ExecutedStep
-            step={step}
-            browserConsole={getBrowserConsole(expandedRowKey)}
-            index={step.synthetics?.step?.index!}
-            loading={loading}
-          />
-        );
+        if (step) {
+          expandedRowsN[expandedRowKey] = (
+            <ExecutedStep
+              step={step}
+              browserConsole={getBrowserConsole(expandedRowKey)}
+              index={step.synthetics?.step?.index!}
+              loading={loading}
+            />
+          );
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #106248 

When navigating between different checks on the step details page, we attempt to preserve the state of the accordion, keeping the appropriate accordion open as the user navigates. This can cause issues when there is an unequal amount of steps between each check, causing an unhandled reference error.

This PR adds additional defense to prevent this error.

**Steps for testing**:
 1. Create a synthetic monitor with one step and run heartbeat
 2. Stop heartbeat, update the same monitor to have two steps, and run heartbeat
 3. Navigate to the step details page for a check that has two steps.
 4. Expand the second row
 5. Navigate to backwards through step details page to previous checks until you get to a check with 1 step.
 6. Observe that there is no error and only one row that is collapsed

<img width="1015" alt="Screen Shot 2021-07-20 at 9 30 16 AM" src="https://user-images.githubusercontent.com/11356435/126364270-df5e2716-4775-4719-b7c8-73a325b265db.png">
<img width="1013" alt="Screen Shot 2021-07-20 at 9 26 45 AM" src="https://user-images.githubusercontent.com/11356435/126364271-4d61e912-9ff7-4b06-aec8-1d9bff9e21d3.png">
