### PR TITLE
[Security Solution] fix metadata api tests

### DIFF
--- a/x-pack/test/functional/es_archives/endpoint/metadata/api_feature/data.json
+++ b/x-pack/test/functional/es_archives/endpoint/metadata/api_feature/data.json
@@ -4,7 +4,7 @@
     "id": "3KVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "963b081e-60d1-482c-befd-a5815fa8290f",
         "version": "6.6.1",
@@ -26,7 +26,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d14",
         "kind": "metric",
         "category": [
@@ -74,7 +74,7 @@
     "id": "3aVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "b3412d6f-b022-4448-8fee-21cc936ea86b",
         "version": "6.0.0",
@@ -96,7 +96,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d15",
         "kind": "metric",
         "category": [
@@ -143,7 +143,7 @@
     "id": "3qVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "3838df35-a095-4af4-8fce-0b6d78793f2e",
         "version": "6.8.0",
@@ -165,7 +165,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d16",
         "kind": "metric",
         "category": [
@@ -210,7 +210,7 @@
     "id": "36VN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "963b081e-60d1-482c-befd-a5815fa8290f",
         "version": "6.6.1",
@@ -232,7 +232,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d18",
         "kind": "metric",
         "category": [
@@ -280,7 +280,7 @@
     "id": "4KVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "b3412d6f-b022-4448-8fee-21cc936ea86b",
         "version": "6.0.0",
@@ -302,7 +302,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d19",
         "kind": "metric",
         "category": [
@@ -348,7 +348,7 @@
     "id": "4aVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "3838df35-a095-4af4-8fce-0b6d78793f2e",
         "version": "6.8.0",
@@ -370,7 +370,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d39",
         "kind": "metric",
         "category": [
@@ -416,7 +416,7 @@
     "id": "4qVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "963b081e-60d1-482c-befd-a5815fa8290f",
         "version": "6.6.1",
@@ -438,7 +438,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d31",
         "kind": "metric",
         "category": [
@@ -485,7 +485,7 @@
     "id": "46VN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "b3412d6f-b022-4448-8fee-21cc936ea86b",
         "version": "6.0.0",
@@ -507,7 +507,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d23",
         "kind": "metric",
         "category": [
@@ -553,7 +553,7 @@
     "id": "5KVN2G8BYQH1gtPUuYk7",
     "index": "metrics-endpoint.metadata-default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "agent": {
         "id": "3838df35-a095-4af4-8fce-0b6d78793f2e",
         "version": "6.8.0",
@@ -575,7 +575,7 @@
         }
       },
       "event": {
-        "created": 1618841405309,
+        "created": 1626897841950,
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d35",
         "kind": "metric",
         "category": [

--- a/x-pack/test/functional/es_archives/endpoint/metadata/destination_index/data.json
+++ b/x-pack/test/functional/es_archives/endpoint/metadata/destination_index/data.json
@@ -4,7 +4,7 @@
     "id": "M92ScEJT9M9QusfIi3hpEb0AAAAAAAAA",
     "index": "metrics-endpoint.metadata_current_default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "Endpoint": {
         "policy": {
           "applied": {
@@ -36,7 +36,7 @@
         "category": [
           "host"
         ],
-        "created": 1618841405309,
+        "created": 1626897841950,
         "dataset": "endpoint.metadata",
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d16",
         "ingested": "2020-09-09T18:25:15.853783Z",
@@ -78,7 +78,7 @@
     "id": "OU3RgCJaNnR90byeDEHutp8AAAAAAAAA",
     "index": "metrics-endpoint.metadata_current_default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "Endpoint": {
         "policy": {
           "applied": {
@@ -110,7 +110,7 @@
         "category": [
           "host"
         ],
-        "created": 1618841405309,
+        "created": 1626897841950,
         "dataset": "endpoint.metadata",
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d14",
         "ingested": "2020-09-09T18:25:14.919526Z",
@@ -155,7 +155,7 @@
     "id": "YjqDCEuI6JmLeLOSyZx_NhMAAAAAAAAA",
     "index": "metrics-endpoint.metadata_current_default",
     "source": {
-      "@timestamp": 1618841405309,
+      "@timestamp": 1626897841950,
       "Endpoint": {
         "policy": {
           "applied": {
@@ -187,7 +187,7 @@
         "category": [
           "host"
         ],
-        "created": 1618841405309,
+        "created": 1626897841950,
         "dataset": "endpoint.metadata",
         "id": "32f5fda2-48e4-4fae-b89e-a18038294d15",
         "ingested": "2020-09-09T18:25:15.853404Z",

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -38,7 +38,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       'windows 10.0',
       '10.101.149.26, 2606:a000:ffc0:39:11ef:37b9:3371:578c',
       '6.8.0',
-      'Apr 19, 2021 @ 14:10:05.309',
+      'Jul 21, 2021 @ 20:04:01.950',
       '',
     ],
     [
@@ -49,7 +49,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       'windows 10.0',
       '10.192.213.130, 10.70.28.129',
       '6.6.1',
-      'Apr 19, 2021 @ 14:10:05.309',
+      'Jul 21, 2021 @ 20:04:01.950',
       '',
     ],
     [
@@ -60,7 +60,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       'windows 10.0',
       '10.46.229.234',
       '6.0.0',
-      'Apr 19, 2021 @ 14:10:05.309',
+      'Jul 21, 2021 @ 20:04:01.950',
       '',
     ],
   ];
@@ -281,7 +281,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             'windows 10.0',
             '10.192.213.130, 10.70.28.129',
             '6.6.1',
-            'Apr 19, 2021 @ 14:10:05.309',
+            'Jul 21, 2021 @ 20:04:01.950',
             '',
           ],
           [
@@ -292,7 +292,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             'windows 10.0',
             '10.46.229.234',
             '6.0.0',
-            'Apr 19, 2021 @ 14:10:05.309',
+            'Jul 21, 2021 @ 20:04:01.950',
             '',
           ],
         ];

--- a/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
@@ -23,8 +23,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertest');
 
-  // Failing: See https://github.com/elastic/kibana/issues/106051
-  describe.skip('test metadata api', () => {
+  describe('test metadata api', () => {
     describe(`POST ${HOST_METADATA_LIST_ROUTE} when index is empty`, () => {
       it('metadata api should return empty result when index is empty', async () => {
         await deleteMetadataStream(getService);
@@ -222,7 +221,7 @@ export default function ({ getService }: FtrProviderContext) {
           (ip: string) => ip === targetEndpointIp
         );
         expect(resultIp).to.eql([targetEndpointIp]);
-        expect(body.hosts[0].metadata.event.created).to.eql(1618841405309);
+        expect(body.hosts[0].metadata.event.created).to.eql(1626897841950);
         expect(body.hosts.length).to.eql(1);
         expect(body.request_page_size).to.eql(10);
         expect(body.request_page_index).to.eql(0);
@@ -264,7 +263,7 @@ export default function ({ getService }: FtrProviderContext) {
         const resultElasticAgentId: string = body.hosts[0].metadata.elastic.agent.id;
         expect(resultHostId).to.eql(targetEndpointId);
         expect(resultElasticAgentId).to.eql(targetElasticAgentId);
-        expect(body.hosts[0].metadata.event.created).to.eql(1618841405309);
+        expect(body.hosts[0].metadata.event.created).to.eql(1626897841950);
         expect(body.hosts[0].host_status).to.eql('unhealthy');
         expect(body.hosts.length).to.eql(1);
         expect(body.request_page_size).to.eql(10);


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/kibana/issues/106051.

transform was not running since timestamps were past 90 days, update to today. tests started breaking exactly 90 days after this last update: [`d425a8a` (#97191)](https://github.com/elastic/kibana/pull/97191/commits/d425a8a635f208e7fcb55745d67c4a53d489f252).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
