### PR TITLE
[7.x] set the doc title when navigating to reporting and unset when navigating away (#106253)

### DIFF
--- a/x-pack/plugins/reporting/public/plugin.ts
+++ b/x-pack/plugins/reporting/public/plugin.ts
@@ -158,7 +158,11 @@ export class ReportingPublicPlugin
           getStartServices(),
           import('./management/mount_management_section'),
         ]);
-        return await mountManagementSection(
+        const {
+          chrome: { docTitle },
+        } = start;
+        docTitle.change(this.title);
+        const umountAppCallback = await mountManagementSection(
           core,
           start,
           license$,
@@ -167,6 +171,11 @@ export class ReportingPublicPlugin
           share.url,
           params
         );
+
+        return () => {
+          docTitle.reset();
+          umountAppCallback();
+        };
       },
     });
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - set the doc title when navigating to reporting and unset when navigating away (#106253)