### PR TITLE
[7.14] set the doc title when navigating to reporting and unset when navigating away (#106253)

### DIFF
--- a/x-pack/plugins/reporting/public/plugin.ts
+++ b/x-pack/plugins/reporting/public/plugin.ts
@@ -153,7 +153,11 @@ export class ReportingPublicPlugin
           getStartServices(),
           import('./management/mount_management_section'),
         ]);
-        return await mountManagementSection(
+        const {
+          chrome: { docTitle },
+        } = start;
+        docTitle.change(this.title);
+        const umountAppCallback = await mountManagementSection(
           core,
           start,
           license$,
@@ -161,6 +165,11 @@ export class ReportingPublicPlugin
           apiClient,
           params
         );
+
+        return () => {
+          docTitle.reset();
+          umountAppCallback();
+        };
       },
     });
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - set the doc title when navigating to reporting and unset when navigating away (#106253)