### PR TITLE
[Security Solution] Flyout overview hover actions

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -80,7 +80,7 @@ const networkFields = [
 const getDescription = ({
   data,
   eventId,
-  // fieldFromBrowserField,
+  fieldFromBrowserField,
   linkValue,
   timelineId,
   values,
@@ -94,7 +94,7 @@ const getDescription = ({
         contextId={timelineId}
         data={data}
         eventId={eventId}
-        // fieldFromBrowserField={fieldFromBrowserField}
+        fieldFromBrowserField={fieldFromBrowserField}
         linkValue={linkValue}
         values={values}
       />
@@ -102,7 +102,7 @@ const getDescription = ({
         contextId={timelineId}
         data={data}
         eventId={eventId}
-        // fieldFromBrowserField={fieldFromBrowserField}
+        fieldFromBrowserField={fieldFromBrowserField}
         linkValue={linkValue}
         timelineId={timelineId}
         values={values}

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -36,6 +36,7 @@ import { endpointAlertCheck } from '../../utils/endpoint_alert_check';
 import { getEmptyValue } from '../empty_value';
 import { ActionCell } from './table/action_cell';
 import { FieldValueCell } from './table/field_value_cell';
+import { TimelineEventsDetailsItem } from '../../../../common';
 import { EventFieldsData } from './types';
 
 export const Indent = styled.div`
@@ -88,11 +89,16 @@ const getDescription = ({
   if (isEmpty(values)) {
     return <>{getEmptyValue()}</>;
   }
+
+  const eventFieldsData = {
+    ...data,
+    ...(fieldFromBrowserField ? fieldFromBrowserField : {}),
+  } as EventFieldsData;
   return (
     <>
       <FieldValueCell
         contextId={timelineId}
-        data={data}
+        data={eventFieldsData}
         eventId={eventId}
         fieldFromBrowserField={fieldFromBrowserField}
         linkValue={linkValue}
@@ -100,7 +106,7 @@ const getDescription = ({
       />
       <ActionCell
         contextId={timelineId}
-        data={data}
+        data={eventFieldsData}
         eventId={eventId}
         fieldFromBrowserField={fieldFromBrowserField}
         linkValue={linkValue}
@@ -117,13 +123,13 @@ const getSummaryRows = ({
   timelineId,
   eventId,
 }: {
-  data: EventFieldsData[];
+  data: TimelineEventsDetailsItem[];
   browserFields: BrowserFields;
   timelineId: string;
   eventId: string;
 }) => {
   const categoryField = find({ category: 'event', field: 'event.category' }, data) as
-    | EventFieldsData
+    | TimelineEventsDetailsItem
     | undefined;
   const eventCategory = Array.isArray(categoryField?.originalValue)
     ? categoryField?.originalValue[0]
@@ -223,7 +229,7 @@ const summaryColumns: Array<EuiBasicTableColumn<SummaryRow>> = getSummaryColumns
 
 const AlertSummaryViewComponent: React.FC<{
   browserFields: BrowserFields;
-  data: EventFieldsData[];
+  data: TimelineEventsDetailsItem[];
   eventId: string;
   timelineId: string;
   title?: string;
@@ -244,13 +250,13 @@ const AlertSummaryViewComponent: React.FC<{
   const agentStatusRow = {
     title: i18n.AGENT_STATUS,
     description: {
-      data: endpointId ?? ({} as EventFieldsData),
+      data: endpointId ?? ({} as TimelineEventsDetailsItem),
       eventId,
       timelineId,
       values: endpointId?.values,
       linkValue: undefined,
     },
-  };
+  } as AlertSummaryRow;
 
   const summaryRowsWithAgentStatus = [...summaryRows, agentStatusRow];
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -170,7 +170,7 @@ const getSummaryRows = ({
         const description = {
           ...initialDescription,
           data: field,
-          values: field.originalValue,
+          values: field.values,
           linkValue: linkValue ?? undefined,
           fieldFromBrowserField: get(`${category}.fields.${field.field}`, browserFields),
         };

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -56,12 +56,9 @@ export interface Item {
 export interface AlertSummaryRow {
   title: string;
   description: {
-    contextId: string;
     data: EventFieldsData;
     eventId: string;
-    fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
-    fieldName: string;
-    fieldType: string;
+    // fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
     linkValue: string | undefined;
     timelineId: string;
     values: string[] | null | undefined;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -58,7 +58,7 @@ export interface AlertSummaryRow {
   description: {
     data: EventFieldsData;
     eventId: string;
-    // fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
+    fieldFromBrowserField?: Readonly<Record<string, Partial<BrowserField>>>;
     linkValue: string | undefined;
     timelineId: string;
     values: string[] | null | undefined;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -24,6 +24,7 @@ import {
 
 import * as i18n from './translations';
 import { ColumnHeaderOptions } from '../../../../common';
+import { EventFieldsData } from './types';
 
 /**
  * Defines the behavior of the search input that appears above the table of data
@@ -56,11 +57,14 @@ export interface AlertSummaryRow {
   title: string;
   description: {
     contextId: string;
+    data: EventFieldsData;
     eventId: string;
+    fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
     fieldName: string;
-    value: string;
     fieldType: string;
     linkValue: string | undefined;
+    timelineId: string;
+    values: string[] | null | undefined;
   };
 }
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -23,8 +23,7 @@ import {
 } from '../../../timelines/components/timeline/body/constants';
 
 import * as i18n from './translations';
-import { ColumnHeaderOptions } from '../../../../common';
-import { EventFieldsData } from './types';
+import { ColumnHeaderOptions, TimelineEventsDetailsItem } from '../../../../common';
 
 /**
  * Defines the behavior of the search input that appears above the table of data
@@ -56,7 +55,7 @@ export interface Item {
 export interface AlertSummaryRow {
   title: string;
   description: {
-    data: EventFieldsData;
+    data: TimelineEventsDetailsItem;
     eventId: string;
     fieldFromBrowserField?: Readonly<Record<string, Partial<BrowserField>>>;
     linkValue: string | undefined;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/helpers.tsx
@@ -213,7 +213,7 @@ export const getSummaryColumns = (
       field: 'title',
       truncateText: false,
       render: getTitle,
-      width: '160px',
+      width: '33%',
       name: '',
     },
     {

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/action_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/action_cell.tsx
@@ -19,7 +19,7 @@ interface Props {
   data: EventFieldsData;
   disabled?: boolean;
   eventId: string;
-  fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
+  fieldFromBrowserField?: Readonly<Record<string, Partial<BrowserField>>>;
   getLinkValue?: (field: string) => string | null;
   linkValue?: string | null | undefined;
   onFilterAdded?: () => void;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/action_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/action_cell.tsx
@@ -20,7 +20,8 @@ interface Props {
   disabled?: boolean;
   eventId: string;
   fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
-  getLinkValue: (field: string) => string | null;
+  getLinkValue?: (field: string) => string | null;
+  linkValue?: string | null | undefined;
   onFilterAdded?: () => void;
   timelineId?: string;
   toggleColumn?: (column: ColumnHeaderOptions) => void;
@@ -34,6 +35,7 @@ export const ActionCell: React.FC<Props> = React.memo(
     eventId,
     fieldFromBrowserField,
     getLinkValue,
+    linkValue,
     onFilterAdded,
     timelineId,
     toggleColumn,
@@ -47,7 +49,7 @@ export const ActionCell: React.FC<Props> = React.memo(
       fieldFromBrowserField,
       fieldType: data.type,
       isObjectArray: data.isObjectArray,
-      linkValue: getLinkValue(data.field),
+      linkValue: (getLinkValue && getLinkValue(data.field)) ?? linkValue,
       values,
     });
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/field_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/field_value_cell.tsx
@@ -18,7 +18,8 @@ export interface FieldValueCellProps {
   data: EventFieldsData;
   eventId: string;
   fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
-  getLinkValue: (field: string) => string | null;
+  getLinkValue?: (field: string) => string | null;
+  linkValue?: string | null | undefined;
   values: string[] | null | undefined;
 }
 
@@ -29,6 +30,7 @@ export const FieldValueCell = React.memo(
     eventId,
     fieldFromBrowserField,
     getLinkValue,
+    linkValue,
     values,
   }: FieldValueCellProps) => {
     return (
@@ -55,7 +57,7 @@ export const FieldValueCell = React.memo(
                     fieldType={data.type}
                     isObjectArray={data.isObjectArray}
                     value={value}
-                    linkValue={getLinkValue(data.field)}
+                    linkValue={(getLinkValue && getLinkValue(data.field)) ?? linkValue}
                   />
                 )}
               </div>

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/field_value_cell.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/field_value_cell.tsx
@@ -17,7 +17,7 @@ export interface FieldValueCellProps {
   contextId: string;
   data: EventFieldsData;
   eventId: string;
-  fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
+  fieldFromBrowserField?: Readonly<Record<string, Partial<BrowserField>>>;
   getLinkValue?: (field: string) => string | null;
   linkValue?: string | null | undefined;
   values: string[] | null | undefined;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/table/use_action_cell_data_provider.ts
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/table/use_action_cell_data_provider.ts
@@ -31,7 +31,7 @@ export interface UseActionCellDataProvider {
   eventId?: string;
   field: string;
   fieldFormat?: string;
-  fieldFromBrowserField: Readonly<Record<string, Partial<BrowserField>>>;
+  fieldFromBrowserField?: Readonly<Record<string, Partial<BrowserField>>>;
   fieldType?: string;
   isObjectArray?: boolean;
   linkValue?: string | null;

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { StatefulTopN } from '../../top_n';
@@ -44,15 +44,18 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
         ? SourcererScopeName.detections
         : SourcererScopeName.default;
     const { browserFields, indexPattern } = useSourcererScope(activeScope);
-    const button = (
-      <EuiButtonIcon
-        aria-label={SHOW_TOP(field)}
-        className="securitySolution__hoverActionButton"
-        data-test-subj="show-top-field"
-        iconSize="s"
-        iconType="visBarVertical"
-        onClick={onClick}
-      />
+    const button = useMemo(
+      () => (
+        <EuiButtonIcon
+          aria-label={SHOW_TOP(field)}
+          className="securitySolution__hoverActionButton"
+          data-test-subj="show-top-field"
+          iconSize="s"
+          iconType="visBarVertical"
+          onClick={onClick}
+        />
+      ),
+      [field, onClick]
     );
     return showTopN ? (
       <EuiPopover button={button} isOpen={showTopN} closePopover={onClick}>
@@ -80,14 +83,7 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
           />
         }
       >
-        <EuiButtonIcon
-          aria-label={SHOW_TOP(field)}
-          className="securitySolution__hoverActionButton"
-          data-test-subj="show-top-field"
-          iconSize="s"
-          iconType="visBarVertical"
-          onClick={onClick}
-        />
+        {button}
       </EuiToolTip>
     );
   }

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
@@ -39,7 +39,7 @@ export const AdditionalContent = styled.div`
 AdditionalContent.displayName = 'AdditionalContent';
 
 const StyledHoverActionsContainer = styled.div<{ $showTopN: boolean }>`
-  padding: ${(props) => (props.$showTopN ? 'none' : `0 ${props.theme.eui.paddingSizes.s}`)};
+  padding: ${(props) => `0 ${props.theme.eui.paddingSizes.s}`};
   display: flex;
 
   &:focus-within {
@@ -58,7 +58,7 @@ const StyledHoverActionsContainer = styled.div<{ $showTopN: boolean }>`
 
   .timelines__hoverActionButton,
   .securitySolution__hoverActionButton {
-    opacity: 0;
+    opacity: ${(props) => (props.$showTopN ? 1 : 0)};
 
     &:focus {
       opacity: 1;
@@ -268,7 +268,7 @@ export const HoverActions: React.FC<Props> = React.memo(
       ]
     );
 
-    const showFilters = !showTopN && values != null;
+    const showFilters = values != null;
 
     return (
       <StyledHoverActionsContainer onKeyDown={onKeyDown} ref={panelRef} $showTopN={showTopN}>
@@ -342,7 +342,7 @@ export const HoverActions: React.FC<Props> = React.memo(
               value={values}
             />
           )}
-          {!showTopN && (
+          {showFilters && (
             <CopyButton
               data-test-subj="hover-actions-copy-button"
               field={field}


### PR DESCRIPTION
## Summary


https://github.com/elastic/security-team/issues/1394
https://github.com/elastic/kibana/pull/105996

1. Reuse the `ActionCell` and `ValueCell` to Overview tab.
2. Fix the padding of Hover actions.
3. Put TopN into a popover, so it wouldn't expand the row height.
4. Document table column distribution is be 1/3 Field, 2/3 value

Todos:
1. Fix inspect overlay on topN is opened
2. Reason field on flyout overview
3. Reuse rule name renderer from alerts table
 

<img width="1675" alt="Screenshot 2021-07-22 at 13 33 17" src="https://user-images.githubusercontent.com/6295984/126639667-75b48705-6b7d-4c44-a27a-460b51640ea5.png">

<img width="1680" alt="Screenshot 2021-07-21 at 11 17 05" src="https://user-images.githubusercontent.com/6295984/126473312-72131de0-8afe-4fc4-a238-aa602fe7ee23.png">


