### PR TITLE
[Logs UI] Prevent the "Alerts and rules" context menu from sticking

### DIFF
--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_dropdown.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_dropdown.tsx
@@ -54,13 +54,18 @@ export const AlertDropdown = () => {
     setPopoverOpen(true);
   }, [setPopoverOpen]);
 
+  const openFlyout = useCallback(() => {
+    setFlyoutVisible(true);
+    closePopover();
+  }, [setFlyoutVisible, closePopover]);
+
   const menuItems = useMemo(() => {
     return [
       <EuiContextMenuItem
         disabled={!canCreateAlerts}
         icon="bell"
         key="createLink"
-        onClick={() => setFlyoutVisible(true)}
+        onClick={openFlyout}
         toolTipContent={!canCreateAlerts ? readOnlyUserTooltipContent : undefined}
         toolTipTitle={!canCreateAlerts ? readOnlyUserTooltipTitle : undefined}
       >
@@ -76,7 +81,7 @@ export const AlertDropdown = () => {
         />
       </EuiContextMenuItem>,
     ];
-  }, [manageAlertsLinkProps, canCreateAlerts]);
+  }, [manageAlertsLinkProps, canCreateAlerts, openFlyout]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

Closes #106404 

Close the context menu when the user selects one of the menu items. It prevents the menu from staying open.