### PR TITLE
[Reporting] Update kibana.json files with owner information

### DIFF
--- a/x-pack/examples/reporting_example/kibana.json
+++ b/x-pack/examples/reporting_example/kibana.json
@@ -4,6 +4,11 @@
   "kibanaVersion": "kibana",
   "server": false,
   "ui": true,
+  "owner": {
+    "name": "Kibana Reporting Services",
+    "githubTeam": "kibana-reporting-services"
+  },
+  "description": "Example integration code for applications to feature reports.",
   "optionalPlugins": [],
   "requiredPlugins": ["reporting", "developerExamples", "navigation", "screenshotMode"]
 }

--- a/x-pack/plugins/reporting/kibana.json
+++ b/x-pack/plugins/reporting/kibana.json
@@ -2,6 +2,11 @@
   "id": "reporting",
   "version": "8.0.0",
   "kibanaVersion": "kibana",
+  "owner": {
+    "name": "Kibana Reporting Services",
+    "githubTeam": "kibana-reporting-services"
+  },
+  "description": "Reporting Services enables applications to feature reports that the user can automate with Watcher and download later.",
   "optionalPlugins": ["security", "spaces", "usageCollection"],
   "configPath": ["xpack", "reporting"],
   "requiredPlugins": [


### PR DESCRIPTION
## Summary

It has been requested that all Kibana plugins must add the owner and description properties to their kibana.json files.

This updates the owner info for the plugins owned by @elastic/kibana-reporting-services 

 - Reporting plugin
 - Reporting Example plugin