### PR TITLE
[ML] Add linking from Discover to Index data visualizer

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.test.tsx
@@ -41,13 +41,21 @@ describe('Discover topnav component', () => {
     const props = getProps(true);
     const component = shallowWithIntl(<DiscoverTopNav {...props} />);
     const topMenuConfig = component.props().config.map((obj: TopNavMenuData) => obj.id);
-    expect(topMenuConfig).toEqual(['options', 'new', 'save', 'open', 'share', 'inspect']);
+    expect(topMenuConfig).toEqual([
+      'options',
+      'new',
+      'save',
+      'open',
+      'share',
+      'inspect',
+      'dataVisualizer',
+    ]);
   });
 
   test('generated config of TopNavMenu config is correct when no discover save permissions are assigned', () => {
     const props = getProps(false);
     const component = shallowWithIntl(<DiscoverTopNav {...props} />);
     const topMenuConfig = component.props().config.map((obj: TopNavMenuData) => obj.id);
-    expect(topMenuConfig).toEqual(['options', 'new', 'open', 'share', 'inspect']);
+    expect(topMenuConfig).toEqual(['options', 'new', 'open', 'share', 'inspect', 'dataVisualizer']);
   });
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.test.ts
@@ -80,6 +80,13 @@ test('getTopNavLinks result', () => {
         "run": [Function],
         "testId": "openInspectorButton",
       },
+      Object {
+        "description": "Open in Data visualizer",
+        "id": "dataVisualizer",
+        "label": "Data visualizer",
+        "run": [Function],
+        "testId": "dataVisualizerTopNavButton",
+      },
     ]
   `);
 });

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/index.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './locator';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.test.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IndexDataVisualizerLocatorDefinition } from './locator';
+
+describe('Index data visualizer locator', () => {
+  const definition = new IndexDataVisualizerLocatorDefinition();
+
+  it('should generate valid URL for the Index Data Visualizer Viewer page with global settings', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      timeRange: {
+        from: 'now-30m',
+        to: 'now',
+      },
+      refreshInterval: { pause: false, value: 300 },
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        '/jobs/new_job/datavisualizer?index=3da93760-e0af-11ea-9ad3-3bcfc330e42a&_a=(DATA_VISUALIZER_INDEX_VIEWER:())&_g=(refreshInterval:(pause:!f,value:300),time:(from:now-30m,to:now))',
+      state: {},
+    });
+  });
+
+  it('should prioritize savedSearchId even when index pattern id is available', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      savedSearchId: '45014020-dffa-11eb-b120-a105fbbe93b3',
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        '/jobs/new_job/datavisualizer?savedSearchId=45014020-dffa-11eb-b120-a105fbbe93b3&_a=(DATA_VISUALIZER_INDEX_VIEWER:())&_g=()',
+      state: {},
+    });
+  });
+
+  it('should generate valid URL with field names and field types', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      visibleFieldNames: ['@timestamp', 'responsetime'],
+      visibleFieldTypes: ['number'],
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        "/jobs/new_job/datavisualizer?_a=(DATA_VISUALIZER_INDEX_VIEWER:(visibleFieldNames:!('@timestamp',responsetime),visibleFieldTypes:!(number)))&_g=()",
+      state: {},
+    });
+  });
+
+  it('should generate valid URL with KQL query', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      query: {
+        searchQuery: {
+          bool: {
+            should: [
+              {
+                match: {
+                  region: 'ap-northwest-1',
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+        searchString: 'region : ap-northwest-1',
+        searchQueryLanguage: 'kuery',
+      },
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        "/jobs/new_job/datavisualizer?index=3da93760-e0af-11ea-9ad3-3bcfc330e42a&_a=(DATA_VISUALIZER_INDEX_VIEWER:(searchQuery:(bool:(minimum_should_match:1,should:!((match:(region:ap-northwest-1))))),searchQueryLanguage:kuery,searchString:'region : ap-northwest-1'))&_g=()",
+      state: {},
+    });
+  });
+
+  it('should generate valid URL with Lucene query', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      query: {
+        searchQuery: {
+          query_string: {
+            query: 'region: ap-northwest-1',
+            analyze_wildcard: true,
+          },
+        },
+        searchString: 'region : ap-northwest-1',
+        searchQueryLanguage: 'lucene',
+      },
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        "/jobs/new_job/datavisualizer?index=3da93760-e0af-11ea-9ad3-3bcfc330e42a&_a=(DATA_VISUALIZER_INDEX_VIEWER:(searchQuery:(query_string:(analyze_wildcard:!t,query:'region: ap-northwest-1')),searchQueryLanguage:lucene,searchString:'region : ap-northwest-1'))&_g=()",
+      state: {},
+    });
+  });
+});

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// @ts-ignore
+import { encode } from 'rison-node';
+import { stringify } from 'query-string';
+import { SerializableState } from '../../../../../../../src/plugins/kibana_utils/common';
+import { RefreshInterval, TimeRange } from '../../../../../../../src/plugins/data/common';
+import { LocatorDefinition, LocatorPublic } from '../../../../../../../src/plugins/share/common';
+import { QueryState } from '../../../../../../../src/plugins/data/public';
+import { Dictionary, isRisonSerializationRequired } from '../../common/util/url_state';
+import { SearchQueryLanguage } from '../types/combined_query';
+
+export const DATA_VISUALIZER_APP_LOCATOR = 'DATA_VISUALIZER_APP_LOCATOR';
+
+export interface IndexDataVisualizerLocatorParams extends SerializableState {
+  /**
+   * Optionally set saved search ID.
+   */
+  savedSearchId?: string;
+
+  /**
+   * Optionally set index pattern ID.
+   */
+  indexPatternId?: string;
+
+  /**
+   * Optionally set the time range in the time picker.
+   */
+  timeRange?: TimeRange;
+
+  /**
+   * Optionally set the refresh interval.
+   */
+  refreshInterval?: RefreshInterval & SerializableState;
+
+  /**
+   * Optionally set a query.
+   */
+  query?: {
+    searchQuery: SerializableState;
+    searchString: string | SerializableState;
+    searchQueryLanguage: SearchQueryLanguage;
+  };
+
+  /**
+   * If not given, will use the uiSettings configuration for `storeInSessionStorage`. useHash determines
+   * whether to hash the data in the url to avoid url length issues.
+   */
+  useHash?: boolean;
+  /**
+   * Optionally set visible field names.
+   */
+  visibleFieldNames?: string[];
+  /**
+   * Optionally set visible field types.
+   */
+  visibleFieldTypes?: string[];
+}
+
+export type IndexDataVisualizerLocator = LocatorPublic<IndexDataVisualizerLocatorParams>;
+
+export class IndexDataVisualizerLocatorDefinition
+  implements LocatorDefinition<IndexDataVisualizerLocatorParams> {
+  public readonly id = DATA_VISUALIZER_APP_LOCATOR;
+
+  constructor() {}
+
+  public readonly getLocation = async (params: IndexDataVisualizerLocatorParams) => {
+    const {
+      indexPatternId,
+      query,
+      refreshInterval,
+      savedSearchId,
+      timeRange,
+      visibleFieldNames,
+      visibleFieldTypes,
+    } = params;
+
+    const appState: {
+      searchQuery?: { [key: string]: any };
+      searchQueryLanguage?: string;
+      searchString?: string | SerializableState;
+      visibleFieldNames?: string[];
+      visibleFieldTypes?: string[];
+    } = {};
+    const queryState: QueryState = {};
+
+    if (query) {
+      appState.searchQuery = query.searchQuery;
+      appState.searchString = query.searchString;
+      appState.searchQueryLanguage = query.searchQueryLanguage;
+    }
+    if (visibleFieldNames) appState.visibleFieldNames = visibleFieldNames;
+    if (visibleFieldTypes) appState.visibleFieldTypes = visibleFieldTypes;
+
+    if (timeRange) queryState.time = timeRange;
+    if (refreshInterval) queryState.refreshInterval = refreshInterval;
+
+    const urlState: Dictionary<any> = {
+      ...(savedSearchId ? { savedSearchId } : { index: indexPatternId }),
+      _a: { DATA_VISUALIZER_INDEX_VIEWER: appState },
+      _g: queryState,
+    };
+
+    const parsedQueryString: Dictionary<any> = {};
+    Object.keys(urlState).forEach((a) => {
+      if (isRisonSerializationRequired(a)) {
+        parsedQueryString[a] = encode(urlState[a]);
+      } else {
+        parsedQueryString[a] = urlState[a];
+      }
+    });
+    const newLocationSearchString = stringify(parsedQueryString, {
+      sort: false,
+      encode: false,
+    });
+
+    const path = `/jobs/new_job/datavisualizer?${newLocationSearchString}`;
+    return {
+      app: 'ml',
+      path,
+      state: {},
+    };
+  };
+}

--- a/x-pack/plugins/data_visualizer/public/plugin.ts
+++ b/x-pack/plugins/data_visualizer/public/plugin.ts
@@ -21,8 +21,14 @@ import type { IndexPatternFieldEditorStart } from '../../../../src/plugins/index
 import { getFileDataVisualizerComponent, getIndexDataVisualizerComponent } from './api';
 import { getMaxBytesFormatted } from './application/common/util/get_max_bytes';
 import { registerHomeAddData, registerHomeFeatureCatalogue } from './register_home';
+import {
+  IndexDataVisualizerLocator,
+  IndexDataVisualizerLocatorDefinition,
+} from './application/index_data_visualizer/locator';
+import { SharePluginSetup } from '../../../../src/plugins/share/public';
 
 export interface DataVisualizerSetupDependencies {
+  share?: SharePluginSetup;
   home?: HomePublicPluginSetup;
 }
 export interface DataVisualizerStartDependencies {
@@ -47,10 +53,16 @@ export class DataVisualizerPlugin
       DataVisualizerSetupDependencies,
       DataVisualizerStartDependencies
     > {
+  private locator?: IndexDataVisualizerLocator;
+
   public setup(core: CoreSetup, plugins: DataVisualizerSetupDependencies) {
     if (plugins.home) {
       registerHomeAddData(plugins.home);
       registerHomeFeatureCatalogue(plugins.home);
+    }
+
+    if (plugins.share) {
+      this.locator = plugins.share.url.locators.create(new IndexDataVisualizerLocatorDefinition());
     }
   }
 
@@ -60,6 +72,7 @@ export class DataVisualizerPlugin
       getFileDataVisualizerComponent,
       getIndexDataVisualizerComponent,
       getMaxBytesFormatted,
+      locator: this.locator,
     };
   }
 }

--- a/x-pack/plugins/ml/public/locator/ml_locator.test.ts
+++ b/x-pack/plugins/ml/public/locator/ml_locator.test.ts
@@ -9,7 +9,7 @@ import { MlLocatorDefinition } from './ml_locator';
 import { ML_PAGES } from '../../common/constants/locator';
 import { ANALYSIS_CONFIG_TYPE } from '../../common/constants/data_frame_analytics';
 
-describe('MlUrlGenerator', () => {
+describe('ML locator', () => {
   const definition = new MlLocatorDefinition();
 
   describe('AnomalyDetection', () => {


### PR DESCRIPTION
## Summary

This PR allows to open the Index data visualizer in a new tab from Discover. Currently it retains the current query, time range, refresh interval.

https://user-images.githubusercontent.com/43350163/126551766-a1dbf2ba-13d8-4a97-8922-6f5068548868.mov

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
