### PR TITLE
fix: remove called to deprecated url.resolve

### DIFF
--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -7,7 +7,6 @@
  */
 
 import { pick, throttle, cloneDeep } from 'lodash';
-import { join } from 'path';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import {
@@ -511,7 +510,7 @@ export class SavedObjectsClient {
   }
 
   private getPath(path: Array<string | undefined>): string {
-    return join(API_BASE_URL, joinUriComponents(...path));
+    return API_BASE_URL + joinUriComponents(...path);
   }
 
   /**

--- a/src/core/public/saved_objects/saved_objects_client.ts
+++ b/src/core/public/saved_objects/saved_objects_client.ts
@@ -7,7 +7,7 @@
  */
 
 import { pick, throttle, cloneDeep } from 'lodash';
-import { resolve as resolveUrl } from 'url';
+import { join } from 'path';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import {
@@ -121,7 +121,7 @@ interface BatchQueueEntry {
   reject: (reason?: any) => void;
 }
 
-const join = (...uriComponents: Array<string | undefined>) =>
+const joinUriComponents = (...uriComponents: Array<string | undefined>) =>
   uriComponents
     .filter((comp): comp is string => Boolean(comp))
     .map(encodeURIComponent)
@@ -511,7 +511,7 @@ export class SavedObjectsClient {
   }
 
   private getPath(path: Array<string | undefined>): string {
-    return resolveUrl(API_BASE_URL, join(...path));
+    return join(API_BASE_URL, joinUriComponents(...path));
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixing a small issue I found on my travels, `url.resolve` is now [deprecated](https://nodejs.org/docs/latest-v14.x/api/url.html#url_url_resolve_from_to), as we are using it to simply join basic paths without the more jazzy href style features, I believe we can just replace it with `path.join`, that has meant me renaming the internal `join` function.
