### PR TITLE
[7.x] [Metrics UI] Increase number of saved objects fetched to 1000 (#106310)

### DIFF
--- a/x-pack/plugins/infra/public/hooks/use_find_saved_object.tsx
+++ b/x-pack/plugins/infra/public/hooks/use_find_saved_object.tsx
@@ -7,9 +7,11 @@
 
 import { useState, useCallback } from 'react';
 import { SavedObjectAttributes, SavedObjectsBatchResponse } from 'src/core/public';
+import { useUiTracker } from '../../../observability/public';
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
 
 export const useFindSavedObject = <SavedObjectType extends SavedObjectAttributes>(type: string) => {
+  const trackMetric = useUiTracker({ app: 'infra_metrics' });
   const kibana = useKibana();
   const [data, setData] = useState<SavedObjectsBatchResponse<SavedObjectType> | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -27,10 +29,17 @@ export const useFindSavedObject = <SavedObjectType extends SavedObjectAttributes
             type,
             search: query,
             searchFields,
+            page: 1,
+            perPage: 1000,
           });
           setError(null);
           setLoading(false);
           setData(d);
+          if (d.total > 1000) {
+            trackMetric({ metric: `over_1000_saved_objects_for_${type}` });
+          } else {
+            trackMetric({ metric: `under_1000_saved_objects_for_${type}` });
+          }
         } catch (e) {
           setLoading(false);
           setError(e);
@@ -38,7 +47,7 @@ export const useFindSavedObject = <SavedObjectType extends SavedObjectAttributes
       };
       fetchData();
     },
-    [type, kibana.services.savedObjects]
+    [type, kibana.services.savedObjects, trackMetric]
   );
 
   const hasView = async (name: string) => {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Increase number of saved objects fetched to 1000 (#106310)