### PR TITLE
[Security solution] [Timeline] Improve timeline title and move description to notes tab

### DIFF
--- a/x-pack/plugins/security_solution/common/types/timeline/index.ts
+++ b/x-pack/plugins/security_solution/common/types/timeline/index.ts
@@ -460,6 +460,17 @@ export enum TimelineTabs {
   eql = 'eql',
 }
 
+/**
+ * Used for scrolling top inside a tab. Especially when swiching tabs.
+ */
+export interface ScrollToTopEvent {
+  /**
+   * Timestamp of the moment when the event happened.
+   * The timestamp might be necessary for the scenario where the event could happen multiple times.
+   */
+  timestamp: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type EmptyObject = Record<any, never>;
 

--- a/x-pack/plugins/security_solution/cypress/integration/timelines/creation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/creation.spec.ts
@@ -16,6 +16,7 @@ import {
   TIMELINE_FLYOUT_WRAPPER,
   TIMELINE_PANEL,
   TIMELINE_TAB_CONTENT_EQL,
+  TIMELINE_TAB_CONTENT_GRAPHS_NOTES,
 } from '../../screens/timeline';
 import { createTimelineTemplate } from '../../tasks/api_calls/timelines';
 
@@ -90,7 +91,9 @@ describe('Timelines', (): void => {
 
     it('can be added notes', () => {
       addNotesToTimeline(getTimeline().notes);
-      cy.get(NOTES_TEXT).should('have.text', getTimeline().notes);
+      cy.get(TIMELINE_TAB_CONTENT_GRAPHS_NOTES)
+        .find(NOTES_TEXT)
+        .should('have.text', getTimeline().notes);
     });
 
     it('should update timeline after adding eql', () => {

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -132,18 +132,17 @@ export const goToQueryTab = () => {
 };
 
 export const addNotesToTimeline = (notes: string) => {
-  let notesCount = 0;
   goToNotesTab().then(() => {
-    cy.get(NOTES_TEXT_AREA).type(notes);
-    cy.root()
-      .pipe(($el) => {
-        notesCount = parseInt($el.find(NOTES_TAB_BUTTON).find('.euiBadge').text(), 10);
-        $el.find(ADD_NOTE_BUTTON).trigger('click');
-        return $el.find(NOTES_TAB_BUTTON).find('.euiBadge');
-      })
-      .should('have.text', notesCount + 1);
-  });
+    cy.get(NOTES_TAB_BUTTON)
+      .find('.euiBadge__text')
+      .then(($el) => {
+        const notesCount = parseInt($el.text(), 10);
 
+        cy.get(NOTES_TEXT_AREA).type(notes);
+        cy.get(ADD_NOTE_BUTTON).trigger('click');
+        cy.get(`${NOTES_TAB_BUTTON} .euiBadge`).should('have.text', `${notesCount + 1}`);
+      });
+  });
   goToQueryTab();
   goToNotesTab();
 };

--- a/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/timeline.ts
@@ -132,14 +132,16 @@ export const goToQueryTab = () => {
 };
 
 export const addNotesToTimeline = (notes: string) => {
+  let notesCount = 0;
   goToNotesTab().then(() => {
     cy.get(NOTES_TEXT_AREA).type(notes);
     cy.root()
       .pipe(($el) => {
+        notesCount = parseInt($el.find(NOTES_TAB_BUTTON).find('.euiBadge').text(), 10);
         $el.find(ADD_NOTE_BUTTON).trigger('click');
         return $el.find(NOTES_TAB_BUTTON).find('.euiBadge');
       })
-      .should('have.text', '1');
+      .should('have.text', notesCount + 1);
   });
 
   goToQueryTab();

--- a/x-pack/plugins/security_solution/public/common/components/line_clamp/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/line_clamp/index.tsx
@@ -38,7 +38,11 @@ const StyledLineClamp = styled.div<{ lineClampHeight: number }>`
 const LineClampComponent: React.FC<{
   children: ReactNode;
   lineClampHeight?: number;
-}> = ({ children, lineClampHeight = LINE_CLAMP_HEIGHT }) => {
+  /**
+   * Overwrites tooggle behaviour.
+   */
+  onReadMore?: () => void;
+}> = ({ children, lineClampHeight = LINE_CLAMP_HEIGHT, onReadMore }) => {
   const [isOverflow, setIsOverflow] = useState<boolean | null>(null);
   const [isExpanded, setIsExpanded] = useState<boolean | null>(null);
   const descriptionRef = useRef<HTMLDivElement>(null);
@@ -91,7 +95,11 @@ const LineClampComponent: React.FC<{
         children
       )}
       {isOverflow && (
-        <ReadMore onClick={toggleReadMore} size="s" data-test-subj="summary-view-readmore">
+        <ReadMore
+          onClick={onReadMore ?? toggleReadMore}
+          size="s"
+          data-test-subj="summary-view-readmore"
+        >
           {i18n.READ_MORE}
         </ReadMore>
       )}

--- a/x-pack/plugins/security_solution/public/common/components/line_clamp/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/line_clamp/index.tsx
@@ -6,8 +6,9 @@
  */
 
 import { EuiButtonEmpty } from '@elastic/eui';
-import React, { useRef, useState, useEffect, useCallback, ReactNode } from 'react';
+import React, { useState, useCallback, ReactNode } from 'react';
 import styled from 'styled-components';
+import { useIsOverflow } from '../../hooks/use_is_overflow';
 import * as i18n from './translations';
 
 const LINE_CLAMP = 3;
@@ -38,32 +39,12 @@ const StyledLineClamp = styled.div<{ lineClampHeight: number }>`
 const LineClampComponent: React.FC<{
   children: ReactNode;
   lineClampHeight?: number;
-  /**
-   * Overwrites tooggle behaviour.
-   */
-  onReadMore?: () => void;
-}> = ({ children, lineClampHeight = LINE_CLAMP_HEIGHT, onReadMore }) => {
-  const [isOverflow, setIsOverflow] = useState<boolean | null>(null);
+}> = ({ children, lineClampHeight = LINE_CLAMP_HEIGHT }) => {
   const [isExpanded, setIsExpanded] = useState<boolean | null>(null);
-  const descriptionRef = useRef<HTMLDivElement>(null);
+  const [isOverflow, descriptionRef] = useIsOverflow(children);
+
   const toggleReadMore = useCallback(() => {
     setIsExpanded((prevState) => !prevState);
-  }, []);
-
-  useEffect(() => {
-    if (descriptionRef?.current?.clientHeight != null) {
-      if (
-        (descriptionRef?.current?.scrollHeight ?? 0) > (descriptionRef?.current?.clientHeight ?? 0)
-      ) {
-        setIsOverflow(true);
-      }
-
-      if (
-        (descriptionRef?.current?.scrollHeight ?? 0) <= (descriptionRef?.current?.clientHeight ?? 0)
-      ) {
-        setIsOverflow(false);
-      }
-    }
   }, []);
 
   if (isExpanded) {
@@ -95,11 +76,7 @@ const LineClampComponent: React.FC<{
         children
       )}
       {isOverflow && (
-        <ReadMore
-          onClick={onReadMore ?? toggleReadMore}
-          size="s"
-          data-test-subj="summary-view-readmore"
-        >
+        <ReadMore onClick={toggleReadMore} size="s" data-test-subj="summary-view-readmore">
           {i18n.READ_MORE}
         </ReadMore>
       )}

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/editor.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/editor.tsx
@@ -17,6 +17,7 @@ interface MarkdownEditorProps {
   editorId?: string;
   dataTestSubj?: string;
   height?: number;
+  autoFocusDisabled?: boolean;
 }
 
 const MarkdownEditorComponent: React.FC<MarkdownEditorProps> = ({
@@ -26,16 +27,18 @@ const MarkdownEditorComponent: React.FC<MarkdownEditorProps> = ({
   editorId,
   dataTestSubj,
   height,
+  autoFocusDisabled = false,
 }) => {
   const [markdownErrorMessages, setMarkdownErrorMessages] = useState([]);
   const onParse = useCallback((err, { messages }) => {
     setMarkdownErrorMessages(err ? [err] : messages);
   }, []);
 
-  useEffect(
-    () => document.querySelector<HTMLElement>('textarea.euiMarkdownEditorTextArea')?.focus(),
-    []
-  );
+  useEffect(() => {
+    if (!autoFocusDisabled) {
+      document.querySelector<HTMLElement>('textarea.euiMarkdownEditorTextArea')?.focus();
+    }
+  }, [autoFocusDisabled]);
 
   return (
     <EuiMarkdownEditor

--- a/x-pack/plugins/security_solution/public/common/components/scroll_to_top/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/scroll_to_top/index.test.tsx
@@ -31,6 +31,24 @@ describe('Scroll to top', () => {
     Object.defineProperty(globalNode.window, 'scroll', { value: null });
     Object.defineProperty(globalNode.window, 'scrollTo', { value: spyScrollTo });
     mount(<HookWrapper hook={() => useScrollToTop()} />);
+
     expect(spyScrollTo).toHaveBeenCalled();
+  });
+
+  test('should not scroll when `shouldScroll` is false', () => {
+    Object.defineProperty(globalNode.window, 'scroll', { value: spyScroll });
+    mount(<HookWrapper hook={() => useScrollToTop(undefined, false)} />);
+
+    expect(spyScrollTo).not.toHaveBeenCalled();
+  });
+
+  test('should scroll the element matching the given selector', () => {
+    const fakeElement = { scroll: spyScroll };
+    Object.defineProperty(globalNode.document, 'querySelector', {
+      value: () => fakeElement,
+    });
+    mount(<HookWrapper hook={() => useScrollToTop('fake selector')} />);
+
+    expect(spyScroll).toHaveBeenCalledWith(0, 0);
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/scroll_to_top/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/scroll_to_top/index.tsx
@@ -7,14 +7,22 @@
 
 import { useEffect } from 'react';
 
-export const useScrollToTop = () => {
+/**
+ * containerSelector: The element with scrolling. It defaults to the window.
+ * shouldScroll: It should be used for conditional scrolling.
+ */
+export const useScrollToTop = (containerSelector?: string, shouldScroll = true) => {
   useEffect(() => {
+    const container = containerSelector ? document.querySelector(containerSelector) : window;
+
+    if (!shouldScroll || !container) return;
+
     // trying to use new API - https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo
-    if (window.scroll) {
-      window.scroll(0, 0);
+    if (container.scroll) {
+      container.scroll(0, 0);
     } else {
       // just a fallback for older browsers
-      window.scrollTo(0, 0);
+      container.scrollTo(0, 0);
     }
   });
 

--- a/x-pack/plugins/security_solution/public/common/hooks/use_is_overflow.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_is_overflow.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * It checks if the element that receives the returned Ref has oveflow the max height.
+ */
+export const useIsOverflow: (
+  dependency: unknown
+) => [isOveflow: boolean | null, ref: React.RefObject<HTMLDivElement>] = (dependency) => {
+  const [isOverflow, setIsOverflow] = useState<boolean | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ref.current?.clientHeight != null) {
+      if ((ref?.current?.scrollHeight ?? 0) > (ref?.current?.clientHeight ?? 0)) {
+        setIsOverflow(true);
+      }
+
+      if ((ref.current?.scrollHeight ?? 0) <= (ref?.current?.clientHeight ?? 0)) {
+        setIsOverflow(false);
+      }
+    }
+  }, [ref, dependency]);
+
+  return [isOverflow, ref];
+};

--- a/x-pack/plugins/security_solution/public/common/mock/utils.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/utils.ts
@@ -24,6 +24,8 @@ import { defaultHeaders } from '../../timelines/components/timeline/body/column_
 interface Global extends NodeJS.Global {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   window?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  document?: any;
 }
 
 export const globalNode: Global = global;

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/active_timelines.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/active_timelines.tsx
@@ -41,6 +41,12 @@ const StyledEuiButtonEmpty = styled(EuiButtonEmpty)`
   }
 `;
 
+const TitleConatiner = styled(EuiFlexItem)`
+  overflow: hidden;
+  display: inline-block;
+  text-overflow: ellipsis;
+`;
+
 const ActiveTimelinesComponent: React.FC<ActiveTimelinesProps> = ({
   timelineId,
   timelineStatus,
@@ -100,7 +106,7 @@ const ActiveTimelinesComponent: React.FC<ActiveTimelinesProps> = ({
             />
           </EuiToolTip>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>{title}</EuiFlexItem>
+        <TitleConatiner grow={false}>{title}</TitleConatiner>
         {!isOpen && (
           <EuiFlexItem grow={false}>
             <TimelineEventsCountBadge />

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/translations.ts
@@ -61,6 +61,10 @@ export const USER_KPI_TITLE = i18n.translate('xpack.securitySolution.timeline.kp
   defaultMessage: 'Users',
 });
 
+export const READ_MORE = i18n.translate('xpack.securitySolution.timeline.properties.readMore', {
+  defaultMessage: 'Read More',
+});
+
 export const TIMELINE_TOGGLE_BUTTON_ARIA_LABEL = ({
   isOpen,
   title,

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/add_note/__snapshots__/new_note.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/add_note/__snapshots__/new_note.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`NewNote renders correctly 1`] = `
 >
   <Memo(MarkdownEditorComponent)
     ariaLabel="Note"
+    autoFocusDisabled={false}
     dataTestSubj="add-a-note"
     height={200}
     onChange={[MockFunction]}

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/add_note/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/add_note/index.tsx
@@ -50,7 +50,8 @@ export const AddNote = React.memo<{
   newNote: string;
   onCancelAddNote?: () => void;
   updateNewNote: UpdateInternalNewNote;
-}>(({ associateNote, newNote, onCancelAddNote, updateNewNote }) => {
+  autoFocusDisabled?: boolean;
+}>(({ associateNote, newNote, onCancelAddNote, updateNewNote, autoFocusDisabled = false }) => {
   const dispatch = useDispatch();
 
   const updateNote = useCallback((note: Note) => dispatch(appActions.updateNote({ note })), [
@@ -87,7 +88,12 @@ export const AddNote = React.memo<{
         <EuiScreenReaderOnly data-test-subj="screenReaderOnly">
           <p>{i18n.YOU_ARE_EDITING_A_NOTE}</p>
         </EuiScreenReaderOnly>
-        <NewNote note={newNote} noteInputHeight={200} updateNewNote={updateNewNote} />
+        <NewNote
+          note={newNote}
+          noteInputHeight={200}
+          updateNewNote={updateNewNote}
+          autoFocusDisabled={autoFocusDisabled}
+        />
         <ButtonsContainer gutterSize="none">
           {onCancelAddNote != null ? (
             <EuiFlexItem grow={false}>

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/add_note/new_note.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/add_note/new_note.tsx
@@ -24,7 +24,8 @@ export const NewNote = React.memo<{
   noteInputHeight: number;
   note: string;
   updateNewNote: UpdateInternalNewNote;
-}>(({ note, noteInputHeight, updateNewNote }) => {
+  autoFocusDisabled?: boolean;
+}>(({ note, noteInputHeight, updateNewNote, autoFocusDisabled = false }) => {
   return (
     <NewNoteTabs data-test-subj="new-note-tabs">
       <MarkdownEditor
@@ -33,6 +34,7 @@ export const NewNote = React.memo<{
         value={note}
         dataTestSubj="add-a-note"
         height={noteInputHeight}
+        autoFocusDisabled={autoFocusDisabled}
       />
     </NewNoteTabs>
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.test.tsx
@@ -10,10 +10,20 @@ import moment from 'moment';
 import { mountWithIntl } from '@kbn/test/jest';
 import React from 'react';
 import '../../../../common/mock/formatted_relative';
-
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { mockTimelineResults } from '../../../../common/mock/timeline_results';
 import { OpenTimelineResult, TimelineResultNote } from '../types';
 import { NotePreviews } from '.';
+
+jest.mock('../../../../common/hooks/use_selector');
+
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+  return {
+    ...original,
+    useDispatch: () => jest.fn(),
+  };
+});
 
 describe('NotePreviews', () => {
   let mockResults: OpenTimelineResult[];
@@ -26,6 +36,7 @@ describe('NotePreviews', () => {
     note1updated = moment('2019-03-24T04:12:33.000Z').valueOf();
     note2updated = moment(note1updated).add(1, 'minute').valueOf();
     note3updated = moment(note2updated).add(1, 'minute').valueOf();
+    (useDeepEqualSelector as jest.Mock).mockReset();
   });
 
   test('it renders a note preview for each note when isModal is false', () => {
@@ -46,24 +57,6 @@ describe('NotePreviews', () => {
     hasNotes[0].notes!.forEach(({ savedObjectId }) => {
       expect(wrapper.find(`[data-test-subj="note-preview-${savedObjectId}"]`).exists()).toBe(true);
     });
-  });
-
-  test('it does NOT render the preview container if notes is undefined', () => {
-    const wrapper = mountWithIntl(<NotePreviews />);
-
-    expect(wrapper.find('[data-test-subj="note-previews-container"]').exists()).toBe(false);
-  });
-
-  test('it does NOT render the preview container if notes is null', () => {
-    const wrapper = mountWithIntl(<NotePreviews notes={null} />);
-
-    expect(wrapper.find('[data-test-subj="note-previews-container"]').exists()).toBe(false);
-  });
-
-  test('it does NOT render the preview container if notes is empty', () => {
-    const wrapper = mountWithIntl(<NotePreviews notes={[]} />);
-
-    expect(wrapper.find('[data-test-subj="note-previews-container"]').exists()).toBe(false);
   });
 
   test('it filters-out non-unique savedObjectIds', () => {
@@ -144,5 +137,27 @@ describe('NotePreviews', () => {
     const wrapper = mountWithIntl(<NotePreviews notes={nonUniqueNotes} />);
 
     expect(wrapper.find(`.euiCommentEvent__headerUsername`).at(2).text()).toEqual('bob');
+  });
+
+  test('it renders timeline description as a note when showTimelineDescription is true and timelineId is defined', () => {
+    const timeline = mockTimelineResults[0];
+    (useDeepEqualSelector as jest.Mock).mockReturnValue(timeline);
+
+    const wrapper = mountWithIntl(
+      <NotePreviews notes={[]} showTimelineDescription timelineId="test-timeline-id" />
+    );
+
+    expect(wrapper.find('[data-test-subj="note-preview-description"]').first().text()).toContain(
+      timeline.description
+    );
+  });
+
+  test('it does`t render timeline description as a note when it is undefined', () => {
+    const timeline = mockTimelineResults[0];
+    (useDeepEqualSelector as jest.Mock).mockReturnValue({ ...timeline, description: undefined });
+
+    const wrapper = mountWithIntl(<NotePreviews notes={[]} />);
+
+    expect(wrapper.find('[data-test-subj="note-preview-description"]').exists()).toBe(false);
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/translations.ts
@@ -18,6 +18,13 @@ export const ADDED_A_NOTE = i18n.translate('xpack.securitySolution.timeline.adde
   defaultMessage: 'added a note',
 });
 
+export const ADDED_A_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.timeline.addedADescriptionLabel',
+  {
+    defaultMessage: 'added description',
+  }
+);
+
 export const AN_UNKNOWN_USER = i18n.translate(
   'xpack.securitySolution.timeline.anUnknownUserLabel',
   {

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_columns.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_columns.test.tsx
@@ -27,6 +27,15 @@ const mockTheme = getMockTheme({ eui: { euiColorMediumShade: '#ece' } });
 
 jest.mock('../../../../common/lib/kibana');
 
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+  return {
+    ...original,
+    useDispatch: () => jest.fn(),
+    useSelector: () => jest.fn(),
+  };
+});
+
 describe('#getCommonColumns', () => {
   let mockResults: OpenTimelineResult[];
 

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_columns.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/timelines_table/common_columns.tsx
@@ -20,7 +20,7 @@ import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
 import { TimelineType } from '../../../../../common/types/timeline';
 
-const DescriptionCell = styled.span`
+const LineClampTextContainer = styled.span`
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 5;
@@ -79,7 +79,11 @@ export const getCommonColumns = ({
             })
           }
         >
-          {isUntitled(timelineResult) ? i18n.UNTITLED_TIMELINE : title}
+          {isUntitled(timelineResult) ? (
+            i18n.UNTITLED_TIMELINE
+          ) : (
+            <LineClampTextContainer>{title}</LineClampTextContainer>
+          )}
         </EuiLink>
       ) : (
         <div data-test-subj={`title-no-saved-object-id-${title || 'no-title'}`}>
@@ -93,9 +97,9 @@ export const getCommonColumns = ({
     field: 'description',
     name: i18n.DESCRIPTION,
     render: (description: string) => (
-      <DescriptionCell data-test-subj="description">
+      <LineClampTextContainer data-test-subj="description">
         {description != null && description.trim().length > 0 ? description : getEmptyTagValue()}
-      </DescriptionCell>
+      </LineClampTextContainer>
     ),
     sortable: false,
   },

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -62,9 +62,9 @@ const StatefulTimelineComponent: React.FC<Props> = ({
   const containerElement = useRef<HTMLDivElement | null>(null);
   const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
   const { selectedPatterns } = useSourcererScope(SourcererScopeName.timeline);
-  const { graphEventId, savedObjectId, timelineType } = useDeepEqualSelector((state) =>
+  const { graphEventId, savedObjectId, timelineType, description } = useDeepEqualSelector((state) =>
     pick(
-      ['graphEventId', 'savedObjectId', 'timelineType'],
+      ['graphEventId', 'savedObjectId', 'timelineType', 'description'],
       getTimeline(state, timelineId) ?? timelineDefaults
     )
   );
@@ -146,6 +146,7 @@ const StatefulTimelineComponent: React.FC<Props> = ({
         setTimelineFullScreen={setTimelineFullScreen}
         timelineId={timelineId}
         timelineType={timelineType}
+        timelineDescription={description}
         timelineFullScreen={timelineFullScreen}
       />
     </TimelineContainer>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/notes_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/notes_tab_content/index.tsx
@@ -23,7 +23,10 @@ import styled from 'styled-components';
 import { useSourcererScope } from '../../../../common/containers/sourcerer';
 import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { timelineActions } from '../../../store/timeline';
-import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import {
+  useDeepEqualSelector,
+  useShallowEqualSelector,
+} from '../../../../common/hooks/use_selector';
 import { TimelineStatus, TimelineTabs } from '../../../../../common/types/timeline';
 import { appSelectors } from '../../../../common/store/app';
 import { AddNote } from '../../notes/add_note';
@@ -33,6 +36,8 @@ import { NotePreviews } from '../../open_timeline/note_previews';
 import { TimelineResultNote } from '../../open_timeline/types';
 import { getTimelineNoteSelector } from './selectors';
 import { DetailsPanel } from '../../side_panel';
+import { getScrollToTopSelector } from '../tabs_content/selectors';
+import { useScrollToTop } from '../../../../common/components/scroll_to_top';
 
 const FullWidthFlexGroup = styled(EuiFlexGroup)`
   width: 100%;
@@ -122,6 +127,12 @@ interface NotesTabContentProps {
 
 const NotesTabContentComponent: React.FC<NotesTabContentProps> = ({ timelineId }) => {
   const dispatch = useDispatch();
+
+  const getScrollToTop = useMemo(() => getScrollToTopSelector(), []);
+  const scrollToTop = useShallowEqualSelector((state) => getScrollToTop(state, timelineId));
+
+  useScrollToTop('#scrollableNotes', !!scrollToTop);
+
   const getTimelineNotes = useMemo(() => getTimelineNoteSelector(), []);
   const {
     createdBy,
@@ -202,7 +213,7 @@ const NotesTabContentComponent: React.FC<NotesTabContentProps> = ({ timelineId }
 
   return (
     <FullWidthFlexGroup>
-      <ScrollableFlexItem grow={2}>
+      <ScrollableFlexItem grow={2} id="scrollableNotes">
         <StyledPanel paddingSize="s">
           <EuiTitle>
             <h3>{NOTES}</h3>
@@ -216,7 +227,12 @@ const NotesTabContentComponent: React.FC<NotesTabContentProps> = ({ timelineId }
           />
           <EuiSpacer size="s" />
           {!isImmutable && (
-            <AddNote associateNote={associateNote} newNote={newNote} updateNewNote={setNewNote} />
+            <AddNote
+              associateNote={associateNote}
+              newNote={newNote}
+              updateNewNote={setNewNote}
+              autoFocusDisabled={!!scrollToTop}
+            />
           )}
         </StyledPanel>
       </ScrollableFlexItem>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/notes_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/notes_tab_content/index.tsx
@@ -208,7 +208,12 @@ const NotesTabContentComponent: React.FC<NotesTabContentProps> = ({ timelineId }
             <h3>{NOTES}</h3>
           </EuiTitle>
           <EuiSpacer />
-          <NotePreviews eventIdToNoteIds={eventIdToNoteIds} notes={notes} timelineId={timelineId} />
+          <NotePreviews
+            eventIdToNoteIds={eventIdToNoteIds}
+            notes={notes}
+            timelineId={timelineId}
+            showTimelineDescription
+          />
           <EuiSpacer size="s" />
           {!isImmutable && (
             <AddNote associateNote={associateNote} newNote={newNote} updateNewNote={setNewNote} />

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
@@ -236,6 +236,7 @@ const TabsContentComponent: React.FC<BasicTimelineTab> = ({
 
   const activeTab = useShallowEqualSelector((state) => getActiveTab(state, timelineId));
   const showTimeline = useShallowEqualSelector((state) => getShowTimeline(state, timelineId));
+
   const numberOfPinnedEvents = useShallowEqualSelector((state) =>
     getNumberOfPinnedEvents(state, timelineId)
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiBadge, EuiLoadingContent, EuiTabs, EuiTab } from '@elastic/eui';
+import { isEmpty } from 'lodash/fp';
 import React, { lazy, memo, Suspense, useCallback, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
@@ -59,6 +60,7 @@ interface BasicTimelineTab {
   timelineId: TimelineId;
   timelineType: TimelineType;
   graphEventId?: string;
+  timelineDescription: string;
 }
 
 const QueryTab: React.FC<{
@@ -222,6 +224,7 @@ const TabsContentComponent: React.FC<BasicTimelineTab> = ({
   timelineFullScreen,
   timelineType,
   graphEventId,
+  timelineDescription,
 }) => {
   const dispatch = useDispatch();
   const getActiveTab = useMemo(() => getActiveTabSelector(), []);
@@ -253,8 +256,10 @@ const TabsContentComponent: React.FC<BasicTimelineTab> = ({
   }, [globalTimelineNoteIds, eventIdToNoteIds]);
 
   const numberOfNotes = useMemo(
-    () => appNotes.filter((appNote) => allTimelineNoteIds.includes(appNote.id)).length,
-    [appNotes, allTimelineNoteIds]
+    () =>
+      appNotes.filter((appNote) => allTimelineNoteIds.includes(appNote.id)).length +
+      (isEmpty(timelineDescription) ? 0 : 1),
+    [appNotes, allTimelineNoteIds, timelineDescription]
   );
 
   const setQueryAsActiveTab = useCallback(() => {
@@ -362,6 +367,7 @@ const TabsContentComponent: React.FC<BasicTimelineTab> = ({
         rowRenderers={rowRenderers}
         timelineId={timelineId}
         timelineType={timelineType}
+        timelineDescription={timelineDescription}
       />
     </>
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/selectors.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/selectors.ts
@@ -27,3 +27,6 @@ export const getEventIdToNoteIdsSelector = () =>
 
 export const getNotesSelector = () =>
   createSelector(selectNotesById, (notesById) => Object.values(notesById));
+
+export const getScrollToTopSelector = () =>
+  createSelector(selectTimeline, (timeline) => timeline?.scrollToTop);

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
@@ -17,7 +17,7 @@ import {
 import { KqlMode, TimelineModel } from './model';
 import { InsertTimeline } from './types';
 import { FieldsEqlOptions } from '../../../../common/search_strategy/timeline';
-import {
+import type {
   TimelineEventsType,
   RowRendererId,
   TimelineTabs,
@@ -204,6 +204,7 @@ export const updateIndexNames = actionCreator<{
 export const setActiveTabTimeline = actionCreator<{
   id: string;
   activeTab: TimelineTabs;
+  scrollToTop?: boolean;
 }>('SET_ACTIVE_TAB_TIMELINE');
 
 export const toggleModalSaveTimeline = actionCreator<{

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/model.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/model.ts
@@ -11,6 +11,7 @@ import type {
   TimelineType,
   TimelineStatus,
   TimelineTabs,
+  ScrollToTopEvent,
 } from '../../../../common/types/timeline';
 import { PinnedEvent } from '../../../../common/types/timeline/pinned_event';
 import type { TGridModelForTimeline } from '../../../../../timelines/public';
@@ -23,6 +24,9 @@ export type TimelineModel = TGridModelForTimeline & {
   /** The selected tab to displayed in the timeline */
   activeTab: TimelineTabs;
   prevActiveTab: TimelineTabs;
+
+  /** Used for scrolling to top when swiching tabs. It includes the timestamp of when the event happened */
+  scrollToTop?: ScrollToTopEvent;
   /** Timeline saved object owner */
   createdBy?: string;
   /** A summary of the events and notes in this timeline */

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/model.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/model.ts
@@ -63,6 +63,8 @@ export type TimelineModel = TGridModelForTimeline & {
   status: TimelineStatus;
   /** updated saved object timestamp */
   updated?: number;
+  /** updated saved object user */
+  updatedBy?: string | null;
   /** timeline is saving */
   isSaving: boolean;
   version: string | null;

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/reducer.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/reducer.ts
@@ -331,7 +331,7 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
       },
     },
   }))
-  .case(setActiveTabTimeline, (state, { id, activeTab }) => ({
+  .case(setActiveTabTimeline, (state, { id, activeTab, scrollToTop }) => ({
     ...state,
     timelineById: {
       ...state.timelineById,
@@ -339,6 +339,11 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
         ...state.timelineById[id],
         activeTab,
         prevActiveTab: state.timelineById[id].activeTab,
+        scrollToTop: scrollToTop
+          ? {
+              timestamp: Math.floor(Date.now() / 1000), // convert to seconds to avoid unnecessary rerenders for multiple clicks
+            }
+          : undefined,
       },
     },
   }))


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/100259

## Summary
When the title or description is too big the timeline table is inaccessible.

After discussing with the team the following changes were suggested:

**Title**

* Truncate the title only in the UI.
* When the user hovers the title we display the full title.
* Truncate the title when it appears in a table.

**Description**

* The description should be a comment in notes like on cases.
* When the user clicks on the "read more" description we move the user to the notes tab (it considers that we display the description very small).
* Truncate the description when it appears in a table.
![Screenshot 2021-07-22 at 17 25 35](https://user-images.githubusercontent.com/1490444/126665956-5b1698b9-cec7-4898-b8e9-d2302d95697f.png)



![Screenshot 2021-07-22 at 17 26 12](https://user-images.githubusercontent.com/1490444/126665949-db0daf34-7def-4158-a93f-f0a9405e41dd.png)
![Screenshot 2021-07-22 at 17 25 49](https://user-images.githubusercontent.com/1490444/126665954-957829d4-68c4-421b-bd08-f1bff20589ae.png)
![Screenshot 2021-07-22 at 17 26 33](https://user-images.githubusercontent.com/1490444/126665937-eedc03d4-ddf6-49e7-9216-ade1588cbecb.png)
![Screenshot 2021-07-22 at 17 26 26](https://user-images.githubusercontent.com/1490444/126665942-b713705f-658f-42c3-9f81-b11ff1d835d3.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


