### PR TITLE
[DOCS] Update Watcher reference

### DIFF
--- a/docs/user/alerting/alerting-getting-started.asciidoc
+++ b/docs/user/alerting/alerting-getting-started.asciidoc
@@ -125,7 +125,7 @@ image::images/rule-concepts-summary.svg[Rules, connectors, alerts and actions wo
 [[alerting-concepts-differences]]
 == Differences from Watcher
 
-{kib} alerting and <<watcher-ui, {es} alerting>> are both used to detect conditions and can trigger actions in response, but they are completely independent alerting systems.
+{kib} alerting and <<watcher-ui,Watcher>> are both used to detect conditions and can trigger actions in response, but they are completely independent alerting systems.
 
 This section will clarify some of the important differences in the function and intent of the two systems.
 


### PR DESCRIPTION
## Summary

Kibana Alerting is now the preferred method for alerting in Elastic. To avoid confusion, we should use "Watcher" and avoid terms like "Elasticsearch alerting."

This updates a reference on the Alerting page. Relates to https://github.com/elastic/elasticsearch/pull/75220

### Preview