### PR TITLE
[Fleet] OpenAPI add specs for all missing routes from #79574

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1643,6 +1643,48 @@
           }
         ]
       }
+    },
+    "/epm/packages/{pkgName}/stats": {
+      "get": {
+        "summary": "Get stats for a package",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "response": {
+                      "$ref": "#/components/schemas/package_usage_stats"
+                    }
+                  },
+                  "required": [
+                    "response"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-package-stats",
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "pkgName",
+          "in": "path",
+          "required": true
+        }
+      ]
     }
   },
   "components": {
@@ -2388,6 +2430,18 @@
           {
             "$ref": "#/components/schemas/new_package_policy"
           }
+        ]
+      },
+      "package_usage_stats": {
+        "title": "Package usage stats",
+        "type": "object",
+        "properties": {
+          "agent_policy_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "agent_policy_count"
         ]
       }
     }

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -76,6 +76,23 @@
           }
         },
         "operationId": "get-settings"
+      },
+      "post": {
+        "summary": "Settings - Update",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/fleet_settings_response"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "update-settings"
       }
     },
     "/epm/categories": {
@@ -1919,37 +1936,41 @@
           "nonFatalErrors"
         ]
       },
-      "fleet_settings_response": {
-        "title": "Fleet Setup response",
+      "settings": {
+        "title": "Settings",
         "type": "object",
         "properties": {
-          "response": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "has_seen_add_data_notice": {
-                "type": "boolean"
-              },
-              "has_seen_fleet_migration_notice": {
-                "type": "boolean"
-              },
-              "fleet_server_hosts": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "fleet_server_hosts",
-              "id"
-            ]
+          "id": {
+            "type": "string"
+          },
+          "has_seen_add_data_notice": {
+            "type": "boolean"
+          },
+          "has_seen_fleet_migration_notice": {
+            "type": "boolean"
+          },
+          "fleet_server_hosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
-          "response"
+          "fleet_server_hosts",
+          "id"
+        ]
+      },
+      "fleet_settings_response": {
+        "title": "Fleet settings response",
+        "type": "object",
+        "properties": {
+          "item": {
+            "$ref": "#/components/schemas/settings"
+          }
+        },
+        "required": [
+          "item"
         ]
       },
       "search_result": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1699,6 +1699,95 @@
         "operationId": "get-outputs"
       }
     },
+    "/outputs/{outputId}": {
+      "get": {
+        "summary": "Output - Info",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "$ref": "#/components/schemas/output"
+                    }
+                  },
+                  "required": [
+                    "item"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-output"
+      },
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "outputId",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "put": {
+        "summary": "Output - Update",
+        "operationId": "update-output",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "hosts": {
+                    "type": "string"
+                  },
+                  "ca_sha256": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object"
+                  },
+                  "config_yaml": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "$ref": "#/components/schemas/output"
+                    }
+                  },
+                  "required": [
+                    "item"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ]
+      }
+    },
     "/epm/packages/{pkgName}/stats": {
       "get": {
         "summary": "Get stats for a package",
@@ -2524,12 +2613,6 @@
         "title": "Output",
         "type": "object",
         "properties": {
-          "hosts": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "id": {
             "type": "string"
           },
@@ -2540,11 +2623,31 @@
             "type": "string"
           },
           "type": {
+            "type": "string",
+            "enum": [
+              "elasticsearch"
+            ]
+          },
+          "hosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ca_sha256": {
+            "type": "string"
+          },
+          "api_key": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "config_yaml": {
             "type": "string"
           }
         },
         "required": [
-          "hosts",
           "id",
           "is_default",
           "name",

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -59,6 +59,25 @@
         ]
       }
     },
+    "/settings": {
+      "get": {
+        "summary": "Settings",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/fleet_settings_response"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-settings"
+      }
+    },
     "/epm/categories": {
       "get": {
         "summary": "Package categories",
@@ -1773,6 +1792,39 @@
         "required": [
           "isInitialized",
           "nonFatalErrors"
+        ]
+      },
+      "fleet_settings_response": {
+        "title": "Fleet Setup response",
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "has_seen_add_data_notice": {
+                "type": "boolean"
+              },
+              "has_seen_fleet_migration_notice": {
+                "type": "boolean"
+              },
+              "fleet_server_hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "fleet_server_hosts",
+              "id"
+            ]
+          }
+        },
+        "required": [
+          "response"
         ]
       },
       "search_result": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1663,6 +1663,42 @@
         ]
       }
     },
+    "/outputs": {
+      "get": {
+        "summary": "Outputs",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/output"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "perPage": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-outputs"
+      }
+    },
     "/epm/packages/{pkgName}/stats": {
       "get": {
         "summary": "Get stats for a package",
@@ -2482,6 +2518,37 @@
           {
             "$ref": "#/components/schemas/new_package_policy"
           }
+        ]
+      },
+      "output": {
+        "title": "Output",
+        "type": "object",
+        "properties": {
+          "hosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "hosts",
+          "id",
+          "is_default",
+          "name",
+          "type"
         ]
       },
       "package_usage_stats": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -36,6 +36,18 @@ paths:
       operationId: setup
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
+  /settings:
+    get:
+      summary: Settings
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/fleet_settings_response'
+      operationId: get-settings
   /epm/categories:
     get:
       summary: Package categories
@@ -1086,6 +1098,28 @@ components:
       required:
         - isInitialized
         - nonFatalErrors
+    fleet_settings_response:
+      title: Fleet Setup response
+      type: object
+      properties:
+        response:
+          type: object
+          properties:
+            id:
+              type: string
+            has_seen_add_data_notice:
+              type: boolean
+            has_seen_fleet_migration_notice:
+              type: boolean
+            fleet_server_hosts:
+              type: array
+              items:
+                type: string
+          required:
+            - fleet_server_hosts
+            - id
+      required:
+        - response
     search_result:
       title: Search result
       type: object

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1008,6 +1008,29 @@ paths:
                   - sucess
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
+  /outputs:
+    get:
+      summary: Outputs
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/output'
+                  total:
+                    type: integer
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+      operationId: get-outputs
   '/epm/packages/{pkgName}/stats':
     get:
       summary: Get stats for a package
@@ -1561,6 +1584,28 @@ components:
             version:
               type: string
         - $ref: '#/components/schemas/new_package_policy'
+    output:
+      title: Output
+      type: object
+      properties:
+        hosts:
+          type: array
+          items:
+            type: string
+        id:
+          type: string
+        is_default:
+          type: boolean
+        name:
+          type: string
+        type:
+          type: string
+      required:
+        - hosts
+        - id
+        - is_default
+        - name
+        - type
     package_usage_stats:
       title: Package usage stats
       type: object

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -996,6 +996,31 @@ paths:
                   - sucess
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
+  '/epm/packages/{pkgName}/stats':
+    get:
+      summary: Get stats for a package
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  response:
+                    $ref: '#/components/schemas/package_usage_stats'
+                required:
+                  - response
+      operationId: get-package-stats
+      security:
+        - basicAuth: []
+    parameters:
+      - schema:
+          type: string
+        name: pkgName
+        in: path
+        required: true
 components:
   securitySchemes:
     basicAuth:
@@ -1502,5 +1527,13 @@ components:
             version:
               type: string
         - $ref: '#/components/schemas/new_package_policy'
+    package_usage_stats:
+      title: Package usage stats
+      type: object
+      properties:
+        agent_policy_count:
+          type: integer
+      required:
+        - agent_policy_count
 security:
   - basicAuth: []

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -48,6 +48,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/fleet_settings_response'
       operationId: get-settings
+    post:
+      summary: Settings - Update
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/fleet_settings_response'
+      operationId: update-settings
   /epm/categories:
     get:
       summary: Package categories
@@ -1175,28 +1186,31 @@ components:
       required:
         - isInitialized
         - nonFatalErrors
-    fleet_settings_response:
-      title: Fleet Setup response
+    settings:
+      title: Settings
       type: object
       properties:
-        response:
-          type: object
-          properties:
-            id:
-              type: string
-            has_seen_add_data_notice:
-              type: boolean
-            has_seen_fleet_migration_notice:
-              type: boolean
-            fleet_server_hosts:
-              type: array
-              items:
-                type: string
-          required:
-            - fleet_server_hosts
-            - id
+        id:
+          type: string
+        has_seen_add_data_notice:
+          type: boolean
+        has_seen_fleet_migration_notice:
+          type: boolean
+        fleet_server_hosts:
+          type: array
+          items:
+            type: string
       required:
-        - response
+        - fleet_server_hosts
+        - id
+    fleet_settings_response:
+      title: Fleet settings response
+      type: object
+      properties:
+        item:
+          $ref: '#/components/schemas/settings'
+      required:
+        - item
     search_result:
       title: Search result
       type: object

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1031,6 +1031,60 @@ paths:
                   perPage:
                     type: integer
       operationId: get-outputs
+  '/outputs/{outputId}':
+    get:
+      summary: Output - Info
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/output'
+                required:
+                  - item
+      operationId: get-output
+    parameters:
+      - schema:
+          type: string
+        name: outputId
+        in: path
+        required: true
+    put:
+      summary: Output - Update
+      operationId: update-output
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                hosts:
+                  type: string
+                ca_sha256:
+                  type: string
+                config:
+                  type: object
+                config_yaml:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/output'
+                required:
+                  - item
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
   '/epm/packages/{pkgName}/stats':
     get:
       summary: Get stats for a package
@@ -1588,10 +1642,6 @@ components:
       title: Output
       type: object
       properties:
-        hosts:
-          type: array
-          items:
-            type: string
         id:
           type: string
         is_default:
@@ -1600,8 +1650,21 @@ components:
           type: string
         type:
           type: string
+          enum:
+            - elasticsearch
+        hosts:
+          type: array
+          items:
+            type: string
+        ca_sha256:
+          type: string
+        api_key:
+          type: string
+        config:
+          type: object
+        config_yaml:
+          type: string
       required:
-        - hosts
         - id
         - is_default
         - name

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_settings_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_settings_response.yaml
@@ -1,0 +1,21 @@
+title: Fleet Setup response
+type: object
+properties:
+  response:
+    type: object
+    properties:
+      id:
+        type: string
+      has_seen_add_data_notice:
+        type: boolean
+      has_seen_fleet_migration_notice:
+        type: boolean
+      fleet_server_hosts:
+        type: array
+        items:
+          type: string
+    required:
+      - fleet_server_hosts
+      - id
+required:
+  - response

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_settings_response.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/fleet_settings_response.yaml
@@ -1,21 +1,7 @@
-title: Fleet Setup response
+title: Fleet settings response
 type: object
 properties:
-  response:
-    type: object
-    properties:
-      id:
-        type: string
-      has_seen_add_data_notice:
-        type: boolean
-      has_seen_fleet_migration_notice:
-        type: boolean
-      fleet_server_hosts:
-        type: array
-        items:
-          type: string
-    required:
-      - fleet_server_hosts
-      - id
+  item:
+    $ref: ./settings.yaml
 required:
-  - response
+  - item

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output.yaml
@@ -1,10 +1,6 @@
 title: Output
 type: object
 properties:
-  hosts:
-    type: array
-    items:
-      type: string
   id:
     type: string
   is_default:
@@ -13,8 +9,20 @@ properties:
     type: string
   type:
     type: string
+    enum: ['elasticsearch']
+  hosts:
+    type: array
+    items:
+      type: string
+  ca_sha256:
+    type: string
+  api_key:
+    type: string
+  config:
+    type: object
+  config_yaml:
+    type: string
 required:
-  - hosts
   - id
   - is_default
   - name

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output.yaml
@@ -1,0 +1,21 @@
+title: Output
+type: object
+properties:
+  hosts:
+    type: array
+    items:
+      type: string
+  id:
+    type: string
+  is_default:
+    type: boolean
+  name:
+    type: string
+  type:
+    type: string
+required:
+  - hosts
+  - id
+  - is_default
+  - name
+  - type

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/package_usage_stats.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/package_usage_stats.yaml
@@ -1,0 +1,7 @@
+title: Package usage stats
+type: object
+properties:
+  agent_policy_count:
+    type: integer
+required:
+  - agent_policy_count

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/settings.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/settings.yaml
@@ -1,0 +1,16 @@
+title: Settings
+type: object
+properties:
+  id:
+    type: string
+  has_seen_add_data_notice:
+    type: boolean
+  has_seen_fleet_migration_notice:
+    type: boolean
+  fleet_server_hosts:
+    type: array
+    items:
+      type: string
+required:
+  - fleet_server_hosts
+  - id

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -66,6 +66,8 @@ paths:
     $ref: 'paths/package_policies@{package_policy_id}.yaml'
   /outputs:
     $ref: paths/outputs.yaml
+  /outputs/{outputId}:
+    $ref: paths/outputs@{output_id}.yaml
   '/epm/packages/{pkgName}/stats':
     $ref: 'paths/epm@packages@{pkg_name}@stats.yaml'
 components:

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -16,6 +16,8 @@ paths:
   # plugin-wide endpoint(s)
   /setup:
     $ref: paths/setup.yaml
+  /settings:
+    $ref: paths/settings.yaml
   # EPM / integrations endpoints
   /epm/categories:
     $ref: paths/epm@categories.yaml

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -64,6 +64,8 @@ paths:
     $ref: paths/package_policies@delete.yaml
   '/package_policies/{packagePolicyId}':
     $ref: 'paths/package_policies@{package_policy_id}.yaml'
+  /outputs:
+    $ref: paths/outputs.yaml
   '/epm/packages/{pkgName}/stats':
     $ref: 'paths/epm@packages@{pkg_name}@stats.yaml'
 components:

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -62,6 +62,8 @@ paths:
     $ref: paths/package_policies@delete.yaml
   '/package_policies/{packagePolicyId}':
     $ref: 'paths/package_policies@{package_policy_id}.yaml'
+  '/epm/packages/{pkgName}/stats':
+    $ref: 'paths/epm@packages@{pkg_name}@stats.yaml'
 components:
   securitySchemes:
     basicAuth:

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@stats.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@stats.yaml
@@ -1,0 +1,24 @@
+get:
+  summary: Get stats for a package
+  tags: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              response:
+                $ref: ../components/schemas/package_usage_stats.yaml
+            required:
+              - response
+  operationId: get-package-stats
+  security:
+    - basicAuth: []
+parameters:
+  - schema:
+      type: string
+    name: pkgName
+    in: path
+    required: true

--- a/x-pack/plugins/fleet/common/openapi/paths/outputs.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/outputs.yaml
@@ -1,0 +1,22 @@
+get:
+  summary: Outputs
+  tags: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              items:
+                type: array
+                items:
+                  $ref: ../components/schemas/output.yaml
+              total:
+                type: integer
+              page:
+                type: integer
+              perPage:
+                type: integer
+  operationId: get-outputs

--- a/x-pack/plugins/fleet/common/openapi/paths/outputs@{output_id}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/outputs@{output_id}.yaml
@@ -1,0 +1,53 @@
+get:
+  summary: Output - Info
+  tags: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              item:
+                $ref: ../components/schemas/output.yaml
+            required:
+              - item
+  operationId: get-output
+parameters:
+  - schema:
+      type: string
+    name: outputId
+    in: path
+    required: true
+put:
+  summary: Output - Update
+  operationId: update-output
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            hosts:
+              type: string
+            ca_sha256:
+              type: string
+            config:
+              type: object
+            config_yaml:
+              type: string
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              item:
+                $ref: ../components/schemas/output.yaml
+            required:
+              - item
+  parameters:
+    - $ref: ../components/headers/kbn_xsrf.yaml

--- a/x-pack/plugins/fleet/common/openapi/paths/settings.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/settings.yaml
@@ -9,3 +9,14 @@ get:
           schema:
             $ref: ../components/schemas/fleet_settings_response.yaml
   operationId: get-settings
+post:
+  summary: Settings - Update
+  tags: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/fleet_settings_response.yaml
+  operationId: update-settings

--- a/x-pack/plugins/fleet/common/openapi/paths/settings.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/settings.yaml
@@ -1,0 +1,11 @@
+get:
+  summary: Settings
+  tags: []
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/fleet_settings_response.yaml
+  operationId: get-settings


### PR DESCRIPTION
## Summary
Add OpenAPI specs for all the missing routes mentioned in https://github.com/elastic/kibana/issues/79574

- [x] `/settings` [commit](https://github.com/elastic/kibana/commit/da25a6091d09ff3c6969eb7d0c74c9abc1d6f904)  & [PR docs](http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/jfsiii/kibana/79574-missing-from-openapi/x-pack/plugins/fleet/common/openapi/bundled.json#operation/get-settings)
- [x] `/outputs` https://github.com/elastic/kibana/commit/ef1434587199e3a5f57f34bfa36d8d0faff11f74 & https://github.com/elastic/kibana/commit/0c1be7eae0e38587edf2783d2e50390ecdd44835 [PR docs start here](http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/jfsiii/kibana/79574-missing-from-openapi/x-pack/plugins/fleet/common/openapi/bundled.json#operation/get-output)
- [x] `/epm/packages/{pkgName}/stats` [commit](https://github.com/elastic/kibana/commit/7d984482874fc6d69b2bbf75b0f64d478ac90f7b) & [PR docs](http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/jfsiii/kibana/79574-missing-from-openapi/x-pack/plugins/fleet/common/openapi/bundled.json#operation/get-package-stats)



### Checklist
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
