### PR TITLE
[Uptime] [User experience] prevent search input focus loss

### DIFF
--- a/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.test.tsx
@@ -6,23 +6,25 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import * as fetcherHook from '../../../../../hooks/use_fetcher';
 import { SelectableUrlList } from './SelectableUrlList';
 import { render } from '../../utils/test_helper';
+import { I18LABELS } from '../../translations';
 
 describe('SelectableUrlList', () => {
+  jest.spyOn(fetcherHook, 'useFetcher').mockReturnValue({
+    data: {},
+    status: fetcherHook.FETCH_STATUS.SUCCESS,
+    refetch: jest.fn(),
+  });
+
+  const customHistory = createMemoryHistory({
+    initialEntries: ['/?searchTerm=blog'],
+  });
+
   it('it uses search term value from url', () => {
-    jest.spyOn(fetcherHook, 'useFetcher').mockReturnValue({
-      data: {},
-      status: fetcherHook.FETCH_STATUS.SUCCESS,
-      refetch: jest.fn(),
-    });
-
-    const customHistory = createMemoryHistory({
-      initialEntries: ['/?searchTerm=blog'],
-    });
-
     const { getByDisplayValue } = render(
       <SelectableUrlList
         initialValue={'blog'}
@@ -39,5 +41,28 @@ describe('SelectableUrlList', () => {
       { customHistory }
     );
     expect(getByDisplayValue('blog')).toBeInTheDocument();
+  });
+
+  it('maintains focus on search input field', () => {
+    const { getByLabelText } = render(
+      <SelectableUrlList
+        initialValue={'blog'}
+        loading={false}
+        data={{ items: [], total: 0 }}
+        onChange={jest.fn()}
+        searchValue={'blog'}
+        onInputChange={jest.fn()}
+        onTermChange={jest.fn()}
+        popoverIsOpen={false}
+        setPopoverIsOpen={jest.fn()}
+        onApply={jest.fn()}
+      />,
+      { customHistory }
+    );
+
+    const input = getByLabelText(I18LABELS.filterByUrl);
+    fireEvent.click(input);
+
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.test.tsx
@@ -5,8 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import React, { useState } from 'react';
+import {
+  fireEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+  screen,
+} from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import * as fetcherHook from '../../../../../hooks/use_fetcher';
 import { SelectableUrlList } from './SelectableUrlList';
@@ -23,6 +28,24 @@ describe('SelectableUrlList', () => {
   const customHistory = createMemoryHistory({
     initialEntries: ['/?searchTerm=blog'],
   });
+
+  function WrappedComponent() {
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+    return (
+      <SelectableUrlList
+        initialValue={'blog'}
+        loading={false}
+        data={{ items: [], total: 0 }}
+        onChange={jest.fn()}
+        searchValue={'blog'}
+        onInputChange={jest.fn()}
+        onTermChange={jest.fn()}
+        popoverIsOpen={Boolean(isPopoverOpen)}
+        setPopoverIsOpen={setIsPopoverOpen}
+        onApply={jest.fn()}
+      />
+    );
+  }
 
   it('it uses search term value from url', () => {
     const { getByDisplayValue } = render(
@@ -64,5 +87,35 @@ describe('SelectableUrlList', () => {
     fireEvent.click(input);
 
     expect(document.activeElement).toBe(input);
+  });
+
+  it('hides popover on escape', async () => {
+    const {
+      getByText,
+      getByLabelText,
+      queryByText,
+    } = render(<WrappedComponent />, { customHistory });
+
+    const input = getByLabelText(I18LABELS.filterByUrl);
+    fireEvent.click(input);
+
+    // wait for title of popover to be present
+    await waitFor(() => {
+      expect(getByText(I18LABELS.getSearchResultsLabel(0))).toBeInTheDocument();
+      screen.debug();
+    });
+
+    // escape key
+    fireEvent.keyDown(input, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27,
+    });
+
+    // wait for title of popover to be removed
+    await waitForElementToBeRemoved(() =>
+      queryByText(I18LABELS.getSearchResultsLabel(0))
+    );
   });
 });

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.tsx
@@ -72,7 +72,7 @@ interface Props {
   searchValue: string;
   popoverIsOpen: boolean;
   initialValue?: string;
-  setPopoverIsOpen: React.Dispatch<SetStateAction<boolean | undefined>>;
+  setPopoverIsOpen: React.Dispatch<SetStateAction<boolean>>;
 }
 
 export function SelectableUrlList({
@@ -93,6 +93,8 @@ export function SelectableUrlList({
 
   const titleRef = useRef<HTMLDivElement>(null);
 
+  const formattedOptions = formatOptions(data.items ?? []);
+
   const onEnterKey = (evt: KeyboardEvent<HTMLInputElement>) => {
     if (evt.key.toLowerCase() === 'enter') {
       onTermChange();
@@ -103,9 +105,6 @@ export function SelectableUrlList({
       }
     }
   };
-
-  // @ts-ignore - not sure, why it's not working
-  useEvent('keydown', onEnterKey, searchRef);
 
   const onInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
     setPopoverIsOpen(true);
@@ -119,14 +118,17 @@ export function SelectableUrlList({
     setPopoverIsOpen(true);
   };
 
-  const formattedOptions = formatOptions(data.items ?? []);
-
   const closePopover = () => {
     setPopoverIsOpen(false);
     if (searchRef) {
       searchRef.blur();
     }
   };
+
+  // @ts-ignore - not sure, why it's not working
+  useEvent('keydown', onEnterKey, searchRef);
+  useEvent('escape', () => setPopoverIsOpen(false), searchRef);
+  useEvent('blur', () => setPopoverIsOpen(false), searchRef);
 
   useEffect(() => {
     if (searchRef && initialValue) {

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/SelectableUrlList.tsx
@@ -109,6 +109,9 @@ export function SelectableUrlList({
 
   const onInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
     setPopoverIsOpen(true);
+    if (searchRef) {
+      searchRef.focus();
+    }
   };
 
   const onSearchInput = (e: React.FormEvent<HTMLInputElement>) => {
@@ -189,6 +192,7 @@ export function SelectableUrlList({
         onInput: onSearchInput,
         inputRef: setSearchRef,
         placeholder: I18LABELS.filterByUrl,
+        'aria-label': I18LABELS.filterByUrl,
       }}
       listProps={{
         rowHeight: 68,
@@ -210,6 +214,7 @@ export function SelectableUrlList({
             closePopover={closePopover}
             style={{ minWidth: 400 }}
             anchorPosition="downLeft"
+            ownFocus={false}
           >
             <div
               style={{

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/URLFilter/URLSearch/index.tsx
@@ -69,7 +69,7 @@ export function URLSearch({
 
   const { searchTerm, percentile } = urlParams;
 
-  const [popoverIsOpen, setPopoverIsOpen] = useState<boolean | undefined>();
+  const [popoverIsOpen, setPopoverIsOpen] = useState<boolean>(false);
 
   const [searchValue, setSearchValue] = useState(searchTerm ?? '');
 


### PR DESCRIPTION
## Summary

Fixes #102324 

Adjusts User Experience search input to preserve focus when the input is clicked.

[Prevents popover from owning focus](https://github.com/elastic/kibana/compare/master...dominiqueclarke:fix/102324-user-experience-search-input-prevent-focus-loss?expand=1#diff-d1b79d306cf2958dc7ac8bb273cc2b248680069de0b1e6239638913e0303fea6R219)
[Explicitly place focus on input when clicked](https://github.com/elastic/kibana/compare/master...dominiqueclarke:fix/102324-user-experience-search-input-prevent-focus-loss?expand=1#diff-d1b79d306cf2958dc7ac8bb273cc2b248680069de0b1e6239638913e0303fea6R111)

An enhancement was also added to [close the popover on escape and blur](https://github.com/elastic/kibana/compare/master...dominiqueclarke:fix/102324-user-experience-search-input-prevent-focus-loss?expand=1#diff-d1b79d306cf2958dc7ac8bb273cc2b248680069de0b1e6239638913e0303fea6R130)

![chrome-capture (17)](https://user-images.githubusercontent.com/11356435/126698847-ef491388-601a-4b20-94b1-b0df8ac44e37.gif)
