### PR TITLE
[7.x] [Metrics UI] Ensure alert dropdown closes properly (#106343)

### DIFF
--- a/x-pack/plugins/infra/public/alerting/common/components/metrics_alert_dropdown.tsx
+++ b/x-pack/plugins/infra/public/alerting/common/components/metrics_alert_dropdown.tsx
@@ -32,6 +32,13 @@ export const MetricsAlertDropdown = () => {
 
   const closeFlyout = useCallback(() => setVisibleFlyoutType(null), [setVisibleFlyoutType]);
 
+  const closePopover = useCallback(() => {
+    setPopoverOpen(false);
+  }, [setPopoverOpen]);
+
+  const togglePopover = useCallback(() => {
+    setPopoverOpen(!popoverOpen);
+  }, [setPopoverOpen, popoverOpen]);
   const infrastructureAlertsPanel = useMemo(
     () => ({
       id: 1,
@@ -40,14 +47,18 @@ export const MetricsAlertDropdown = () => {
       }),
       items: [
         {
+          'data-test-subj': 'inventory-alerts-create-rule',
           name: i18n.translate('xpack.infra.alerting.createInventoryRuleButton', {
             defaultMessage: 'Create inventory rule',
           }),
-          onClick: () => setVisibleFlyoutType('inventory'),
+          onClick: () => {
+            closePopover();
+            setVisibleFlyoutType('inventory');
+          },
         },
       ],
     }),
-    [setVisibleFlyoutType]
+    [setVisibleFlyoutType, closePopover]
   );
 
   const metricsAlertsPanel = useMemo(
@@ -58,14 +69,18 @@ export const MetricsAlertDropdown = () => {
       }),
       items: [
         {
+          'data-test-subj': 'metrics-threshold-alerts-create-rule',
           name: i18n.translate('xpack.infra.alerting.createThresholdRuleButton', {
             defaultMessage: 'Create threshold rule',
           }),
-          onClick: () => setVisibleFlyoutType('threshold'),
+          onClick: () => {
+            closePopover();
+            setVisibleFlyoutType('threshold');
+          },
         },
       ],
     }),
-    [setVisibleFlyoutType]
+    [setVisibleFlyoutType, closePopover]
   );
 
   const manageAlertsLinkProps = useLinkProps({
@@ -89,12 +104,14 @@ export const MetricsAlertDropdown = () => {
       canCreateAlerts
         ? [
             {
+              'data-test-subj': 'inventory-alerts-menu-option',
               name: i18n.translate('xpack.infra.alerting.infrastructureDropdownMenu', {
                 defaultMessage: 'Infrastructure',
               }),
               panel: 1,
             },
             {
+              'data-test-subj': 'metrics-threshold-alerts-menu-option',
               name: i18n.translate('xpack.infra.alerting.metricsDropdownMenu', {
                 defaultMessage: 'Metrics',
               }),
@@ -120,14 +137,6 @@ export const MetricsAlertDropdown = () => {
     [infrastructureAlertsPanel, metricsAlertsPanel, firstPanelMenuItems, canCreateAlerts]
   );
 
-  const closePopover = useCallback(() => {
-    setPopoverOpen(false);
-  }, [setPopoverOpen]);
-
-  const openPopover = useCallback(() => {
-    setPopoverOpen(true);
-  }, [setPopoverOpen]);
-
   return (
     <>
       <EuiPopover
@@ -138,7 +147,8 @@ export const MetricsAlertDropdown = () => {
             color="text"
             iconSide={'right'}
             iconType={'arrowDown'}
-            onClick={openPopover}
+            onClick={togglePopover}
+            data-test-subj="infrastructure-alerts-and-rules"
           >
             <FormattedMessage
               id="xpack.infra.alerting.alertsButton"
@@ -149,7 +159,7 @@ export const MetricsAlertDropdown = () => {
         isOpen={popoverOpen}
         closePopover={closePopover}
       >
-        <EuiContextMenu initialPanelId={0} panels={panels} />
+        <EuiContextMenu initialPanelId={0} panels={panels} data-test-subj="metrics-alert-menu" />
       </EuiPopover>
       <AlertFlyout visibleFlyoutType={visibleFlyoutType} onClose={closeFlyout} />
     </>

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -56,37 +56,64 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
+    describe('alerts flyouts', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
+        await pageObjects.common.navigateToApp('infraOps');
+        await pageObjects.infraHome.waitForLoading();
+        await pageObjects.infraHome.goToTime(DATE_WITH_DATA);
+      });
+      after(
+        async () =>
+          await esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs')
+      );
+
+      it('should open and close inventory alert flyout', async () => {
+        await pageObjects.infraHome.openInventoryAlertFlyout();
+        await pageObjects.infraHome.closeAlertFlyout();
+      });
+
+      it('should open and close inventory alert flyout', async () => {
+        await pageObjects.infraHome.openMetricsThresholdAlertFlyout();
+        await pageObjects.infraHome.closeAlertFlyout();
+      });
+
+      it('should open and close alerts popover using button', async () => {
+        await pageObjects.infraHome.clickAlertsAndRules();
+        await pageObjects.infraHome.ensurePopoverOpened();
+        await pageObjects.infraHome.clickAlertsAndRules();
+        await pageObjects.infraHome.ensurePopoverClosed();
+      });
+    });
+
     describe('Saved Views', () => {
       before(() => esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       after(() => esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
+      it('should have save and load controls', async () => {
+        await pageObjects.common.navigateToApp('infraOps');
+        await pageObjects.infraHome.goToTime(DATE_WITH_DATA);
+        await pageObjects.infraSavedViews.getSavedViewsButton();
+        await pageObjects.infraSavedViews.ensureViewIsLoaded('Default view');
+      });
 
-      describe('Inventory Test save functionality', () => {
-        it('should have save and load controls', async () => {
-          await pageObjects.common.navigateToApp('infraOps');
-          await pageObjects.infraHome.goToTime(DATE_WITH_DATA);
-          await pageObjects.infraSavedViews.getSavedViewsButton();
-          await pageObjects.infraSavedViews.ensureViewIsLoaded('Default view');
-        });
+      it('should open popover', async () => {
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
+        await pageObjects.infraSavedViews.closeSavedViewsPopover();
+      });
 
-        it('should open popover', async () => {
-          await pageObjects.infraSavedViews.clickSavedViewsButton();
-          await pageObjects.infraSavedViews.closeSavedViewsPopover();
-        });
+      it('should create new saved view and load it', async () => {
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
+        await pageObjects.infraSavedViews.clickSaveNewViewButton();
+        await pageObjects.infraSavedViews.getCreateSavedViewModal();
+        await pageObjects.infraSavedViews.createNewSavedView('view1');
+        await pageObjects.infraSavedViews.ensureViewIsLoaded('view1');
+      });
 
-        it('should create new saved view and load it', async () => {
-          await pageObjects.infraSavedViews.clickSavedViewsButton();
-          await pageObjects.infraSavedViews.clickSaveNewViewButton();
-          await pageObjects.infraSavedViews.getCreateSavedViewModal();
-          await pageObjects.infraSavedViews.createNewSavedView('view1');
-          await pageObjects.infraSavedViews.ensureViewIsLoaded('view1');
-        });
-
-        it('should new views should be listed in the load views list', async () => {
-          await pageObjects.infraSavedViews.clickSavedViewsButton();
-          await pageObjects.infraSavedViews.clickLoadViewButton();
-          await pageObjects.infraSavedViews.ensureViewIsLoadable('view1');
-          await pageObjects.infraSavedViews.closeSavedViewsLoadModal();
-        });
+      it('should new views should be listed in the load views list', async () => {
+        await pageObjects.infraSavedViews.clickSavedViewsButton();
+        await pageObjects.infraSavedViews.clickLoadViewButton();
+        await pageObjects.infraSavedViews.ensureViewIsLoadable('view1');
+        await pageObjects.infraSavedViews.closeSavedViewsLoadModal();
       });
     });
   });

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -195,5 +195,37 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await thresholdInput.clearValueWithKeyboard({ charByChar: true });
       await thresholdInput.type([threshold]);
     },
+
+    async clickAlertsAndRules() {
+      await testSubjects.click('infrastructure-alerts-and-rules');
+    },
+
+    async ensurePopoverOpened() {
+      await testSubjects.existOrFail('metrics-alert-menu');
+    },
+
+    async ensurePopoverClosed() {
+      await testSubjects.missingOrFail('metrics-alert-menu');
+    },
+
+    async openInventoryAlertFlyout() {
+      await testSubjects.click('infrastructure-alerts-and-rules');
+      await testSubjects.click('inventory-alerts-menu-option');
+      await testSubjects.click('inventory-alerts-create-rule');
+      await testSubjects.missingOrFail('inventory-alerts-create-rule');
+      await testSubjects.find('euiFlyoutCloseButton');
+    },
+
+    async openMetricsThresholdAlertFlyout() {
+      await testSubjects.click('infrastructure-alerts-and-rules');
+      await testSubjects.click('metrics-threshold-alerts-menu-option');
+      await testSubjects.click('metrics-threshold-alerts-create-rule');
+      await testSubjects.missingOrFail('metrics-threshold-alerts-create-rule');
+      await testSubjects.find('euiFlyoutCloseButton');
+    },
+
+    async closeAlertFlyout() {
+      await testSubjects.click('euiFlyoutCloseButton');
+    },
   };
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Ensure alert dropdown closes properly (#106343)