### PR TITLE
[Canvas] Register `expression_functions` in `{expression}/public/plugin.ts`. 

### DIFF
--- a/src/plugins/expression_reveal_image/public/plugin.ts
+++ b/src/plugins/expression_reveal_image/public/plugin.ts
@@ -9,6 +9,7 @@
 import { CoreSetup, CoreStart, Plugin } from '../../../core/public';
 import { ExpressionsStart, ExpressionsSetup } from '../../expressions/public';
 import { revealImageRenderer } from './expression_renderers';
+import { revealImageFunction } from '../common/expression_functions';
 
 interface SetupDeps {
   expressions: ExpressionsSetup;
@@ -30,6 +31,7 @@ export class ExpressionRevealImagePlugin
       StartDeps
     > {
   public setup(core: CoreSetup, { expressions }: SetupDeps): ExpressionRevealImagePluginSetup {
+    expressions.registerFunction(revealImageFunction);
     expressions.registerRenderer(revealImageRenderer);
   }
 

--- a/src/plugins/expression_shape/public/plugin.ts
+++ b/src/plugins/expression_shape/public/plugin.ts
@@ -9,6 +9,7 @@
 import { CoreSetup, CoreStart, Plugin } from '../../../core/public';
 import { ExpressionsStart, ExpressionsSetup } from '../../expressions/public';
 import { shapeRenderer } from './expression_renderers';
+import { shapeFunction } from '../common/expression_functions';
 
 interface SetupDeps {
   expressions: ExpressionsSetup;
@@ -24,6 +25,7 @@ export type ExpressionShapePluginStart = void;
 export class ExpressionShapePlugin
   implements Plugin<ExpressionShapePluginSetup, ExpressionShapePluginStart, SetupDeps, StartDeps> {
   public setup(core: CoreSetup, { expressions }: SetupDeps): ExpressionShapePluginSetup {
+    expressions.registerFunction(shapeFunction);
     expressions.registerRenderer(shapeRenderer);
   }
 


### PR DESCRIPTION
#### At this PR `expression_functions` has been registered at `public/plugin.ts` in addition to `server` at further plugins:
- `expression_reveal_image`
- `expression_shape`

#### Testing Notes
This registers some expression functions on the server side. There is no way to test this as there is nothing that uses the server side functions currently.  