### PR TITLE
Restore legacy SAML ACS endpoint.

### DIFF
--- a/x-pack/plugins/security/server/routes/authentication/saml.test.ts
+++ b/x-pack/plugins/security/server/routes/authentication/saml.test.ts
@@ -43,6 +43,15 @@ describe('SAML authentication routes', () => {
       routeHandler = acsRouteHandler;
     });
 
+    it('additionally registers BWC route', () => {
+      expect(
+        router.post.mock.calls.find(([{ path }]) => path === '/api/security/saml/callback')
+      ).toBeDefined();
+      expect(
+        router.post.mock.calls.find(([{ path }]) => path === '/api/security/v1/saml')
+      ).toBeDefined();
+    });
+
     it('correctly defines route.', () => {
       expect(routeConfig.options).toEqual({
         authRequired: false,

--- a/x-pack/plugins/security/server/routes/authentication/saml.ts
+++ b/x-pack/plugins/security/server/routes/authentication/saml.ts
@@ -14,40 +14,56 @@ import { ROUTE_TAG_AUTH_FLOW, ROUTE_TAG_CAN_REDIRECT } from '../tags';
 /**
  * Defines routes required for SAML authentication.
  */
-export function defineSAMLRoutes({ router, getAuthenticationService }: RouteDefinitionParams) {
-  router.post(
-    {
-      path: '/api/security/saml/callback',
-      validate: {
-        body: schema.object(
-          { SAMLResponse: schema.string(), RelayState: schema.maybe(schema.string()) },
-          { unknowns: 'ignore' }
-        ),
-      },
-      options: {
-        authRequired: false,
-        xsrfRequired: false,
-        tags: [ROUTE_TAG_CAN_REDIRECT, ROUTE_TAG_AUTH_FLOW],
-      },
-    },
-    async (context, request, response) => {
-      // When authenticating using SAML we _expect_ to redirect to the Kibana target location.
-      const authenticationResult = await getAuthenticationService().login(request, {
-        provider: { type: SAMLAuthenticationProvider.type },
-        value: {
-          type: SAMLLogin.LoginWithSAMLResponse,
-          samlResponse: request.body.SAMLResponse,
-          relayState: request.body.RelayState,
+export function defineSAMLRoutes({
+  router,
+  getAuthenticationService,
+  basePath,
+  logger,
+}: RouteDefinitionParams) {
+  // Generate two identical routes with new and deprecated URL and issue a warning if route with deprecated URL is ever used.
+  for (const path of ['/api/security/saml/callback', '/api/security/v1/saml']) {
+    router.post(
+      {
+        path,
+        validate: {
+          body: schema.object(
+            { SAMLResponse: schema.string(), RelayState: schema.maybe(schema.string()) },
+            { unknowns: 'ignore' }
+          ),
         },
-      });
+        options: {
+          authRequired: false,
+          xsrfRequired: false,
+          tags: [ROUTE_TAG_CAN_REDIRECT, ROUTE_TAG_AUTH_FLOW],
+        },
+      },
+      async (context, request, response) => {
+        if (path === '/api/security/v1/saml') {
+          const serverBasePath = basePath.serverBasePath;
+          logger.warn(
+            // When authenticating using SAML we _expect_ to redirect to the SAML Identity provider.
+            `The "${serverBasePath}${path}" URL is deprecated and might stop working in the next major version, please use "${serverBasePath}/api/security/saml/callback" URL instead.`
+          );
+        }
 
-      if (authenticationResult.redirected()) {
-        return response.redirected({
-          headers: { location: authenticationResult.redirectURL! },
+        // When authenticating using SAML we _expect_ to redirect to the Kibana target location.
+        const authenticationResult = await getAuthenticationService().login(request, {
+          provider: { type: SAMLAuthenticationProvider.type },
+          value: {
+            type: SAMLLogin.LoginWithSAMLResponse,
+            samlResponse: request.body.SAMLResponse,
+            relayState: request.body.RelayState,
+          },
         });
-      }
 
-      return response.unauthorized({ body: authenticationResult.error });
-    }
-  );
+        if (authenticationResult.redirected()) {
+          return response.redirected({
+            headers: { location: authenticationResult.redirectURL! },
+          });
+        }
+
+        return response.unauthorized({ body: authenticationResult.error });
+      }
+    );
+  }
 }

--- a/x-pack/plugins/security/server/routes/authentication/saml.ts
+++ b/x-pack/plugins/security/server/routes/authentication/saml.ts
@@ -42,7 +42,7 @@ export function defineSAMLRoutes({
           const serverBasePath = basePath.serverBasePath;
           logger.warn(
             // When authenticating using SAML we _expect_ to redirect to the SAML Identity provider.
-            `The "${serverBasePath}${path}" URL is deprecated and might stop working in the next major version, please use "${serverBasePath}/api/security/saml/callback" URL instead.`
+            `The "${serverBasePath}${path}" URL is deprecated and might stop working in a future release. Please use "${serverBasePath}/api/security/saml/callback" URL instead.`
           );
         }
 


### PR DESCRIPTION
## Summary

__Revert of: https://github.com/elastic/kibana/pull/47929__

We agreed to continue supporting old ACS routes for the time being. 

Considering the nature of the change (new and old routes are almost exact copies) it seems reasonable to not write additional integration tests for the legacy route. We may reconsider this decision if the implementation diverge in the future or we discover bugs related to the old route only.