### PR TITLE
Include upcoming default values for the session timeouts in the deprecation log.

### DIFF
--- a/x-pack/plugins/security/server/config_deprecations.test.ts
+++ b/x-pack/plugins/security/server/config_deprecations.test.ts
@@ -29,11 +29,45 @@ const applyConfigDeprecations = (settings: Record<string, any> = {}) => {
 };
 
 describe('Config Deprecations', () => {
-  it('does not report deprecations for default configuration', () => {
-    const defaultConfig = { xpack: { security: {} } };
+  it('does not report any deprecations if session timeouts are specified', () => {
+    const defaultConfig = { xpack: { security: { session: { idleTimeout: 123, lifespan: 345 } } } };
     const { messages, migrated } = applyConfigDeprecations(cloneDeep(defaultConfig));
     expect(migrated).toEqual(defaultConfig);
     expect(messages).toHaveLength(0);
+  });
+
+  it('reports that session idleTimeout and lifespan will have default values if none of them is specified', () => {
+    const defaultConfig = { xpack: { security: {} } };
+    const { messages, migrated } = applyConfigDeprecations(cloneDeep(defaultConfig));
+    expect(migrated).toEqual(defaultConfig);
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "Session idle timeout (\\"xpack.security.session.idleTimeout\\") will be set to 1 hour by default in the next major version (8.0).",
+        "Session lifespan (\\"xpack.security.session.lifespan\\") will be set to 30 days by default in the next major version (8.0).",
+      ]
+    `);
+  });
+
+  it('reports that session idleTimeout will have a default value if it is not specified', () => {
+    const defaultConfig = { xpack: { security: { session: { lifespan: 345 } } } };
+    const { messages, migrated } = applyConfigDeprecations(cloneDeep(defaultConfig));
+    expect(migrated).toEqual(defaultConfig);
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "Session idle timeout (\\"xpack.security.session.idleTimeout\\") will be set to 1 hour by default in the next major version (8.0).",
+      ]
+    `);
+  });
+
+  it('reports that session lifespan will have a default value if it is not specified', () => {
+    const defaultConfig = { xpack: { security: { session: { idleTimeout: 123 } } } };
+    const { messages, migrated } = applyConfigDeprecations(cloneDeep(defaultConfig));
+    expect(migrated).toEqual(defaultConfig);
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "Session lifespan (\\"xpack.security.session.lifespan\\") will be set to 30 days by default in the next major version (8.0).",
+      ]
+    `);
   });
 
   it('renames sessionTimeout to session.idleTimeout', () => {
@@ -50,6 +84,7 @@ describe('Config Deprecations', () => {
     expect(messages).toMatchInlineSnapshot(`
       Array [
         "\\"xpack.security.sessionTimeout\\" is deprecated and has been replaced by \\"xpack.security.session.idleTimeout\\"",
+        "Session lifespan (\\"xpack.security.session.lifespan\\") will be set to 30 days by default in the next major version (8.0).",
       ]
     `);
   });
@@ -58,6 +93,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             appender: {
               kind: 'console',
@@ -80,6 +116,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             appender: {
               layout: { kind: 'pattern' },
@@ -102,6 +139,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             appender: {
               policy: { kind: 'time-interval' },
@@ -124,6 +162,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             appender: {
               strategy: { kind: 'numeric' },
@@ -146,6 +185,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             appender: {
               type: 'file',
@@ -169,6 +209,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             enabled: true,
           },
@@ -188,6 +229,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             enabled: true,
             appender: {
@@ -207,6 +249,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           audit: {
             enabled: true,
             appender: {
@@ -231,6 +274,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           authorization: {
             legacyFallback: {
               enabled: true,
@@ -251,6 +295,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           authc: {
             saml: {
               maxRedirectURLSize: 123,
@@ -271,6 +316,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           authc: {
             providers: {
               saml: {
@@ -295,6 +341,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           authc: {
             providers: ['basic', 'saml'],
           },
@@ -314,6 +361,7 @@ describe('Config Deprecations', () => {
     const config = {
       xpack: {
         security: {
+          session: { idleTimeout: 123, lifespan: 345 },
           authc: {
             providers: ['basic', 'token'],
           },
@@ -335,6 +383,7 @@ describe('Config Deprecations', () => {
       xpack: {
         security: {
           enabled: false,
+          session: { idleTimeout: 123, lifespan: 345 },
         },
       },
     };
@@ -352,6 +401,7 @@ describe('Config Deprecations', () => {
       xpack: {
         security: {
           enabled: true,
+          session: { idleTimeout: 123, lifespan: 345 },
         },
       },
     };

--- a/x-pack/plugins/security/server/config_deprecations.ts
+++ b/x-pack/plugins/security/server/config_deprecations.ts
@@ -110,4 +110,36 @@ export const securityConfigDeprecationProvider: ConfigDeprecationProvider = ({
       });
     }
   },
+  // Default values for session expiration timeouts.
+  (settings, fromPath, addDeprecation) => {
+    if (settings?.xpack?.security?.session?.idleTimeout === undefined) {
+      addDeprecation({
+        message:
+          'Session idle timeout ("xpack.security.session.idleTimeout") will be set to 1 hour by default in the next major version (8.0).',
+        documentationUrl:
+          'https://www.elastic.co/guide/en/kibana/current/xpack-security-session-management.html#session-idle-timeout',
+        correctiveActions: {
+          manualSteps: [
+            `Use "xpack.security.session.idleTimeout" in your Kibana configuration to change default session idle timeout.`,
+            `To disable session idle timeout, set "xpack.security.session.idleTimeout" to 0.`,
+          ],
+        },
+      });
+    }
+
+    if (settings?.xpack?.security?.session?.lifespan === undefined) {
+      addDeprecation({
+        message:
+          'Session lifespan ("xpack.security.session.lifespan") will be set to 30 days by default in the next major version (8.0).',
+        documentationUrl:
+          'https://www.elastic.co/guide/en/kibana/current/xpack-security-session-management.html#session-lifespan',
+        correctiveActions: {
+          manualSteps: [
+            `Use "xpack.security.session.lifespan" in your Kibana configuration to change default session lifespan.`,
+            `To disable session lifespan, set "xpack.security.session.lifespan" to 0.`,
+          ],
+        },
+      });
+    }
+  },
 ];


### PR DESCRIPTION
## Summary

Include upcoming default values for the session timeouts in the deprecation log.

__Follow-up for: https://github.com/elastic/kibana/pull/106061__
