### PR TITLE
[7.x] [Security solution] [Endpoint] Unify subtitle text in flyout and modal for event filters (#106562)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -31,16 +31,10 @@ import { ExceptionBuilder } from '../../../../../../shared_imports';
 
 import { useEventFiltersSelector } from '../../hooks';
 import { getFormEntryStateMutable, getHasNameError, getNewComment } from '../../../store/selector';
-import {
-  FORM_DESCRIPTION,
-  NAME_LABEL,
-  NAME_ERROR,
-  NAME_PLACEHOLDER,
-  OS_LABEL,
-  RULE_NAME,
-} from './translations';
+import { NAME_LABEL, NAME_ERROR, NAME_PLACEHOLDER, OS_LABEL, RULE_NAME } from './translations';
 import { OS_TITLES } from '../../../../../common/translations';
 import { ENDPOINT_EVENT_FILTERS_LIST_ID, EVENT_FILTER_LIST_TYPE } from '../../../constants';
+import { ABOUT_EVENT_FILTERS } from '../../translations';
 
 const OPERATING_SYSTEMS: readonly OperatingSystem[] = [
   OperatingSystem.MAC,
@@ -205,8 +199,12 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
 
     return !isIndexPatternLoading && exception ? (
       <EuiForm component="div">
-        <EuiText size="s">{FORM_DESCRIPTION}</EuiText>
-        <EuiSpacer size="m" />
+        {!exception || !exception.item_id ? (
+          <EuiText color="subdued" size="xs">
+            {ABOUT_EVENT_FILTERS}
+            <EuiSpacer size="m" />
+          </EuiText>
+        ) : null}
         {nameInputMemo}
         <EuiSpacer size="m" />
         {allowSelectOs ? (

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/translations.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/translations.ts
@@ -7,13 +7,6 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const FORM_DESCRIPTION = i18n.translate(
-  'xpack.securitySolution.eventFilter.modal.description',
-  {
-    defaultMessage: "Events are filtered when the rule's conditions are met:",
-  }
-);
-
 export const NAME_PLACEHOLDER = i18n.translate(
   'xpack.securitySolution.eventFilter.form.name.placeholder',
   {

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/event_filters_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/event_filters_list_page.tsx
@@ -44,6 +44,7 @@ import { EventFilterDeleteModal } from './components/event_filter_delete_modal';
 
 import { SearchBar } from '../../../components/search_bar';
 import { BackToExternalAppButton } from '../../../components/back_to_external_app_button';
+import { ABOUT_EVENT_FILTERS } from './translations';
 
 type EventListPaginatedContent = PaginatedContentProps<
   Immutable<ExceptionListItemSchema>,
@@ -195,11 +196,7 @@ export const EventFiltersListPage = memo(() => {
           defaultMessage="Event Filters"
         />
       }
-      subtitle={i18n.translate('xpack.securitySolution.eventFilters.aboutInfo', {
-        defaultMessage:
-          'Add an event filter to exclude high volume or unwanted events from being written to Elasticsearch. Event ' +
-          'filters are processed by the Endpoint Security integration, and are applied to hosts running this integration on their agents.',
-      })}
+      subtitle={ABOUT_EVENT_FILTERS}
       actions={
         doesDataExist && (
           <EuiButton

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/translations.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/translations.ts
@@ -51,3 +51,9 @@ export const getGetErrorMessage = (getError: ServerApiError) => {
     values: { error: getError.message },
   });
 };
+
+export const ABOUT_EVENT_FILTERS = i18n.translate('xpack.securitySolution.eventFilters.aboutInfo', {
+  defaultMessage:
+    'Add an event filter to exclude high volume or unwanted events from being written to Elasticsearch. Event ' +
+    'filters are processed by the Endpoint Security integration, and are applied to hosts running this integration on their agents.',
+});

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -22012,7 +22012,6 @@
     "xpack.securitySolution.eventFilter.form.updateSuccessToastTitle": "\"{name}\"が正常に更新されました",
     "xpack.securitySolution.eventFilter.modal.actions.cancel": "キャンセル",
     "xpack.securitySolution.eventFilter.modal.actions.confirm": "エンドポイントイベントフィルターを追加",
-    "xpack.securitySolution.eventFilter.modal.description": "ルールの条件が満たされたときにイベントがフィルタリングされます。",
     "xpack.securitySolution.eventFilter.modal.subtitle": "Endpoint Security",
     "xpack.securitySolution.eventFilter.modal.title": "エンドポイントイベントフィルターを追加",
     "xpack.securitySolution.eventFilter.search.placeholder": "次のフィールドで検索：名前、コメント、値",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -22330,7 +22330,6 @@
     "xpack.securitySolution.eventFilter.form.updateSuccessToastTitle": "“{name}”已成功更新。",
     "xpack.securitySolution.eventFilter.modal.actions.cancel": "取消",
     "xpack.securitySolution.eventFilter.modal.actions.confirm": "添加终端事件筛选",
-    "xpack.securitySolution.eventFilter.modal.description": "满足规则的条件时将筛选事件：",
     "xpack.securitySolution.eventFilter.modal.subtitle": "Endpoint Security",
     "xpack.securitySolution.eventFilter.modal.title": "添加终端事件筛选",
     "xpack.securitySolution.eventFilter.search.placeholder": "搜索下面的字段：name、comments、value",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security solution] [Endpoint] Unify subtitle text in flyout and modal for event filters (#106562)