### PR TITLE
[ML] Functional tests - some stability fixes for cloud test execution

### DIFF
--- a/x-pack/test/api_integration/apis/ml/modules/index.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/index.ts
@@ -8,6 +8,7 @@
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
   const ml = getService('ml');
   const supertest = getService('supertest');
 
@@ -15,8 +16,12 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
   describe('modules', function () {
     before(async () => {
+      // use empty_kibana to make sure the fleet setup is removed correctly after the tests
+      await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
+
       // Fleet need to be setup to be able to setup packages
       await supertest.post(`/api/fleet/setup`).set({ 'kbn-xsrf': 'some-xsrf-token' }).expect(200);
+
       for (const fleetPackage of fleetPackages) {
         await ml.testResources.installFleetPackage(fleetPackage);
       }
@@ -26,6 +31,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       for (const fleetPackage of fleetPackages) {
         await ml.testResources.removeFleetPackage(fleetPackage);
       }
+      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
     });
 
     loadTestFile(require.resolve('./get_module'));

--- a/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
+++ b/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
@@ -20,6 +20,7 @@ import {
 } from './index';
 
 export default function ({ getService }: FtrProviderContext) {
+  const canvasElement = getService('canvasElement');
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
@@ -312,12 +313,17 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.wizard.assertAdvancedQueryEditorSwitchExists();
           await transform.wizard.assertAdvancedQueryEditorSwitchCheckState(false);
 
+          // Disable anti-aliasing to stabilize canvas image rendering assertions
+          await canvasElement.disableAntiAliasing();
+
           await transform.testExecution.logTestStep('enables the index preview histogram charts');
           await transform.wizard.enableIndexPreviewHistogramCharts(false);
           await transform.testExecution.logTestStep('displays the index preview histogram charts');
           await transform.wizard.assertIndexPreviewHistogramCharts(
             testData.expected.histogramCharts
           );
+
+          await canvasElement.resetAntiAliasing();
 
           if (isPivotTransformTestData(testData)) {
             await transform.testExecution.logTestStep('adds the group by entries');

--- a/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
+++ b/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
@@ -20,7 +20,6 @@ import {
 } from './index';
 
 export default function ({ getService }: FtrProviderContext) {
-  const canvasElement = getService('canvasElement');
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
@@ -313,17 +312,12 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.wizard.assertAdvancedQueryEditorSwitchExists();
           await transform.wizard.assertAdvancedQueryEditorSwitchCheckState(false);
 
-          // Disable anti-aliasing to stabilize canvas image rendering assertions
-          await canvasElement.disableAntiAliasing();
-
           await transform.testExecution.logTestStep('enables the index preview histogram charts');
           await transform.wizard.enableIndexPreviewHistogramCharts(false);
           await transform.testExecution.logTestStep('displays the index preview histogram charts');
           await transform.wizard.assertIndexPreviewHistogramCharts(
             testData.expected.histogramCharts
           );
-
-          await canvasElement.resetAntiAliasing();
 
           if (isPivotTransformTestData(testData)) {
             await transform.testExecution.logTestStep('adds the group by entries');

--- a/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
@@ -404,42 +404,58 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
     },
 
     async assertConfigurationStepActive() {
-      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardConfigurationStep active');
+      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardConfigurationStep active', {
+        timeout: 3000,
+      });
     },
 
     async assertAdditionalOptionsStepActive() {
-      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardAdvancedStep active');
+      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardAdvancedStep active', {
+        timeout: 3000,
+      });
     },
 
     async assertDetailsStepActive() {
-      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardDetailsStep active');
+      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardDetailsStep active', {
+        timeout: 3000,
+      });
     },
 
     async assertCreateStepActive() {
-      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardCreateStep active');
+      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardCreateStep active', {
+        timeout: 3000,
+      });
     },
 
     async assertValidationStepActive() {
-      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardValidationStepWrapper active');
+      await testSubjects.existOrFail('mlAnalyticsCreateJobWizardValidationStepWrapper active', {
+        timeout: 3000,
+      });
     },
 
     async continueToAdditionalOptionsStep() {
-      await retry.tryForTime(5000, async () => {
-        await testSubjects.clickWhenNotDisabled('mlAnalyticsCreateJobWizardContinueButton');
+      await retry.tryForTime(15 * 1000, async () => {
+        await testSubjects.clickWhenNotDisabled(
+          'mlAnalyticsCreateJobWizardConfigurationStep active > mlAnalyticsCreateJobWizardContinueButton'
+        );
         await this.assertAdditionalOptionsStepActive();
       });
     },
 
     async continueToDetailsStep() {
-      await retry.tryForTime(5000, async () => {
-        await testSubjects.clickWhenNotDisabled('mlAnalyticsCreateJobWizardContinueButton');
+      await retry.tryForTime(15 * 1000, async () => {
+        await testSubjects.clickWhenNotDisabled(
+          'mlAnalyticsCreateJobWizardAdvancedStep active > mlAnalyticsCreateJobWizardContinueButton'
+        );
         await this.assertDetailsStepActive();
       });
     },
 
     async continueToValidationStep() {
-      await retry.tryForTime(5000, async () => {
-        await testSubjects.clickWhenNotDisabled('mlAnalyticsCreateJobWizardContinueButton');
+      await retry.tryForTime(15 * 1000, async () => {
+        await testSubjects.clickWhenNotDisabled(
+          'mlAnalyticsCreateJobWizardDetailsStep active > mlAnalyticsCreateJobWizardContinueButton'
+        );
         await this.assertValidationStepActive();
       });
     },
@@ -456,8 +472,10 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
     },
 
     async continueToCreateStep() {
-      await retry.tryForTime(5000, async () => {
-        await testSubjects.clickWhenNotDisabled('mlAnalyticsCreateJobWizardContinueButton');
+      await retry.tryForTime(15 * 1000, async () => {
+        await testSubjects.clickWhenNotDisabled(
+          'mlAnalyticsCreateJobWizardValidationStepWrapper active > mlAnalyticsCreateJobWizardContinueButton'
+        );
         await this.assertCreateStepActive();
       });
     },


### PR DESCRIPTION
## Summary

This PR stabilizes some functional tests for cloud execution / execution in different order.

### Details

- Reset fleet setup after module tests (7788679)
  - Initializing Fleet for the module API tests creates some Kibana dashboards that stay after the test suite has finished and can make other tests fail that expect no dashboards to exist. I had a chat with Fleet folks and there's no API to reset Fleet initialization, so the easiest way is to load the `empty_kibana` archive before the test suite and unload it after. This will remove all things from `.kibana` including the Fleet initialization.
- Additional check and retry for anomaly explorer dashboard integration (10cb9d3)
  - Sometimes, clicking the `select all dashboards` checkbox doesn't work due to timing issues, so a retry is added for that action. Also, another assertion for setting the searchbox filter is added.
- Stabilize DFA job wizard step navigation (42b9e7807e4077b1252195434ef100006bca947a)
  - While waiting for the next wizard step to be active after clicking the `next` button, we sometimes noticed timeouts on the inner checks that didn't trigger the outer retry. With this PR, the timeouts are adjusted such that it gives a shorter time for the next section to be active and if that fails it tries to click the `next` button again. Also, we now make sure to click the `next` button from the correct section.