### PR TITLE
[Security Solutions] Fix hosts external alerts deeplink URL

### DIFF
--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -215,7 +215,7 @@ const nestedDeepLinks: SecurityDeepLinks = {
         title: i18n.translate('xpack.securitySolution.search.hosts.externalAlerts', {
           defaultMessage: 'External Alerts',
         }),
-        path: `${HOSTS_PATH}/alerts`,
+        path: `${HOSTS_PATH}/externalAlerts`,
       },
     ],
     premium: [


### PR DESCRIPTION
## Summary

Fix the global search "Hosts > External Alerts" item https://github.com/elastic/kibana/issues/104049
Deeplink url modified to the proper url.

![Captura de Pantalla 2021-07-26 a les 12 53 54](https://user-images.githubusercontent.com/17747913/126977912-165b5697-fa3e-4aa3-9bec-ab430a007443.png)

