### PR TITLE
[7.x] [Pie, XY] MAkes the filter button in legend keyword accessible (#106374)

### DIFF
--- a/src/plugins/vis_type_pie/public/utils/get_legend_actions.tsx
+++ b/src/plugins/vis_type_pie/public/utils/get_legend_actions.tsx
@@ -81,6 +81,9 @@ export const getLegendActions = (
 
     const Button = (
       <div
+        tabIndex={0}
+        role="button"
+        aria-pressed="false"
         style={{
           display: 'flex',
           justifyContent: 'center',
@@ -90,7 +93,7 @@ export const getLegendActions = (
           marginRight: 4,
         }}
         data-test-subj={`legend-${title}`}
-        onKeyPress={() => undefined}
+        onKeyPress={() => setPopoverOpen(!popoverOpen)}
         onClick={() => setPopoverOpen(!popoverOpen)}
       >
         <EuiIcon size="s" type="boxesVertical" />

--- a/src/plugins/vis_type_xy/public/utils/get_legend_actions.tsx
+++ b/src/plugins/vis_type_xy/public/utils/get_legend_actions.tsx
@@ -66,6 +66,9 @@ export const getLegendActions = (
 
     const Button = (
       <div
+        tabIndex={0}
+        role="button"
+        aria-pressed="false"
         style={{
           display: 'flex',
           justifyContent: 'center',
@@ -75,7 +78,7 @@ export const getLegendActions = (
           marginRight: 4,
         }}
         data-test-subj={`legend-${name}`}
-        onKeyPress={() => undefined}
+        onKeyPress={() => setPopoverOpen(!popoverOpen)}
         onClick={() => setPopoverOpen(!popoverOpen)}
       >
         <EuiIcon size="s" type="boxesVertical" />


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Pie, XY] MAkes the filter button in legend keyword accessible (#106374)