### PR TITLE
[Fleet] Display full featured header when creating policies from policy page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -43,7 +43,10 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
     'data-test-subj': dataTestSubj,
   }) => {
     const pageTitle = useMemo(() => {
-      if ((from === 'package' || from === 'package-edit' || from === 'edit') && packageInfo) {
+      if (
+        (from === 'package' || from === 'package-edit' || from === 'edit' || from === 'policy') &&
+        packageInfo
+      ) {
         return (
           <EuiFlexGroup alignItems="center" gutterSize="m">
             <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

Ensure the full header w/ integration name, icon, etc is displayed when creating policies from the policy page. 

Fixes #106573

<details>
<summary>Screen Recording</summary>

![Kapture 2021-07-26 at 08 29 59](https://user-images.githubusercontent.com/6766512/126988897-45578da7-6a10-424b-8e21-35073f8e81b6.gif)
</details>