### PR TITLE
[Security solution] [Timeline] Fix timeline title when navigating to different tabs

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
@@ -157,6 +157,7 @@ export const addTimelineToStore = ({
     [id]: {
       ...timeline,
       isLoading: timelineById[id].isLoading,
+      initialized: timelineById[id].initialized,
       dateRange:
         timeline.status === TimelineStatus.immutable &&
         timeline.timelineType === TimelineType.template

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/model.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/model.ts
@@ -72,6 +72,7 @@ export type TimelineModel = TGridModelForTimeline & {
   /** timeline is saving */
   isSaving: boolean;
   version: string | null;
+  initialized?: boolean;
 };
 
 export type SubsetTimelineModel = Readonly<

--- a/x-pack/plugins/timelines/public/store/t_grid/helpers.test.tsx
+++ b/x-pack/plugins/timelines/public/store/t_grid/helpers.test.tsx
@@ -13,7 +13,7 @@ import { mockGlobalState } from '../../mock/global_state';
 import { TGridModelSettings } from '.';
 
 const id = 'foo';
-const timelineById = {
+const defaultTimelineById = {
   ...mockGlobalState.timelineById,
 };
 
@@ -28,16 +28,32 @@ describe('setInitializeTgridSettings', () => {
       sort, // <-- override
     };
 
-    expect(setInitializeTgridSettings({ id, timelineById, tGridSettingsProps })[id].sort).toEqual(
-      sort
-    );
+    expect(
+      setInitializeTgridSettings({ id, timelineById: defaultTimelineById, tGridSettingsProps })[id]
+        .sort
+    ).toEqual(sort);
   });
 
   test('it returns the default sort when tGridSettingsProps does NOT contain an override', () => {
     const tGridSettingsProps = { footerText: 'test' }; // <-- no `sort` override
 
-    expect(setInitializeTgridSettings({ id, timelineById, tGridSettingsProps })[id].sort).toEqual(
-      tGridDefaults.sort
-    );
+    expect(
+      setInitializeTgridSettings({ id, timelineById: defaultTimelineById, tGridSettingsProps })[id]
+        .sort
+    ).toEqual(tGridDefaults.sort);
+  });
+
+  test('it doesn`t overwrite the timeline if it is initialized', () => {
+    const tGridSettingsProps = { title: 'testTitle' };
+
+    const timelineById = {
+      [id]: {
+        ...defaultTimelineById.test,
+        initialized: true,
+      },
+    };
+
+    const result = setInitializeTgridSettings({ id, timelineById, tGridSettingsProps });
+    expect(result).toBe(timelineById);
   });
 });

--- a/x-pack/plugins/timelines/public/store/t_grid/helpers.ts
+++ b/x-pack/plugins/timelines/public/store/t_grid/helpers.ts
@@ -160,20 +160,24 @@ export const setInitializeTgridSettings = ({
 }: InitializeTgridParams): TimelineById => {
   const timeline = timelineById[id];
 
-  return {
-    ...timelineById,
-    [id]: {
-      ...tGridDefaults,
-      ...timeline,
-      ...getTGridManageDefaults(id),
-      ...tGridSettingsProps,
-      ...(!timeline || (isEmpty(timeline.columns) && !isEmpty(tGridSettingsProps.defaultColumns))
-        ? { columns: tGridSettingsProps.defaultColumns }
-        : {}),
-      sort: tGridSettingsProps.sort ?? tGridDefaults.sort,
-      loadingEventIds: tGridDefaults.loadingEventIds,
-    },
-  };
+  return !timeline?.initialized
+    ? {
+        ...timelineById,
+        [id]: {
+          ...tGridDefaults,
+          ...getTGridManageDefaults(id),
+          ...timeline,
+          ...tGridSettingsProps,
+          ...(!timeline ||
+          (isEmpty(timeline.columns) && !isEmpty(tGridSettingsProps.defaultColumns))
+            ? { columns: tGridSettingsProps.defaultColumns }
+            : {}),
+          sort: tGridSettingsProps.sort ?? tGridDefaults.sort,
+          loadingEventIds: tGridDefaults.loadingEventIds,
+          initialized: true,
+        },
+      }
+    : timelineById;
 };
 
 interface ApplyDeltaToTimelineColumnWidth {

--- a/x-pack/plugins/timelines/public/store/t_grid/model.ts
+++ b/x-pack/plugins/timelines/public/store/t_grid/model.ts
@@ -82,6 +82,7 @@ export interface TGridModel extends TGridModelSettings {
   selectedEventIds: Record<string, TimelineNonEcsData[]>;
   savedObjectId: string | null;
   version: string | null;
+  initialized?: boolean;
 }
 
 export type TGridModelForTimeline = Pick<


### PR DESCRIPTION
Original issue: https://github.com/elastic/kibana/issues/103441
It also fixes this issue: https://github.com/elastic/kibana/issues/106819

## Summary

The Saved Timeline name in the security app bottom bar is reset to untitled when the user navigates to any page with a timeline.

### Why? 
`getTGridManageDefaults` was overwriting the timeline title while initializing the grid.

### The fix
I added a new redux timeline field called `initialized`. It is set to true by `setInitializeTgridSettings`. Whenever `setInitializeTgridSettings` is called, and the field is already truthy, it prevents the grid from getting initialized a second time.

### How to reproduce it

1. Open timeline
<img width="1000" alt="Screenshot 2021-07-26 at 14 33 49" src="https://user-images.githubusercontent.com/1490444/126989585-07a50e51-09ec-4384-b168-037ff2524df8.png">

2. Go to any item of the manage tab group

3. Go back to the timeline

<img width="1000" alt="Screenshot 2021-07-26 at 14 34 02" src="https://user-images.githubusercontent.com/1490444/126989578-81db3ab8-24ad-4780-a819-333dbcffc891.png">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
