### PR TITLE
[ci] raise the max-old-space-size for scripts/build_api_docs

### DIFF
--- a/test/scripts/checks/type_check_plugin_public_api_docs.sh
+++ b/test/scripts/checks/type_check_plugin_public_api_docs.sh
@@ -14,4 +14,4 @@ checks-reporter-with-killswitch "Check Types" \
   node scripts/type_check
 
 echo " -- building api docs"
-node scripts/build_api_docs
+node --max-old-space-size 8000 scripts/build_api_docs

--- a/test/scripts/checks/type_check_plugin_public_api_docs.sh
+++ b/test/scripts/checks/type_check_plugin_public_api_docs.sh
@@ -14,4 +14,4 @@ checks-reporter-with-killswitch "Check Types" \
   node scripts/type_check
 
 echo " -- building api docs"
-node --max-old-space-size 8000 scripts/build_api_docs
+node --max-old-space-size=8000 scripts/build_api_docs


### PR DESCRIPTION
We've seen a few PRs run out of memory when running `node scripts/build_api_docs` which, which node for some reason isn't reporting with a non-zero exit code, and leads to CI completing without the api docs metrics being reported, leading to a massive comment with tons of empty metrics. This prevents that scenario by raising the max-old-space-size for that node process to ~8GB.