### PR TITLE
[ML] Add link from Discover top navigation to Index data visualizer

### DIFF
--- a/src/plugins/discover/public/__mocks__/services.ts
+++ b/src/plugins/discover/public/__mocks__/services.ts
@@ -12,9 +12,11 @@ import { DEFAULT_COLUMNS_SETTING } from '../../common';
 import { savedSearchMock } from './saved_search';
 import { UI_SETTINGS } from '../../../data/common';
 import { TopNavMenu } from '../../../navigation/public';
+import { addTopNavDataServiceMock } from '../application/apps/main/services/add_top_nav_data.mock';
 const dataPlugin = dataPluginMock.createStartContract();
 
 export const discoverServiceMock = ({
+  addTopNavData: addTopNavDataServiceMock.create(),
   core: coreMock.createStart(),
   chrome: chromeServiceMock.createStartContract(),
   history: () => ({

--- a/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.test.tsx
@@ -23,6 +23,7 @@ import { DiscoverLayoutProps } from './types';
 import { SavedSearchDataSubject } from '../../services/use_saved_search';
 import { discoverServiceMock } from '../../../../../__mocks__/services';
 import { FetchStatus } from '../../../../types';
+import { waitFor } from '@testing-library/react';
 
 setHeaderActionMenuMounter(jest.fn());
 
@@ -63,14 +64,18 @@ function getProps(indexPattern: IndexPattern): DiscoverLayoutProps {
 }
 
 describe('Discover component', () => {
-  test('selected index pattern without time field displays no chart toggle', () => {
+  test('selected index pattern without time field displays no chart toggle', async () => {
     const component = mountWithIntl(<DiscoverLayout {...getProps(indexPatternMock)} />);
-    expect(component.find('[data-test-subj="discoverChartToggle"]').exists()).toBeFalsy();
+    await waitFor(() => {
+      expect(component.find('[data-test-subj="discoverChartToggle"]').exists()).toBeFalsy();
+    });
   });
-  test('selected index pattern with time field displays chart toggle', () => {
+  test('selected index pattern with time field displays chart toggle', async () => {
     const component = mountWithIntl(
       <DiscoverLayout {...getProps(indexPatternWithTimefieldMock)} />
     );
-    expect(component.find('[data-test-subj="discoverChartToggle"]').exists()).toBeTruthy();
+    await waitFor(() => {
+      expect(component.find('[data-test-subj="discoverChartToggle"]').exists()).toBeTruthy();
+    });
   });
 });

--- a/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
@@ -51,6 +51,7 @@ import { DiscoverUninitialized } from '../uninitialized/uninitialized';
 import { SavedSearchDataMessage } from '../../services/use_saved_search';
 import { useDataGridColumns } from '../../../../helpers/use_data_grid_columns';
 import { FetchStatus } from '../../../../types';
+import { useRegisteredTopNavLinks } from '../../../../helpers/use_registered_top_nav_links';
 
 const DocTableLegacyMemoized = React.memo(DocTableLegacy);
 const SidebarMemoized = React.memo(DiscoverSidebarResponsive);
@@ -133,7 +134,6 @@ export function DiscoverLayout({
     state,
     useNewFieldsApi,
   });
-
   const onOpenInspector = useCallback(() => {
     // prevent overlapping
     if (inspectorAdapters) {
@@ -217,6 +217,20 @@ export function DiscoverLayout({
     [uiSettings, indexPattern.timeFieldName]
   );
 
+  const registeredTopNavLinks = useRegisteredTopNavLinks({
+    services,
+    indexPattern,
+    onOpenInspector,
+    query: state.query,
+    savedQuery: state.savedQuery,
+    stateContainer,
+    updateQuery: onUpdateQuery,
+    searchSource,
+    navigateTo,
+    savedSearch,
+    columns,
+  });
+
   return (
     <I18nProvider>
       <EuiPage className="dscPage" data-fetch-counter={fetchCounter}>
@@ -231,6 +245,7 @@ export function DiscoverLayout({
           services={services}
           stateContainer={stateContainer}
           updateQuery={onUpdateQuery}
+          registeredTopNavLinks={registeredTopNavLinks}
         />
         <EuiPageBody className="dscPageBody" aria-describedby="savedSearchTitle">
           <h1 id="savedSearchTitle" className="euiScreenReaderOnly">

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.test.tsx
@@ -33,6 +33,7 @@ function getProps(savePermissions = true): DiscoverTopNavProps {
     updateQuery: jest.fn(),
     onOpenInspector: jest.fn(),
     searchSource: {} as ISearchSource,
+    registeredTopNavLinks: [],
   };
 }
 
@@ -41,21 +42,13 @@ describe('Discover topnav component', () => {
     const props = getProps(true);
     const component = shallowWithIntl(<DiscoverTopNav {...props} />);
     const topMenuConfig = component.props().config.map((obj: TopNavMenuData) => obj.id);
-    expect(topMenuConfig).toEqual([
-      'options',
-      'new',
-      'save',
-      'open',
-      'share',
-      'inspect',
-      'dataVisualizer',
-    ]);
+    expect(topMenuConfig).toEqual(['options', 'new', 'save', 'open', 'share', 'inspect']);
   });
 
   test('generated config of TopNavMenu config is correct when no discover save permissions are assigned', () => {
     const props = getProps(false);
     const component = shallowWithIntl(<DiscoverTopNav {...props} />);
     const topMenuConfig = component.props().config.map((obj: TopNavMenuData) => obj.id);
-    expect(topMenuConfig).toEqual(['options', 'new', 'open', 'share', 'inspect', 'dataVisualizer']);
+    expect(topMenuConfig).toEqual(['options', 'new', 'open', 'share', 'inspect']);
   });
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.test.tsx
@@ -41,13 +41,21 @@ describe('Discover topnav component', () => {
     const props = getProps(true);
     const component = shallowWithIntl(<DiscoverTopNav {...props} />);
     const topMenuConfig = component.props().config.map((obj: TopNavMenuData) => obj.id);
-    expect(topMenuConfig).toEqual(['options', 'new', 'save', 'open', 'share', 'inspect']);
+    expect(topMenuConfig).toEqual([
+      'options',
+      'new',
+      'save',
+      'open',
+      'share',
+      'inspect',
+      'dataVisualizer',
+    ]);
   });
 
   test('generated config of TopNavMenu config is correct when no discover save permissions are assigned', () => {
     const props = getProps(false);
     const component = shallowWithIntl(<DiscoverTopNav {...props} />);
     const topMenuConfig = component.props().config.map((obj: TopNavMenuData) => obj.id);
-    expect(topMenuConfig).toEqual(['options', 'new', 'open', 'share', 'inspect']);
+    expect(topMenuConfig).toEqual(['options', 'new', 'open', 'share', 'inspect', 'dataVisualizer']);
   });
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/discover_topnav.tsx
@@ -11,6 +11,7 @@ import { getTopNavLinks } from './get_top_nav_links';
 import { Query, TimeRange } from '../../../../../../../data/common/query';
 import { getHeaderActionMenuMounter } from '../../../../../kibana_services';
 import { GetStateReturn } from '../../services/discover_state';
+import type { TopNavMenuData } from '../../../../../../../navigation/public';
 
 export type DiscoverTopNavProps = Pick<
   DiscoverLayoutProps,
@@ -21,6 +22,7 @@ export type DiscoverTopNavProps = Pick<
   savedQuery?: string;
   updateQuery: (payload: { dateRange: TimeRange; query?: Query }, isUpdate?: boolean) => void;
   stateContainer: GetStateReturn;
+  registeredTopNavLinks: TopNavMenuData[];
 };
 
 export const DiscoverTopNav = ({
@@ -34,6 +36,7 @@ export const DiscoverTopNav = ({
   navigateTo,
   savedSearch,
   services,
+  registeredTopNavLinks,
 }: DiscoverTopNavProps) => {
   const showDatePicker = useMemo(() => indexPattern.isTimeBased(), [indexPattern]);
   const { TopNavMenu } = services.navigation.ui;
@@ -47,8 +50,18 @@ export const DiscoverTopNav = ({
         state: stateContainer,
         onOpenInspector,
         searchSource,
+        registeredTopNavLinks,
       }),
-    [indexPattern, navigateTo, onOpenInspector, searchSource, stateContainer, savedSearch, services]
+    [
+      indexPattern,
+      navigateTo,
+      onOpenInspector,
+      searchSource,
+      stateContainer,
+      savedSearch,
+      services,
+      registeredTopNavLinks,
+    ]
   );
 
   const updateSavedQueryId = (newSavedQueryId: string | undefined) => {

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.test.ts
@@ -80,13 +80,6 @@ test('getTopNavLinks result', () => {
         "run": [Function],
         "testId": "openInspectorButton",
       },
-      Object {
-        "description": "Open in Data visualizer",
-        "id": "dataVisualizer",
-        "label": "Data visualizer",
-        "run": [Function],
-        "testId": "dataVisualizerTopNavButton",
-      },
     ]
   `);
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.test.ts
@@ -80,6 +80,13 @@ test('getTopNavLinks result', () => {
         "run": [Function],
         "testId": "openInspectorButton",
       },
+      Object {
+        "description": "Open in Data visualizer",
+        "id": "dataVisualizer",
+        "label": "Data visualizer",
+        "run": [Function],
+        "testId": "dataVisualizerTopNavButton",
+      },
     ]
   `);
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
@@ -8,12 +8,6 @@
 
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
-import {
-  fromKueryExpression,
-  toElasticsearchQuery,
-  luceneStringToDsl,
-  decorateQuery,
-} from '@kbn/es-query';
 import { showOpenSearchPanel } from './show_open_search_panel';
 import { getSharingData, showPublicUrlSwitch } from '../../utils/get_sharing_data';
 import { unhashUrl } from '../../../../../../../kibana_utils/public';
@@ -23,8 +17,7 @@ import { onSaveSearch } from './on_save_search';
 import { GetStateReturn } from '../../services/discover_state';
 import { IndexPattern, ISearchSource } from '../../../../../kibana_services';
 import { openOptionsPopover } from './open_options_popover';
-import { RefreshInterval, UI_SETTINGS } from '../../../../../../../data/public';
-import { SerializableState } from '../../../../../../../kibana_utils/common';
+import { TopNavMenuData } from '../../../../../../../navigation/public';
 
 /**
  * Helper function to build the top nav links
@@ -37,6 +30,7 @@ export const getTopNavLinks = ({
   state,
   onOpenInspector,
   searchSource,
+  registeredTopNavLinks,
 }: {
   indexPattern: IndexPattern;
   navigateTo: (url: string) => void;
@@ -45,6 +39,7 @@ export const getTopNavLinks = ({
   state: GetStateReturn;
   onOpenInspector: () => void;
   searchSource: ISearchSource;
+  registeredTopNavLinks?: TopNavMenuData[];
 }) => {
   const options = {
     id: 'options',
@@ -157,59 +152,6 @@ export const getTopNavLinks = ({
     },
   };
 
-  const dataVisualizer = {
-    id: 'dataVisualizer',
-    label: i18n.translate('discover.localMenu.dataVisualizerTitle', {
-      defaultMessage: 'Data visualizer',
-    }),
-    description: i18n.translate('discover.localMenu.dataVisualizerDescription', {
-      defaultMessage: 'Open in Data visualizer',
-    }),
-    testId: 'dataVisualizerTopNavButton',
-    run: async () => {
-      if (!services?.share?.url.locators) {
-        return;
-      }
-      const dvUrlGenerator = services.share.url.locators.get('DATA_VISUALIZER_APP_LOCATOR');
-      const extractedQuery = state.appStateContainer.getState().query;
-      const timeRange = services.timefilter.getTime();
-      const refreshInterval = services.timefilter.getRefreshInterval() as RefreshInterval &
-        SerializableState;
-
-      const params: SerializableState = {
-        indexPatternId: indexPattern.id,
-        savedSearchId: savedSearch.id,
-        timeRange,
-        refreshInterval,
-      };
-      if (extractedQuery) {
-        const queryLanguage = extractedQuery.language;
-        const qryString = extractedQuery.query;
-        let qry;
-        if (queryLanguage === 'kuery') {
-          const ast = fromKueryExpression(qryString);
-          qry = toElasticsearchQuery(ast, indexPattern);
-        } else {
-          qry = luceneStringToDsl(qryString);
-          decorateQuery(qry, services.uiSettings.get(UI_SETTINGS.QUERY_STRING_OPTIONS));
-        }
-
-        params.query = {
-          searchQuery: qry as SerializableState,
-          searchString: qryString,
-          searchQueryLanguage: queryLanguage,
-        };
-      }
-
-      const url = await dvUrlGenerator?.getUrl(params, { absolute: true });
-
-      // We want to open the Data visualizer in a new tab
-      if (url !== undefined) {
-        window.open(url, '_blank');
-      }
-    },
-  };
-
   return [
     ...(services.capabilities.advancedSettings.save ? [options] : []),
     newSearch,
@@ -217,6 +159,6 @@ export const getTopNavLinks = ({
     openSearch,
     shareSearch,
     inspectSearch,
-    dataVisualizer,
+    ...(Array.isArray(registeredTopNavLinks) ? registeredTopNavLinks : []),
   ];
 };

--- a/src/plugins/discover/public/application/apps/main/discover_main_app.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/discover_main_app.test.tsx
@@ -16,11 +16,12 @@ import { SavedObject } from '../../../../../../core/types';
 import { IndexPatternAttributes } from '../../../../../data/common';
 import { setHeaderActionMenuMounter } from '../../../kibana_services';
 import { findTestSubject } from '@elastic/eui/lib/test';
+import { waitFor } from '@testing-library/react';
 
 setHeaderActionMenuMounter(jest.fn());
 
 describe('DiscoverMainApp', () => {
-  test('renders', () => {
+  test('renders', async () => {
     const { history } = createSearchSessionMock();
     const indexPatternList = ([indexPatternMock].map((ip) => {
       return { ...ip, ...{ attributes: { title: ip.title } } };
@@ -38,9 +39,10 @@ describe('DiscoverMainApp', () => {
         }}
       />
     );
-
-    expect(findTestSubject(component, 'indexPattern-switch-link').text()).toBe(
-      indexPatternMock.title
-    );
+    await waitFor(() => {
+      expect(findTestSubject(component, 'indexPattern-switch-link').text()).toBe(
+        indexPatternMock.title
+      );
+    });
   });
 });

--- a/src/plugins/discover/public/application/apps/main/services/add_top_nav_data.mock.ts
+++ b/src/plugins/discover/public/application/apps/main/services/add_top_nav_data.mock.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { AddTopNavDataService, AddTopNavDataServiceSetup } from './add_top_nav_data';
+import type { PublicMethodsOf } from '@kbn/utility-types';
+
+const createSetupMock = (): jest.Mocked<AddTopNavDataServiceSetup> => {
+  const setup = {
+    registerTopNavLinkGetter: jest.fn(),
+  };
+  return setup;
+};
+
+const createMock = (): jest.Mocked<PublicMethodsOf<AddTopNavDataService>> => {
+  const service = {
+    setup: jest.fn(),
+    getTopNavLinkGetters: jest.fn(() => []),
+  };
+  service.setup.mockImplementation(createSetupMock);
+  return service;
+};
+
+export const addTopNavDataServiceMock = {
+  createSetup: createSetupMock,
+  create: createMock,
+};

--- a/src/plugins/discover/public/application/apps/main/services/add_top_nav_data.ts
+++ b/src/plugins/discover/public/application/apps/main/services/add_top_nav_data.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { DiscoverTopNavProps } from '../components/top_nav/discover_topnav';
+import type { TopNavMenuData } from '../../../../../../navigation/public';
+
+/**
+ * Async callback function that generates a TopNavMenuData object
+ * given the arguments provided
+ */
+export type AddNavLinkCallback = (
+  params: Omit<DiscoverTopNavProps, 'registeredTopNavLinks'>
+) => Promise<TopNavMenuData>;
+
+/**
+ * Service for other plugins to register additional links or actions
+ * within Discover (e.g. top navigation bar)
+ */
+export class AddTopNavDataService {
+  private TopNavMenuDatas: Record<string, AddNavLinkCallback> = {};
+
+  public setup() {
+    return {
+      /**
+       * Registers an async callback function that will return a valid top nav link action
+       */
+      registerTopNavLinkGetter: (id: string, callbackFn: AddNavLinkCallback) => {
+        if (this.TopNavMenuDatas[id]) {
+          throw new Error(`link ${id} already exists`);
+        }
+        this.TopNavMenuDatas[id] = callbackFn;
+      },
+    };
+  }
+
+  public getTopNavLinkGetters() {
+    return Object.values(this.TopNavMenuDatas);
+  }
+}
+
+export type AddTopNavDataServiceSetup = ReturnType<AddTopNavDataService['setup']>;

--- a/src/plugins/discover/public/application/helpers/use_registered_top_nav_links.ts
+++ b/src/plugins/discover/public/application/helpers/use_registered_top_nav_links.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { TopNavMenuData } from '../../../../navigation/public';
+import { DiscoverLayoutProps } from '../apps/main/components/layout/types';
+import { Query } from '../../../../../../../../../../../private/var/tmp/_bazel_quynhnguyen/bd5cc7ce3740c1abb2c63a2609d8bb9f/execroot/kibana/bazel-out/darwin-fastbuild/bin/packages/kbn-es-query';
+import { TimeRange } from '../../../../data/common';
+import { GetStateReturn } from '../apps/main/services/discover_state';
+
+export type UseRegisteredTopNavLinksProps = Pick<
+  DiscoverLayoutProps,
+  'indexPattern' | 'navigateTo' | 'savedSearch' | 'services' | 'searchSource'
+> & {
+  onOpenInspector: () => void;
+  query?: Query;
+  savedQuery?: string;
+  updateQuery: (payload: { dateRange: TimeRange; query?: Query }, isUpdate?: boolean) => void;
+  stateContainer: GetStateReturn;
+  columns: string[];
+};
+
+export const useRegisteredTopNavLinks = ({
+  services,
+  indexPattern,
+  onOpenInspector,
+  query,
+  savedQuery,
+  stateContainer,
+  updateQuery,
+  searchSource,
+  navigateTo,
+  savedSearch,
+  columns,
+}: UseRegisteredTopNavLinksProps) => {
+  const [registeredTopNavLinks, setRegisteredTopNavLinks] = useState<TopNavMenuData[]>([]);
+
+  useEffect(() => {
+    let unmounted = false;
+
+    const loadRegisteredTopNavLinks = async () => {
+      if (services?.addTopNavData) {
+        const callbacks = services.addTopNavData.getTopNavLinkGetters();
+        const params = {
+          indexPattern,
+          onOpenInspector,
+          query,
+          savedQuery,
+          stateContainer,
+          updateQuery,
+          searchSource,
+          navigateTo,
+          savedSearch,
+          services,
+          columns,
+        };
+        const links = await Promise.all(
+          callbacks.map((cb) => {
+            return cb(params);
+          })
+        );
+
+        if (!unmounted) {
+          setRegisteredTopNavLinks(links);
+        }
+      }
+    };
+    loadRegisteredTopNavLinks();
+
+    return () => {
+      unmounted = true;
+    };
+  }, [
+    services?.addTopNavData,
+    indexPattern,
+    onOpenInspector,
+    query,
+    savedQuery,
+    stateContainer,
+    updateQuery,
+    searchSource,
+    navigateTo,
+    savedSearch,
+    services,
+    columns,
+  ]);
+  return useMemo(() => registeredTopNavLinks, [registeredTopNavLinks]);
+};

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -36,9 +36,11 @@ import { KibanaLegacyStart } from '../../kibana_legacy/public';
 import { UrlForwardingStart } from '../../url_forwarding/public';
 import { NavigationPublicPluginStart } from '../../navigation/public';
 import { IndexPatternFieldEditorStart } from '../../index_pattern_field_editor/public';
+import type { AddTopNavDataService } from './application/apps/main/services/add_top_nav_data';
 
 export interface DiscoverServices {
   addBasePath: (path: string) => string;
+  addTopNavData: AddTopNavDataService;
   capabilities: Capabilities;
   chrome: ChromeStart;
   core: CoreStart;
@@ -68,7 +70,8 @@ export async function buildServices(
   core: CoreStart,
   plugins: DiscoverStartPlugins,
   context: PluginInitializerContext,
-  getEmbeddableInjector: () => Promise<auto.IInjectorService>
+  getEmbeddableInjector: () => Promise<auto.IInjectorService>,
+  addTopNavDataService: AddTopNavDataService
 ): Promise<DiscoverServices> {
   const services = {
     savedObjectsClient: core.savedObjects.client,
@@ -78,6 +81,7 @@ export async function buildServices(
   const { usageCollection } = plugins;
 
   return {
+    addTopNavData: addTopNavDataService,
     addBasePath: core.http.basePath.prepend,
     capabilities: core.application.capabilities,
     chrome: core.chrome,

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/index.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './locator';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.test.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IndexDataVisualizerLocatorDefinition } from './locator';
+
+describe('Index data visualizer locator', () => {
+  const definition = new IndexDataVisualizerLocatorDefinition();
+
+  it('should generate valid URL for the Index Data Visualizer Viewer page with global settings', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      timeRange: {
+        from: 'now-30m',
+        to: 'now',
+      },
+      refreshInterval: { pause: false, value: 300 },
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        '/jobs/new_job/datavisualizer?index=3da93760-e0af-11ea-9ad3-3bcfc330e42a&_a=(DATA_VISUALIZER_INDEX_VIEWER:())&_g=(refreshInterval:(pause:!f,value:300),time:(from:now-30m,to:now))',
+      state: {},
+    });
+  });
+
+  it('should prioritize savedSearchId even when index pattern id is available', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      savedSearchId: '45014020-dffa-11eb-b120-a105fbbe93b3',
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        '/jobs/new_job/datavisualizer?savedSearchId=45014020-dffa-11eb-b120-a105fbbe93b3&_a=(DATA_VISUALIZER_INDEX_VIEWER:())&_g=()',
+      state: {},
+    });
+  });
+
+  it('should generate valid URL with field names and field types', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      visibleFieldNames: ['@timestamp', 'responsetime'],
+      visibleFieldTypes: ['number'],
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        "/jobs/new_job/datavisualizer?_a=(DATA_VISUALIZER_INDEX_VIEWER:(visibleFieldNames:!('@timestamp',responsetime),visibleFieldTypes:!(number)))&_g=()",
+      state: {},
+    });
+  });
+
+  it('should generate valid URL with KQL query', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      query: {
+        searchQuery: {
+          bool: {
+            should: [
+              {
+                match: {
+                  region: 'ap-northwest-1',
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+        searchString: 'region : ap-northwest-1',
+        searchQueryLanguage: 'kuery',
+      },
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        "/jobs/new_job/datavisualizer?index=3da93760-e0af-11ea-9ad3-3bcfc330e42a&_a=(DATA_VISUALIZER_INDEX_VIEWER:(searchQuery:(bool:(minimum_should_match:1,should:!((match:(region:ap-northwest-1))))),searchQueryLanguage:kuery,searchString:'region : ap-northwest-1'))&_g=()",
+      state: {},
+    });
+  });
+
+  it('should generate valid URL with Lucene query', async () => {
+    const location = await definition.getLocation({
+      indexPatternId: '3da93760-e0af-11ea-9ad3-3bcfc330e42a',
+      query: {
+        searchQuery: {
+          query_string: {
+            query: 'region: ap-northwest-1',
+            analyze_wildcard: true,
+          },
+        },
+        searchString: 'region : ap-northwest-1',
+        searchQueryLanguage: 'lucene',
+      },
+    });
+
+    expect(location).toMatchObject({
+      app: 'ml',
+      path:
+        "/jobs/new_job/datavisualizer?index=3da93760-e0af-11ea-9ad3-3bcfc330e42a&_a=(DATA_VISUALIZER_INDEX_VIEWER:(searchQuery:(query_string:(analyze_wildcard:!t,query:'region: ap-northwest-1')),searchQueryLanguage:lucene,searchString:'region : ap-northwest-1'))&_g=()",
+      state: {},
+    });
+  });
+});

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/locator/locator.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// @ts-ignore
+import { encode } from 'rison-node';
+import { stringify } from 'query-string';
+import { SerializableState } from '../../../../../../../src/plugins/kibana_utils/common';
+import { RefreshInterval, TimeRange } from '../../../../../../../src/plugins/data/common';
+import { LocatorDefinition, LocatorPublic } from '../../../../../../../src/plugins/share/common';
+import { QueryState } from '../../../../../../../src/plugins/data/public';
+import { Dictionary, isRisonSerializationRequired } from '../../common/util/url_state';
+import { SearchQueryLanguage } from '../types/combined_query';
+
+export const DATA_VISUALIZER_APP_LOCATOR = 'DATA_VISUALIZER_APP_LOCATOR';
+
+export interface IndexDataVisualizerLocatorParams extends SerializableState {
+  /**
+   * Optionally set saved search ID.
+   */
+  savedSearchId?: string;
+
+  /**
+   * Optionally set index pattern ID.
+   */
+  indexPatternId?: string;
+
+  /**
+   * Optionally set the time range in the time picker.
+   */
+  timeRange?: TimeRange;
+
+  /**
+   * Optionally set the refresh interval.
+   */
+  refreshInterval?: RefreshInterval & SerializableState;
+
+  /**
+   * Optionally set a query.
+   */
+  query?: {
+    searchQuery: SerializableState;
+    searchString: string | SerializableState;
+    searchQueryLanguage: SearchQueryLanguage;
+  };
+
+  /**
+   * If not given, will use the uiSettings configuration for `storeInSessionStorage`. useHash determines
+   * whether to hash the data in the url to avoid url length issues.
+   */
+  useHash?: boolean;
+  /**
+   * Optionally set visible field names.
+   */
+  visibleFieldNames?: string[];
+  /**
+   * Optionally set visible field types.
+   */
+  visibleFieldTypes?: string[];
+}
+
+export type IndexDataVisualizerLocator = LocatorPublic<IndexDataVisualizerLocatorParams>;
+
+export class IndexDataVisualizerLocatorDefinition
+  implements LocatorDefinition<IndexDataVisualizerLocatorParams> {
+  public readonly id = DATA_VISUALIZER_APP_LOCATOR;
+
+  constructor() {}
+
+  public readonly getLocation = async (params: IndexDataVisualizerLocatorParams) => {
+    const {
+      indexPatternId,
+      query,
+      refreshInterval,
+      savedSearchId,
+      timeRange,
+      visibleFieldNames,
+      visibleFieldTypes,
+    } = params;
+
+    const appState: {
+      searchQuery?: { [key: string]: any };
+      searchQueryLanguage?: string;
+      searchString?: string | SerializableState;
+      visibleFieldNames?: string[];
+      visibleFieldTypes?: string[];
+    } = {};
+    const queryState: QueryState = {};
+
+    if (query) {
+      appState.searchQuery = query.searchQuery;
+      appState.searchString = query.searchString;
+      appState.searchQueryLanguage = query.searchQueryLanguage;
+    }
+    if (visibleFieldNames) appState.visibleFieldNames = visibleFieldNames;
+    if (visibleFieldTypes) appState.visibleFieldTypes = visibleFieldTypes;
+
+    if (timeRange) queryState.time = timeRange;
+    if (refreshInterval) queryState.refreshInterval = refreshInterval;
+
+    const urlState: Dictionary<any> = {
+      ...(savedSearchId ? { savedSearchId } : { index: indexPatternId }),
+      _a: { DATA_VISUALIZER_INDEX_VIEWER: appState },
+      _g: queryState,
+    };
+
+    const parsedQueryString: Dictionary<any> = {};
+    Object.keys(urlState).forEach((a) => {
+      if (isRisonSerializationRequired(a)) {
+        parsedQueryString[a] = encode(urlState[a]);
+      } else {
+        parsedQueryString[a] = urlState[a];
+      }
+    });
+    const newLocationSearchString = stringify(parsedQueryString, {
+      sort: false,
+      encode: false,
+    });
+
+    const path = `/jobs/new_job/datavisualizer?${newLocationSearchString}`;
+    return {
+      app: 'ml',
+      path,
+      state: {},
+    };
+  };
+}

--- a/x-pack/plugins/data_visualizer/public/plugin.ts
+++ b/x-pack/plugins/data_visualizer/public/plugin.ts
@@ -21,8 +21,14 @@ import type { IndexPatternFieldEditorStart } from '../../../../src/plugins/index
 import { getFileDataVisualizerComponent, getIndexDataVisualizerComponent } from './api';
 import { getMaxBytesFormatted } from './application/common/util/get_max_bytes';
 import { registerHomeAddData, registerHomeFeatureCatalogue } from './register_home';
+import {
+  IndexDataVisualizerLocator,
+  IndexDataVisualizerLocatorDefinition,
+} from './application/index_data_visualizer/locator';
+import { SharePluginSetup } from '../../../../src/plugins/share/public';
 
 export interface DataVisualizerSetupDependencies {
+  share?: SharePluginSetup;
   home?: HomePublicPluginSetup;
 }
 export interface DataVisualizerStartDependencies {
@@ -47,10 +53,16 @@ export class DataVisualizerPlugin
       DataVisualizerSetupDependencies,
       DataVisualizerStartDependencies
     > {
+  private locator?: IndexDataVisualizerLocator;
+
   public setup(core: CoreSetup, plugins: DataVisualizerSetupDependencies) {
     if (plugins.home) {
       registerHomeAddData(plugins.home);
       registerHomeFeatureCatalogue(plugins.home);
+    }
+
+    if (plugins.share) {
+      this.locator = plugins.share.url.locators.create(new IndexDataVisualizerLocatorDefinition());
     }
   }
 
@@ -60,6 +72,7 @@ export class DataVisualizerPlugin
       getFileDataVisualizerComponent,
       getIndexDataVisualizerComponent,
       getMaxBytesFormatted,
+      locator: this.locator,
     };
   }
 }

--- a/x-pack/plugins/ml/public/locator/ml_locator.test.ts
+++ b/x-pack/plugins/ml/public/locator/ml_locator.test.ts
@@ -9,7 +9,7 @@ import { MlLocatorDefinition } from './ml_locator';
 import { ML_PAGES } from '../../common/constants/locator';
 import { ANALYSIS_CONFIG_TYPE } from '../../common/constants/data_frame_analytics';
 
-describe('MlUrlGenerator', () => {
+describe('ML locator', () => {
   const definition = new MlLocatorDefinition();
 
   describe('AnomalyDetection', () => {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/106470. This draft PR adds the ability to navigate from Discover top navigation to the Index data visualizer. It also implements a POC for a way for other plugins to register actions or links during setup.

https://user-images.githubusercontent.com/43350163/126551766-a1dbf2ba-13d8-4a97-8922-6f5068548868.mov

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
