### PR TITLE
[Cases] Add Swimlane & ServiceNow SecOps to README

### DIFF
--- a/x-pack/plugins/cases/README.md
+++ b/x-pack/plugins/cases/README.md
@@ -60,12 +60,12 @@ cases: CasesUiStart;
 ### `getAllCases`
 Arguments:
 
-|Property|Description|
-|---|---|
-|caseDetailsNavigation|`CasesNavigation<CaseDetailsHrefSchema, 'configurable'>` route configuration to generate the case details url for the case details page
-|configureCasesNavigation|`CasesNavigation` route configuration for configure cases page
-|createCaseNavigation|`CasesNavigation` route configuration for create cases page
-|userCanCrud|`boolean;` user permissions to crud
+| Property                 | Description                                                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| caseDetailsNavigation    | `CasesNavigation<CaseDetailsHrefSchema, 'configurable'>` route configuration to generate the case details url for the case details page |
+| configureCasesNavigation | `CasesNavigation` route configuration for configure cases page                                                                          |
+| createCaseNavigation     | `CasesNavigation` route configuration for create cases page                                                                             |
+| userCanCrud              | `boolean;` user permissions to crud                                                                                                     |
 
 UI component:
 ![All Cases Component][all-cases-img]
@@ -73,14 +73,14 @@ UI component:
 ### `getAllCasesSelectorModal`
 Arguments:
 
-|Property|Description|
-|---|---|
-|alertData?|`Omit<CommentRequestAlertType, 'type'>;` alert data to post to case
-|createCaseNavigation|`CasesNavigation` route configuration for create cases page
-|hiddenStatuses?|`CaseStatuses[];` array of hidden statuses
-|onRowClick|<code>(theCase?: Case &vert; SubCase) => void;</code> callback for row click, passing case in row
-|updateCase?|<code>(theCase: Case &vert; SubCase) => void;</code> callback after case has been updated
-|userCanCrud|`boolean;` user permissions to crud
+| Property             | Description                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| alertData?           | `Omit<CommentRequestAlertType, 'type'>;` alert data to post to case                               |
+| createCaseNavigation | `CasesNavigation` route configuration for create cases page                                       |
+| hiddenStatuses?      | `CaseStatuses[];` array of hidden statuses                                                        |
+| onRowClick           | <code>(theCase?: Case &vert; SubCase) => void;</code> callback for row click, passing case in row |
+| updateCase?          | <code>(theCase: Case &vert; SubCase) => void;</code> callback after case has been updated         |
+| userCanCrud          | `boolean;` user permissions to crud                                                               |
 
 UI component:
 ![All Cases Selector Modal Component][all-cases-modal-img]
@@ -88,27 +88,27 @@ UI component:
 ### `getCaseView`
 Arguments:
 
-|Property|Description|
-|---|---|
-|caseDetailsNavigation|`CasesNavigation<CaseDetailsHrefSchema, 'configurable'>` route configuration to generate the case details url for the case details page
-|caseId|`string;` ID of the case
-|configureCasesNavigation|`CasesNavigation` route configuration for configure cases page
-|createCaseNavigation|`CasesNavigation` route configuration for create cases page
-|getCaseDetailHrefWithCommentId|`(commentId: string) => string;` callback to generate the case details url with a comment id reference from the case id and comment id
-|onComponentInitialized?|`() => void;` callback when component has initialized
-|onCaseDataSuccess?| `(data: Case) => void;` optional callback to handle case data in consuming application
-|ruleDetailsNavigation| <code>CasesNavigation<string &vert; null &vert; undefined, 'configurable'></code>
-|showAlertDetails| `(alertId: string, index: string) => void;` callback to show alert details
-|subCaseId?| `string;` subcase id
-|timelineIntegration?.editor_plugins| Plugins needed for integrating timeline into markdown editor.
-|timelineIntegration?.editor_plugins.parsingPlugin| `Plugin;`
-|timelineIntegration?.editor_plugins.processingPluginRenderer| `React.FC<TimelineProcessingPluginRendererProps & { position: EuiMarkdownAstNodePosition }>`
-|timelineIntegration?.editor_plugins.uiPlugin?| `EuiMarkdownEditorUiPlugin`
-|timelineIntegration?.hooks.useInsertTimeline| `(value: string, onChange: (newValue: string) => void): UseInsertTimelineReturn`
-|timelineIntegration?.ui?.renderInvestigateInTimelineActionComponent?| `(alertIds: string[]) => JSX.Element;` space to render `InvestigateInTimelineActionComponent`
-|timelineIntegration?.ui?renderTimelineDetailsPanel?| `() => JSX.Element;` space to render `TimelineDetailsPanel`
-|useFetchAlertData| `(alertIds: string[]) => [boolean, Record<string, Ecs>];` fetch alerts
-|userCanCrud| `boolean;` user permissions to crud
+| Property                                                             | Description                                                                                                                             |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| caseDetailsNavigation                                                | `CasesNavigation<CaseDetailsHrefSchema, 'configurable'>` route configuration to generate the case details url for the case details page |
+| caseId                                                               | `string;` ID of the case                                                                                                                |
+| configureCasesNavigation                                             | `CasesNavigation` route configuration for configure cases page                                                                          |
+| createCaseNavigation                                                 | `CasesNavigation` route configuration for create cases page                                                                             |
+| getCaseDetailHrefWithCommentId                                       | `(commentId: string) => string;` callback to generate the case details url with a comment id reference from the case id and comment id  |
+| onComponentInitialized?                                              | `() => void;` callback when component has initialized                                                                                   |
+| onCaseDataSuccess?                                                   | `(data: Case) => void;` optional callback to handle case data in consuming application                                                  |
+| ruleDetailsNavigation                                                | <code>CasesNavigation<string &vert; null &vert; undefined, 'configurable'></code>                                                       |
+| showAlertDetails                                                     | `(alertId: string, index: string) => void;` callback to show alert details                                                              |
+| subCaseId?                                                           | `string;` subcase id                                                                                                                    |
+| timelineIntegration?.editor_plugins                                  | Plugins needed for integrating timeline into markdown editor.                                                                           |
+| timelineIntegration?.editor_plugins.parsingPlugin                    | `Plugin;`                                                                                                                               |
+| timelineIntegration?.editor_plugins.processingPluginRenderer         | `React.FC<TimelineProcessingPluginRendererProps & { position: EuiMarkdownAstNodePosition }>`                                            |
+| timelineIntegration?.editor_plugins.uiPlugin?                        | `EuiMarkdownEditorUiPlugin`                                                                                                             |
+| timelineIntegration?.hooks.useInsertTimeline                         | `(value: string, onChange: (newValue: string) => void): UseInsertTimelineReturn`                                                        |
+| timelineIntegration?.ui?.renderInvestigateInTimelineActionComponent? | `(alertIds: string[]) => JSX.Element;` space to render `InvestigateInTimelineActionComponent`                                           |
+| timelineIntegration?.ui?renderTimelineDetailsPanel?                  | `() => JSX.Element;` space to render `TimelineDetailsPanel`                                                                             |
+| useFetchAlertData                                                    | `(alertIds: string[]) => [boolean, Record<string, Ecs>];` fetch alerts                                                                  |
+| userCanCrud                                                          | `boolean;` user permissions to crud                                                                                                     |
 
 UI component:
  ![Case View Component][case-view-img] 
@@ -116,16 +116,16 @@ UI component:
 ### `getCreateCase`
 Arguments: 
 
-|Property|Description|
-|---|---|
-|afterCaseCreated?|`(theCase: Case) => Promise<void>;` callback passing newly created case before pushCaseToExternalService is called
-|onCancel|`() => void;` callback when create case is canceled
-|onSuccess|`(theCase: Case) => Promise<void>;` callback passing newly created case after pushCaseToExternalService is called
-|timelineIntegration?.editor_plugins| Plugins needed for integrating timeline into markdown editor.
-|timelineIntegration?.editor_plugins.parsingPlugin| `Plugin;`
-|timelineIntegration?.editor_plugins.processingPluginRenderer| `React.FC<TimelineProcessingPluginRendererProps & { position: EuiMarkdownAstNodePosition }>`
-|timelineIntegration?.editor_plugins.uiPlugin?| `EuiMarkdownEditorUiPlugin`
-|timelineIntegration?.hooks.useInsertTimeline| `(value: string, onChange: (newValue: string) => void): UseInsertTimelineReturn`
+| Property                                                     | Description                                                                                                        |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| afterCaseCreated?                                            | `(theCase: Case) => Promise<void>;` callback passing newly created case before pushCaseToExternalService is called |
+| onCancel                                                     | `() => void;` callback when create case is canceled                                                                |
+| onSuccess                                                    | `(theCase: Case) => Promise<void>;` callback passing newly created case after pushCaseToExternalService is called  |
+| timelineIntegration?.editor_plugins                          | Plugins needed for integrating timeline into markdown editor.                                                      |
+| timelineIntegration?.editor_plugins.parsingPlugin            | `Plugin;`                                                                                                          |
+| timelineIntegration?.editor_plugins.processingPluginRenderer | `React.FC<TimelineProcessingPluginRendererProps & { position: EuiMarkdownAstNodePosition }>`                       |
+| timelineIntegration?.editor_plugins.uiPlugin?                | `EuiMarkdownEditorUiPlugin`                                                                                        |
+| timelineIntegration?.hooks.useInsertTimeline                 | `(value: string, onChange: (newValue: string) => void): UseInsertTimelineReturn`                                   |
 
 UI component:
  ![Create Component][create-img]
@@ -133,9 +133,9 @@ UI component:
  ### `getConfigureCases`
  Arguments:
  
- |Property|Description|
- |---|---|
- |userCanCrud|`boolean;`  user permissions to crud
+ | Property    | Description                          |
+ | ----------- | ------------------------------------ |
+ | userCanCrud | `boolean;`  user permissions to crud |
  
  UI component:
   ![Configure Component][configure-img] 
@@ -143,12 +143,12 @@ UI component:
 ### `getRecentCases`
 Arguments:
 
-|Property|Description|
-|---|---|
-|allCasesNavigation|`CasesNavigation` route configuration for configure cases page
-|caseDetailsNavigation|`CasesNavigation<CaseDetailsHrefSchema, 'configurable'>` route configuration to generate the case details url for the case details page
-|createCaseNavigation|`CasesNavigation` route configuration for create case page
-|maxCasesToShow|`number;` number of cases to show in widget
+| Property              | Description                                                                                                                             |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| allCasesNavigation    | `CasesNavigation` route configuration for configure cases page                                                                          |
+| caseDetailsNavigation | `CasesNavigation<CaseDetailsHrefSchema, 'configurable'>` route configuration to generate the case details url for the case details page |
+| createCaseNavigation  | `CasesNavigation` route configuration for create case page                                                                              |
+| maxCasesToShow        | `number;` number of cases to show in widget                                                                                             |
   
 UI component:
  ![Recent Cases Component][recent-cases-img] 
@@ -211,24 +211,38 @@ This action type has no `secrets` properties.
 
 #### `connector`
 
-| Property | Description                                                                                       | Type              |
-| -------- | ------------------------------------------------------------------------------------------------- | ----------------- |
-| id       | ID of the connector used for pushing case updates to external systems.                            | string            |
-| name     | The connector name.                                                                               | string            |
+| Property | Description                                                                                                                       | Type              |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| id       | ID of the connector used for pushing case updates to external systems.                                                            | string            |
+| name     | The connector name.                                                                                                               | string            |
 | type     | The type of the connector. Must be one of these: `.servicenow`, `.servicenow-sir`, `.swimlane`, `jira`, `.resilient`, and `.none` | string            |
-| fields   | Object containing the connector’s fields.                                                         | [fields](#fields) |
+| fields   | Object containing the connector’s fields.                                                                                         | [fields](#fields) |
 
 #### `fields`
 
-For ServiceNow connectors:
+For ServiceNow ITSM connectors (`.servicenow`):
 
-| Property | Description                   | Type   |
-| -------- | ----------------------------- | ------ |
-| urgency  | The urgency of the incident.  | string |
-| severity | The severity of the incident. | string |
-| impact   | The impact of the incident.   | string |
+| Property    | Description                    | Type   |
+| ----------- | ------------------------------ | ------ |
+| urgency     | The urgency of the incident.   | string |
+| severity    | The severity of the incident.  | string |
+| impact      | The impact of the incident.    | string |
+| category    | The category in ServiceNow.    | string |
+| subcategory | The subcategory in ServiceNow. | string |
 
-For Jira connectors:
+For ServiceNow SecOps connectors (`.servicenow-sir`):
+
+| Property    | Description                                                       | Type    |
+| ----------- | ----------------------------------------------------------------- | ------- |
+| category    | The category in ServiceNow.                                       | string  |
+| destIp      | Include all destination IPs from all alerts attached to the case. | boolean |
+| malwareHash | Include all malware hashes from all alerts attached to the case.  | boolean |
+| malwareUrl  | Include all malware URLs from all alerts attached to the case.    | boolean |
+| priority    | The priority of the incident.                                     | string  |
+| sourceIp    | Include all sources IPs from all alerts attached to the case.     | boolean |
+| subcategory | The subcategory in ServiceNow.                                    | string  |
+
+For Jira connectors (`.jira`):
 
 | Property  | Description                                                          | Type   |
 | --------- | -------------------------------------------------------------------- | ------ |
@@ -236,12 +250,20 @@ For Jira connectors:
 | priority  | The priority of the issue.                                           | string |
 | parent    | The key of the parent issue (Valid when the issue type is Sub-task). | string |
 
-For IBM Resilient connectors:
+For IBM Resilient connectors (`.resilient`):
 
 | Property     | Description                     | Type     |
 | ------------ | ------------------------------- | -------- |
 | issueTypes   | The issue types of the issue.   | string[] |
 | severityCode | The severity code of the issue. | string   |
+
+For Swimlane (`.swimlane`):
+
+| Property | Description         | Type   |
+| -------- | ------------------- | ------ |
+| caseId   | The ID of the case. | string |
+
+Connectors of type (`.none`) should have the `fields` attribute set to `null`.
 
 #### `settings`
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Swimlane & ServiceNow SecOps connectors to the README file of Cases.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
