### PR TITLE
[ML] Fix correlation chart y-axis labels.

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/correlations_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/correlations_chart.tsx
@@ -72,7 +72,7 @@ const chartTheme: PartialTheme = {
 
 // Log based axis cannot start a 0. Use a small positive number instead.
 const yAxisDomain = {
-  min: 0.00001,
+  min: 0.9,
 };
 
 interface CorrelationsChartProps {
@@ -135,7 +135,18 @@ export function CorrelationsChart({
 
   if (!Array.isArray(overallHistogram)) return <div />;
   const annotationsDataValues: LineAnnotationDatum[] = [
-    { dataValue: markerValue, details: `${markerPercentile}th percentile` },
+    {
+      dataValue: markerValue,
+      details: i18n.translate(
+        'xpack.apm.correlations.latency.chart.percentileMarkerLabel',
+        {
+          defaultMessage: '{markerPercentile}th percentile',
+          values: {
+            markerPercentile,
+          },
+        }
+      ),
+    },
   ];
 
   const xMax = Math.max(...overallHistogram.map((d) => d.key)) ?? 0;

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
@@ -356,7 +356,8 @@ export function MlLatencyCorrelations({ onClose }: Props) {
               {i18n.translate(
                 'xpack.apm.correlations.latencyCorrelations.chartTitle',
                 {
-                  defaultMessage: 'Latency distribution for {name}',
+                  defaultMessage:
+                    'Latency distribution for {name} (Log-Log Plot)',
                   values: {
                     name: transactionName ?? serviceName,
                   },

--- a/x-pack/test/functional/apps/apm/correlations/latency_correlations.ts
+++ b/x-pack/test/functional/apps/apm/correlations/latency_correlations.ts
@@ -123,7 +123,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             'apmCorrelationsLatencyCorrelationsChartTitle'
           );
           expect(apmCorrelationsLatencyCorrelationsChartTitle).to.be(
-            `Latency distribution for ${testData.serviceName}`
+            `Latency distribution for ${testData.serviceName} (Log-Log Plot)`
           );
           await testSubjects.existOrFail('apmCorrelationsChart', {
             timeout: 10000,


### PR DESCRIPTION
## Summary

Fixes #106681.

- Adjust the minimum value of the correlation chart's y axis.
- Adds `Log-Log Plot` to the section header to indicate the chart type. 
- Adds a missing translation

Before:

![image](https://user-images.githubusercontent.com/230104/127060250-f5801a74-774a-4e6a-83d3-e0feedbdc046.png)

After:

![image](https://user-images.githubusercontent.com/230104/127060281-7f911bbc-36d3-4a14-8830-d24272cb7d9c.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
