### PR TITLE
Add initContext as optional service param; add Kibana version to Canvas

### DIFF
--- a/src/plugins/presentation_util/public/services/create/factory.ts
+++ b/src/plugins/presentation_util/public/services/create/factory.ts
@@ -7,7 +7,7 @@
  */
 
 import { BehaviorSubject } from 'rxjs';
-import { CoreStart, AppUpdater } from 'src/core/public';
+import { CoreStart, AppUpdater, PluginInitializerContext } from 'src/core/public';
 
 /**
  * A factory function for creating a service.
@@ -28,6 +28,7 @@ export interface KibanaPluginServiceParams<Start extends {}> {
   coreStart: CoreStart;
   startPlugins: Start;
   appUpdater?: BehaviorSubject<AppUpdater>;
+  initContext?: PluginInitializerContext;
 }
 
 /**

--- a/x-pack/plugins/canvas/public/index.ts
+++ b/x-pack/plugins/canvas/public/index.ts
@@ -18,4 +18,5 @@ export interface WithKibanaProps {
   };
 }
 
-export const plugin = (_initializerContext: PluginInitializerContext) => new CanvasPlugin();
+export const plugin = (initializerContext: PluginInitializerContext) =>
+  new CanvasPlugin(initializerContext);

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -15,6 +15,7 @@ import {
   AppMountParameters,
   AppUpdater,
   DEFAULT_APP_CATEGORIES,
+  PluginInitializerContext,
 } from '../../../../src/core/public';
 import { HomePublicPluginSetup } from '../../../../src/plugins/home/public';
 import { initLoadingIndicator } from './lib/loading_indicator';
@@ -73,6 +74,11 @@ export type CanvasStart = void;
 export class CanvasPlugin
   implements Plugin<CanvasSetup, CanvasStart, CanvasSetupDeps, CanvasStartDeps> {
   private appUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
+  private initContext: PluginInitializerContext;
+
+  constructor(initContext: PluginInitializerContext) {
+    this.initContext = initContext;
+  }
 
   public setup(coreSetup: CoreSetup<CanvasStartDeps>, setupPlugins: CanvasSetupDeps) {
     const { api: canvasApi, registries } = getPluginApi(setupPlugins.expressions);
@@ -105,7 +111,9 @@ export class CanvasPlugin
         srcPlugin.start(coreStart, startPlugins);
 
         const { pluginServices } = await import('./services');
-        pluginServices.setRegistry(pluginServiceRegistry.start({ coreStart, startPlugins }));
+        pluginServices.setRegistry(
+          pluginServiceRegistry.start({ coreStart, startPlugins, initContext: this.initContext })
+        );
 
         // Load application bundle
         const { renderApp, initializeCanvas, teardownCanvas } = await import('./application');

--- a/x-pack/plugins/canvas/public/services/kibana/platform.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/platform.ts
@@ -25,7 +25,7 @@ export const platformServiceFactory: CanvaPlatformServiceFactory = ({ coreStart,
     getBasePathInterface: () => coreStart.http.basePath,
     getElasticWebsiteUrl: () => coreStart.docLinks.ELASTIC_WEBSITE_URL,
     getDocLinkVersion: () => coreStart.docLinks.DOC_LINK_VERSION,
-    getKibanaVersion: () => initContext?.env.packageInfo.version,
+    getKibanaVersion: () => initContext.env.packageInfo.version,
     // TODO: is there a better type for this?  The capabilities type allows for a Record,
     // though we don't do this.  So this cast may be the best option.
     getHasWriteAccess: () => coreStart.application.capabilities.canvas.save as boolean,

--- a/x-pack/plugins/canvas/public/services/kibana/platform.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/platform.ts
@@ -15,12 +15,17 @@ export type CanvaPlatformServiceFactory = KibanaPluginServiceFactory<
   CanvasStartDeps
 >;
 
-export const platformServiceFactory: CanvaPlatformServiceFactory = ({ coreStart }) => {
+export const platformServiceFactory: CanvaPlatformServiceFactory = ({ coreStart, initContext }) => {
+  if (!initContext) {
+    throw new Error('Canvas platform service requires init context');
+  }
+
   return {
     getBasePath: coreStart.http.basePath.get,
     getBasePathInterface: () => coreStart.http.basePath,
     getElasticWebsiteUrl: () => coreStart.docLinks.ELASTIC_WEBSITE_URL,
     getDocLinkVersion: () => coreStart.docLinks.DOC_LINK_VERSION,
+    getKibanaVersion: () => initContext?.env.packageInfo.version,
     // TODO: is there a better type for this?  The capabilities type allows for a Record,
     // though we don't do this.  So this cast may be the best option.
     getHasWriteAccess: () => coreStart.application.capabilities.canvas.save as boolean,

--- a/x-pack/plugins/canvas/public/services/platform.ts
+++ b/x-pack/plugins/canvas/public/services/platform.ts
@@ -19,6 +19,7 @@ export interface CanvasPlatformService {
   getBasePathInterface: () => IBasePath;
   getDocLinkVersion: () => string;
   getElasticWebsiteUrl: () => string;
+  getKibanaVersion: () => string;
   getHasWriteAccess: () => boolean;
   getUISetting: (key: string, defaultValue?: any) => any;
   setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => void;

--- a/x-pack/plugins/canvas/public/services/stubs/platform.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/platform.ts
@@ -24,6 +24,7 @@ export const platformServiceFactory: CanvasPlatformServiceFactory = () => ({
   getBasePathInterface: noop,
   getDocLinkVersion: () => 'dockLinkVersion',
   getElasticWebsiteUrl: () => 'https://elastic.co',
+  getKibanaVersion: () => 'kibanaVersion',
   getHasWriteAccess: () => true,
   getUISetting,
   setBreadcrumbs: noop,


### PR DESCRIPTION
> Prerequisite for https://github.com/elastic/kibana/pull/106137

This PR adds the `PluginInitializerContext` as an optional (therefore passive) parameter for the Presentation Util Services Abstraction for Kibana-based services.  It also adds a new method for the `platform` service in Canvas to return the current Kibana version for new Reporting.