### PR TITLE
[7.x] [DOCS] Removes image from color field formatter (#106744)

### DIFF
--- a/docs/management/field-formatters/color-formatter.asciidoc
+++ b/docs/management/field-formatters/color-formatter.asciidoc
@@ -1,5 +1,3 @@
 The *Color* field formatter enables you to specify colors with ranges of values for a number field.
 
 When you select the *Color* formatter, click *Add Color*, then specify the *Range*, *Text color*, and *Background color*.
-
-image::images/colorformatter.png[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Removes image from color field formatter (#106744)