### PR TITLE
[App Search] Attempt to add protocols to crawler urls when they are submitted for validation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -21,12 +21,18 @@ jest.mock('../../crawler_overview_logic', () => ({
   },
 }));
 
+jest.mock('./utils', () => ({
+  ...(jest.requireActual('./utils') as object),
+  getDomainWithProtocol: jest.fn().mockImplementation((domain) => domain),
+}));
+
 import { nextTick } from '@kbn/test/jest';
 
 import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
 import { CrawlerDomain } from '../../types';
 
 import { AddDomainLogic, AddDomainLogicValues } from './add_domain_logic';
+import { getDomainWithProtocol } from './utils';
 
 const DEFAULT_VALUES: AddDomainLogicValues = {
   addDomainFormInputValue: 'https://',
@@ -272,16 +278,18 @@ describe('AddDomainLogic', () => {
     });
 
     describe('validateDomain', () => {
-      it('extracts the domain and entrypoint and passes them to the callback ', () => {
+      it('extracts the domain and entrypoint and passes them to the callback ', async () => {
         mount({ addDomainFormInputValue: 'https://swiftype.com/site-search' });
         jest.spyOn(AddDomainLogic.actions, 'onValidateDomain');
 
         AddDomainLogic.actions.validateDomain();
+        await nextTick();
 
         expect(AddDomainLogic.actions.onValidateDomain).toHaveBeenCalledWith(
           'https://swiftype.com',
           '/site-search'
         );
+        expect(getDomainWithProtocol).toHaveBeenCalledWith('https://swiftype.com');
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.ts
@@ -21,7 +21,7 @@ import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
 import { CrawlerDataFromServer, CrawlerDomain } from '../../types';
 import { crawlerDataServerToClient } from '../../utils';
 
-import { extractDomainAndEntryPointFromUrl } from './utils';
+import { extractDomainAndEntryPointFromUrl, getDomainWithProtocol } from './utils';
 
 export interface AddDomainLogicValues {
   addDomainFormInputValue: string;
@@ -156,11 +156,14 @@ export const AddDomainLogic = kea<MakeLogicType<AddDomainLogicValues, AddDomainL
         actions.onSubmitNewDomainError(errorMessages);
       }
     },
-    validateDomain: () => {
+    validateDomain: async () => {
       const { domain, entryPoint } = extractDomainAndEntryPointFromUrl(
         values.addDomainFormInputValue.trim()
       );
-      actions.onValidateDomain(domain, entryPoint);
+
+      const domainWithProtocol = await getDomainWithProtocol(domain);
+
+      actions.onValidateDomain(domainWithProtocol, entryPoint);
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.test.ts
@@ -45,7 +45,7 @@ describe('getDomainWithProtocol', () => {
     expect(http.post).toHaveBeenCalledTimes(0);
   });
 
-  it('returns domain with https protocol if back-end valdates https', async () => {
+  it('returns domain with https protocol if the back-end validates https', async () => {
     http.post.mockReturnValueOnce(Promise.resolve({ valid: true }));
     const result = await getDomainWithProtocol('elastic.co');
 
@@ -56,9 +56,10 @@ describe('getDomainWithProtocol', () => {
     });
   });
 
-  it('returns domain with http protocol if back-end valdates http', async () => {
-    http.post.mockReturnValueOnce(Promise.resolve({ valid: false }));
-    http.post.mockReturnValueOnce(Promise.resolve({ valid: true }));
+  it('returns domain with http protocol if the back-end validates http', async () => {
+    http.post
+      .mockReturnValueOnce(Promise.resolve({ valid: false }))
+      .mockReturnValueOnce(Promise.resolve({ valid: true }));
     const result = await getDomainWithProtocol('elastic.co');
 
     expect(result).toEqual('http://elastic.co');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -65,3 +65,12 @@ export interface CrawlerData {
 export interface CrawlerDataFromServer {
   domains: CrawlerDomainFromServer[];
 }
+
+export interface CrawlerDomainValidationResultFromServer {
+  valid: boolean;
+  results: Array<{
+    name: string;
+    result: 'ok' | 'warning' | 'failure';
+    comment: string;
+  }>;
+}

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -144,4 +144,41 @@ describe('crawler routes', () => {
       mockRouter.shouldValidate(request);
     });
   });
+
+  describe('POST /api/app_search/crawler/validate_url', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/app_search/crawler/validate_url',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/crawler/validate_url',
+      });
+    });
+
+    it('validates correctly with body', () => {
+      const request = {
+        body: { url: 'elastic.co', checks: ['tcp', 'url_request'] },
+      };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without a body', () => {
+      const request = {
+        body: {},
+      };
+      mockRouter.shouldThrow(request);
+    });
+  });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -69,4 +69,19 @@ export function registerCrawlerRoutes({
       path: '/api/as/v0/engines/:name/crawler/domains/:id',
     })
   );
+
+  router.post(
+    {
+      path: '/api/app_search/crawler/validate_url',
+      validate: {
+        body: schema.object({
+          url: schema.string(),
+          checks: schema.arrayOf(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/crawler/validate_url',
+    })
+  );
 }


### PR DESCRIPTION
## Summary

This adds a step to the validation process for the Add Domain form for the Crawler Overview wherein we attempt to add `http://` or `https://` protocol if it is missing to any url supplied by the user.

This happens in the background, there is no feedback supplied to the user, even for a failure or server error.  In this case we do not modify the url.  We rely on later validation steps (to be added in a follow-up PR) to communicate more detailed feedback to the user when submit the domain.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
