### PR TITLE
[Buildkite] Sync with master updates since Buildkite was disabled

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export KBN_NP_PLUGINS_BUILT=true
 
 echo "--- Build Kibana Distribution"
-node scripts/build --debug --no-oss
+node scripts/build --debug
 
 echo "--- Archive Kibana Distribution"
 linuxBuild="$(find "$KIBANA_DIR/target" -name 'kibana-*-linux-x86_64.tar.gz')"

--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -67,6 +67,6 @@ export TEST_KIBANA_HOST=localhost
 export TEST_KIBANA_PORT=6101
 export TEST_KIBANA_URL="http://elastic:changeme@localhost:6101"
 export TEST_ES_URL="http://elastic:changeme@localhost:6102"
-export TEST_ES_TRANSPORT_PORT=6103
+export TEST_ES_TRANSPORT_PORT=6301-6309
 export TEST_CORS_SERVER_PORT=6106
 export ALERTING_PROXY_PORT=6105

--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -6,7 +6,7 @@ if [[ ! "${DISABLE_CI_STATS_SHIPPING:-}" ]]; then
   echo "--- Ship Kibana Distribution Metrics to CI Stats"
   node scripts/ship_ci_stats \
     --metrics target/optimizer_bundle_metrics.json \
-    --metrics node_modules/@kbn/ui-shared-deps/shared_built_assets/metrics.json
+    --metrics build/kibana/node_modules/@kbn/ui-shared-deps/shared_built_assets/metrics.json
 fi
 
 echo "--- Upload Build Artifacts"


### PR DESCRIPTION
Bring over all changes relevant to the `on merge` Buildkite job that have made it into master since Buildkite was disabled, i.e. since 2507d37.

Tested [here](https://buildkite.com/elastic/kibana-on-merge/builds/774).

Also, I'm going to go ahead and use this PR as a test for #106467 if that is merged reasonably soon.