### PR TITLE
[Fleet] Do not display add agent from the integration table in agent …

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -273,6 +273,7 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
               agentPolicy={agentPolicy}
               packagePolicy={packagePolicy}
               viewDataStep={viewDataStep}
+              showAddAgent={true}
             />
           );
         },

--- a/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
@@ -23,7 +23,8 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   agentPolicy: AgentPolicy;
   packagePolicy: PackagePolicy;
   viewDataStep?: EuiStepProps;
-}> = ({ agentPolicy, packagePolicy, viewDataStep }) => {
+  showAddAgent?: boolean;
+}> = ({ agentPolicy, packagePolicy, viewDataStep, showAddAgent }) => {
   const [isEnrollmentFlyoutOpen, setIsEnrollmentFlyoutOpen] = useState(false);
   const { getHref } = useLink();
   const hasWriteCapabilities = useCapabilities().write;
@@ -47,19 +48,23 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
     //     defaultMessage="View integration"
     //   />
     // </EuiContextMenuItem>,
-    <EuiContextMenuItem
-      icon="plusInCircle"
-      onClick={() => {
-        setIsActionsMenuOpen(false);
-        setIsEnrollmentFlyoutOpen(true);
-      }}
-      key="addAgent"
-    >
-      <FormattedMessage
-        id="xpack.fleet.epm.packageDetails.integrationList.addAgent"
-        defaultMessage="Add Agent"
-      />
-    </EuiContextMenuItem>,
+    ...(showAddAgent
+      ? [
+          <EuiContextMenuItem
+            icon="plusInCircle"
+            onClick={() => {
+              setIsActionsMenuOpen(false);
+              setIsEnrollmentFlyoutOpen(true);
+            }}
+            key="addAgent"
+          >
+            <FormattedMessage
+              id="xpack.fleet.epm.packageDetails.integrationList.addAgent"
+              defaultMessage="Add Agent"
+            />
+          </EuiContextMenuItem>,
+        ]
+      : []),
     <EuiContextMenuItem
       disabled={!hasWriteCapabilities}
       icon="pencil"


### PR DESCRIPTION
## Description 

Resolve #106676

The same component is used in the integration table in the agent policy section and in the agent policy table in the integration view, we should show the add agent only for the second one.

## UI Change

<img width="1263" alt="Screen Shot 2021-07-26 at 4 00 29 PM" src="https://user-images.githubusercontent.com/1336873/127052096-032c95bd-9b9c-4348-9c16-207cc1839977.png">
