### PR TITLE
[DOCS][Dev Tools] Uses task-oriented titles

### DIFF
--- a/docs/dev-tools/console/console.asciidoc
+++ b/docs/dev-tools/console/console.asciidoc
@@ -1,7 +1,7 @@
 [[console-kibana]]
-== Console
+== Run {es} API requests
 
-*Console* enables you to interact with the REST API of {es}. You can:
+Interact with the REST API of {es} with *Console*. You can:
 
 * Send requests to {es} and view the responses
 * View API documentation

--- a/docs/dev-tools/painlesslab/index.asciidoc
+++ b/docs/dev-tools/painlesslab/index.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[painlesslab]]
-== Painless Lab
+== Debug Painless scripts
 
 beta::[]
 


### PR DESCRIPTION
## Summary

This PR changes titles of Dev Tools docs to use task-oriented titles.