### PR TITLE
[TSVB] Fixes bug with tophit aggregation and index not exist

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
@@ -120,7 +120,10 @@ const TopHitAggUi = (props) => {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
   const fieldsSelector = getIndexPatternKey(indexPattern);
-  const field = fields[fieldsSelector].find((f) => f.name === model.field);
+  const field =
+    fields && fields[fieldsSelector] && fields[fieldsSelector].length
+      ? fields[fieldsSelector].find((f) => f.name === model.field)
+      : {};
   const aggWithOptions = getAggWithOptions(field, aggWithOptionsRestrictFields);
   const orderOptions = getOrderOptions();
 

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
@@ -120,10 +120,7 @@ const TopHitAggUi = (props) => {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
   const fieldsSelector = getIndexPatternKey(indexPattern);
-  const field =
-    fields && fields[fieldsSelector] && fields[fieldsSelector].length
-      ? fields[fieldsSelector].find((f) => f.name === model.field)
-      : {};
+  const field = fields?.[fieldsSelector]?.find((f) => f.name === model.field) ?? {};
   const aggWithOptions = getAggWithOptions(field, aggWithOptionsRestrictFields);
   const orderOptions = getOrderOptions();
 

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
@@ -120,7 +120,7 @@ const TopHitAggUi = (props) => {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
   const fieldsSelector = getIndexPatternKey(indexPattern);
-  const field = fields?.[fieldsSelector]?.find((f) => f.name === model.field) ?? {};
+  const field = fields?.[fieldsSelector]?.find((f) => f.name === model.field);
   const aggWithOptions = getAggWithOptions(field, aggWithOptionsRestrictFields);
   const orderOptions = getOrderOptions();
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/104695
It fixes a bug on TSVB that occurs only for visualizations that have been created without the index pattern mode (string mode) and the index doesn't exist. This happens only for the top_hit aggregation.

What happens here is that it detects no fields and as a result it crashes. We want to display the "No data" screen.

I added some extra checks to fix it.

### How to test it
Insert this [SO](https://gist.github.com/stratoula/2fc952c28d95c24ef328a8cf36a10b41) (from 7.14) and open it. It should not crash and should display "No results found".
