### PR TITLE
[Timelion app] Stabilize the flakiness in cloud

### DIFF
--- a/test/functional/apps/timelion/_expression_typeahead.js
+++ b/test/functional/apps/timelion/_expression_typeahead.js
@@ -54,8 +54,7 @@ export default function ({ getPageObjects }) {
         });
 
         it('should show index pattern suggestions for index argument', async () => {
-          await PageObjects.timelion.updateExpression('index');
-          await PageObjects.timelion.clickSuggestion();
+          await PageObjects.timelion.updateExpression('index=');
           const suggestions = await PageObjects.timelion.getSuggestionItemsText();
           expect(suggestions.length).to.eql(1);
           expect(suggestions[0].includes('logstash-*')).to.eql(true);
@@ -63,8 +62,7 @@ export default function ({ getPageObjects }) {
         });
 
         it('should show field suggestions for timefield argument when index pattern set', async () => {
-          await PageObjects.timelion.updateExpression(',timefield');
-          await PageObjects.timelion.clickSuggestion();
+          await PageObjects.timelion.updateExpression(',timefield=');
           const suggestions = await PageObjects.timelion.getSuggestionItemsText();
           expect(suggestions.length).to.eql(4);
           expect(suggestions[0].includes('@timestamp')).to.eql(true);
@@ -72,8 +70,7 @@ export default function ({ getPageObjects }) {
         });
 
         it('should show field suggestions for split argument when index pattern set', async () => {
-          await PageObjects.timelion.updateExpression(',split');
-          await PageObjects.timelion.clickSuggestion();
+          await PageObjects.timelion.updateExpression(',split=');
           const suggestions = await PageObjects.timelion.getSuggestionItemsText();
           expect(suggestions.length).not.to.eql(0);
           expect(suggestions[0].includes('@message.raw')).to.eql(true);
@@ -81,8 +78,7 @@ export default function ({ getPageObjects }) {
         });
 
         it('should show field suggestions for metric argument when index pattern set', async () => {
-          await PageObjects.timelion.updateExpression(',metric');
-          await PageObjects.timelion.clickSuggestion();
+          await PageObjects.timelion.updateExpression(',metric=');
           await PageObjects.timelion.updateExpression('avg:');
           await PageObjects.timelion.clickSuggestion(0);
           const suggestions = await PageObjects.timelion.getSuggestionItemsText();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/105872
There is some flakiness with the clickSuggestion function on cloud. I could increase the wait time but I think that we can simplify it a bit and hopefully the flakiness will disappear.

Test runner 100 times https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1771/


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios