### PR TITLE
[Security solution] [Cases] Fix add-cases comments error message is displaying after buttons

### DIFF
--- a/x-pack/plugins/cases/public/components/markdown_editor/eui_form.tsx
+++ b/x-pack/plugins/cases/public/components/markdown_editor/eui_form.tsx
@@ -36,17 +36,17 @@ export const MarkdownEditorForm: React.FC<MarkdownEditorFormProps> = ({
   const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
 
   return (
-    <EuiFormRow
-      data-test-subj={dataTestSubj}
-      describedByIds={idAria ? [idAria] : undefined}
-      error={errorMessage}
-      fullWidth
-      helpText={field.helpText}
-      isInvalid={isInvalid}
-      label={field.label}
-      labelAppend={field.labelAppend}
-    >
-      <>
+    <>
+      <EuiFormRow
+        data-test-subj={dataTestSubj}
+        describedByIds={idAria ? [idAria] : undefined}
+        fullWidth
+        error={errorMessage}
+        helpText={field.helpText}
+        isInvalid={isInvalid}
+        label={field.label}
+        labelAppend={field.labelAppend}
+      >
         <MarkdownEditor
           ariaLabel={idAria}
           editorId={id}
@@ -54,12 +54,12 @@ export const MarkdownEditorForm: React.FC<MarkdownEditorFormProps> = ({
           value={field.value as string}
           data-test-subj={`${dataTestSubj}-markdown-editor`}
         />
-        {bottomRightContent && (
-          <BottomContentWrapper justifyContent={'flexEnd'}>
-            <EuiFlexItem grow={false}>{bottomRightContent}</EuiFlexItem>
-          </BottomContentWrapper>
-        )}
-      </>
-    </EuiFormRow>
+      </EuiFormRow>
+      {bottomRightContent && (
+        <BottomContentWrapper justifyContent={'flexEnd'}>
+          <EuiFlexItem grow={false}>{bottomRightContent}</EuiFlexItem>
+        </BottomContentWrapper>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/104616

## Summary

Fix add-cases comments error message is displaying after buttons.

### Before
<img width="1078" alt="Screenshot 2021-07-27 at 11 58 27" src="https://user-images.githubusercontent.com/1490444/127135292-80de1a2d-508a-41ea-8871-7d24b382f284.png">

### After
<img width="1084" alt="Screenshot 2021-07-27 at 11 58 00" src="https://user-images.githubusercontent.com/1490444/127135303-edd13ca8-b31b-4e6a-b2ac-a128ac9ea5d2.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
