### PR TITLE
[7.x] [ILM] Server to use new in_use_by property returned by ES API (#106243)

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/__jest__/__snapshots__/policy_table.test.tsx.snap
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/__snapshots__/policy_table.test.tsx.snap
@@ -138,6 +138,7 @@ Array [
 
 exports[`policy table should sort when modified date header is clicked 1`] = `
 Array [
+  "testy0",
   "testy104",
   "testy103",
   "testy102",
@@ -147,13 +148,11 @@ Array [
   "testy98",
   "testy97",
   "testy96",
-  "testy95",
 ]
 `;
 
 exports[`policy table should sort when modified date header is clicked 2`] = `
 Array [
-  "testy0",
   "testy1",
   "testy2",
   "testy3",
@@ -163,6 +162,7 @@ Array [
   "testy7",
   "testy8",
   "testy9",
+  "testy10",
 ]
 `;
 

--- a/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/edit_policy/constants.ts
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/edit_policy/constants.ts
@@ -17,7 +17,7 @@ export const NEW_SNAPSHOT_POLICY_NAME = 'my_new_snapshot_policy';
 
 export const POLICY_WITH_MIGRATE_OFF: PolicyFromES = {
   version: 1,
-  modified_date: Date.now().toString(),
+  modifiedDate: Date.now().toString(),
   policy: {
     name: 'my_policy',
     phases: {
@@ -40,7 +40,7 @@ export const POLICY_WITH_MIGRATE_OFF: PolicyFromES = {
 
 export const POLICY_WITH_INCLUDE_EXCLUDE: PolicyFromES = {
   version: 1,
-  modified_date: Date.now().toString(),
+  modifiedDate: Date.now().toString(),
   policy: {
     name: 'my_policy',
     phases: {
@@ -73,7 +73,7 @@ export const POLICY_WITH_INCLUDE_EXCLUDE: PolicyFromES = {
 
 export const DELETE_PHASE_POLICY: PolicyFromES = {
   version: 1,
-  modified_date: Date.now().toString(),
+  modifiedDate: Date.now().toString(),
   policy: {
     phases: {
       hot: {
@@ -107,7 +107,7 @@ export const DELETE_PHASE_POLICY: PolicyFromES = {
 
 export const getDefaultHotPhasePolicy = (policyName: string): PolicyFromES => ({
   version: 1,
-  modified_date: Date.now().toString(),
+  modifiedDate: Date.now().toString(),
   policy: {
     name: policyName,
     phases: {
@@ -127,7 +127,7 @@ export const getDefaultHotPhasePolicy = (policyName: string): PolicyFromES => ({
 
 export const POLICY_WITH_NODE_ATTR_AND_OFF_ALLOCATION: PolicyFromES = {
   version: 1,
-  modified_date: Date.now().toString(),
+  modifiedDate: Date.now().toString(),
   policy: {
     phases: {
       hot: {
@@ -160,7 +160,7 @@ export const POLICY_WITH_NODE_ATTR_AND_OFF_ALLOCATION: PolicyFromES = {
 
 export const POLICY_WITH_NODE_ROLE_ALLOCATION: PolicyFromES = {
   version: 1,
-  modified_date: Date.now().toString(),
+  modifiedDate: Date.now().toString(),
   policy: {
     phases: {
       hot: {
@@ -238,8 +238,8 @@ export const getGeneratedPolicies = (): PolicyFromES[] => {
   for (let i = 0; i < 105; i++) {
     policies.push({
       version: i,
-      modified_date: moment().subtract(i, 'days').toISOString(),
-      linkedIndices: i % 2 === 0 ? [`index${i}`] : undefined,
+      modifiedDate: moment().subtract(i, 'days').toISOString(),
+      indices: i % 2 === 0 ? [`index${i}`] : [],
       name: `testy${i}`,
       policy: {
         ...policy,

--- a/x-pack/plugins/index_lifecycle_management/__jest__/policy_table.test.tsx
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/policy_table.test.tsx
@@ -32,12 +32,16 @@ initHttp(
 );
 initUiMetric(usageCollectionPluginMock.createSetupContract());
 
+// use a date far in the past to check the sorting
+const testDate = '2020-07-21T14:16:58.666Z';
+const testDateFormatted = moment(testDate).format('YYYY-MM-DD HH:mm:ss');
+
 const policies: PolicyFromES[] = [];
 for (let i = 0; i < 105; i++) {
   policies.push({
     version: i,
-    modified_date: moment().subtract(i, 'days').toISOString(),
-    linkedIndices: i % 2 === 0 ? [`index${i}`] : undefined,
+    modifiedDate: i === 0 ? testDate : moment().subtract(i, 'days').toISOString(),
+    indices: i % 2 === 0 ? [`index${i}`] : [],
     name: `testy${i}`,
     policy: {
       name: `testy${i}`,
@@ -138,10 +142,10 @@ describe('policy table', () => {
     testSort('version');
   });
   test('should sort when modified date header is clicked', () => {
-    testSort('modified_date');
+    testSort('modifiedDate');
   });
   test('should sort when linked indices header is clicked', () => {
-    testSort('linkedIndices');
+    testSort('indices');
   });
   test('should have proper actions in context menu when there are linked indices', () => {
     const rendered = openContextMenu(0);
@@ -173,5 +177,12 @@ describe('policy table', () => {
     deleteButton.simulate('click');
     rendered.update();
     expect(rendered.find('.euiModal--confirmation').exists()).toBeTruthy();
+  });
+  test('displays policy properties', () => {
+    const rendered = mountWithIntl(component);
+    const firstRow = findTestSubject(rendered, 'policyTableRow').at(0).text();
+    const version = 0;
+    const numberOfIndices = 1;
+    expect(firstRow).toBe(`testy0${numberOfIndices}${version}${testDateFormatted}Actions`);
   });
 });

--- a/x-pack/plugins/index_lifecycle_management/common/types/policies.ts
+++ b/x-pack/plugins/index_lifecycle_management/common/types/policies.ts
@@ -29,11 +29,13 @@ export interface Phases {
 }
 
 export interface PolicyFromES {
-  modified_date: string;
+  modifiedDate: string;
   name: string;
   policy: SerializedPolicy;
   version: number;
-  linkedIndices?: string[];
+  indices?: string[];
+  dataStreams?: string[];
+  indexTemplates?: string[];
 }
 
 export interface SerializedPhase {

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy.container.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy.container.tsx
@@ -44,7 +44,7 @@ export const EditPolicy: React.FunctionComponent<Props & RouteComponentProps<Rou
   const {
     services: { breadcrumbService, license },
   } = useKibana();
-  const { error, isLoading, data: policies, resendRequest } = useLoadPoliciesList(false);
+  const { error, isLoading, data: policies, resendRequest } = useLoadPoliciesList();
 
   useEffect(() => {
     breadcrumbService.setBreadcrumbs('editPolicy');

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_table/components/table_content.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_table/components/table_content.tsx
@@ -41,14 +41,11 @@ import { sortTable } from '../../../services';
 import { trackUiMetric } from '../../../services/ui_metric';
 
 import { UIM_EDIT_CLICK } from '../../../constants';
+import { TableColumn } from '../index';
 import { AddPolicyToTemplateConfirmModal } from './add_policy_to_template_confirm_modal';
 import { ConfirmDelete } from './confirm_delete';
 
-type PolicyProperty = Extract<
-  keyof PolicyFromES,
-  'version' | 'name' | 'linkedIndices' | 'modified_date'
->;
-const COLUMNS: Array<[PolicyProperty, { label: string; width: number }]> = [
+const COLUMNS: Array<[TableColumn, { label: string; width: number }]> = [
   [
     'name',
     {
@@ -59,7 +56,7 @@ const COLUMNS: Array<[PolicyProperty, { label: string; width: number }]> = [
     },
   ],
   [
-    'linkedIndices',
+    'indices',
     {
       label: i18n.translate('xpack.indexLifecycleMgmt.policyTable.headers.linkedIndicesHeader', {
         defaultMessage: 'Linked indices',
@@ -77,7 +74,7 @@ const COLUMNS: Array<[PolicyProperty, { label: string; width: number }]> = [
     },
   ],
   [
-    'modified_date',
+    'modifiedDate',
     {
       label: i18n.translate('xpack.indexLifecycleMgmt.policyTable.headers.modifiedDateHeader', {
         defaultMessage: 'Modified date',
@@ -104,7 +101,7 @@ export const TableContent: React.FunctionComponent<Props> = ({
   history,
 }) => {
   const [popoverPolicy, setPopoverPolicy] = useState<string>();
-  const [sort, setSort] = useState<{ sortField: PolicyProperty; isSortAscending: boolean }>({
+  const [sort, setSort] = useState<{ sortField: TableColumn; isSortAscending: boolean }>({
     sortField: 'name',
     isSortAscending: true,
   });
@@ -131,7 +128,7 @@ export const TableContent: React.FunctionComponent<Props> = ({
     }
   };
 
-  const onSort = (column: PolicyProperty) => {
+  const onSort = (column: TableColumn) => {
     const newIsSortAscending = sort.sortField === column ? !sort.isSortAscending : true;
     setSort({ sortField: column, isSortAscending: newIsSortAscending });
   };
@@ -162,7 +159,7 @@ export const TableContent: React.FunctionComponent<Props> = ({
   );
 
   const buildActionPanelTree = (policy: PolicyFromES): EuiContextMenuPanelDescriptor[] => {
-    const hasLinkedIndices = Boolean(policy.linkedIndices && policy.linkedIndices.length);
+    const hasLinkedIndices = Boolean(policy.indices && policy.indices.length);
 
     const viewIndicesLabel = i18n.translate(
       'xpack.indexLifecycleMgmt.policyTable.viewIndicesButtonText',
@@ -239,13 +236,13 @@ export const TableContent: React.FunctionComponent<Props> = ({
           {value}
         </EuiLink>
       );
-    } else if (fieldName === 'linkedIndices') {
+    } else if (fieldName === 'indices') {
       return (
         <EuiText>
           <b>{value ? (value as string[]).length : '0'}</b>
         </EuiText>
       );
-    } else if (fieldName === 'modified_date' && value) {
+    } else if (fieldName === 'modifiedDate' && value) {
       return moment(value).format('YYYY-MM-DD HH:mm:ss');
     }
     return value;

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_table/index.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_table/index.ts
@@ -5,4 +5,11 @@
  * 2.0.
  */
 
+import { PolicyFromES } from '../../../../common/types';
+
 export { PolicyTable } from './policy_table.container';
+
+export type TableColumn = Extract<
+  keyof PolicyFromES,
+  'version' | 'name' | 'indices' | 'modifiedDate'
+>;

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_table/policy_table.container.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_table/policy_table.container.tsx
@@ -25,7 +25,7 @@ export const PolicyTable: React.FunctionComponent<Props & RouteComponentProps> =
   const {
     services: { breadcrumbService },
   } = useKibana();
-  const { data: policies, isLoading, error, resendRequest } = useLoadPoliciesList(true);
+  const { data: policies, isLoading, error, resendRequest } = useLoadPoliciesList();
 
   useEffect(() => {
     breadcrumbService.setBreadcrumbs('policies');

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/api.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/api.ts
@@ -7,13 +7,14 @@
 
 import { METRIC_TYPE } from '@kbn/analytics';
 
+import { IndexSettings } from '../../../../index_management/common';
+
 import {
   PolicyFromES,
   SerializedPolicy,
   ListNodesRouteResponse,
   ListSnapshotReposResponse,
 } from '../../../common/types';
-
 import {
   UIM_POLICY_DELETE,
   UIM_POLICY_ATTACH_INDEX,
@@ -23,7 +24,6 @@ import {
 } from '../constants';
 import { trackUiMetric } from './ui_metric';
 import { sendGet, sendPost, sendDelete, useRequest } from './http';
-import { IndexSettings } from '../../../../index_management/common/types';
 
 export const useLoadNodes = () => {
   return useRequest<ListNodesRouteResponse>({
@@ -49,15 +49,14 @@ export const useLoadIndexTemplates = (legacy: boolean = false) => {
   });
 };
 
-export async function loadPolicies(withIndices: boolean) {
-  return await sendGet('policies', { withIndices });
+export async function loadPolicies() {
+  return await sendGet('policies');
 }
 
-export const useLoadPoliciesList = (withIndices: boolean) => {
+export const useLoadPoliciesList = () => {
   return useRequest<PolicyFromES[]>({
     path: `policies`,
     method: 'get',
-    query: { withIndices },
   });
 };
 

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/sort_table.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/sort_table.ts
@@ -7,14 +7,15 @@
 
 import { sortBy } from 'lodash';
 import { PolicyFromES } from '../../../common/types';
+import { TableColumn } from '../sections/policy_table';
 
 export const sortTable = (
   array: PolicyFromES[] = [],
-  sortField: Extract<keyof PolicyFromES, 'version' | 'name' | 'linkedIndices' | 'modified_date'>,
+  sortField: TableColumn,
   isSortAscending: boolean
 ): PolicyFromES[] => {
   let sorter;
-  if (sortField === 'linkedIndices') {
+  if (sortField === 'indices') {
     sorter = (item: PolicyFromES) => (item[sortField] || []).length;
   } else {
     sorter = (item: PolicyFromES) => item[sortField];

--- a/x-pack/plugins/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.tsx
@@ -216,7 +216,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
   }
   async componentDidMount() {
     try {
-      const policies = await loadPolicies(false);
+      const policies = await loadPolicies();
       this.setState({ policies });
     } catch (err) {
       showApiError(

--- a/x-pack/plugins/index_lifecycle_management/server/routes/api/policies/register_fetch_route.ts
+++ b/x-pack/plugins/index_lifecycle_management/server/routes/api/policies/register_fetch_route.ts
@@ -5,23 +5,42 @@
  * 2.0.
  */
 
-import { schema } from '@kbn/config-schema';
 import { ElasticsearchClient } from 'kibana/server';
 import { ApiResponse } from '@elastic/elasticsearch';
 
-import { IndexLifecyclePolicy, PolicyFromES } from '../../../../common/types';
+import { PolicyFromES, SerializedPolicy } from '../../../../common/types';
 import { RouteDependencies } from '../../../types';
 import { addBasePath } from '../../../services';
 
 interface PoliciesMap {
-  [K: string]: Omit<PolicyFromES, 'name'>;
+  [K: string]: {
+    modified_date: string;
+    policy: SerializedPolicy;
+    version: number;
+    in_use_by: {
+      indices: string[];
+      data_streams: string[];
+      composable_templates: string[];
+    };
+  };
 }
 function formatPolicies(policiesMap: PoliciesMap): PolicyFromES[] {
   return Object.keys(policiesMap).reduce((accum: PolicyFromES[], lifecycleName: string) => {
     const policyEntry = policiesMap[lifecycleName];
+    const {
+      in_use_by: { indices, data_streams: dataStreams, composable_templates: indexTemplates },
+      modified_date: modifiedDate,
+      policy,
+      version,
+    } = policyEntry;
     accum.push({
-      ...policyEntry,
       name: lifecycleName,
+      modifiedDate,
+      version,
+      policy,
+      indices,
+      dataStreams,
+      indexTemplates,
     });
     return accum;
   }, []);
@@ -33,38 +52,14 @@ async function fetchPolicies(client: ElasticsearchClient): Promise<ApiResponse<P
     ignore: [404],
   };
 
-  // @ts-expect-error Policy doesn't contain name property
+  // @ts-expect-error Policy doesn't contain all known properties (name, in_use_by)
   return client.ilm.getLifecycle({}, options);
 }
 
-async function addLinkedIndices(client: ElasticsearchClient, policiesMap: PoliciesMap) {
-  const options = {
-    // we allow 404 since they may have no policies
-    ignore: [404],
-  };
-
-  const response = await client.ilm.explainLifecycle<{
-    indices: { [indexName: string]: IndexLifecyclePolicy };
-  }>({ index: '*,.*' }, options); // '*,.*' will include hidden indices
-  const policyExplanation = response.body;
-  Object.entries(policyExplanation.indices).forEach(([indexName, { policy }]) => {
-    if (policy && policiesMap[policy]) {
-      policiesMap[policy].linkedIndices = policiesMap[policy].linkedIndices || [];
-      policiesMap[policy].linkedIndices!.push(indexName);
-    }
-  });
-}
-
-const querySchema = schema.object({
-  withIndices: schema.boolean({ defaultValue: false }),
-});
-
 export function registerFetchRoute({ router, license, lib: { handleEsError } }: RouteDependencies) {
   router.get(
-    { path: addBasePath('/policies'), validate: { query: querySchema } },
+    { path: addBasePath('/policies'), validate: false },
     license.guardApiRoute(async (context, request, response) => {
-      const query = request.query as typeof querySchema.type;
-      const { withIndices } = query;
       const { asCurrentUser } = context.core.elasticsearch.client;
 
       try {
@@ -72,11 +67,8 @@ export function registerFetchRoute({ router, license, lib: { handleEsError } }: 
         if (policiesResponse.statusCode === 404) {
           return response.ok({ body: [] });
         }
-        const { body: policiesMap } = policiesResponse;
-        if (withIndices) {
-          await addLinkedIndices(asCurrentUser, policiesMap);
-        }
-        return response.ok({ body: formatPolicies(policiesMap) });
+
+        return response.ok({ body: formatPolicies(policiesResponse.body) });
       } catch (error) {
         return handleEsError({ error, response });
       }

--- a/x-pack/test/api_integration/apis/management/index_lifecycle_management/policies.js
+++ b/x-pack/test/api_integration/apis/management/index_lifecycle_management/policies.js
@@ -69,7 +69,7 @@ export default function ({ getService }) {
 
         const { body } = await loadPolicies(true);
         const fetchedPolicy = body.find((p) => p.name === policyName);
-        expect(fetchedPolicy.linkedIndices).to.eql([indexName]);
+        expect(fetchedPolicy.indices).to.eql([indexName]);
       });
 
       it('should add hidden indices linked to policies', async () => {
@@ -97,7 +97,7 @@ export default function ({ getService }) {
         const { body } = await loadPolicies(true);
         const fetchedPolicy = body.find((p) => p.name === policyName);
         // The index name is dynamically generated as .ds-<indexName>-XXX so we don't check for exact match
-        expect(fetchedPolicy.linkedIndices[0]).to.contain(indexName);
+        expect(fetchedPolicy.indices[0]).to.contain(indexName);
       });
     });
 

--- a/x-pack/test/functional/page_objects/index_lifecycle_management_page.ts
+++ b/x-pack/test/functional/page_objects/index_lifecycle_management_page.ts
@@ -88,11 +88,11 @@ export function IndexLifecycleManagementPageProvider({ getService }: FtrProvider
       return mapAsync(policies, async (policy) => {
         const policyNameElement = await policy.findByTestSubject('policyTableCell-name');
         const policyLinkedIndicesElement = await policy.findByTestSubject(
-          'policyTableCell-linkedIndices'
+          'policyTableCell-indices'
         );
         const policyVersionElement = await policy.findByTestSubject('policyTableCell-version');
         const policyModifiedDateElement = await policy.findByTestSubject(
-          'policyTableCell-modified_date'
+          'policyTableCell-modifiedDate'
         );
         const policyActionsButtonElement = await policy.findByTestSubject(
           'policyActionsContextMenuButton'
@@ -100,7 +100,7 @@ export function IndexLifecycleManagementPageProvider({ getService }: FtrProvider
 
         return {
           name: await policyNameElement.getVisibleText(),
-          linkedIndices: await policyLinkedIndicesElement.getVisibleText(),
+          indices: await policyLinkedIndicesElement.getVisibleText(),
           version: await policyVersionElement.getVisibleText(),
           modifiedDate: await policyModifiedDateElement.getVisibleText(),
           actionsButton: policyActionsButtonElement,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ILM] Server to use new in_use_by property returned by ES API (#106243)