### PR TITLE
[Fleet] Fix breadcrumbs on agent policy sub-tabs

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/index.tsx
@@ -8,11 +8,14 @@
 import React, { memo } from 'react';
 
 import type { AgentPolicy, PackagePolicy } from '../../../../../types';
+import { useBreadcrumbs } from '../../../../../hooks';
 
 import { NoPackagePolicies } from './no_package_policies';
 import { PackagePoliciesTable } from './package_policies_table';
 
 export const PackagePoliciesView = memo<{ agentPolicy: AgentPolicy }>(({ agentPolicy }) => {
+  useBreadcrumbs('policy_details', { policyName: agentPolicy.name });
+
   if (agentPolicy.package_policies.length === 0) {
     return <NoPackagePolicies policyId={agentPolicy.id} />;
   }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
@@ -28,6 +28,7 @@ import {
   useConfig,
   sendGetAgentStatus,
   useAgentPolicyRefresh,
+  useBreadcrumbs,
 } from '../../../../../hooks';
 import {
   AgentPolicyForm,
@@ -43,6 +44,7 @@ const FormWrapper = styled.div`
 
 export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
   ({ agentPolicy: originalAgentPolicy }) => {
+    useBreadcrumbs('policy_details', { policyName: originalAgentPolicy.name });
     const { notifications } = useStartServices();
     const {
       agents: { enabled: isFleetEnabled },


### PR DESCRIPTION
## Summary

Fixes missing policy name in `Settings` and `Integrations` tabs for the Agent Policy details screen.

![Kapture 2021-07-27 at 08 55 08](https://user-images.githubusercontent.com/6766512/127157154-602dbcf3-f6eb-4c04-aa73-7d7f96b3551b.gif)

Closes #106680
