### PR TITLE
[Upgrade Assistant] Refactor ML deprecation response

### DIFF
--- a/x-pack/plugins/upgrade_assistant/common/types.ts
+++ b/x-pack/plugins/upgrade_assistant/common/types.ts
@@ -178,6 +178,9 @@ export interface DeprecationInfo {
   message: string;
   url: string;
   details?: string;
+  _meta?: {
+    [key: string]: string;
+  };
 }
 
 export interface IndexSettingsDeprecationInfo {

--- a/x-pack/plugins/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
+++ b/x-pack/plugins/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
@@ -24,7 +24,11 @@
       "level": "critical",
       "message": "model snapshot [1] for job [deprecation_check_job] needs to be deleted or upgraded",
       "url": "",
-      "details": "details"
+      "details": "details",
+      "_meta": {
+        "snapshot_id": "1",
+        "job_id": "deprecation_check_job"
+      }
     }
   ],
   "node_settings": [

--- a/x-pack/plugins/upgrade_assistant/server/lib/es_migration_apis.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/es_migration_apis.ts
@@ -18,7 +18,27 @@ import { esIndicesStateCheck } from './es_indices_state_check';
 export async function getUpgradeAssistantStatus(
   dataClient: IScopedClusterClient
 ): Promise<UpgradeAssistantStatus> {
-  const { body: deprecations } = await dataClient.asCurrentUser.migration.deprecations();
+  // const { body: deprecations } = await dataClient.asCurrentUser.migration.deprecations();
+
+  const deprecations = {
+    cluster_settings: [],
+    node_settings: [],
+    index_settings: {},
+    ml_settings: [
+      {
+        level: 'critical',
+        message: 'model snapshot [1627343998] for job [my_job] needs to be deleted or upgraded',
+        url:
+          'https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html',
+        details:
+          "model snapshot [1627343998] for job [my_job] supports minimum version [6.3.0] and needs to be at least [7.0.0]. The model snapshot's latest record timestamp is [2021-07-23T03:48:47.000Z]",
+        _meta: {
+          snapshot_id: '1627392073', // ID of an older snapshot associated with the job ID defined (cannot be snapshot currently in use)
+          job_id: 'my_job', // ID of your ML job
+        },
+      },
+    ],
+  };
 
   const cluster = getClusterDeprecations(deprecations);
   const indices = await getCombinedIndexInfos(deprecations, dataClient);

--- a/x-pack/plugins/upgrade_assistant/server/lib/es_migration_apis.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/es_migration_apis.ts
@@ -18,27 +18,7 @@ import { esIndicesStateCheck } from './es_indices_state_check';
 export async function getUpgradeAssistantStatus(
   dataClient: IScopedClusterClient
 ): Promise<UpgradeAssistantStatus> {
-  // const { body: deprecations } = await dataClient.asCurrentUser.migration.deprecations();
-
-  const deprecations = {
-    cluster_settings: [],
-    node_settings: [],
-    index_settings: {},
-    ml_settings: [
-      {
-        level: 'critical',
-        message: 'model snapshot [1627343998] for job [my_job] needs to be deleted or upgraded',
-        url:
-          'https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-upgrade-job-model-snapshot.html',
-        details:
-          "model snapshot [1627343998] for job [my_job] supports minimum version [6.3.0] and needs to be at least [7.0.0]. The model snapshot's latest record timestamp is [2021-07-23T03:48:47.000Z]",
-        _meta: {
-          snapshot_id: '1627392073', // ID of an older snapshot associated with the job ID defined (cannot be snapshot currently in use)
-          job_id: 'my_job', // ID of your ML job
-        },
-      },
-    ],
-  };
+  const { body: deprecations } = await dataClient.asCurrentUser.migration.deprecations();
 
   const cluster = getClusterDeprecations(deprecations);
   const indices = await getCombinedIndexInfos(deprecations, dataClient);


### PR DESCRIPTION
This PR incorporates ES changes made in https://github.com/elastic/elasticsearch/issues/73089.

Previously, in order to implement deleting or upgrading ML snapshots, we had to extract the `snapshot_id` and `job_id` from the deprecation message. The ES deprecation info API now supports a `_meta` field where this information is stored.

### How to test
This is not easy to fully test on `master`. However, you can follow the steps in https://github.com/elastic/kibana/pull/100066 and mock the response from the deprecation info API (example commit: https://github.com/elastic/kibana/pull/106847/commits/074c556647413f73335612483cf4ff45a7dd61ca).

I have tested this on the 7.x branch with real deprecations to confirm everything is still working as expected.

![ml_upgrade](https://user-images.githubusercontent.com/5226211/127162115-b5cd220d-0b66-4d3b-b4b9-7e1d07f5d0c6.gif)


