### PR TITLE
[Lens] moving store loading to middleware

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -70,6 +70,7 @@ const sessionIdSubject = new Subject<string>();
 describe('Lens App', () => {
   let defaultDoc: Document;
   let defaultSavedObjectId: string;
+
   const mockDatasource: DatasourceMock = createMockDatasource('testDatasource');
   const mockDatasource2: DatasourceMock = createMockDatasource('testDatasource2');
   const datasourceMap = {

--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { FC, useCallback } from 'react';
-
+import { DeepPartial } from '@reduxjs/toolkit';
 import { AppMountParameters, CoreSetup, CoreStart } from 'kibana/public';
 import { FormattedMessage, I18nProvider } from '@kbn/i18n/react';
 import { HashRouter, Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -32,7 +32,14 @@ import { ACTION_VISUALIZE_LENS_FIELD } from '../../../../../src/plugins/ui_actio
 import { LensAttributeService } from '../lens_attribute_service';
 import { LensAppServices, RedirectToOriginProps, HistoryLocationState } from './types';
 import { KibanaContextProvider } from '../../../../../src/plugins/kibana_react/public';
-import { makeConfigureStore, navigateAway, LensRootStore, loadInitial } from '../state_management';
+import {
+  makeConfigureStore,
+  navigateAway,
+  LensRootStore,
+  loadInitial,
+  LensState,
+} from '../state_management';
+import { getPreloadedState } from '../state_management/lens_slice';
 
 export async function getLensServices(
   coreStart: CoreStart,
@@ -160,13 +167,16 @@ export async function mountApp(
   }
 
   const { datasourceMap, visualizationMap } = instance;
-  const lensStore: LensRootStore = makeConfigureStore({
+  const storeDeps = {
     lensServices,
     datasourceMap,
     visualizationMap,
     embeddableEditorIncomingState,
     initialContext,
-  });
+  };
+  const lensStore: LensRootStore = makeConfigureStore(storeDeps, {
+    lens: getPreloadedState(storeDeps),
+  } as DeepPartial<LensState>);
 
   const EditorRenderer = React.memo(
     (props: { id?: string; history: History<unknown>; editByValue?: boolean }) => {

--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -13,17 +13,13 @@ import { HashRouter, Route, RouteComponentProps, Switch } from 'react-router-dom
 import { History } from 'history';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { i18n } from '@kbn/i18n';
-
-import { DashboardFeatureFlagConfig } from 'src/plugins/dashboard/public';
 import { Provider } from 'react-redux';
-import { isEqual } from 'lodash';
-import { EmbeddableEditorState } from 'src/plugins/embeddable/public';
 import { Storage } from '../../../../../src/plugins/kibana_utils/public';
 
 import { LensReportManager, setReportManager, trackUiEvent } from '../lens_ui_telemetry';
 
 import { App } from './app';
-import { Datasource, EditorFrameStart, Visualization } from '../types';
+import { EditorFrameStart } from '../types';
 import { addHelpMenuToAppChrome } from '../help_menu_util';
 import { LensPluginStartDependencies } from '../plugin';
 import { LENS_EMBEDDABLE_TYPE, LENS_EDIT_BY_VALUE, APP_ID } from '../../common';
@@ -32,32 +28,11 @@ import {
   LensByReferenceInput,
   LensByValueInput,
 } from '../embeddable/embeddable';
-import {
-  ACTION_VISUALIZE_LENS_FIELD,
-  VisualizeFieldContext,
-} from '../../../../../src/plugins/ui_actions/public';
+import { ACTION_VISUALIZE_LENS_FIELD } from '../../../../../src/plugins/ui_actions/public';
 import { LensAttributeService } from '../lens_attribute_service';
 import { LensAppServices, RedirectToOriginProps, HistoryLocationState } from './types';
 import { KibanaContextProvider } from '../../../../../src/plugins/kibana_react/public';
-
-import {
-  makeConfigureStore,
-  navigateAway,
-  getPreloadedState,
-  LensRootStore,
-  setState,
-  LensAppState,
-  updateLayer,
-  updateVisualizationState,
-} from '../state_management';
-import { getPersistedDoc } from './save_modal_container';
-import { getResolvedDateRange, getInitialDatasourceId } from '../utils';
-import { initializeDatasources } from '../editor_frame_service/editor_frame';
-import { generateId } from '../id_generator';
-import {
-  getVisualizeFieldSuggestions,
-  switchToSuggestion,
-} from '../editor_frame_service/editor_frame/suggestion_helpers';
+import { makeConfigureStore, navigateAway, LensRootStore, loadInitial } from '../state_management';
 
 export async function getLensServices(
   coreStart: CoreStart,
@@ -114,7 +89,7 @@ export async function mountApp(
 
   const lensServices = await getLensServices(coreStart, startDependencies, attributeService);
 
-  const { stateTransfer, data, storage, dashboardFeatureFlag } = lensServices;
+  const { stateTransfer, data, storage } = lensServices;
 
   const embeddableEditorIncomingState = stateTransfer?.getIncomingEditorState(APP_ID);
 
@@ -183,37 +158,16 @@ export async function mountApp(
   if (embeddableEditorIncomingState?.searchSessionId) {
     data.search.session.continue(embeddableEditorIncomingState.searchSessionId);
   }
+
   const { datasourceMap, visualizationMap } = instance;
-
-  const initialDatasourceId = getInitialDatasourceId(datasourceMap);
-  const datasourceStates: LensAppState['datasourceStates'] = {};
-  if (initialDatasourceId) {
-    datasourceStates[initialDatasourceId] = {
-      state: null,
-      isLoading: true,
-    };
-  }
-
-  const preloadedState = getPreloadedState({
-    isLoading: true,
-    query: data.query.queryString.getQuery(),
-    // Do not use app-specific filters from previous app,
-    // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
-    filters: !initialContext
-      ? data.query.filterManager.getGlobalFilters()
-      : data.query.filterManager.getFilters(),
-    searchSessionId: data.search.session.getSessionId(),
-    resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
-    isLinkedToOriginatingApp: Boolean(embeddableEditorIncomingState?.originatingApp),
-    activeDatasourceId: initialDatasourceId,
-    datasourceStates,
-    visualization: {
-      state: null,
-      activeId: Object.keys(visualizationMap)[0] || null,
-    },
+  const lensStore: LensRootStore = makeConfigureStore({
+    lensServices,
+    initialContext,
+    embeddableEditorIncomingState,
+    datasourceMap,
+    visualizationMap,
   });
 
-  const lensStore: LensRootStore = makeConfigureStore(preloadedState, { data });
   const EditorRenderer = React.memo(
     (props: { id?: string; history: History<unknown>; editByValue?: boolean }) => {
       const redirectCallback = useCallback(
@@ -224,17 +178,7 @@ export async function mountApp(
       );
       trackUiEvent('loaded');
       const initialInput = getInitialInput(props.id, props.editByValue);
-      loadInitialStore(
-        redirectCallback,
-        initialInput,
-        lensServices,
-        lensStore,
-        embeddableEditorIncomingState,
-        dashboardFeatureFlag,
-        datasourceMap,
-        visualizationMap,
-        initialContext
-      );
+      lensStore.dispatch(loadInitial({ redirectCallback, initialInput }));
 
       return (
         <Provider store={lensStore}>
@@ -308,182 +252,4 @@ export async function mountApp(
     unlistenParentHistory();
     lensStore.dispatch(navigateAway());
   };
-}
-
-export function loadInitialStore(
-  redirectCallback: (savedObjectId?: string) => void,
-  initialInput: LensEmbeddableInput | undefined,
-  lensServices: LensAppServices,
-  lensStore: LensRootStore,
-  embeddableEditorIncomingState: EmbeddableEditorState | undefined,
-  dashboardFeatureFlag: DashboardFeatureFlagConfig,
-  datasourceMap: Record<string, Datasource>,
-  visualizationMap: Record<string, Visualization>,
-  initialContext?: VisualizeFieldContext
-) {
-  const { attributeService, chrome, notifications, data } = lensServices;
-  const { persistedDoc } = lensStore.getState().lens;
-  if (
-    !initialInput ||
-    (attributeService.inputIsRefType(initialInput) &&
-      initialInput.savedObjectId === persistedDoc?.savedObjectId)
-  ) {
-    return initializeDatasources(
-      datasourceMap,
-      lensStore.getState().lens.datasourceStates,
-      undefined,
-      initialContext,
-      {
-        isFullEditor: true,
-      }
-    )
-      .then((result) => {
-        const datasourceStates = Object.entries(result).reduce(
-          (state, [datasourceId, datasourceState]) => ({
-            ...state,
-            [datasourceId]: {
-              ...datasourceState,
-              isLoading: false,
-            },
-          }),
-          {}
-        );
-        lensStore.dispatch(
-          setState({
-            datasourceStates,
-            isLoading: false,
-          })
-        );
-        if (initialContext) {
-          const selectedSuggestion = getVisualizeFieldSuggestions({
-            datasourceMap,
-            datasourceStates,
-            visualizationMap,
-            activeVisualizationId: Object.keys(visualizationMap)[0] || null,
-            visualizationState: null,
-            visualizeTriggerFieldContext: initialContext,
-          });
-          if (selectedSuggestion) {
-            switchToSuggestion(lensStore.dispatch, selectedSuggestion, 'SWITCH_VISUALIZATION');
-          }
-        }
-        const activeDatasourceId = getInitialDatasourceId(datasourceMap);
-        const visualization = lensStore.getState().lens.visualization;
-        const activeVisualization =
-          visualization.activeId && visualizationMap[visualization.activeId];
-
-        if (visualization.state === null && activeVisualization) {
-          const newLayerId = generateId();
-
-          const initialVisualizationState = activeVisualization.initialize(() => newLayerId);
-          lensStore.dispatch(
-            updateLayer({
-              datasourceId: activeDatasourceId!,
-              layerId: newLayerId,
-              updater: datasourceMap[activeDatasourceId!].insertLayer,
-            })
-          );
-          lensStore.dispatch(
-            updateVisualizationState({
-              visualizationId: activeVisualization.id,
-              updater: initialVisualizationState,
-            })
-          );
-        }
-      })
-      .catch((e: { message: string }) => {
-        notifications.toasts.addDanger({
-          title: e.message,
-        });
-        redirectCallback();
-      });
-  }
-
-  getPersistedDoc({
-    initialInput,
-    attributeService,
-    data,
-    chrome,
-    notifications,
-  })
-    .then(
-      (doc) => {
-        if (doc) {
-          const currentSessionId = data.search.session.getSessionId();
-          const docDatasourceStates = Object.entries(doc.state.datasourceStates).reduce(
-            (stateMap, [datasourceId, datasourceState]) => ({
-              ...stateMap,
-              [datasourceId]: {
-                isLoading: true,
-                state: datasourceState,
-              },
-            }),
-            {}
-          );
-
-          initializeDatasources(
-            datasourceMap,
-            docDatasourceStates,
-            doc.references,
-            initialContext,
-            {
-              isFullEditor: true,
-            }
-          )
-            .then((result) => {
-              const activeDatasourceId = getInitialDatasourceId(datasourceMap, doc);
-
-              lensStore.dispatch(
-                setState({
-                  query: doc.state.query,
-                  searchSessionId:
-                    dashboardFeatureFlag.allowByValueEmbeddables &&
-                    Boolean(embeddableEditorIncomingState?.originatingApp) &&
-                    !(initialInput as LensByReferenceInput)?.savedObjectId &&
-                    currentSessionId
-                      ? currentSessionId
-                      : data.search.session.start(),
-                  ...(!isEqual(persistedDoc, doc) ? { persistedDoc: doc } : null),
-                  activeDatasourceId,
-                  visualization: {
-                    activeId: doc.visualizationType,
-                    state: doc.state.visualization,
-                  },
-                  datasourceStates: Object.entries(result).reduce(
-                    (state, [datasourceId, datasourceState]) => ({
-                      ...state,
-                      [datasourceId]: {
-                        ...datasourceState,
-                        isLoading: false,
-                      },
-                    }),
-                    {}
-                  ),
-                  isLoading: false,
-                })
-              );
-            })
-            .catch((e: { message: string }) =>
-              notifications.toasts.addDanger({
-                title: e.message,
-              })
-            );
-        } else {
-          redirectCallback();
-        }
-      },
-      () => {
-        lensStore.dispatch(
-          setState({
-            isLoading: false,
-          })
-        );
-        redirectCallback();
-      }
-    )
-    .catch((e: { message: string }) =>
-      notifications.toasts.addDanger({
-        title: e.message,
-      })
-    );
 }

--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -162,10 +162,10 @@ export async function mountApp(
   const { datasourceMap, visualizationMap } = instance;
   const lensStore: LensRootStore = makeConfigureStore({
     lensServices,
-    initialContext,
-    embeddableEditorIncomingState,
     datasourceMap,
     visualizationMap,
+    embeddableEditorIncomingState,
+    initialContext,
   });
 
   const EditorRenderer = React.memo(

--- a/x-pack/plugins/lens/public/app_plugin/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/types.ts
@@ -34,7 +34,7 @@ import {
   EmbeddableEditorState,
   EmbeddableStateTransfer,
 } from '../../../../../src/plugins/embeddable/public';
-import { Datasource, EditorFrameInstance, Visualization } from '../types';
+import { DatasourceMap, EditorFrameInstance, VisualizationMap } from '../types';
 import { PresentationUtilPluginStart } from '../../../../../src/plugins/presentation_util/public';
 export interface RedirectToOriginProps {
   input?: LensEmbeddableInput;
@@ -54,8 +54,8 @@ export interface LensAppProps {
 
   // State passed in by the container which is used to determine the id of the Originating App.
   incomingState?: EmbeddableEditorState;
-  datasourceMap: Record<string, Datasource>;
-  visualizationMap: Record<string, Visualization>;
+  datasourceMap: DatasourceMap;
+  visualizationMap: VisualizationMap;
 }
 
 export type RunSave = (
@@ -82,7 +82,7 @@ export interface LensTopNavMenuProps {
   indicateNoData: boolean;
   setIsSaveModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
   runSave: RunSave;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   title?: string;
 }
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -27,11 +27,8 @@ import {
 } from '../../../state_management';
 
 export const ConfigPanelWrapper = memo(function ConfigPanelWrapper(props: ConfigPanelWrapperProps) {
-  const activeVisualization = props.visualizationMap[props.activeVisualizationId || ''];
-  const { visualizationState } = props;
-
-  return activeVisualization && visualizationState ? (
-    <LayerPanels {...props} activeVisualization={activeVisualization} />
+  return props.activeVisualization && props.visualizationState ? (
+    <LayerPanels {...props} activeVisualization={props.activeVisualization} />
   ) : null;
 });
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
@@ -15,8 +15,7 @@ import {
 export interface ConfigPanelWrapperProps {
   activeDatasourceId: string;
   visualizationState: unknown;
-  visualizationMap: Record<string, Visualization>;
-  activeVisualizationId: string | null;
+  activeVisualization: Visualization | null;
   framePublicAPI: FramePublicAPI;
   datasourceMap: Record<string, Datasource>;
   datasourceStates: Record<

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
@@ -8,16 +8,16 @@
 import {
   Visualization,
   FramePublicAPI,
-  Datasource,
   DatasourceDimensionEditorProps,
   VisualizationDimensionGroupConfig,
+  DatasourceMap,
 } from '../../../types';
 export interface ConfigPanelWrapperProps {
   activeDatasourceId: string;
   visualizationState: unknown;
   activeVisualization: Visualization | null;
   framePublicAPI: FramePublicAPI;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {
@@ -32,7 +32,7 @@ export interface ConfigPanelWrapperProps {
 export interface LayerPanelProps {
   activeDatasourceId: string;
   visualizationState: unknown;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   activeVisualization: Visualization;
   framePublicAPI: FramePublicAPI;
   datasourceStates: Record<

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/data_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/data_panel_wrapper.tsx
@@ -13,7 +13,7 @@ import { EuiPopover, EuiButtonIcon, EuiContextMenuPanel, EuiContextMenuItem } fr
 import { createSelector } from '@reduxjs/toolkit';
 import { NativeRenderer } from '../../native_renderer';
 import { DragContext, DragDropIdentifier } from '../../drag_drop';
-import { StateSetter, DatasourceDataPanelProps, Datasource } from '../../types';
+import { StateSetter, DatasourceDataPanelProps, DatasourceMap } from '../../types';
 import { UiActionsStart } from '../../../../../../src/plugins/ui_actions/public';
 import {
   switchDatasource,
@@ -27,7 +27,7 @@ import { initializeDatasources } from './state_helpers';
 
 interface DataPanelWrapperProps {
   datasourceState: unknown;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   activeDatasource: string | null;
   datasourceIsLoading: boolean;
   showNoDataPopover: () => void;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
@@ -125,11 +125,12 @@ export function EditorFrame(props: EditorFrameProps) {
         configPanel={
           allLoaded && (
             <ConfigPanelWrapper
+              activeVisualization={
+                visualization.activeId ? props.visualizationMap[visualization.activeId] : null
+              }
               activeDatasourceId={activeDatasourceId!}
               datasourceMap={props.datasourceMap}
               datasourceStates={datasourceStates}
-              visualizationMap={props.visualizationMap}
-              activeVisualizationId={visualization.activeId}
               visualizationState={visualization.state}
               framePublicAPI={framePublicAPI}
               core={props.core}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useRef, useMemo } from 'react';
 import { CoreStart } from 'kibana/public';
 import { ReactExpressionRendererType } from '../../../../../../src/plugins/expressions/public';
-import { Datasource, FramePublicAPI, Visualization } from '../../types';
+import { DatasourceMap, FramePublicAPI, VisualizationMap } from '../../types';
 import { DataPanelWrapper } from './data_panel_wrapper';
 import { ConfigPanelWrapper } from './config_panel';
 import { FrameLayout } from './frame_layout';
@@ -22,8 +22,8 @@ import { trackUiEvent } from '../../lens_ui_telemetry';
 import { useLensSelector, useLensDispatch } from '../../state_management';
 
 export interface EditorFrameProps {
-  datasourceMap: Record<string, Datasource>;
-  visualizationMap: Record<string, Visualization>;
+  datasourceMap: DatasourceMap;
+  visualizationMap: VisualizationMap;
   ExpressionRenderer: ReactExpressionRendererType;
   core: CoreStart;
   plugins: EditorFrameStartPlugins;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/expression_helpers.ts
@@ -6,11 +6,11 @@
  */
 
 import { Ast, fromExpression, ExpressionFunctionAST } from '@kbn/interpreter/common';
-import { Visualization, Datasource, DatasourcePublicAPI } from '../../types';
+import { Visualization, DatasourcePublicAPI, DatasourceMap } from '../../types';
 
 export function prependDatasourceExpression(
   visualizationExpression: Ast | string | null,
-  datasourceMap: Record<string, Datasource>,
+  datasourceMap: DatasourceMap,
   datasourceStates: Record<
     string,
     {
@@ -80,7 +80,7 @@ export function buildExpression({
   description?: string;
   visualization: Visualization | null;
   visualizationState: unknown;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/state_helpers.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/state_helpers.ts
@@ -10,11 +10,13 @@ import { Ast } from '@kbn/interpreter/common';
 import memoizeOne from 'memoize-one';
 import {
   Datasource,
+  DatasourceMap,
   DatasourcePublicAPI,
   FramePublicAPI,
   InitializationOptions,
   Visualization,
   VisualizationDimensionGroupConfig,
+  VisualizationMap,
 } from '../../types';
 import { buildExpression } from './expression_helpers';
 import { Document } from '../../persistence/saved_object_store';
@@ -28,7 +30,7 @@ import {
 } from '../error_helper';
 
 export async function initializeDatasources(
-  datasourceMap: Record<string, Datasource>,
+  datasourceMap: DatasourceMap,
   datasourceStates: Record<string, { state: unknown; isLoading: boolean }>,
   references?: SavedObjectReference[],
   initialContext?: VisualizeFieldContext,
@@ -55,7 +57,7 @@ export async function initializeDatasources(
 }
 
 export const createDatasourceLayers = memoizeOne(function createDatasourceLayers(
-  datasourceMap: Record<string, Datasource>,
+  datasourceMap: DatasourceMap,
   datasourceStates: Record<string, { state: unknown; isLoading: boolean }>
 ) {
   const datasourceLayers: Record<string, DatasourcePublicAPI> = {};
@@ -78,7 +80,7 @@ export const createDatasourceLayers = memoizeOne(function createDatasourceLayers
 
 export async function persistedStateToExpression(
   datasources: Record<string, Datasource>,
-  visualizations: Record<string, Visualization>,
+  visualizations: VisualizationMap,
   doc: Document
 ): Promise<{ ast: Ast | null; errors: ErrorMessage[] | undefined }> {
   const {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
@@ -18,6 +18,8 @@ import {
   TableSuggestion,
   DatasourceSuggestion,
   DatasourcePublicAPI,
+  DatasourceMap,
+  VisualizationMap,
 } from '../../types';
 import { DragDropIdentifier } from '../../drag_drop';
 import { LensDispatch, selectSuggestion, switchVisualization } from '../../state_management';
@@ -57,7 +59,7 @@ export function getSuggestions({
   activeData,
   mainPalette,
 }: {
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {
@@ -65,7 +67,7 @@ export function getSuggestions({
       state: unknown;
     }
   >;
-  visualizationMap: Record<string, Visualization>;
+  visualizationMap: VisualizationMap;
   activeVisualizationId: string | null;
   subVisualizationId?: string;
   visualizationState: unknown;
@@ -140,7 +142,7 @@ export function getVisualizeFieldSuggestions({
   visualizationState,
   visualizeTriggerFieldContext,
 }: {
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {
@@ -148,7 +150,7 @@ export function getVisualizeFieldSuggestions({
       state: unknown;
     }
   >;
-  visualizationMap: Record<string, Visualization>;
+  visualizationMap: VisualizationMap;
   activeVisualizationId: string | null;
   subVisualizationId?: string;
   visualizationState: unknown;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -25,7 +25,14 @@ import { Ast, toExpression } from '@kbn/interpreter/common';
 import { i18n } from '@kbn/i18n';
 import classNames from 'classnames';
 import { ExecutionContextSearch } from 'src/plugins/data/public';
-import { Datasource, Visualization, FramePublicAPI, DatasourcePublicAPI } from '../../types';
+import {
+  Datasource,
+  Visualization,
+  FramePublicAPI,
+  DatasourcePublicAPI,
+  DatasourceMap,
+  VisualizationMap,
+} from '../../types';
 import { getSuggestions, switchToSuggestion } from './suggestion_helpers';
 import {
   ReactExpressionRendererProps,
@@ -45,7 +52,7 @@ const MAX_SUGGESTIONS_DISPLAYED = 5;
 
 export interface SuggestionPanelProps {
   activeDatasourceId: string | null;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {
@@ -54,7 +61,7 @@ export interface SuggestionPanelProps {
     }
   >;
   activeVisualizationId: string | null;
-  visualizationMap: Record<string, Visualization>;
+  visualizationMap: VisualizationMap;
   visualizationState: unknown;
   ExpressionRenderer: ReactExpressionRendererType;
   frame: FramePublicAPI;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -20,7 +20,13 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { Visualization, FramePublicAPI, Datasource, VisualizationType } from '../../../types';
+import {
+  Visualization,
+  FramePublicAPI,
+  VisualizationType,
+  VisualizationMap,
+  DatasourceMap,
+} from '../../../types';
 import { getSuggestions, switchToSuggestion, Suggestion } from '../suggestion_helpers';
 import { trackUiEvent } from '../../../lens_ui_telemetry';
 import { ToolbarButton } from '../../../../../../../src/plugins/kibana_react/public';
@@ -44,9 +50,9 @@ interface VisualizationSelection {
 }
 
 interface Props {
-  visualizationMap: Record<string, Visualization>;
   framePublicAPI: FramePublicAPI;
-  datasourceMap: Record<string, Datasource>;
+  visualizationMap: VisualizationMap;
+  datasourceMap: DatasourceMap;
 }
 
 type SelectableEntry = EuiSelectableOption<{ value: string }>;
@@ -55,7 +61,7 @@ function VisualizationSummary({
   visualizationMap,
   visualization,
 }: {
-  visualizationMap: Record<string, Visualization>;
+  visualizationMap: VisualizationMap;
   visualization: {
     activeId: string | null;
     state: unknown;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -34,12 +34,12 @@ import {
   ReactExpressionRendererType,
 } from '../../../../../../../src/plugins/expressions/public';
 import {
-  Datasource,
-  Visualization,
   FramePublicAPI,
   isLensBrushEvent,
   isLensFilterEvent,
   isLensEditEvent,
+  VisualizationMap,
+  DatasourceMap,
 } from '../../../types';
 import { DragDrop, DragContext, DragDropIdentifier } from '../../../drag_drop';
 import { Suggestion, switchToSuggestion } from '../suggestion_helpers';
@@ -62,10 +62,10 @@ import {
 
 export interface WorkspacePanelProps {
   activeVisualizationId: string | null;
-  visualizationMap: Record<string, Visualization>;
+  visualizationMap: VisualizationMap;
   visualizationState: unknown;
   activeDatasourceId: string | null;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -10,7 +10,7 @@ import './workspace_panel_wrapper.scss';
 import React, { useCallback } from 'react';
 import { EuiPageContent, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import classNames from 'classnames';
-import { Datasource, FramePublicAPI, Visualization } from '../../../types';
+import { DatasourceMap, FramePublicAPI, VisualizationMap } from '../../../types';
 import { NativeRenderer } from '../../../native_renderer';
 import { ChartSwitch } from './chart_switch';
 import { WarningsPopover } from './warnings_popover';
@@ -21,9 +21,9 @@ export interface WorkspacePanelWrapperProps {
   children: React.ReactNode | React.ReactNode[];
   framePublicAPI: FramePublicAPI;
   visualizationState: unknown;
-  visualizationMap: Record<string, Visualization>;
+  visualizationMap: VisualizationMap;
   visualizationId: string | null;
-  datasourceMap: Record<string, Datasource>;
+  datasourceMap: DatasourceMap;
   datasourceStates: Record<
     string,
     {

--- a/x-pack/plugins/lens/public/mocks.tsx
+++ b/x-pack/plugins/lens/public/mocks.tsx
@@ -35,7 +35,7 @@ import {
 import { LensAttributeService } from './lens_attribute_service';
 import { EmbeddableStateTransfer } from '../../../../src/plugins/embeddable/public';
 
-import { makeConfigureStore, getPreloadedState, LensAppState } from './state_management/index';
+import { makeConfigureStore, LensAppState } from './state_management/index';
 import { getResolvedDateRange } from './utils';
 import { presentationUtilPluginMock } from '../../../../src/plugins/presentation_util/public/mocks';
 import { DatasourcePublicAPI, Datasource, Visualization, FramePublicAPI } from './types';
@@ -82,6 +82,11 @@ export function createMockVisualization(): jest.Mocked<Visualization> {
   };
 }
 
+const visualizationMap = {
+  vis: createMockVisualization(),
+  vis2: createMockVisualization(),
+};
+
 export type DatasourceMock = jest.Mocked<Datasource> & {
   publicAPIMock: jest.Mocked<DatasourcePublicAPI>;
 };
@@ -125,6 +130,13 @@ export function createMockDatasource(id: string): DatasourceMock {
     checkIntegrity: jest.fn((_state) => []),
   };
 }
+
+const mockDatasource: DatasourceMock = createMockDatasource('testDatasource');
+const mockDatasource2: DatasourceMock = createMockDatasource('testDatasource2');
+const datasourceMap = {
+  testDatasource2: mockDatasource2,
+  testDatasource: mockDatasource,
+};
 
 export function createExpressionRendererMock(): jest.Mock<
   React.ReactElement,
@@ -403,8 +415,8 @@ export function makeLensStore({
   const lensStore = makeConfigureStore(
     {
       lensServices: { ...makeDefaultServices(), data },
-      datasourceMap:
-      visualizationMap: 
+      datasourceMap,
+      visualizationMap,
     },
     {
       ...defaultState,

--- a/x-pack/plugins/lens/public/mocks.tsx
+++ b/x-pack/plugins/lens/public/mocks.tsx
@@ -16,6 +16,7 @@ import moment from 'moment';
 import { Provider } from 'react-redux';
 import { act } from 'react-dom/test-utils';
 import { ReactExpressionRendererProps } from 'src/plugins/expressions/public';
+import { DeepPartial } from '@reduxjs/toolkit';
 import { LensPublicStart } from '.';
 import { visualizationTypes } from './xy_visualization/types';
 import { navigationPluginMock } from '../../../../src/plugins/navigation/public/mocks';
@@ -35,7 +36,7 @@ import {
 import { LensAttributeService } from './lens_attribute_service';
 import { EmbeddableStateTransfer } from '../../../../src/plugins/embeddable/public';
 
-import { makeConfigureStore, LensAppState } from './state_management/index';
+import { makeConfigureStore, LensAppState, LensState } from './state_management/index';
 import { getResolvedDateRange } from './utils';
 import { presentationUtilPluginMock } from '../../../../src/plugins/presentation_util/public/mocks';
 import { DatasourcePublicAPI, Datasource, Visualization, FramePublicAPI } from './types';
@@ -419,13 +420,15 @@ export function makeLensStore({
       visualizationMap,
     },
     {
-      ...defaultState,
-      searchSessionId: data.search.session.start(),
-      query: data.query.queryString.getQuery(),
-      filters: data.query.filterManager.getGlobalFilters(),
-      resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
-      ...preloadedState,
-    }
+      lens: {
+        ...defaultState,
+        searchSessionId: data.search.session.start(),
+        query: data.query.queryString.getQuery(),
+        filters: data.query.filterManager.getGlobalFilters(),
+        resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
+        ...preloadedState,
+      },
+    } as DeepPartial<LensState>
   );
 
   const origDispatch = lensStore.dispatch;

--- a/x-pack/plugins/lens/public/mocks.tsx
+++ b/x-pack/plugins/lens/public/mocks.tsx
@@ -401,16 +401,18 @@ export function makeLensStore({
     data = mockDataPlugin();
   }
   const lensStore = makeConfigureStore(
-    getPreloadedState({
+    {
+      lensServices: { ...makeDefaultServices(), data },
+      datasourceMap:
+      visualizationMap: 
+    },
+    {
       ...defaultState,
       searchSessionId: data.search.session.start(),
       query: data.query.queryString.getQuery(),
       filters: data.query.filterManager.getGlobalFilters(),
       resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
       ...preloadedState,
-    }),
-    {
-      data,
     }
   );
 

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -8,11 +8,10 @@
 import { configureStore, getDefaultMiddleware, DeepPartial } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
-import { lensSlice, initialState } from './lens_slice';
+import { lensSlice } from './lens_slice';
 import { timeRangeMiddleware } from './time_range_middleware';
 import { optimizingMiddleware } from './optimizing_middleware';
-import { LensAppState, LensState, StoreDeps } from './types';
-import { getInitialDatasourceId, getResolvedDateRange } from '../utils';
+import { LensState, LensStoreDeps } from './types';
 import { initMiddleware } from './init_middleware';
 export * from './types';
 
@@ -38,53 +37,9 @@ export const {
   setToggleFullscreen,
 } = lensSlice.actions;
 
-export const getPreloadedState = (
-  {
-    lensServices: { data },
-    initialContext,
-    embeddableEditorIncomingState,
-    datasourceMap,
-    visualizationMap,
-  }: StoreDeps,
-  preloadedState?: Partial<LensAppState>
-) => {
-  const initialDatasourceId = getInitialDatasourceId(datasourceMap);
-  const datasourceStates: LensAppState['datasourceStates'] = {};
-  if (initialDatasourceId) {
-    datasourceStates[initialDatasourceId] = {
-      state: null,
-      isLoading: true,
-    };
-  }
-
-  const state = {
-    lens: {
-      ...initialState,
-      isLoading: true,
-      query: data.query.queryString.getQuery(),
-      // Do not use app-specific filters from previous app,
-      // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
-      filters: !initialContext
-        ? data.query.filterManager.getGlobalFilters()
-        : data.query.filterManager.getFilters(),
-      searchSessionId: data.search.session.getSessionId(),
-      resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
-      isLinkedToOriginatingApp: Boolean(embeddableEditorIncomingState?.originatingApp),
-      activeDatasourceId: initialDatasourceId,
-      datasourceStates,
-      visualization: {
-        state: null as unknown,
-        activeId: Object.keys(visualizationMap)[0] || null,
-      },
-      ...preloadedState,
-    },
-  } as DeepPartial<LensState>;
-  return state;
-};
-
 export const makeConfigureStore = (
-  storeDeps: StoreDeps,
-  preloadedState?: Partial<LensAppState>
+  storeDeps: LensStoreDeps,
+  preloadedState: DeepPartial<LensState>
 ) => {
   const middleware = [
     ...getDefaultMiddleware({
@@ -99,7 +54,7 @@ export const makeConfigureStore = (
   return configureStore({
     reducer,
     middleware,
-    preloadedState: getPreloadedState(storeDeps, preloadedState),
+    preloadedState,
   });
 };
 

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -46,7 +46,7 @@ export const getPreloadedState = (
     datasourceMap,
     visualizationMap,
   }: StoreDeps,
-  preloadedState: Partial<LensAppState>
+  preloadedState?: Partial<LensAppState>
 ) => {
   const initialDatasourceId = getInitialDatasourceId(datasourceMap);
   const datasourceStates: LensAppState['datasourceStates'] = {};
@@ -82,7 +82,10 @@ export const getPreloadedState = (
   return state;
 };
 
-export const makeConfigureStore = (storeDeps: StoreDeps, preloadedState: Partial<LensAppState>) => {
+export const makeConfigureStore = (
+  storeDeps: StoreDeps,
+  preloadedState?: Partial<LensAppState>
+) => {
   const middleware = [
     ...getDefaultMiddleware({
       serializableCheck: false,

--- a/x-pack/plugins/lens/public/state_management/index.ts
+++ b/x-pack/plugins/lens/public/state_management/index.ts
@@ -5,16 +5,15 @@
  * 2.0.
  */
 
-import { configureStore, DeepPartial, getDefaultMiddleware } from '@reduxjs/toolkit';
+import { configureStore, getDefaultMiddleware, DeepPartial } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
 import { lensSlice, initialState } from './lens_slice';
 import { timeRangeMiddleware } from './time_range_middleware';
 import { optimizingMiddleware } from './optimizing_middleware';
-import { externalContextMiddleware } from './external_context_middleware';
-
-import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
-import { LensAppState, LensState } from './types';
+import { LensAppState, LensState, StoreDeps } from './types';
+import { getInitialDatasourceId, getResolvedDateRange } from '../utils';
+import { initMiddleware } from './init_middleware';
 export * from './types';
 
 export const reducer = {
@@ -22,8 +21,9 @@ export const reducer = {
 };
 
 export const {
-  setState,
+  loadInitial,
   navigateAway,
+  setState,
   setSaveable,
   onActiveDataChange,
   updateState,
@@ -38,36 +38,65 @@ export const {
   setToggleFullscreen,
 } = lensSlice.actions;
 
-export const getPreloadedState = (initializedState: Partial<LensAppState>) => {
+export const getPreloadedState = (
+  {
+    lensServices: { data },
+    initialContext,
+    embeddableEditorIncomingState,
+    datasourceMap,
+    visualizationMap,
+  }: StoreDeps,
+  preloadedState: Partial<LensAppState>
+) => {
+  const initialDatasourceId = getInitialDatasourceId(datasourceMap);
+  const datasourceStates: LensAppState['datasourceStates'] = {};
+  if (initialDatasourceId) {
+    datasourceStates[initialDatasourceId] = {
+      state: null,
+      isLoading: true,
+    };
+  }
+
   const state = {
     lens: {
       ...initialState,
-      ...initializedState,
+      isLoading: true,
+      query: data.query.queryString.getQuery(),
+      // Do not use app-specific filters from previous app,
+      // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
+      filters: !initialContext
+        ? data.query.filterManager.getGlobalFilters()
+        : data.query.filterManager.getFilters(),
+      searchSessionId: data.search.session.getSessionId(),
+      resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
+      isLinkedToOriginatingApp: Boolean(embeddableEditorIncomingState?.originatingApp),
+      activeDatasourceId: initialDatasourceId,
+      datasourceStates,
+      visualization: {
+        state: null as unknown,
+        activeId: Object.keys(visualizationMap)[0] || null,
+      },
+      ...preloadedState,
     },
   } as DeepPartial<LensState>;
   return state;
 };
 
-type PreloadedState = ReturnType<typeof getPreloadedState>;
-
-export const makeConfigureStore = (
-  preloadedState: PreloadedState,
-  { data }: { data: DataPublicPluginStart }
-) => {
+export const makeConfigureStore = (storeDeps: StoreDeps, preloadedState: Partial<LensAppState>) => {
   const middleware = [
     ...getDefaultMiddleware({
       serializableCheck: false,
     }),
+    initMiddleware(storeDeps),
     optimizingMiddleware(),
-    timeRangeMiddleware(data),
-    externalContextMiddleware(data),
+    timeRangeMiddleware(storeDeps.lensServices.data),
   ];
   if (process.env.NODE_ENV === 'development') middleware.push(logger);
 
   return configureStore({
     reducer,
     middleware,
-    preloadedState,
+    preloadedState: getPreloadedState(storeDeps, preloadedState),
   });
 };
 

--- a/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
+import { StoreDeps } from '..';
+import { lensSlice } from '../lens_slice';
+import { loadInitial } from './load_initial';
+import { subscribeToExternalContext } from './subscribe_to_external_context';
+
+export const initMiddleware = (storeDeps: StoreDeps) => (store: MiddlewareAPI) => {
+  const unsubscribeFromExternalContext = subscribeToExternalContext(
+    storeDeps.lensServices.data,
+    store.getState,
+    store.dispatch
+  );
+  return (next: Dispatch) => (action: PayloadAction) => {
+    if (lensSlice.actions.loadInitial.match(action)) {
+      return loadInitial(
+        store,
+        storeDeps,
+        action.payload.redirectCallback,
+        action.payload.initialInput
+      );
+    } else if (lensSlice.actions.navigateAway.match(action)) {
+      return unsubscribeFromExternalContext();
+    }
+    next(action);
+  };
+};

--- a/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
@@ -6,12 +6,12 @@
  */
 
 import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
-import { StoreDeps } from '..';
+import { LensStoreDeps } from '..';
 import { lensSlice } from '../lens_slice';
 import { loadInitial } from './load_initial';
 import { subscribeToExternalContext } from './subscribe_to_external_context';
 
-export const initMiddleware = (storeDeps: StoreDeps) => (store: MiddlewareAPI) => {
+export const initMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAPI) => {
   const unsubscribeFromExternalContext = subscribeToExternalContext(
     storeDeps.lensServices.data,
     store.getState,

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.test.tsx
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.test.tsx
@@ -4,11 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { makeDefaultServices, makeLensStore, defaultDoc, createMockVisualization } from '../mocks';
-import { createMockDatasource, DatasourceMock } from '../mocks';
+import {
+  makeDefaultServices,
+  makeLensStore,
+  defaultDoc,
+  createMockVisualization,
+  createMockDatasource,
+  DatasourceMock,
+} from '../../mocks';
 import { act } from 'react-dom/test-utils';
-import { loadInitialStore } from './mounter';
-import { LensEmbeddableInput } from '../embeddable/embeddable';
+import { loadInitial } from './load_initial';
+import { LensEmbeddableInput } from '../../embeddable';
 
 const defaultSavedObjectId = '1234';
 const preloadedState = {
@@ -20,7 +26,6 @@ const preloadedState = {
 };
 
 describe('Mounter', () => {
-  const byValueFlag = { allowByValueEmbeddables: true };
   const mockDatasource: DatasourceMock = createMockDatasource('testDatasource');
   const mockDatasource2: DatasourceMock = createMockDatasource('testDatasource2');
   const datasourceMap = {
@@ -61,20 +66,24 @@ describe('Mounter', () => {
     const redirectCallback = jest.fn();
     services.attributeService.unwrapAttributes = jest.fn().mockResolvedValue(defaultDoc);
 
-    const lensStore = await makeLensStore({
-      data: services.data,
-      preloadedState,
-    });
-    await act(async () => {
-      await loadInitialStore(
-        redirectCallback,
-        undefined,
-        services,
-        lensStore,
-        undefined,
-        byValueFlag,
+    const lensStore = await makeLensStore(
+      {
+        visualizationMap,
         datasourceMap,
-        visualizationMap
+        lensServices: services
+      }
+      
+      preloadedState);
+    await act(async () => {
+      await loadInitial(
+        lensStore,
+        {
+          lensServices: services,
+          datasourceMap,
+          visualizationMap,
+        },
+        redirectCallback,
+        ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput
       );
     });
     expect(mockDatasource.initialize).toHaveBeenCalled();
@@ -87,15 +96,14 @@ describe('Mounter', () => {
 
     const lensStore = await makeLensStore({ data: services.data, preloadedState });
     await act(async () => {
-      await loadInitialStore(
-        redirectCallback,
-        undefined,
-        services,
+      await loadInitial(
         lensStore,
-        undefined,
-        byValueFlag,
-        datasourceMap,
-        visualizationMap
+        {
+          lensServices: services,
+          datasourceMap,
+          visualizationMap,
+        },
+        redirectCallback
       );
     });
     expect(mockDatasource.initialize).toHaveBeenCalled();
@@ -114,20 +122,19 @@ describe('Mounter', () => {
   // it.skip('should pass the datasource api for each layer to the visualization', async () => {})
   // it('displays errors from the frame in a toast', async () => {
 
-  describe('loadInitialStore', () => {
+  describe('loadInitial', () => {
     it('does not load a document if there is no initial input', async () => {
       const services = makeDefaultServices();
       const redirectCallback = jest.fn();
       const lensStore = makeLensStore({ data: services.data, preloadedState });
-      await loadInitialStore(
-        redirectCallback,
-        undefined,
-        services,
+      await loadInitial(
         lensStore,
-        undefined,
-        byValueFlag,
-        datasourceMap,
-        visualizationMap
+        {
+          lensServices: services,
+          datasourceMap,
+          visualizationMap,
+        },
+        redirectCallback
       );
       expect(services.attributeService.unwrapAttributes).not.toHaveBeenCalled();
     });
@@ -139,15 +146,15 @@ describe('Mounter', () => {
 
       const lensStore = await makeLensStore({ data: services.data, preloadedState });
       await act(async () => {
-        await loadInitialStore(
-          redirectCallback,
-          { savedObjectId: defaultSavedObjectId } as LensEmbeddableInput,
-          services,
+        await loadInitial(
           lensStore,
-          undefined,
-          byValueFlag,
-          datasourceMap,
-          visualizationMap
+          {
+            lensServices: services,
+            datasourceMap,
+            visualizationMap,
+          },
+          redirectCallback,
+          ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput
         );
       });
 
@@ -175,43 +182,43 @@ describe('Mounter', () => {
       const lensStore = makeLensStore({ data: services.data, preloadedState });
 
       await act(async () => {
-        await loadInitialStore(
-          redirectCallback,
-          { savedObjectId: defaultSavedObjectId } as LensEmbeddableInput,
-          services,
+        await loadInitial(
           lensStore,
-          undefined,
-          byValueFlag,
-          datasourceMap,
-          visualizationMap
+          {
+            lensServices: services,
+            datasourceMap,
+            visualizationMap,
+          },
+          redirectCallback,
+          ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput
         );
       });
 
       await act(async () => {
-        await loadInitialStore(
-          redirectCallback,
-          { savedObjectId: defaultSavedObjectId } as LensEmbeddableInput,
-          services,
+        await loadInitial(
           lensStore,
-          undefined,
-          byValueFlag,
-          datasourceMap,
-          visualizationMap
+          {
+            lensServices: services,
+            datasourceMap,
+            visualizationMap,
+          },
+          redirectCallback,
+          ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput
         );
       });
 
       expect(services.attributeService.unwrapAttributes).toHaveBeenCalledTimes(1);
 
       await act(async () => {
-        await loadInitialStore(
-          redirectCallback,
-          { savedObjectId: '5678' } as LensEmbeddableInput,
-          services,
+        await loadInitial(
           lensStore,
-          undefined,
-          byValueFlag,
-          datasourceMap,
-          visualizationMap
+          {
+            lensServices: services,
+            datasourceMap,
+            visualizationMap,
+          },
+          redirectCallback,
+          ({ savedObjectId: '5678' } as unknown) as LensEmbeddableInput
         );
       });
 
@@ -227,15 +234,15 @@ describe('Mounter', () => {
       services.attributeService.unwrapAttributes = jest.fn().mockRejectedValue('failed to load');
 
       await act(async () => {
-        await loadInitialStore(
-          redirectCallback,
-          { savedObjectId: defaultSavedObjectId } as LensEmbeddableInput,
-          services,
+        await loadInitial(
           lensStore,
-          undefined,
-          byValueFlag,
-          datasourceMap,
-          visualizationMap
+          {
+            lensServices: services,
+            datasourceMap,
+            visualizationMap,
+          },
+          redirectCallback,
+          ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput
         );
       });
       expect(services.attributeService.unwrapAttributes).toHaveBeenCalledWith({
@@ -251,15 +258,15 @@ describe('Mounter', () => {
       const services = makeDefaultServices();
       const lensStore = makeLensStore({ data: services.data, preloadedState });
       await act(async () => {
-        await loadInitialStore(
-          redirectCallback,
-          ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput,
-          services,
+        await loadInitial(
           lensStore,
-          undefined,
-          byValueFlag,
-          datasourceMap,
-          visualizationMap
+          {
+            lensServices: services,
+            datasourceMap,
+            visualizationMap,
+          },
+          redirectCallback,
+          ({ savedObjectId: defaultSavedObjectId } as unknown) as LensEmbeddableInput
         );
       });
 

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.test.tsx
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.test.tsx
@@ -66,14 +66,10 @@ describe('Mounter', () => {
     const redirectCallback = jest.fn();
     services.attributeService.unwrapAttributes = jest.fn().mockResolvedValue(defaultDoc);
 
-    const lensStore = await makeLensStore(
-      {
-        visualizationMap,
-        datasourceMap,
-        lensServices: services
-      }
-      
-      preloadedState);
+    const lensStore = await makeLensStore({
+      data: services.data,
+      preloadedState,
+    });
     await act(async () => {
       await loadInitial(
         lensStore,

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
@@ -8,7 +8,7 @@
 import { MiddlewareAPI } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
 import { setState } from '..';
-import { updateLayer, updateVisualizationState, StoreDeps } from '..';
+import { updateLayer, updateVisualizationState, LensStoreDeps } from '..';
 import { LensEmbeddableInput, LensByReferenceInput } from '../../embeddable/embeddable';
 import { getInitialDatasourceId } from '../../utils';
 import { initializeDatasources } from '../../editor_frame_service/editor_frame';
@@ -27,7 +27,7 @@ export function loadInitial(
     visualizationMap,
     embeddableEditorIncomingState,
     initialContext,
-  }: StoreDeps,
+  }: LensStoreDeps,
   redirectCallback: (savedObjectId?: string) => void,
   initialInput?: LensEmbeddableInput
 ) {

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MiddlewareAPI } from '@reduxjs/toolkit';
+import { isEqual } from 'lodash';
+import { setState } from '..';
+import { updateLayer, updateVisualizationState, StoreDeps } from '..';
+import { LensEmbeddableInput, LensByReferenceInput } from '../../embeddable/embeddable';
+import { getInitialDatasourceId } from '../../utils';
+import { initializeDatasources } from '../../editor_frame_service/editor_frame';
+import { generateId } from '../../id_generator';
+import {
+  getVisualizeFieldSuggestions,
+  switchToSuggestion,
+} from '../../editor_frame_service/editor_frame/suggestion_helpers';
+import { getPersistedDoc } from '../../app_plugin/save_modal_container';
+
+export function loadInitial(
+  store: MiddlewareAPI,
+  {
+    lensServices,
+    datasourceMap,
+    visualizationMap,
+    embeddableEditorIncomingState,
+    initialContext,
+  }: StoreDeps,
+  redirectCallback: (savedObjectId?: string) => void,
+  initialInput?: LensEmbeddableInput
+) {
+  const { getState, dispatch } = store;
+  const { attributeService, chrome, notifications, data, dashboardFeatureFlag } = lensServices;
+  const { persistedDoc } = getState().lens;
+  if (
+    !initialInput ||
+    (attributeService.inputIsRefType(initialInput) &&
+      initialInput.savedObjectId === persistedDoc?.savedObjectId)
+  ) {
+    return initializeDatasources(
+      datasourceMap,
+      getState().lens.datasourceStates,
+      undefined,
+      initialContext,
+      {
+        isFullEditor: true,
+      }
+    )
+      .then((result) => {
+        const datasourceStates = Object.entries(result).reduce(
+          (state, [datasourceId, datasourceState]) => ({
+            ...state,
+            [datasourceId]: {
+              ...datasourceState,
+              isLoading: false,
+            },
+          }),
+          {}
+        );
+        dispatch(
+          setState({
+            datasourceStates,
+            isLoading: false,
+          })
+        );
+        if (initialContext) {
+          const selectedSuggestion = getVisualizeFieldSuggestions({
+            datasourceMap,
+            datasourceStates,
+            visualizationMap,
+            activeVisualizationId: Object.keys(visualizationMap)[0] || null,
+            visualizationState: null,
+            visualizeTriggerFieldContext: initialContext,
+          });
+          if (selectedSuggestion) {
+            switchToSuggestion(dispatch, selectedSuggestion, 'SWITCH_VISUALIZATION');
+          }
+        }
+        const activeDatasourceId = getInitialDatasourceId(datasourceMap);
+        const visualization = getState().lens.visualization;
+        const activeVisualization =
+          visualization.activeId && visualizationMap[visualization.activeId];
+
+        if (visualization.state === null && activeVisualization) {
+          const newLayerId = generateId();
+
+          const initialVisualizationState = activeVisualization.initialize(() => newLayerId);
+          dispatch(
+            updateLayer({
+              datasourceId: activeDatasourceId!,
+              layerId: newLayerId,
+              updater: datasourceMap[activeDatasourceId!].insertLayer,
+            })
+          );
+          dispatch(
+            updateVisualizationState({
+              visualizationId: activeVisualization.id,
+              updater: initialVisualizationState,
+            })
+          );
+        }
+      })
+      .catch((e: { message: string }) => {
+        notifications.toasts.addDanger({
+          title: e.message,
+        });
+        redirectCallback();
+      });
+  }
+  getPersistedDoc({
+    initialInput,
+    attributeService,
+    data,
+    chrome,
+    notifications,
+  })
+    .then(
+      (doc) => {
+        if (doc) {
+          const currentSessionId = data.search.session.getSessionId();
+          const docDatasourceStates = Object.entries(doc.state.datasourceStates).reduce(
+            (stateMap, [datasourceId, datasourceState]) => ({
+              ...stateMap,
+              [datasourceId]: {
+                isLoading: true,
+                state: datasourceState,
+              },
+            }),
+            {}
+          );
+
+          initializeDatasources(
+            datasourceMap,
+            docDatasourceStates,
+            doc.references,
+            initialContext,
+            {
+              isFullEditor: true,
+            }
+          )
+            .then((result) => {
+              const activeDatasourceId = getInitialDatasourceId(datasourceMap, doc);
+
+              dispatch(
+                setState({
+                  query: doc.state.query,
+                  searchSessionId:
+                    dashboardFeatureFlag.allowByValueEmbeddables &&
+                    Boolean(embeddableEditorIncomingState?.originatingApp) &&
+                    !(initialInput as LensByReferenceInput)?.savedObjectId &&
+                    currentSessionId
+                      ? currentSessionId
+                      : data.search.session.start(),
+                  ...(!isEqual(persistedDoc, doc) ? { persistedDoc: doc } : null),
+                  activeDatasourceId,
+                  visualization: {
+                    activeId: doc.visualizationType,
+                    state: doc.state.visualization,
+                  },
+                  datasourceStates: Object.entries(result).reduce(
+                    (state, [datasourceId, datasourceState]) => ({
+                      ...state,
+                      [datasourceId]: {
+                        ...datasourceState,
+                        isLoading: false,
+                      },
+                    }),
+                    {}
+                  ),
+                  isLoading: false,
+                })
+              );
+            })
+            .catch((e: { message: string }) =>
+              notifications.toasts.addDanger({
+                title: e.message,
+              })
+            );
+        } else {
+          redirectCallback();
+        }
+      },
+      () => {
+        dispatch(
+          setState({
+            isLoading: false,
+          })
+        );
+        redirectCallback();
+      }
+    )
+    .catch((e: { message: string }) =>
+      notifications.toasts.addDanger({
+        title: e.message,
+      })
+    );
+}

--- a/x-pack/plugins/lens/public/state_management/init_middleware/subscribe_to_external_context.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/subscribe_to_external_context.ts
@@ -7,34 +7,15 @@
 
 import { delay, finalize, switchMap, tap } from 'rxjs/operators';
 import { debounce, isEqual } from 'lodash';
-import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
-import { trackUiEvent } from '../lens_ui_telemetry';
-
+import { trackUiEvent } from '../../lens_ui_telemetry';
 import {
   waitUntilNextSessionCompletes$,
   DataPublicPluginStart,
-} from '../../../../../src/plugins/data/public';
-import { setState, LensGetState, LensDispatch } from '.';
-import { LensAppState } from './types';
-import { getResolvedDateRange } from '../utils';
+} from '../../../../../../src/plugins/data/public';
+import { setState, LensGetState, LensDispatch } from '..';
+import { getResolvedDateRange } from '../../utils';
 
-export const externalContextMiddleware = (data: DataPublicPluginStart) => (
-  store: MiddlewareAPI
-) => {
-  const unsubscribeFromExternalContext = subscribeToExternalContext(
-    data,
-    store.getState,
-    store.dispatch
-  );
-  return (next: Dispatch) => (action: PayloadAction<Partial<LensAppState>>) => {
-    if (action.type === 'lens/navigateAway') {
-      unsubscribeFromExternalContext();
-    }
-    next(action);
-  };
-};
-
-function subscribeToExternalContext(
+export function subscribeToExternalContext(
   data: DataPublicPluginStart,
   getState: LensGetState,
   dispatch: LensDispatch

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -8,7 +8,8 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
 import { LensEmbeddableInput } from '..';
 import { TableInspectorAdapter } from '../editor_frame_service/types';
-import { LensAppState } from './types';
+import { getInitialDatasourceId, getResolvedDateRange } from '../utils';
+import { LensAppState, LensStoreDeps } from './types';
 
 export const initialState: LensAppState = {
   searchSessionId: '',
@@ -25,6 +26,44 @@ export const initialState: LensAppState = {
     state: null,
     activeId: null,
   },
+};
+
+export const getPreloadedState = ({
+  lensServices: { data },
+  initialContext,
+  embeddableEditorIncomingState,
+  datasourceMap,
+  visualizationMap,
+}: LensStoreDeps) => {
+  const initialDatasourceId = getInitialDatasourceId(datasourceMap);
+  const datasourceStates: LensAppState['datasourceStates'] = {};
+  if (initialDatasourceId) {
+    datasourceStates[initialDatasourceId] = {
+      state: null,
+      isLoading: true,
+    };
+  }
+
+  const state = {
+    ...initialState,
+    isLoading: true,
+    query: data.query.queryString.getQuery(),
+    // Do not use app-specific filters from previous app,
+    // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
+    filters: !initialContext
+      ? data.query.filterManager.getGlobalFilters()
+      : data.query.filterManager.getFilters(),
+    searchSessionId: data.search.session.getSessionId(),
+    resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
+    isLinkedToOriginatingApp: Boolean(embeddableEditorIncomingState?.originatingApp),
+    activeDatasourceId: initialDatasourceId,
+    datasourceStates,
+    visualization: {
+      state: null as unknown,
+      activeId: Object.keys(visualizationMap)[0] || null,
+    },
+  };
+  return state;
 };
 
 export const lensSlice = createSlice({

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -6,6 +6,7 @@
  */
 
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
+import { LensEmbeddableInput } from '..';
 import { TableInspectorAdapter } from '../editor_frame_service/types';
 import { LensAppState } from './types';
 
@@ -254,6 +255,13 @@ export const lensSlice = createSlice({
       };
     },
     navigateAway: (state) => state,
+    loadInitial: (
+      state,
+      payload: PayloadAction<{
+        initialInput?: LensEmbeddableInput;
+        redirectCallback: (savedObjectId?: string) => void;
+      }>
+    ) => state,
   },
 });
 

--- a/x-pack/plugins/lens/public/state_management/optimizing_middleware.ts
+++ b/x-pack/plugins/lens/public/state_management/optimizing_middleware.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { Dispatch, MiddlewareAPI, PayloadAction } from '@reduxjs/toolkit';
+import { Dispatch, MiddlewareAPI, Action } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
-import { LensAppState } from './types';
+import { lensSlice } from './lens_slice';
 
 /** cancels updates to the store that don't change the state */
 export const optimizingMiddleware = () => (store: MiddlewareAPI) => {
-  return (next: Dispatch) => (action: PayloadAction<Partial<LensAppState>>) => {
-    if (action.type === 'lens/onActiveDataChange') {
+  return (next: Dispatch) => (action: Action) => {
+    if (lensSlice.actions.onActiveDataChange.match(action)) {
       if (isEqual(store.getState().lens.activeData, action.payload)) {
         return;
       }

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -13,7 +13,7 @@ import { Document } from '../persistence';
 import { TableInspectorAdapter } from '../editor_frame_service/types';
 import { DateRange } from '../../common';
 import { LensAppServices } from '../app_plugin/types';
-import { Datasource, Visualization } from '../types';
+import { DatasourceMap, VisualizationMap } from '../types';
 
 export interface PreviewState {
   visualization: {
@@ -56,8 +56,8 @@ export interface LensState {
 
 export interface LensStoreDeps {
   lensServices: LensAppServices;
-  datasourceMap: Record<string, Datasource>;
-  visualizationMap: Record<string, Visualization>;
+  datasourceMap: DatasourceMap;
+  visualizationMap: VisualizationMap;
   initialContext?: VisualizeFieldContext;
   embeddableEditorIncomingState?: EmbeddableEditorState;
 }

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -54,7 +54,7 @@ export interface LensState {
   lens: LensAppState;
 }
 
-export interface StoreDeps {
+export interface LensStoreDeps {
   lensServices: LensAppServices;
   datasourceMap: Record<string, Datasource>;
   visualizationMap: Record<string, Visualization>;

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -5,11 +5,15 @@
  * 2.0.
  */
 
+import { VisualizeFieldContext } from 'src/plugins/ui_actions/public';
+import { EmbeddableEditorState } from 'src/plugins/embeddable/public';
 import { Filter, Query, SavedQuery } from '../../../../../src/plugins/data/public';
 import { Document } from '../persistence';
 
 import { TableInspectorAdapter } from '../editor_frame_service/types';
 import { DateRange } from '../../common';
+import { LensAppServices } from '../app_plugin/types';
+import { Datasource, Visualization } from '../types';
 
 export interface PreviewState {
   visualization: {
@@ -48,4 +52,12 @@ export type DispatchSetState = (
 
 export interface LensState {
   lens: LensAppState;
+}
+
+export interface StoreDeps {
+  lensServices: LensAppServices;
+  datasourceMap: Record<string, Datasource>;
+  visualizationMap: Record<string, Visualization>;
+  initialContext?: VisualizeFieldContext;
+  embeddableEditorIncomingState?: EmbeddableEditorState;
 }

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -45,10 +45,13 @@ export interface EditorFrameProps {
   showNoDataPopover: () => void;
 }
 
+export type VisualizationMap = Record<string, Visualization>;
+export type DatasourceMap = Record<string, Datasource>;
+
 export interface EditorFrameInstance {
   EditorFrameContainer: (props: EditorFrameProps) => React.ReactElement;
-  datasourceMap: Record<string, Datasource>;
-  visualizationMap: Record<string, Visualization>;
+  datasourceMap: DatasourceMap;
+  visualizationMap: VisualizationMap;
 }
 
 export interface EditorFrameSetup {

--- a/x-pack/plugins/lens/public/utils.ts
+++ b/x-pack/plugins/lens/public/utils.ts
@@ -13,7 +13,7 @@ import { SavedObjectReference } from 'kibana/public';
 import { Filter, Query } from 'src/plugins/data/public';
 import { uniq } from 'lodash';
 import { Document } from './persistence/saved_object_store';
-import { Datasource } from './types';
+import { Datasource, DatasourceMap } from './types';
 import { extractFilterReferences } from './persistence';
 
 export function getVisualizeGeoFieldMessage(fieldType: string) {
@@ -55,10 +55,7 @@ export function getActiveDatasourceIdFromDoc(doc?: Document) {
   return firstDatasourceFromDoc || null;
 }
 
-export const getInitialDatasourceId = (
-  datasourceMap: Record<string, Datasource>,
-  doc?: Document
-) => {
+export const getInitialDatasourceId = (datasourceMap: DatasourceMap, doc?: Document) => {
   return (doc && getActiveDatasourceIdFromDoc(doc)) || Object.keys(datasourceMap)[0] || null;
 };
 


### PR DESCRIPTION
## Summary

Two main changes:

1. Moves loading the app logic to init middleware instead of loading it directly in the mounter
2. `subscribeToExternalContext` also moved to init middleware as it's also part of initialization.
