### PR TITLE
[ML] Anomaly Detection: ability to clear warning notification from jobs list - improvements

### DIFF
--- a/x-pack/plugins/ml/common/constants/index_patterns.ts
+++ b/x-pack/plugins/ml/common/constants/index_patterns.ts
@@ -11,4 +11,3 @@ export const ML_ANNOTATIONS_INDEX_PATTERN = '.ml-annotations-6';
 
 export const ML_RESULTS_INDEX_PATTERN = '.ml-anomalies-*';
 export const ML_NOTIFICATION_INDEX_PATTERN = '.ml-notifications*';
-export const ML_NOTIFICATION_INDEX_02 = '.ml-notifications-000002';

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
@@ -81,7 +81,7 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
           })
         );
       }
-    }, [jobId, notificationIndices.length]);
+    }, [jobId, JSON.stringify(notificationIndices)]);
 
     useEffect(() => {
       fetchMessages();

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
@@ -30,6 +30,7 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
     const canCreateJob = checkPermission('canCreateJob');
 
     const [messages, setMessages] = useState<JobMessage[]>([]);
+    const [notificationIndices, setNotificationIndices] = useState<string[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
     const [isClearing, setIsClearing] = useState<boolean>(false);
@@ -42,7 +43,10 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
     const fetchMessages = async () => {
       setIsLoading(true);
       try {
-        setMessages(await ml.jobs.jobAuditMessages({ jobId, start, end }));
+        const messagesResp = await ml.jobs.jobAuditMessages({ jobId, start, end });
+
+        setMessages(messagesResp.messages);
+        setNotificationIndices(messagesResp.notificationIndices);
         setIsLoading(false);
       } catch (error) {
         setIsLoading(false);
@@ -63,7 +67,7 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
     const clearMessages = useCallback(async () => {
       setIsClearing(true);
       try {
-        await clearJobAuditMessages(jobId);
+        await clearJobAuditMessages(jobId, notificationIndices);
         setIsClearing(false);
         if (typeof refreshJobList === 'function') {
           refreshJobList();
@@ -77,7 +81,7 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
           })
         );
       }
-    }, [jobId]);
+    }, [jobId, notificationIndices.length]);
 
     useEffect(() => {
       fetchMessages();

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/job_details/job_messages_pane.tsx
@@ -87,7 +87,7 @@ export const JobMessagesPane: FC<JobMessagesPaneProps> = React.memo(
       fetchMessages();
     }, []);
 
-    const disabled = messages.length > 0 && messages[0].clearable === false;
+    const disabled = notificationIndices.length === 0;
 
     const clearButton = (
       <EuiButton

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/jobs.ts
@@ -153,15 +153,15 @@ export const jobsApiProvider = (httpService: HttpService) => ({
       ...(start !== undefined && end !== undefined ? { start, end } : {}),
     };
 
-    return httpService.http<JobMessage[]>({
+    return httpService.http<{ messages: JobMessage[]; notificationIndices: string[] }>({
       path: `${ML_BASE_PATH}/job_audit_messages/messages${jobIdString}`,
       method: 'GET',
       query,
     });
   },
 
-  clearJobAuditMessages(jobId: string) {
-    const body = JSON.stringify({ jobId });
+  clearJobAuditMessages(jobId: string, notificationIndices: string[]) {
+    const body = JSON.stringify({ jobId, notificationIndices });
     return httpService.http<{ success: boolean; latest_cleared: number }>({
       path: `${ML_BASE_PATH}/job_audit_messages/clear_messages`,
       method: 'PUT',

--- a/x-pack/plugins/ml/server/models/job_audit_messages/is_clearable.test.ts
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/is_clearable.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isClearable } from './job_audit_messages';
+
+const supportedNotificationIndices = [
+  '.ml-notifications-000002',
+  '.ml-notifications-000003',
+  '.ml-notifications-000004',
+];
+
+const unsupportedIndices = ['.ml-notifications-000001', 'index-does-not-exist'];
+
+describe('jobAuditMessages - isClearable', () => {
+  it('should return true for indices ending in a six digit number with the last number >= 2', () => {
+    supportedNotificationIndices.forEach((index) => {
+      expect(isClearable(index)).toEqual(true);
+    });
+  });
+
+  it('should return false for indices not ending in a six digit number with the last number >= 2', () => {
+    unsupportedIndices.forEach((index) => {
+      expect(isClearable(index)).toEqual(false);
+    });
+  });
+
+  it('should return false for empty string or missing argument', () => {
+    expect(isClearable('')).toEqual(false);
+    expect(isClearable()).toEqual(false);
+  });
+});

--- a/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.d.ts
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.d.ts
@@ -10,6 +10,8 @@ import type { MlClient } from '../../lib/ml_client';
 import type { JobSavedObjectService } from '../../saved_objects';
 import { JobMessage } from '../../../common/types/audit_message';
 
+export function isClearable(index?: string): boolean;
+
 export function jobAuditMessagesProvider(
   client: IScopedClusterClient,
   mlClient: MlClient
@@ -24,5 +26,8 @@ export function jobAuditMessagesProvider(
     }
   ) => { messages: JobMessage[]; notificationIndices: string[] };
   getAuditMessagesSummary: (jobIds?: string[]) => any;
-  clearJobAuditMessages: (jobId: string, notificationIndices: string[]) => any;
+  clearJobAuditMessages: (
+    jobId: string,
+    notificationIndices: string[]
+  ) => { success: boolean; last_cleared: number };
 };

--- a/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.d.ts
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.d.ts
@@ -8,6 +8,7 @@
 import { IScopedClusterClient } from 'kibana/server';
 import type { MlClient } from '../../lib/ml_client';
 import type { JobSavedObjectService } from '../../saved_objects';
+import { JobMessage } from '../../../common/types/audit_message';
 
 export function jobAuditMessagesProvider(
   client: IScopedClusterClient,
@@ -21,7 +22,7 @@ export function jobAuditMessagesProvider(
       start?: string;
       end?: string;
     }
-  ) => any;
+  ) => { messages: JobMessage[]; notificationIndices: string[] };
   getAuditMessagesSummary: (jobIds?: string[]) => any;
-  clearJobAuditMessages: (jobId: string) => any;
+  clearJobAuditMessages: (jobId: string, notificationIndices: string[]) => any;
 };

--- a/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
@@ -36,7 +36,7 @@ const anomalyDetectorTypeFilter = {
   },
 };
 
-function isClearable(index) {
+export function isClearable(index) {
   if (typeof index === 'string') {
     const match = index.match(/\d{6}$/);
     return match !== null && match.length && Number(match[match.length - 1]) >= 2;
@@ -135,13 +135,13 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
 
     if (body.hits.total.value > 0) {
       let notificationIndex;
-      messages = body.hits.hits.map((hit) => {
+      body.hits.hits.forEach((hit) => {
         if (notificationIndex !== hit._index && isClearable(hit._index)) {
           notificationIndices.push(hit._index);
           notificationIndex = hit._index;
         }
 
-        return hit._source;
+        messages.push(hit._source);
       });
     }
     messages = await jobSavedObjectService.filterJobsForSpace(

--- a/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
@@ -39,6 +39,14 @@ const anomalyDetectorTypeFilter = {
   },
 };
 
+function isClearable(index) {
+  if (typeof index === 'string') {
+    const match = index.match(/\d{6}$/);
+    return match !== null && match.length && Number(match[match.length - 1]) >= 2;
+  }
+  return false;
+}
+
 export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
   // search for audit messages,
   // jobId is optional. without it, all jobs will be listed.
@@ -128,7 +136,7 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
     let messages = [];
     if (body.hits.total.value > 0) {
       messages = body.hits.hits.map((hit) => ({
-        clearable: hit._index === ML_NOTIFICATION_INDEX_02,
+        clearable: isClearable(hit._index),
         ...hit._source,
       }));
     }

--- a/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
@@ -136,14 +136,12 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
     if (body.hits.total.value > 0) {
       let notificationIndex;
       messages = body.hits.hits.map((hit) => {
-        if (notificationIndex !== hit._index) {
+        if (notificationIndex !== hit._index && isClearable(hit._index)) {
           notificationIndices.push(hit._index);
           notificationIndex = hit._index;
         }
-        return {
-          clearable: isClearable(hit._index),
-          ...hit._source,
-        };
+
+        return hit._source;
       });
     }
     messages = await jobSavedObjectService.filterJobsForSpace(

--- a/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
+++ b/x-pack/plugins/ml/server/models/job_audit_messages/job_audit_messages.js
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import {
-  ML_NOTIFICATION_INDEX_PATTERN,
-  ML_NOTIFICATION_INDEX_02,
-} from '../../../common/constants/index_patterns';
+import { ML_NOTIFICATION_INDEX_PATTERN } from '../../../common/constants/index_patterns';
 import { MESSAGE_LEVEL } from '../../../common/constants/message_levels';
 import moment from 'moment';
 
@@ -134,18 +131,27 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
     });
 
     let messages = [];
+    const notificationIndices = [];
+
     if (body.hits.total.value > 0) {
-      messages = body.hits.hits.map((hit) => ({
-        clearable: isClearable(hit._index),
-        ...hit._source,
-      }));
+      let notificationIndex;
+      messages = body.hits.hits.map((hit) => {
+        if (notificationIndex !== hit._index) {
+          notificationIndices.push(hit._index);
+          notificationIndex = hit._index;
+        }
+        return {
+          clearable: isClearable(hit._index),
+          ...hit._source,
+        };
+      });
     }
     messages = await jobSavedObjectService.filterJobsForSpace(
       'anomaly-detector',
       messages,
       'job_id'
     );
-    return messages;
+    return { messages, notificationIndices };
   }
 
   // search highest, most recent audit messages for all jobs for the last 24hrs.
@@ -289,7 +295,7 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
   const clearedTime = new Date().getTime();
 
   // Sets 'cleared' to true for messages in the last 24hrs and index new message for clear action
-  async function clearJobAuditMessages(jobId) {
+  async function clearJobAuditMessages(jobId, notificationIndices) {
     const newClearedMessage = {
       job_id: jobId,
       job_type: 'anomaly_detection',
@@ -317,9 +323,9 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
       },
     };
 
-    await Promise.all([
+    const promises = [
       asInternalUser.updateByQuery({
-        index: ML_NOTIFICATION_INDEX_02,
+        index: notificationIndices.join(','),
         ignore_unavailable: true,
         refresh: false,
         conflicts: 'proceed',
@@ -331,12 +337,16 @@ export function jobAuditMessagesProvider({ asInternalUser }, mlClient) {
           },
         },
       }),
-      asInternalUser.index({
-        index: ML_NOTIFICATION_INDEX_02,
-        body: newClearedMessage,
-        refresh: 'wait_for',
-      }),
-    ]);
+      ...notificationIndices.map((index) =>
+        asInternalUser.index({
+          index,
+          body: newClearedMessage,
+          refresh: 'wait_for',
+        })
+      ),
+    ];
+
+    await Promise.all(promises);
 
     return { success: true, last_cleared: clearedTime };
   }

--- a/x-pack/plugins/ml/server/routes/job_audit_messages.ts
+++ b/x-pack/plugins/ml/server/routes/job_audit_messages.ts
@@ -121,8 +121,8 @@ export function jobAuditMessagesRoutes({ router, routeGuard }: RouteInitializati
       async ({ client, mlClient, request, response, jobSavedObjectService }) => {
         try {
           const { clearJobAuditMessages } = jobAuditMessagesProvider(client, mlClient);
-          const { jobId } = request.body;
-          const resp = await clearJobAuditMessages(jobId);
+          const { jobId, notificationIndices } = request.body;
+          const resp = await clearJobAuditMessages(jobId, notificationIndices);
 
           return response.ok({
             body: resp,

--- a/x-pack/plugins/ml/server/routes/schemas/job_audit_messages_schema.ts
+++ b/x-pack/plugins/ml/server/routes/schemas/job_audit_messages_schema.ts
@@ -20,4 +20,5 @@ export const jobAuditMessagesQuerySchema = schema.object({
 
 export const clearJobAuditMessagesBodySchema = schema.object({
   jobId: schema.string(),
+  notificationIndices: schema.arrayOf(schema.string()),
 });


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/kibana/issues/103742

This PR
- removes hard coding of the notifications index and checks that the index is clearable if it ends with a 6 digit number and that number is >= 2 since `.ml-notifications-000002` and up support clearing.
- updates the get audit messages endpoint to return a list of clearable indices that the messages are stored on
- passes the clearable index name(s) storing the job messages to the clear messages endpoint. This is for cases where a job may have messages indexed in two different ml-notifications-* indices.
- updates the disabled `Clear messages` button check so that it is enabled if any messages are from a clearable index




### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


