### PR TITLE
[APM] Return default error message when log and exception are not available

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/get_error_name.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/get_error_name.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { APMError } from '../../../typings/es_schemas/ui/apm_error';
+import { NOT_AVAILABLE_LABEL } from '../../../common/i18n';
+import { getErrorName } from './get_error_name';
+
+describe('getErrorName', () => {
+  it('returns log message', () => {
+    expect(
+      getErrorName({
+        error: {
+          log: { message: 'bar' },
+          exception: [{ message: 'foo' }],
+        },
+      } as APMError)
+    ).toEqual('bar');
+  });
+  it('returns exception message', () => {
+    expect(
+      getErrorName({
+        error: {
+          exception: [{ message: 'foo' }],
+        },
+      } as APMError)
+    ).toEqual('foo');
+  });
+  it('returns default message', () => {
+    expect(getErrorName({} as APMError)).toEqual(NOT_AVAILABLE_LABEL);
+  });
+});

--- a/x-pack/plugins/apm/server/lib/helpers/get_error_name.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/get_error_name.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
+import { NOT_AVAILABLE_LABEL } from '../../../common/i18n';
+import { Maybe } from '../../../typings/common';
 import { APMError } from '../../../typings/es_schemas/ui/apm_error';
 
-export function getErrorName({ error }: APMError) {
-  return error.log?.message || error.exception?.[0]?.message;
+export function getErrorName({ error }: { error: Maybe<APMError['error']> }) {
+  return (
+    error?.log?.message || error?.exception?.[0]?.message || NOT_AVAILABLE_LABEL
+  );
 }

--- a/x-pack/plugins/apm/server/lib/services/get_service_error_groups/get_service_error_group_main_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_error_groups/get_service_error_group_main_statistics.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { kqlQuery, rangeQuery } from '../../../../../observability/server';
 import {
   ERROR_EXC_MESSAGE,
   ERROR_GROUP_ID,
@@ -12,9 +13,7 @@ import {
   SERVICE_NAME,
   TRANSACTION_TYPE,
 } from '../../../../common/elasticsearch_fieldnames';
-import { NOT_AVAILABLE_LABEL } from '../../../../common/i18n';
 import { ProcessorEvent } from '../../../../common/processor_event';
-import { rangeQuery, kqlQuery } from '../../../../../observability/server';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getErrorName } from '../../helpers/get_error_name';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
@@ -82,8 +81,7 @@ export async function getServiceErrorGroupMainStatistics({
   const errorGroups =
     response.aggregations?.error_groups.buckets.map((bucket) => ({
       group_id: bucket.key as string,
-      name:
-        getErrorName(bucket.sample.hits.hits[0]._source) ?? NOT_AVAILABLE_LABEL,
+      name: getErrorName(bucket.sample.hits.hits[0]._source),
       last_seen: new Date(
         bucket.sample.hits.hits[0]?._source['@timestamp']
       ).getTime(),

--- a/x-pack/plugins/apm/server/lib/services/get_service_error_groups/index.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_error_groups/index.ts
@@ -5,13 +5,10 @@
  * 2.0.
  */
 
-import { ValuesType } from 'utility-types';
 import { orderBy } from 'lodash';
-import { NOT_AVAILABLE_LABEL } from '../../../../common/i18n';
+import { ValuesType } from 'utility-types';
+import { kqlQuery, rangeQuery } from '../../../../../observability/server';
 import { PromiseReturnType } from '../../../../../observability/typings/common';
-import { rangeQuery, kqlQuery } from '../../../../../observability/server';
-import { environmentQuery } from '../../../../common/utils/environment_query';
-import { ProcessorEvent } from '../../../../common/processor_event';
 import {
   ERROR_EXC_MESSAGE,
   ERROR_GROUP_ID,
@@ -19,10 +16,12 @@ import {
   SERVICE_NAME,
   TRANSACTION_TYPE,
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup, SetupTimeRange } from '../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../common/processor_event';
+import { environmentQuery } from '../../../../common/utils/environment_query';
+import { withApmSpan } from '../../../utils/with_apm_span';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { getErrorName } from '../../helpers/get_error_name';
-import { withApmSpan } from '../../../utils/with_apm_span';
+import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 
 export type ServiceErrorGroupItem = ValuesType<
   PromiseReturnType<typeof getServiceErrorGroups>
@@ -108,9 +107,7 @@ export async function getServiceErrorGroups({
     const errorGroups =
       response.aggregations?.error_groups.buckets.map((bucket) => ({
         group_id: bucket.key as string,
-        name:
-          getErrorName(bucket.sample.hits.hits[0]._source) ??
-          NOT_AVAILABLE_LABEL,
+        name: getErrorName(bucket.sample.hits.hits[0]._source),
         last_seen: new Date(
           bucket.sample.hits.hits[0]?._source['@timestamp']
         ).getTime(),


### PR DESCRIPTION
The query that groups error by `grouping_key` expects the error samples to have either a `log` or an `exception`. But these properties are not required, so there's no guarantee that we can use them.

I solve it by returning a fallback (`NOT_AVAILABLE_LABEL`) when those properties are not defined in the error object.

