### PR TITLE
[7.x] [App Search] Backport Domains Table and Add Domain Flyout for Crawler Overview (#101176)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_flyout.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiButton, EuiButtonEmpty, EuiFlyout, EuiFlyoutBody } from '@elastic/eui';
+
+import { AddDomainFlyout } from './add_domain_flyout';
+import { AddDomainForm } from './add_domain_form';
+import { AddDomainFormErrors } from './add_domain_form_errors';
+import { AddDomainFormSubmitButton } from './add_domain_form_submit_button';
+
+describe('AddDomainFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is hidden by default', () => {
+    const wrapper = shallow(<AddDomainFlyout />);
+
+    expect(wrapper.find(EuiFlyout)).toHaveLength(0);
+  });
+
+  it('displays the flyout when the button is pressed', () => {
+    const wrapper = shallow(<AddDomainFlyout />);
+
+    wrapper.find(EuiButton).simulate('click');
+
+    expect(wrapper.find(EuiFlyout)).toHaveLength(1);
+  });
+
+  describe('flyout', () => {
+    let wrapper: ShallowWrapper;
+
+    beforeEach(() => {
+      wrapper = shallow(<AddDomainFlyout />);
+
+      wrapper.find(EuiButton).simulate('click');
+    });
+
+    it('displays form errors', () => {
+      expect(wrapper.find(EuiFlyoutBody).dive().find(AddDomainFormErrors)).toHaveLength(1);
+    });
+
+    it('contains a form to add domains', () => {
+      expect(wrapper.find(AddDomainForm)).toHaveLength(1);
+    });
+
+    it('contains a cancel buttonn', () => {
+      wrapper.find(EuiButtonEmpty).simulate('click');
+      expect(wrapper.find(EuiFlyout)).toHaveLength(0);
+    });
+
+    it('contains a submit button', () => {
+      expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(1);
+    });
+
+    it('hides the flyout on close', () => {
+      wrapper.find(EuiFlyout).simulate('close');
+
+      expect(wrapper.find(EuiFlyout)).toHaveLength(0);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_flyout.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiPortal,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { CANCEL_BUTTON_LABEL } from '../../../../../shared/constants';
+
+import { AddDomainForm } from './add_domain_form';
+import { AddDomainFormErrors } from './add_domain_form_errors';
+import { AddDomainFormSubmitButton } from './add_domain_form_submit_button';
+
+export const AddDomainFlyout: React.FC = () => {
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+
+  return (
+    <>
+      <EuiButton
+        size="s"
+        color="success"
+        iconType="plusInCircle"
+        onClick={() => setIsFlyoutVisible(true)}
+      >
+        {i18n.translate(
+          'xpack.enterpriseSearch.appSearch.crawler.addDomainFlyout.openButtonLabel',
+          {
+            defaultMessage: 'Add domain',
+          }
+        )}
+      </EuiButton>
+
+      {isFlyoutVisible && (
+        <EuiPortal>
+          <EuiFlyout onClose={() => setIsFlyoutVisible(false)}>
+            <EuiFlyoutHeader>
+              <EuiTitle size="m">
+                <h2>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.appSearch.crawler.addDomainFlyout.title',
+                    {
+                      defaultMessage: 'Add a new domain',
+                    }
+                  )}
+                </h2>
+              </EuiTitle>
+            </EuiFlyoutHeader>
+            <EuiFlyoutBody banner={<AddDomainFormErrors />}>
+              <EuiText>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.addDomainFlyout.description',
+                  {
+                    defaultMessage:
+                      'You can add multiple domains to this engine\'s web crawler. Add another domain here and modify the entry points and crawl rules from the "Manage" page.',
+                  }
+                )}
+                <p />
+              </EuiText>
+              <EuiSpacer size="l" />
+              <AddDomainForm />
+            </EuiFlyoutBody>
+            <EuiFlyoutFooter>
+              <EuiFlexGroup justifyContent="spaceBetween">
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty onClick={() => setIsFlyoutVisible(false)}>
+                    {CANCEL_BUTTON_LABEL}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <AddDomainFormSubmitButton />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlyoutFooter>
+          </EuiFlyout>
+        </EuiPortal>
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockActions, setMockValues } from '../../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiButton, EuiFieldText, EuiForm } from '@elastic/eui';
+
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { rerender } from '../../../../../test_helpers';
+
+import { AddDomainForm } from './add_domain_form';
+
+const MOCK_VALUES = {
+  addDomainFormInputValue: 'https://',
+  entryPointValue: '/',
+};
+
+const MOCK_ACTIONS = {
+  setAddDomainFormInputValue: jest.fn(),
+  validateDomain: jest.fn(),
+};
+
+describe('AddDomainForm', () => {
+  let wrapper: ShallowWrapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockActions(MOCK_ACTIONS);
+    setMockValues(MOCK_VALUES);
+    wrapper = shallow(<AddDomainForm />);
+  });
+
+  it('renders', () => {
+    expect(wrapper.find(EuiForm)).toHaveLength(1);
+  });
+
+  it('contains a submit button', () => {
+    expect(wrapper.find(EuiButton).prop('type')).toEqual('submit');
+  });
+
+  it('validates domain on submit', () => {
+    wrapper.find(EuiForm).simulate('submit', { preventDefault: jest.fn() });
+
+    expect(MOCK_ACTIONS.validateDomain).toHaveBeenCalledTimes(1);
+  });
+
+  describe('url field', () => {
+    it('uses the value from the logic', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        addDomainFormInputValue: 'test value',
+      });
+
+      rerender(wrapper);
+
+      expect(wrapper.find(EuiFieldText).prop('value')).toEqual('test value');
+    });
+
+    it('sets the value in the logic on change', () => {
+      wrapper.find(EuiFieldText).simulate('change', { target: { value: 'test value' } });
+
+      expect(MOCK_ACTIONS.setAddDomainFormInputValue).toHaveBeenCalledWith('test value');
+    });
+  });
+
+  describe('validate domain button', () => {
+    it('is enabled when the input has a value', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        addDomainFormInputValue: 'https://elastic.co',
+      });
+
+      rerender(wrapper);
+
+      expect(wrapper.find(EuiButton).prop('disabled')).toEqual(false);
+    });
+
+    it('is disabled when the input value is empty', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        addDomainFormInputValue: '',
+      });
+
+      rerender(wrapper);
+
+      expect(wrapper.find(EuiButton).prop('disabled')).toEqual(true);
+    });
+  });
+
+  describe('entry point indicator', () => {
+    it('is hidden when the entry point is /', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        entryPointValue: '/',
+      });
+
+      rerender(wrapper);
+
+      expect(wrapper.find(FormattedMessage)).toHaveLength(0);
+    });
+
+    it('displays the entry point otherwise', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        entryPointValue: '/guide',
+      });
+
+      rerender(wrapper);
+
+      expect(wrapper.find(FormattedMessage)).toHaveLength(1);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import {
+  EuiButton,
+  EuiCode,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiFieldText,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { AddDomainLogic } from './add_domain_logic';
+
+export const AddDomainForm: React.FC = () => {
+  const { setAddDomainFormInputValue, validateDomain } = useActions(AddDomainLogic);
+
+  const { addDomainFormInputValue, entryPointValue } = useValues(AddDomainLogic);
+
+  return (
+    <>
+      <EuiForm
+        onSubmit={(event) => {
+          event.preventDefault();
+          validateDomain();
+        }}
+        component="form"
+      >
+        <EuiFormRow
+          fullWidth
+          label={
+            i18n.translate('xpack.enterpriseSearch.appSearch.crawler.addDomainForm.urlLabel', {
+              defaultMessage: 'Domain URL',
+            }) /* "Domain URL"*/
+          }
+          helpText={
+            <EuiText size="s">
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.urlHelpText',
+                {
+                  defaultMessage: 'Domain URLs require a protocol and cannot contain any paths.',
+                }
+              )}
+            </EuiText>
+          }
+        >
+          <EuiFlexGroup>
+            <EuiFlexItem grow>
+              <EuiFieldText
+                autoFocus
+                placeholder="https://"
+                value={addDomainFormInputValue}
+                onChange={(e) => setAddDomainFormInputValue(e.target.value)}
+                fullWidth
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton type="submit" fill disabled={addDomainFormInputValue.length === 0}>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.validateButtonLabel',
+                  {
+                    defaultMessage: 'Validate Domain',
+                  }
+                )}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFormRow>
+
+        {entryPointValue !== '/' && (
+          <>
+            <EuiSpacer />
+            <EuiText size="s">
+              <p>
+                <strong>
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.appSearch.crawler.addDomainForm.entryPointLabel"
+                    defaultMessage="Web Crawler entry point has been set as {entryPointValue}"
+                    values={{
+                      entryPointValue: <EuiCode>{entryPointValue}</EuiCode>,
+                    }}
+                  />
+                </strong>
+              </p>
+            </EuiText>
+          </>
+        )}
+      </EuiForm>
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_errors.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { setMockValues } from '../../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { AddDomainFormErrors } from './add_domain_form_errors';
+
+describe('AddDomainFormErrors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is empty when there are no errors', () => {
+    setMockValues({
+      errors: [],
+    });
+
+    const wrapper = shallow(<AddDomainFormErrors />);
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('displays all the errors from the logic', () => {
+    setMockValues({
+      errors: ['first error', 'second error'],
+    });
+
+    const wrapper = shallow(<AddDomainFormErrors />);
+
+    expect(wrapper.find('p')).toHaveLength(2);
+    expect(wrapper.find('p').first().text()).toContain('first error');
+    expect(wrapper.find('p').last().text()).toContain('second error');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_errors.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { AddDomainLogic } from './add_domain_logic';
+
+export const AddDomainFormErrors: React.FC = () => {
+  const { errors } = useValues(AddDomainLogic);
+
+  if (errors.length > 0) {
+    return (
+      <EuiCallOut
+        color="danger"
+        iconType="alert"
+        title={i18n.translate(
+          'xpack.enterpriseSearch.appSearch.crawler.addDomainForm.errorsTitle',
+          {
+            defaultMessage: 'Something went wrong. Please address the errors and try again.',
+          }
+        )}
+      >
+        {errors.map((message, index) => (
+          <p key={index}>{message}</p>
+        ))}
+      </EuiCallOut>
+    );
+  }
+
+  return null;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_submit_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_submit_button.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockActions, setMockValues } from '../../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiButton } from '@elastic/eui';
+
+import { AddDomainFormSubmitButton } from './add_domain_form_submit_button';
+
+describe('AddDomainFormSubmitButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is disabled when the domain has not been validated', () => {
+    setMockValues({
+      hasValidationCompleted: false,
+    });
+
+    const wrapper = shallow(<AddDomainFormSubmitButton />);
+
+    expect(wrapper.prop('disabled')).toBe(true);
+  });
+
+  it('is enabled when the domain has been validated', () => {
+    setMockValues({
+      hasValidationCompleted: true,
+    });
+
+    const wrapper = shallow(<AddDomainFormSubmitButton />);
+
+    expect(wrapper.prop('disabled')).toBe(false);
+  });
+
+  it('submits the domain on click', () => {
+    const submitNewDomain = jest.fn();
+
+    setMockActions({
+      submitNewDomain,
+    });
+    setMockValues({
+      hasValidationCompleted: true,
+    });
+
+    const wrapper = shallow(<AddDomainFormSubmitButton />);
+
+    wrapper.find(EuiButton).simulate('click');
+
+    expect(submitNewDomain).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_submit_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_form_submit_button.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiButton } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { AddDomainLogic } from './add_domain_logic';
+
+export const AddDomainFormSubmitButton: React.FC = () => {
+  const { submitNewDomain } = useActions(AddDomainLogic);
+
+  const { hasValidationCompleted } = useValues(AddDomainLogic);
+
+  return (
+    <EuiButton fill type="button" disabled={!hasValidationCompleted} onClick={submitNewDomain}>
+      {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.addDomainForm.submitButtonLabel', {
+        defaultMessage: 'Add domain',
+      })}
+    </EuiButton>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -21,12 +21,18 @@ jest.mock('../../crawler_overview_logic', () => ({
   },
 }));
 
+jest.mock('./utils', () => ({
+  ...(jest.requireActual('./utils') as object),
+  getDomainWithProtocol: jest.fn().mockImplementation((domain) => domain),
+}));
+
 import { nextTick } from '@kbn/test/jest';
 
 import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
 import { CrawlerDomain } from '../../types';
 
 import { AddDomainLogic, AddDomainLogicValues } from './add_domain_logic';
+import { getDomainWithProtocol } from './utils';
 
 const DEFAULT_VALUES: AddDomainLogicValues = {
   addDomainFormInputValue: 'https://',
@@ -272,16 +278,18 @@ describe('AddDomainLogic', () => {
     });
 
     describe('validateDomain', () => {
-      it('extracts the domain and entrypoint and passes them to the callback ', () => {
+      it('extracts the domain and entrypoint and passes them to the callback ', async () => {
         mount({ addDomainFormInputValue: 'https://swiftype.com/site-search' });
         jest.spyOn(AddDomainLogic.actions, 'onValidateDomain');
 
         AddDomainLogic.actions.validateDomain();
+        await nextTick();
 
         expect(AddDomainLogic.actions.onValidateDomain).toHaveBeenCalledWith(
           'https://swiftype.com',
           '/site-search'
         );
+        expect(getDomainWithProtocol).toHaveBeenCalledWith('https://swiftype.com');
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -1,0 +1,300 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  LogicMounter,
+  mockFlashMessageHelpers,
+  mockHttpValues,
+  mockKibanaValues,
+} from '../../../../../__mocks__/kea_logic';
+import '../../../../__mocks__/engine_logic.mock';
+
+jest.mock('../../crawler_overview_logic', () => ({
+  CrawlerOverviewLogic: {
+    actions: {
+      onReceiveCrawlerData: jest.fn(),
+    },
+  },
+}));
+
+import { nextTick } from '@kbn/test/jest';
+
+import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
+import { CrawlerDomain } from '../../types';
+
+import { AddDomainLogic, AddDomainLogicValues } from './add_domain_logic';
+
+const DEFAULT_VALUES: AddDomainLogicValues = {
+  addDomainFormInputValue: 'https://',
+  allowSubmit: false,
+  entryPointValue: '/',
+  hasValidationCompleted: false,
+  errors: [],
+};
+
+describe('AddDomainLogic', () => {
+  const { mount } = new LogicMounter(AddDomainLogic);
+  const { flashSuccessToast } = mockFlashMessageHelpers;
+  const { http } = mockHttpValues;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has default values', () => {
+    mount();
+    expect(AddDomainLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    describe('clearDomainFormInputValue', () => {
+      beforeAll(() => {
+        mount({
+          addDomainFormInputValue: 'http://elastic.co',
+          entryPointValue: '/foo',
+          hasValidationCompleted: true,
+          errors: ['first error', 'second error'],
+        });
+
+        AddDomainLogic.actions.clearDomainFormInputValue();
+      });
+
+      it('should clear the input value', () => {
+        expect(AddDomainLogic.values.addDomainFormInputValue).toEqual('https://');
+      });
+
+      it('should clear the entry point value', () => {
+        expect(AddDomainLogic.values.entryPointValue).toEqual('/');
+      });
+
+      it('should reset validation completion', () => {
+        expect(AddDomainLogic.values.hasValidationCompleted).toEqual(false);
+      });
+
+      it('should clear errors', () => {
+        expect(AddDomainLogic.values.errors).toEqual([]);
+      });
+    });
+
+    describe('onSubmitNewDomainError', () => {
+      it('should set errors', () => {
+        mount();
+
+        AddDomainLogic.actions.onSubmitNewDomainError(['first error', 'second error']);
+
+        expect(AddDomainLogic.values.errors).toEqual(['first error', 'second error']);
+      });
+    });
+
+    describe('onValidateDomain', () => {
+      beforeAll(() => {
+        mount({
+          addDomainFormInputValue: 'https://elastic.co',
+          entryPointValue: '/customers',
+          hasValidationCompleted: true,
+          errors: ['first error', 'second error'],
+        });
+
+        AddDomainLogic.actions.onValidateDomain('https://swiftype.com', '/site-search');
+      });
+
+      it('should set the input value', () => {
+        expect(AddDomainLogic.values.addDomainFormInputValue).toEqual('https://swiftype.com');
+      });
+
+      it('should set the entry point value', () => {
+        expect(AddDomainLogic.values.entryPointValue).toEqual('/site-search');
+      });
+
+      it('should flag validation as being completed', () => {
+        expect(AddDomainLogic.values.hasValidationCompleted).toEqual(true);
+      });
+
+      it('should clear errors', () => {
+        expect(AddDomainLogic.values.errors).toEqual([]);
+      });
+    });
+
+    describe('setAddDomainFormInputValue', () => {
+      beforeAll(() => {
+        mount({
+          addDomainFormInputValue: 'https://elastic.co',
+          entryPointValue: '/customers',
+          hasValidationCompleted: true,
+          errors: ['first error', 'second error'],
+        });
+
+        AddDomainLogic.actions.setAddDomainFormInputValue('https://swiftype.com/site-search');
+      });
+
+      it('should set the input value', () => {
+        expect(AddDomainLogic.values.addDomainFormInputValue).toEqual(
+          'https://swiftype.com/site-search'
+        );
+      });
+
+      it('should clear the entry point value', () => {
+        expect(AddDomainLogic.values.entryPointValue).toEqual('/');
+      });
+
+      it('should reset validation completion', () => {
+        expect(AddDomainLogic.values.hasValidationCompleted).toEqual(false);
+      });
+
+      it('should clear errors', () => {
+        expect(AddDomainLogic.values.errors).toEqual([]);
+      });
+    });
+
+    describe('submitNewDomain', () => {
+      it('should clear errors', () => {
+        expect(AddDomainLogic.values.errors).toEqual([]);
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('onSubmitNewDomainSuccess', () => {
+      it('should flash a success toast', () => {
+        const { navigateToUrl } = mockKibanaValues;
+        mount();
+
+        AddDomainLogic.actions.onSubmitNewDomainSuccess({ id: 'test-domain' } as CrawlerDomain);
+
+        expect(flashSuccessToast).toHaveBeenCalled();
+        expect(navigateToUrl).toHaveBeenCalledWith(
+          '/engines/some-engine/crawler/domains/test-domain'
+        );
+      });
+    });
+
+    describe('submitNewDomain', () => {
+      it('calls the domains endpoint with a JSON formatted body', async () => {
+        mount({
+          addDomainFormInputValue: 'https://elastic.co',
+          entryPointValue: '/guide',
+        });
+        http.post.mockReturnValueOnce(Promise.resolve({}));
+
+        AddDomainLogic.actions.submitNewDomain();
+        await nextTick();
+
+        expect(http.post).toHaveBeenCalledWith(
+          '/api/app_search/engines/some-engine/crawler/domains',
+          {
+            query: {
+              respond_with: 'crawler_details',
+            },
+            body: JSON.stringify({
+              name: 'https://elastic.co',
+              entry_points: [{ value: '/guide' }],
+            }),
+          }
+        );
+      });
+
+      describe('on success', () => {
+        beforeEach(() => {
+          mount();
+        });
+
+        it('sets crawler data', async () => {
+          http.post.mockReturnValueOnce(
+            Promise.resolve({
+              domains: [],
+            })
+          );
+
+          AddDomainLogic.actions.submitNewDomain();
+          await nextTick();
+
+          expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith({
+            domains: [],
+          });
+        });
+
+        it('calls the success callback with the most recent domain', async () => {
+          http.post.mockReturnValueOnce(
+            Promise.resolve({
+              domains: [
+                {
+                  id: '1',
+                  name: 'https://elastic.co/guide',
+                },
+                {
+                  id: '2',
+                  name: 'https://swiftype.co/site-search',
+                },
+              ],
+            })
+          );
+          jest.spyOn(AddDomainLogic.actions, 'onSubmitNewDomainSuccess');
+          AddDomainLogic.actions.submitNewDomain();
+          await nextTick();
+
+          expect(AddDomainLogic.actions.onSubmitNewDomainSuccess).toHaveBeenCalledWith({
+            id: '2',
+            url: 'https://swiftype.co/site-search',
+          });
+        });
+      });
+
+      describe('on error', () => {
+        beforeEach(() => {
+          mount();
+          jest.spyOn(AddDomainLogic.actions, 'onSubmitNewDomainError');
+        });
+
+        it('passes error messages to the error callback', async () => {
+          http.post.mockReturnValueOnce(
+            Promise.reject({
+              body: {
+                attributes: {
+                  errors: ['first error', 'second error'],
+                },
+              },
+            })
+          );
+
+          AddDomainLogic.actions.submitNewDomain();
+          await nextTick();
+
+          expect(AddDomainLogic.actions.onSubmitNewDomainError).toHaveBeenCalledWith([
+            'first error',
+            'second error',
+          ]);
+        });
+      });
+    });
+
+    describe('validateDomain', () => {
+      it('extracts the domain and entrypoint and passes them to the callback ', () => {
+        mount({ addDomainFormInputValue: 'https://swiftype.com/site-search' });
+        jest.spyOn(AddDomainLogic.actions, 'onValidateDomain');
+
+        AddDomainLogic.actions.validateDomain();
+
+        expect(AddDomainLogic.actions.onValidateDomain).toHaveBeenCalledWith(
+          'https://swiftype.com',
+          '/site-search'
+        );
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('allowSubmit', () => {
+      it('gets set true when validation is completed', () => {
+        mount({ hasValidationCompleted: false });
+        expect(AddDomainLogic.values.allowSubmit).toEqual(false);
+
+        mount({ hasValidationCompleted: true });
+        expect(AddDomainLogic.values.allowSubmit).toEqual(true);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.ts
@@ -21,7 +21,7 @@ import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
 import { CrawlerDataFromServer, CrawlerDomain } from '../../types';
 import { crawlerDataServerToClient } from '../../utils';
 
-import { extractDomainAndEntryPointFromUrl } from './utils';
+import { extractDomainAndEntryPointFromUrl, getDomainWithProtocol } from './utils';
 
 export interface AddDomainLogicValues {
   addDomainFormInputValue: string;
@@ -156,11 +156,14 @@ export const AddDomainLogic = kea<MakeLogicType<AddDomainLogicValues, AddDomainL
         actions.onSubmitNewDomainError(errorMessages);
       }
     },
-    validateDomain: () => {
+    validateDomain: async () => {
       const { domain, entryPoint } = extractDomainAndEntryPointFromUrl(
         values.addDomainFormInputValue.trim()
       );
-      actions.onValidateDomain(domain, entryPoint);
+
+      const domainWithProtocol = await getDomainWithProtocol(domain);
+
+      actions.onValidateDomain(domainWithProtocol, entryPoint);
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { i18n } from '@kbn/i18n';
+
+import { flashSuccessToast } from '../../../../../shared/flash_messages';
+import { getErrorsFromHttpResponse } from '../../../../../shared/flash_messages/handle_api_errors';
+
+import { HttpLogic } from '../../../../../shared/http';
+import { KibanaLogic } from '../../../../../shared/kibana';
+import { ENGINE_CRAWLER_DOMAIN_PATH } from '../../../../routes';
+import { EngineLogic, generateEnginePath } from '../../../engine';
+
+import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
+import { CrawlerDataFromServer, CrawlerDomain } from '../../types';
+import { crawlerDataServerToClient } from '../../utils';
+
+import { extractDomainAndEntryPointFromUrl } from './utils';
+
+export interface AddDomainLogicValues {
+  addDomainFormInputValue: string;
+  allowSubmit: boolean;
+  hasValidationCompleted: boolean;
+  entryPointValue: string;
+  errors: string[];
+}
+
+export interface AddDomainLogicActions {
+  clearDomainFormInputValue(): void;
+  setAddDomainFormInputValue(newValue: string): string;
+  onSubmitNewDomainError(errors: string[]): { errors: string[] };
+  onSubmitNewDomainSuccess(domain: CrawlerDomain): { domain: CrawlerDomain };
+  onValidateDomain(
+    newValue: string,
+    newEntryPointValue: string
+  ): { newValue: string; newEntryPointValue: string };
+  submitNewDomain(): void;
+  validateDomain(): void;
+}
+
+const DEFAULT_SELECTOR_VALUES = {
+  addDomainFormInputValue: 'https://',
+  entryPointValue: '/',
+};
+
+export const AddDomainLogic = kea<MakeLogicType<AddDomainLogicValues, AddDomainLogicActions>>({
+  path: ['enterprise_search', 'app_search', 'crawler', 'add_domain'],
+  actions: () => ({
+    clearDomainFormInputValue: true,
+    setAddDomainFormInputValue: (newValue) => newValue,
+    onSubmitNewDomainSuccess: (domain) => ({ domain }),
+    onSubmitNewDomainError: (errors) => ({ errors }),
+    onValidateDomain: (newValue, newEntryPointValue) => ({
+      newValue,
+      newEntryPointValue,
+    }),
+    submitNewDomain: true,
+    validateDomain: true,
+  }),
+  reducers: () => ({
+    addDomainFormInputValue: [
+      DEFAULT_SELECTOR_VALUES.addDomainFormInputValue,
+      {
+        clearDomainFormInputValue: () => DEFAULT_SELECTOR_VALUES.addDomainFormInputValue,
+        setAddDomainFormInputValue: (_, newValue: string) => newValue,
+        onValidateDomain: (_, { newValue }: { newValue: string }) => newValue,
+      },
+    ],
+    entryPointValue: [
+      DEFAULT_SELECTOR_VALUES.entryPointValue,
+      {
+        clearDomainFormInputValue: () => DEFAULT_SELECTOR_VALUES.entryPointValue,
+        setAddDomainFormInputValue: () => DEFAULT_SELECTOR_VALUES.entryPointValue,
+        onValidateDomain: (_, { newEntryPointValue }) => newEntryPointValue,
+      },
+    ],
+    // TODO When 4-step validation is added this will become a selector as
+    // we'll use individual step results to determine whether this is true/false
+    hasValidationCompleted: [
+      false,
+      {
+        clearDomainFormInputValue: () => false,
+        setAddDomainFormInputValue: () => false,
+        onValidateDomain: () => true,
+      },
+    ],
+    errors: [
+      [],
+      {
+        clearDomainFormInputValue: () => [],
+        setAddDomainFormInputValue: () => [],
+        onValidateDomain: () => [],
+        submitNewDomain: () => [],
+        onSubmitNewDomainError: (_, { errors }) => errors,
+      },
+    ],
+  }),
+  selectors: ({ selectors }) => ({
+    // TODO include selectors.blockingFailures once 4-step validation is migrated
+    allowSubmit: [
+      () => [selectors.hasValidationCompleted], // should eventually also contain selectors.hasBlockingFailures when that is added
+      (hasValidationCompleted: boolean) => hasValidationCompleted, // && !hasBlockingFailures
+    ],
+  }),
+  listeners: ({ actions, values }) => ({
+    onSubmitNewDomainSuccess: ({ domain }) => {
+      flashSuccessToast(
+        i18n.translate(
+          'xpack.enterpriseSearch.appSearch.crawler.domainsTable.action.add.successMessage',
+          {
+            defaultMessage: "Successfully added domain '{domainUrl}'",
+            values: {
+              domainUrl: domain.url,
+            },
+          }
+        )
+      );
+      KibanaLogic.values.navigateToUrl(
+        generateEnginePath(ENGINE_CRAWLER_DOMAIN_PATH, { domainId: domain.id })
+      );
+    },
+    submitNewDomain: async () => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      const requestBody = JSON.stringify({
+        name: values.addDomainFormInputValue.trim(),
+        entry_points: [{ value: values.entryPointValue }],
+      });
+
+      try {
+        const response = await http.post(`/api/app_search/engines/${engineName}/crawler/domains`, {
+          query: {
+            respond_with: 'crawler_details',
+          },
+          body: requestBody,
+        });
+
+        const crawlerData = crawlerDataServerToClient(response as CrawlerDataFromServer);
+        CrawlerOverviewLogic.actions.onReceiveCrawlerData(crawlerData);
+        const newDomain = crawlerData.domains[crawlerData.domains.length - 1];
+        if (newDomain) {
+          actions.onSubmitNewDomainSuccess(newDomain);
+        }
+        // If there is not a new domain, that means the server responded with a 200 but
+        // didn't actually persist the new domain to our BE, and we take no action
+      } catch (e) {
+        // we surface errors inside the form instead of in flash messages
+        const errorMessages = getErrorsFromHttpResponse(e);
+        actions.onSubmitNewDomainError(errorMessages);
+      }
+    },
+    validateDomain: () => {
+      const { domain, entryPoint } = extractDomainAndEntryPointFromUrl(
+        values.addDomainFormInputValue.trim()
+      );
+      actions.onValidateDomain(domain, entryPoint);
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { extractDomainAndEntryPointFromUrl } from './utils';
+
+describe('extractDomainAndEntryPointFromUrl', () => {
+  it('extracts a provided entry point and domain', () => {
+    expect(extractDomainAndEntryPointFromUrl('https://elastic.co/guide')).toEqual({
+      domain: 'https://elastic.co',
+      entryPoint: '/guide',
+    });
+  });
+
+  it('provides a default entry point if there is only a domain', () => {
+    expect(extractDomainAndEntryPointFromUrl('https://elastic.co')).toEqual({
+      domain: 'https://elastic.co',
+      entryPoint: '/',
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.test.ts
@@ -4,7 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { extractDomainAndEntryPointFromUrl } from './utils';
+import { mockHttpValues } from '../../../../../__mocks__/kea_logic';
+
+import { extractDomainAndEntryPointFromUrl, getDomainWithProtocol } from './utils';
 
 describe('extractDomainAndEntryPointFromUrl', () => {
   it('extracts a provided entry point and domain', () => {
@@ -19,5 +21,69 @@ describe('extractDomainAndEntryPointFromUrl', () => {
       domain: 'https://elastic.co',
       entryPoint: '/',
     });
+  });
+});
+
+describe('getDomainWithProtocol', () => {
+  const { http } = mockHttpValues;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes through domain if it starts with https', async () => {
+    const result = await getDomainWithProtocol('https://elastic.co');
+
+    expect(result).toEqual('https://elastic.co');
+    expect(http.post).toHaveBeenCalledTimes(0);
+  });
+
+  it('passes through domain if it starts with http', async () => {
+    const result = await getDomainWithProtocol('http://elastic.co');
+
+    expect(result).toEqual('http://elastic.co');
+    expect(http.post).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns domain with https protocol if the back-end validates https', async () => {
+    http.post.mockReturnValueOnce(Promise.resolve({ valid: true }));
+    const result = await getDomainWithProtocol('elastic.co');
+
+    expect(result).toEqual('https://elastic.co');
+    expect(http.post).toHaveBeenCalledTimes(1);
+    expect(http.post).toHaveBeenCalledWith('/api/app_search/crawler/validate_url', {
+      body: JSON.stringify({ url: 'https://elastic.co', checks: ['tcp', 'url_request'] }),
+    });
+  });
+
+  it('returns domain with http protocol if the back-end validates http', async () => {
+    http.post
+      .mockReturnValueOnce(Promise.resolve({ valid: false }))
+      .mockReturnValueOnce(Promise.resolve({ valid: true }));
+    const result = await getDomainWithProtocol('elastic.co');
+
+    expect(result).toEqual('http://elastic.co');
+    expect(http.post).toHaveBeenCalledTimes(2);
+    expect(http.post).toHaveBeenLastCalledWith('/api/app_search/crawler/validate_url', {
+      body: JSON.stringify({ url: 'http://elastic.co', checks: ['tcp', 'url_request'] }),
+    });
+  });
+
+  it('passes through domain if back-end throws error', async () => {
+    http.post.mockReturnValueOnce(Promise.reject());
+
+    const result = await getDomainWithProtocol('elastic.co');
+
+    expect(result).toEqual('elastic.co');
+    expect(http.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through domain if back-end fails to validate https and http', async () => {
+    http.post.mockReturnValueOnce(Promise.resolve({ valid: false }));
+    http.post.mockReturnValueOnce(Promise.resolve({ valid: false }));
+    const result = await getDomainWithProtocol('elastic.co');
+
+    expect(result).toEqual('elastic.co');
+    expect(http.post).toHaveBeenCalledTimes(2);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/utils.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const extractDomainAndEntryPointFromUrl = (
+  url: string
+): { domain: string; entryPoint: string } => {
+  let domain = url;
+  let entryPoint = '/';
+
+  const pathSlashIndex = url.search(/[^\:\/]\//);
+  if (pathSlashIndex !== -1) {
+    domain = url.substring(0, pathSlashIndex + 1);
+    entryPoint = url.substring(pathSlashIndex + 1);
+  }
+
+  return { domain, entryPoint };
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/custom_formatted_timestamp.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/custom_formatted_timestamp.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { FormattedRelative } from '@kbn/i18n/react';
+
+import { FormattedDateTime } from '../../../utils/formatted_date_time';
+
+import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
+
+describe('CustomFormattedTimestamp', () => {
+  const mockToday = jest
+    .spyOn(global.Date, 'now')
+    .mockImplementation(() => new Date('1970-01-02').valueOf());
+
+  afterAll(() => mockToday.mockRestore());
+
+  it('uses a relative time format (x minutes ago) if the timestamp is from today', () => {
+    const wrapper = shallow(<CustomFormattedTimestamp timestamp="1970-01-02" />);
+
+    expect(wrapper.find(FormattedRelative).prop('value')).toEqual(new Date('1970-01-02'));
+  });
+
+  it('uses a date if the timestamp is before today', () => {
+    const wrapper = shallow(<CustomFormattedTimestamp timestamp="1970-01-01" />);
+
+    expect(wrapper.find(FormattedDateTime).prop('date')).toEqual(new Date('1970-01-01'));
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/custom_formatted_timestamp.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/custom_formatted_timestamp.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { FormattedRelative } from '@kbn/i18n/react';
+
+import { FormattedDateTime } from '../../../utils/formatted_date_time';
+
+interface CustomFormattedTimestampProps {
+  timestamp: string;
+}
+
+export const CustomFormattedTimestamp: React.FC<CustomFormattedTimestampProps> = ({
+  timestamp,
+}) => {
+  const date = new Date(timestamp);
+  const isDateToday = date >= new Date(new Date(Date.now()).toDateString());
+  return isDateToday ? (
+    <FormattedRelative value={date} />
+  ) : (
+    <FormattedDateTime date={date} hideTime />
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/domains_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/domains_table.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockKibanaValues, setMockActions, setMockValues } from '../../../../__mocks__/kea_logic';
+import '../../../__mocks__/engine_logic.mock';
+
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiBasicTable, EuiButtonIcon, EuiInMemoryTable } from '@elastic/eui';
+
+import { mountWithIntl } from '../../../../test_helpers';
+
+import { CrawlerDomain } from '../types';
+
+import { DomainsTable } from './domains_table';
+
+const domains: CrawlerDomain[] = [
+  {
+    id: '1234',
+    documentCount: 9999,
+    url: 'elastic.co',
+    crawlRules: [],
+    entryPoints: [],
+    sitemaps: [],
+    lastCrawl: '2020-01-01T00:00:00-05:00',
+    createdOn: '2020-01-01T00:00:00-05:00',
+  },
+];
+
+const values = {
+  // EngineLogic
+  engineName: 'some-engine',
+  // CrawlerOverviewLogic
+  domains,
+  // AppLogic
+  myRole: { canManageEngineCrawler: false },
+};
+
+const actions = {
+  // CrawlerOverviewLogic
+  deleteDomain: jest.fn(),
+};
+
+describe('DomainsTable', () => {
+  let wrapper: ShallowWrapper;
+  let tableContent: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  beforeAll(() => {
+    setMockValues(values);
+    setMockActions(actions);
+    wrapper = shallow(<DomainsTable />);
+    tableContent = mountWithIntl(<DomainsTable />)
+      .find(EuiInMemoryTable)
+      .text();
+  });
+
+  it('renders', () => {
+    expect(wrapper.find(EuiInMemoryTable)).toHaveLength(1);
+  });
+
+  describe('columns', () => {
+    const getTable = () => wrapper.find(EuiInMemoryTable).dive().find(EuiBasicTable).dive();
+
+    beforeEach(() => {
+      wrapper = shallow(<DomainsTable />);
+      tableContent = mountWithIntl(<DomainsTable />)
+        .find(EuiInMemoryTable)
+        .text();
+    });
+
+    it('renders a url column', () => {
+      expect(tableContent).toContain('elastic.co');
+    });
+
+    it('renders a last crawled column', () => {
+      expect(tableContent).toContain('Last activity');
+      expect(tableContent).toContain('Jan 1, 2020');
+    });
+
+    it('renders a document count column', () => {
+      expect(tableContent).toContain('Documents');
+      expect(tableContent).toContain('9,999');
+    });
+
+    describe('actions column', () => {
+      const getActions = () => getTable().find('ExpandedItemActions');
+      const getActionItems = () => getActions().dive().find('DefaultItemAction');
+
+      it('will hide the action buttons if the user cannot manage/delete engines', () => {
+        setMockValues({
+          ...values,
+          // AppLogic
+          myRole: { canManageEngineCrawler: false },
+        });
+        wrapper = shallow(<DomainsTable />);
+
+        expect(getActions()).toHaveLength(0);
+      });
+
+      describe('when the user can manage/delete engines', () => {
+        const getManageAction = () => getActionItems().at(0).dive().find(EuiButtonIcon);
+        const getDeleteAction = () => getActionItems().at(1).dive().find(EuiButtonIcon);
+
+        beforeEach(() => {
+          setMockValues({
+            ...values,
+            // AppLogic
+            myRole: { canManageEngineCrawler: true },
+          });
+          wrapper = shallow(<DomainsTable />);
+        });
+
+        describe('manage action', () => {
+          it('sends the user to the engine overview on click', () => {
+            const { navigateToUrl } = mockKibanaValues;
+
+            getManageAction().simulate('click');
+
+            expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/crawler/domains/1234');
+          });
+        });
+
+        describe('delete action', () => {
+          it('clicking the action and confirming deletes the domain', () => {
+            jest.spyOn(global, 'confirm').mockReturnValueOnce(true);
+
+            getDeleteAction().simulate('click');
+
+            expect(actions.deleteDomain).toHaveBeenCalledWith(
+              expect.objectContaining({ id: '1234' })
+            );
+          });
+
+          it('clicking the action and not confirming does not delete the engine', () => {
+            jest.spyOn(global, 'confirm').mockReturnValueOnce(false);
+
+            getDeleteAction().simulate('click');
+
+            expect(actions.deleteDomain).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/domains_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/domains_table.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiInMemoryTable, EuiBasicTableColumn } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { FormattedNumber } from '@kbn/i18n/react';
+
+import { DELETE_BUTTON_LABEL, MANAGE_BUTTON_LABEL } from '../../../../shared/constants';
+import { KibanaLogic } from '../../../../shared/kibana';
+import { AppLogic } from '../../../app_logic';
+import { ENGINE_CRAWLER_DOMAIN_PATH } from '../../../routes';
+import { generateEnginePath } from '../../engine';
+import { CrawlerOverviewLogic } from '../crawler_overview_logic';
+import { CrawlerDomain } from '../types';
+
+import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
+
+export const DomainsTable: React.FC = () => {
+  const { domains } = useValues(CrawlerOverviewLogic);
+
+  const { deleteDomain } = useActions(CrawlerOverviewLogic);
+
+  const {
+    myRole: { canManageEngineCrawler },
+  } = useValues(AppLogic);
+
+  const columns: Array<EuiBasicTableColumn<CrawlerDomain>> = [
+    {
+      field: 'url',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.domainsTable.column.domainURL',
+        {
+          defaultMessage: 'Domain URL',
+        }
+      ),
+    },
+    {
+      field: 'lastCrawl',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.domainsTable.column.lastActivity',
+        {
+          defaultMessage: 'Last activity',
+        }
+      ),
+      render: (lastCrawl: CrawlerDomain['lastCrawl']) =>
+        lastCrawl ? <CustomFormattedTimestamp timestamp={lastCrawl} /> : '',
+    },
+    {
+      field: 'documentCount',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.domainsTable.column.documents',
+        {
+          defaultMessage: 'Documents',
+        }
+      ),
+      render: (documentCount: CrawlerDomain['documentCount']) => (
+        <FormattedNumber value={documentCount} />
+      ),
+    },
+  ];
+
+  const actionsColumn: EuiBasicTableColumn<CrawlerDomain> = {
+    name: i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTable.column.actions', {
+      defaultMessage: 'Actions',
+    }),
+    actions: [
+      {
+        name: MANAGE_BUTTON_LABEL,
+        description: i18n.translate(
+          'xpack.enterpriseSearch.appSearch.crawler.domainsTable.action.manage.buttonLabel',
+          {
+            defaultMessage: 'Manage this domain',
+          }
+        ),
+        type: 'icon',
+        icon: 'eye',
+        onClick: (domain) =>
+          KibanaLogic.values.navigateToUrl(
+            generateEnginePath(ENGINE_CRAWLER_DOMAIN_PATH, { domainId: domain.id })
+          ),
+      },
+      {
+        name: DELETE_BUTTON_LABEL,
+        description: i18n.translate(
+          'xpack.enterpriseSearch.appSearch.crawler.domainsTable.action.delete.buttonLabel',
+          {
+            defaultMessage: 'Delete this domain',
+          }
+        ),
+        type: 'icon',
+        icon: 'trash',
+        color: 'danger',
+        onClick: (domain) => {
+          if (
+            window.confirm(
+              i18n.translate(
+                'xpack.enterpriseSearch.appSearch.crawler.domainsTable.action.delete.confirmationPopupMessage',
+                {
+                  defaultMessage:
+                    'Are you sure you want to remove the domain "{domainUrl}" and all of its settings?',
+                  values: {
+                    domainUrl: domain.url,
+                  },
+                }
+              )
+            )
+          ) {
+            deleteDomain(domain);
+          }
+        },
+      },
+    ],
+  };
+
+  if (canManageEngineCrawler) {
+    columns.push(actionsColumn);
+  }
+
+  return <EuiInMemoryTable items={domains} columns={columns} />;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_landing.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_landing.test.tsx
@@ -19,12 +19,9 @@ describe('CrawlerLanding', () => {
   let wrapper: ShallowWrapper;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     setMockValues({ ...mockEngineValues });
     wrapper = shallow(<CrawlerLanding />);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   it('contains an external documentation link', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
+import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
 
@@ -44,7 +45,7 @@ describe('CrawlerOverview', () => {
 
     // TODO test for CrawlRequestsTable after it is built in a future PR
 
-    // TODO test for AddDomainForm after it is built in a future PR
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
 
     // TODO test for empty state after it is built in a future PR
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockActions, setMockValues } from '../../../__mocks__';
+import '../../../__mocks__/shallow_useeffect.mock';
+import '../../__mocks__/engine_logic.mock';
+
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiCode } from '@elastic/eui';
+
+import { CrawlerOverview } from './crawler_overview';
+
+const actions = {
+  fetchCrawlerData: jest.fn(),
+};
+
+const values = {
+  dataLoading: false,
+  domains: [],
+};
+
+describe('CrawlerOverview', () => {
+  let wrapper: ShallowWrapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues(values);
+    setMockActions(actions);
+    wrapper = shallow(<CrawlerOverview />);
+  });
+
+  it('renders', () => {
+    expect(wrapper.find(EuiCode)).toHaveLength(1);
+  });
+
+  it('calls fetchCrawlerData on page load', () => {
+    expect(actions.fetchCrawlerData).toHaveBeenCalledTimes(1);
+  });
+
+  // TODO after DomainsTable is built in a future PR
+  // it('contains a DomainsTable', () => {})
+
+  // TODO after CrawlRequestsTable is built in a future PR
+  // it('containss a CrawlRequestsTable,() => {})
+
+  // TODO after AddDomainForm is built in a future PR
+  // it('contains an AddDomainForm' () => {})
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { setMockActions, setMockValues } from '../../../__mocks__';
+import { setMockActions, setMockValues } from '../../../__mocks__/kea_logic';
 import '../../../__mocks__/shallow_useeffect.mock';
 import '../../__mocks__/engine_logic.mock';
 
@@ -13,43 +13,39 @@ import React from 'react';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
-import { EuiCode } from '@elastic/eui';
-
+import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
 
-const actions = {
-  fetchCrawlerData: jest.fn(),
-};
-
-const values = {
-  dataLoading: false,
-  domains: [],
-};
-
 describe('CrawlerOverview', () => {
+  const mockActions = {
+    fetchCrawlerData: jest.fn(),
+  };
+
+  const mockValues = {
+    dataLoading: false,
+    domains: [],
+  };
+
   let wrapper: ShallowWrapper;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    setMockValues(values);
-    setMockActions(actions);
+    setMockValues(mockValues);
+    setMockActions(mockActions);
     wrapper = shallow(<CrawlerOverview />);
   });
 
-  it('renders', () => {
-    expect(wrapper.find(EuiCode)).toHaveLength(1);
-  });
-
   it('calls fetchCrawlerData on page load', () => {
-    expect(actions.fetchCrawlerData).toHaveBeenCalledTimes(1);
+    expect(mockActions.fetchCrawlerData).toHaveBeenCalledTimes(1);
   });
 
-  // TODO after DomainsTable is built in a future PR
-  // it('contains a DomainsTable', () => {})
+  it('renders', () => {
+    expect(wrapper.find(DomainsTable)).toHaveLength(1);
 
-  // TODO after CrawlRequestsTable is built in a future PR
-  // it('containss a CrawlRequestsTable,() => {})
+    // TODO test for CrawlRequestsTable after it is built in a future PR
 
-  // TODO after AddDomainForm is built in a future PR
-  // it('contains an AddDomainForm' () => {})
+    // TODO test for AddDomainForm after it is built in a future PR
+
+    // TODO test for empty state after it is built in a future PR
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -9,9 +9,14 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
+import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
@@ -31,6 +36,21 @@ export const CrawlerOverview: React.FC = () => {
       pageHeader={{ pageTitle: CRAWLER_TITLE }}
       isLoading={dataLoading}
     >
+      <EuiFlexGroup direction="row" alignItems="stretch">
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h3>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTitle', {
+                defaultMessage: 'Domains',
+              })}
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <AddDomainFlyout />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
       <DomainsTable />
     </AppSearchPageTemplate>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -9,16 +9,15 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiCode } from '@elastic/eui';
-
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
+import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
 
 export const CrawlerOverview: React.FC = () => {
-  const { dataLoading, domains } = useValues(CrawlerOverviewLogic);
+  const { dataLoading } = useValues(CrawlerOverviewLogic);
 
   const { fetchCrawlerData } = useActions(CrawlerOverviewLogic);
 
@@ -32,7 +31,7 @@ export const CrawlerOverview: React.FC = () => {
       pageHeader={{ pageTitle: CRAWLER_TITLE }}
       isLoading={dataLoading}
     >
-      <EuiCode language="json">{JSON.stringify(domains, null, 2)}</EuiCode>
+      <DomainsTable />
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiCode } from '@elastic/eui';
+
+import { getEngineBreadcrumbs } from '../engine';
+import { AppSearchPageTemplate } from '../layout';
+
+import { CRAWLER_TITLE } from './constants';
+import { CrawlerOverviewLogic } from './crawler_overview_logic';
+
+export const CrawlerOverview: React.FC = () => {
+  const { dataLoading, domains } = useValues(CrawlerOverviewLogic);
+
+  const { fetchCrawlerData } = useActions(CrawlerOverviewLogic);
+
+  useEffect(() => {
+    fetchCrawlerData();
+  }, []);
+
+  return (
+    <AppSearchPageTemplate
+      pageChrome={getEngineBreadcrumbs([CRAWLER_TITLE])}
+      pageHeader={{ pageTitle: CRAWLER_TITLE }}
+      isLoading={dataLoading}
+    >
+      <EuiCode language="json">{JSON.stringify(domains, null, 2)}</EuiCode>
+    </AppSearchPageTemplate>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { LogicMounter, mockHttpValues, mockFlashMessageHelpers } from '../../../__mocks__';
+import {
+  LogicMounter,
+  mockHttpValues,
+  mockFlashMessageHelpers,
+} from '../../../__mocks__/kea_logic';
 import '../../__mocks__/engine_logic.mock';
 
 import { nextTick } from '@kbn/test/jest';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogicMounter, mockHttpValues, mockFlashMessageHelpers } from '../../../__mocks__';
+import '../../__mocks__/engine_logic.mock';
+
+import { nextTick } from '@kbn/test/jest';
+
+import { CrawlerOverviewLogic } from './crawler_overview_logic';
+import { CrawlerPolicies, CrawlerRules, CrawlRule } from './types';
+
+const DEFAULT_VALUES = {
+  dataLoading: true,
+  domains: [],
+};
+
+const DEFAULT_CRAWL_RULE: CrawlRule = {
+  id: '-',
+  policy: CrawlerPolicies.allow,
+  rule: CrawlerRules.regex,
+  pattern: '.*',
+};
+
+describe('CrawlerOverviewLogic', () => {
+  const { mount } = new LogicMounter(CrawlerOverviewLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mount();
+  });
+
+  it('has expected default values', () => {
+    expect(CrawlerOverviewLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    describe('onFetchCrawlerData', () => {
+      const crawlerData = {
+        domains: [
+          {
+            id: '507f1f77bcf86cd799439011',
+            createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+            url: 'moviedatabase.com',
+            documentCount: 13,
+            sitemaps: [],
+            entryPoints: [],
+            crawlRules: [],
+            defaultCrawlRule: DEFAULT_CRAWL_RULE,
+          },
+        ],
+      };
+
+      beforeEach(() => {
+        CrawlerOverviewLogic.actions.onFetchCrawlerData(crawlerData);
+      });
+
+      it('should set all received data as top-level values', () => {
+        expect(CrawlerOverviewLogic.values.domains).toEqual(crawlerData.domains);
+      });
+
+      it('should set dataLoading to false', () => {
+        expect(CrawlerOverviewLogic.values.dataLoading).toEqual(false);
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('fetchCrawlerData', () => {
+      it('calls onFetchCrawlerData with retrieved data that has been converted from server to client', async () => {
+        jest.spyOn(CrawlerOverviewLogic.actions, 'onFetchCrawlerData');
+
+        http.get.mockReturnValue(
+          Promise.resolve({
+            domains: [
+              {
+                id: '507f1f77bcf86cd799439011',
+                name: 'moviedatabase.com',
+                created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+                document_count: 13,
+                sitemaps: [],
+                entry_points: [],
+                crawl_rules: [],
+              },
+            ],
+          })
+        );
+        CrawlerOverviewLogic.actions.fetchCrawlerData();
+        await nextTick();
+
+        expect(http.get).toHaveBeenCalledWith('/api/app_search/engines/some-engine/crawler');
+        expect(CrawlerOverviewLogic.actions.onFetchCrawlerData).toHaveBeenCalledWith({
+          domains: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+              url: 'moviedatabase.com',
+              documentCount: 13,
+              sitemaps: [],
+              entryPoints: [],
+              crawlRules: [],
+            },
+          ],
+        });
+      });
+
+      it('calls flashApiErrors when there is an error', async () => {
+        http.get.mockReturnValue(Promise.reject('error'));
+        CrawlerOverviewLogic.actions.fetchCrawlerData();
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -11,7 +11,14 @@ import '../../__mocks__/engine_logic.mock';
 import { nextTick } from '@kbn/test/jest';
 
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
-import { CrawlerPolicies, CrawlerRules, CrawlRule } from './types';
+import {
+  CrawlerDataFromServer,
+  CrawlerDomain,
+  CrawlerPolicies,
+  CrawlerRules,
+  CrawlRule,
+} from './types';
+import { crawlerDataServerToClient } from './utils';
 
 const DEFAULT_VALUES = {
   dataLoading: true,
@@ -25,10 +32,26 @@ const DEFAULT_CRAWL_RULE: CrawlRule = {
   pattern: '.*',
 };
 
+const MOCK_SERVER_DATA: CrawlerDataFromServer = {
+  domains: [
+    {
+      id: '507f1f77bcf86cd799439011',
+      name: 'elastic.co',
+      created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      document_count: 13,
+      sitemaps: [],
+      entry_points: [],
+      crawl_rules: [],
+    },
+  ],
+};
+
+const MOCK_CLIENT_DATA = crawlerDataServerToClient(MOCK_SERVER_DATA);
+
 describe('CrawlerOverviewLogic', () => {
   const { mount } = new LogicMounter(CrawlerOverviewLogic);
   const { http } = mockHttpValues;
-  const { flashAPIErrors } = mockFlashMessageHelpers;
+  const { flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -40,13 +63,13 @@ describe('CrawlerOverviewLogic', () => {
   });
 
   describe('actions', () => {
-    describe('onFetchCrawlerData', () => {
+    describe('onReceiveCrawlerData', () => {
       const crawlerData = {
         domains: [
           {
             id: '507f1f77bcf86cd799439011',
             createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
-            url: 'moviedatabase.com',
+            url: 'elastic.co',
             documentCount: 13,
             sitemaps: [],
             entryPoints: [],
@@ -57,7 +80,7 @@ describe('CrawlerOverviewLogic', () => {
       };
 
       beforeEach(() => {
-        CrawlerOverviewLogic.actions.onFetchCrawlerData(crawlerData);
+        CrawlerOverviewLogic.actions.onReceiveCrawlerData(crawlerData);
       });
 
       it('should set all received data as top-level values', () => {
@@ -72,46 +95,51 @@ describe('CrawlerOverviewLogic', () => {
 
   describe('listeners', () => {
     describe('fetchCrawlerData', () => {
-      it('calls onFetchCrawlerData with retrieved data that has been converted from server to client', async () => {
-        jest.spyOn(CrawlerOverviewLogic.actions, 'onFetchCrawlerData');
+      it('calls onReceiveCrawlerData with retrieved data that has been converted from server to client', async () => {
+        jest.spyOn(CrawlerOverviewLogic.actions, 'onReceiveCrawlerData');
 
-        http.get.mockReturnValue(
-          Promise.resolve({
-            domains: [
-              {
-                id: '507f1f77bcf86cd799439011',
-                name: 'moviedatabase.com',
-                created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
-                document_count: 13,
-                sitemaps: [],
-                entry_points: [],
-                crawl_rules: [],
-              },
-            ],
-          })
-        );
+        http.get.mockReturnValue(Promise.resolve(MOCK_SERVER_DATA));
         CrawlerOverviewLogic.actions.fetchCrawlerData();
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith('/api/app_search/engines/some-engine/crawler');
-        expect(CrawlerOverviewLogic.actions.onFetchCrawlerData).toHaveBeenCalledWith({
-          domains: [
-            {
-              id: '507f1f77bcf86cd799439011',
-              createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
-              url: 'moviedatabase.com',
-              documentCount: 13,
-              sitemaps: [],
-              entryPoints: [],
-              crawlRules: [],
-            },
-          ],
-        });
+        expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith(
+          MOCK_CLIENT_DATA
+        );
       });
 
       it('calls flashApiErrors when there is an error', async () => {
         http.get.mockReturnValue(Promise.reject('error'));
         CrawlerOverviewLogic.actions.fetchCrawlerData();
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+
+    describe('deleteDomain', () => {
+      it('calls onReceiveCrawlerData with retrieved data that has been converted from server to client', async () => {
+        jest.spyOn(CrawlerOverviewLogic.actions, 'onReceiveCrawlerData');
+
+        http.delete.mockReturnValue(Promise.resolve(MOCK_SERVER_DATA));
+        CrawlerOverviewLogic.actions.deleteDomain({ id: '1234' } as CrawlerDomain);
+        await nextTick();
+
+        expect(http.delete).toHaveBeenCalledWith(
+          '/api/app_search/engines/some-engine/crawler/domains/1234',
+          {
+            query: { respond_with: 'crawler_details' },
+          }
+        );
+        expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith(
+          MOCK_CLIENT_DATA
+        );
+        expect(setSuccessMessage).toHaveBeenCalled();
+      });
+
+      it('calls flashApiErrors when there is an error', async () => {
+        http.delete.mockReturnValue(Promise.reject('error'));
+        CrawlerOverviewLogic.actions.deleteDomain({ id: '1234' } as CrawlerDomain);
         await nextTick();
 
         expect(flashAPIErrors).toHaveBeenCalledWith('error');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { flashAPIErrors } from '../../../shared/flash_messages';
+
+import { HttpLogic } from '../../../shared/http';
+import { EngineLogic } from '../engine';
+
+import { CrawlerData, CrawlerDataFromServer, CrawlerDomain } from './types';
+import { crawlerDataServerToClient } from './utils';
+
+interface CrawlerOverviewValues {
+  dataLoading: boolean;
+  domains: CrawlerDomain[];
+}
+
+interface CrawlerOverviewActions {
+  fetchCrawlerData(): void;
+  onFetchCrawlerData(data: CrawlerData): { data: CrawlerData };
+}
+
+export const CrawlerOverviewLogic = kea<
+  MakeLogicType<CrawlerOverviewValues, CrawlerOverviewActions>
+>({
+  path: ['enterprise_search', 'app_search', 'crawler', 'crawler_overview'],
+  actions: {
+    fetchCrawlerData: true,
+    onFetchCrawlerData: (data) => ({ data }),
+  },
+  reducers: {
+    dataLoading: [
+      true,
+      {
+        onFetchCrawlerData: () => false,
+      },
+    ],
+    domains: [
+      [],
+      {
+        onFetchCrawlerData: (_, { data: { domains } }) => domains,
+      },
+    ],
+  },
+  listeners: ({ actions }) => ({
+    fetchCrawlerData: async () => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const response = await http.get(`/api/app_search/engines/${engineName}/crawler`);
+        const crawlerData = crawlerDataServerToClient(response as CrawlerDataFromServer);
+        actions.onFetchCrawlerData(crawlerData);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_router.test.tsx
@@ -11,17 +11,31 @@ import { Switch } from 'react-router-dom';
 import { shallow } from 'enzyme';
 
 import { CrawlerLanding } from './crawler_landing';
+import { CrawlerOverview } from './crawler_overview';
 import { CrawlerRouter } from './crawler_router';
 
 describe('CrawlerRouter', () => {
+  const OLD_ENV = process.env;
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders a landing page', () => {
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('renders a landing page by default', () => {
     const wrapper = shallow(<CrawlerRouter />);
 
     expect(wrapper.find(Switch)).toHaveLength(1);
     expect(wrapper.find(CrawlerLanding)).toHaveLength(1);
+  });
+
+  it('renders a crawler overview in dev', () => {
+    process.env.NODE_ENV = 'development';
+    const wrapper = shallow(<CrawlerRouter />);
+
+    expect(wrapper.find(CrawlerOverview)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_router.tsx
@@ -9,12 +9,13 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import { CrawlerLanding } from './crawler_landing';
+import { CrawlerOverview } from './crawler_overview';
 
 export const CrawlerRouter: React.FC = () => {
   return (
     <Switch>
       <Route>
-        <CrawlerLanding />
+        {process.env.NODE_ENV === 'development' ? <CrawlerOverview /> : <CrawlerLanding />}
       </Route>
     </Switch>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_router.tsx
@@ -8,13 +8,15 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { ENGINE_CRAWLER_PATH } from '../../routes';
+
 import { CrawlerLanding } from './crawler_landing';
 import { CrawlerOverview } from './crawler_overview';
 
 export const CrawlerRouter: React.FC = () => {
   return (
     <Switch>
-      <Route>
+      <Route exact path={ENGINE_CRAWLER_PATH}>
         {process.env.NODE_ENV === 'development' ? <CrawlerOverview /> : <CrawlerLanding />}
       </Route>
     </Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum CrawlerPolicies {
+  allow = 'allow',
+  deny = 'deny',
+}
+
+export enum CrawlerRules {
+  beginsWith = 'begins',
+  endsWith = 'ends',
+  contains = 'contains',
+  regex = 'regex',
+}
+
+export interface CrawlRule {
+  id: string;
+  policy: CrawlerPolicies;
+  rule: CrawlerRules;
+  pattern: string;
+}
+
+export interface EntryPoint {
+  id: string;
+  value: string;
+}
+
+export interface Sitemap {
+  id: string;
+  url: string;
+}
+
+export interface CrawlerDomain {
+  createdOn: string;
+  documentCount: number;
+  id: string;
+  lastCrawl?: string;
+  url: string;
+  crawlRules: CrawlRule[];
+  defaultCrawlRule?: CrawlRule;
+  entryPoints: EntryPoint[];
+  sitemaps: Sitemap[];
+}
+
+export interface CrawlerDomainFromServer {
+  id: string;
+  name: string;
+  created_on: string;
+  last_visited_at?: string;
+  document_count: number;
+  crawl_rules: CrawlRule[];
+  default_crawl_rule?: CrawlRule;
+  entry_points: EntryPoint[];
+  sitemaps: Sitemap[];
+}
+
+export interface CrawlerData {
+  domains: CrawlerDomain[];
+}
+
+export interface CrawlerDataFromServer {
+  domains: CrawlerDomainFromServer[];
+}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -65,3 +65,12 @@ export interface CrawlerData {
 export interface CrawlerDataFromServer {
   domains: CrawlerDomainFromServer[];
 }
+
+export interface CrawlerDomainValidationResultFromServer {
+  valid: boolean;
+  results: Array<{
+    name: string;
+    result: 'ok' | 'warning' | 'failure';
+    comment: string;
+  }>;
+}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CrawlerPolicies, CrawlerRules, CrawlRule, CrawlerDomainFromServer } from './types';
+
+import { crawlerDomainServerToClient, crawlerDataServerToClient } from './utils';
+
+const DEFAULT_CRAWL_RULE: CrawlRule = {
+  id: '-',
+  policy: CrawlerPolicies.allow,
+  rule: CrawlerRules.regex,
+  pattern: '.*',
+};
+
+describe('crawlerDomainServerToClient', () => {
+  it('converts the API payload into properties matching our code style', () => {
+    const id = '507f1f77bcf86cd799439011';
+    const name = 'moviedatabase.com';
+
+    const defaultServerPayload = {
+      id,
+      name,
+      created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      document_count: 13,
+      sitemaps: [],
+      entry_points: [],
+      crawl_rules: [],
+    };
+
+    const defaultClientPayload = {
+      id,
+      createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      url: name,
+      documentCount: 13,
+      sitemaps: [],
+      entryPoints: [],
+      crawlRules: [],
+    };
+
+    expect(crawlerDomainServerToClient(defaultServerPayload)).toStrictEqual(defaultClientPayload);
+    expect(
+      crawlerDomainServerToClient({
+        ...defaultServerPayload,
+        last_visited_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      })
+    ).toStrictEqual({ ...defaultClientPayload, lastCrawl: 'Mon, 31 Aug 2020 17:00:00 +0000' });
+    expect(
+      crawlerDomainServerToClient({
+        ...defaultServerPayload,
+        default_crawl_rule: DEFAULT_CRAWL_RULE,
+      })
+    ).toStrictEqual({ ...defaultClientPayload, defaultCrawlRule: DEFAULT_CRAWL_RULE });
+  });
+});
+
+describe('crawlerDataServerToClient', () => {
+  it('converts all domains from the server form to their client form', () => {
+    const domains: CrawlerDomainFromServer[] = [
+      {
+        id: 'x',
+        name: 'moviedatabase.com',
+        document_count: 13,
+        created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+        sitemaps: [],
+        entry_points: [],
+        crawl_rules: [],
+        default_crawl_rule: DEFAULT_CRAWL_RULE,
+      },
+      {
+        id: 'y',
+        name: 'swiftype.com',
+        last_visited_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+        document_count: 40,
+        created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+        sitemaps: [],
+        entry_points: [],
+        crawl_rules: [],
+      },
+    ];
+
+    const output = crawlerDataServerToClient({
+      domains,
+    });
+
+    expect(output.domains).toHaveLength(2);
+    expect(output.domains[0]).toEqual(crawlerDomainServerToClient(domains[0]));
+    expect(output.domains[1]).toEqual(crawlerDomainServerToClient(domains[1]));
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  CrawlerDomain,
+  CrawlerDomainFromServer,
+  CrawlerData,
+  CrawlerDataFromServer,
+} from './types';
+
+export function crawlerDomainServerToClient(payload: CrawlerDomainFromServer): CrawlerDomain {
+  const {
+    id,
+    name,
+    sitemaps,
+    created_on: createdOn,
+    last_visited_at: lastCrawl,
+    document_count: documentCount,
+    crawl_rules: crawlRules,
+    default_crawl_rule: defaultCrawlRule,
+    entry_points: entryPoints,
+  } = payload;
+
+  const clientPayload: CrawlerDomain = {
+    id,
+    url: name,
+    documentCount,
+    createdOn,
+    crawlRules,
+    sitemaps,
+    entryPoints,
+  };
+
+  if (lastCrawl) {
+    clientPayload.lastCrawl = lastCrawl;
+  }
+
+  if (defaultCrawlRule) {
+    clientPayload.defaultCrawlRule = defaultCrawlRule;
+  }
+
+  return clientPayload;
+}
+
+export function crawlerDataServerToClient(payload: CrawlerDataFromServer): CrawlerData {
+  const { domains } = payload;
+
+  return {
+    domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
+  };
+}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -37,7 +37,7 @@ export const ENGINE_SCHEMA_PATH = `${ENGINE_PATH}/schema`;
 export const ENGINE_REINDEX_JOB_PATH = `${ENGINE_SCHEMA_PATH}/reindex_job/:reindexJobId`;
 
 export const ENGINE_CRAWLER_PATH = `${ENGINE_PATH}/crawler`;
-// TODO: Crawler sub-pages
+export const ENGINE_CRAWLER_DOMAIN_PATH = `${ENGINE_CRAWLER_PATH}/domains/:domainId`;
 
 export const META_ENGINE_CREATION_PATH = `${ENGINES_PATH}/new_meta_engine`; // This is safe from conflicting with an :engineName path because engine names cannot have underscores
 export const META_ENGINE_SOURCE_ENGINES_PATH = `${ENGINE_PATH}/engines`;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
@@ -9,7 +9,7 @@ import '../../__mocks__/kea_logic/kibana_logic.mock';
 
 import { FlashMessagesLogic } from './flash_messages_logic';
 
-import { flashAPIErrors } from './handle_api_errors';
+import { flashAPIErrors, getErrorsFromHttpResponse } from './handle_api_errors';
 
 describe('flashAPIErrors', () => {
   const mockHttpError = {
@@ -68,10 +68,29 @@ describe('flashAPIErrors', () => {
     try {
       flashAPIErrors(Error('whatever') as any);
     } catch (e) {
-      expect(e.message).toEqual('whatever');
       expect(FlashMessagesLogic.actions.setFlashMessages).toHaveBeenCalledWith([
-        { type: 'error', message: 'An unexpected error occurred' },
+        { type: 'error', message: expect.any(String) },
       ]);
     }
+  });
+});
+
+describe('getErrorsFromHttpResponse', () => {
+  it('should return errors from the response if present', () => {
+    expect(
+      getErrorsFromHttpResponse({
+        body: { attributes: { errors: ['first error', 'second error'] } },
+      } as any)
+    ).toEqual(['first error', 'second error']);
+  });
+
+  it('should return a message from the responnse if no errors', () => {
+    expect(getErrorsFromHttpResponse({ body: { message: 'test message' } } as any)).toEqual([
+      'test message',
+    ]);
+  });
+
+  it('should return the a default message otherwise', () => {
+    expect(getErrorsFromHttpResponse({} as any)).toEqual([expect.any(String)]);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
@@ -40,13 +40,22 @@ export const defaultErrorMessage = i18n.translate(
   }
 );
 
+export const getErrorsFromHttpResponse = (response: HttpResponse<ErrorResponse>) => {
+  return Array.isArray(response?.body?.attributes?.errors)
+    ? response.body!.attributes.errors
+    : [response?.body?.message || defaultErrorMessage];
+};
+
 /**
  * Converts API/HTTP errors into user-facing Flash Messages
  */
-export const flashAPIErrors = (error: HttpResponse<ErrorResponse>, { isQueued }: Options = {}) => {
-  const errorFlashMessages: IFlashMessage[] = Array.isArray(error?.body?.attributes?.errors)
-    ? error.body!.attributes.errors.map((message) => ({ type: 'error', message }))
-    : [{ type: 'error', message: error?.body?.message || defaultErrorMessage }];
+export const flashAPIErrors = (
+  response: HttpResponse<ErrorResponse>,
+  { isQueued }: Options = {}
+) => {
+  const errorFlashMessages: IFlashMessage[] = getErrorsFromHttpResponse(
+    response
+  ).map((message) => ({ type: 'error', message }));
 
   if (isQueued) {
     FlashMessagesLogic.actions.setQueuedMessages(errorFlashMessages);
@@ -56,7 +65,7 @@ export const flashAPIErrors = (error: HttpResponse<ErrorResponse>, { isQueued }:
 
   // If this was a programming error or a failed request (such as a CORS) error,
   // we rethrow the error so it shows up in the developer console
-  if (!error?.body?.message) {
-    throw error;
+  if (!response?.body?.message) {
+    throw response;
   }
 };

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -31,5 +31,61 @@ describe('crawler routes', () => {
         path: '/api/as/v0/engines/:name/crawler',
       });
     });
+
+    it('validates correctly with name', () => {
+      const request = { params: { name: 'some-engine' } };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without name', () => {
+      const request = { params: {} };
+      mockRouter.shouldThrow(request);
+    });
+  });
+
+  describe('DELETE /api/app_search/engines/{name}/crawler/domains/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'delete',
+        path: '/api/app_search/engines/{name}/crawler/domains/{id}',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/engines/:name/crawler/domains/:id',
+      });
+    });
+
+    it('validates correctly with name and id', () => {
+      const request = { params: { name: 'some-engine', id: '1234' } };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without name', () => {
+      const request = { params: { id: '1234' } };
+      mockRouter.shouldThrow(request);
+    });
+
+    it('fails validation without id', () => {
+      const request = { params: { name: 'test-engine' } };
+      mockRouter.shouldThrow(request);
+    });
+
+    it('accepts a query param', () => {
+      const request = {
+        params: { name: 'test-engine', id: '1234' },
+        query: { respond_with: 'crawler_details' },
+      };
+      mockRouter.shouldValidate(request);
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockDependencies, mockRequestHandler, MockRouter } from '../../__mocks__';
+
+import { registerCrawlerRoutes } from './crawler';
+
+describe('crawler routes', () => {
+  describe('GET /api/app_search/engines/{name}/crawler', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/engines/{name}/crawler',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/engines/:name/crawler',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -43,6 +43,62 @@ describe('crawler routes', () => {
     });
   });
 
+  describe('POST /api/app_search/engines/{name}/crawler/domains', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/app_search/engines/{name}/crawler/domains',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/engines/:name/crawler/domains',
+      });
+    });
+
+    it('validates correctly with params and body', () => {
+      const request = {
+        params: { name: 'some-engine' },
+        body: { name: 'https://elastic.co/guide', entry_points: [{ value: '/guide' }] },
+      };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('accepts a query param', () => {
+      const request = {
+        params: { name: 'some-engine' },
+        body: { name: 'https://elastic.co/guide', entry_points: [{ value: '/guide' }] },
+        query: { respond_with: 'crawler_details' },
+      };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without a name param', () => {
+      const request = {
+        params: {},
+        body: { name: 'https://elastic.co/guide', entry_points: [{ value: '/guide' }] },
+      };
+      mockRouter.shouldThrow(request);
+    });
+
+    it('fails validation without a body', () => {
+      const request = {
+        params: { name: 'some-engine' },
+        body: {},
+      };
+      mockRouter.shouldThrow(request);
+    });
+  });
+
   describe('DELETE /api/app_search/engines/{name}/crawler/domains/{id}', () => {
     let mockRouter: MockRouter;
 

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -144,4 +144,41 @@ describe('crawler routes', () => {
       mockRouter.shouldValidate(request);
     });
   });
+
+  describe('POST /api/app_search/crawler/validate_url', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/app_search/crawler/validate_url',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/crawler/validate_url',
+      });
+    });
+
+    it('validates correctly with body', () => {
+      const request = {
+        body: { url: 'elastic.co', checks: ['tcp', 'url_request'] },
+      };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without a body', () => {
+      const request = {
+        body: {},
+      };
+      mockRouter.shouldThrow(request);
+    });
+  });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -26,4 +26,22 @@ export function registerCrawlerRoutes({
       path: '/api/as/v0/engines/:name/crawler',
     })
   );
+
+  router.delete(
+    {
+      path: '/api/app_search/engines/{name}/crawler/domains/{id}',
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+          id: schema.string(),
+        }),
+        query: schema.object({
+          respond_with: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/engines/:name/crawler/domains/:id',
+    })
+  );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import { RouteDependencies } from '../../plugin';
+
+export function registerCrawlerRoutes({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/app_search/engines/{name}/crawler',
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/engines/:name/crawler',
+    })
+  );
+}

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -27,6 +27,31 @@ export function registerCrawlerRoutes({
     })
   );
 
+  router.post(
+    {
+      path: '/api/app_search/engines/{name}/crawler/domains',
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+        body: schema.object({
+          name: schema.string(),
+          entry_points: schema.arrayOf(
+            schema.object({
+              value: schema.string(),
+            })
+          ),
+        }),
+        query: schema.object({
+          respond_with: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/engines/:name/crawler/domains',
+    })
+  );
+
   router.delete(
     {
       path: '/api/app_search/engines/{name}/crawler/domains/{id}',

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -69,4 +69,19 @@ export function registerCrawlerRoutes({
       path: '/api/as/v0/engines/:name/crawler/domains/:id',
     })
   );
+
+  router.post(
+    {
+      path: '/api/app_search/crawler/validate_url',
+      validate: {
+        body: schema.object({
+          url: schema.string(),
+          checks: schema.arrayOf(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/crawler/validate_url',
+    })
+  );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
@@ -9,6 +9,7 @@ import { RouteDependencies } from '../../plugin';
 
 import { registerAnalyticsRoutes } from './analytics';
 import { registerApiLogsRoutes } from './api_logs';
+import { registerCrawlerRoutes } from './crawler';
 import { registerCredentialsRoutes } from './credentials';
 import { registerCurationsRoutes } from './curations';
 import { registerDocumentsRoutes, registerDocumentRoutes } from './documents';
@@ -42,4 +43,5 @@ export const registerAppSearchRoutes = (dependencies: RouteDependencies) => {
   registerResultSettingsRoutes(dependencies);
   registerApiLogsRoutes(dependencies);
   registerOnboardingRoutes(dependencies);
+  registerCrawlerRoutes(dependencies);
 };


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [App Search] Initial logic for Crawler Overview (#101176)
 - App Search: Domains Table for Crawler Overview (#101515) 
 - [App Search] New Add Domain Flyout for Crawler (#106102)
 - [App Search] Attempt to add protocols to crawler urls when they are submitted for validation (#106764)