### PR TITLE
Update README.md

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/README.md
+++ b/x-pack/plugins/fleet/common/openapi/README.md
@@ -1,10 +1,10 @@
 # OpenAPI
 
-The current self-contained spec file is [as JSON](https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.json) or [as YAML](https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.yaml) and can be used for online tools like those found at https://openapi.tools/
+The current self-contained spec file is [as JSON](https://raw.githubusercontent.com/elastic/kibana/7.14/x-pack/plugins/fleet/common/openapi/bundled.json) or [as YAML](https://raw.githubusercontent.com/elastic/kibana/7.14/x-pack/plugins/fleet/common/openapi/bundled.yaml) and can be used for online tools like those found at https://openapi.tools/
 
 For example, online viewers for the specification like these:
 
-| <a href="https://mrin9.github.io/OpenAPI-Viewer/#/load/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fkibana%2Fmaster%2Fx-pack%2Fplugins%2Ffleet%2Fcommon%2Fopenapi%2Fbundled.json">View spec using MrinDoc</a>  |  <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/master/x-pack/plugins/fleet/common/openapi/bundled.json">View spec using Swagger UI</a> |
+| <a href="https://mrin9.github.io/OpenAPI-Viewer/#/load/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fkibana%2F7%2E14%2Fx-pack%2Fplugins%2Ffleet%2Fcommon%2Fopenapi%2Fbundled.json">View spec using MrinDoc</a>  |  <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/7.14/x-pack/plugins/fleet/common/openapi/bundled.json">View spec using Swagger UI</a> |
 |----|----|
 | <img alt="Screen Shot 2021-03-09 at 10 14 52 AM" src="https://user-images.githubusercontent.com/57655/110493024-8944dd80-80c0-11eb-97b2-0666fcca3b09.png">  | <img alt="Screen Shot 2021-03-09 at 10 14 04 AM" src="https://user-images.githubusercontent.com/57655/110493019-88ac4700-80c0-11eb-982b-d5d352143003.png"> |
 


### PR DESCRIPTION
## Summary
A fix contributing towards Observability Docs work for Fleet API linking as discussed in slack.
 - we've updated the docs to include a link to this file in Kibana repo and this is updating it to be branch specific for the live linked api docs instances