### PR TITLE
[7.12] [DOC] server.basePath vs server.rewriteBasePath (#106798)

### DIFF
--- a/docs/developer/advanced/development-basepath.asciidoc
+++ b/docs/developer/advanced/development-basepath.asciidoc
@@ -3,9 +3,9 @@
 
 In dev mode, {kib} by default runs behind a proxy which adds a random path component to its URL.
 
-You can set this explicitly using `server.basePath` in <<settings>>. 
+You can set this explicitly using <<server-basePath,`server.basePath`>>. This setting cannot end in a slash (/).
 
-Use the server.rewriteBasePath setting to tell {kib} if it should remove the basePath from requests it receives, and to prevent a deprecation warning at startup. This setting cannot end in a slash (/).
+Use <<server-rewriteBasePath,`server.rewriteBasePath`>> to tell {kib} if it should remove the basePath from requests it receives, and to prevent a deprecation warning at startup. 
 
 If you want to turn off the basepath when in development mode, start {kib} with the `--no-base-path` flag
 
@@ -13,6 +13,5 @@ If you want to turn off the basepath when in development mode, start {kib} with 
 ----
 yarn start --no-base-path
 ----
-
 
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [DOC] server.basePath vs server.rewriteBasePath (#106798)