### PR TITLE
[Metrics UI] Correct inaccurate offsetting for non-rate aggregations inside of metrics threshold alerts

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -235,29 +235,30 @@ const getValuesFromAggregations = (
       }));
     }
     if (aggType === Aggregators.P95 || aggType === Aggregators.P99) {
-      return (
-        buckets
-          .map((bucket) => {
-            const values = bucket.aggregatedValue?.values || [];
-            const firstValue = first(values);
-            if (!firstValue) return null;
-            return { key: bucket.from_as_string, value: firstValue.value };
-          })
-          // P95 & P99 can only be calculated accurately on full buckets
-          .filter(dropPartialBuckets(dropPartialBucketsOptions))
-      );
+      return buckets.map((bucket) => {
+        const values = bucket.aggregatedValue?.values || [];
+        const firstValue = first(values);
+        if (!firstValue) return null;
+        return { key: bucket.from_as_string, value: firstValue.value };
+      });
     }
 
     if (aggType === Aggregators.AVERAGE) {
-      return (
-        buckets
-          .map((bucket) => ({
-            key: bucket.key_as_string ?? bucket.from_as_string,
-            value: bucket.aggregatedValue?.value ?? null,
-          }))
-          // AVG can only be calculated accurately on full buckets
-          .filter(dropPartialBuckets(dropPartialBucketsOptions))
-      );
+      return buckets.map((bucket) => ({
+        key: bucket.key_as_string ?? bucket.from_as_string,
+        value: bucket.aggregatedValue?.value ?? null,
+      }));
+      // AVG can only be calculated accurately on full buckets
+      // .filter(dropPartialBuckets(dropPartialBucketsOptions))
+    }
+
+    if (aggType === Aggregators.RATE) {
+      return buckets
+        .map((bucket) => ({
+          key: bucket.key_as_string ?? bucket.from_as_string,
+          value: bucket.aggregatedValue?.value ?? null,
+        }))
+        .filter(dropPartialBuckets(dropPartialBucketsOptions));
     }
 
     return buckets.map((bucket) => ({

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -235,23 +235,29 @@ const getValuesFromAggregations = (
       }));
     }
     if (aggType === Aggregators.P95 || aggType === Aggregators.P99) {
-      return buckets
-        .map((bucket) => {
-          const values = bucket.aggregatedValue?.values || [];
-          const firstValue = first(values);
-          if (!firstValue) return null;
-          return { key: bucket.from_as_string, value: firstValue.value };
-        })
-        .filter(dropPartialBuckets(dropPartialBucketsOptions));
+      return (
+        buckets
+          .map((bucket) => {
+            const values = bucket.aggregatedValue?.values || [];
+            const firstValue = first(values);
+            if (!firstValue) return null;
+            return { key: bucket.from_as_string, value: firstValue.value };
+          })
+          // P95 & P99 can only be calculated accurately on full buckets
+          .filter(dropPartialBuckets(dropPartialBucketsOptions))
+      );
     }
 
     if (aggType === Aggregators.AVERAGE) {
-      buckets
-        .map((bucket) => ({
-          key: bucket.key_as_string ?? bucket.from_as_string,
-          value: bucket.aggregatedValue?.value ?? null,
-        }))
-        .filter(dropPartialBuckets(dropPartialBucketsOptions));
+      return (
+        buckets
+          .map((bucket) => ({
+            key: bucket.key_as_string ?? bucket.from_as_string,
+            value: bucket.aggregatedValue?.value ?? null,
+          }))
+          // AVG can only be calculated accurately on full buckets
+          .filter(dropPartialBuckets(dropPartialBucketsOptions))
+      );
     }
 
     return buckets.map((bucket) => ({

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -126,8 +126,10 @@ const getMetric: (
     .add(1, timeUnit)
     .startOf(timeUnit)
     .valueOf();
+
   // We need enough data for 5 buckets worth of data. We also need
   // to convert the intervalAsSeconds to milliseconds.
+  // TODO: We only need to get 5 buckets for the rate query, so this logic should move there.
   const minimumFrom = to - intervalAsMS * MINIMUM_BUCKETS;
 
   const from = roundTimestamp(

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -248,8 +248,6 @@ const getValuesFromAggregations = (
         key: bucket.key_as_string ?? bucket.from_as_string,
         value: bucket.aggregatedValue?.value ?? null,
       }));
-      // AVG can only be calculated accurately on full buckets
-      // .filter(dropPartialBuckets(dropPartialBucketsOptions))
     }
 
     if (aggType === Aggregators.RATE) {

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -6,6 +6,7 @@
  */
 
 import { mapValues, first, last, isNaN } from 'lodash';
+import moment from 'moment';
 import { ElasticsearchClient } from 'kibana/server';
 import {
   isTooManyBucketsPreviewException,
@@ -121,7 +122,10 @@ const getMetric: (
   const intervalAsSeconds = getIntervalInSeconds(interval);
   const intervalAsMS = intervalAsSeconds * 1000;
 
-  const to = roundTimestamp(timeframe ? timeframe.end : Date.now(), timeUnit);
+  const to = moment(timeframe ? timeframe.end : Date.now())
+    .add(1, timeUnit)
+    .startOf(timeUnit)
+    .valueOf();
   // We need enough data for 5 buckets worth of data. We also need
   // to convert the intervalAsSeconds to milliseconds.
   const minimumFrom = to - intervalAsMS * MINIMUM_BUCKETS;
@@ -223,13 +227,12 @@ const getValuesFromAggregations = (
   try {
     const { buckets } = aggregations.aggregatedIntervals;
     if (!buckets.length) return null; // No Data state
+
     if (aggType === Aggregators.COUNT) {
-      return buckets
-        .map((bucket) => ({
-          key: bucket.from_as_string,
-          value: bucket.doc_count,
-        }))
-        .filter(dropPartialBuckets(dropPartialBucketsOptions));
+      return buckets.map((bucket) => ({
+        key: bucket.from_as_string,
+        value: bucket.doc_count,
+      }));
     }
     if (aggType === Aggregators.P95 || aggType === Aggregators.P99) {
       return buckets
@@ -241,12 +244,20 @@ const getValuesFromAggregations = (
         })
         .filter(dropPartialBuckets(dropPartialBucketsOptions));
     }
-    return buckets
-      .map((bucket) => ({
-        key: bucket.key_as_string ?? bucket.from_as_string,
-        value: bucket.aggregatedValue?.value ?? null,
-      }))
-      .filter(dropPartialBuckets(dropPartialBucketsOptions));
+
+    if (aggType === Aggregators.AVERAGE) {
+      buckets
+        .map((bucket) => ({
+          key: bucket.key_as_string ?? bucket.from_as_string,
+          value: bucket.aggregatedValue?.value ?? null,
+        }))
+        .filter(dropPartialBuckets(dropPartialBucketsOptions));
+    }
+
+    return buckets.map((bucket) => ({
+      key: bucket.key_as_string ?? bucket.from_as_string,
+      value: bucket.aggregatedValue?.value ?? null,
+    }));
   } catch (e) {
     return NaN; // Error state
   }

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -39,7 +39,10 @@ export const getElasticsearchMetricQuery = (
   const to = timeframe.end;
   const from = timeframe.start;
   const offset = calculateDateHistogramOffset({ from, to, interval, field: timefield });
-  const offsetInMS = parseInt(offset, 10);
+  const offsetInMS =
+    [Aggregators.P95, Aggregators.P99, Aggregators.AVERAGE].indexOf(aggType) > -1
+      ? parseInt(offset, 10)
+      : 0;
 
   const aggregations =
     aggType === Aggregators.COUNT
@@ -57,7 +60,7 @@ export const getElasticsearchMetricQuery = (
         };
 
   const baseAggs =
-    [Aggregators.AVERAGE, Aggregators.P95, Aggregators.P99].indexOf(aggType) > -1
+    aggType === Aggregators.RATE
       ? {
           aggregatedIntervals: {
             date_histogram: {

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -57,7 +57,7 @@ export const getElasticsearchMetricQuery = (
         };
 
   const baseAggs =
-    aggType === Aggregators.RATE
+    [Aggregators.AVERAGE, Aggregators.P95, Aggregators.P99].indexOf(aggType) > -1
       ? {
           aggregatedIntervals: {
             date_histogram: {

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -39,6 +39,8 @@ export const getElasticsearchMetricQuery = (
   const to = timeframe.end;
   const from = timeframe.start;
 
+  const deliveryDelay = 60 * 1000; // INFO: This allows us to account for any delay ES has in indexing the most recent data.
+
   const aggregations =
     aggType === Aggregators.COUNT
       ? {}
@@ -74,10 +76,12 @@ export const getElasticsearchMetricQuery = (
           aggregatedIntervals: {
             date_range: {
               field: timefield,
-              ranges: Array.from(Array(Math.floor((to - from) / intervalAsMS)), (_, i) => ({
-                from: from + intervalAsMS * i,
-                to: from + intervalAsMS * (i + 1),
-              })),
+              ranges: [
+                {
+                  from: from - intervalAsMS,
+                  to: from + intervalAsMS - deliveryDelay,
+                },
+              ],
             },
             aggregations,
           },

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -78,8 +78,8 @@ export const getElasticsearchMetricQuery = (
               field: timefield,
               ranges: [
                 {
-                  from: from - intervalAsMS,
-                  to: from + intervalAsMS - deliveryDelay,
+                  from: to - intervalAsMS - deliveryDelay,
+                  to: to - deliveryDelay,
                 },
               ],
             },

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -38,11 +38,17 @@ export const getElasticsearchMetricQuery = (
   const intervalAsMS = intervalAsSeconds * 1000;
   const to = timeframe.end;
   const from = timeframe.start;
-  const offset = calculateDateHistogramOffset({ from, to, interval, field: timefield });
-  const offsetInMS =
-    [Aggregators.P95, Aggregators.P99, Aggregators.AVERAGE].indexOf(aggType) > -1
-      ? parseInt(offset, 10)
-      : 0;
+  let offset = '0ms';
+  let offsetInMS = 0;
+
+  if (
+    [Aggregators.P95, Aggregators.P99, Aggregators.AVERAGE, Aggregators.RATE].indexOf(aggType) > -1
+  ) {
+    // Only calculate offset for aggs that require a full bucket to evaluate
+    offset = calculateDateHistogramOffset({ from, to, interval, field: timefield });
+  }
+
+  offsetInMS = parseInt(offset, 10);
 
   const aggregations =
     aggType === Aggregators.COUNT

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
@@ -245,9 +245,9 @@ describe('The metric threshold alert type', () => {
         },
       });
     test('alerts based on the doc_count value instead of the aggregatedValue', async () => {
-      await execute(Comparator.GT, [2]);
+      await execute(Comparator.GT, [0.9]);
       expect(mostRecentAction(instanceID).id).toBe(FIRED_ACTIONS.id);
-      await execute(Comparator.LT, [1.5]);
+      await execute(Comparator.LT, [0.5]);
       expect(mostRecentAction(instanceID)).toBe(undefined);
     });
   });

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
@@ -202,7 +202,7 @@ describe('The metric threshold alert type', () => {
     });
     test('sends no alert when some, but not all, criteria cross the threshold', async () => {
       const instanceID = '*';
-      await execute(Comparator.LT_OR_EQ, [1.0], [3.0]);
+      await execute(Comparator.LT_OR_EQ, [1.0], [2.5]);
       expect(mostRecentAction(instanceID)).toBe(undefined);
     });
     test('alerts only on groups that meet all criteria when querying with a groupBy parameter', async () => {
@@ -221,7 +221,7 @@ describe('The metric threshold alert type', () => {
       expect(reasons[0]).toContain('test.metric.1');
       expect(reasons[1]).toContain('test.metric.2');
       expect(reasons[0]).toContain('current value is 1');
-      expect(reasons[1]).toContain('current value is 3.5');
+      expect(reasons[1]).toContain('current value is 3');
       expect(reasons[0]).toContain('threshold of 1');
       expect(reasons[1]).toContain('threshold of 3');
     });


### PR DESCRIPTION
## Summary

Fixes #106887.

This PR drops all logic for offsets in data evaluation. `Offset` was introduced to avoid an issue with eventually consistent data, but because offset scales proportionally to the time span, the larger the evaluation period (e.g. for 12hrs), the more data we ignore. Instead, we are introducing a static "offset" of a minute for all evaluation periods to account for eventually consistent data.

Note: This PR doesn't fix the alert preview charts. That'll require a change to the metrics API.

