### PR TITLE
[APM] Fix data streams docs link url

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Settings/schema/schema_overview.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/schema/schema_overview.tsx
@@ -258,8 +258,8 @@ export function SchemaOverviewHeading() {
             ),
             dataStreamsDocLink: (
               <ElasticDocsLink
-                section="/elasticsearch/reference"
-                path="/data-streams.html"
+                section="/apm/server"
+                path="/apm-integration-data-streams.html"
                 target="_blank"
               >
                 {i18n.translate(


### PR DESCRIPTION
Fixes #105651.

Updates the Docs link URL to the correct apm-server section on data streams.