### PR TITLE
[7.x] Fix and re-enable basic login selector functional tests. (#106822)

### DIFF
--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -16,7 +16,11 @@ interface LoginOptions {
   expectForbidden?: boolean;
 }
 
-type LoginExpectedResult = 'spaceSelector' | 'error' | 'chrome';
+type LoginExpectedResult =
+  | 'spaceSelector'
+  | 'error'
+  | 'chrome'
+  | (() => unknown | Promise<unknown>);
 
 export class SecurityPageObject extends FtrService {
   private readonly browser = this.ctx.getService('browser');
@@ -77,7 +81,13 @@ export class SecurityPageObject extends FtrService {
   });
 
   public loginSelector = Object.freeze({
-    login: async (providerType: string, providerName: string, options?: Record<string, any>) => {
+    login: async (
+      providerType: string,
+      providerName: string,
+      options?: Omit<Record<string, any>, 'expectedLoginResult'> & {
+        expectedLoginResult?: LoginExpectedResult;
+      }
+    ) => {
       this.log.debug(`Starting login flow for ${providerType}/${providerName}`);
 
       await this.loginSelector.verifyLoginSelectorIsVisible();
@@ -97,7 +107,7 @@ export class SecurityPageObject extends FtrService {
         await this.testSubjects.click('loginSubmit');
       }
 
-      await this.waitForLoginResult('chrome');
+      await this.waitForLoginResult(options?.expectedLoginResult ?? 'chrome');
 
       this.log.debug(`Finished login process currentUrl = ${await this.browser.getCurrentUrl()}`);
     },
@@ -210,6 +220,13 @@ export class SecurityPageObject extends FtrService {
     if (expectedResult === 'chrome') {
       await this.find.byCssSelector('[data-test-subj="userMenuButton"]', 20000);
       this.log.debug(`Finished login process currentUrl = ${await this.browser.getCurrentUrl()}`);
+    }
+
+    if (expectedResult instanceof Function) {
+      await expectedResult();
+      this.log.debug(
+        `Finished login process, await for custom condition. currentUrl = ${await this.browser.getCurrentUrl()}`
+      );
     }
   }
 

--- a/x-pack/test/security_functional/fixtures/common/test_endpoints/public/plugin.tsx
+++ b/x-pack/test/security_functional/fixtures/common/test_endpoints/public/plugin.tsx
@@ -11,10 +11,13 @@ import React from 'react';
 
 export class TestEndpointsPlugin implements Plugin {
   public setup(core: CoreSetup) {
+    // Prevent auto-logout on server `401` errors.
+    core.http.anonymousPaths.register('/authentication/app');
     core.application.register({
       id: 'authentication_app',
       title: 'Authentication app',
       appRoute: '/authentication/app',
+      chromeless: true,
       async mount({ element }) {
         ReactDOM.render(
           <div data-test-subj="testEndpointsAuthenticationApp">Authenticated!</div>,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix and re-enable basic login selector functional tests. (#106822)