### PR TITLE
[Data] do not import types from the legacy elasticsearch package

### DIFF
--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.searchsourcefields.fieldsfromsource.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.searchsourcefields.fieldsfromsource.md
@@ -14,5 +14,5 @@ Retreive fields directly from \_source (legacy behavior)
 <b>Signature:</b>
 
 ```typescript
-fieldsFromSource?: NameList;
+fieldsFromSource?: estypes.Fields;
 ```

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.searchsourcefields.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.searchsourcefields.md
@@ -18,7 +18,7 @@ export interface SearchSourceFields
 |  --- | --- | --- |
 |  [aggs](./kibana-plugin-plugins-data-public.searchsourcefields.aggs.md) | <code>object &#124; IAggConfigs &#124; (() =&gt; object)</code> | [AggConfigs](./kibana-plugin-plugins-data-public.aggconfigs.md) |
 |  [fields](./kibana-plugin-plugins-data-public.searchsourcefields.fields.md) | <code>SearchFieldValue[]</code> | Retrieve fields via the search Fields API |
-|  [fieldsFromSource](./kibana-plugin-plugins-data-public.searchsourcefields.fieldsfromsource.md) | <code>NameList</code> | Retreive fields directly from \_source (legacy behavior) |
+|  [fieldsFromSource](./kibana-plugin-plugins-data-public.searchsourcefields.fieldsfromsource.md) | <code>estypes.Fields</code> | Retreive fields directly from \_source (legacy behavior) |
 |  [filter](./kibana-plugin-plugins-data-public.searchsourcefields.filter.md) | <code>Filter[] &#124; Filter &#124; (() =&gt; Filter[] &#124; Filter &#124; undefined)</code> | [Filter](./kibana-plugin-plugins-data-public.filter.md) |
 |  [from](./kibana-plugin-plugins-data-public.searchsourcefields.from.md) | <code>number</code> |  |
 |  [highlight](./kibana-plugin-plugins-data-public.searchsourcefields.highlight.md) | <code>any</code> |  |
@@ -29,7 +29,7 @@ export interface SearchSourceFields
 |  [searchAfter](./kibana-plugin-plugins-data-public.searchsourcefields.searchafter.md) | <code>EsQuerySearchAfter</code> |  |
 |  [size](./kibana-plugin-plugins-data-public.searchsourcefields.size.md) | <code>number</code> |  |
 |  [sort](./kibana-plugin-plugins-data-public.searchsourcefields.sort.md) | <code>EsQuerySortValue &#124; EsQuerySortValue[]</code> | [EsQuerySortValue](./kibana-plugin-plugins-data-public.esquerysortvalue.md) |
-|  [source](./kibana-plugin-plugins-data-public.searchsourcefields.source.md) | <code>NameList</code> |  |
+|  [source](./kibana-plugin-plugins-data-public.searchsourcefields.source.md) | <code>boolean &#124; estypes.Fields</code> |  |
 |  [terminate\_after](./kibana-plugin-plugins-data-public.searchsourcefields.terminate_after.md) | <code>number</code> |  |
 |  [timeout](./kibana-plugin-plugins-data-public.searchsourcefields.timeout.md) | <code>string</code> |  |
 |  [trackTotalHits](./kibana-plugin-plugins-data-public.searchsourcefields.tracktotalhits.md) | <code>boolean &#124; number</code> |  |

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.searchsourcefields.source.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.searchsourcefields.source.md
@@ -7,5 +7,5 @@
 <b>Signature:</b>
 
 ```typescript
-source?: NameList;
+source?: boolean | estypes.Fields;
 ```

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.asyncsearchstatusresponse._shards.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.asyncsearchstatusresponse._shards.md
@@ -7,5 +7,5 @@
 <b>Signature:</b>
 
 ```typescript
-_shards: ShardsResponse;
+_shards: estypes.ShardStatistics;
 ```

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.asyncsearchstatusresponse.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.asyncsearchstatusresponse.md
@@ -14,6 +14,6 @@ export interface AsyncSearchStatusResponse extends Omit<AsyncSearchResponse, 're
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [\_shards](./kibana-plugin-plugins-data-server.asyncsearchstatusresponse._shards.md) | <code>ShardsResponse</code> |  |
+|  [\_shards](./kibana-plugin-plugins-data-server.asyncsearchstatusresponse._shards.md) | <code>estypes.ShardStatistics</code> |  |
 |  [completion\_status](./kibana-plugin-plugins-data-server.asyncsearchstatusresponse.completion_status.md) | <code>number</code> |  |
 

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 import type { estypes } from '@elastic/elasticsearch';
-import { NameList } from 'elasticsearch';
 import { IAggConfigs } from 'src/plugins/data/public';
 import { Query } from '../..';
 import { Filter } from '../../es_query';
@@ -90,7 +89,7 @@ export interface SearchSourceFields {
   aggs?: object | IAggConfigs | (() => object);
   from?: number;
   size?: number;
-  source?: NameList;
+  source?: boolean | estypes.Fields;
   version?: boolean;
   /**
    * Retrieve fields via the search Fields API
@@ -101,7 +100,7 @@ export interface SearchSourceFields {
    *
    * @deprecated It is recommended to use `fields` wherever possible.
    */
-  fieldsFromSource?: NameList;
+  fieldsFromSource?: estypes.Fields;
   /**
    * {@link IndexPatternService}
    */

--- a/src/plugins/data/common/search/tabify/tabify_docs.test.ts
+++ b/src/plugins/data/common/search/tabify/tabify_docs.test.ts
@@ -8,7 +8,7 @@
 
 import { tabifyDocs } from './tabify_docs';
 import { IndexPattern } from '../../index_patterns/index_patterns';
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 
 describe('tabifyDocs', () => {
   const fieldFormats = {
@@ -33,6 +33,7 @@ describe('tabifyDocs', () => {
     fieldFormats: fieldFormats as any,
   });
 
+  // @ts-expect-error not full inteface
   const response = {
     hits: {
       hits: [
@@ -46,7 +47,7 @@ describe('tabifyDocs', () => {
         },
       ],
     },
-  } as SearchResponse<unknown>;
+  } as estypes.SearchResponse<unknown>;
 
   it('converts fields by default', () => {
     const table = tabifyDocs(response, index);

--- a/src/plugins/data/common/search/tabify/tabify_docs.ts
+++ b/src/plugins/data/common/search/tabify/tabify_docs.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 import { isPlainObject } from 'lodash';
 import { IndexPattern } from '../../index_patterns/index_patterns';
 import { Datatable, DatatableColumn, DatatableColumnType } from '../../../../expressions/common';
@@ -18,7 +18,7 @@ export interface TabifyDocsOptions {
 }
 
 export function flattenHit(
-  hit: SearchResponse<unknown>['hits']['hits'][0],
+  hit: estypes.SearchHit,
   indexPattern?: IndexPattern,
   params?: TabifyDocsOptions
 ) {
@@ -58,7 +58,7 @@ export function flattenHit(
     }
   }
 
-  flatten(hit.fields);
+  flatten(hit.fields || {});
   if (params?.source !== false && hit._source) {
     flatten(hit._source as Record<string, any>);
   }
@@ -72,7 +72,7 @@ export function flattenHit(
 }
 
 export const tabifyDocs = (
-  esResponse: SearchResponse<unknown>,
+  esResponse: estypes.SearchResponse<unknown>,
   index?: IndexPattern,
   params: TabifyDocsOptions = {}
 ): Datatable => {

--- a/src/plugins/data/public/public.api.md
+++ b/src/plugins/data/public/public.api.md
@@ -71,7 +71,6 @@ import { MatchAllFilter as MatchAllFilter_2 } from '@kbn/es-query';
 import { MaybePromise } from '@kbn/utility-types';
 import { Moment } from 'moment';
 import moment from 'moment';
-import { NameList } from 'elasticsearch';
 import { ObjectType } from '@kbn/config-schema';
 import { Observable } from 'rxjs';
 import { PackageInfo } from '@kbn/config';
@@ -2478,7 +2477,7 @@ export interface SearchSourceFields {
     // Warning: (ae-forgotten-export) The symbol "SearchFieldValue" needs to be exported by the entry point index.d.ts
     fields?: SearchFieldValue[];
     // @deprecated
-    fieldsFromSource?: NameList;
+    fieldsFromSource?: estypes.Fields;
     // (undocumented)
     filter?: Filter[] | Filter | (() => Filter[] | Filter | undefined);
     // (undocumented)
@@ -2506,7 +2505,7 @@ export interface SearchSourceFields {
     // (undocumented)
     sort?: EsQuerySortValue | EsQuerySortValue[];
     // (undocumented)
-    source?: NameList;
+    source?: boolean | estypes.Fields;
     // (undocumented)
     terminate_after?: number;
     // (undocumented)

--- a/src/plugins/data/public/ui/shard_failure_modal/__mocks__/shard_failure_response.ts
+++ b/src/plugins/data/public/ui/shard_failure_modal/__mocks__/shard_failure_response.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 
-export const shardFailureResponse: SearchResponse<any> = {
+export const shardFailureResponse: estypes.SearchResponse<any> = {
   _shards: {
     total: 2,
     successful: 1,

--- a/src/plugins/data/server/autocomplete/terms_agg.test.ts
+++ b/src/plugins/data/server/autocomplete/terms_agg.test.ts
@@ -12,7 +12,7 @@ import { ConfigSchema } from '../../config';
 import type { DeeplyMockedKeys } from '@kbn/utility-types/jest';
 import type { ApiResponse } from '@elastic/elasticsearch';
 import { termsAggSuggestions } from './terms_agg';
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 import { duration } from 'moment';
 
 let savedObjectsClientMock: jest.Mocked<SavedObjectsClientContract>;
@@ -22,6 +22,8 @@ const configMock = ({
     valueSuggestions: { timeout: duration(4513), terminateAfter: duration(98430) },
   },
 } as unknown) as ConfigSchema;
+
+// @ts-expect-error not full interface
 const mockResponse = {
   body: {
     aggregations: {
@@ -30,7 +32,7 @@ const mockResponse = {
       },
     },
   },
-} as ApiResponse<SearchResponse<any>>;
+} as ApiResponse<estypes.SearchResponse<any>>;
 
 jest.mock('../index_patterns');
 

--- a/src/plugins/data/server/search/strategies/es_search/response_utils.test.ts
+++ b/src/plugins/data/server/search/strategies/es_search/response_utils.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { getTotalLoaded, toKibanaSearchResponse, shimHitsTotal } from './response_utils';
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 
 describe('response utils', () => {
   describe('getTotalLoaded', () => {
@@ -19,7 +19,7 @@ describe('response utils', () => {
           skipped: 5,
           total: 100,
         },
-      } as unknown) as SearchResponse<unknown>);
+      } as unknown) as estypes.SearchResponse<unknown>);
 
       expect(result).toEqual({
         total: 100,
@@ -37,7 +37,7 @@ describe('response utils', () => {
           skipped: 5,
           total: 100,
         },
-      } as unknown) as SearchResponse<unknown>);
+      } as unknown) as estypes.SearchResponse<unknown>);
 
       expect(result).toEqual({
         rawResponse: {

--- a/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
@@ -9,7 +9,7 @@
 import type { Observable } from 'rxjs';
 import type { IScopedClusterClient, Logger, SharedGlobalConfig } from 'kibana/server';
 import { catchError, first, tap } from 'rxjs/operators';
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 import { from } from 'rxjs';
 import type { ISearchStrategy, SearchStrategyDependencies } from '../../types';
 import type {
@@ -121,7 +121,7 @@ export const enhancedEsSearchStrategyProvider = (
       });
 
       const esResponse = await shimAbortSignal(promise, options?.abortSignal);
-      const response = esResponse.body as SearchResponse<any>;
+      const response = esResponse.body as estypes.SearchResponse<any>;
       return {
         rawResponse: shimHitsTotal(response, options),
         ...getTotalLoaded(response),

--- a/src/plugins/data/server/search/strategies/ese_search/types.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/types.ts
@@ -7,7 +7,6 @@
  */
 
 import type { estypes } from '@elastic/elasticsearch';
-import { ShardsResponse } from 'elasticsearch';
 
 export interface AsyncSearchResponse<T = unknown> {
   id?: string;
@@ -19,5 +18,5 @@ export interface AsyncSearchResponse<T = unknown> {
 }
 export interface AsyncSearchStatusResponse extends Omit<AsyncSearchResponse, 'response'> {
   completion_status: number;
-  _shards: ShardsResponse;
+  _shards: estypes.ShardStatistics;
 }

--- a/src/plugins/data/server/server.api.md
+++ b/src/plugins/data/server/server.api.md
@@ -52,7 +52,6 @@ import { Logger as Logger_2 } from 'kibana/server';
 import { LoggerFactory } from '@kbn/logging';
 import { Moment } from 'moment';
 import moment from 'moment';
-import { NameList } from 'elasticsearch';
 import { Observable } from 'rxjs';
 import { PackageInfo } from '@kbn/config';
 import { PathConfigType } from '@kbn/utils';
@@ -73,7 +72,6 @@ import { SavedObjectsFindResponse } from 'kibana/server';
 import { SavedObjectsUpdateResponse } from 'kibana/server';
 import { Search } from '@elastic/elasticsearch/api/requestParams';
 import { SerializedFieldFormat as SerializedFieldFormat_2 } from 'src/plugins/expressions/common';
-import { ShardsResponse } from 'elasticsearch';
 import { SharedGlobalConfig as SharedGlobalConfig_2 } from 'kibana/server';
 import { ToastInputFields } from 'src/core/public/notifications';
 import { TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport';
@@ -312,7 +310,7 @@ export interface AsyncSearchStatusResponse extends Omit<AsyncSearchResponse, 're
     // (undocumented)
     completion_status: number;
     // (undocumented)
-    _shards: ShardsResponse;
+    _shards: estypes.ShardStatistics;
 }
 
 // Warning: (ae-missing-release-tag) "BUCKET_TYPES" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/x-pack/plugins/data_enhanced/server/collectors/fetch.ts
+++ b/x-pack/plugins/data_enhanced/server/collectors/fetch.ts
@@ -7,7 +7,6 @@
 import type { estypes } from '@elastic/elasticsearch';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { SearchResponse } from 'elasticsearch';
 import { SharedGlobalConfig, Logger } from 'kibana/server';
 import { CollectorFetchContext } from '../../../../../src/plugins/usage_collection/server';
 import { SEARCH_SESSION_TYPE } from '../../../../../src/plugins/data/common';
@@ -22,7 +21,7 @@ export function fetchProvider(config$: Observable<SharedGlobalConfig>, logger: L
   return async ({ esClient }: CollectorFetchContext): Promise<ReportedUsage> => {
     try {
       const config = await config$.pipe(first()).toPromise();
-      const { body: esResponse } = await esClient.search<SearchResponse<unknown>>({
+      const { body: esResponse } = await esClient.search<unknown>({
         index: config.kibana.index,
         body: {
           size: 0,


### PR DESCRIPTION
## Summary

Use types provided by `@elastic/elasticsearch` package.