### PR TITLE
[Actions] Swimlane: Fix connectorType schema

### DIFF
--- a/x-pack/plugins/actions/server/builtin_action_types/swimlane/schema.ts
+++ b/x-pack/plugins/actions/server/builtin_action_types/swimlane/schema.ts
@@ -31,7 +31,11 @@ export const ConfigMappingSchema = schema.object(ConfigMapping);
 export const SwimlaneServiceConfiguration = {
   apiUrl: schema.string(),
   appId: schema.string(),
-  connectorType: schema.string(),
+  connectorType: schema.oneOf([
+    schema.literal('all'),
+    schema.literal('alerts'),
+    schema.literal('cases'),
+  ]),
   mappings: ConfigMappingSchema,
 };
 

--- a/x-pack/plugins/actions/server/builtin_action_types/swimlane/service.test.ts
+++ b/x-pack/plugins/actions/server/builtin_action_types/swimlane/service.test.ts
@@ -35,7 +35,7 @@ describe('Swimlane Service', () => {
   const config = {
     apiUrl: 'https://test.swimlane.com/',
     appId: 'bcq16kdTbz5jlwM6h',
-    connectorType: 'all',
+    connectorType: 'all' as const,
     mappings,
   };
   const apiToken = 'token';

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/swimlane/steps/swimlane_fields.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/swimlane/steps/swimlane_fields.tsx
@@ -37,9 +37,9 @@ interface Props {
 }
 
 const connectorTypeButtons = [
-  { id: 'all', label: 'All' },
-  { id: 'alerts', label: 'Alerts' },
-  { id: 'cases', label: 'Cases' },
+  { id: SwimlaneConnectorType.All, label: 'All' },
+  { id: SwimlaneConnectorType.Alerts, label: 'Alerts' },
+  { id: SwimlaneConnectorType.Cases, label: 'Cases' },
 ];
 
 const SwimlaneFieldsComponent: React.FC<Props> = ({

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/actions/builtin_action_types/swimlane.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/actions/builtin_action_types/swimlane.ts
@@ -25,7 +25,7 @@ export default function swimlaneTest({ getService }: FtrProviderContext) {
     config: {
       apiUrl: 'http://swimlane.mynonexistent.com',
       appId: '123456asdf',
-      connectorType: 'all',
+      connectorType: 'all' as const,
       mappings: {
         alertIdConfig: {
           id: 'ednjls',
@@ -181,6 +181,7 @@ export default function swimlaneTest({ getService }: FtrProviderContext) {
             name: 'A swimlane action',
             connector_type_id: '.swimlane',
             config: {
+              connectorType: 'all' as const,
               appId: mockSwimlane.config.appId,
               mappings: mockSwimlane.config.mappings,
             },
@@ -205,6 +206,7 @@ export default function swimlaneTest({ getService }: FtrProviderContext) {
             name: 'A swimlane action',
             connector_type_id: '.swimlane',
             config: {
+              connectorType: 'all' as const,
               mappings: mockSwimlane.config.mappings,
               apiUrl: swimlaneSimulatorURL,
             },
@@ -261,6 +263,31 @@ export default function swimlaneTest({ getService }: FtrProviderContext) {
               statusCode: 400,
               error: 'Bad Request',
               message: `error validating action type config: error configuring connector action: target url "${mockSwimlane.config.apiUrl}" is not added to the Kibana config xpack.actions.allowedHosts`,
+            });
+          });
+      });
+
+      it('should respond with a 400 Bad Request if connectorType is not supported', async () => {
+        await supertest
+          .post('/api/actions/connector')
+          .set('kbn-xsrf', 'foo')
+          .send({
+            name: 'A swimlane action',
+            connector_type_id: '.swimlane',
+            config: {
+              ...mockSwimlane.config,
+              apiUrl: swimlaneSimulatorURL,
+              connectorType: 'not-supported',
+            },
+            secrets: mockSwimlane.secrets,
+          })
+          .expect(400)
+          .then((resp: any) => {
+            expect(resp.body).to.eql({
+              statusCode: 400,
+              error: 'Bad Request',
+              message:
+                'error validating action type config: [connectorType]: types that failed validation:\n- [connectorType.0]: expected value to equal [all]\n- [connectorType.1]: expected value to equal [alerts]\n- [connectorType.2]: expected value to equal [cases]',
             });
           });
       });


### PR DESCRIPTION
## Summary

This PR restricts the `connectorType` to be one of `all`, `alerts`, or `cases`.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
