### PR TITLE
[ML] Transforms: Adds a type column to the transforms management table

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.tsx
@@ -247,6 +247,7 @@ export const ExpandedRow: FC<Props> = ({ item }) => {
       onTabClick={() => {}}
       expand={false}
       style={{ width: '100%' }}
+      data-test-subj="transformExpandedRowTabbedContent"
     />
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_search_bar_filters.tsx
@@ -9,7 +9,12 @@ import React from 'react';
 import { EuiBadge, SearchFilterConfig } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { TermClause, FieldClause, Value } from './common';
-import { TRANSFORM_MODE, TRANSFORM_STATE } from '../../../../../../common/constants';
+import {
+  TRANSFORM_FUNCTION,
+  TRANSFORM_MODE,
+  TRANSFORM_STATE,
+} from '../../../../../../common/constants';
+import { isLatestTransform, isPivotTransform } from '../../../../../../common/types/transform';
 import { TransformListRow } from '../../../../common';
 import { getTaskStateBadge } from './use_columns';
 
@@ -93,7 +98,20 @@ export const filterTransforms = (
         // the status value is an array of string(s) e.g. ['failed', 'stopped']
         ts = transforms.filter((transform) => (c.value as Value[]).includes(transform.stats.state));
       } else {
-        ts = transforms.filter((transform) => transform.mode === c.value);
+        ts = transforms.filter((transform) => {
+          if (c.field === 'mode') {
+            return transform.mode === c.value;
+          }
+          if (c.field === 'type') {
+            if (c.value === TRANSFORM_FUNCTION.PIVOT) {
+              return isPivotTransform(transform.config);
+            }
+            if (c.value === TRANSFORM_FUNCTION.LATEST) {
+              return isLatestTransform(transform.config);
+            }
+          }
+          return false;
+        });
       }
     }
 

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.test.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.test.tsx
@@ -20,13 +20,14 @@ describe('Transform: Job List Columns', () => {
 
     const columns: ReturnType<typeof useColumns>['columns'] = result.current.columns;
 
-    expect(columns).toHaveLength(7);
+    expect(columns).toHaveLength(8);
     expect(columns[0].isExpander).toBeTruthy();
     expect(columns[1].name).toBe('ID');
     expect(columns[2].name).toBe('Description');
-    expect(columns[3].name).toBe('Status');
-    expect(columns[4].name).toBe('Mode');
-    expect(columns[5].name).toBe('Progress');
-    expect(columns[6].name).toBe('Actions');
+    expect(columns[3].name).toBe('Type');
+    expect(columns[4].name).toBe('Status');
+    expect(columns[5].name).toBe('Mode');
+    expect(columns[6].name).toBe('Progress');
+    expect(columns[7].name).toBe('Actions');
   });
 });

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.tsx
@@ -23,7 +23,11 @@ import {
   RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 
-import { TransformId } from '../../../../../../common/types/transform';
+import {
+  isLatestTransform,
+  isPivotTransform,
+  TransformId,
+} from '../../../../../../common/types/transform';
 import { TransformStats } from '../../../../../../common/types/transform_stats';
 import { TRANSFORM_STATE } from '../../../../../../common/constants';
 
@@ -95,6 +99,7 @@ export const useColumns = (
     EuiTableComputedColumnType<TransformListRow>,
     EuiTableComputedColumnType<TransformListRow>,
     EuiTableComputedColumnType<TransformListRow>,
+    EuiTableComputedColumnType<TransformListRow>,
     EuiTableActionsColumnType<TransformListRow>
   ] = [
     {
@@ -144,6 +149,27 @@ export const useColumns = (
       name: i18n.translate('xpack.transform.description', { defaultMessage: 'Description' }),
       sortable: true,
       truncateText: true,
+    },
+    {
+      name: i18n.translate('xpack.transform.type', { defaultMessage: 'Type' }),
+      'data-test-subj': 'transformListColumnType',
+      sortable: (item: TransformListRow) => item.mode,
+      truncateText: true,
+      render(item: TransformListRow) {
+        let transformType = i18n.translate('xpack.transform.type.unknown', {
+          defaultMessage: 'unknown',
+        });
+        if (isPivotTransform(item.config) === true) {
+          transformType = i18n.translate('xpack.transform.type.pivot', { defaultMessage: 'pivot' });
+        }
+        if (isLatestTransform(item.config) === true) {
+          transformType = i18n.translate('xpack.transform.type.latest', {
+            defaultMessage: 'latest',
+          });
+        }
+        return <EuiBadge color="hollow">{transformType}</EuiBadge>;
+      },
+      width: '100px',
     },
     {
       name: i18n.translate('xpack.transform.status', { defaultMessage: 'Status' }),

--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -149,7 +149,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -327,7 +326,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -367,7 +365,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'latest',
             mode: 'batch',
             progress: '100',
           },
@@ -581,7 +578,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowFields(testData.transformId, {
             id: testData.transformId,
             description: testData.transformDescription,
-            type: testData.expected.row.type,
+            type: testData.type,
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,

--- a/x-pack/test/functional/apps/transform/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation_index_pattern.ts
@@ -149,6 +149,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -326,6 +327,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -365,6 +367,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'latest',
             mode: 'batch',
             progress: '100',
           },
@@ -578,6 +581,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowFields(testData.transformId, {
             id: testData.transformId,
             description: testData.transformDescription,
+            type: testData.expected.row.type,
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,

--- a/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
+++ b/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
@@ -174,6 +174,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -226,6 +227,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'latest',
             mode: 'batch',
             progress: '100',
           },

--- a/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
+++ b/x-pack/test/functional/apps/transform/creation_runtime_mappings.ts
@@ -174,7 +174,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -227,7 +226,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'latest',
             mode: 'batch',
             progress: '100',
           },

--- a/x-pack/test/functional/apps/transform/creation_saved_search.ts
+++ b/x-pack/test/functional/apps/transform/creation_saved_search.ts
@@ -21,6 +21,7 @@ export default function ({ getService }: FtrProviderContext) {
   const transform = getService('transform');
 
   describe('creation_saved_search', function () {
+    this.tags(['pete']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await transform.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
@@ -64,6 +65,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -101,6 +103,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'latest',
             mode: 'batch',
             progress: '100',
           },
@@ -279,6 +282,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowFields(testData.transformId, {
             id: testData.transformId,
             description: testData.transformDescription,
+            type: testData.expected.row.type,
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,

--- a/x-pack/test/functional/apps/transform/creation_saved_search.ts
+++ b/x-pack/test/functional/apps/transform/creation_saved_search.ts
@@ -21,7 +21,6 @@ export default function ({ getService }: FtrProviderContext) {
   const transform = getService('transform');
 
   describe('creation_saved_search', function () {
-    this.tags(['pete']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await transform.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');

--- a/x-pack/test/functional/apps/transform/creation_saved_search.ts
+++ b/x-pack/test/functional/apps/transform/creation_saved_search.ts
@@ -64,7 +64,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -102,7 +101,6 @@ export default function ({ getService }: FtrProviderContext) {
           },
           row: {
             status: TRANSFORM_STATE.STOPPED,
-            type: 'latest',
             mode: 'batch',
             progress: '100',
           },
@@ -281,7 +279,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowFields(testData.transformId, {
             id: testData.transformId,
             description: testData.transformDescription,
-            type: testData.expected.row.type,
+            type: testData.type,
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,

--- a/x-pack/test/functional/apps/transform/deleting.ts
+++ b/x-pack/test/functional/apps/transform/deleting.ts
@@ -24,6 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'batch',
             progress: 100,
           },
@@ -35,6 +36,7 @@ export default function ({ getService }: FtrProviderContext) {
         expected: {
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'continuous',
             progress: undefined,
           },
@@ -50,6 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
           messageText: 'updated transform.',
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'latest',
             mode: 'batch',
             progress: 100,
           },
@@ -106,6 +109,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowFields(testData.originalConfig.id, {
             id: testData.originalConfig.id,
             description: testData.originalConfig.description,
+            type: testData.expected.row.type,
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,

--- a/x-pack/test/functional/apps/transform/editing.ts
+++ b/x-pack/test/functional/apps/transform/editing.ts
@@ -70,6 +70,7 @@ export default function ({ getService }: FtrProviderContext) {
           messageText: 'updated transform.',
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'pivot',
             mode: 'batch',
             progress: '100',
           },
@@ -85,6 +86,7 @@ export default function ({ getService }: FtrProviderContext) {
           messageText: 'updated transform.',
           row: {
             status: TRANSFORM_STATE.STOPPED,
+            type: 'latest',
             mode: 'batch',
             progress: '100',
           },
@@ -170,6 +172,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.table.assertTransformRowFields(testData.originalConfig.id, {
             id: testData.originalConfig.id,
             description: testData.transformDescription,
+            type: testData.expected.row.type,
             status: testData.expected.row.status,
             mode: testData.expected.row.mode,
             progress: testData.expected.row.progress,

--- a/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/107043
-  describe.skip('for user with full transform access', function () {
+  describe('for user with full transform access', function () {
     describe('with no data loaded', function () {
       before(async () => {
         await transform.securityUI.loginAsTransformPowerUser();

--- a/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
@@ -13,7 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  describe('for user with full transform access', function () {
+  describe('for user with read only transform access', function () {
     describe('with no data loaded', function () {
       before(async () => {
         await transform.securityUI.loginAsTransformViewer();

--- a/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const transform = getService('transform');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/107043
-  describe.skip('for user with full transform access', function () {
+  describe('for user with full transform access', function () {
     describe('with no data loaded', function () {
       before(async () => {
         await transform.securityUI.loginAsTransformViewer();

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -195,25 +195,45 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
       });
     }
 
+    public async ensureDetailsOpen() {
+      await retry.tryForTime(30 * 1000, async () => {
+        if (!(await testSubjects.exists('transformExpandedRowTabbedContent'))) {
+          await testSubjects.click('transformListRowDetailsToggle');
+          await testSubjects.existOrFail('transformExpandedRowTabbedContent', { timeout: 1000 });
+        }
+      });
+    }
+
+    public async ensureDetailsClosed() {
+      await retry.tryForTime(30 * 1000, async () => {
+        if (await testSubjects.exists('transformExpandedRowTabbedContent')) {
+          await testSubjects.click('transformListRowDetailsToggle');
+          await testSubjects.missingOrFail('transformExpandedRowTabbedContent', { timeout: 1000 });
+        }
+      });
+    }
+
     public async assertTransformExpandedRow() {
-      await testSubjects.click('transformListRowDetailsToggle');
+      await retry.tryForTime(30 * 1000, async () => {
+        await this.ensureDetailsOpen();
 
-      // The expanded row should show the details tab content by default
-      await testSubjects.existOrFail('transformDetailsTab');
-      await testSubjects.existOrFail('~transformDetailsTabContent');
+        // The expanded row should show the details tab content by default
+        await testSubjects.existOrFail('transformDetailsTab');
+        await testSubjects.existOrFail('~transformDetailsTabContent');
 
-      // Walk through the rest of the tabs and check if the corresponding content shows up
-      await testSubjects.existOrFail('transformJsonTab');
-      await testSubjects.click('transformJsonTab');
-      await testSubjects.existOrFail('~transformJsonTabContent');
+        // Walk through the rest of the tabs and check if the corresponding content shows up
+        await testSubjects.existOrFail('transformJsonTab');
+        await testSubjects.click('transformJsonTab');
+        await testSubjects.existOrFail('~transformJsonTabContent');
 
-      await testSubjects.existOrFail('transformMessagesTab');
-      await testSubjects.click('transformMessagesTab');
-      await testSubjects.existOrFail('~transformMessagesTabContent');
+        await testSubjects.existOrFail('transformMessagesTab');
+        await testSubjects.click('transformMessagesTab');
+        await testSubjects.existOrFail('~transformMessagesTabContent');
 
-      await testSubjects.existOrFail('transformPreviewTab');
-      await testSubjects.click('transformPreviewTab');
-      await testSubjects.existOrFail('~transformPivotPreview');
+        await testSubjects.existOrFail('transformPreviewTab');
+        await testSubjects.click('transformPreviewTab');
+        await testSubjects.existOrFail('~transformPivotPreview');
+      });
     }
 
     public async assertTransformExpandedRowMessages(expectedText: string) {

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -37,6 +37,11 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
             .find('.euiTableCellContent')
             .text()
             .trim(),
+          type: $tr
+            .findTestSubject('transformListColumnType')
+            .find('.euiTableCellContent')
+            .text()
+            .trim(),
           status: $tr
             .findTestSubject('transformListColumnStatus')
             .find('.euiTableCellContent')

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -213,36 +213,36 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
       });
     }
 
+    public async switchToExpandedRowTab(tabSubject: string, contentSubject: string) {
+      await retry.tryForTime(30 * 1000, async () => {
+        await testSubjects.click(tabSubject);
+        await testSubjects.existOrFail(contentSubject, { timeout: 1000 });
+      });
+    }
+
     public async assertTransformExpandedRow() {
       await this.ensureDetailsOpen();
       await retry.tryForTime(30 * 1000, async () => {
         // The expanded row should show the details tab content by default
         await testSubjects.existOrFail('transformDetailsTab', { timeout: 1000 });
         await testSubjects.existOrFail('~transformDetailsTabContent', { timeout: 1000 });
-
-        // Walk through the rest of the tabs and check if the corresponding content shows up
-        await testSubjects.click('transformJsonTab');
-        await testSubjects.existOrFail('~transformJsonTabContent', { timeout: 1000 });
-
-        await testSubjects.click('transformMessagesTab');
-        await testSubjects.existOrFail('~transformMessagesTabContent', { timeout: 1000 });
-
-        await testSubjects.click('transformPreviewTab');
-        await testSubjects.existOrFail('~transformPivotPreview', { timeout: 1000 });
       });
+
+      // Walk through the rest of the tabs and check if the corresponding content shows up
+      await this.switchToExpandedRowTab('transformJsonTab', '~transformJsonTabContent');
+      await this.switchToExpandedRowTab('transformMessagesTab', '~transformMessagesTabContent');
+      await this.switchToExpandedRowTab('transformPreviewTab', '~transformPivotPreview');
     }
 
     public async assertTransformExpandedRowMessages(expectedText: string) {
-      await testSubjects.click('transformListRowDetailsToggle');
+      await this.ensureDetailsOpen();
 
       // The expanded row should show the details tab content by default
       await testSubjects.existOrFail('transformDetailsTab');
       await testSubjects.existOrFail('~transformDetailsTabContent');
 
       // Click on the messages tab and assert the messages
-      await testSubjects.existOrFail('transformMessagesTab');
-      await testSubjects.click('transformMessagesTab');
-      await testSubjects.existOrFail('~transformMessagesTabContent');
+      await this.switchToExpandedRowTab('transformMessagesTab', '~transformMessagesTabContent');
       await retry.tryForTime(30 * 1000, async () => {
         const actualText = await testSubjects.getVisibleText('~transformMessagesTabContent');
         expect(actualText.toLowerCase()).to.contain(

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -214,25 +214,21 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
     }
 
     public async assertTransformExpandedRow() {
+      await this.ensureDetailsOpen();
       await retry.tryForTime(30 * 1000, async () => {
-        await this.ensureDetailsOpen();
-
         // The expanded row should show the details tab content by default
-        await testSubjects.existOrFail('transformDetailsTab');
-        await testSubjects.existOrFail('~transformDetailsTabContent');
+        await testSubjects.existOrFail('transformDetailsTab', { timeout: 1000 });
+        await testSubjects.existOrFail('~transformDetailsTabContent', { timeout: 1000 });
 
         // Walk through the rest of the tabs and check if the corresponding content shows up
-        await testSubjects.existOrFail('transformJsonTab');
         await testSubjects.click('transformJsonTab');
-        await testSubjects.existOrFail('~transformJsonTabContent');
+        await testSubjects.existOrFail('~transformJsonTabContent', { timeout: 1000 });
 
-        await testSubjects.existOrFail('transformMessagesTab');
         await testSubjects.click('transformMessagesTab');
-        await testSubjects.existOrFail('~transformMessagesTabContent');
+        await testSubjects.existOrFail('~transformMessagesTabContent', { timeout: 1000 });
 
-        await testSubjects.existOrFail('transformPreviewTab');
         await testSubjects.click('transformPreviewTab');
-        await testSubjects.existOrFail('~transformPivotPreview');
+        await testSubjects.existOrFail('~transformPivotPreview', { timeout: 1000 });
       });
     }
 


### PR DESCRIPTION
## Summary

Adds a 'Type' column to the Transforms management table which displays whether the transform is a pivot or a latest type of transform.

![image](https://user-images.githubusercontent.com/7405507/127316976-a1996f3f-d93a-4135-a188-4563a78849c0.png)

Adds support to the search bar to allow for queries on transform, of the form `type:pivot`

![image](https://user-images.githubusercontent.com/7405507/127317262-985b2cd4-e821-4b4b-ac08-0d756eb0b67d.png)

Also added stabilization for the tests for the expanded row content following flaky test seen in https://github.com/elastic/kibana/pull/106960.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Fixes #89704
