### PR TITLE
Wait for user avatar to finish loading before declaring login successful

### DIFF
--- a/x-pack/plugins/security/public/nav_control/nav_control_component.test.tsx
+++ b/x-pack/plugins/security/public/nav_control/nav_control_component.test.tsx
@@ -64,6 +64,7 @@ describe('SecurityNavControl', () => {
         onClick={[Function]}
       >
         <EuiAvatar
+          data-test-subj="userMenuAvatar"
           name="foo"
           size="s"
         />

--- a/x-pack/plugins/security/public/nav_control/nav_control_component.tsx
+++ b/x-pack/plugins/security/public/nav_control/nav_control_component.tsx
@@ -100,7 +100,7 @@ export class SecurityNavControl extends Component<Props, State> {
       (authenticatedUser && (authenticatedUser.full_name || authenticatedUser.username)) || '';
 
     const buttonContents = authenticatedUser ? (
-      <EuiAvatar name={username} size="s" />
+      <EuiAvatar name={username} size="s" data-test-subj="userMenuAvatar" />
     ) : (
       <EuiLoadingSpinner size="m" />
     );

--- a/x-pack/plugins/security/public/nav_control/nav_control_service.test.ts
+++ b/x-pack/plugins/security/public/nav_control/nav_control_service.test.ts
@@ -86,6 +86,7 @@ describe('SecurityNavControlService', () => {
                     <div
                       aria-label="some-user"
                       class="euiAvatar euiAvatar--s euiAvatar--user"
+                      data-test-subj="userMenuAvatar"
                       style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
                       title="some-user"
                     >

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -218,7 +218,7 @@ export class SecurityPageObject extends FtrService {
     }
 
     if (expectedResult === 'chrome') {
-      await this.find.byCssSelector('[data-test-subj="userMenuButton"]', 20000);
+      await this.find.byCssSelector('[data-test-subj="userMenuAvatar"]', 20000);
       this.log.debug(`Finished login process currentUrl = ${await this.browser.getCurrentUrl()}`);
     }
 


### PR DESCRIPTION
## Summary

Resolves #104244 by waiting for the user avatar to finish loading before declaring a login attempt successful. Prior to this change, an unexpected delay could cause subsequent test assertions to fail, because we don't yet have the user's information.

Flaky test suite: https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1785/