### PR TITLE
[Security solution][Endpoint] Set event filters form as error when there are no entries

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/store/action.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/store/action.ts
@@ -48,7 +48,7 @@ export type EventFiltersInitFromId = Action<'eventFiltersInitFromId'> & {
 
 export type EventFiltersChangeForm = Action<'eventFiltersChangeForm'> & {
   payload: {
-    entry: UpdateExceptionListItemSchema | CreateExceptionListItemSchema;
+    entry?: UpdateExceptionListItemSchema | CreateExceptionListItemSchema;
     hasNameError?: boolean;
     hasItemsError?: boolean;
     hasOSError?: boolean;

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/store/reducer.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/store/reducer.test.ts
@@ -67,6 +67,25 @@ describe('event filters reducer', () => {
       });
     });
 
+    it('change form values without entry', () => {
+      const newComment = 'new comment';
+      const result = eventFiltersPageReducer(initialState, {
+        type: 'eventFiltersChangeForm',
+        payload: { newComment },
+      });
+
+      expect(result).toStrictEqual({
+        ...initialState,
+        form: {
+          ...initialState.form,
+          newComment,
+          submissionResourceState: {
+            type: 'UninitialisedResourceState',
+          },
+        },
+      });
+    });
+
     it('change form status', () => {
       const result = eventFiltersPageReducer(initialState, {
         type: 'eventFiltersFormStateChanged',

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/store/reducer.ts
@@ -100,7 +100,7 @@ const eventFiltersChangeForm: CaseReducer<EventFiltersChangeForm> = (state, acti
     ...state,
     form: {
       ...state.form,
-      entry: action.payload.entry,
+      entry: action.payload.entry !== undefined ? action.payload.entry : state.form.entry,
       hasItemsError:
         action.payload.hasItemsError !== undefined
           ? action.payload.hasItemsError

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -68,7 +68,7 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
         dispatch({
           type: 'eventFiltersChangeForm',
           payload: {
-            ...(arg.exceptionItems[0]
+            ...(arg.exceptionItems[0] !== undefined
               ? {
                   entry: {
                     ...arg.exceptionItems[0],

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -18,8 +18,12 @@ import {
   EuiText,
 } from '@elastic/eui';
 
-import { isEmpty } from 'lodash/fp';
-import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import type {
+  ExceptionListItemSchema,
+  CreateExceptionListItemSchema,
+  UpdateExceptionListItemSchema,
+} from '@kbn/securitysolution-io-ts-list-types';
+
 import { OperatingSystem } from '../../../../../../../common/endpoint/types';
 import { AddExceptionComments } from '../../../../../../common/components/exceptions/add_exception_comments';
 import { filterIndexPatterns } from '../../../../../../common/components/exceptions/helpers';
@@ -65,17 +69,22 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
 
     const handleOnBuilderChange = useCallback(
       (arg: ExceptionBuilder.OnChangeProps) => {
-        if (isEmpty(arg.exceptionItems)) return;
         dispatch({
           type: 'eventFiltersChangeForm',
           payload: {
-            entry: {
-              ...arg.exceptionItems[0],
-              name: exception?.name ?? '',
-              comments: exception?.comments ?? [],
-              os_types: exception?.os_types ?? [OperatingSystem.WINDOWS],
-            },
-            hasItemsError: arg.errorExists || !arg.exceptionItems[0].entries.length,
+            ...(arg.exceptionItems[0]
+              ? {
+                  entry: {
+                    ...arg.exceptionItems[0],
+                    name: exception?.name ?? '',
+                    comments: exception?.comments ?? [],
+                    os_types: exception?.os_types ?? [OperatingSystem.WINDOWS],
+                  },
+                  hasItemsError: arg.errorExists || !arg.exceptionItems[0]?.entries?.length,
+                }
+              : {
+                  hasItemsError: true,
+                }),
           },
         });
       },

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -18,11 +18,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 
-import type {
-  ExceptionListItemSchema,
-  CreateExceptionListItemSchema,
-  UpdateExceptionListItemSchema,
-} from '@kbn/securitysolution-io-ts-list-types';
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 
 import { OperatingSystem } from '../../../../../../../common/endpoint/types';
 import { AddExceptionComments } from '../../../../../../common/components/exceptions/add_exception_comments';


### PR DESCRIPTION
## Summary

Sets event filters form to error when there are no entries in form.


![set form to error when there is no more entries](https://user-images.githubusercontent.com/15727784/127326780-511816e1-0d80-4ded-8edd-269be6ccf43a.gif)

![set form to error when there is no more entries in event list](https://user-images.githubusercontent.com/15727784/127326987-de4f1dfa-a1c2-4ade-b3ad-e5883a9fc86a.gif)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
