### PR TITLE
[7.x] [Security Solution][Endpoint] Allow access to Endpoint Metadata for users that might only have READONLY access (#106328)

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -118,7 +118,7 @@ interface AgentBase {
 export interface Agent extends AgentBase {
   id: string;
   access_api_key?: string;
-  status?: string;
+  status?: AgentStatus;
   packages: string[];
 }
 

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -35,12 +35,8 @@ export const getAgentHandler: RequestHandler<
   const esClient = context.core.elasticsearch.client.asCurrentUser;
 
   try {
-    const agent = await AgentService.getAgentById(esClient, request.params.agentId);
     const body: GetOneAgentResponse = {
-      item: {
-        ...agent,
-        status: AgentService.getAgentStatus(agent),
-      },
+      item: await AgentService.getAgentById(esClient, request.params.agentId),
     };
 
     return response.ok({ body });
@@ -91,12 +87,8 @@ export const updateAgentHandler: RequestHandler<
     await AgentService.updateAgent(esClient, request.params.agentId, {
       user_provided_metadata: request.body.user_provided_metadata,
     });
-    const agent = await AgentService.getAgentById(esClient, request.params.agentId);
     const body = {
-      item: {
-        ...agent,
-        status: AgentService.getAgentStatus(agent),
-      },
+      item: await AgentService.getAgentById(esClient, request.params.agentId),
     };
 
     return response.ok({ body });
@@ -132,10 +124,7 @@ export const getAgentsHandler: RequestHandler<
       : 0;
 
     const body: GetAgentsResponse = {
-      list: agents.map((agent) => ({
-        ...agent,
-        status: AgentService.getAgentStatus(agent),
-      })),
+      list: agents,
       total,
       totalInactive,
       page,

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -199,9 +199,8 @@ export async function getAgentById(esClient: ElasticsearchClient, agentId: strin
     if (agentHit.body.found === false) {
       throw agentNotFoundError;
     }
-    const agent = searchHitToAgent(agentHit.body);
 
-    return agent;
+    return searchHitToAgent(agentHit.body);
   } catch (err) {
     if (isESClientError(err) && err.meta.statusCode === 404) {
       throw agentNotFoundError;

--- a/x-pack/plugins/fleet/server/services/agents/helpers.ts
+++ b/x-pack/plugins/fleet/server/services/agents/helpers.ts
@@ -9,6 +9,7 @@ import type { estypes } from '@elastic/elasticsearch';
 
 import type { SearchHit } from '../../../../../../src/core/types/elasticsearch';
 import type { Agent, AgentSOAttributes, FleetServerAgent } from '../../types';
+import { getAgentStatus } from '../../../common/services/agent_status';
 
 type FleetServerAgentESResponse =
   | estypes.MgetHit<FleetServerAgent>
@@ -17,7 +18,7 @@ type FleetServerAgentESResponse =
 
 export function searchHitToAgent(hit: FleetServerAgentESResponse): Agent {
   // @ts-expect-error @elastic/elasticsearch MultiGetHit._source is optional
-  return {
+  const agent: Agent = {
     id: hit._id,
     ...hit._source,
     policy_revision: hit._source?.policy_revision_idx,
@@ -25,6 +26,9 @@ export function searchHitToAgent(hit: FleetServerAgentESResponse): Agent {
     status: undefined,
     packages: hit._source?.packages ?? [],
   };
+
+  agent.status = getAgentStatus(agent);
+  return agent;
 }
 
 export function agentSOAttributesToFleetServerAgentDoc(

--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -20,8 +20,7 @@ export async function getAgentStatusById(
   esClient: ElasticsearchClient,
   agentId: string
 ): Promise<AgentStatus> {
-  const agent = await getAgentById(esClient, agentId);
-  return AgentStatusKueryHelper.getAgentStatus(agent);
+  return (await getAgentById(esClient, agentId)).status!;
 }
 
 export const getAgentStatus = AgentStatusKueryHelper.getAgentStatus;

--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/base_data_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/base_data_generator.ts
@@ -105,7 +105,7 @@ export class BaseDataGenerator<GeneratedDoc extends {} = {}> {
     return [7, ...this.randomNGenerator(20, 2)].map((x) => x.toString()).join('.');
   }
 
-  protected randomChoice<T>(choices: T[]): T {
+  protected randomChoice<T>(choices: T[] | readonly T[]): T {
     return choices[this.randomN(choices.length)];
   }
 

--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/fleet_agent_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/fleet_agent_generator.ts
@@ -9,7 +9,19 @@ import { estypes } from '@elastic/elasticsearch';
 import { DeepPartial } from 'utility-types';
 import { merge } from 'lodash';
 import { BaseDataGenerator } from './base_data_generator';
-import { Agent, AGENTS_INDEX, FleetServerAgent } from '../../../../fleet/common';
+import { Agent, AGENTS_INDEX, AgentStatus, FleetServerAgent } from '../../../../fleet/common';
+
+const agentStatusList: readonly AgentStatus[] = [
+  'offline',
+  'error',
+  'online',
+  'inactive',
+  'warning',
+  'enrolling',
+  'unenrolling',
+  'updating',
+  'degraded',
+];
 
 export class FleetAgentGenerator extends BaseDataGenerator<Agent> {
   /**
@@ -40,7 +52,7 @@ export class FleetAgentGenerator extends BaseDataGenerator<Agent> {
         id: hit._id,
         policy_revision: hit._source?.policy_revision_idx,
         access_api_key: undefined,
-        status: undefined,
+        status: this.randomAgentStatus(),
         packages: hit._source?.packages ?? [],
       },
       overrides
@@ -115,5 +127,9 @@ export class FleetAgentGenerator extends BaseDataGenerator<Agent> {
       },
       overrides
     );
+  }
+
+  private randomAgentStatus() {
+    return this.randomChoice(agentStatusList);
   }
 }

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { httpServerMock } from '../../../../../src/core/server/mocks';
 import { EndpointAppContextService } from './endpoint_app_context_services';
 
 describe('test endpoint app context services', () => {
@@ -16,11 +15,5 @@ describe('test endpoint app context services', () => {
   it('should return undefined on getManifestManager if dependencies are not enabled', async () => {
     const endpointAppContextService = new EndpointAppContextService();
     expect(endpointAppContextService.getManifestManager()).toEqual(undefined);
-  });
-  it('should throw error on getScopedSavedObjectsClient if start is not called', async () => {
-    const endpointAppContextService = new EndpointAppContextService();
-    expect(() =>
-      endpointAppContextService.getScopedSavedObjectsClient(httpServerMock.createKibanaRequest())
-    ).toThrow(Error);
   });
 });

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import {
-  KibanaRequest,
-  Logger,
-  SavedObjectsServiceStart,
-  SavedObjectsClientContract,
-} from 'src/core/server';
+import { KibanaRequest, Logger } from 'src/core/server';
 import { ExceptionListClient } from '../../../lists/server';
 import { SecurityPluginStart } from '../../../security/server';
 import {
@@ -36,6 +31,8 @@ import {
   CasesClient,
   PluginStartContract as CasesPluginStartContract,
 } from '../../../cases/server';
+import { EndpointMetadataService } from './services/metadata';
+import { EndpointAppContentServicesNotStartedError } from './errors';
 
 export type EndpointAppContextServiceStartContract = Partial<
   Pick<
@@ -44,13 +41,13 @@ export type EndpointAppContextServiceStartContract = Partial<
   >
 > & {
   logger: Logger;
+  endpointMetadataService: EndpointMetadataService;
   manifestManager?: ManifestManager;
   appClientFactory: AppClientFactory;
   security: SecurityPluginStart;
   alerting: AlertsPluginStartContract;
   config: ConfigType;
   registerIngestCallback?: FleetStartContract['registerExternalCallback'];
-  savedObjectsStart: SavedObjectsServiceStart;
   licenseService: LicenseService;
   exceptionListsClient: ExceptionListClient | undefined;
   cases: CasesPluginStartContract | undefined;
@@ -65,12 +62,11 @@ export class EndpointAppContextService {
   private manifestManager: ManifestManager | undefined;
   private packagePolicyService: PackagePolicyServiceInterface | undefined;
   private agentPolicyService: AgentPolicyServiceInterface | undefined;
-  private savedObjectsStart: SavedObjectsServiceStart | undefined;
   private config: ConfigType | undefined;
   private license: LicenseService | undefined;
   public security: SecurityPluginStart | undefined;
   private cases: CasesPluginStartContract | undefined;
-
+  private endpointMetadataService: EndpointMetadataService | undefined;
   private experimentalFeatures: ExperimentalFeatures | undefined;
 
   public start(dependencies: EndpointAppContextServiceStartContract) {
@@ -78,12 +74,11 @@ export class EndpointAppContextService {
     this.packagePolicyService = dependencies.packagePolicyService;
     this.agentPolicyService = dependencies.agentPolicyService;
     this.manifestManager = dependencies.manifestManager;
-    this.savedObjectsStart = dependencies.savedObjectsStart;
     this.config = dependencies.config;
     this.license = dependencies.licenseService;
     this.security = dependencies.security;
     this.cases = dependencies.cases;
-
+    this.endpointMetadataService = dependencies.endpointMetadataService;
     this.experimentalFeatures = parseExperimentalConfigValue(this.config.enableExperimental);
 
     if (this.manifestManager && dependencies.registerIngestCallback) {
@@ -116,6 +111,13 @@ export class EndpointAppContextService {
     return this.experimentalFeatures;
   }
 
+  public getEndpointMetadataService(): EndpointMetadataService {
+    if (!this.endpointMetadataService) {
+      throw new EndpointAppContentServicesNotStartedError();
+    }
+    return this.endpointMetadataService;
+  }
+
   public getAgentService(): AgentService | undefined {
     return this.agentService;
   }
@@ -132,23 +134,16 @@ export class EndpointAppContextService {
     return this.manifestManager;
   }
 
-  public getScopedSavedObjectsClient(req: KibanaRequest): SavedObjectsClientContract {
-    if (!this.savedObjectsStart) {
-      throw new Error(`must call start on ${EndpointAppContextService.name} to call getter`);
-    }
-    return this.savedObjectsStart.getScopedClient(req, { excludedWrappers: ['security'] });
-  }
-
   public getLicenseService(): LicenseService {
     if (!this.license) {
-      throw new Error(`must call start on ${EndpointAppContextService.name} to call getter`);
+      throw new EndpointAppContentServicesNotStartedError();
     }
     return this.license;
   }
 
   public async getCasesClient(req: KibanaRequest): Promise<CasesClient> {
     if (!this.cases) {
-      throw new Error(`must call start on ${EndpointAppContextService.name} to call getter`);
+      throw new EndpointAppContentServicesNotStartedError();
     }
     return this.cases.getCasesClientWithRequest(req);
   }

--- a/x-pack/plugins/security_solution/server/endpoint/errors.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/errors.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable max-classes-per-file */
+
+export class EndpointError extends Error {
+  constructor(message: string, public readonly meta?: unknown) {
+    super(message);
+    // For debugging - capture name of subclasses
+    this.name = this.constructor.name;
+  }
+}
+
+export class NotFoundError extends EndpointError {}
+
+export class EndpointAppContentServicesNotStartedError extends EndpointError {
+  constructor() {
+    super('EndpointAppContextService has not been started (EndpointAppContextService.start())');
+  }
+}

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -37,6 +37,7 @@ import { parseExperimentalConfigValue } from '../../common/experimental_features
 // a restricted path.
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { createCasesClientMock } from '../../../cases/server/client/mocks';
+import { EndpointMetadataService } from './services/metadata';
 
 /**
  * Creates a mocked EndpointAppContext.
@@ -65,7 +66,6 @@ export const createMockEndpointAppContextService = (
     getAgentService: jest.fn(),
     getAgentPolicyService: jest.fn(),
     getManifestManager: jest.fn().mockReturnValue(mockManifestManager ?? jest.fn()),
-    getScopedSavedObjectsClient: jest.fn(),
   } as unknown) as jest.Mocked<EndpointAppContextService>;
 };
 
@@ -76,14 +76,23 @@ export const createMockEndpointAppContextServiceStartContract = (): jest.Mocked<
   const factory = new AppClientFactory();
   const config = createMockConfig();
   const casesClientMock = createCasesClientMock();
+  const savedObjectsStart = savedObjectsServiceMock.createStartContract();
+  const agentService = createMockAgentService();
+  const agentPolicyService = createMockAgentPolicyService();
+  const endpointMetadataService = new EndpointMetadataService(
+    savedObjectsStart,
+    agentService,
+    agentPolicyService
+  );
 
   factory.setup({ getSpaceId: () => 'mockSpace', config });
 
   return {
-    agentService: createMockAgentService(),
+    agentService,
+    agentPolicyService,
+    endpointMetadataService,
     packageService: createMockPackageService(),
     logger: loggingSystemMock.create().get('mock_endpoint_app_context'),
-    savedObjectsStart: savedObjectsServiceMock.createStartContract(),
     manifestManager: getManifestManagerMock(),
     appClientFactory: factory,
     security: securityMock.createStart(),

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -9,7 +9,9 @@ import Boom from '@hapi/boom';
 
 import { TypeOf } from '@kbn/config-schema';
 import {
+  IKibanaResponse,
   IScopedClusterClient,
+  KibanaResponseFactory,
   Logger,
   RequestHandler,
   SavedObjectsClientContract,
@@ -35,6 +37,8 @@ import {
   queryResponseToHostListResult,
   queryResponseToHostResult,
 } from './support/query_strategies';
+import { NotFoundError } from '../../errors';
+import { EndpointHostUnEnrolledError } from '../../services/metadata';
 
 export interface MetadataRequestContext {
   esClient?: IScopedClusterClient;
@@ -56,6 +60,33 @@ const IGNORED_ELASTIC_AGENT_IDS = [
 
 export const getLogger = (endpointAppContext: EndpointAppContext): Logger => {
   return endpointAppContext.logFactory.get('metadata');
+};
+
+const errorHandler = <E extends Error>(
+  logger: Logger,
+  res: KibanaResponseFactory,
+  error: E
+): IKibanaResponse => {
+  if (error instanceof NotFoundError) {
+    return res.notFound({ body: error });
+  }
+
+  if (error instanceof EndpointHostUnEnrolledError) {
+    return res.badRequest({ body: error });
+  }
+
+  // legacy check for Boom errors. `ts-ignore` is for the errors around non-standard error properties
+  // @ts-ignore
+  const boomStatusCode = error.isBoom && error?.output?.statusCode;
+  if (boomStatusCode) {
+    return res.customError({
+      statusCode: boomStatusCode,
+      body: error,
+    });
+  }
+
+  // Kibana CORE will take care of `500` errors when the handler `throw`'s, including logging the error
+  throw error;
 };
 
 export const getMetadataListRequestHandler = function (
@@ -122,34 +153,17 @@ export const getMetadataRequestHandler = function (
   SecuritySolutionRequestHandlerContext
 > {
   return async (context, request, response) => {
-    const agentService = endpointAppContext.service.getAgentService();
-    if (agentService === undefined) {
-      throw new Error('agentService not available');
-    }
-
-    const metadataRequestContext: MetadataRequestContext = {
-      esClient: context.core.elasticsearch.client,
-      endpointAppContextService: endpointAppContext.service,
-      logger,
-      requestHandlerContext: context,
-      savedObjectsClient: context.core.savedObjects.client,
-    };
+    const endpointMetadataService = endpointAppContext.service.getEndpointMetadataService();
 
     try {
-      const doc = await getHostData(metadataRequestContext, request?.params?.id);
-      if (doc) {
-        return response.ok({ body: doc });
-      }
-      return response.notFound({ body: 'Endpoint Not Found' });
-    } catch (err) {
-      logger.warn(JSON.stringify(err, null, 2));
-      if (err.isBoom) {
-        return response.customError({
-          statusCode: err.output.statusCode,
-          body: { message: err.message },
-        });
-      }
-      throw err;
+      return response.ok({
+        body: await endpointMetadataService.getEnrichedHostMetadata(
+          context.core.elasticsearch.client.asCurrentUser,
+          request.params.id
+        ),
+      });
+    } catch (error) {
+      return errorHandler(logger, response, error);
     }
   };
 };

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -11,7 +11,6 @@ import {
   RouteConfig,
   SavedObjectsClientContract,
 } from 'kibana/server';
-import { SavedObjectsErrorHelpers } from '../../../../../../../src/core/server/';
 import {
   elasticsearchServiceMock,
   httpServerMock,
@@ -41,12 +40,14 @@ import {
   metadataTransformPrefix,
 } from '../../../../common/endpoint/constants';
 import type { SecuritySolutionPluginRouter } from '../../../types';
-import { PackagePolicyServiceInterface } from '../../../../../fleet/server';
+import { AgentNotFoundError, PackagePolicyServiceInterface } from '../../../../../fleet/server';
 import {
   ClusterClientMock,
   ScopedClusterClientMock,
   // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 } from '../../../../../../../src/core/server/elasticsearch/client/mocks';
+import { EndpointHostNotFoundError } from '../../services/metadata';
+import { FleetAgentGenerator } from '../../../../common/endpoint/data_generators/fleet_agent_generator';
 
 describe('test endpoint route', () => {
   let routerMock: jest.Mocked<SecuritySolutionPluginRouter>;
@@ -71,6 +72,7 @@ describe('test endpoint route', () => {
     page: 1,
     perPage: 1,
   };
+  const agentGenerator = new FleetAgentGenerator('seed');
 
   beforeEach(() => {
     mockScopedClient = elasticsearchServiceMock.createScopedClusterClient();
@@ -337,7 +339,7 @@ describe('test endpoint route', () => {
         });
         expect(mockResponse.notFound).toBeCalled();
         const message = mockResponse.notFound.mock.calls[0][0]?.body;
-        expect(message).toEqual('Endpoint Not Found');
+        expect(message).toBeInstanceOf(EndpointHostNotFoundError);
       });
 
       it('should return a single endpoint with status healthy', async () => {
@@ -346,10 +348,9 @@ describe('test endpoint route', () => {
           params: { id: response.hits.hits[0]._id },
         });
 
-        mockAgentService.getAgentStatusById = jest.fn().mockReturnValue('online');
-        mockAgentService.getAgent = jest.fn().mockReturnValue(({
-          active: true,
-        } as unknown) as Agent);
+        mockAgentService.getAgent = jest
+          .fn()
+          .mockReturnValue(agentGenerator.generate({ status: 'online' }));
         (mockScopedClient.asCurrentUser.search as jest.Mock).mockImplementationOnce(() =>
           Promise.resolve({ body: response })
         );
@@ -382,13 +383,9 @@ describe('test endpoint route', () => {
           params: { id: response.hits.hits[0]._id },
         });
 
-        mockAgentService.getAgentStatusById = jest.fn().mockImplementation(() => {
-          SavedObjectsErrorHelpers.createGenericNotFoundError();
-        });
-
-        mockAgentService.getAgent = jest.fn().mockImplementation(() => {
-          SavedObjectsErrorHelpers.createGenericNotFoundError();
-        });
+        mockAgentService.getAgent = jest
+          .fn()
+          .mockRejectedValue(new AgentNotFoundError('not found'));
 
         (mockScopedClient.asCurrentUser.search as jest.Mock).mockImplementationOnce(() =>
           Promise.resolve({ body: response })
@@ -421,10 +418,11 @@ describe('test endpoint route', () => {
           params: { id: response.hits.hits[0]._id },
         });
 
-        mockAgentService.getAgentStatusById = jest.fn().mockReturnValue('warning');
-        mockAgentService.getAgent = jest.fn().mockReturnValue(({
-          active: true,
-        } as unknown) as Agent);
+        mockAgentService.getAgent = jest.fn().mockReturnValue(
+          agentGenerator.generate({
+            status: 'error',
+          })
+        );
         (mockScopedClient.asCurrentUser.search as jest.Mock).mockImplementationOnce(() =>
           Promise.resolve({ body: response })
         );
@@ -473,7 +471,7 @@ describe('test endpoint route', () => {
         );
 
         expect(mockScopedClient.asCurrentUser.search).toHaveBeenCalledTimes(1);
-        expect(mockResponse.customError).toBeCalled();
+        expect(mockResponse.badRequest).toBeCalled();
       });
     });
   });

--- a/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/errors.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/errors.ts
@@ -7,7 +7,9 @@
 
 /* eslint-disable max-classes-per-file */
 
-export class TrustedAppNotFoundError extends Error {
+import { NotFoundError } from '../../errors';
+
+export class TrustedAppNotFoundError extends NotFoundError {
   constructor(id: string) {
     super(`Trusted Application (${id}) not found`);
   }

--- a/x-pack/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ElasticsearchClient,
+  Logger,
+  SavedObjectsClientContract,
+  SavedObjectsServiceStart,
+} from 'kibana/server';
+import { HostInfo, HostMetadata } from '../../../../common/endpoint/types';
+import { Agent, AgentPolicy, PackagePolicy } from '../../../../../fleet/common';
+import {
+  AgentNotFoundError,
+  AgentPolicyServiceInterface,
+  AgentService,
+} from '../../../../../fleet/server';
+import {
+  EndpointHostNotFoundError,
+  EndpointHostUnEnrolledError,
+  FleetAgentNotFoundError,
+  FleetAgentPolicyNotFoundError,
+} from './errors';
+import { getESQueryHostMetadataByID } from '../../routes/metadata/query_builders';
+import { queryResponseToHostResult } from '../../routes/metadata/support/query_strategies';
+import { DEFAULT_ENDPOINT_HOST_STATUS, fleetAgentStatusToEndpointHostStatus } from '../../utils';
+import { EndpointError } from '../../errors';
+import { createInternalReadonlySoClient } from '../../utils/create_internal_readonly_so_client';
+
+type AgentPolicyWithPackagePolicies = Omit<AgentPolicy, 'package_policies'> & {
+  package_policies: PackagePolicy[];
+};
+
+// Will wrap the given Error with `EndpointError`, which will
+// help getting a good picture of where in our code the error originated from.
+const wrapErrorIfNeeded = (error: Error): EndpointError =>
+  error instanceof EndpointError ? error : new EndpointError(error.message, error);
+
+// used as the callback to `Promise#catch()` to ensure errors
+// (especially those from kibana/elasticsearch clients) are wrapped
+const catchAndWrapError = <E extends Error>(error: E) => Promise.reject(wrapErrorIfNeeded(error));
+
+export class EndpointMetadataService {
+  /**
+   * For internal use only by the `this.DANGEROUS_INTERNAL_SO_CLIENT`
+   * @deprecated
+   */
+  private __DANGEROUS_INTERNAL_SO_CLIENT: SavedObjectsClientContract | undefined;
+
+  constructor(
+    private savedObjectsStart: SavedObjectsServiceStart,
+    private readonly agentService: AgentService,
+    private readonly agentPolicyService: AgentPolicyServiceInterface,
+    private readonly logger?: Logger
+  ) {}
+
+  /**
+   * An INTERNAL Saved Object client that is effectively the system user and has all privileges and permissions and
+   * can access any saved object. Used primarly to retrieve fleet data for endpoint enrichment (so that users are
+   * not required to have superuser role)
+   *
+   * **IMPORTANT: SHOULD BE USED ONLY FOR READ-ONLY ACCESS AND WITH DISCRETION**
+   *
+   * @private
+   */
+  public get DANGEROUS_INTERNAL_SO_CLIENT() {
+    // The INTERNAL SO client must be created during the first time its used. This is because creating it during
+    // instance initialization (in `constructor(){}`) causes the SO Client to be invalid (perhaps because this
+    // instantiation is happening during the plugin's the start phase)
+    if (!this.__DANGEROUS_INTERNAL_SO_CLIENT) {
+      this.__DANGEROUS_INTERNAL_SO_CLIENT = createInternalReadonlySoClient(this.savedObjectsStart);
+    }
+
+    return this.__DANGEROUS_INTERNAL_SO_CLIENT;
+  }
+
+  /**
+   * Retrieve a single endpoint host metadata. Note that the return endpoint document, if found,
+   * could be associated with a Fleet Agent that is no longer active. If wanting to ensure the
+   * endpoint is associated with an active Fleet Agent, then use `getEnrichedHostMetadata()` instead
+   *
+   * @param esClient Elasticsearch Client (usually scoped to the user's context)
+   * @param endpointId the endpoint id (from `agent.id`)
+   *
+   * @throws
+   */
+  async getHostMetadata(esClient: ElasticsearchClient, endpointId: string): Promise<HostMetadata> {
+    const query = getESQueryHostMetadataByID(endpointId);
+    const queryResult = await esClient.search<HostMetadata>(query).catch(catchAndWrapError);
+    const endpointMetadata = queryResponseToHostResult(queryResult.body).result;
+
+    if (endpointMetadata) {
+      return endpointMetadata;
+    }
+
+    throw new EndpointHostNotFoundError(`Endpoint with id ${endpointId} not found`);
+  }
+
+  /**
+   * Retrieve a single endpoint host metadata along with fleet information
+   *
+   * @param esClient Elasticsearch Client (usually scoped to the user's context)
+   * @param endpointId the endpoint id (from `agent.id`)
+   *
+   * @throws
+   */
+  async getEnrichedHostMetadata(
+    esClient: ElasticsearchClient,
+    endpointId: string
+  ): Promise<HostInfo> {
+    const endpointMetadata = await this.getHostMetadata(esClient, endpointId);
+
+    let fleetAgentId = endpointMetadata.elastic.agent.id;
+    let fleetAgent: Agent | undefined;
+
+    // Get Fleet agent
+    try {
+      if (!fleetAgentId) {
+        fleetAgentId = endpointMetadata.agent.id;
+        this.logger?.warn(`Missing elastic agent id, using host id instead ${fleetAgentId}`);
+      }
+
+      fleetAgent = await this.getFleetAgent(esClient, fleetAgentId);
+    } catch (error) {
+      if (error instanceof FleetAgentNotFoundError) {
+        this.logger?.warn(`agent with id ${fleetAgentId} not found`);
+      } else {
+        throw error;
+      }
+    }
+
+    // If the agent is not longer active, then that means that the Agent/Endpoint have been un-enrolled from the host
+    if (fleetAgent && !fleetAgent.active) {
+      throw new EndpointHostUnEnrolledError(
+        `Endpoint with id ${endpointId} (Fleet agent id ${fleetAgentId}) is unenrolled`
+      );
+    }
+
+    // ------------------------------------------------------------------------------
+    // Any failures in enriching the Host form this point should NOT cause an error
+    // ------------------------------------------------------------------------------
+    try {
+      let fleetAgentPolicy: AgentPolicyWithPackagePolicies | undefined;
+      let endpointPackagePolicy: PackagePolicy | undefined;
+
+      // Get Agent Policy and Endpoint Package Policy
+      if (fleetAgent) {
+        try {
+          fleetAgentPolicy = await this.getFleetAgentPolicy(fleetAgent.policy_id!);
+          endpointPackagePolicy = fleetAgentPolicy.package_policies.find(
+            (policy) => policy.package?.name === 'endpoint'
+          );
+        } catch (error) {
+          this.logger?.error(error);
+        }
+      }
+
+      return {
+        metadata: endpointMetadata,
+        host_status: fleetAgent
+          ? fleetAgentStatusToEndpointHostStatus(fleetAgent.status!)
+          : DEFAULT_ENDPOINT_HOST_STATUS,
+        policy_info: {
+          agent: {
+            applied: {
+              revision: fleetAgent?.policy_revision ?? 0,
+              id: fleetAgent?.policy_id ?? '',
+            },
+            configured: {
+              revision: fleetAgentPolicy?.revision ?? 0,
+              id: fleetAgentPolicy?.id ?? '',
+            },
+          },
+          endpoint: {
+            revision: endpointPackagePolicy?.revision ?? 0,
+            id: endpointPackagePolicy?.id ?? '',
+          },
+        },
+      };
+    } catch (error) {
+      throw wrapErrorIfNeeded(error);
+    }
+  }
+
+  /**
+   * Retrieve a single Fleet Agent data
+   *
+   * @param esClient Elasticsearch Client (usually scoped to the user's context)
+   * @param agentId The elastic agent id (`from `elastic.agent.id`)
+   */
+  async getFleetAgent(esClient: ElasticsearchClient, agentId: string): Promise<Agent> {
+    try {
+      return await this.agentService.getAgent(esClient, agentId);
+    } catch (error) {
+      if (error instanceof AgentNotFoundError) {
+        throw new FleetAgentNotFoundError(`agent with id ${agentId} not found`, error);
+      }
+
+      throw new EndpointError(error.message, error);
+    }
+  }
+
+  /**
+   * Retrieve a specific Fleet Agent Policy
+   *
+   * @param agentPolicyId
+   *
+   * @throws
+   */
+  async getFleetAgentPolicy(agentPolicyId: string): Promise<AgentPolicyWithPackagePolicies> {
+    const agentPolicy = await this.agentPolicyService
+      .get(this.DANGEROUS_INTERNAL_SO_CLIENT, agentPolicyId, true)
+      .catch(catchAndWrapError);
+
+    if (agentPolicy) {
+      return agentPolicy as AgentPolicyWithPackagePolicies;
+    }
+
+    throw new FleetAgentPolicyNotFoundError(
+      `Fleet agent policy with id ${agentPolicyId} not found`
+    );
+  }
+}

--- a/x-pack/plugins/security_solution/server/endpoint/services/metadata/errors.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/metadata/errors.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable max-classes-per-file */
+
+import { EndpointError, NotFoundError } from '../../errors';
+
+export class EndpointHostNotFoundError extends NotFoundError {}
+
+export class EndpointHostUnEnrolledError extends EndpointError {}
+
+export class FleetAgentNotFoundError extends NotFoundError {}
+
+export class FleetAgentPolicyNotFoundError extends NotFoundError {}

--- a/x-pack/plugins/security_solution/server/endpoint/services/metadata/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/metadata/index.ts
@@ -5,6 +5,5 @@
  * 2.0.
  */
 
-export * from './artifacts';
-export { getMetadataForEndpoints } from './metadata/metadata';
-export * from './actions';
+export * from './endpoint_metadata_service';
+export * from './errors';

--- a/x-pack/plugins/security_solution/server/endpoint/services/metadata/metadata.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/metadata/metadata.ts
@@ -7,10 +7,12 @@
 
 import { SearchRequest } from '@elastic/elasticsearch/api/types';
 import { SearchResponse } from 'elasticsearch';
-import { HostMetadata } from '../../../common/endpoint/types';
-import { SecuritySolutionRequestHandlerContext } from '../../types';
-import { getESQueryHostMetadataByIDs } from '../routes/metadata/query_builders';
-import { queryResponseToHostListResult } from '../routes/metadata/support/query_strategies';
+import { HostMetadata } from '../../../../common/endpoint/types';
+import { SecuritySolutionRequestHandlerContext } from '../../../types';
+import { getESQueryHostMetadataByIDs } from '../../routes/metadata/query_builders';
+import { queryResponseToHostListResult } from '../../routes/metadata/support/query_strategies';
+
+// FIXME: fold this function into the EndpointMetadaService
 
 export async function getMetadataForEndpoints(
   endpointIDs: string[],

--- a/x-pack/plugins/security_solution/server/endpoint/utils/create_internal_readonly_so_client.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/utils/create_internal_readonly_so_client.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  savedObjectsServiceMock,
+  savedObjectsClientMock,
+} from '../../../../../../src/core/server/mocks';
+import { SavedObjectsClientContract } from 'kibana/server';
+import {
+  createInternalReadonlySoClient,
+  InternalReadonlySoClientMethodNotAllowedError,
+} from './create_internal_readonly_so_client';
+
+describe('When using the `createInternalReadonlySoClient`', () => {
+  let realSoClientMock: ReturnType<typeof savedObjectsClientMock.create>;
+  let readonlySoClient: ReturnType<typeof createInternalReadonlySoClient>;
+
+  beforeEach(() => {
+    const soStartContract = savedObjectsServiceMock.createStartContract();
+    realSoClientMock = savedObjectsClientMock.create();
+    soStartContract.getScopedClient.mockReturnValue(realSoClientMock);
+    readonlySoClient = createInternalReadonlySoClient(soStartContract);
+  });
+
+  it.each<keyof SavedObjectsClientContract>([
+    'get',
+    'bulkGet',
+    'checkConflicts',
+    'collectMultiNamespaceReferences',
+    'find',
+    'resolve',
+  ])('should allow usage of %s() method', (methodName) => {
+    expect(() => readonlySoClient[methodName]).not.toThrow();
+  });
+
+  it.each<keyof SavedObjectsClientContract>([
+    'bulkCreate',
+    'bulkUpdate',
+    'create',
+    'createPointInTimeFinder',
+    'delete',
+    'removeReferencesTo',
+    'openPointInTimeForType',
+    'closePointInTime',
+    'update',
+    'updateObjectsSpaces',
+  ])('should throw if usage of %s() is attempted', (methodName) => {
+    expect(() => readonlySoClient[methodName]).toThrow(
+      InternalReadonlySoClientMethodNotAllowedError
+    );
+  });
+});

--- a/x-pack/plugins/security_solution/server/endpoint/utils/create_internal_readonly_so_client.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/utils/create_internal_readonly_so_client.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KibanaRequest, SavedObjectsClientContract, SavedObjectsServiceStart } from 'kibana/server';
+import { EndpointError } from '../errors';
+
+type SavedObjectsClientContractKeys = keyof SavedObjectsClientContract;
+
+const RESTRICTED_METHODS: readonly SavedObjectsClientContractKeys[] = [
+  'bulkCreate',
+  'bulkUpdate',
+  'create',
+  'createPointInTimeFinder',
+  'delete',
+  'removeReferencesTo',
+  'openPointInTimeForType',
+  'closePointInTime',
+  'update',
+  'updateObjectsSpaces',
+];
+
+export class InternalReadonlySoClientMethodNotAllowedError extends EndpointError {}
+
+/**
+ * Creates an internal (system user) Saved Objects client (permissions turned off) that can only perform READ
+ * operations.
+ */
+export const createInternalReadonlySoClient = (
+  savedObjectsServiceStart: SavedObjectsServiceStart
+): SavedObjectsClientContract => {
+  const fakeRequest = ({
+    headers: {},
+    getBasePath: () => '',
+    path: '/',
+    route: { settings: {} },
+    url: { href: {} },
+    raw: { req: { url: '/' } },
+  } as unknown) as KibanaRequest;
+
+  const internalSoClient = savedObjectsServiceStart.getScopedClient(fakeRequest, {
+    excludedWrappers: ['security'],
+  });
+
+  return new Proxy(internalSoClient, {
+    get(
+      target: SavedObjectsClientContract,
+      methodName: SavedObjectsClientContractKeys,
+      receiver: unknown
+    ): unknown {
+      if (RESTRICTED_METHODS.includes(methodName)) {
+        throw new InternalReadonlySoClientMethodNotAllowedError(
+          `Method [${methodName}] not allowed on internal readonly SO Client`
+        );
+      }
+
+      return Reflect.get(target, methodName, receiver);
+    },
+  }) as SavedObjectsClientContract;
+};

--- a/x-pack/plugins/security_solution/server/endpoint/utils/fleet_agent_status_to_endpoint_host_status.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/utils/fleet_agent_status_to_endpoint_host_status.ts
@@ -8,6 +8,8 @@
 import { AgentStatus } from '../../../../fleet/common';
 import { HostStatus } from '../../../common/endpoint/types';
 
+// For an understanding of how fleet agent status is calculated:
+// @see `x-pack/plugins/fleet/common/services/agent_status.ts`
 const STATUS_MAPPING: ReadonlyMap<AgentStatus, HostStatus> = new Map([
   ['online', HostStatus.HEALTHY],
   ['offline', HostStatus.OFFLINE],
@@ -20,10 +22,12 @@ const STATUS_MAPPING: ReadonlyMap<AgentStatus, HostStatus> = new Map([
   ['degraded', HostStatus.UNHEALTHY],
 ]);
 
+export const DEFAULT_ENDPOINT_HOST_STATUS = HostStatus.UNHEALTHY;
+
 /**
  * A Map of Fleet Agent Status to Endpoint Host Status.
  * Default status is `HostStatus.UNHEALTHY`
  */
 export const fleetAgentStatusToEndpointHostStatus = (status: AgentStatus): HostStatus => {
-  return STATUS_MAPPING.get(status) || HostStatus.UNHEALTHY;
+  return STATUS_MAPPING.get(status) || DEFAULT_ENDPOINT_HOST_STATUS;
 };

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -89,6 +89,7 @@ import { PolicyWatcher } from './endpoint/lib/policy/license_watch';
 import { parseExperimentalConfigValue } from '../common/experimental_features';
 import { migrateArtifactsToFleet } from './endpoint/lib/artifacts/migrate_artifacts_to_fleet';
 import { getKibanaPrivilegesFeaturePrivileges } from './features';
+import { EndpointMetadataService } from './endpoint/services/metadata';
 
 export interface SetupPlugins {
   alerting: AlertingSetup;
@@ -390,6 +391,12 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       packageService: plugins.fleet?.packageService,
       packagePolicyService: plugins.fleet?.packagePolicyService,
       agentPolicyService: plugins.fleet?.agentPolicyService,
+      endpointMetadataService: new EndpointMetadataService(
+        core.savedObjects,
+        plugins.fleet?.agentService!,
+        plugins.fleet?.agentPolicyService!,
+        logger
+      ),
       appClientFactory: this.appClientFactory,
       security: plugins.security,
       alerting: plugins.alerting,
@@ -398,7 +405,6 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       logger,
       manifestManager,
       registerIngestCallback,
-      savedObjectsStart: core.savedObjects,
       licenseService,
       exceptionListsClient: this.lists!.getExceptionListClient(savedObjectsClient, 'kibana'),
     });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution][Endpoint] Allow access to Endpoint Metadata for users that might only have READONLY access (#106328)