### PR TITLE
chore(NA): remove getScopedSavedObjectsClient from handlers test file

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/handlers.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/handlers.test.ts
@@ -116,7 +116,6 @@ describe('handlers', () => {
     };
 
     context.service.getPackagePolicyService = () => packagePolicyClient;
-    context.service.getScopedSavedObjectsClient = () => savedObjectClient;
 
     // Ensure that `logFactory.get()` always returns the same instance for the same given prefix
     const instances = new Map<string, ReturnType<typeof context.logFactory.get>>();


### PR DESCRIPTION
This PR removes a legacy statement that was left in the handlers.test.ts file after https://github.com/elastic/kibana/pull/106328 got merged