### PR TITLE
[ML] Data frame analytics: ensure results view loads correctly for job created in dev tools

### DIFF
--- a/x-pack/plugins/ml/common/types/data_frame_analytics.ts
+++ b/x-pack/plugins/ml/common/types/data_frame_analytics.ts
@@ -80,9 +80,9 @@ export interface DataFrameAnalyticsConfig {
     runtime_mappings?: RuntimeMappings;
   };
   analysis: AnalysisConfig;
-  analyzed_fields: {
-    includes: string[];
-    excludes: string[];
+  analyzed_fields?: {
+    includes?: string[];
+    excludes?: string[];
   };
   model_memory_limit: string;
   max_num_threads?: number;

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/exploration_page_wrapper/exploration_page_wrapper.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/exploration_page_wrapper/exploration_page_wrapper.tsx
@@ -116,8 +116,8 @@ export const ExplorationPageWrapper: FC<Props> = ({
   const resultsField = jobConfig?.dest.results_field ?? '';
   const scatterplotFieldOptions = useScatterplotFieldOptions(
     indexPattern,
-    jobConfig?.analyzed_fields.includes,
-    jobConfig?.analyzed_fields.excludes,
+    jobConfig?.analyzed_fields?.includes,
+    jobConfig?.analyzed_fields?.excludes,
     resultsField
   );
 

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/outlier_exploration.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/outlier_exploration/outlier_exploration.tsx
@@ -92,8 +92,8 @@ export const OutlierExploration: FC<ExplorationProps> = React.memo(({ jobId }) =
 
   const scatterplotFieldOptions = useScatterplotFieldOptions(
     indexPattern,
-    jobConfig?.analyzed_fields.includes,
-    jobConfig?.analyzed_fields.excludes,
+    jobConfig?.analyzed_fields?.includes,
+    jobConfig?.analyzed_fields?.excludes,
     resultsField
   );
 

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/validation.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/validation.ts
@@ -448,7 +448,7 @@ export async function validateAnalyticsJob(
 ) {
   const messages = await getValidationCheckMessages(
     client.asCurrentUser,
-    job.analyzed_fields.includes,
+    job?.analyzed_fields?.includes || [],
     job.analysis,
     job.source
   );


### PR DESCRIPTION
## Summary

 Fixes https://github.com/elastic/kibana/issues/106275

Checks that `analytized_fields` exists before trying to access `includes` or `excludes`. Extends fix to outlier detection results page.

Before:

![image](https://user-images.githubusercontent.com/47184485/126355121-0479b912-1ddd-4230-8c53-c80286659d97.png)

After:

![image](https://user-images.githubusercontent.com/6446462/127340664-8b311389-3c15-47d2-a965-fd1140ee5364.png)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




