### PR TITLE
[Stack monitoring] Fix alerts-modal-button not found error on functional tests

### DIFF
--- a/x-pack/plugins/monitoring/public/alerts/enable_alerts_modal.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/enable_alerts_modal.tsx
@@ -134,7 +134,10 @@ export const EnableAlertsModal: React.FC<Props> = ({ alerts }: Props) => {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty onClick={remindLaterClick}>
+        <EuiButtonEmpty
+          onClick={remindLaterClick}
+          data-test-subj="alerts-modal-remind-later-button"
+        >
           <FormattedMessage
             id="xpack.monitoring.alerts.modal.remindLater"
             defaultMessage="Remind me later"

--- a/x-pack/test/functional/page_objects/monitoring_page.ts
+++ b/x-pack/test/functional/page_objects/monitoring_page.ts
@@ -17,7 +17,7 @@ export class MonitoringPageObject extends FtrService {
   }
 
   async closeAlertsModal() {
-    return this.testSubjects.click('alerts-modal-button');
+    return this.testSubjects.click('alerts-modal-remind-later-button');
   }
 
   async clickBreadcrumb(subj: string) {

--- a/x-pack/test/functional/services/monitoring/cluster_list.js
+++ b/x-pack/test/functional/services/monitoring/cluster_list.js
@@ -15,7 +15,7 @@ export function MonitoringClusterListProvider({ getService, getPageObjects }) {
   const SUBJ_SEARCH_BAR = `${SUBJ_TABLE_CONTAINER} > monitoringTableToolBar`;
 
   const SUBJ_CLUSTER_ROW_PREFIX = `${SUBJ_TABLE_CONTAINER} > clusterRow_`;
-  const ALERTS_MODAL_BUTTON = 'alerts-modal-button';
+  const ALERTS_MODAL_BUTTON = 'alerts-modal-remind-later-button';
 
   return new (class ClusterList {
     async assertDefaults() {

--- a/x-pack/test/functional/services/monitoring/cluster_overview.js
+++ b/x-pack/test/functional/services/monitoring/cluster_overview.js
@@ -76,7 +76,7 @@ export function MonitoringClusterOverviewProvider({ getService }) {
     }
 
     closeAlertsModal() {
-      return testSubjects.click('alerts-modal-button');
+      return testSubjects.click('alerts-modal-remind-later-button');
     }
 
     getEsStatus() {


### PR DESCRIPTION
## Summary
This closes some functional tests that failed because of the new alerts modal. Tests failed in cloud but not locally.

The fix in the PR and the previous implementation are not meant to test the alert modal behavior. The implementation is only to make the existing tests pass.

The root cause for these failures is that in cloud alerts were created and not clean up after each test run and locally alerts were not created because of some [security checks](https://github.com/elastic/kibana/blob/master/x-pack/plugins/monitoring/server/routes/api/v1/alerts/enable.ts#L41) that prevent alerts to be created. I suspect that the main reason of this difference is that locally tests are run using HTTP, while in cloud they run with https. I'm not sure if there is something else that is different.

Since we were expecting the alerts modal to be present in each test and we were closing the modal with the "Ok" button, alerts were created in cloud in the first test that was executed. Since alerts are not clean up in the teardown, the following tests were failing because the alert modal was not shown.
I changed that, so instead of closing the modal with the "Ok" button, we close it with the "Remind later" option, so alerts are not created and the modal is shown in all tests.

I created an issue to work on some improvements: https://github.com/elastic/kibana/issues/107136