### PR TITLE
remove elasticsearch package imports from reporting

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { SearchResponse } from 'elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 import { IScopedClusterClient, IUiSettingsClient } from 'src/core/server';
 import { IScopedSearchClient } from 'src/plugins/data/server';
 import { Datatable } from 'src/plugins/expressions/server';
@@ -93,7 +93,7 @@ export class CsvGenerator {
     };
     const results = (
       await this.clients.data.search(searchParams, { strategy: ES_SEARCH_STRATEGY }).toPromise()
-    ).rawResponse as SearchResponse<unknown>;
+    ).rawResponse as estypes.SearchResponse<unknown>;
 
     return results;
   }
@@ -107,7 +107,7 @@ export class CsvGenerator {
           scroll_id: scrollId,
         },
       })
-    ).body as SearchResponse<unknown>;
+    ).body;
     return results;
   }
 
@@ -321,13 +321,13 @@ export class CsvGenerator {
         if (this.cancellationToken.isCancelled()) {
           break;
         }
-        let results: SearchResponse<unknown> | undefined;
+        let results: estypes.SearchResponse<unknown> | undefined;
         if (scrollId == null) {
           // open a scroll cursor in Elasticsearch
           results = await this.scan(index, searchSource, scrollSettings);
           scrollId = results?._scroll_id;
           if (results.hits?.total != null) {
-            totalRecords = results.hits.total;
+            totalRecords = results.hits.total as number;
             this.logger.debug(`Total search results: ${totalRecords}`);
           }
         } else {

--- a/x-pack/plugins/reporting/server/routes/generation.ts
+++ b/x-pack/plugins/reporting/server/routes/generation.ts
@@ -6,7 +6,6 @@
  */
 
 import Boom from '@hapi/boom';
-import { errors as elasticsearchErrors } from 'elasticsearch';
 import { kibanaResponseFactory } from 'src/core/server';
 import { ReportingCore } from '../';
 import { API_BASE_URL } from '../../common/constants';
@@ -15,8 +14,6 @@ import { enqueueJobFactory } from '../lib/enqueue_job';
 import { registerGenerateFromJobParams } from './generate_from_jobparams';
 import { registerGenerateCsvFromSavedObjectImmediate } from './csv_searchsource_immediate';
 import { HandlerFunction } from './types';
-
-const esErrors = elasticsearchErrors as Record<string, any>;
 
 const getDownloadBaseUrl = (reporting: ReportingCore) => {
   const config = reporting.getConfig();
@@ -74,24 +71,6 @@ export function registerJobGenerationRoutes(reporting: ReportingCore, logger: Lo
       return res.customError({
         statusCode: err.output.statusCode,
         body: err.output.payload.message,
-      });
-    }
-
-    if (err instanceof esErrors['401']) {
-      return res.unauthorized({
-        body: `Sorry, you aren't authenticated`,
-      });
-    }
-
-    if (err instanceof esErrors['403']) {
-      return res.forbidden({
-        body: `Sorry, you are not authorized`,
-      });
-    }
-
-    if (err instanceof esErrors['404']) {
-      return res.notFound({
-        body: err.message,
       });
     }
 


### PR DESCRIPTION
## Summary

Use typings imported from `@elastic/elasticsearch` package
