### PR TITLE
[7.x] [XY axis] Disables the custom extents for the percentage mode (#106835)

### DIFF
--- a/src/plugins/vis_type_xy/public/editor/common_config.tsx
+++ b/src/plugins/vis_type_xy/public/editor/common_config.tsx
@@ -23,7 +23,13 @@ export function getOptionTabs(showElasticChartsOptions = false) {
         defaultMessage: 'Metrics & axes',
       }),
       editor: (props: VisEditorOptionsProps<VisParams>) => (
-        <ValidationWrapper {...props} component={MetricsAxisOptions} />
+        <ValidationWrapper
+          {...props}
+          extraProps={{
+            showElasticChartsOptions,
+          }}
+          component={MetricsAxisOptions}
+        />
       ),
     },
     {

--- a/src/plugins/vis_type_xy/public/editor/components/options/index.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/index.tsx
@@ -23,6 +23,11 @@ export const PointSeriesOptions = (
   >
 ) => <PointSeriesOptionsLazy {...props} />;
 
-export const MetricsAxisOptions = (props: ValidationVisOptionsProps<VisParams>) => (
-  <MetricsAxisOptionsLazy {...props} />
-);
+export const MetricsAxisOptions = (
+  props: ValidationVisOptionsProps<
+    VisParams,
+    {
+      showElasticChartsOptions: boolean;
+    }
+  >
+) => <MetricsAxisOptionsLazy {...props} />;

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/custom_extents_options.test.tsx.snap
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/custom_extents_options.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`CustomExtentsOptions component should init with the default set of prop
   />
   <SwitchOption
     data-test-subj="yAxisSetYExtents"
+    disabled={false}
     label="Set axis extents"
     paramName="setYExtents"
     setValue={[Function]}

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/index.test.tsx.snap
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/index.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`MetricsAxisOptions component should init with the default set of props 
   />
   <ValueAxesPanel
     addValueAxis={[Function]}
+    isNewLibrary={false}
     onValueAxisPositionChanged={[Function]}
     removeValueAxis={[Function]}
     seriesParams={

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/value_axes_panel.test.tsx.snap
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/value_axes_panel.test.tsx.snap
@@ -120,6 +120,7 @@ exports[`ValueAxesPanel component should init with the default set of props 1`] 
         }
       }
       index={0}
+      isNewLibrary={false}
       onValueAxisPositionChanged={[MockFunction]}
       setMultipleValidity={[MockFunction]}
       setParamByIndex={[MockFunction]}
@@ -228,6 +229,7 @@ exports[`ValueAxesPanel component should init with the default set of props 1`] 
         }
       }
       index={1}
+      isNewLibrary={false}
       onValueAxisPositionChanged={[MockFunction]}
       setMultipleValidity={[MockFunction]}
       setParamByIndex={[MockFunction]}

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/value_axis_options.test.tsx.snap
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/__snapshots__/value_axis_options.test.tsx.snap
@@ -138,6 +138,7 @@ exports[`ValueAxisOptions component should init with the default set of props 1`
           "type": "linear",
         }
       }
+      disableAxisExtents={false}
       setMultipleValidity={[MockFunction]}
       setValueAxis={[Function]}
       setValueAxisScale={[Function]}

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/custom_extents_options.test.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/custom_extents_options.test.tsx
@@ -120,6 +120,12 @@ describe('CustomExtentsOptions component', () => {
       expect(comp.find(YExtents).exists()).toBeFalsy();
     });
 
+    it('should hide YExtents when the switch is disabled', () => {
+      const comp = shallow(<CustomExtentsOptions {...defaultProps} disableAxisExtents={true} />);
+
+      expect(comp.find(YExtents).exists()).toBeFalsy();
+    });
+
     it('should call setValueAxis when value is true', () => {
       const comp = shallow(<CustomExtentsOptions {...defaultProps} />);
       comp.find({ paramName: SET_Y_EXTENTS }).prop('setValue')(SET_Y_EXTENTS, true);

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/custom_extents_options.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/custom_extents_options.tsx
@@ -21,6 +21,7 @@ export interface CustomExtentsOptionsProps {
   setMultipleValidity(paramName: string, isValid: boolean): void;
   setValueAxis<T extends keyof ValueAxis>(paramName: T, value: ValueAxis[T]): void;
   setValueAxisScale: SetScale;
+  disableAxisExtents?: boolean;
 }
 
 function CustomExtentsOptions({
@@ -28,6 +29,7 @@ function CustomExtentsOptions({
   setMultipleValidity,
   setValueAxis,
   setValueAxisScale,
+  disableAxisExtents = false,
 }: CustomExtentsOptionsProps) {
   const invalidBoundsMarginMessage = i18n.translate(
     'visTypeXy.controls.pointSeries.valueAxes.scaleToDataBounds.minNeededBoundsMargin',
@@ -111,9 +113,10 @@ function CustomExtentsOptions({
         paramName="setYExtents"
         value={axisScale.setYExtents}
         setValue={onSetYExtentsChange}
+        disabled={disableAxisExtents}
       />
 
-      {axisScale.setYExtents && (
+      {axisScale.setYExtents && !disableAxisExtents && (
         <YExtents
           scale={axisScale}
           setScale={setValueAxisScale}

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/index.test.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/index.test.tsx
@@ -54,7 +54,12 @@ const createAggs = (aggs: any[]) => ({
 
 describe('MetricsAxisOptions component', () => {
   let setValue: jest.Mock;
-  let defaultProps: ValidationVisOptionsProps<VisParams>;
+  let defaultProps: ValidationVisOptionsProps<
+    VisParams,
+    {
+      showElasticChartsOptions: boolean;
+    }
+  >;
   let axis: ValueAxis;
   let axisRight: ValueAxis;
   let chart: SeriesParam;
@@ -81,6 +86,9 @@ describe('MetricsAxisOptions component', () => {
     defaultProps = {
       aggs: createAggs([aggCount]),
       isTabSelected: true,
+      extraProps: {
+        showElasticChartsOptions: false,
+      },
       vis: {
         type: {
           type: ChartType.Area,
@@ -236,7 +244,12 @@ describe('MetricsAxisOptions component', () => {
     const getProps = (
       valuePosition1: Position = Position.Right,
       valuePosition2: Position = Position.Left
-    ): ValidationVisOptionsProps<VisParams> => ({
+    ): ValidationVisOptionsProps<
+      VisParams,
+      {
+        showElasticChartsOptions: boolean;
+      }
+    > => ({
       ...defaultProps,
       stateParams: {
         ...defaultProps.stateParams,
@@ -374,7 +387,12 @@ describe('MetricsAxisOptions component', () => {
   describe('onCategoryAxisPositionChanged', () => {
     const getProps = (
       position: Position = Position.Bottom
-    ): ValidationVisOptionsProps<VisParams> => ({
+    ): ValidationVisOptionsProps<
+      VisParams,
+      {
+        showElasticChartsOptions: boolean;
+      }
+    > => ({
       ...defaultProps,
       stateParams: {
         ...defaultProps.stateParams,

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/index.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/index.tsx
@@ -43,8 +43,17 @@ export type ChangeValueAxis = (
 
 const VALUE_AXIS_PREFIX = 'ValueAxis-';
 
-function MetricsAxisOptions(props: ValidationVisOptionsProps<VisParams>) {
-  const { stateParams, setValue, aggs, vis, isTabSelected } = props;
+function MetricsAxisOptions(
+  props: ValidationVisOptionsProps<
+    VisParams,
+    {
+      // TODO: Remove when vis_type_vislib is removed
+      // https://github.com/elastic/kibana/issues/56143
+      showElasticChartsOptions: boolean;
+    }
+  >
+) {
+  const { stateParams, setValue, aggs, vis, isTabSelected, extraProps } = props;
 
   const setParamByIndex: SetParamByIndex = useCallback(
     (axesName, index, paramName, value) => {
@@ -326,6 +335,7 @@ function MetricsAxisOptions(props: ValidationVisOptionsProps<VisParams>) {
         setMultipleValidity={props.setMultipleValidity}
         seriesParams={stateParams.seriesParams}
         valueAxes={stateParams.valueAxes}
+        isNewLibrary={extraProps?.showElasticChartsOptions}
       />
       <EuiSpacer size="s" />
       <CategoryAxisPanel

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axes_panel.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axes_panel.tsx
@@ -32,6 +32,7 @@ export interface ValueAxesPanelProps {
   seriesParams: SeriesParam[];
   valueAxes: ValueAxis[];
   setMultipleValidity: (paramName: string, isValid: boolean) => void;
+  isNewLibrary?: boolean;
 }
 
 function ValueAxesPanel(props: ValueAxesPanelProps) {
@@ -149,6 +150,7 @@ function ValueAxesPanel(props: ValueAxesPanelProps) {
               onValueAxisPositionChanged={props.onValueAxisPositionChanged}
               setParamByIndex={props.setParamByIndex}
               setMultipleValidity={props.setMultipleValidity}
+              isNewLibrary={props.isNewLibrary ?? false}
             />
           </>
         </EuiAccordion>

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axis_options.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axis_options.tsx
@@ -36,6 +36,7 @@ export interface ValueAxisOptionsParams {
   setParamByIndex: SetParamByIndex;
   valueAxis: ValueAxis;
   setMultipleValidity: (paramName: string, isValid: boolean) => void;
+  isNewLibrary?: boolean;
 }
 
 export function ValueAxisOptions({
@@ -45,6 +46,7 @@ export function ValueAxisOptions({
   onValueAxisPositionChanged,
   setParamByIndex,
   setMultipleValidity,
+  isNewLibrary = false,
 }: ValueAxisOptionsParams) {
   const setValueAxis = useCallback(
     <T extends keyof ValueAxis>(paramName: T, value: ValueAxis[T]) =>
@@ -191,6 +193,7 @@ export function ValueAxisOptions({
             setMultipleValidity={setMultipleValidity}
             setValueAxisScale={setValueAxisScale}
             setValueAxis={setValueAxis}
+            disableAxisExtents={isNewLibrary && axis.scale.mode === 'percentage'}
           />
         </>
       </EuiAccordion>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [XY axis] Disables the custom extents for the percentage mode (#106835)