### PR TITLE
Do not expect legacy Elasticsearch JS client errors in tests.

### DIFF
--- a/x-pack/plugins/security/server/errors.test.ts
+++ b/x-pack/plugins/security/server/errors.test.ts
@@ -7,7 +7,6 @@
 
 import { errors as esErrors } from '@elastic/elasticsearch';
 import Boom from '@hapi/boom';
-import { errors as legacyESErrors } from 'elasticsearch';
 
 import * as errors from './errors';
 import { securityMock } from './mocks';
@@ -72,11 +71,6 @@ describe('lib/errors', () => {
       ).toBe(401);
     });
 
-    it('extracts status code from legacy Elasticsearch client error', () => {
-      expect(errors.getErrorStatusCode(new legacyESErrors.BadRequest())).toBe(400);
-      expect(errors.getErrorStatusCode(new legacyESErrors.AuthenticationException())).toBe(401);
-    });
-
     it('extracts status code from `status` property', () => {
       expect(errors.getErrorStatusCode({ statusText: 'Bad Request', status: 400 })).toBe(400);
       expect(errors.getErrorStatusCode({ statusText: 'Unauthorized', status: 401 })).toBe(401);
@@ -118,13 +112,6 @@ describe('lib/errors', () => {
           )
         )
       ).toBe(JSON.stringify({ field1: 'value-1', field2: 'value-2' }));
-    });
-
-    it('extracts status code from legacy Elasticsearch client error', () => {
-      expect(errors.getDetailedErrorMessage(new legacyESErrors.BadRequest())).toBe('Bad Request');
-      expect(errors.getDetailedErrorMessage(new legacyESErrors.AuthenticationException())).toBe(
-        'Authentication Exception'
-      );
     });
 
     it('extracts `message` property', () => {

--- a/x-pack/plugins/security/server/routes/users/change_password.test.ts
+++ b/x-pack/plugins/security/server/routes/users/change_password.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { errors } from 'elasticsearch';
+import { errors } from '@elastic/elasticsearch';
 
 import type { ObjectType } from '@kbn/config-schema';
 import type { PublicMethodsOf } from '@kbn/utility-types';
@@ -18,6 +18,7 @@ import { mockAuthenticatedUser } from '../../../common/model/authenticated_user.
 import { AuthenticationResult } from '../../authentication';
 import type { InternalAuthenticationServiceStart } from '../../authentication';
 import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { securityMock } from '../../mocks';
 import type { Session } from '../../session_management';
 import { sessionMock } from '../../session_management/session.mock';
 import type { SecurityRequestHandlerContext, SecurityRouter } from '../../types';
@@ -109,9 +110,9 @@ describe('Change password', () => {
     });
 
     it('returns 403 if old password is wrong.', async () => {
-      const changePasswordFailure = new (errors.AuthenticationException as any)('Unauthorized', {
-        body: { error: { header: { 'WWW-Authenticate': 'Negotiate' } } },
-      });
+      const changePasswordFailure = new errors.ResponseError(
+        securityMock.createApiResponse({ statusCode: 401, body: {} })
+      );
       mockContext.core.elasticsearch.client.asCurrentUser.security.changePassword.mockRejectedValue(
         changePasswordFailure
       );


### PR DESCRIPTION
## Summary

We can no longer receive legacy ES errors in our code base, and hence don't need to account for them in tests. We finally can remove these two last references to the legacy ES package.
