### PR TITLE
[Fleet] Fix agent details breadcrumb

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/index.tsx
@@ -295,7 +295,7 @@ const AgentDetailsPageContent: React.FunctionComponent<{
   agent: Agent;
   agentPolicy?: AgentPolicy;
 }> = ({ agent, agentPolicy }) => {
-  useBreadcrumbs('agent_list', {
+  useBreadcrumbs('agent_details', {
     agentHost:
       typeof agent.local_metadata.host === 'object' &&
       typeof agent.local_metadata.host.hostname === 'string'


### PR DESCRIPTION
## Summary

Fixes agent detail page breadcrumbs to properly include agent host/name as appropriate. 

Fixes #106680

![Kapture 2021-07-29 at 07 40 31](https://user-images.githubusercontent.com/6766512/127485951-669ab772-8fb7-41ae-aa0c-77a58c7e9e84.gif)