### PR TITLE
[7.x] Make onChange in CodeEditor optional (#107128)

### DIFF
--- a/api_docs/kibana_react.json
+++ b/api_docs/kibana_react.json
@@ -3719,48 +3719,15 @@
             "label": "onChange",
             "description": [],
             "signature": [
-              "(value: string, event: ",
+              "((value: string, event: ",
               "editor",
-              ".IModelContentChangedEvent) => void"
+              ".IModelContentChangedEvent) => void) | undefined"
             ],
             "source": {
               "path": "src/plugins/kibana_react/public/url_template_editor/url_template_editor.tsx",
               "lineNumber": 27
             },
-            "deprecated": false,
-            "returnComment": [],
-            "children": [
-              {
-                "parentPluginId": "kibanaReact",
-                "id": "def-public.value",
-                "type": "string",
-                "tags": [],
-                "label": "value",
-                "description": [],
-                "source": {
-                  "path": "src/plugins/kibana_react/public/code_editor/code_editor.tsx",
-                  "lineNumber": 37
-                },
-                "deprecated": false
-              },
-              {
-                "parentPluginId": "kibanaReact",
-                "id": "def-public.event",
-                "type": "Object",
-                "tags": [],
-                "label": "event",
-                "description": [],
-                "signature": [
-                  "editor",
-                  ".IModelContentChangedEvent"
-                ],
-                "source": {
-                  "path": "src/plugins/kibana_react/public/code_editor/code_editor.tsx",
-                  "lineNumber": 37
-                },
-                "deprecated": false
-              }
-            ]
+            "deprecated": false
           },
           {
             "parentPluginId": "kibanaReact",

--- a/api_docs/kibana_react.mdx
+++ b/api_docs/kibana_react.mdx
@@ -18,7 +18,7 @@ import kibanaReactObj from './kibana_react.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 257 | 5 | 228 | 4 |
+| 258 | 5 | 228 | 4 |
 
 ## Client
 

--- a/src/plugins/discover/public/application/components/json_code_editor/json_code_editor_common.tsx
+++ b/src/plugins/discover/public/application/components/json_code_editor/json_code_editor_common.tsx
@@ -56,7 +56,6 @@ export const JsonCodeEditorCommon = ({
           languageId={XJsonLang.ID}
           width={width}
           value={jsonValue || ''}
-          onChange={() => {}}
           editorDidMount={onEditorDidMount}
           aria-label={codeEditorAriaLabel}
           options={{

--- a/src/plugins/discover/public/application/components/source_viewer/__snapshots__/source_viewer.test.tsx.snap
+++ b/src/plugins/discover/public/application/components/source_viewer/__snapshots__/source_viewer.test.tsx.snap
@@ -546,7 +546,6 @@ exports[`Source Viewer component renders json code editor 1`] = `
                 aria-label="Read only JSON view of an elasticsearch document"
                 editorDidMount={[Function]}
                 languageId="xjson"
-                onChange={[Function]}
                 options={
                   Object {
                     "automaticLayout": true,

--- a/src/plugins/inspector/public/views/requests/components/details/req_code_viewer.tsx
+++ b/src/plugins/inspector/public/views/requests/components/details/req_code_viewer.tsx
@@ -54,7 +54,6 @@ export const RequestCodeViewer = ({ json }: RequestCodeViewerProps) => (
       <CodeEditor
         languageId={XJsonLang.ID}
         value={json}
-        onChange={() => {}}
         options={{
           readOnly: true,
           lineNumbers: 'off',

--- a/src/plugins/kibana_react/public/code_editor/code_editor.tsx
+++ b/src/plugins/kibana_react/public/code_editor/code_editor.tsx
@@ -34,7 +34,7 @@ export interface Props {
   value: string;
 
   /** Function invoked when text in editor is changed */
-  onChange: (value: string, event: monaco.editor.IModelContentChangedEvent) => void;
+  onChange?: (value: string, event: monaco.editor.IModelContentChangedEvent) => void;
 
   /**
    * Options for the Monaco Code Editor

--- a/src/plugins/vis_type_vega/public/vega_inspector/components/spec_viewer.tsx
+++ b/src/plugins/vis_type_vega/public/vega_inspector/components/spec_viewer.tsx
@@ -74,7 +74,6 @@ export const SpecViewer = ({ vegaAdapter, ...rest }: SpecViewerProps) => {
         <CodeEditor
           languageId={XJsonLang.ID}
           value={spec}
-          onChange={() => {}}
           options={{
             readOnly: true,
             lineNumbers: 'off',

--- a/x-pack/plugins/data_enhanced/public/search/sessions_mgmt/components/actions/inspect_button.tsx
+++ b/x-pack/plugins/data_enhanced/public/search/sessions_mgmt/components/actions/inspect_button.tsx
@@ -35,7 +35,6 @@ const InspectFlyout = ({ uiSettings, searchSession }: InspectFlyoutProps) => {
         <CodeEditor
           languageId="json"
           value={JSON.stringify(searchSession.initialState, null, 2)}
-          onChange={() => {}}
           options={{
             readOnly: true,
             lineNumbers: 'off',

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -75,7 +75,6 @@ export class ImportCompleteView extends Component<Props, {}> {
           <CodeEditor
             languageId="json"
             value={jsonAsString}
-            onChange={() => {}}
             options={{
               readOnly: true,
               lineNumbers: 'off',


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make onChange in CodeEditor optional (#107128)