### PR TITLE
[Metrics UI] move show history button right and change icon

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/bottom_drawer.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/bottom_drawer.tsx
@@ -39,15 +39,7 @@ export const BottomDrawer: React.FC<{
   return (
     <BottomActionContainer ref={isOpen ? measureRef : null} isOpen={isOpen} outerWidth={width}>
       <BottomActionTopBar ref={isOpen ? null : measureRef}>
-        <EuiFlexItem grow={false}>
-          <ShowHideButton
-            aria-expanded={isOpen}
-            iconType={isOpen ? 'arrowDown' : 'arrowRight'}
-            onClick={onClick}
-          >
-            {isOpen ? hideHistory : showHistory}
-          </ShowHideButton>
-        </EuiFlexItem>
+        <LeftSideSpacer />
         <EuiFlexItem
           grow={false}
           style={{
@@ -58,7 +50,16 @@ export const BottomDrawer: React.FC<{
         >
           {children}
         </EuiFlexItem>
-        <RightSideSpacer />
+
+        <EuiFlexItem grow={false}>
+          <ShowHideButton
+            aria-expanded={isOpen}
+            iconType={isOpen ? 'eyeClosed' : 'eye'}
+            onClick={onClick}
+          >
+            {isOpen ? hideHistory : showHistory}
+          </ShowHideButton>
+        </EuiFlexItem>
       </BottomActionTopBar>
       <EuiFlexGroup style={{ marginTop: 0 }}>
         <Timeline isVisible={isOpen} interval={interval} yAxisFormatter={formatter} />
@@ -89,6 +90,6 @@ const ShowHideButton = euiStyled(EuiButtonEmpty).attrs({ size: 's' })`
   width: 140px;
 `;
 
-const RightSideSpacer = euiStyled(EuiSpacer).attrs({ size: 'xs' })`
+const LeftSideSpacer = euiStyled(EuiSpacer).attrs({ size: 'xs' })`
   width: 140px;
 `;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/104095

Moves "Show history" to the right and changes icon

![Screen Shot 2021-07-29 at 10 15 34 AM](https://user-images.githubusercontent.com/1676003/127508055-2eb8cdf8-b730-4e92-b2ab-6428d533f529.png)
![Screen Shot 2021-07-29 at 10 15 24 AM](https://user-images.githubusercontent.com/1676003/127508073-8dbd2ad4-38ae-4cc9-ad53-855172702ee5.png)
