### PR TITLE
[7.14] [Metrics UI] Correct inaccurate offsetting for non-rate aggregations inside of metrics threshold alerts (#106947)

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -180,6 +180,7 @@ const getValuesFromAggregations = (
   try {
     const { buckets } = aggregations.aggregatedIntervals;
     if (!buckets.length) return null; // No Data state
+
     if (aggType === Aggregators.COUNT) {
       return buckets.map((bucket) => ({
         key: bucket.to_as_string,

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
@@ -59,25 +59,4 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
     });
   });
 
-  describe('handles time', () => {
-    const end = new Date('2020-07-08T22:07:27.235Z').valueOf();
-    const timerange = {
-      end,
-      start: end - 5 * 60 * 1000,
-    };
-    const searchBody = getElasticsearchMetricQuery(
-      expressionParams,
-      timefield,
-      undefined,
-      undefined,
-      timerange
-    );
-    test('by rounding timestamps to the nearest timeUnit', () => {
-      const rangeFilter = searchBody.query.bool.filter.find((filter) =>
-        filter.hasOwnProperty('range')
-      )?.range[timefield];
-      expect(rangeFilter?.lte).toBe(1594246020000);
-      expect(rangeFilter?.gte).toBe(1594245720000);
-    });
-  });
 });

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
@@ -58,5 +58,4 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
       );
     });
   });
-
 });

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
@@ -204,7 +204,7 @@ describe('The metric threshold alert type', () => {
     });
     test('sends no alert when some, but not all, criteria cross the threshold', async () => {
       const instanceID = '*';
-      await execute(Comparator.LT_OR_EQ, [1.0], [3.0]);
+      await execute(Comparator.LT_OR_EQ, [1.0], [2.5]);
       expect(mostRecentAction(instanceID)).toBe(undefined);
     });
     test('alerts only on groups that meet all criteria when querying with a groupBy parameter', async () => {
@@ -223,7 +223,7 @@ describe('The metric threshold alert type', () => {
       expect(reasons[0]).toContain('test.metric.1');
       expect(reasons[1]).toContain('test.metric.2');
       expect(reasons[0]).toContain('current value is 1');
-      expect(reasons[1]).toContain('current value is 3.5');
+      expect(reasons[1]).toContain('current value is 3');
       expect(reasons[0]).toContain('threshold of 1');
       expect(reasons[1]).toContain('threshold of 3');
     });
@@ -247,9 +247,9 @@ describe('The metric threshold alert type', () => {
         },
       });
     test('alerts based on the doc_count value instead of the aggregatedValue', async () => {
-      await execute(Comparator.GT, [2]);
+      await execute(Comparator.GT, [0.9]);
       expect(mostRecentAction(instanceID).id).toBe(FIRED_ACTIONS.id);
-      await execute(Comparator.LT, [1.5]);
+      await execute(Comparator.LT, [0.5]);
       expect(mostRecentAction(instanceID)).toBe(undefined);
     });
   });


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Metrics UI] Correct inaccurate offsetting for non-rate aggregations inside of metrics threshold alerts (#106947)