### PR TITLE
[visualize] use IndexPattern instead of IIndexPattern

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -11,7 +11,7 @@ import { Subscription } from 'rxjs';
 import { i18n } from '@kbn/i18n';
 import { VISUALIZE_EMBEDDABLE_TYPE } from './constants';
 import {
-  IIndexPattern,
+  IndexPattern,
   TimeRange,
   Query,
   esFilters,
@@ -47,7 +47,7 @@ const getKeys = <T extends {}>(o: T): Array<keyof T> => Object.keys(o) as Array<
 
 export interface VisualizeEmbeddableConfiguration {
   vis: Vis;
-  indexPatterns?: IIndexPattern[];
+  indexPatterns?: IndexPattern[];
   editPath: string;
   editUrl: string;
   capabilities: { visualizeSave: boolean; dashboardSave: boolean };
@@ -69,7 +69,7 @@ export interface VisualizeOutput extends EmbeddableOutput {
   editPath: string;
   editApp: string;
   editUrl: string;
-  indexPatterns?: IIndexPattern[];
+  indexPatterns?: IndexPattern[];
   visTypeName: string;
 }
 

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -182,7 +182,7 @@ export class VisualizationsPlugin
       showNewVisModal,
       /**
        * creates new instance of Vis
-       * @param {IIndexPattern} indexPattern - index pattern to use
+       * @param {IndexPattern} indexPattern - index pattern to use
        * @param {VisState} visState - visualization configuration
        */
       createVis: async (visType: string, visState: SerializedVis) =>

--- a/src/plugins/visualizations/public/saved_visualizations/_saved_vis.ts
+++ b/src/plugins/visualizations/public/saved_visualizations/_saved_vis.ts
@@ -19,7 +19,7 @@ import { updateOldState } from '../legacy/vis_update_state';
 import { extractReferences, injectReferences } from './saved_visualization_references';
 import { createSavedSearchesLoader } from '../../../discover/public';
 import type { SavedObjectsClientContract } from '../../../../core/public';
-import type { IIndexPattern, IndexPatternsContract } from '../../../../plugins/data/public';
+import type { IndexPatternsContract } from '../../../../plugins/data/public';
 import type { ISavedVis, SerializedVis } from '../types';
 
 export interface SavedVisServices {
@@ -93,7 +93,7 @@ export function createSavedVisClass(services: SavedVisServices) {
         extractReferences,
         injectReferences,
         id: (opts.id as string) || '',
-        indexPattern: opts.indexPattern as IIndexPattern,
+        indexPattern: opts.indexPattern,
         defaults: {
           title: '',
           visState,


### PR DESCRIPTION
## Summary

Use `IndexPattern` instead of `IIndexPattern` as `IIndexPattern` is deprecated due to too much ambiguity in its definition.
