### PR TITLE
[input control vis] use IndexPattern instead of IIndexPattern

### DIFF
--- a/src/plugins/input_control_vis/public/components/editor/control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/control_editor.tsx
@@ -22,7 +22,7 @@ import {
 import { RangeControlEditor } from './range_control_editor';
 import { ListControlEditor } from './list_control_editor';
 import { getTitle, ControlParams, CONTROL_TYPES, ControlParamsOptions } from '../../editor_utils';
-import { IIndexPattern } from '../../../../data/public';
+import { IndexPattern } from '../../../../data/public';
 import { InputControlVisDependencies } from '../../plugin';
 
 import './control_editor.scss';
@@ -35,7 +35,7 @@ interface ControlEditorUiProps {
   handleRemoveControl: (controlIndex: number) => void;
   handleIndexPatternChange: (controlIndex: number, indexPatternId: string) => void;
   handleFieldNameChange: (controlIndex: number, fieldName: string) => void;
-  getIndexPattern: (indexPatternId: string) => Promise<IIndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
   handleOptionsChange: <T extends keyof ControlParamsOptions>(
     controlIndex: number,
     optionName: T,

--- a/src/plugins/input_control_vis/public/components/editor/controls_tab.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/controls_tab.tsx
@@ -20,7 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { VisEditorOptionsProps } from 'src/plugins/visualizations/public';
-import { IIndexPattern } from 'src/plugins/data/public';
+import { IndexPattern } from 'src/plugins/data/public';
 import { ControlEditor } from './control_editor';
 import {
   addControl,
@@ -49,7 +49,7 @@ class ControlsTab extends PureComponent<ControlsTabProps, ControlsTabUiState> {
     type: CONTROL_TYPES.LIST,
   };
 
-  getIndexPattern = async (indexPatternId: string): Promise<IIndexPattern> => {
+  getIndexPattern = async (indexPatternId: string): Promise<IndexPattern> => {
     const [, startDeps] = await this.props.deps.core.getStartServices();
     return await startDeps.data.indexPatterns.get(indexPatternId);
   };

--- a/src/plugins/input_control_vis/public/components/editor/field_select.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/field_select.tsx
@@ -12,7 +12,7 @@ import React, { Component } from 'react';
 import { injectI18n, FormattedMessage, InjectedIntlProps } from '@kbn/i18n/react';
 import { EuiFormRow, EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
-import { IIndexPattern, IFieldType } from '../../../../data/public';
+import { IndexPattern, IFieldType } from '../../../../data/public';
 
 interface FieldSelectUiState {
   isLoading: boolean;
@@ -21,7 +21,7 @@ interface FieldSelectUiState {
 }
 
 export type FieldSelectUiProps = InjectedIntlProps & {
-  getIndexPattern: (indexPatternId: string) => Promise<IIndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
   indexPatternId: string;
   onChange: (value: any) => void;
   fieldName?: string;
@@ -74,7 +74,7 @@ class FieldSelectUi extends Component<FieldSelectUiProps, FieldSelectUiState> {
       return;
     }
 
-    let indexPattern: IIndexPattern;
+    let indexPattern: IndexPattern;
     try {
       indexPattern = await this.props.getIndexPattern(indexPatternId);
     } catch (err) {

--- a/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/list_control_editor.tsx
@@ -14,7 +14,7 @@ import { EuiFormRow, EuiFieldNumber, EuiSwitch, EuiSelect } from '@elastic/eui';
 import { IndexPatternSelectFormRow } from './index_pattern_select_form_row';
 import { FieldSelect } from './field_select';
 import { ControlParams, ControlParamsOptions } from '../../editor_utils';
-import { IIndexPattern, IFieldType, IndexPatternSelectProps } from '../../../../data/public';
+import { IndexPattern, IFieldType, IndexPatternSelectProps } from '../../../../data/public';
 import { InputControlVisDependencies } from '../../plugin';
 
 interface ListControlEditorState {
@@ -25,7 +25,7 @@ interface ListControlEditorState {
 }
 
 interface ListControlEditorProps {
-  getIndexPattern: (indexPatternId: string) => Promise<IIndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
   controlIndex: number;
   controlParams: ControlParams;
   handleFieldNameChange: (fieldName: string) => void;
@@ -104,7 +104,7 @@ export class ListControlEditor extends PureComponent<
       return;
     }
 
-    let indexPattern: IIndexPattern;
+    let indexPattern: IndexPattern;
     try {
       indexPattern = await this.props.getIndexPattern(this.props.controlParams.indexPattern);
     } catch (err) {

--- a/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
+++ b/src/plugins/input_control_vis/public/components/editor/range_control_editor.tsx
@@ -14,13 +14,13 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { IndexPatternSelectFormRow } from './index_pattern_select_form_row';
 import { FieldSelect } from './field_select';
 import { ControlParams, ControlParamsOptions } from '../../editor_utils';
-import { IIndexPattern, IFieldType, IndexPatternSelectProps } from '../../../../data/public';
+import { IndexPattern, IFieldType, IndexPatternSelectProps } from '../../../../data/public';
 import { InputControlVisDependencies } from '../../plugin';
 
 interface RangeControlEditorProps {
   controlIndex: number;
   controlParams: ControlParams;
-  getIndexPattern: (indexPatternId: string) => Promise<IIndexPattern>;
+  getIndexPattern: (indexPatternId: string) => Promise<IndexPattern>;
   handleFieldNameChange: (fieldName: string) => void;
   handleIndexPatternChange: (indexPatternId: string) => void;
   handleOptionsChange: <T extends keyof ControlParamsOptions>(

--- a/src/plugins/input_control_vis/public/test_utils/get_index_pattern_mock.ts
+++ b/src/plugins/input_control_vis/public/test_utils/get_index_pattern_mock.ts
@@ -6,12 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { IIndexPattern } from 'src/plugins/data/public';
+import { IndexPattern } from 'src/plugins/data/public';
 
 /**
  * Returns forced **Partial** IndexPattern for use in tests
  */
-export const getIndexPatternMock = (): Promise<IIndexPattern> => {
+export const getIndexPatternMock = (): Promise<IndexPattern> => {
   return Promise.resolve({
     id: 'mockIndexPattern',
     title: 'mockIndexPattern',
@@ -20,5 +20,5 @@ export const getIndexPatternMock = (): Promise<IIndexPattern> => {
       { name: 'textField', type: 'string', aggregatable: false },
       { name: 'numberField', type: 'number', aggregatable: true },
     ],
-  } as IIndexPattern);
+  } as IndexPattern);
 };


### PR DESCRIPTION
## Summary

Use `IndexPattern` instead of `IIndexPattern` as `IIndexPattern` is deprecated due to too much ambiguity in its definition.
