### PR TITLE
[state containers] use IndexPattern instead of IIndexPattern

### DIFF
--- a/examples/state_containers_examples/public/with_data_services/app.tsx
+++ b/examples/state_containers_examples/public/with_data_services/app.tsx
@@ -26,7 +26,7 @@ import {
   DataPublicPluginStart,
   esFilters,
   Filter,
-  IIndexPattern,
+  IndexPattern,
   Query,
   QueryState,
   syncQueryStateWithUrl,
@@ -127,7 +127,7 @@ export const App = ({
 };
 
 function useIndexPattern(data: DataPublicPluginStart) {
-  const [indexPattern, setIndexPattern] = useState<IIndexPattern>();
+  const [indexPattern, setIndexPattern] = useState<IndexPattern>();
   useEffect(() => {
     const fetchIndexPattern = async () => {
       const defaultIndexPattern = await data.indexPatterns.getDefault();


### PR DESCRIPTION
## Summary

Use `IndexPattern` instead of `IIndexPattern` as `IIndexPattern` is deprecated due to too much ambiguity in its definition.