### PR TITLE
[7.x] [i18n] EUI token use FormattedMessage instead of i18n.translate: the sequel (#107080)

### DIFF
--- a/src/core/public/i18n/i18n_eui_mapping.tsx
+++ b/src/core/public/i18n/i18n_eui_mapping.tsx
@@ -685,11 +685,13 @@ export const getEuiContextMapping = (): EuiTokensObject => {
         defaultMessage: 'Next page, {page}',
         values: { page },
       }),
-    'euiPagination.pageOfTotalCompressed': ({ page, total }: EuiValues) =>
-      i18n.translate('core.euiPagination.pageOfTotalCompressed', {
-        defaultMessage: '{page} of {total}',
-        values: { page, total },
-      }),
+    'euiPagination.pageOfTotalCompressed': ({ page, total }: EuiValues) => (
+      <FormattedMessage
+        id="core.euiPagination.pageOfTotalCompressed"
+        defaultMessage="{page} of {total}"
+        values={{ page, total }}
+      />
+    ),
     'euiPagination.previousPage': ({ page }: EuiValues) =>
       i18n.translate('core.euiPagination.previousPage', {
         defaultMessage: 'Previous page, {page}',


### PR DESCRIPTION
Backports the following commits to 7.x:
 - reinstate #105841 (#107080)