### PR TITLE
[Fleet] Missing SO Installation migration

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -42,7 +42,7 @@ import {
   migrateSettingsToV7130,
   migrateOutputToV7130,
 } from './migrations/to_v7_13_0';
-import { migratePackagePolicyToV7140 } from './migrations/to_v7_14_0';
+import { migratePackagePolicyToV7140, migrateInstallationToV7140 } from './migrations/to_v7_14_0';
 import { migratePackagePolicyToV7150 } from './migrations/to_v7_15_0';
 
 /*
@@ -319,6 +319,9 @@ const getSavedObjectTypes = (
         install_status: { type: 'keyword' },
         install_source: { type: 'keyword' },
       },
+    },
+    migrations: {
+      '7.14.0': migrateInstallationToV7140,
     },
   },
   [ASSETS_SAVED_OBJECT_TYPE]: {

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/to_v7_10_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/to_v7_10_0.ts
@@ -127,12 +127,3 @@ export const migrateAgentActionToV7100 = (
     },
   });
 };
-
-export const migrateInstallationToV7100: SavedObjectMigrationFn<
-  Exclude<Installation, 'install_source'>,
-  Installation
-> = (installationDoc) => {
-  installationDoc.attributes.install_source = 'registry';
-
-  return installationDoc;
-};

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/to_v7_10_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/to_v7_10_0.ts
@@ -15,7 +15,6 @@ import type {
   EnrollmentAPIKey,
   Settings,
   AgentAction,
-  Installation,
 } from '../../types';
 
 export const migrateAgentToV7100: SavedObjectMigrationFn<

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/to_v7_14_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/to_v7_14_0.ts
@@ -7,7 +7,7 @@
 
 import type { SavedObjectMigrationFn } from 'kibana/server';
 
-import type { PackagePolicy } from '../../../common';
+import type { PackagePolicy, Installation } from '../../../common';
 
 import { migrateEndpointPackagePolicyToV7140 } from './security_solution';
 
@@ -26,4 +26,18 @@ export const migratePackagePolicyToV7140: SavedObjectMigrationFn<PackagePolicy, 
   }
 
   return updatedPackagePolicyDoc;
+};
+
+export const migrateInstallationToV7140: SavedObjectMigrationFn<Installation, Installation> = (
+  doc
+) => {
+  // Fix a missing migration for user that used Fleet before 7.9
+  if (!doc.attributes.install_source) {
+    doc.attributes.install_source = 'registry';
+  }
+  if (!doc.attributes.install_version) {
+    doc.attributes.install_version = doc.attributes.version;
+  }
+
+  return doc;
 };

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -93,6 +93,7 @@ export default function (providerContext: FtrProviderContext) {
       delete packageInfoRes.body.response.savedObject.version;
       delete packageInfoRes.body.response.savedObject.updated_at;
       delete packageInfoRes.body.response.savedObject.coreMigrationVersion;
+      delete packageInfoRes.body.response.savedObject.migrationVersion;
 
       expectSnapshot(packageInfoRes.body.response).toMatch();
     });


### PR DESCRIPTION
## Summary

Resolve #107154  

While introducing the `install_source` and `install_version` property on the Installation saved object in Fleet in 7.10 we missed a migration. That PR fix that by adding the migration for 7.14.0.
