### PR TITLE
[7.x] use IndexPattern instead of IIndexPattern (#107108)

### DIFF
--- a/x-pack/plugins/uptime/public/hooks/update_kuery_string.ts
+++ b/x-pack/plugins/uptime/public/hooks/update_kuery_string.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { esKuery, IIndexPattern } from '../../../../../src/plugins/data/public';
+import { esKuery } from '../../../../../src/plugins/data/public';
+import type { IndexPattern } from '../../../../../src/plugins/data/public';
 import { combineFiltersAndUserSearch, stringifyKueries } from '../../common/lib';
 
 const getKueryString = (urlFilters: string): string => {
@@ -25,7 +26,7 @@ const getKueryString = (urlFilters: string): string => {
 };
 
 export const useUpdateKueryString = (
-  indexPattern: IIndexPattern | null,
+  indexPattern: IndexPattern | null,
   filterQueryString = '',
   urlFilters: string
 ): [string?, Error?] => {

--- a/x-pack/plugins/uptime/public/state/reducers/index_pattern.ts
+++ b/x-pack/plugins/uptime/public/state/reducers/index_pattern.ts
@@ -7,10 +7,10 @@
 
 import { handleActions, Action } from 'redux-actions';
 import { getIndexPattern, getIndexPatternSuccess, getIndexPatternFail } from '../actions';
-import { IIndexPattern } from '../../../../../../src/plugins/data/common/index_patterns';
+import type { IndexPattern } from '../../../../../../src/plugins/data/common/index_patterns';
 
 export interface IndexPatternState {
-  index_pattern: IIndexPattern | null;
+  index_pattern: IndexPattern | null;
   errors: any[];
   loading: boolean;
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - use IndexPattern instead of IIndexPattern (#107108)