### PR TITLE
Fix the API docs bug, where optional functions on interfaces were losing their children.

### DIFF
--- a/api_docs/actions.json
+++ b/api_docs/actions.json
@@ -214,8 +214,8 @@
             ],
             "path": "x-pack/plugins/actions/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "actions",
@@ -1838,6 +1838,22 @@
         ],
         "path": "x-pack/plugins/actions/common/rewrite_request_case.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "actions",
+            "id": "def-common.requested",
+            "type": "Object",
+            "tags": [],
+            "label": "requested",
+            "description": [],
+            "signature": [
+              "{ [K in keyof T as CamelToSnake<RenameActionToConnector<Extract<K, string>>>]: T[K]; }"
+            ],
+            "path": "x-pack/plugins/actions/common/rewrite_request_case.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1868,6 +1884,22 @@
         ],
         "path": "x-pack/plugins/actions/common/rewrite_request_case.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "actions",
+            "id": "def-common.responded",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "responded",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "x-pack/plugins/actions/common/rewrite_request_case.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/actions.mdx
+++ b/api_docs/actions.mdx
@@ -18,7 +18,7 @@ import actionsObj from './actions.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 117 | 0 | 117 | 7 |
+| 119 | 0 | 119 | 7 |
 
 ## Server
 

--- a/api_docs/alerting.json
+++ b/api_docs/alerting.json
@@ -29,6 +29,48 @@
         ],
         "path": "x-pack/plugins/alerting/public/alert_navigation_registry/types.ts",
         "deprecated": false,
+        "returnComment": [
+          "A URL that is meant to be relative to your application id, or a state object that your application uses to render\nthe rule. This information is intended to be used with cores NavigateToApp function, along with the application id that was\noriginally registered to {@link PluginSetupContract.registerNavigation}."
+        ],
+        "children": [
+          {
+            "parentPluginId": "alerting",
+            "id": "def-public.alert",
+            "type": "Object",
+            "tags": [],
+            "label": "alert",
+            "description": [],
+            "signature": [
+              "{ enabled: boolean; id: string; name: string; params: never; actions: ",
+              {
+                "pluginId": "alerting",
+                "scope": "common",
+                "docId": "kibAlertingPluginApi",
+                "section": "def-common.AlertAction",
+                "text": "AlertAction"
+              },
+              "[]; throttle: string | null; tags: string[]; alertTypeId: string; consumer: string; schedule: ",
+              {
+                "pluginId": "alerting",
+                "scope": "common",
+                "docId": "kibAlertingPluginApi",
+                "section": "def-common.IntervalSchedule",
+                "text": "IntervalSchedule"
+              },
+              "; scheduledTaskId?: string | undefined; createdBy: string | null; updatedBy: string | null; createdAt: Date; updatedAt: Date; apiKeyOwner: string | null; notifyWhen: \"onActionGroupChange\" | \"onActiveAlert\" | \"onThrottleInterval\" | null; muteAll: boolean; mutedInstanceIds: string[]; executionStatus: ",
+              {
+                "pluginId": "alerting",
+                "scope": "common",
+                "docId": "kibAlertingPluginApi",
+                "section": "def-common.AlertExecutionStatus",
+                "text": "AlertExecutionStatus"
+              },
+              "; }"
+            ],
+            "path": "x-pack/plugins/alerting/public/alert_navigation_registry/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -67,35 +109,42 @@
           ],
           "path": "x-pack/plugins/alerting/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "alerting",
-              "id": "def-public.applicationId",
+              "id": "def-public.PluginSetupContract.registerNavigation.$1",
               "type": "string",
               "tags": [],
               "label": "applicationId",
               "description": [
                 "The application id that the user should be navigated to, to view a particular alert in a custom way."
               ],
+              "signature": [
+                "string"
+              ],
               "path": "x-pack/plugins/alerting/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "alerting",
-              "id": "def-public.ruleType",
+              "id": "def-public.PluginSetupContract.registerNavigation.$2",
               "type": "string",
               "tags": [],
               "label": "ruleType",
               "description": [
                 "The rule type that has been registered with Alerting.Server.PluginSetupContract.registerType. If\nno such rule with that id exists, a warning is output to the console log. It used to throw an error, but that was temporarily moved\nbecause it was causing flaky test failures with https://github.com/elastic/kibana/issues/59229 and needs to be\ninvestigated more."
               ],
+              "signature": [
+                "string"
+              ],
               "path": "x-pack/plugins/alerting/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "alerting",
-              "id": "def-public.handler",
+              "id": "def-public.PluginSetupContract.registerNavigation.$3",
               "type": "Function",
               "tags": [],
               "label": "handler",
@@ -103,21 +152,20 @@
                 "The navigation handler should return either a relative URL, or a state object. This information can be used,\nin conjunction with the consumer id, to navigate the user to a custom URL to view a rule's details."
               ],
               "signature": [
-                "(alert: Pick<",
                 {
                   "pluginId": "alerting",
-                  "scope": "common",
+                  "scope": "public",
                   "docId": "kibAlertingPluginApi",
-                  "section": "def-common.Alert",
-                  "text": "Alert"
-                },
-                "<never>, \"enabled\" | \"id\" | \"name\" | \"params\" | \"actions\" | \"throttle\" | \"tags\" | \"alertTypeId\" | \"consumer\" | \"schedule\" | \"scheduledTaskId\" | \"createdBy\" | \"updatedBy\" | \"createdAt\" | \"updatedAt\" | \"apiKeyOwner\" | \"notifyWhen\" | \"muteAll\" | \"mutedInstanceIds\" | \"executionStatus\">) => string | ",
-                "JsonObject"
+                  "section": "def-public.AlertNavigationHandler",
+                  "text": "AlertNavigationHandler"
+                }
               ],
               "path": "x-pack/plugins/alerting/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "alerting",
@@ -141,23 +189,26 @@
           ],
           "path": "x-pack/plugins/alerting/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "alerting",
-              "id": "def-public.applicationId",
+              "id": "def-public.PluginSetupContract.registerDefaultNavigation.$1",
               "type": "string",
               "tags": [],
               "label": "applicationId",
               "description": [
                 "The application id that the user should be navigated to, to view a particular alert in a custom way."
               ],
+              "signature": [
+                "string"
+              ],
               "path": "x-pack/plugins/alerting/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "alerting",
-              "id": "def-public.handler",
+              "id": "def-public.PluginSetupContract.registerDefaultNavigation.$2",
               "type": "Function",
               "tags": [],
               "label": "handler",
@@ -165,21 +216,20 @@
                 "The navigation handler should return either a relative URL, or a state object. This information can be used,\nin conjunction with the consumer id, to navigate the user to a custom URL to view a rule's details."
               ],
               "signature": [
-                "(alert: Pick<",
                 {
                   "pluginId": "alerting",
-                  "scope": "common",
+                  "scope": "public",
                   "docId": "kibAlertingPluginApi",
-                  "section": "def-common.Alert",
-                  "text": "Alert"
-                },
-                "<never>, \"enabled\" | \"id\" | \"name\" | \"params\" | \"actions\" | \"throttle\" | \"tags\" | \"alertTypeId\" | \"consumer\" | \"schedule\" | \"scheduledTaskId\" | \"createdBy\" | \"updatedBy\" | \"createdAt\" | \"updatedAt\" | \"apiKeyOwner\" | \"notifyWhen\" | \"muteAll\" | \"mutedInstanceIds\" | \"executionStatus\">) => string | ",
-                "JsonObject"
+                  "section": "def-public.AlertNavigationHandler",
+                  "text": "AlertNavigationHandler"
+                }
               ],
               "path": "x-pack/plugins/alerting/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -223,19 +273,23 @@
           ],
           "path": "x-pack/plugins/alerting/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "alerting",
-              "id": "def-public.alertId",
+              "id": "def-public.PluginStartContract.getNavigation.$1",
               "type": "string",
               "tags": [],
               "label": "alertId",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "x-pack/plugins/alerting/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",
@@ -955,8 +1009,8 @@
             ],
             "path": "x-pack/plugins/alerting/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "alerting",
@@ -995,8 +1049,8 @@
             ],
             "path": "x-pack/plugins/alerting/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "alerting",
@@ -1010,8 +1064,8 @@
             ],
             "path": "x-pack/plugins/alerting/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1102,19 +1156,23 @@
             ],
             "path": "x-pack/plugins/alerting/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "alerting",
-                "id": "def-server.id",
+                "id": "def-server.AlertServices.alertInstanceFactory.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/alerting/server/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1660,8 +1718,8 @@
             ],
             "path": "x-pack/plugins/alerting/server/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/alerting.mdx
+++ b/api_docs/alerting.mdx
@@ -18,7 +18,7 @@ import alertingObj from './alerting.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 242 | 0 | 234 | 16 |
+| 243 | 0 | 235 | 16 |
 
 ## Client
 

--- a/api_docs/apm.json
+++ b/api_docs/apm.json
@@ -3928,8 +3928,8 @@
           ],
           "path": "x-pack/plugins/apm/server/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "apm",
@@ -3959,32 +3959,67 @@
           ],
           "path": "x-pack/plugins/apm/server/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "apm",
-              "id": "def-server.params",
+              "id": "def-server.APMPluginSetup.createApmEventClient.$1.params",
               "type": "Object",
               "tags": [],
               "label": "params",
               "description": [],
-              "signature": [
-                "{ debug?: boolean | undefined; request: ",
-                {
-                  "pluginId": "core",
-                  "scope": "server",
-                  "docId": "kibCoreHttpPluginApi",
-                  "section": "def-server.KibanaRequest",
-                  "text": "KibanaRequest"
-                },
-                "<unknown, unknown, unknown, any>; context: ",
-                "ApmPluginRequestHandlerContext",
-                "; }"
-              ],
               "path": "x-pack/plugins/apm/server/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "children": [
+                {
+                  "parentPluginId": "apm",
+                  "id": "def-server.APMPluginSetup.createApmEventClient.$1.params.debug",
+                  "type": "CompoundType",
+                  "tags": [],
+                  "label": "debug",
+                  "description": [],
+                  "signature": [
+                    "boolean | undefined"
+                  ],
+                  "path": "x-pack/plugins/apm/server/types.ts",
+                  "deprecated": false
+                },
+                {
+                  "parentPluginId": "apm",
+                  "id": "def-server.APMPluginSetup.createApmEventClient.$1.params.request",
+                  "type": "Object",
+                  "tags": [],
+                  "label": "request",
+                  "description": [],
+                  "signature": [
+                    {
+                      "pluginId": "core",
+                      "scope": "server",
+                      "docId": "kibCoreHttpPluginApi",
+                      "section": "def-server.KibanaRequest",
+                      "text": "KibanaRequest"
+                    },
+                    "<unknown, unknown, unknown, any>"
+                  ],
+                  "path": "x-pack/plugins/apm/server/types.ts",
+                  "deprecated": false
+                },
+                {
+                  "parentPluginId": "apm",
+                  "id": "def-server.APMPluginSetup.createApmEventClient.$1.params.context",
+                  "type": "Object",
+                  "tags": [],
+                  "label": "context",
+                  "description": [],
+                  "signature": [
+                    "ApmPluginRequestHandlerContext"
+                  ],
+                  "path": "x-pack/plugins/apm/server/types.ts",
+                  "deprecated": false
+                }
+              ]
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/apm.mdx
+++ b/api_docs/apm.mdx
@@ -18,7 +18,7 @@ Contact APM UI for questions regarding this plugin.
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 39 | 0 | 39 | 30 |
+| 42 | 0 | 42 | 30 |
 
 ## Client
 

--- a/api_docs/bfetch.json
+++ b/api_docs/bfetch.json
@@ -56,6 +56,35 @@
         ],
         "path": "src/plugins/bfetch/public/batching/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "bfetch",
+            "id": "def-public.payload",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "payload",
+            "description": [],
+            "signature": [
+              "Payload"
+            ],
+            "path": "src/plugins/bfetch/public/batching/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "bfetch",
+            "id": "def-public.signal",
+            "type": "Object",
+            "tags": [],
+            "label": "signal",
+            "description": [],
+            "signature": [
+              "AbortSignal | undefined"
+            ],
+            "path": "src/plugins/bfetch/public/batching/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -86,11 +115,10 @@
           ],
           "path": "src/plugins/bfetch/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "bfetch",
-              "id": "def-public.params",
+              "id": "def-public.BfetchPublicContract.fetchStreaming.$1",
               "type": "Object",
               "tags": [],
               "label": "params",
@@ -99,9 +127,11 @@
                 "FetchStreamingParams"
               ],
               "path": "src/plugins/bfetch/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "bfetch",
@@ -125,11 +155,10 @@
           ],
           "path": "src/plugins/bfetch/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "bfetch",
-              "id": "def-public.params",
+              "id": "def-public.BfetchPublicContract.batchedFunction.$1",
               "type": "Object",
               "tags": [],
               "label": "params",
@@ -139,9 +168,11 @@
                 "<Payload, Result>"
               ],
               "path": "src/plugins/bfetch/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",
@@ -184,11 +215,10 @@
             ],
             "path": "src/plugins/bfetch/server/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "bfetch",
-                "id": "def-server.data",
+                "id": "def-server.BatchProcessingRouteParams.onBatchItem.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "data",
@@ -197,9 +227,11 @@
                   "BatchItemData"
                 ],
                 "path": "src/plugins/bfetch/server/plugin.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -241,6 +273,48 @@
         ],
         "path": "src/plugins/bfetch/server/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "bfetch",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCorePluginApi",
+                "section": "def-server.RequestHandlerContext",
+                "text": "RequestHandlerContext"
+              }
+            ],
+            "path": "src/plugins/bfetch/server/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "bfetch",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<P, Q, B, Method>"
+            ],
+            "path": "src/plugins/bfetch/server/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -283,21 +357,24 @@
           ],
           "path": "src/plugins/bfetch/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "bfetch",
-              "id": "def-server.path",
+              "id": "def-server.BfetchServerSetup.addBatchProcessingRoute.$1",
               "type": "string",
               "tags": [],
               "label": "path",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/bfetch/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "bfetch",
-              "id": "def-server.handler",
+              "id": "def-server.BfetchServerSetup.addBatchProcessingRoute.$2",
               "type": "Function",
               "tags": [],
               "label": "handler",
@@ -322,9 +399,11 @@
                 "<BatchItemData, BatchItemResult>"
               ],
               "path": "src/plugins/bfetch/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "bfetch",
@@ -354,21 +433,24 @@
           ],
           "path": "src/plugins/bfetch/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "bfetch",
-              "id": "def-server.path",
+              "id": "def-server.BfetchServerSetup.addStreamingResponseRoute.$1",
               "type": "string",
               "tags": [],
               "label": "path",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/bfetch/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "bfetch",
-              "id": "def-server.params",
+              "id": "def-server.BfetchServerSetup.addStreamingResponseRoute.$2",
               "type": "Function",
               "tags": [],
               "label": "params",
@@ -393,9 +475,11 @@
                 "<Payload, Response>"
               ],
               "path": "src/plugins/bfetch/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "bfetch",
@@ -625,42 +709,30 @@
           ],
           "path": "src/plugins/bfetch/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "bfetch",
-              "id": "def-server.streamHandler",
+              "id": "def-server.BfetchServerSetup.createStreamingRequestHandler.$1",
               "type": "Function",
               "tags": [],
               "label": "streamHandler",
               "description": [],
               "signature": [
-                "(context: ",
                 {
-                  "pluginId": "core",
+                  "pluginId": "bfetch",
                   "scope": "server",
-                  "docId": "kibCorePluginApi",
-                  "section": "def-server.RequestHandlerContext",
-                  "text": "RequestHandlerContext"
+                  "docId": "kibBfetchPluginApi",
+                  "section": "def-server.StreamingRequestHandler",
+                  "text": "StreamingRequestHandler"
                 },
-                ", request: ",
-                {
-                  "pluginId": "core",
-                  "scope": "server",
-                  "docId": "kibCoreHttpPluginApi",
-                  "section": "def-server.KibanaRequest",
-                  "text": "KibanaRequest"
-                },
-                "<P, Q, B, Method>) => ",
-                "Observable",
-                "<Response> | Promise<",
-                "Observable",
-                "<Response>>"
+                "<Response, P, Q, B, Method>"
               ],
               "path": "src/plugins/bfetch/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -1118,22 +1190,23 @@
             ],
             "path": "src/plugins/bfetch/common/buffer/create_batched_function.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "bfetch",
-                "id": "def-common.args",
+                "id": "def-common.BatchedFunctionParams.onCall.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "args",
                 "description": [],
                 "signature": [
-                  "Func extends (...args: infer P) => any ? P : never"
+                  "Parameters<Func>"
                 ],
                 "path": "src/plugins/bfetch/common/buffer/create_batched_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "bfetch",
@@ -1147,11 +1220,10 @@
             ],
             "path": "src/plugins/bfetch/common/buffer/create_batched_function.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "bfetch",
-                "id": "def-common.items",
+                "id": "def-common.BatchedFunctionParams.onBatch.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "items",
@@ -1160,9 +1232,11 @@
                   "BatchEntry[]"
                 ],
                 "path": "src/plugins/bfetch/common/buffer/create_batched_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "bfetch",
@@ -1393,11 +1467,10 @@
             ],
             "path": "src/plugins/bfetch/common/buffer/item_buffer.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "bfetch",
-                "id": "def-common.items",
+                "id": "def-common.ItemBufferParams.onFlush.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "items",
@@ -1406,9 +1479,11 @@
                   "Item[]"
                 ],
                 "path": "src/plugins/bfetch/common/buffer/item_buffer.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/bfetch.mdx
+++ b/api_docs/bfetch.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 73 | 1 | 62 | 2 |
+| 77 | 1 | 66 | 2 |
 
 ## Client
 

--- a/api_docs/cases.json
+++ b/api_docs/cases.json
@@ -444,11 +444,10 @@
             ],
             "path": "x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "cases",
-                "id": "def-public.theCase",
+                "id": "def-public.AllCasesSelectorModalProps.onRowClick.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "theCase",
@@ -472,9 +471,11 @@
                   " | undefined"
                 ],
                 "path": "x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -495,7 +496,30 @@
               ") => void) | undefined"
             ],
             "path": "x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "cases",
+                "id": "def-public.AllCasesSelectorModalProps.updateCase.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "newCase",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "cases",
+                    "scope": "common",
+                    "docId": "kibCasesPluginApi",
+                    "section": "def-common.Case",
+                    "text": "Case"
+                  }
+                ],
+                "path": "x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -550,7 +574,30 @@
               ") => void) | undefined"
             ],
             "path": "x-pack/plugins/cases/public/components/case_view/index.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "cases",
+                "id": "def-public.CaseViewProps.onCaseDataSuccess.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "data",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "cases",
+                    "scope": "common",
+                    "docId": "kibCasesPluginApi",
+                    "section": "def-common.Case",
+                    "text": "Case"
+                  }
+                ],
+                "path": "x-pack/plugins/cases/public/components/case_view/index.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -643,7 +690,44 @@
               ", postComment: (args: PostComment) => Promise<void>) => Promise<void>) | undefined"
             ],
             "path": "x-pack/plugins/cases/public/components/create/index.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "cases",
+                "id": "def-public.CreateCaseProps.afterCaseCreated.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "theCase",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "cases",
+                    "scope": "common",
+                    "docId": "kibCasesPluginApi",
+                    "section": "def-common.Case",
+                    "text": "Case"
+                  }
+                ],
+                "path": "x-pack/plugins/cases/public/components/create/index.tsx",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "cases",
+                "id": "def-public.CreateCaseProps.afterCaseCreated.$2",
+                "type": "Function",
+                "tags": [],
+                "label": "postComment",
+                "description": [],
+                "signature": [
+                  "(args: PostComment) => Promise<void>"
+                ],
+                "path": "x-pack/plugins/cases/public/components/create/index.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -703,8 +787,8 @@
             ],
             "path": "x-pack/plugins/cases/public/components/create/index.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -726,11 +810,10 @@
             ],
             "path": "x-pack/plugins/cases/public/components/create/index.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "cases",
-                "id": "def-public.theCase",
+                "id": "def-public.CreateCaseProps.onSuccess.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "theCase",
@@ -745,9 +828,11 @@
                   }
                 ],
                 "path": "x-pack/plugins/cases/public/components/create/index.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -911,13 +996,10 @@
           ],
           "path": "x-pack/plugins/cases/public/types.ts",
           "deprecated": false,
-          "returnComment": [
-            "A react component that displays all cases"
-          ],
           "children": [
             {
               "parentPluginId": "cases",
-              "id": "def-public.props",
+              "id": "def-public.CasesUiStart.getAllCases.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -934,8 +1016,12 @@
                 }
               ],
               "path": "x-pack/plugins/cases/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "A react component that displays all cases"
           ]
         },
         {
@@ -968,13 +1054,10 @@
           ],
           "path": "x-pack/plugins/cases/public/types.ts",
           "deprecated": false,
-          "returnComment": [
-            "A react component that is a modal for selecting a case"
-          ],
           "children": [
             {
               "parentPluginId": "cases",
-              "id": "def-public.props",
+              "id": "def-public.CasesUiStart.getAllCasesSelectorModal.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -991,8 +1074,12 @@
                 }
               ],
               "path": "x-pack/plugins/cases/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "A react component that is a modal for selecting a case"
           ]
         },
         {
@@ -1025,13 +1112,10 @@
           ],
           "path": "x-pack/plugins/cases/public/types.ts",
           "deprecated": false,
-          "returnComment": [
-            "A react component for viewing a specific case"
-          ],
           "children": [
             {
               "parentPluginId": "cases",
-              "id": "def-public.props",
+              "id": "def-public.CasesUiStart.getCaseView.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1048,8 +1132,12 @@
                 }
               ],
               "path": "x-pack/plugins/cases/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "A react component for viewing a specific case"
           ]
         },
         {
@@ -1082,13 +1170,10 @@
           ],
           "path": "x-pack/plugins/cases/public/types.ts",
           "deprecated": false,
-          "returnComment": [
-            "A react component for configuring a specific case"
-          ],
           "children": [
             {
               "parentPluginId": "cases",
-              "id": "def-public.props",
+              "id": "def-public.CasesUiStart.getConfigureCases.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1105,8 +1190,12 @@
                 }
               ],
               "path": "x-pack/plugins/cases/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "A react component for configuring a specific case"
           ]
         },
         {
@@ -1139,13 +1228,10 @@
           ],
           "path": "x-pack/plugins/cases/public/types.ts",
           "deprecated": false,
-          "returnComment": [
-            "A react component for creating a new case"
-          ],
           "children": [
             {
               "parentPluginId": "cases",
-              "id": "def-public.props",
+              "id": "def-public.CasesUiStart.getCreateCase.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1162,8 +1248,12 @@
                 }
               ],
               "path": "x-pack/plugins/cases/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "A react component for creating a new case"
           ]
         },
         {
@@ -1196,13 +1286,10 @@
           ],
           "path": "x-pack/plugins/cases/public/types.ts",
           "deprecated": false,
-          "returnComment": [
-            "A react component for showing recent cases"
-          ],
           "children": [
             {
               "parentPluginId": "cases",
-              "id": "def-public.props",
+              "id": "def-public.CasesUiStart.getRecentCases.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1219,8 +1306,12 @@
                 }
               ],
               "path": "x-pack/plugins/cases/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "A react component for showing recent cases"
           ]
         }
       ],
@@ -3941,7 +4032,52 @@
               "((caseId: string, caseConnectorId: string, subCaseId?: string | undefined) => void) | undefined"
             ],
             "path": "x-pack/plugins/cases/common/ui/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "cases",
+                "id": "def-common.UpdateByKey.fetchCaseUserActions.$1",
+                "type": "string",
+                "tags": [],
+                "label": "caseId",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "x-pack/plugins/cases/common/ui/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "cases",
+                "id": "def-common.UpdateByKey.fetchCaseUserActions.$2",
+                "type": "string",
+                "tags": [],
+                "label": "caseConnectorId",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "x-pack/plugins/cases/common/ui/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "cases",
+                "id": "def-common.UpdateByKey.fetchCaseUserActions.$3",
+                "type": "string",
+                "tags": [],
+                "label": "subCaseId",
+                "description": [],
+                "signature": [
+                  "string | undefined"
+                ],
+                "path": "x-pack/plugins/cases/common/ui/types.ts",
+                "deprecated": false,
+                "isRequired": false
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -3962,7 +4098,30 @@
               ") => void) | undefined"
             ],
             "path": "x-pack/plugins/cases/common/ui/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "cases",
+                "id": "def-common.UpdateByKey.updateCase.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "newCase",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "cases",
+                    "scope": "common",
+                    "docId": "kibCasesPluginApi",
+                    "section": "def-common.Case",
+                    "text": "Case"
+                  }
+                ],
+                "path": "x-pack/plugins/cases/common/ui/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -3994,7 +4153,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/cases/common/ui/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "cases",
@@ -4007,7 +4168,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/cases/common/ui/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/cases.mdx
+++ b/api_docs/cases.mdx
@@ -18,7 +18,7 @@ Contact [Security Solution Threat Hunting](https://github.com/orgs/elastic/teams
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 451 | 0 | 409 | 14 |
+| 459 | 0 | 417 | 14 |
 
 ## Client
 

--- a/api_docs/charts.json
+++ b/api_docs/charts.json
@@ -1354,11 +1354,10 @@
             ],
             "path": "src/plugins/charts/public/services/palettes/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "charts",
-                "id": "def-public.state",
+                "id": "def-public.PaletteDefinition.toExpression.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -1369,9 +1368,11 @@
                   "T | undefined"
                 ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "charts",
@@ -1403,11 +1404,10 @@
             ],
             "path": "src/plugins/charts/public/services/palettes/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "charts",
-                "id": "def-public.series",
+                "id": "def-public.PaletteDefinition.getCategoricalColor.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "series",
@@ -1425,11 +1425,12 @@
                   "[]"
                 ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "charts",
-                "id": "def-public.chartConfiguration",
+                "id": "def-public.PaletteDefinition.getCategoricalColor.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "chartConfiguration",
@@ -1445,11 +1446,12 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "charts",
-                "id": "def-public.state",
+                "id": "def-public.PaletteDefinition.getCategoricalColor.$3",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -1460,9 +1462,11 @@
                   "T | undefined"
                 ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "charts",
@@ -1478,21 +1482,24 @@
             ],
             "path": "src/plugins/charts/public/services/palettes/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "charts",
-                "id": "def-public.size",
+                "id": "def-public.PaletteDefinition.getCategoricalColors.$1",
                 "type": "number",
                 "tags": [],
                 "label": "size",
                 "description": [],
+                "signature": [
+                  "number"
+                ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "charts",
-                "id": "def-public.state",
+                "id": "def-public.PaletteDefinition.getCategoricalColors.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -1501,9 +1508,11 @@
                   "T | undefined"
                 ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "charts",
@@ -1533,7 +1542,70 @@
               "((value: number | undefined, state: T, { min, max }: { min: number; max: number; }) => string | undefined) | undefined"
             ],
             "path": "src/plugins/charts/public/services/palettes/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "charts",
+                "id": "def-public.PaletteDefinition.getColorForValue.$1",
+                "type": "number",
+                "tags": [],
+                "label": "value",
+                "description": [],
+                "signature": [
+                  "number | undefined"
+                ],
+                "path": "src/plugins/charts/public/services/palettes/types.ts",
+                "deprecated": false,
+                "isRequired": false
+              },
+              {
+                "parentPluginId": "charts",
+                "id": "def-public.PaletteDefinition.getColorForValue.$2",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  "T"
+                ],
+                "path": "src/plugins/charts/public/services/palettes/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "charts",
+                "id": "def-public.PaletteDefinition.getColorForValue.$3.minmax",
+                "type": "Object",
+                "tags": [],
+                "label": "{ min, max }",
+                "description": [],
+                "path": "src/plugins/charts/public/services/palettes/types.ts",
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "charts",
+                    "id": "def-public.PaletteDefinition.getColorForValue.$3.minmax.min",
+                    "type": "number",
+                    "tags": [],
+                    "label": "min",
+                    "description": [],
+                    "path": "src/plugins/charts/public/services/palettes/types.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "charts",
+                    "id": "def-public.PaletteDefinition.getColorForValue.$3.minmax.max",
+                    "type": "number",
+                    "tags": [],
+                    "label": "max",
+                    "description": [],
+                    "path": "src/plugins/charts/public/services/palettes/types.ts",
+                    "deprecated": false
+                  }
+                ]
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1627,19 +1699,23 @@
             ],
             "path": "src/plugins/charts/public/services/palettes/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "charts",
-                "id": "def-public.name",
+                "id": "def-public.PaletteRegistry.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/charts/public/services/palettes/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "charts",
@@ -1661,8 +1737,8 @@
             ],
             "path": "src/plugins/charts/public/services/palettes/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/charts.mdx
+++ b/api_docs/charts.mdx
@@ -18,7 +18,7 @@ Contact [Kibana App](https://github.com/orgs/elastic/teams/kibana-app) for quest
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 190 | 2 | 159 | 1 |
+| 195 | 2 | 164 | 1 |
 
 ## Client
 

--- a/api_docs/core.json
+++ b/api_docs/core.json
@@ -1453,8 +1453,8 @@
             ],
             "path": "src/core/public/deprecations/deprecations_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1472,19 +1472,23 @@
             ],
             "path": "src/core/public/deprecations/deprecations_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.domainId",
+                "id": "def-public.DeprecationsServiceStart.getDeprecations.$1",
                 "type": "string",
                 "tags": [],
                 "label": "domainId",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/deprecations/deprecations_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1502,11 +1506,10 @@
             ],
             "path": "src/core/public/deprecations/deprecations_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.details",
+                "id": "def-public.DeprecationsServiceStart.isDeprecationResolvable.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "details",
@@ -1515,9 +1518,11 @@
                   "DomainDeprecationDetails"
                 ],
                 "path": "src/core/public/deprecations/deprecations_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1543,11 +1548,10 @@
             ],
             "path": "src/core/public/deprecations/deprecations_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.details",
+                "id": "def-public.DeprecationsServiceStart.resolveDeprecation.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "details",
@@ -1556,9 +1560,11 @@
                   "DomainDeprecationDetails"
                 ],
                 "path": "src/core/public/deprecations/deprecations_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1784,11 +1790,10 @@
             ],
             "path": "src/core/public/execution_context/execution_context_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.context",
+                "id": "def-public.ExecutionContextServiceStart.create.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "context",
@@ -1797,9 +1802,11 @@
                   "KibanaExecutionContext"
                 ],
                 "path": "src/core/public/execution_context/execution_context_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1868,11 +1875,10 @@
             ],
             "path": "src/core/public/fatal_errors/fatal_errors_service.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.error",
+                "id": "def-public.FatalErrorsSetup.add.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "error",
@@ -1883,11 +1889,12 @@
                   "string | Error"
                 ],
                 "path": "src/core/public/fatal_errors/fatal_errors_service.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-public.source",
+                "id": "def-public.FatalErrorsSetup.add.$2",
                 "type": "string",
                 "tags": [],
                 "label": "source",
@@ -1898,9 +1905,11 @@
                   "string | undefined"
                 ],
                 "path": "src/core/public/fatal_errors/fatal_errors_service.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1926,8 +1935,8 @@
             ],
             "path": "src/core/public/fatal_errors/fatal_errors_service.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1958,22 +1967,34 @@
             ],
             "path": "src/core/public/i18n/i18n_service.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.__0",
+                "id": "def-public.I18nStart.Context.$1.children",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{ children }",
                 "description": [],
-                "signature": [
-                  "{ children: React.ReactNode; }"
-                ],
                 "path": "src/core/public/i18n/i18n_service.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-public.I18nStart.Context.$1.children.children",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "children",
+                    "description": [],
+                    "signature": [
+                      "string | number | boolean | {} | React.ReactElement<any, string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)> | React.ReactNodeArray | React.ReactPortal | null | undefined"
+                    ],
+                    "path": "src/core/public/i18n/i18n_service.tsx",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2000,8 +2021,8 @@
             ],
             "path": "src/core/public/execution_context/execution_context_container.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2017,8 +2038,8 @@
             ],
             "path": "src/core/public/execution_context/execution_context_container.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2106,21 +2127,24 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-public.defaultOverride",
+                "id": "def-public.IUiSettingsClient.get.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "defaultOverride",
@@ -2129,9 +2153,11 @@
                   "T | undefined"
                 ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2149,21 +2175,24 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.get$.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-public.defaultOverride",
+                "id": "def-public.IUiSettingsClient.get$.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "defaultOverride",
@@ -2172,9 +2201,11 @@
                   "T | undefined"
                 ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2194,8 +2225,8 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2211,21 +2242,24 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.set.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-public.value",
+                "id": "def-public.IUiSettingsClient.set.$2",
                 "type": "Any",
                 "tags": [],
                 "label": "value",
@@ -2234,9 +2268,11 @@
                   "any"
                 ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2252,19 +2288,23 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.remove.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2280,19 +2320,23 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.isDeclared.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2308,19 +2352,23 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.isDefault.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2336,19 +2384,23 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.isCustom.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2364,19 +2416,23 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.key",
+                "id": "def-public.IUiSettingsClient.isOverridden.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2394,8 +2450,8 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2413,8 +2469,8 @@
             ],
             "path": "src/core/public/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -3753,7 +3809,23 @@
                   }
                 ],
                 "path": "src/core/public/overlays/flyout/flyout_service.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-public.element",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "element",
+                    "description": [],
+                    "signature": [
+                      "T"
+                    ],
+                    "path": "src/core/public/types.ts",
+                    "deprecated": false
+                  }
+                ]
               },
               {
                 "parentPluginId": "core",
@@ -3834,7 +3906,23 @@
                   }
                 ],
                 "path": "src/core/public/overlays/modal/modal_service.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-public.element",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "element",
+                    "description": [],
+                    "signature": [
+                      "T"
+                    ],
+                    "path": "src/core/public/types.ts",
+                    "deprecated": false
+                  }
+                ]
               },
               {
                 "parentPluginId": "core",
@@ -6444,6 +6532,26 @@
         ],
         "path": "src/core/public/types.ts",
         "deprecated": false,
+        "returnComment": [
+          "a {@link UnmountCallback} that unmount the element on call."
+        ],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-public.element",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "element",
+            "description": [
+              "the container element to render into"
+            ],
+            "signature": [
+              "T"
+            ],
+            "path": "src/core/public/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6484,6 +6592,29 @@
         ],
         "path": "src/core/public/plugins/plugin.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-public.core",
+            "type": "Object",
+            "tags": [],
+            "label": "core",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "public",
+                "docId": "kibCorePluginApi",
+                "section": "def-public.PluginInitializerContext",
+                "text": "PluginInitializerContext"
+              },
+              "<object>"
+            ],
+            "path": "src/core/public/plugins/plugin.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6640,6 +6771,8 @@
         ],
         "path": "src/core/public/index.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -7085,6 +7218,8 @@
         ],
         "path": "src/core/public/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -7944,24 +8079,7 @@
         "path": "src/core/server/elasticsearch/legacy/scoped_cluster_client.ts",
         "deprecated": true,
         "removeBy": "7.16",
-        "references": [
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/types.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/types.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/target/types/server/types.d.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/target/types/server/types.d.ts"
-          }
-        ],
+        "references": [],
         "children": [
           {
             "parentPluginId": "core",
@@ -8150,120 +8268,7 @@
             "path": "src/core/server/elasticsearch/legacy/scoped_cluster_client.ts",
             "deprecated": true,
             "removeBy": "7.16",
-            "references": [
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/data_streams/register_delete_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_clear_cache_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_close_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_flush_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_forcemerge_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_list_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_open_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_refresh_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_reload_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_delete_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_freeze_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/indices/register_unfreeze_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/templates/register_get_routes.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/templates/register_get_routes.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/templates/register_delete_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/templates/register_create_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/templates/register_update_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/templates/register_simulate_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/mapping/register_mapping_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/settings/register_load_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/settings/register_update_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/stats/register_stats_route.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/component_templates/get.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/component_templates/get.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/component_templates/create.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/component_templates/update.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/component_templates/delete.ts"
-              },
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/routes/api/component_templates/privileges.ts"
-              }
-            ],
+            "references": [],
             "children": [
               {
                 "parentPluginId": "core",
@@ -10377,11 +10382,10 @@
             ],
             "path": "src/core/server/deprecations/deprecations_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.deprecationContext",
+                "id": "def-server.DeprecationsServiceSetup.registerDeprecations.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "deprecationContext",
@@ -10396,9 +10400,11 @@
                   }
                 ],
                 "path": "src/core/server/deprecations/deprecations_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -10607,23 +10613,26 @@
             ],
             "path": "src/core/server/elasticsearch/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.type",
+                "id": "def-server.ElasticsearchServicePreboot.createClient.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [
                   "Unique identifier of the client"
                 ],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/elasticsearch/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.clientConfig",
+                "id": "def-server.ElasticsearchServicePreboot.createClient.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "clientConfig",
@@ -10642,9 +10651,11 @@
                   "> | undefined"
                 ],
                 "path": "src/core/server/elasticsearch/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -10772,23 +10783,26 @@
             ],
             "path": "src/core/server/elasticsearch/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.type",
+                "id": "def-server.ElasticsearchServiceStart.createClient.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [
                   "Unique identifier of the client"
                 ],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/elasticsearch/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.clientConfig",
+                "id": "def-server.ElasticsearchServiceStart.createClient.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "clientConfig",
@@ -10807,9 +10821,11 @@
                   "> | undefined"
                 ],
                 "path": "src/core/server/elasticsearch/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -10860,10 +10876,6 @@
             "path": "src/core/server/elasticsearch/types.ts",
             "deprecated": true,
             "references": [
-              {
-                "plugin": "indexManagement",
-                "path": "x-pack/plugins/index_management/server/plugin.ts"
-              },
               {
                 "plugin": "globalSearch",
                 "path": "x-pack/plugins/global_search/server/services/context.ts"
@@ -11802,11 +11814,10 @@
             ],
             "path": "src/core/server/http_resources/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.route",
+                "id": "def-server.HttpResources.register.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "route",
@@ -11822,25 +11833,25 @@
                   "<P, Q, B, \"get\">"
                 ],
                 "path": "src/core/server/http_resources/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.handler",
+                "id": "def-server.HttpResources.register.$2",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(context: Context, request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
+                    "section": "def-server.RequestHandler",
+                    "text": "RequestHandler"
                   },
-                  "<P, Q, B, \"get\">, response: { custom: <T extends string | Record<string, any> | Error | { message: string | Error; attributes?: Record<string, any> | undefined; } | Buffer | ",
+                  "<P, Q, B, Context, \"get\", { custom: <T extends string | Record<string, any> | Error | { message: string | Error; attributes?: Record<string, any> | undefined; } | Buffer | ",
                   "Stream",
                   " | undefined>(options: ",
                   {
@@ -12022,28 +12033,14 @@
                     "section": "def-server.HttpResourcesServiceToolkit",
                     "text": "HttpResourcesServiceToolkit"
                   },
-                  ") => ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.IKibanaResponse",
-                    "text": "IKibanaResponse"
-                  },
-                  "<any> | Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.IKibanaResponse",
-                    "text": "IKibanaResponse"
-                  },
-                  "<any>>"
+                  ">"
                 ],
                 "path": "src/core/server/http_resources/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -12120,11 +12117,10 @@
             ],
             "path": "src/core/server/http_resources/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.options",
+                "id": "def-server.HttpResourcesServiceToolkit.renderCoreApp.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -12140,9 +12136,11 @@
                   " | undefined"
                 ],
                 "path": "src/core/server/http_resources/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12174,11 +12172,10 @@
             ],
             "path": "src/core/server/http_resources/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.options",
+                "id": "def-server.HttpResourcesServiceToolkit.renderAnonymousCoreApp.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -12194,9 +12191,11 @@
                   " | undefined"
                 ],
                 "path": "src/core/server/http_resources/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12228,11 +12227,10 @@
             ],
             "path": "src/core/server/http_resources/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.options",
+                "id": "def-server.HttpResourcesServiceToolkit.renderHtml.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -12247,9 +12245,11 @@
                   }
                 ],
                 "path": "src/core/server/http_resources/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12281,11 +12281,10 @@
             ],
             "path": "src/core/server/http_resources/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.options",
+                "id": "def-server.HttpResourcesServiceToolkit.renderJs.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -12300,9 +12299,11 @@
                   }
                 ],
                 "path": "src/core/server/http_resources/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -12420,11 +12421,10 @@
             ],
             "path": "src/core/server/elasticsearch/client/cluster_client.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.request",
+                "id": "def-server.IClusterClient.asScoped.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "request",
@@ -12433,31 +12433,17 @@
                   {
                     "pluginId": "core",
                     "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
-                  },
-                  "<unknown, unknown, unknown, any> | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.LegacyRequest",
-                    "text": "LegacyRequest"
-                  },
-                  " | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
                     "docId": "kibCorePluginApi",
-                    "section": "def-server.FakeRequest",
-                    "text": "FakeRequest"
+                    "section": "def-server.ScopeableRequest",
+                    "text": "ScopeableRequest"
                   }
                 ],
                 "path": "src/core/server/elasticsearch/client/cluster_client.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -13310,8 +13296,8 @@
             ],
             "path": "src/core/server/elasticsearch/client/cluster_client.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -13612,8 +13598,8 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13629,19 +13615,23 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.key",
+                "id": "def-server.IUiSettingsClient.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13657,8 +13647,8 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13676,8 +13666,8 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13693,22 +13683,23 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.changes",
+                "id": "def-server.IUiSettingsClient.setMany.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "changes",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13724,21 +13715,24 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.key",
+                "id": "def-server.IUiSettingsClient.set.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.value",
+                "id": "def-server.IUiSettingsClient.set.$2",
                 "type": "Any",
                 "tags": [],
                 "label": "value",
@@ -13747,9 +13741,11 @@
                   "any"
                 ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13765,19 +13761,23 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.key",
+                "id": "def-server.IUiSettingsClient.remove.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13793,11 +13793,10 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.keys",
+                "id": "def-server.IUiSettingsClient.removeMany.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "keys",
@@ -13806,9 +13805,11 @@
                   "string[]"
                 ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13824,19 +13825,23 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.key",
+                "id": "def-server.IUiSettingsClient.isOverridden.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13852,19 +13857,23 @@
             ],
             "path": "src/core/server/ui_settings/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.key",
+                "id": "def-server.IUiSettingsClient.isSensitive.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/ui_settings/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -13992,24 +14001,7 @@
         "path": "src/core/server/elasticsearch/legacy/api_types.ts",
         "deprecated": true,
         "removeBy": "7.16",
-        "references": [
-          {
-            "plugin": "crossClusterReplication",
-            "path": "x-pack/plugins/cross_cluster_replication/server/plugin.ts"
-          },
-          {
-            "plugin": "crossClusterReplication",
-            "path": "x-pack/plugins/cross_cluster_replication/server/plugin.ts"
-          },
-          {
-            "plugin": "indexLifecycleManagement",
-            "path": "x-pack/plugins/index_lifecycle_management/server/plugin.ts"
-          },
-          {
-            "plugin": "indexLifecycleManagement",
-            "path": "x-pack/plugins/index_lifecycle_management/server/plugin.ts"
-          }
-        ],
+        "references": [],
         "children": [
           {
             "parentPluginId": "core",
@@ -16264,8 +16256,8 @@
             ],
             "path": "src/core/server/metrics/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -17497,8 +17489,8 @@
             ],
             "path": "src/core/server/preboot/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -17514,23 +17506,26 @@
             ],
             "path": "src/core/server/preboot/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.reason",
+                "id": "def-server.PrebootServicePreboot.holdSetupUntilResolved.$1",
                 "type": "string",
                 "tags": [],
                 "label": "reason",
                 "description": [
                   "A string that explains the reason why this promise should hold `setup`. It's supposed to be a human\nreadable string that will be recorded in the logs or standard output."
                 ],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/preboot/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.promise",
+                "id": "def-server.PrebootServicePreboot.holdSetupUntilResolved.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "promise",
@@ -17541,9 +17536,11 @@
                   "Promise<{ shouldReloadConfig: boolean; } | undefined>"
                 ],
                 "path": "src/core/server/preboot/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -17586,11 +17583,10 @@
             ],
             "path": "src/core/server/deprecations/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.context",
+                "id": "def-server.RegisterDeprecationsConfig.getDeprecations.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "context",
@@ -17605,9 +17601,11 @@
                   }
                 ],
                 "path": "src/core/server/deprecations/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -18527,8 +18525,8 @@
             ],
             "path": "src/core/server/status/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -18965,6 +18963,22 @@
         ],
         "path": "node_modules/@kbn/config/target/deprecation/types.d.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.details",
+            "type": "Object",
+            "tags": [],
+            "label": "details",
+            "description": [],
+            "signature": [
+              "DeprecatedConfigDetails"
+            ],
+            "path": "node_modules/@kbn/config/target/deprecation/types.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19021,6 +19035,8 @@
         ],
         "path": "src/core/server/capabilities/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -19051,6 +19067,52 @@
         ],
         "path": "src/core/server/capabilities/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "src/core/server/capabilities/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.uiCapabilities",
+            "type": "Object",
+            "tags": [],
+            "label": "uiCapabilities",
+            "description": [],
+            "signature": [
+              "Capabilities"
+            ],
+            "path": "src/core/server/capabilities/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.useDefaultCapabilities",
+            "type": "boolean",
+            "tags": [],
+            "label": "useDefaultCapabilities",
+            "description": [],
+            "path": "src/core/server/capabilities/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19071,6 +19133,22 @@
         ],
         "path": "node_modules/@kbn/config/target/deprecation/types.d.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.factory",
+            "type": "Object",
+            "tags": [],
+            "label": "factory",
+            "description": [],
+            "signature": [
+              "ConfigDeprecationFactory"
+            ],
+            "path": "node_modules/@kbn/config/target/deprecation/types.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19332,6 +19410,35 @@
         ],
         "path": "src/core/server/context/container/context.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/core/server/context/container/context.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.args",
+            "type": "Array",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              "any[]"
+            ],
+            "path": "src/core/server/context/container/context.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19572,6 +19679,55 @@
         ],
         "path": "src/core/server/http_resources/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "Context"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<P, Q, B, Method>"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.response",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "ResponseFactory"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19792,6 +19948,223 @@
         ],
         "path": "src/core/server/context/container/context.ts",
         "deprecated": false,
+        "returnComment": [
+          "The context value associated with this key. May also return a Promise which will be resolved before\nattaching to the context object."
+        ],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [
+              "- A partial context object containing only the keys for values provided by plugin dependencies"
+            ],
+            "signature": [
+              "{ [P in Exclude<keyof Context, ContextName>]: Context[P]; }"
+            ],
+            "path": "src/core/server/context/container/context.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.rest",
+            "type": "Object",
+            "tags": [],
+            "label": "rest",
+            "description": [
+              "- Additional parameters provided by the service owner of this context"
+            ],
+            "signature": [
+              "[request: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>, response: { custom: <T extends string | Record<string, any> | Error | { message: string | Error; attributes?: Record<string, any> | undefined; } | Buffer | ",
+              "Stream",
+              " | undefined>(options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<T>) => ",
+              "KibanaResponse",
+              "<T>; badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; ok: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; accepted: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; noContent: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<undefined>; }]"
+            ],
+            "path": "src/core/server/context/container/context.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19911,16 +20284,7 @@
         "path": "src/core/server/elasticsearch/legacy/cluster_client.ts",
         "deprecated": true,
         "removeBy": "7.16",
-        "references": [
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/plugin.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/plugin.ts"
-          }
-        ],
+        "references": [],
         "initialIsOpen": false
       },
       {
@@ -19958,18 +20322,6 @@
         "removeBy": "7.16",
         "references": [
           {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/types.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/types.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/server/types.ts"
-          },
-          {
             "plugin": "globalSearch",
             "path": "x-pack/plugins/global_search/server/types.ts"
           },
@@ -19984,18 +20336,6 @@
           {
             "plugin": "globalSearch",
             "path": "x-pack/plugins/global_search/target/types/server/types.d.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/target/types/server/types.d.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/target/types/server/types.d.ts"
-          },
-          {
-            "plugin": "indexManagement",
-            "path": "x-pack/plugins/index_management/target/types/server/types.d.ts"
           }
         ],
         "initialIsOpen": false
@@ -20271,6 +20611,29 @@
         ],
         "path": "src/core/server/plugins/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.core",
+            "type": "Object",
+            "tags": [],
+            "label": "core",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCorePluginApi",
+                "section": "def-server.PluginInitializerContext",
+                "text": "PluginInitializerContext"
+              },
+              "<unknown>"
+            ],
+            "path": "src/core/server/plugins/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -20457,6 +20820,8 @@
         ],
         "path": "src/core/server/index.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {

--- a/api_docs/core.mdx
+++ b/api_docs/core.mdx
@@ -18,7 +18,7 @@ import coreObj from './core.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 2363 | 148 | 1081 | 31 |
+| 2450 | 149 | 1165 | 31 |
 
 ## Client
 

--- a/api_docs/core_application.json
+++ b/api_docs/core_application.json
@@ -871,7 +871,9 @@
               "(() => void) | undefined"
             ],
             "path": "src/core/public/application/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1495,31 +1497,29 @@
                 "path": "x-pack/plugins/maps/target/types/public/routes/map_page/map_app/map_app.d.ts"
               }
             ],
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.handler",
+                "id": "def-public.AppMountParameters.onAppLeave.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(factory: ",
-                  "AppLeaveActionFactory",
-                  ", nextAppId?: string | undefined) => ",
                   {
                     "pluginId": "core",
                     "scope": "public",
                     "docId": "kibCoreApplicationPluginApi",
-                    "section": "def-public.AppLeaveAction",
-                    "text": "AppLeaveAction"
+                    "section": "def-public.AppLeaveHandler",
+                    "text": "AppLeaveHandler"
                   }
                 ],
                 "path": "src/core/public/application/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1543,11 +1543,10 @@
             ],
             "path": "src/core/public/application/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.menuMount",
+                "id": "def-public.AppMountParameters.setHeaderActionMenu.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "menuMount",
@@ -1563,9 +1562,11 @@
                   "<HTMLElement> | undefined"
                 ],
                 "path": "src/core/public/application/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1951,6 +1952,35 @@
             "path": "x-pack/plugins/security_solution/public/app/app.tsx"
           }
         ],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-public.factory",
+            "type": "Object",
+            "tags": [],
+            "label": "factory",
+            "description": [],
+            "signature": [
+              "AppLeaveActionFactory"
+            ],
+            "path": "src/core/public/application/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-public.nextAppId",
+            "type": "string",
+            "tags": [],
+            "label": "nextAppId",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "src/core/public/application/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1991,6 +2021,31 @@
         ],
         "path": "src/core/public/application/types.ts",
         "deprecated": false,
+        "returnComment": [
+          "An unmounting function that will be called to unmount the application. See {@link AppUnmount}."
+        ],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-public.params",
+            "type": "Object",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "public",
+                "docId": "kibCoreApplicationPluginApi",
+                "section": "def-public.AppMountParameters",
+                "text": "AppMountParameters"
+              },
+              "<HistoryLocationState>"
+            ],
+            "path": "src/core/public/application/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -2007,6 +2062,8 @@
         ],
         "path": "src/core/public/application/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -2079,6 +2136,29 @@
         ],
         "path": "src/core/public/application/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-public.app",
+            "type": "Object",
+            "tags": [],
+            "label": "app",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "public",
+                "docId": "kibCoreApplicationPluginApi",
+                "section": "def-public.App",
+                "text": "App"
+              },
+              "<unknown>"
+            ],
+            "path": "src/core/public/application/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/core_application.mdx
+++ b/api_docs/core_application.mdx
@@ -18,7 +18,7 @@ import coreApplicationObj from './core_application.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 2363 | 148 | 1081 | 31 |
+| 2450 | 149 | 1165 | 31 |
 
 ## Client
 

--- a/api_docs/core_chrome.json
+++ b/api_docs/core_chrome.json
@@ -212,7 +212,24 @@
               "((element: HTMLDivElement) => () => void) | undefined"
             ],
             "path": "src/core/public/chrome/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "core",
+                "id": "def-public.ChromeHelpExtension.content.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "element",
+                "description": [],
+                "signature": [
+                  "HTMLDivElement"
+                ],
+                "path": "src/core/public/chrome/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/core_chrome.mdx
+++ b/api_docs/core_chrome.mdx
@@ -18,7 +18,7 @@ import coreChromeObj from './core_chrome.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 2363 | 148 | 1081 | 31 |
+| 2450 | 149 | 1165 | 31 |
 
 ## Client
 

--- a/api_docs/core_http.json
+++ b/api_docs/core_http.json
@@ -1592,8 +1592,8 @@
             ],
             "path": "src/core/public/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1609,19 +1609,23 @@
             ],
             "path": "src/core/public/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.url",
+                "id": "def-public.IBasePath.prepend.$1",
                 "type": "string",
                 "tags": [],
                 "label": "url",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -1637,19 +1641,23 @@
             ],
             "path": "src/core/public/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-public.url",
+                "id": "def-public.IBasePath.remove.$1",
                 "type": "string",
                 "tags": [],
                 "label": "url",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/public/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2826,11 +2834,10 @@
             ],
             "path": "src/core/server/http/lifecycle/auth.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.data",
+                "id": "def-server.AuthToolkit.authenticated.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "data",
@@ -2846,9 +2853,11 @@
                   " | undefined"
                 ],
                 "path": "src/core/server/http/lifecycle/auth.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2871,8 +2880,8 @@
             ],
             "path": "src/core/server/http/lifecycle/auth.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -2895,11 +2904,10 @@
             ],
             "path": "src/core/server/http/lifecycle/auth.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.headers",
+                "id": "def-server.AuthToolkit.redirected.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "headers",
@@ -2908,9 +2916,11 @@
                   "({ location: string; } & Record<\"accept\" | \"accept-language\" | \"accept-patch\" | \"accept-ranges\" | \"access-control-allow-credentials\" | \"access-control-allow-headers\" | \"access-control-allow-methods\" | \"access-control-allow-origin\" | \"access-control-expose-headers\" | \"access-control-max-age\" | \"access-control-request-headers\" | \"access-control-request-method\" | \"age\" | \"allow\" | \"alt-svc\" | \"authorization\" | \"cache-control\" | \"connection\" | \"content-disposition\" | \"content-encoding\" | \"content-language\" | \"content-length\" | \"content-location\" | \"content-range\" | \"content-type\" | \"cookie\" | \"date\" | \"expect\" | \"expires\" | \"forwarded\" | \"from\" | \"host\" | \"if-match\" | \"if-modified-since\" | \"if-none-match\" | \"if-unmodified-since\" | \"last-modified\" | \"location\" | \"origin\" | \"pragma\" | \"proxy-authenticate\" | \"proxy-authorization\" | \"public-key-pins\" | \"range\" | \"referer\" | \"retry-after\" | \"sec-websocket-accept\" | \"sec-websocket-extensions\" | \"sec-websocket-key\" | \"sec-websocket-protocol\" | \"sec-websocket-version\" | \"set-cookie\" | \"strict-transport-security\" | \"tk\" | \"trailer\" | \"transfer-encoding\" | \"upgrade\" | \"user-agent\" | \"vary\" | \"via\" | \"warning\" | \"www-authenticate\", string | string[]>) | ({ location: string; } & Record<string, string | string[]>)"
                 ],
                 "path": "src/core/server/http/lifecycle/auth.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -3493,11 +3503,10 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.cookieOptions",
+                "id": "def-server.HttpServiceSetup.createCookieSessionStorageFactory.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "cookieOptions",
@@ -3513,9 +3522,11 @@
                   "<T>"
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -3539,170 +3550,29 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.handler",
+                "id": "def-server.HttpServiceSetup.registerOnPreRouting.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
-                  },
-                  "<unknown, unknown, unknown, any>, response: { badRequest: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; unauthorized: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; forbidden: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; notFound: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; conflict: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; customError: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.CustomHttpResponseOptions",
-                    "text": "CustomHttpResponseOptions"
-                  },
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">) => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; redirected: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.RedirectResponseOptions",
-                    "text": "RedirectResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; }, toolkit: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.OnPreRoutingToolkit",
-                    "text": "OnPreRoutingToolkit"
-                  },
-                  ") => Next | RewriteUrl | ",
-                  "KibanaResponse",
-                  "<any> | Promise<Next | RewriteUrl | ",
-                  "KibanaResponse",
-                  "<any>>"
+                    "section": "def-server.OnPreRoutingHandler",
+                    "text": "OnPreRoutingHandler"
+                  }
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -3726,170 +3596,29 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.handler",
+                "id": "def-server.HttpServiceSetup.registerOnPreAuth.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
-                  },
-                  "<unknown, unknown, unknown, any>, response: { badRequest: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; unauthorized: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; forbidden: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; notFound: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; conflict: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; customError: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.CustomHttpResponseOptions",
-                    "text": "CustomHttpResponseOptions"
-                  },
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">) => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; redirected: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.RedirectResponseOptions",
-                    "text": "RedirectResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; }, toolkit: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.OnPreAuthToolkit",
-                    "text": "OnPreAuthToolkit"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<any> | Next | Promise<",
-                  "KibanaResponse",
-                  "<any> | Next>"
+                    "section": "def-server.OnPreAuthHandler",
+                    "text": "OnPreAuthHandler"
+                  }
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -3913,230 +3642,29 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.handler",
+                "id": "def-server.HttpServiceSetup.registerAuth.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
-                  },
-                  "<unknown, unknown, unknown, any>, response: { badRequest: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; unauthorized: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; forbidden: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; notFound: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; conflict: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; customError: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.CustomHttpResponseOptions",
-                    "text": "CustomHttpResponseOptions"
-                  },
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">) => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; redirected: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.RedirectResponseOptions",
-                    "text": "RedirectResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; }, toolkit: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.AuthToolkit",
-                    "text": "AuthToolkit"
-                  },
-                  ") => ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.IKibanaResponse",
-                    "text": "IKibanaResponse"
-                  },
-                  "<any> | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.Authenticated",
-                    "text": "Authenticated"
-                  },
-                  " | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.AuthNotHandled",
-                    "text": "AuthNotHandled"
-                  },
-                  " | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.AuthRedirected",
-                    "text": "AuthRedirected"
-                  },
-                  " | Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.IKibanaResponse",
-                    "text": "IKibanaResponse"
-                  },
-                  "<any> | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.Authenticated",
-                    "text": "Authenticated"
-                  },
-                  " | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.AuthNotHandled",
-                    "text": "AuthNotHandled"
-                  },
-                  " | ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.AuthRedirected",
-                    "text": "AuthRedirected"
-                  },
-                  ">"
+                    "section": "def-server.AuthenticationHandler",
+                    "text": "AuthenticationHandler"
+                  }
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -4160,170 +3688,29 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.handler",
+                "id": "def-server.HttpServiceSetup.registerOnPostAuth.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
-                  },
-                  "<unknown, unknown, unknown, any>, response: { badRequest: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; unauthorized: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; forbidden: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; notFound: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; conflict: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; customError: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.CustomHttpResponseOptions",
-                    "text": "CustomHttpResponseOptions"
-                  },
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">) => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; redirected: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.RedirectResponseOptions",
-                    "text": "RedirectResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; }, toolkit: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.OnPostAuthToolkit",
-                    "text": "OnPostAuthToolkit"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<any> | Next | Promise<",
-                  "KibanaResponse",
-                  "<any> | Next>"
+                    "section": "def-server.OnPostAuthHandler",
+                    "text": "OnPostAuthHandler"
+                  }
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -4347,46 +3734,29 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.handler",
+                "id": "def-server.HttpServiceSetup.registerOnPreResponse.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "handler",
                 "description": [],
                 "signature": [
-                  "(request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
-                  },
-                  "<unknown, unknown, unknown, any>, preResponse: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.OnPreResponseInfo",
-                    "text": "OnPreResponseInfo"
-                  },
-                  ", toolkit: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.OnPreResponseToolkit",
-                    "text": "OnPreResponseToolkit"
-                  },
-                  ") => Render | Next | Promise<OnPreResponseResult>"
+                    "section": "def-server.OnPreResponseHandler",
+                    "text": "OnPreResponseHandler"
+                  }
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -4518,8 +3888,8 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -4558,11 +3928,10 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.contextName",
+                "id": "def-server.HttpServiceSetup.registerRouteHandlerContext.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "contextName",
@@ -4571,204 +3940,32 @@
                   "ContextName"
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.provider",
+                "id": "def-server.HttpServiceSetup.registerRouteHandlerContext.$2",
                 "type": "Function",
                 "tags": [],
                 "label": "provider",
                 "description": [],
                 "signature": [
-                  "(context: Pick<Context, Exclude<keyof Context, ContextName>>, request: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.KibanaRequest",
-                    "text": "KibanaRequest"
+                    "docId": "kibCorePluginApi",
+                    "section": "def-server.IContextProvider",
+                    "text": "IContextProvider"
                   },
-                  "<unknown, unknown, unknown, any>, response: { custom: <T extends string | Record<string, any> | Error | { message: string | Error; attributes?: Record<string, any> | undefined; } | Buffer | ",
-                  "Stream",
-                  " | undefined>(options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.CustomHttpResponseOptions",
-                    "text": "CustomHttpResponseOptions"
-                  },
-                  "<T>) => ",
-                  "KibanaResponse",
-                  "<T>; badRequest: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; unauthorized: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; forbidden: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; notFound: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; conflict: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ErrorHttpResponseOptions",
-                    "text": "ErrorHttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; customError: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.CustomHttpResponseOptions",
-                    "text": "CustomHttpResponseOptions"
-                  },
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">) => ",
-                  "KibanaResponse",
-                  "<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.ResponseError",
-                    "text": "ResponseError"
-                  },
-                  ">; redirected: (options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.RedirectResponseOptions",
-                    "text": "RedirectResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; ok: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.HttpResponseOptions",
-                    "text": "HttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; accepted: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.HttpResponseOptions",
-                    "text": "HttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<string | Record<string, any> | Buffer | ",
-                  "Stream",
-                  ">; noContent: (options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreHttpPluginApi",
-                    "section": "def-server.HttpResponseOptions",
-                    "text": "HttpResponseOptions"
-                  },
-                  ") => ",
-                  "KibanaResponse",
-                  "<undefined>; }) => Context[ContextName] | Promise<Context[ContextName]>"
+                  "<Context, ContextName>"
                 ],
                 "path": "src/core/server/http/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -4791,8 +3988,8 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -4896,8 +4093,8 @@
             ],
             "path": "src/core/server/http/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -5678,7 +4875,56 @@
                   "<any>>"
                 ],
                 "path": "src/core/server/http/router/router.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.context",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "context",
+                    "description": [],
+                    "signature": [
+                      "Context"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.request",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "request",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "core",
+                        "scope": "server",
+                        "docId": "kibCoreHttpPluginApi",
+                        "section": "def-server.KibanaRequest",
+                        "text": "KibanaRequest"
+                      },
+                      "<P, Q, B, Method>"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.response",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "response",
+                    "description": [],
+                    "signature": [
+                      "ResponseFactory"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           },
@@ -6117,7 +5363,56 @@
                   "<any>>"
                 ],
                 "path": "src/core/server/http/router/router.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.context",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "context",
+                    "description": [],
+                    "signature": [
+                      "Context"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.request",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "request",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "core",
+                        "scope": "server",
+                        "docId": "kibCoreHttpPluginApi",
+                        "section": "def-server.KibanaRequest",
+                        "text": "KibanaRequest"
+                      },
+                      "<P, Q, B, Method>"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.response",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "response",
+                    "description": [],
+                    "signature": [
+                      "ResponseFactory"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           },
@@ -6556,7 +5851,56 @@
                   "<any>>"
                 ],
                 "path": "src/core/server/http/router/router.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.context",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "context",
+                    "description": [],
+                    "signature": [
+                      "Context"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.request",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "request",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "core",
+                        "scope": "server",
+                        "docId": "kibCoreHttpPluginApi",
+                        "section": "def-server.KibanaRequest",
+                        "text": "KibanaRequest"
+                      },
+                      "<P, Q, B, Method>"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.response",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "response",
+                    "description": [],
+                    "signature": [
+                      "ResponseFactory"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           },
@@ -6995,7 +6339,56 @@
                   "<any>>"
                 ],
                 "path": "src/core/server/http/router/router.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.context",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "context",
+                    "description": [],
+                    "signature": [
+                      "Context"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.request",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "request",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "core",
+                        "scope": "server",
+                        "docId": "kibCoreHttpPluginApi",
+                        "section": "def-server.KibanaRequest",
+                        "text": "KibanaRequest"
+                      },
+                      "<P, Q, B, Method>"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.response",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "response",
+                    "description": [],
+                    "signature": [
+                      "ResponseFactory"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           },
@@ -7434,7 +6827,56 @@
                   "<any>>"
                 ],
                 "path": "src/core/server/http/router/router.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.context",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "context",
+                    "description": [],
+                    "signature": [
+                      "Context"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.request",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "request",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "core",
+                        "scope": "server",
+                        "docId": "kibCoreHttpPluginApi",
+                        "section": "def-server.KibanaRequest",
+                        "text": "KibanaRequest"
+                      },
+                      "<P, Q, B, Method>"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.response",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "response",
+                    "description": [],
+                    "signature": [
+                      "ResponseFactory"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           },
@@ -7877,7 +7319,56 @@
                   "<any>>"
                 ],
                 "path": "src/core/server/http/router/router.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.context",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "context",
+                    "description": [],
+                    "signature": [
+                      "Context"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.request",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "request",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "core",
+                        "scope": "server",
+                        "docId": "kibCoreHttpPluginApi",
+                        "section": "def-server.KibanaRequest",
+                        "text": "KibanaRequest"
+                      },
+                      "<P, Q, B, Method>"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "core",
+                    "id": "def-server.response",
+                    "type": "Uncategorized",
+                    "tags": [],
+                    "label": "response",
+                    "description": [],
+                    "signature": [
+                      "ResponseFactory"
+                    ],
+                    "path": "src/core/server/http/router/router.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           }
@@ -8075,8 +7566,8 @@
             ],
             "path": "src/core/server/http/lifecycle/on_post_auth.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8105,8 +7596,8 @@
             ],
             "path": "src/core/server/http/lifecycle/on_pre_auth.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8242,11 +7733,10 @@
             ],
             "path": "src/core/server/http/lifecycle/on_pre_response.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.responseRender",
+                "id": "def-server.OnPreResponseToolkit.render.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "responseRender",
@@ -8261,9 +7751,11 @@
                   }
                 ],
                 "path": "src/core/server/http/lifecycle/on_pre_response.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -8287,11 +7779,10 @@
             ],
             "path": "src/core/server/http/lifecycle/on_pre_response.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.responseExtensions",
+                "id": "def-server.OnPreResponseToolkit.next.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "responseExtensions",
@@ -8307,9 +7798,11 @@
                   " | undefined"
                 ],
                 "path": "src/core/server/http/lifecycle/on_pre_response.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8338,8 +7831,8 @@
             ],
             "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -8355,19 +7848,23 @@
             ],
             "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.url",
+                "id": "def-server.OnPreRoutingToolkit.rewriteUrl.$1",
                 "type": "string",
                 "tags": [],
                 "label": "url",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8685,11 +8182,10 @@
             ],
             "path": "src/core/server/http/router/validator/validator.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.value",
+                "id": "def-server.RouteValidationResultFactory.ok.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "value",
@@ -8698,9 +8194,11 @@
                   "T"
                 ],
                 "path": "src/core/server/http/router/validator/validator.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -8722,11 +8220,10 @@
             ],
             "path": "src/core/server/http/router/validator/validator.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.error",
+                "id": "def-server.RouteValidationResultFactory.badRequest.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "error",
@@ -8735,11 +8232,12 @@
                   "string | Error"
                 ],
                 "path": "src/core/server/http/router/validator/validator.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.path",
+                "id": "def-server.RouteValidationResultFactory.badRequest.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "path",
@@ -8748,9 +8246,11 @@
                   "string[] | undefined"
                 ],
                 "path": "src/core/server/http/router/validator/validator.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -9090,11 +8590,10 @@
             ],
             "path": "src/core/server/http/cookie_session_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.sessionValue",
+                "id": "def-server.SessionStorageCookieOptions.validate.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "sessionValue",
@@ -9103,9 +8602,11 @@
                   "T | T[]"
                 ],
                 "path": "src/core/server/http/cookie_session_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -9187,11 +8688,10 @@
             ],
             "path": "src/core/server/http/session_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.request",
+                "id": "def-server.SessionStorageFactory.asScoped.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "request",
@@ -9207,9 +8707,11 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "src/core/server/http/session_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -9464,6 +8966,189 @@
         ],
         "path": "src/core/server/http/lifecycle/auth.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "src/core/server/http/lifecycle/auth.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.response",
+            "type": "Object",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "{ badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; }"
+            ],
+            "path": "src/core/server/http/lifecycle/auth.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.toolkit",
+            "type": "Object",
+            "tags": [],
+            "label": "toolkit",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.AuthToolkit",
+                "text": "AuthToolkit"
+              }
+            ],
+            "path": "src/core/server/http/lifecycle/auth.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -9566,6 +9251,38 @@
         ],
         "path": "src/core/server/http/auth_headers_storage.ts",
         "deprecated": false,
+        "returnComment": [
+          "authentication headers {@link AuthHeaders} for - an incoming request."
+        ],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any> | ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.LegacyRequest",
+                "text": "LegacyRequest"
+              }
+            ],
+            "path": "src/core/server/http/auth_headers_storage.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -9606,6 +9323,36 @@
         ],
         "path": "src/core/server/http/auth_state_storage.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any> | ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.LegacyRequest",
+                "text": "LegacyRequest"
+              }
+            ],
+            "path": "src/core/server/http/auth_state_storage.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -9720,6 +9467,36 @@
         ],
         "path": "src/core/server/http/auth_state_storage.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any> | ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.LegacyRequest",
+                "text": "LegacyRequest"
+              }
+            ],
+            "path": "src/core/server/http/auth_state_storage.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10274,6 +10051,189 @@
         ],
         "path": "src/core/server/http/lifecycle/on_post_auth.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "src/core/server/http/lifecycle/on_post_auth.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.response",
+            "type": "Object",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "{ badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; }"
+            ],
+            "path": "src/core/server/http/lifecycle/on_post_auth.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.toolkit",
+            "type": "Object",
+            "tags": [],
+            "label": "toolkit",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.OnPostAuthToolkit",
+                "text": "OnPostAuthToolkit"
+              }
+            ],
+            "path": "src/core/server/http/lifecycle/on_post_auth.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10438,6 +10398,189 @@
         ],
         "path": "src/core/server/http/lifecycle/on_pre_auth.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_auth.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.response",
+            "type": "Object",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "{ badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; }"
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_auth.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.toolkit",
+            "type": "Object",
+            "tags": [],
+            "label": "toolkit",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.OnPreAuthToolkit",
+                "text": "OnPreAuthToolkit"
+              }
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_auth.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10478,6 +10621,67 @@
         ],
         "path": "src/core/server/http/lifecycle/on_pre_response.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_response.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.preResponse",
+            "type": "Object",
+            "tags": [],
+            "label": "preResponse",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.OnPreResponseInfo",
+                "text": "OnPreResponseInfo"
+              }
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_response.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.toolkit",
+            "type": "Object",
+            "tags": [],
+            "label": "toolkit",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.OnPreResponseToolkit",
+                "text": "OnPreResponseToolkit"
+              }
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_response.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10642,6 +10846,189 @@
         ],
         "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.response",
+            "type": "Object",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "{ badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; }"
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.toolkit",
+            "type": "Object",
+            "tags": [],
+            "label": "toolkit",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.OnPreRoutingToolkit",
+                "text": "OnPreRoutingToolkit"
+              }
+            ],
+            "path": "src/core/server/http/lifecycle/on_pre_routing.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10705,6 +11092,55 @@
         ],
         "path": "src/core/server/http/router/router.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "Context"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<P, Q, B, Method>"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.response",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "ResponseFactory"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10925,6 +11361,217 @@
         ],
         "path": "src/core/server/http/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "{ [P in Exclude<keyof Context, ContextName>]: Context[P]; }"
+            ],
+            "path": "src/core/server/context/container/context.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.rest",
+            "type": "Object",
+            "tags": [],
+            "label": "rest",
+            "description": [],
+            "signature": [
+              "[request: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>, response: { custom: <T extends string | Record<string, any> | Error | { message: string | Error; attributes?: Record<string, any> | undefined; } | Buffer | ",
+              "Stream",
+              " | undefined>(options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<T>) => ",
+              "KibanaResponse",
+              "<T>; badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; ok: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; accepted: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; noContent: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<undefined>; }]"
+            ],
+            "path": "src/core/server/context/container/context.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -11329,6 +11976,95 @@
         ],
         "path": "src/core/server/http/router/router.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.handler",
+            "type": "Function",
+            "tags": [],
+            "label": "handler",
+            "description": [],
+            "signature": [
+              "(context: Context, request: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<P, Q, B, Method>, response: ResponseFactory) => ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.IKibanaResponse",
+                "text": "IKibanaResponse"
+              },
+              "<any> | Promise<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.IKibanaResponse",
+                "text": "IKibanaResponse"
+              },
+              "<any>>"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "core",
+                "id": "def-server.context",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "context",
+                "description": [],
+                "signature": [
+                  "Context"
+                ],
+                "path": "src/core/server/http/router/router.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "core",
+                "id": "def-server.request",
+                "type": "Object",
+                "tags": [],
+                "label": "request",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "core",
+                    "scope": "server",
+                    "docId": "kibCoreHttpPluginApi",
+                    "section": "def-server.KibanaRequest",
+                    "text": "KibanaRequest"
+                  },
+                  "<P, Q, B, Method>"
+                ],
+                "path": "src/core/server/http/router/router.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "core",
+                "id": "def-server.response",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "response",
+                "description": [],
+                "signature": [
+                  "ResponseFactory"
+                ],
+                "path": "src/core/server/http/router/router.ts",
+                "deprecated": false
+              }
+            ]
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -11615,6 +12351,289 @@
         ],
         "path": "src/core/server/http/router/router.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.route",
+            "type": "Object",
+            "tags": [],
+            "label": "route",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RouteConfig",
+                "text": "RouteConfig"
+              },
+              "<P, Q, B, Method>"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.handler",
+            "type": "Function",
+            "tags": [],
+            "label": "handler",
+            "description": [],
+            "signature": [
+              "(context: Context, request: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<P, Q, B, Method>, response: { custom: <T extends string | Record<string, any> | Error | { message: string | Error; attributes?: Record<string, any> | undefined; } | Buffer | ",
+              "Stream",
+              " | undefined>(options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<T>) => ",
+              "KibanaResponse",
+              "<T>; badRequest: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; unauthorized: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; forbidden: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; notFound: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; conflict: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ErrorHttpResponseOptions",
+                "text": "ErrorHttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; customError: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.CustomHttpResponseOptions",
+                "text": "CustomHttpResponseOptions"
+              },
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">) => ",
+              "KibanaResponse",
+              "<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.ResponseError",
+                "text": "ResponseError"
+              },
+              ">; redirected: (options: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RedirectResponseOptions",
+                "text": "RedirectResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; ok: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; accepted: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<string | Record<string, any> | Buffer | ",
+              "Stream",
+              ">; noContent: (options?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.HttpResponseOptions",
+                "text": "HttpResponseOptions"
+              },
+              ") => ",
+              "KibanaResponse",
+              "<undefined>; }) => ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.IKibanaResponse",
+                "text": "IKibanaResponse"
+              },
+              "<any> | Promise<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.IKibanaResponse",
+                "text": "IKibanaResponse"
+              },
+              "<any>>"
+            ],
+            "path": "src/core/server/http/router/router.ts",
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "core",
+                "id": "def-server.context",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "context",
+                "description": [],
+                "signature": [
+                  "Context"
+                ],
+                "path": "src/core/server/http/router/router.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "core",
+                "id": "def-server.request",
+                "type": "Object",
+                "tags": [],
+                "label": "request",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "core",
+                    "scope": "server",
+                    "docId": "kibCoreHttpPluginApi",
+                    "section": "def-server.KibanaRequest",
+                    "text": "KibanaRequest"
+                  },
+                  "<P, Q, B, Method>"
+                ],
+                "path": "src/core/server/http/router/router.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "core",
+                "id": "def-server.response",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "response",
+                "description": [],
+                "signature": [
+                  "ResponseFactory"
+                ],
+                "path": "src/core/server/http/router/router.ts",
+                "deprecated": false
+              }
+            ]
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -11647,6 +12666,41 @@
         ],
         "path": "src/core/server/http/router/validator/validator.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.data",
+            "type": "Any",
+            "tags": [],
+            "label": "data",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "src/core/server/http/router/validator/validator.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.validationResult",
+            "type": "Object",
+            "tags": [],
+            "label": "validationResult",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.RouteValidationResultFactory",
+                "text": "RouteValidationResultFactory"
+              }
+            ],
+            "path": "src/core/server/http/router/validator/validator.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/core_http.mdx
+++ b/api_docs/core_http.mdx
@@ -18,7 +18,7 @@ import coreHttpObj from './core_http.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 2363 | 148 | 1081 | 31 |
+| 2450 | 149 | 1165 | 31 |
 
 ## Client
 

--- a/api_docs/core_saved_objects.json
+++ b/api_docs/core_saved_objects.json
@@ -9107,8 +9107,8 @@
             ],
             "path": "src/core/server/saved_objects/service/lib/point_in_time_finder.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -9124,8 +9124,8 @@
             ],
             "path": "src/core/server/saved_objects/service/lib/point_in_time_finder.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -12748,19 +12748,23 @@
             ],
             "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.msg",
+                "id": "def-server.SavedObjectsMigrationLogger.debug.$1",
                 "type": "string",
                 "tags": [],
                 "label": "msg",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12774,19 +12778,23 @@
             ],
             "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.msg",
+                "id": "def-server.SavedObjectsMigrationLogger.info.$1",
                 "type": "string",
                 "tags": [],
                 "label": "msg",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12820,19 +12828,23 @@
                 "path": "x-pack/plugins/lens/server/migrations/saved_object_migrations.ts"
               }
             ],
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.msg",
+                "id": "def-server.SavedObjectsMigrationLogger.warning.$1",
                 "type": "string",
                 "tags": [],
                 "label": "msg",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12846,19 +12858,23 @@
             ],
             "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.msg",
+                "id": "def-server.SavedObjectsMigrationLogger.warn.$1",
                 "type": "string",
                 "tags": [],
                 "label": "msg",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -12876,21 +12892,24 @@
             ],
             "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.msg",
+                "id": "def-server.SavedObjectsMigrationLogger.error.$1",
                 "type": "string",
                 "tags": [],
                 "label": "msg",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.meta",
+                "id": "def-server.SavedObjectsMigrationLogger.error.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "meta",
@@ -12899,9 +12918,11 @@
                   "Meta"
                 ],
                 "path": "src/core/server/saved_objects/migrations/core/migration_logger.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -13254,11 +13275,10 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.req",
+                "id": "def-server.SavedObjectsRepositoryFactory.createScopedRepository.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "req",
@@ -13274,11 +13294,12 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.includedHiddenTypes",
+                "id": "def-server.SavedObjectsRepositoryFactory.createScopedRepository.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "includedHiddenTypes",
@@ -13289,9 +13310,11 @@
                   "string[] | undefined"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13315,11 +13338,10 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.includedHiddenTypes",
+                "id": "def-server.SavedObjectsRepositoryFactory.createInternalRepository.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "includedHiddenTypes",
@@ -13330,9 +13352,11 @@
                   "string[] | undefined"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -13521,37 +13545,29 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.clientFactoryProvider",
+                "id": "def-server.SavedObjectsServiceSetup.setClientFactoryProvider.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "clientFactoryProvider",
                 "description": [],
                 "signature": [
-                  "(repositoryFactory: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsRepositoryFactory",
-                    "text": "SavedObjectsRepositoryFactory"
-                  },
-                  ") => ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsClientFactory",
-                    "text": "SavedObjectsClientFactory"
+                    "section": "def-server.SavedObjectsClientFactoryProvider",
+                    "text": "SavedObjectsClientFactoryProvider"
                   }
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13575,58 +13591,57 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.priority",
+                "id": "def-server.SavedObjectsServiceSetup.addClientWrapper.$1",
                 "type": "number",
                 "tags": [],
                 "label": "priority",
                 "description": [],
+                "signature": [
+                  "number"
+                ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.id",
+                "id": "def-server.SavedObjectsServiceSetup.addClientWrapper.$2",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.factory",
+                "id": "def-server.SavedObjectsServiceSetup.addClientWrapper.$3",
                 "type": "Function",
                 "tags": [],
                 "label": "factory",
                 "description": [],
                 "signature": [
-                  "(options: ",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsClientWrapperOptions",
-                    "text": "SavedObjectsClientWrapperOptions"
-                  },
-                  ") => Pick<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsClient",
-                    "text": "SavedObjectsClient"
-                  },
-                  ", \"get\" | \"delete\" | \"create\" | \"bulkCreate\" | \"checkConflicts\" | \"find\" | \"bulkGet\" | \"resolve\" | \"update\" | \"collectMultiNamespaceReferences\" | \"updateObjectsSpaces\" | \"bulkUpdate\" | \"removeReferencesTo\" | \"openPointInTimeForType\" | \"closePointInTime\" | \"createPointInTimeFinder\" | \"errors\">"
+                    "section": "def-server.SavedObjectsClientWrapperFactory",
+                    "text": "SavedObjectsClientWrapperFactory"
+                  }
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13650,11 +13665,10 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.type",
+                "id": "def-server.SavedObjectsServiceSetup.registerType.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "type",
@@ -13670,9 +13684,11 @@
                   "<Attributes>"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -13727,11 +13743,10 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.req",
+                "id": "def-server.SavedObjectsServiceStart.getScopedClient.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "req",
@@ -13747,11 +13762,12 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.options",
+                "id": "def-server.SavedObjectsServiceStart.getScopedClient.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -13767,9 +13783,11 @@
                   " | undefined"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13801,11 +13819,10 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.req",
+                "id": "def-server.SavedObjectsServiceStart.createScopedRepository.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "req",
@@ -13823,11 +13840,12 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "core",
-                "id": "def-server.includedHiddenTypes",
+                "id": "def-server.SavedObjectsServiceStart.createScopedRepository.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "includedHiddenTypes",
@@ -13838,9 +13856,11 @@
                   "string[] | undefined"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13864,11 +13884,10 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.includedHiddenTypes",
+                "id": "def-server.SavedObjectsServiceStart.createInternalRepository.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "includedHiddenTypes",
@@ -13879,9 +13898,11 @@
                   "string[] | undefined"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13904,8 +13925,8 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -13937,322 +13958,31 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.client",
+                "id": "def-server.SavedObjectsServiceStart.createExporter.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "client",
                 "description": [],
                 "signature": [
-                  "{ get: <T = unknown>(type: string, id: string, options?: ",
+                  "Pick<",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
+                    "section": "def-server.SavedObjectsClient",
+                    "text": "SavedObjectsClient"
                   },
-                  ") => Promise<",
-                  "SavedObject",
-                  "<T>>; delete: (type: string, id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsDeleteOptions",
-                    "text": "SavedObjectsDeleteOptions"
-                  },
-                  ") => Promise<{}>; create: <T = unknown>(type: string, attributes: T, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCreateOptions",
-                    "text": "SavedObjectsCreateOptions"
-                  },
-                  " | undefined) => Promise<",
-                  "SavedObject",
-                  "<T>>; bulkCreate: <T = unknown>(objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkCreateObject",
-                    "text": "SavedObjectsBulkCreateObject"
-                  },
-                  "<T>[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCreateOptions",
-                    "text": "SavedObjectsCreateOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkResponse",
-                    "text": "SavedObjectsBulkResponse"
-                  },
-                  "<T>>; checkConflicts: (objects?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCheckConflictsObject",
-                    "text": "SavedObjectsCheckConflictsObject"
-                  },
-                  "[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCheckConflictsResponse",
-                    "text": "SavedObjectsCheckConflictsResponse"
-                  },
-                  ">; find: <T = unknown, A = unknown>(options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsFindOptions",
-                    "text": "SavedObjectsFindOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsFindResponse",
-                    "text": "SavedObjectsFindResponse"
-                  },
-                  "<T, A>>; bulkGet: <T = unknown>(objects?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkGetObject",
-                    "text": "SavedObjectsBulkGetObject"
-                  },
-                  "[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkResponse",
-                    "text": "SavedObjectsBulkResponse"
-                  },
-                  "<T>>; resolve: <T = unknown>(type: string, id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsResolveResponse",
-                    "text": "SavedObjectsResolveResponse"
-                  },
-                  "<T>>; update: <T = unknown>(type: string, id: string, attributes: Partial<T>, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateOptions",
-                    "text": "SavedObjectsUpdateOptions"
-                  },
-                  "<T>) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateResponse",
-                    "text": "SavedObjectsUpdateResponse"
-                  },
-                  "<T>>; collectMultiNamespaceReferences: (objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCollectMultiNamespaceReferencesObject",
-                    "text": "SavedObjectsCollectMultiNamespaceReferencesObject"
-                  },
-                  "[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCollectMultiNamespaceReferencesOptions",
-                    "text": "SavedObjectsCollectMultiNamespaceReferencesOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCollectMultiNamespaceReferencesResponse",
-                    "text": "SavedObjectsCollectMultiNamespaceReferencesResponse"
-                  },
-                  ">; updateObjectsSpaces: (objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateObjectsSpacesObject",
-                    "text": "SavedObjectsUpdateObjectsSpacesObject"
-                  },
-                  "[], spacesToAdd: string[], spacesToRemove: string[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateObjectsSpacesOptions",
-                    "text": "SavedObjectsUpdateObjectsSpacesOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateObjectsSpacesResponse",
-                    "text": "SavedObjectsUpdateObjectsSpacesResponse"
-                  },
-                  ">; bulkUpdate: <T = unknown>(objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkUpdateObject",
-                    "text": "SavedObjectsBulkUpdateObject"
-                  },
-                  "<T>[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkUpdateOptions",
-                    "text": "SavedObjectsBulkUpdateOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkUpdateResponse",
-                    "text": "SavedObjectsBulkUpdateResponse"
-                  },
-                  "<T>>; removeReferencesTo: (type: string, id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsRemoveReferencesToOptions",
-                    "text": "SavedObjectsRemoveReferencesToOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsRemoveReferencesToResponse",
-                    "text": "SavedObjectsRemoveReferencesToResponse"
-                  },
-                  ">; openPointInTimeForType: (type: string | string[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsOpenPointInTimeOptions",
-                    "text": "SavedObjectsOpenPointInTimeOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsOpenPointInTimeResponse",
-                    "text": "SavedObjectsOpenPointInTimeResponse"
-                  },
-                  ">; closePointInTime: (id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsClosePointInTimeResponse",
-                    "text": "SavedObjectsClosePointInTimeResponse"
-                  },
-                  ">; createPointInTimeFinder: <T = unknown, A = unknown>(findOptions: Pick<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsFindOptions",
-                    "text": "SavedObjectsFindOptions"
-                  },
-                  ", \"type\" | \"filter\" | \"aggs\" | \"fields\" | \"perPage\" | \"sortField\" | \"sortOrder\" | \"search\" | \"searchFields\" | \"rootSearchFields\" | \"hasReference\" | \"hasReferenceOperator\" | \"defaultSearchOperator\" | \"namespaces\" | \"typeToNamespacesMap\" | \"preference\">, dependencies?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCreatePointInTimeFinderDependencies",
-                    "text": "SavedObjectsCreatePointInTimeFinderDependencies"
-                  },
-                  " | undefined) => ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.ISavedObjectsPointInTimeFinder",
-                    "text": "ISavedObjectsPointInTimeFinder"
-                  },
-                  "<T, A>; errors: typeof ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsErrorHelpers",
-                    "text": "SavedObjectsErrorHelpers"
-                  },
-                  "; }"
+                  ", \"get\" | \"delete\" | \"create\" | \"bulkCreate\" | \"checkConflicts\" | \"find\" | \"bulkGet\" | \"resolve\" | \"update\" | \"collectMultiNamespaceReferences\" | \"updateObjectsSpaces\" | \"bulkUpdate\" | \"removeReferencesTo\" | \"openPointInTimeForType\" | \"closePointInTime\" | \"createPointInTimeFinder\" | \"errors\">"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -14284,322 +14014,31 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "core",
-                "id": "def-server.client",
+                "id": "def-server.SavedObjectsServiceStart.createImporter.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "client",
                 "description": [],
                 "signature": [
-                  "{ get: <T = unknown>(type: string, id: string, options?: ",
+                  "Pick<",
                   {
                     "pluginId": "core",
                     "scope": "server",
                     "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
+                    "section": "def-server.SavedObjectsClient",
+                    "text": "SavedObjectsClient"
                   },
-                  ") => Promise<",
-                  "SavedObject",
-                  "<T>>; delete: (type: string, id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsDeleteOptions",
-                    "text": "SavedObjectsDeleteOptions"
-                  },
-                  ") => Promise<{}>; create: <T = unknown>(type: string, attributes: T, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCreateOptions",
-                    "text": "SavedObjectsCreateOptions"
-                  },
-                  " | undefined) => Promise<",
-                  "SavedObject",
-                  "<T>>; bulkCreate: <T = unknown>(objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkCreateObject",
-                    "text": "SavedObjectsBulkCreateObject"
-                  },
-                  "<T>[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCreateOptions",
-                    "text": "SavedObjectsCreateOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkResponse",
-                    "text": "SavedObjectsBulkResponse"
-                  },
-                  "<T>>; checkConflicts: (objects?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCheckConflictsObject",
-                    "text": "SavedObjectsCheckConflictsObject"
-                  },
-                  "[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCheckConflictsResponse",
-                    "text": "SavedObjectsCheckConflictsResponse"
-                  },
-                  ">; find: <T = unknown, A = unknown>(options: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsFindOptions",
-                    "text": "SavedObjectsFindOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsFindResponse",
-                    "text": "SavedObjectsFindResponse"
-                  },
-                  "<T, A>>; bulkGet: <T = unknown>(objects?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkGetObject",
-                    "text": "SavedObjectsBulkGetObject"
-                  },
-                  "[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkResponse",
-                    "text": "SavedObjectsBulkResponse"
-                  },
-                  "<T>>; resolve: <T = unknown>(type: string, id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsResolveResponse",
-                    "text": "SavedObjectsResolveResponse"
-                  },
-                  "<T>>; update: <T = unknown>(type: string, id: string, attributes: Partial<T>, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateOptions",
-                    "text": "SavedObjectsUpdateOptions"
-                  },
-                  "<T>) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateResponse",
-                    "text": "SavedObjectsUpdateResponse"
-                  },
-                  "<T>>; collectMultiNamespaceReferences: (objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCollectMultiNamespaceReferencesObject",
-                    "text": "SavedObjectsCollectMultiNamespaceReferencesObject"
-                  },
-                  "[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCollectMultiNamespaceReferencesOptions",
-                    "text": "SavedObjectsCollectMultiNamespaceReferencesOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCollectMultiNamespaceReferencesResponse",
-                    "text": "SavedObjectsCollectMultiNamespaceReferencesResponse"
-                  },
-                  ">; updateObjectsSpaces: (objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateObjectsSpacesObject",
-                    "text": "SavedObjectsUpdateObjectsSpacesObject"
-                  },
-                  "[], spacesToAdd: string[], spacesToRemove: string[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateObjectsSpacesOptions",
-                    "text": "SavedObjectsUpdateObjectsSpacesOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsUpdateObjectsSpacesResponse",
-                    "text": "SavedObjectsUpdateObjectsSpacesResponse"
-                  },
-                  ">; bulkUpdate: <T = unknown>(objects: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkUpdateObject",
-                    "text": "SavedObjectsBulkUpdateObject"
-                  },
-                  "<T>[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkUpdateOptions",
-                    "text": "SavedObjectsBulkUpdateOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBulkUpdateResponse",
-                    "text": "SavedObjectsBulkUpdateResponse"
-                  },
-                  "<T>>; removeReferencesTo: (type: string, id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsRemoveReferencesToOptions",
-                    "text": "SavedObjectsRemoveReferencesToOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsRemoveReferencesToResponse",
-                    "text": "SavedObjectsRemoveReferencesToResponse"
-                  },
-                  ">; openPointInTimeForType: (type: string | string[], options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsOpenPointInTimeOptions",
-                    "text": "SavedObjectsOpenPointInTimeOptions"
-                  },
-                  ") => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsOpenPointInTimeResponse",
-                    "text": "SavedObjectsOpenPointInTimeResponse"
-                  },
-                  ">; closePointInTime: (id: string, options?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsBaseOptions",
-                    "text": "SavedObjectsBaseOptions"
-                  },
-                  " | undefined) => Promise<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsClosePointInTimeResponse",
-                    "text": "SavedObjectsClosePointInTimeResponse"
-                  },
-                  ">; createPointInTimeFinder: <T = unknown, A = unknown>(findOptions: Pick<",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsFindOptions",
-                    "text": "SavedObjectsFindOptions"
-                  },
-                  ", \"type\" | \"filter\" | \"aggs\" | \"fields\" | \"perPage\" | \"sortField\" | \"sortOrder\" | \"search\" | \"searchFields\" | \"rootSearchFields\" | \"hasReference\" | \"hasReferenceOperator\" | \"defaultSearchOperator\" | \"namespaces\" | \"typeToNamespacesMap\" | \"preference\">, dependencies?: ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsCreatePointInTimeFinderDependencies",
-                    "text": "SavedObjectsCreatePointInTimeFinderDependencies"
-                  },
-                  " | undefined) => ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.ISavedObjectsPointInTimeFinder",
-                    "text": "ISavedObjectsPointInTimeFinder"
-                  },
-                  "<T, A>; errors: typeof ",
-                  {
-                    "pluginId": "core",
-                    "scope": "server",
-                    "docId": "kibCoreSavedObjectsPluginApi",
-                    "section": "def-server.SavedObjectsErrorHelpers",
-                    "text": "SavedObjectsErrorHelpers"
-                  },
-                  "; }"
+                  ", \"get\" | \"delete\" | \"create\" | \"bulkCreate\" | \"checkConflicts\" | \"find\" | \"bulkGet\" | \"resolve\" | \"update\" | \"collectMultiNamespaceReferences\" | \"updateObjectsSpaces\" | \"bulkUpdate\" | \"removeReferencesTo\" | \"openPointInTimeForType\" | \"closePointInTime\" | \"createPointInTimeFinder\" | \"errors\">"
                 ],
                 "path": "src/core/server/saved_objects/saved_objects_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -14623,8 +14062,8 @@
             ],
             "path": "src/core/server/saved_objects/saved_objects_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -14941,7 +14380,25 @@
               "<Attributes>) => string) | undefined"
             ],
             "path": "src/core/server/saved_objects/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "core",
+                "id": "def-server.SavedObjectsTypeManagementDefinition.getTitle.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "savedObject",
+                "description": [],
+                "signature": [
+                  "SavedObject",
+                  "<Attributes>"
+                ],
+                "path": "src/core/server/saved_objects/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -14958,7 +14415,25 @@
               "<Attributes>) => string) | undefined"
             ],
             "path": "src/core/server/saved_objects/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "core",
+                "id": "def-server.SavedObjectsTypeManagementDefinition.getEditUrl.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "savedObject",
+                "description": [],
+                "signature": [
+                  "SavedObject",
+                  "<Attributes>"
+                ],
+                "path": "src/core/server/saved_objects/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "core",
@@ -14975,7 +14450,27 @@
               "<Attributes>) => { path: string; uiCapabilitiesPath: string; }) | undefined"
             ],
             "path": "src/core/server/saved_objects/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "core",
+                "id": "def-server.SavedObjectsTypeManagementDefinition.getInAppUrl.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "savedObject",
+                "description": [],
+                "signature": [
+                  "SavedObject",
+                  "<Attributes>"
+                ],
+                "path": "src/core/server/saved_objects/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": [
+              "an object containing a `path` and `uiCapabilitiesPath` properties. the `path` is the path to\nthe object page, relative to the base path. `uiCapabilitiesPath` is the path to check in the\n{@link Capabilities | uiCapabilities} to check if the user has permission to access the object."
+            ]
           },
           {
             "parentPluginId": "core",
@@ -15948,6 +15443,41 @@
         ],
         "path": "src/core/server/saved_objects/migrations/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.doc",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "doc",
+            "description": [],
+            "signature": [
+              "SavedObjectDoc<InputAttributes> & Partial<Referencable>"
+            ],
+            "path": "src/core/server/saved_objects/migrations/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectMigrationContext",
+                "text": "SavedObjectMigrationContext"
+              }
+            ],
+            "path": "src/core/server/saved_objects/migrations/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -16312,6 +15842,30 @@
         ],
         "path": "src/core/server/saved_objects/service/lib/scoped_client_provider.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ request: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>; includedHiddenTypes?: string[] | undefined; }"
+            ],
+            "path": "src/core/server/saved_objects/service/lib/scoped_client_provider.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -16343,6 +15897,28 @@
         ],
         "path": "src/core/server/saved_objects/service/lib/scoped_client_provider.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.repositoryFactory",
+            "type": "Object",
+            "tags": [],
+            "label": "repositoryFactory",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectsRepositoryFactory",
+                "text": "SavedObjectsRepositoryFactory"
+              }
+            ],
+            "path": "src/core/server/saved_objects/service/lib/scoped_client_provider.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -16375,6 +15951,28 @@
         ],
         "path": "src/core/server/saved_objects/service/lib/scoped_client_provider.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.options",
+            "type": "Object",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectsClientWrapperOptions",
+                "text": "SavedObjectsClientWrapperOptions"
+              }
+            ],
+            "path": "src/core/server/saved_objects/service/lib/scoped_client_provider.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -16457,6 +16055,42 @@
         ],
         "path": "src/core/server/saved_objects/export/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectsExportTransformContext",
+                "text": "SavedObjectsExportTransformContext"
+              }
+            ],
+            "path": "src/core/server/saved_objects/export/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "core",
+            "id": "def-server.objects",
+            "type": "Array",
+            "tags": [],
+            "label": "objects",
+            "description": [],
+            "signature": [
+              "SavedObject",
+              "<T>[]"
+            ],
+            "path": "src/core/server/saved_objects/export/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -16577,6 +16211,23 @@
         ],
         "path": "src/core/server/saved_objects/import/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.objects",
+            "type": "Array",
+            "tags": [],
+            "label": "objects",
+            "description": [],
+            "signature": [
+              "SavedObject",
+              "<T>[]"
+            ],
+            "path": "src/core/server/saved_objects/import/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -16653,6 +16304,30 @@
         ],
         "path": "src/core/server/saved_objects/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "core",
+            "id": "def-server.toolkit",
+            "type": "Object",
+            "tags": [],
+            "label": "toolkit",
+            "description": [],
+            "signature": [
+              "{ readonlyEsClient: Pick<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCorePluginApi",
+                "section": "def-server.ElasticsearchClient",
+                "text": "ElasticsearchClient"
+              },
+              ", \"search\">; }"
+            ],
+            "path": "src/core/server/saved_objects/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/core_saved_objects.mdx
+++ b/api_docs/core_saved_objects.mdx
@@ -18,7 +18,7 @@ import coreSavedObjectsObj from './core_saved_objects.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 2363 | 148 | 1081 | 31 |
+| 2450 | 149 | 1165 | 31 |
 
 ## Client
 

--- a/api_docs/dashboard.json
+++ b/api_docs/dashboard.json
@@ -1222,7 +1222,8 @@
               "\nOptionally apply filers. NOTE: if given and used in conjunction with `dashboardId`, and the\nsaved dashboard has filters saved with it, this will _replace_ those filters."
             ],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/dashboard/public/locator.ts",
             "deprecated": false
@@ -1230,14 +1231,15 @@
           {
             "parentPluginId": "dashboard",
             "id": "def-public.DashboardAppLocatorParams.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [
               "\nOptionally set a query. NOTE: if given and used in conjunction with `dashboardId`, and the\nsaved dashboard has a query saved with it, this will _replace_ that query."
             ],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/dashboard/public/locator.ts",
             "deprecated": false
@@ -1532,7 +1534,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[]"
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/dashboard/public/types.ts",
             "deprecated": false
@@ -1550,12 +1553,12 @@
           {
             "parentPluginId": "dashboard",
             "id": "def-public.DashboardContainerInput.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [],
             "signature": [
-              "any"
+              "{ query: string | { [key: string]: any; }; language: string; }"
             ],
             "path": "src/plugins/dashboard/public/types.ts",
             "deprecated": false
@@ -1961,7 +1964,8 @@
             "label": "getQuery",
             "description": [],
             "signature": [
-              "() => any"
+              "() => ",
+              "Query"
             ],
             "path": "src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts",
             "deprecated": false,
@@ -1976,7 +1980,9 @@
             "label": "getFilters",
             "description": [],
             "signature": [
-              "() => any[]"
+              "() => ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts",
             "deprecated": false,
@@ -2098,7 +2104,8 @@
               "\nOptionally apply filers. NOTE: if given and used in conjunction with `dashboardId`, and the\nsaved dashboard has filters saved with it, this will _replace_ those filters."
             ],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/dashboard/public/url_generator.ts",
             "deprecated": false
@@ -2106,14 +2113,15 @@
           {
             "parentPluginId": "dashboard",
             "id": "def-public.DashboardUrlGeneratorState.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [
               "\nOptionally set a query. NOTE: if given and used in conjunction with `dashboardId`, and the\nsaved dashboard has a query saved with it, this will _replace_ that query."
             ],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/dashboard/public/url_generator.ts",
             "deprecated": false

--- a/api_docs/dashboard.json
+++ b/api_docs/dashboard.json
@@ -1995,11 +1995,10 @@
             ],
             "path": "src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "dashboard",
-                "id": "def-public.editMode",
+                "id": "def-public.DashboardSavedObject.getFullEditPath.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "editMode",
@@ -2008,9 +2007,11 @@
                   "boolean | undefined"
                 ],
                 "path": "src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2508,8 +2509,8 @@
           ],
           "path": "src/plugins/dashboard/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "dashboard",
@@ -2523,8 +2524,8 @@
           ],
           "path": "src/plugins/dashboard/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "dashboard",

--- a/api_docs/dashboard.mdx
+++ b/api_docs/dashboard.mdx
@@ -18,7 +18,7 @@ import dashboardObj from './dashboard.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 160 | 4 | 137 | 9 |
+| 160 | 1 | 137 | 9 |
 
 ## Client
 

--- a/api_docs/data.json
+++ b/api_docs/data.json
@@ -11767,7 +11767,67 @@
               ") | undefined"
             ],
             "path": "src/plugins/data/common/index_patterns/fields/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.IFieldType.toSpec.$1.options",
+                "type": "Object",
+                "tags": [],
+                "label": "options",
+                "description": [],
+                "path": "src/plugins/data/common/index_patterns/fields/types.ts",
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "data",
+                    "id": "def-public.IFieldType.toSpec.$1.options.getFormatterForField",
+                    "type": "Function",
+                    "tags": [],
+                    "label": "getFormatterForField",
+                    "description": [],
+                    "signature": [
+                      "((field: ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.IFieldType",
+                        "text": "IFieldType"
+                      },
+                      " | ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.IndexPatternField",
+                        "text": "IndexPatternField"
+                      },
+                      " | ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.FieldSpec",
+                        "text": "FieldSpec"
+                      },
+                      ") => ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataFieldFormatsPluginApi",
+                        "section": "def-common.FieldFormat",
+                        "text": "FieldFormat"
+                      },
+                      ") | undefined"
+                    ],
+                    "path": "src/plugins/data/common/index_patterns/fields/types.ts",
+                    "deprecated": false
+                  }
+                ]
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -11796,18 +11856,6 @@
         "deprecated": true,
         "references": [
           {
-            "plugin": "savedObjects",
-            "path": "src/plugins/saved_objects/public/types.ts"
-          },
-          {
-            "plugin": "savedObjects",
-            "path": "src/plugins/saved_objects/public/types.ts"
-          },
-          {
-            "plugin": "savedObjects",
-            "path": "src/plugins/saved_objects/public/types.ts"
-          },
-          {
             "plugin": "observability",
             "path": "x-pack/plugins/observability/public/components/shared/exploratory_view/types.ts"
           },
@@ -12526,14 +12574,6 @@
           {
             "plugin": "observability",
             "path": "x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/utils.ts"
-          },
-          {
-            "plugin": "maps",
-            "path": "x-pack/plugins/maps/public/embeddable/types.ts"
-          },
-          {
-            "plugin": "maps",
-            "path": "x-pack/plugins/maps/public/embeddable/types.ts"
           },
           {
             "plugin": "ml",
@@ -12796,7 +12836,46 @@
               ") | undefined"
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.IIndexPattern.getFormatterForField.$1",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.IFieldType",
+                    "text": "IFieldType"
+                  },
+                  " | ",
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.IndexPatternField",
+                    "text": "IndexPatternField"
+                  },
+                  " | ",
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.FieldSpec",
+                    "text": "FieldSpec"
+                  }
+                ],
+                "path": "src/plugins/data/common/index_patterns/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -14002,11 +14081,10 @@
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.fields",
+                "id": "def-public.ISearchStartSearchSource.create.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "fields",
@@ -14022,9 +14100,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/data/common/search/search_source/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -14048,8 +14128,8 @@
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -14117,11 +14197,10 @@
             ],
             "path": "src/plugins/data/common/search/aggs/param_types/optioned.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.agg",
+                "id": "def-public.OptionedValueProp.isCompatible.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "agg",
@@ -14136,9 +14215,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/search/aggs/param_types/optioned.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -15408,6 +15489,32 @@
         ],
         "path": "src/plugins/data/common/field_formats/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-public.key",
+            "type": "string",
+            "tags": [],
+            "label": "key",
+            "description": [],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-public.defaultOverride",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "defaultOverride",
+            "description": [],
+            "signature": [
+              "T | undefined"
+            ],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -17737,6 +17844,42 @@
         ],
         "path": "src/plugins/data/common/search/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-public.request",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              "SearchStrategyRequest"
+            ],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-public.options",
+            "type": "Object",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "data",
+                "scope": "common",
+                "docId": "kibDataSearchPluginApi",
+                "section": "def-common.ISearchOptions",
+                "text": "ISearchOptions"
+              },
+              " | undefined"
+            ],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -30964,7 +31107,67 @@
               ") | undefined"
             ],
             "path": "src/plugins/data/common/index_patterns/fields/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.IFieldType.toSpec.$1.options",
+                "type": "Object",
+                "tags": [],
+                "label": "options",
+                "description": [],
+                "path": "src/plugins/data/common/index_patterns/fields/types.ts",
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "data",
+                    "id": "def-server.IFieldType.toSpec.$1.options.getFormatterForField",
+                    "type": "Function",
+                    "tags": [],
+                    "label": "getFormatterForField",
+                    "description": [],
+                    "signature": [
+                      "((field: ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.IFieldType",
+                        "text": "IFieldType"
+                      },
+                      " | ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.IndexPatternField",
+                        "text": "IndexPatternField"
+                      },
+                      " | ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.FieldSpec",
+                        "text": "FieldSpec"
+                      },
+                      ") => ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataFieldFormatsPluginApi",
+                        "section": "def-common.FieldFormat",
+                        "text": "FieldFormat"
+                      },
+                      ") | undefined"
+                    ],
+                    "path": "src/plugins/data/common/index_patterns/fields/types.ts",
+                    "deprecated": false
+                  }
+                ]
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -31341,11 +31544,10 @@
             ],
             "path": "src/plugins/data/common/search/aggs/param_types/optioned.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-server.agg",
+                "id": "def-server.OptionedValueProp.isCompatible.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "agg",
@@ -31360,9 +31562,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/search/aggs/param_types/optioned.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -31785,6 +31989,32 @@
         ],
         "path": "src/plugins/data/common/field_formats/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-server.key",
+            "type": "string",
+            "tags": [],
+            "label": "key",
+            "description": [],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-server.defaultOverride",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "defaultOverride",
+            "description": [],
+            "signature": [
+              "T | undefined"
+            ],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -37924,19 +38154,23 @@
             ],
             "path": "src/plugins/data/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.type",
+                "id": "def-common.FilterValueFormatter.getConverterFor.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -40283,6 +40517,32 @@
         ],
         "path": "src/plugins/data/common/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.key",
+            "type": "string",
+            "tags": [],
+            "label": "key",
+            "description": [],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.defaultOverride",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "defaultOverride",
+            "description": [],
+            "signature": [
+              "T | undefined"
+            ],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/data.json
+++ b/api_docs/data.json
@@ -1973,7 +1973,9 @@
             "label": "getSearchSourceTimeFilter",
             "description": [],
             "signature": [
-              "(forceNow?: Date | undefined) => any[]"
+              "(forceNow?: Date | undefined) => ",
+              "RangeFilter",
+              "[] | { meta: { index: string | undefined; params: {}; alias: string; disabled: boolean; negate: boolean; }; query: { bool: { should: { bool: { filter: { range: { [x: string]: { gte: string; lte: string; }; }; }[]; }; }[]; minimum_should_match: number; }; }; }[]"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_configs.ts",
             "deprecated": false,
@@ -7554,7 +7556,9 @@
             "section": "def-common.TimeRange",
             "text": "TimeRange"
           },
-          ", options: { forceNow?: Date | undefined; fieldName?: string | undefined; } | undefined) => any"
+          ", options: { forceNow?: Date | undefined; fieldName?: string | undefined; } | undefined) => ",
+          "RangeFilter",
+          " | undefined"
         ],
         "path": "src/plugins/data/common/query/timefilter/get_time.ts",
         "deprecated": false,
@@ -7818,7 +7822,8 @@
         "label": "isFilter",
         "description": [],
         "signature": [
-          "(x: unknown) => x is any"
+          "(x: unknown) => x is ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -7851,7 +7856,9 @@
         "label": "isFilters",
         "description": [],
         "signature": [
-          "(x: unknown) => x is any[]"
+          "(x: unknown) => x is ",
+          "Filter",
+          "[]"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -7939,7 +7946,8 @@
         "label": "isQuery",
         "description": [],
         "signature": [
-          "(x: unknown) => x is any"
+          "(x: unknown) => x is ",
+          "Query"
         ],
         "path": "src/plugins/data/common/query/is_query.ts",
         "deprecated": false,
@@ -8109,7 +8117,17 @@
                 "section": "def-common.GeoPoint",
                 "text": "GeoPoint"
               },
-              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: any; }, \"filter\" | \"geo_bounding_box\"> & Pick<{ geo_bounding_box?: ({ type: \"geo_bounding_box\"; } & GeoBox) | ({ type: \"geo_bounding_box\"; } & { top_left: ",
+              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: ",
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.ExpressionValueBoxed",
+                "text": "ExpressionValueBoxed"
+              },
+              "<\"kibana_query\", ",
+              "Query",
+              "> | undefined; }, \"filter\" | \"geo_bounding_box\"> & Pick<{ geo_bounding_box?: ({ type: \"geo_bounding_box\"; } & GeoBox) | ({ type: \"geo_bounding_box\"; } & { top_left: ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -8141,7 +8159,17 @@
                 "section": "def-common.GeoPoint",
                 "text": "GeoPoint"
               },
-              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: any; }, never>, \"enabled\" | \"id\" | \"filter\" | \"customLabel\" | \"schema\" | \"geo_bounding_box\" | \"json\" | \"timeShift\">, ",
+              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: ",
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.ExpressionValueBoxed",
+                "text": "ExpressionValueBoxed"
+              },
+              "<\"kibana_query\", ",
+              "Query",
+              "> | undefined; }, never>, \"enabled\" | \"id\" | \"filter\" | \"customLabel\" | \"schema\" | \"geo_bounding_box\" | \"json\" | \"timeShift\">, ",
               "AggExpressionType",
               ", ",
               {
@@ -10294,7 +10322,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[]"
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/actions/apply_filter_action.ts",
             "deprecated": false
@@ -10363,7 +10392,9 @@
             "signature": [
               "({ data, negate, }: ",
               "ValueClickDataContext",
-              ") => Promise<any[]>"
+              ") => Promise<",
+              "Filter",
+              "[]>"
             ],
             "path": "src/plugins/data/public/types.ts",
             "deprecated": false,
@@ -10394,7 +10425,9 @@
             "signature": [
               "(event: ",
               "RangeSelectDataContext",
-              ") => Promise<any[]>"
+              ") => Promise<",
+              "Filter",
+              "[]>"
             ],
             "path": "src/plugins/data/public/types.ts",
             "deprecated": false,
@@ -14358,14 +14391,15 @@
           {
             "parentPluginId": "data",
             "id": "def-public.SearchSourceFields.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [
               "\n{@link Query}"
             ],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false
@@ -14373,14 +14407,21 @@
           {
             "parentPluginId": "data",
             "id": "def-public.SearchSourceFields.filter",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "filter",
             "description": [
               "\n{@link Filter}"
             ],
             "signature": [
-              "any"
+              "Filter",
+              " | ",
+              "Filter",
+              "[] | (() => ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[] | undefined) | undefined"
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false
@@ -15036,7 +15077,8 @@
         "label": "CustomFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { query: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -15252,7 +15294,13 @@
         "label": "ExecutionContextSearch",
         "description": [],
         "signature": [
-          "{ filters?: any[] | undefined; query?: any; timeRange?: ",
+          "{ filters?: ",
+          "Filter",
+          "[] | undefined; query?: ",
+          "Query",
+          " | ",
+          "Query",
+          "[] | undefined; timeRange?: ",
           {
             "pluginId": "data",
             "scope": "common",
@@ -15276,7 +15324,10 @@
         "label": "ExistsFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "FilterMeta",
+          "; exists?: { field: string; } | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -15527,7 +15578,11 @@
         "label": "Filter",
         "description": [],
         "signature": [
-          "any"
+          "{ $state?: { store: ",
+          "FilterStateStore",
+          "; } | undefined; meta: ",
+          "FilterMeta",
+          "; query?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -18427,7 +18482,10 @@
         "label": "MatchAllFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "MatchAllFilterMeta",
+          "; match_all: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -18469,7 +18527,10 @@
         "label": "PhraseFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "PhraseFilterMeta",
+          "; script?: { script: { source?: string | undefined; lang?: \"painless\" | \"expression\" | \"mustache\" | \"java\" | undefined; params: { [key: string]: PhraseFilterValue; }; }; } | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -18486,11 +18547,28 @@
         "label": "PhrasesFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "PhrasesFilterMeta",
+          "; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
         "references": [],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-public.Query",
+        "type": "Type",
+        "tags": [],
+        "label": "Query",
+        "description": [],
+        "signature": [
+          "{ query: string | { [key: string]: any; }; language: string; }"
+        ],
+        "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/types.d.ts",
+        "deprecated": false,
         "initialIsOpen": false
       },
       {
@@ -18503,7 +18581,14 @@
         "label": "RangeFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & ",
+          "EsRangeFilter",
+          " & { meta: ",
+          "RangeFilterMeta",
+          "; script?: { script: { params: any; lang: ",
+          "ScriptLanguage",
+          "; source: string; }; } | undefined; match_all?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -18529,7 +18614,10 @@
         "label": "RangeFilterMeta",
         "description": [],
         "signature": [
-          "any"
+          "FilterMeta",
+          " & { params: ",
+          "RangeFilterParams",
+          "; field?: string | undefined; formattedValue?: string | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -18546,7 +18634,7 @@
         "label": "RangeFilterParams",
         "description": [],
         "signature": [
-          "any"
+          "RangeFilterParams"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -19179,171 +19267,755 @@
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.buildEmptyFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildEmptyFilter",
             "description": [],
             "signature": [
-              "any"
+              "(isPinned: boolean, index?: string | undefined) => ",
+              "Filter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.isPinned",
+                "type": "boolean",
+                "tags": [],
+                "label": "isPinned",
+                "description": [],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_empty_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.index",
+                "type": "string",
+                "tags": [],
+                "label": "index",
+                "description": [],
+                "signature": [
+                  "string | undefined"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_empty_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.buildPhrasesFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildPhrasesFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", params: string[], indexPattern: ",
+              "IndexPatternBase",
+              ") => ",
+              "PhrasesFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.params",
+                "type": "Array",
+                "tags": [],
+                "label": "params",
+                "description": [],
+                "signature": [
+                  "string[]"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.buildExistsFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildExistsFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", indexPattern: ",
+              "IndexPatternBase",
+              ") => ",
+              "ExistsFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.buildPhraseFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildPhraseFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", value: PhraseFilterValue, indexPattern: ",
+              "IndexPatternBase",
+              ") => ",
+              "PhraseFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.value",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "value",
+                "description": [],
+                "signature": [
+                  "string | number | boolean"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.buildQueryFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildQueryFilter",
             "description": [],
             "signature": [
-              "any"
+              "(query: any, index: string, alias: string) => ",
+              "QueryStringFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.query",
+                "type": "Any",
+                "tags": [],
+                "label": "query",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.index",
+                "type": "string",
+                "tags": [],
+                "label": "index",
+                "description": [],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.alias",
+                "type": "string",
+                "tags": [],
+                "label": "alias",
+                "description": [],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.buildRangeFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildRangeFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", params: ",
+              "RangeFilterParams",
+              ", indexPattern: ",
+              "IndexPatternBase",
+              ", formattedValue?: string | undefined) => ",
+              "RangeFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.params",
+                "type": "Object",
+                "tags": [],
+                "label": "params",
+                "description": [],
+                "signature": [
+                  "RangeFilterParams"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-public.formattedValue",
+                "type": "string",
+                "tags": [],
+                "label": "formattedValue",
+                "description": [],
+                "signature": [
+                  "string | undefined"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isPhraseFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isPhraseFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              ") => filter is ",
+              "PhraseFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isExistsFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isExistsFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              ") => filter is ",
+              "ExistsFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isPhrasesFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isPhrasesFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              ") => filter is ",
+              "PhrasesFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isRangeFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isRangeFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter?: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              " | undefined) => filter is ",
+              "RangeFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter",
+                  " | undefined"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isMatchAllFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isMatchAllFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              ") => filter is ",
+              "MatchAllFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/match_all_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isMissingFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isMissingFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              ") => filter is ",
+              "MissingFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/missing_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.isQueryStringFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "isQueryStringFilter",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              ") => filter is ",
+              "QueryStringFilter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "RangeFilter",
+                  " | ",
+                  "ExistsFilter",
+                  " | ",
+                  "GeoBoundingBoxFilter",
+                  " | ",
+                  "GeoPolygonFilter",
+                  " | ",
+                  "PhraseFilter",
+                  " | ",
+                  "PhrasesFilter",
+                  " | ",
+                  "MatchAllFilter",
+                  " | ",
+                  "MissingFilter"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
@@ -19353,7 +20025,9 @@
             "label": "isFilterPinned",
             "description": [],
             "signature": [
-              "(filter: any) => boolean | undefined"
+              "(filter: ",
+              "Filter",
+              ") => boolean | undefined"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19362,12 +20036,16 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filter",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "{ $state?: { store: ",
+                  "FilterStateStore",
+                  "; } | undefined; meta: ",
+                  "FilterMeta",
+                  "; query?: any; }"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
                 "deprecated": false
@@ -19382,7 +20060,11 @@
             "label": "toggleFilterNegated",
             "description": [],
             "signature": [
-              "(filter: any) => { meta: { negate: boolean; alias: string | null; disabled: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }; $state?: { store: any; } | undefined; query?: any; }"
+              "(filter: ",
+              "Filter",
+              ") => { meta: { negate: boolean; alias: string | null; disabled: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }; $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; query?: any; }"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19391,12 +20073,16 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filter",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "{ $state?: { store: ",
+                  "FilterStateStore",
+                  "; } | undefined; meta: ",
+                  "FilterMeta",
+                  "; query?: any; }"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
                 "deprecated": false
@@ -19411,7 +20097,10 @@
             "label": "disableFilter",
             "description": [],
             "signature": [
-              "(filter: any) => any"
+              "(filter: ",
+              "Filter",
+              ") => ",
+              "Filter"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19420,12 +20109,16 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filter",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "{ $state?: { store: ",
+                  "FilterStateStore",
+                  "; } | undefined; meta: ",
+                  "FilterMeta",
+                  "; query?: any; }"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
                 "deprecated": false
@@ -19435,28 +20128,70 @@
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.getPhraseFilterField",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "getPhraseFilterField",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "PhraseFilter",
+              ") => string"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "Filter",
+                  " & { meta: ",
+                  "PhraseFilterMeta",
+                  "; script?: { script: { source?: string | undefined; lang?: \"painless\" | \"expression\" | \"mustache\" | \"java\" | undefined; params: { [key: string]: PhraseFilterValue; }; }; } | undefined; }"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-public.esFilters.getPhraseFilterValue",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "getPhraseFilterValue",
             "description": [],
             "signature": [
-              "any"
+              "(filter: ",
+              "PhraseFilter",
+              ") => PhraseFilterValue"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.filter",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "filter",
+                "description": [],
+                "signature": [
+                  "Filter",
+                  " & { meta: ",
+                  "PhraseFilterMeta",
+                  "; script?: { script: { source?: string | undefined; lang?: \"painless\" | \"expression\" | \"mustache\" | \"java\" | undefined; params: { [key: string]: PhraseFilterValue; }; }; } | undefined; }"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
@@ -19466,7 +20201,9 @@
             "label": "getDisplayValueFromFilter",
             "description": [],
             "signature": [
-              "(filter: any, indexPatterns: ",
+              "(filter: ",
+              "Filter",
+              ", indexPatterns: ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -19483,12 +20220,16 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filter",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "{ $state?: { store: ",
+                  "FilterStateStore",
+                  "; } | undefined; meta: ",
+                  "FilterMeta",
+                  "; query?: any; }"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/lib/get_display_value.ts",
                 "deprecated": false
@@ -19523,7 +20264,15 @@
             "label": "compareFilters",
             "description": [],
             "signature": [
-              "(first: any, second: any, comparatorOptions?: ",
+              "(first: ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[], second: ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[], comparatorOptions?: ",
               "FilterCompareOptions",
               " | undefined) => boolean"
             ],
@@ -19534,12 +20283,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.first",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "first",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " | ",
+                  "Filter",
+                  "[]"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/compare_filters.d.ts",
                 "deprecated": false
@@ -19547,12 +20299,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.second",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "second",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " | ",
+                  "Filter",
+                  "[]"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/compare_filters.d.ts",
                 "deprecated": false
@@ -19610,7 +20365,9 @@
                 "section": "def-common.IFieldType",
                 "text": "IFieldType"
               },
-              ", values: any, operation: string, index: string) => any[]"
+              ", values: any, operation: string, index: string) => ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19698,7 +20455,11 @@
             "label": "onlyDisabledFiltersChanged",
             "description": [],
             "signature": [
-              "(newFilters?: any[] | undefined, oldFilters?: any[] | undefined) => boolean"
+              "(newFilters?: ",
+              "Filter",
+              "[] | undefined, oldFilters?: ",
+              "Filter",
+              "[] | undefined) => boolean"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19712,7 +20473,8 @@
                 "label": "newFilters",
                 "description": [],
                 "signature": [
-                  "any[] | undefined"
+                  "Filter",
+                  "[] | undefined"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/only_disabled.d.ts",
                 "deprecated": false
@@ -19725,7 +20487,8 @@
                 "label": "oldFilters",
                 "description": [],
                 "signature": [
-                  "any[] | undefined"
+                  "Filter",
+                  "[] | undefined"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/only_disabled.d.ts",
                 "deprecated": false
@@ -19742,7 +20505,9 @@
             "signature": [
               "(timeFilter: Pick<",
               "Timefilter",
-              ", \"isTimeRangeSelectorEnabled\" | \"isAutoRefreshSelectorEnabled\" | \"isTimeTouched\" | \"getEnabledUpdated$\" | \"getTimeUpdate$\" | \"getRefreshIntervalUpdate$\" | \"getAutoRefreshFetch$\" | \"getFetch$\" | \"getTime\" | \"getAbsoluteTime\" | \"setTime\" | \"getRefreshInterval\" | \"setRefreshInterval\" | \"createFilter\" | \"getBounds\" | \"calculateBounds\" | \"getActiveBounds\" | \"enableTimeRangeSelector\" | \"disableTimeRangeSelector\" | \"enableAutoRefreshSelector\" | \"disableAutoRefreshSelector\" | \"getTimeDefaults\" | \"getRefreshIntervalDefaults\">, filter: any) => void"
+              ", \"isTimeRangeSelectorEnabled\" | \"isAutoRefreshSelectorEnabled\" | \"isTimeTouched\" | \"getEnabledUpdated$\" | \"getTimeUpdate$\" | \"getRefreshIntervalUpdate$\" | \"getAutoRefreshFetch$\" | \"getFetch$\" | \"getTime\" | \"getAbsoluteTime\" | \"setTime\" | \"getRefreshInterval\" | \"setRefreshInterval\" | \"createFilter\" | \"getBounds\" | \"calculateBounds\" | \"getActiveBounds\" | \"enableTimeRangeSelector\" | \"disableTimeRangeSelector\" | \"enableAutoRefreshSelector\" | \"disableAutoRefreshSelector\" | \"getTimeDefaults\" | \"getRefreshIntervalDefaults\">, filter: ",
+              "RangeFilter",
+              ") => void"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19830,7 +20595,9 @@
                     "section": "def-common.TimeRange",
                     "text": "TimeRange"
                   },
-                  " | undefined) => any; getBounds: () => ",
+                  " | undefined) => ",
+                  "RangeFilter",
+                  " | undefined; getBounds: () => ",
                   {
                     "pluginId": "data",
                     "scope": "common",
@@ -19886,12 +20653,19 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filter",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " & ",
+                  "EsRangeFilter",
+                  " & { meta: ",
+                  "RangeFilterMeta",
+                  "; script?: { script: { params: any; lang: ",
+                  "ScriptLanguage",
+                  "; source: string; }; } | undefined; match_all?: any; }"
                 ],
                 "path": "src/plugins/data/public/query/timefilter/lib/change_time_filter.ts",
                 "deprecated": false
@@ -19906,7 +20680,9 @@
             "label": "convertRangeFilterToTimeRangeString",
             "description": [],
             "signature": [
-              "(filter: any) => ",
+              "(filter: ",
+              "RangeFilter",
+              ") => ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -19922,12 +20698,19 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filter",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " & ",
+                  "EsRangeFilter",
+                  " & { meta: ",
+                  "RangeFilterMeta",
+                  "; script?: { script: { params: any; lang: ",
+                  "ScriptLanguage",
+                  "; source: string; }; } | undefined; match_all?: any; }"
                 ],
                 "path": "src/plugins/data/public/query/timefilter/lib/change_time_filter.ts",
                 "deprecated": false
@@ -19942,7 +20725,11 @@
             "label": "mapAndFlattenFilters",
             "description": [],
             "signature": [
-              "(filters: any[]) => any[]"
+              "(filters: ",
+              "Filter",
+              "[]) => ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19956,7 +20743,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/lib/map_and_flatten_filters.ts",
                 "deprecated": false
@@ -19971,7 +20759,13 @@
             "label": "extractTimeFilter",
             "description": [],
             "signature": [
-              "(timeFieldName: string, filters: any[]) => { restOfFilters: any[]; timeRangeFilter: any; }"
+              "(timeFieldName: string, filters: ",
+              "Filter",
+              "[]) => { restOfFilters: ",
+              "Filter",
+              "[]; timeRangeFilter: ",
+              "RangeFilter",
+              " | undefined; }"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -19995,7 +20789,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/timefilter/lib/extract_time_filter.ts",
                 "deprecated": false
@@ -20010,7 +20805,11 @@
             "label": "extractTimeRange",
             "description": [],
             "signature": [
-              "(filters: any[], timeFieldName?: string | undefined) => { restOfFilters: any[]; timeRange?: ",
+              "(filters: ",
+              "Filter",
+              "[], timeFieldName?: string | undefined) => { restOfFilters: ",
+              "Filter",
+              "[]; timeRange?: ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -20032,7 +20831,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/timefilter/lib/extract_time_filter.ts",
                 "deprecated": false
@@ -20894,11 +21694,23 @@
             "signature": [
               "(indexPattern: ",
               "IndexPatternBase",
-              " | undefined, queries: any, filters: any, config?: ",
+              " | undefined, queries: ",
+              "Query",
+              " | ",
+              "Query",
+              "[], filters: ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[], config?: ",
               "EsQueryConfig",
               " | undefined) => { bool: { must: ",
               "DslQuery",
-              "[]; filter: any[]; should: never[]; must_not: any[]; }; }"
+              "[]; filter: ",
+              "Filter",
+              "[]; should: never[]; must_not: ",
+              "Filter",
+              "[]; }; }"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -20921,12 +21733,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.queries",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "queries",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Query",
+                  " | ",
+                  "Query",
+                  "[]"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/es_query/build_es_query.d.ts",
                 "deprecated": false
@@ -20934,12 +21749,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.filters",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " | ",
+                  "Filter",
+                  "[]"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/es_query/build_es_query.d.ts",
                 "deprecated": false
@@ -20998,9 +21816,15 @@
             "label": "buildQueryFromFilters",
             "description": [],
             "signature": [
-              "(filters: any[] | undefined, indexPattern: ",
+              "(filters: ",
+              "Filter",
+              "[] | undefined, indexPattern: ",
               "IndexPatternBase",
-              " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: any[]; should: never[]; must_not: any[]; }"
+              " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: ",
+              "Filter",
+              "[]; should: never[]; must_not: ",
+              "Filter",
+              "[]; }"
             ],
             "path": "src/plugins/data/public/deprecated.ts",
             "deprecated": false,
@@ -21014,7 +21838,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[] | undefined"
+                  "Filter",
+                  "[] | undefined"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/es_query/from_filters.d.ts",
                 "deprecated": false
@@ -23334,7 +24159,9 @@
             "\nquery service\n{@link QueryStart}"
           ],
           "signature": [
-            "{ addToQueryLog: (appName: string, { language, query }: any) => void; filterManager: ",
+            "{ addToQueryLog: (appName: string, { language, query }: ",
+            "Query",
+            ") => void; filterManager: ",
             {
               "pluginId": "data",
               "scope": "public",
@@ -23390,7 +24217,11 @@
             },
             " | undefined) => { bool: { must: ",
             "DslQuery",
-            "[]; filter: any[]; should: never[]; must_not: any[]; }; }; }"
+            "[]; filter: ",
+            "Filter",
+            "[]; should: never[]; must_not: ",
+            "Filter",
+            "[]; }; }; }"
           ],
           "path": "src/plugins/data/public/types.ts",
           "deprecated": false
@@ -27493,9 +28324,15 @@
         "label": "buildQueryFromFilters",
         "description": [],
         "signature": [
-          "(filters: any[] | undefined, indexPattern: ",
+          "(filters: ",
+          "Filter",
+          "[] | undefined, indexPattern: ",
           "IndexPatternBase",
-          " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: any[]; should: never[]; must_not: any[]; }"
+          " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: ",
+          "Filter",
+          "[]; should: never[]; must_not: ",
+          "Filter",
+          "[]; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -27510,7 +28347,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "node_modules/@kbn/es-query/target_types/es_query/from_filters.d.ts",
             "deprecated": false
@@ -27650,7 +28488,9 @@
             "section": "def-common.TimeRange",
             "text": "TimeRange"
           },
-          ", options: { forceNow?: Date | undefined; fieldName?: string | undefined; } | undefined) => any"
+          ", options: { forceNow?: Date | undefined; fieldName?: string | undefined; } | undefined) => ",
+          "RangeFilter",
+          " | undefined"
         ],
         "path": "src/plugins/data/common/query/timefilter/get_time.ts",
         "deprecated": false,
@@ -27840,7 +28680,17 @@
                 "section": "def-common.GeoPoint",
                 "text": "GeoPoint"
               },
-              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: any; }, \"filter\" | \"geo_bounding_box\"> & Pick<{ geo_bounding_box?: ({ type: \"geo_bounding_box\"; } & GeoBox) | ({ type: \"geo_bounding_box\"; } & { top_left: ",
+              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: ",
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.ExpressionValueBoxed",
+                "text": "ExpressionValueBoxed"
+              },
+              "<\"kibana_query\", ",
+              "Query",
+              "> | undefined; }, \"filter\" | \"geo_bounding_box\"> & Pick<{ geo_bounding_box?: ({ type: \"geo_bounding_box\"; } & GeoBox) | ({ type: \"geo_bounding_box\"; } & { top_left: ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -27872,7 +28722,17 @@
                 "section": "def-common.GeoPoint",
                 "text": "GeoPoint"
               },
-              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: any; }, never>, \"enabled\" | \"id\" | \"filter\" | \"customLabel\" | \"schema\" | \"geo_bounding_box\" | \"json\" | \"timeShift\">, ",
+              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: ",
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.ExpressionValueBoxed",
+                "text": "ExpressionValueBoxed"
+              },
+              "<\"kibana_query\", ",
+              "Query",
+              "> | undefined; }, never>, \"enabled\" | \"id\" | \"filter\" | \"customLabel\" | \"schema\" | \"geo_bounding_box\" | \"json\" | \"timeShift\">, ",
               "AggExpressionType",
               ", ",
               {
@@ -31820,7 +32680,13 @@
         "label": "ExecutionContextSearch",
         "description": [],
         "signature": [
-          "{ filters?: any[] | undefined; query?: any; timeRange?: ",
+          "{ filters?: ",
+          "Filter",
+          "[] | undefined; query?: ",
+          "Query",
+          " | ",
+          "Query",
+          "[] | undefined; timeRange?: ",
           {
             "pluginId": "data",
             "scope": "common",
@@ -32027,7 +32893,11 @@
         "label": "Filter",
         "description": [],
         "signature": [
-          "any"
+          "{ $state?: { store: ",
+          "FilterStateStore",
+          "; } | undefined; meta: ",
+          "FilterMeta",
+          "; query?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -34449,6 +35319,20 @@
       },
       {
         "parentPluginId": "data",
+        "id": "def-server.Query",
+        "type": "Type",
+        "tags": [],
+        "label": "Query",
+        "description": [],
+        "signature": [
+          "{ query: string | { [key: string]: any; }; language: string; }"
+        ],
+        "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/types.d.ts",
+        "deprecated": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
         "id": "def-server.TimeRange",
         "type": "Type",
         "tags": [],
@@ -34533,15 +35417,52 @@
           {
             "parentPluginId": "data",
             "id": "def-server.esFilters.buildQueryFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildQueryFilter",
             "description": [],
             "signature": [
-              "any"
+              "(query: any, index: string, alias: string) => ",
+              "QueryStringFilter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.query",
+                "type": "Any",
+                "tags": [],
+                "label": "query",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.index",
+                "type": "string",
+                "tags": [],
+                "label": "index",
+                "description": [],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.alias",
+                "type": "string",
+                "tags": [],
+                "label": "alias",
+                "description": [],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
@@ -34553,7 +35474,8 @@
             "signature": [
               "(indexPatternString: string, queryDsl: any, disabled: boolean, negate: boolean, alias: string | null, store: ",
               "FilterStateStore",
-              ") => any"
+              ") => ",
+              "Filter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
             "deprecated": false,
@@ -34566,7 +35488,7 @@
                 "tags": [],
                 "label": "indexPatternString",
                 "description": [],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
                 "deprecated": false
               },
               {
@@ -34579,7 +35501,7 @@
                 "signature": [
                   "any"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
                 "deprecated": false
               },
               {
@@ -34589,7 +35511,7 @@
                 "tags": [],
                 "label": "disabled",
                 "description": [],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
                 "deprecated": false
               },
               {
@@ -34599,7 +35521,7 @@
                 "tags": [],
                 "label": "negate",
                 "description": [],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
                 "deprecated": false
               },
               {
@@ -34612,7 +35534,7 @@
                 "signature": [
                   "string | null"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
                 "deprecated": false
               },
               {
@@ -34625,7 +35547,7 @@
                 "signature": [
                   "FilterStateStore"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
                 "deprecated": false
               }
             ]
@@ -34633,28 +35555,89 @@
           {
             "parentPluginId": "data",
             "id": "def-server.esFilters.buildEmptyFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildEmptyFilter",
             "description": [],
             "signature": [
-              "any"
+              "(isPinned: boolean, index?: string | undefined) => ",
+              "Filter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.isPinned",
+                "type": "boolean",
+                "tags": [],
+                "label": "isPinned",
+                "description": [],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_empty_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.index",
+                "type": "string",
+                "tags": [],
+                "label": "index",
+                "description": [],
+                "signature": [
+                  "string | undefined"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_empty_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-server.esFilters.buildExistsFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildExistsFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", indexPattern: ",
+              "IndexPatternBase",
+              ") => ",
+              "ExistsFilter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
@@ -34672,7 +35655,8 @@
               "FILTERS",
               ", negate: boolean, disabled: boolean, params: any, alias: string | null, store?: ",
               "FilterStateStore",
-              " | undefined) => any"
+              " | undefined) => ",
+              "Filter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
             "deprecated": false,
@@ -34688,7 +35672,7 @@
                 "signature": [
                   "IndexPatternBase"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34701,7 +35685,7 @@
                 "signature": [
                   "IndexPatternFieldBase"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34714,7 +35698,7 @@
                 "signature": [
                   "FILTERS"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34724,7 +35708,7 @@
                 "tags": [],
                 "label": "negate",
                 "description": [],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34734,7 +35718,7 @@
                 "tags": [],
                 "label": "disabled",
                 "description": [],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34747,7 +35731,7 @@
                 "signature": [
                   "any"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34760,7 +35744,7 @@
                 "signature": [
                   "string | null"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               },
               {
@@ -34774,7 +35758,7 @@
                   "FilterStateStore",
                   " | undefined"
                 ],
-                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
                 "deprecated": false
               }
             ]
@@ -34782,41 +35766,197 @@
           {
             "parentPluginId": "data",
             "id": "def-server.esFilters.buildPhraseFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildPhraseFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", value: PhraseFilterValue, indexPattern: ",
+              "IndexPatternBase",
+              ") => ",
+              "PhraseFilter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.value",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "value",
+                "description": [],
+                "signature": [
+                  "string | number | boolean"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-server.esFilters.buildPhrasesFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildPhrasesFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", params: string[], indexPattern: ",
+              "IndexPatternBase",
+              ") => ",
+              "PhrasesFilter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.params",
+                "type": "Array",
+                "tags": [],
+                "label": "params",
+                "description": [],
+                "signature": [
+                  "string[]"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
             "id": "def-server.esFilters.buildRangeFilter",
-            "type": "Any",
+            "type": "Function",
             "tags": [],
             "label": "buildRangeFilter",
             "description": [],
             "signature": [
-              "any"
+              "(field: ",
+              "IndexPatternFieldBase",
+              ", params: ",
+              "RangeFilterParams",
+              ", indexPattern: ",
+              "IndexPatternBase",
+              ", formattedValue?: string | undefined) => ",
+              "RangeFilter"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
-            "deprecated": false
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.field",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  "IndexPatternFieldBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.params",
+                "type": "Object",
+                "tags": [],
+                "label": "params",
+                "description": [],
+                "signature": [
+                  "RangeFilterParams"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.indexPattern",
+                "type": "Object",
+                "tags": [],
+                "label": "indexPattern",
+                "description": [],
+                "signature": [
+                  "IndexPatternBase"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.formattedValue",
+                "type": "string",
+                "tags": [],
+                "label": "formattedValue",
+                "description": [],
+                "signature": [
+                  "string | undefined"
+                ],
+                "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+                "deprecated": false
+              }
+            ]
           },
           {
             "parentPluginId": "data",
@@ -34826,7 +35966,9 @@
             "label": "isFilterDisabled",
             "description": [],
             "signature": [
-              "(filter: any) => boolean"
+              "(filter: ",
+              "Filter",
+              ") => boolean"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
             "deprecated": false,
@@ -34835,12 +35977,16 @@
               {
                 "parentPluginId": "data",
                 "id": "def-server.filter",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "{ $state?: { store: ",
+                  "FilterStateStore",
+                  "; } | undefined; meta: ",
+                  "FilterMeta",
+                  "; query?: any; }"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
                 "deprecated": false
@@ -35015,9 +36161,15 @@
             "label": "buildQueryFromFilters",
             "description": [],
             "signature": [
-              "(filters: any[] | undefined, indexPattern: ",
+              "(filters: ",
+              "Filter",
+              "[] | undefined, indexPattern: ",
               "IndexPatternBase",
-              " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: any[]; should: never[]; must_not: any[]; }"
+              " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: ",
+              "Filter",
+              "[]; should: never[]; must_not: ",
+              "Filter",
+              "[]; }"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
             "deprecated": false,
@@ -35031,7 +36183,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[] | undefined"
+                  "Filter",
+                  "[] | undefined"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/es_query/from_filters.d.ts",
                 "deprecated": false
@@ -35105,11 +36258,23 @@
             "signature": [
               "(indexPattern: ",
               "IndexPatternBase",
-              " | undefined, queries: any, filters: any, config?: ",
+              " | undefined, queries: ",
+              "Query",
+              " | ",
+              "Query",
+              "[], filters: ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[], config?: ",
               "EsQueryConfig",
               " | undefined) => { bool: { must: ",
               "DslQuery",
-              "[]; filter: any[]; should: never[]; must_not: any[]; }; }"
+              "[]; filter: ",
+              "Filter",
+              "[]; should: never[]; must_not: ",
+              "Filter",
+              "[]; }; }"
             ],
             "path": "src/plugins/data/server/deprecated.ts",
             "deprecated": false,
@@ -35132,12 +36297,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-server.queries",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "queries",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Query",
+                  " | ",
+                  "Query",
+                  "[]"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/es_query/build_es_query.d.ts",
                 "deprecated": false
@@ -35145,12 +36313,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-server.filters",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " | ",
+                  "Filter",
+                  "[]"
                 ],
                 "path": "node_modules/@kbn/es-query/target_types/es_query/build_es_query.d.ts",
                 "deprecated": false
@@ -36615,7 +37786,8 @@
         "signature": [
           "(indexPatternString: string, queryDsl: any, disabled: boolean, negate: boolean, alias: string | null, store: ",
           "FilterStateStore",
-          ") => any"
+          ") => ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -36629,7 +37801,7 @@
             "tags": [],
             "label": "indexPatternString",
             "description": [],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
             "deprecated": false
           },
           {
@@ -36642,7 +37814,7 @@
             "signature": [
               "any"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
             "deprecated": false
           },
           {
@@ -36652,7 +37824,7 @@
             "tags": [],
             "label": "disabled",
             "description": [],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
             "deprecated": false
           },
           {
@@ -36662,7 +37834,7 @@
             "tags": [],
             "label": "negate",
             "description": [],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
             "deprecated": false
           },
           {
@@ -36675,7 +37847,7 @@
             "signature": [
               "string | null"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
             "deprecated": false
           },
           {
@@ -36688,7 +37860,51 @@
             "signature": [
               "FilterStateStore"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/custom_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.buildEmptyFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "buildEmptyFilter",
+        "description": [],
+        "signature": [
+          "(isPinned: boolean, index?: string | undefined) => ",
+          "Filter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.isPinned",
+            "type": "boolean",
+            "tags": [],
+            "label": "isPinned",
+            "description": [],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_empty_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.index",
+            "type": "string",
+            "tags": [],
+            "label": "index",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_empty_filter.d.ts",
             "deprecated": false
           }
         ],
@@ -36706,11 +37922,23 @@
         "signature": [
           "(indexPattern: ",
           "IndexPatternBase",
-          " | undefined, queries: any, filters: any, config?: ",
+          " | undefined, queries: ",
+          "Query",
+          " | ",
+          "Query",
+          "[], filters: ",
+          "Filter",
+          " | ",
+          "Filter",
+          "[], config?: ",
           "EsQueryConfig",
           " | undefined) => { bool: { must: ",
           "DslQuery",
-          "[]; filter: any[]; should: never[]; must_not: any[]; }; }"
+          "[]; filter: ",
+          "Filter",
+          "[]; should: never[]; must_not: ",
+          "Filter",
+          "[]; }; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -36734,12 +37962,15 @@
           {
             "parentPluginId": "data",
             "id": "def-common.queries",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "queries",
             "description": [],
             "signature": [
-              "any"
+              "Query",
+              " | ",
+              "Query",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/es_query/build_es_query.d.ts",
             "deprecated": false
@@ -36747,12 +37978,15 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filters",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "filters",
             "description": [],
             "signature": [
-              "any"
+              "Filter",
+              " | ",
+              "Filter",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/es_query/build_es_query.d.ts",
             "deprecated": false
@@ -36776,6 +38010,57 @@
       },
       {
         "parentPluginId": "data",
+        "id": "def-common.buildExistsFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "buildExistsFilter",
+        "description": [],
+        "signature": [
+          "(field: ",
+          "IndexPatternFieldBase",
+          ", indexPattern: ",
+          "IndexPatternBase",
+          ") => ",
+          "ExistsFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.field",
+            "type": "Object",
+            "tags": [],
+            "label": "field",
+            "description": [],
+            "signature": [
+              "IndexPatternFieldBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.indexPattern",
+            "type": "Object",
+            "tags": [],
+            "label": "indexPattern",
+            "description": [],
+            "signature": [
+              "IndexPatternBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
         "id": "def-common.buildFilter",
         "type": "Function",
         "tags": [
@@ -36792,7 +38077,8 @@
           "FILTERS",
           ", negate: boolean, disabled: boolean, params: any, alias: string | null, store?: ",
           "FilterStateStore",
-          " | undefined) => any"
+          " | undefined) => ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -36809,7 +38095,7 @@
             "signature": [
               "IndexPatternBase"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36822,7 +38108,7 @@
             "signature": [
               "IndexPatternFieldBase"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36835,7 +38121,7 @@
             "signature": [
               "FILTERS"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36845,7 +38131,7 @@
             "tags": [],
             "label": "negate",
             "description": [],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36855,7 +38141,7 @@
             "tags": [],
             "label": "disabled",
             "description": [],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36868,7 +38154,7 @@
             "signature": [
               "any"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36881,7 +38167,7 @@
             "signature": [
               "string | null"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
             "deprecated": false
           },
           {
@@ -36895,7 +38181,189 @@
               "FilterStateStore",
               " | undefined"
             ],
-            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters.d.ts",
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/build_filters.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.buildPhraseFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "buildPhraseFilter",
+        "description": [],
+        "signature": [
+          "(field: ",
+          "IndexPatternFieldBase",
+          ", value: PhraseFilterValue, indexPattern: ",
+          "IndexPatternBase",
+          ") => ",
+          "PhraseFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.field",
+            "type": "Object",
+            "tags": [],
+            "label": "field",
+            "description": [],
+            "signature": [
+              "IndexPatternFieldBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.value",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "value",
+            "description": [],
+            "signature": [
+              "string | number | boolean"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.indexPattern",
+            "type": "Object",
+            "tags": [],
+            "label": "indexPattern",
+            "description": [],
+            "signature": [
+              "IndexPatternBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.buildPhrasesFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "buildPhrasesFilter",
+        "description": [],
+        "signature": [
+          "(field: ",
+          "IndexPatternFieldBase",
+          ", params: string[], indexPattern: ",
+          "IndexPatternBase",
+          ") => ",
+          "PhrasesFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.field",
+            "type": "Object",
+            "tags": [],
+            "label": "field",
+            "description": [],
+            "signature": [
+              "IndexPatternFieldBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.params",
+            "type": "Array",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              "string[]"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.indexPattern",
+            "type": "Object",
+            "tags": [],
+            "label": "indexPattern",
+            "description": [],
+            "signature": [
+              "IndexPatternBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.buildQueryFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "buildQueryFilter",
+        "description": [],
+        "signature": [
+          "(query: any, index: string, alias: string) => ",
+          "QueryStringFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.query",
+            "type": "Any",
+            "tags": [],
+            "label": "query",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.index",
+            "type": "string",
+            "tags": [],
+            "label": "index",
+            "description": [],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.alias",
+            "type": "string",
+            "tags": [],
+            "label": "alias",
+            "description": [],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
             "deprecated": false
           }
         ],
@@ -36911,9 +38379,15 @@
         "label": "buildQueryFromFilters",
         "description": [],
         "signature": [
-          "(filters: any[] | undefined, indexPattern: ",
+          "(filters: ",
+          "Filter",
+          "[] | undefined, indexPattern: ",
           "IndexPatternBase",
-          " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: any[]; should: never[]; must_not: any[]; }"
+          " | undefined, ignoreFilterIfFieldNotInIndex?: boolean | undefined) => { must: never[]; filter: ",
+          "Filter",
+          "[]; should: never[]; must_not: ",
+          "Filter",
+          "[]; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -36928,7 +38402,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "node_modules/@kbn/es-query/target_types/es_query/from_filters.d.ts",
             "deprecated": false
@@ -36958,6 +38433,85 @@
               "boolean | undefined"
             ],
             "path": "node_modules/@kbn/es-query/target_types/es_query/from_filters.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.buildRangeFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "buildRangeFilter",
+        "description": [],
+        "signature": [
+          "(field: ",
+          "IndexPatternFieldBase",
+          ", params: ",
+          "RangeFilterParams",
+          ", indexPattern: ",
+          "IndexPatternBase",
+          ", formattedValue?: string | undefined) => ",
+          "RangeFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.field",
+            "type": "Object",
+            "tags": [],
+            "label": "field",
+            "description": [],
+            "signature": [
+              "IndexPatternFieldBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.params",
+            "type": "Object",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              "RangeFilterParams"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.indexPattern",
+            "type": "Object",
+            "tags": [],
+            "label": "indexPattern",
+            "description": [],
+            "signature": [
+              "IndexPatternBase"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.formattedValue",
+            "type": "string",
+            "tags": [],
+            "label": "formattedValue",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
             "deprecated": false
           }
         ],
@@ -37053,7 +38607,15 @@
         "label": "compareFilters",
         "description": [],
         "signature": [
-          "(first: any, second: any, comparatorOptions?: ",
+          "(first: ",
+          "Filter",
+          " | ",
+          "Filter",
+          "[], second: ",
+          "Filter",
+          " | ",
+          "Filter",
+          "[], comparatorOptions?: ",
           "FilterCompareOptions",
           " | undefined) => boolean"
         ],
@@ -37065,12 +38627,15 @@
           {
             "parentPluginId": "data",
             "id": "def-common.first",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "first",
             "description": [],
             "signature": [
-              "any"
+              "Filter",
+              " | ",
+              "Filter",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/compare_filters.d.ts",
             "deprecated": false
@@ -37078,12 +38643,15 @@
           {
             "parentPluginId": "data",
             "id": "def-common.second",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "second",
             "description": [],
             "signature": [
-              "any"
+              "Filter",
+              " | ",
+              "Filter",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/compare_filters.d.ts",
             "deprecated": false
@@ -37289,9 +38857,15 @@
         "label": "dedupFilters",
         "description": [],
         "signature": [
-          "(existingFilters: any[], filters: any[], comparatorOptions?: ",
+          "(existingFilters: ",
+          "Filter",
+          "[], filters: ",
+          "Filter",
+          "[], comparatorOptions?: ",
           "FilterCompareOptions",
-          " | undefined) => any[]"
+          " | undefined) => ",
+          "Filter",
+          "[]"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37306,7 +38880,8 @@
             "label": "existingFilters",
             "description": [],
             "signature": [
-              "any[]"
+              "Filter",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/dedup_filters.d.ts",
             "deprecated": false
@@ -37319,7 +38894,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[]"
+              "Filter",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/dedup_filters.d.ts",
             "deprecated": false
@@ -37351,7 +38927,10 @@
         "label": "disableFilter",
         "description": [],
         "signature": [
-          "(filter: any) => any"
+          "(filter: ",
+          "Filter",
+          ") => ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37361,12 +38940,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -37384,7 +38967,10 @@
         "label": "enableFilter",
         "description": [],
         "signature": [
-          "(filter: any) => any"
+          "(filter: ",
+          "Filter",
+          ") => ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37394,12 +38980,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -37564,6 +39154,146 @@
       },
       {
         "parentPluginId": "data",
+        "id": "def-common.getPhraseFilterField",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "getPhraseFilterField",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "PhraseFilter",
+          ") => string"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "Filter",
+              " & { meta: ",
+              "PhraseFilterMeta",
+              "; script?: { script: { source?: string | undefined; lang?: \"painless\" | \"expression\" | \"mustache\" | \"java\" | undefined; params: { [key: string]: PhraseFilterValue; }; }; } | undefined; }"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.getPhraseFilterValue",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "getPhraseFilterValue",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "PhraseFilter",
+          ") => PhraseFilterValue"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "Filter",
+              " & { meta: ",
+              "PhraseFilterMeta",
+              "; script?: { script: { source?: string | undefined; lang?: \"painless\" | \"expression\" | \"mustache\" | \"java\" | undefined; params: { [key: string]: PhraseFilterValue; }; }; } | undefined; }"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isExistsFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isExistsFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "ExistsFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/exists_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
         "id": "def-common.isFilter",
         "type": "Function",
         "tags": [
@@ -37572,7 +39302,8 @@
         "label": "isFilter",
         "description": [],
         "signature": [
-          "(x: unknown) => x is any"
+          "(x: unknown) => x is ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37605,7 +39336,9 @@
         "label": "isFilterDisabled",
         "description": [],
         "signature": [
-          "(filter: any) => boolean"
+          "(filter: ",
+          "Filter",
+          ") => boolean"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37615,12 +39348,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -37638,7 +39375,9 @@
         "label": "isFilterPinned",
         "description": [],
         "signature": [
-          "(filter: any) => boolean | undefined"
+          "(filter: ",
+          "Filter",
+          ") => boolean | undefined"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37648,12 +39387,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -37671,7 +39414,9 @@
         "label": "isFilters",
         "description": [],
         "signature": [
-          "(x: unknown) => x is any[]"
+          "(x: unknown) => x is ",
+          "Filter",
+          "[]"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37698,6 +39443,519 @@
               "unknown"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isGeoBoundingBoxFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isGeoBoundingBoxFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "GeoBoundingBoxFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/geo_bounding_box_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isGeoPolygonFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isGeoPolygonFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "GeoPolygonFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/geo_polygon_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isMatchAllFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isMatchAllFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "MatchAllFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/match_all_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isMissingFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isMissingFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "MissingFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/missing_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isPhraseFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isPhraseFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "PhraseFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrase_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isPhrasesFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isPhrasesFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "PhrasesFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/phrases_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isQueryStringFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isQueryStringFilter",
+        "description": [],
+        "signature": [
+          "(filter: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          ") => filter is ",
+          "QueryStringFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/query_string_filter.d.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.isRangeFilter",
+        "type": "Function",
+        "tags": [
+          "deprecated"
+        ],
+        "label": "isRangeFilter",
+        "description": [],
+        "signature": [
+          "(filter?: ",
+          "RangeFilter",
+          " | ",
+          "ExistsFilter",
+          " | ",
+          "GeoBoundingBoxFilter",
+          " | ",
+          "GeoPolygonFilter",
+          " | ",
+          "PhraseFilter",
+          " | ",
+          "PhrasesFilter",
+          " | ",
+          "MatchAllFilter",
+          " | ",
+          "MissingFilter",
+          " | undefined) => filter is ",
+          "RangeFilter"
+        ],
+        "path": "src/plugins/data/common/es_query/index.ts",
+        "deprecated": true,
+        "references": [],
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.filter",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "filter",
+            "description": [],
+            "signature": [
+              "RangeFilter",
+              " | ",
+              "ExistsFilter",
+              " | ",
+              "GeoBoundingBoxFilter",
+              " | ",
+              "GeoPolygonFilter",
+              " | ",
+              "PhraseFilter",
+              " | ",
+              "PhrasesFilter",
+              " | ",
+              "MatchAllFilter",
+              " | ",
+              "MissingFilter",
+              " | undefined"
+            ],
+            "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/range_filter.d.ts",
             "deprecated": false
           }
         ],
@@ -37747,7 +40005,11 @@
         "label": "onlyDisabledFiltersChanged",
         "description": [],
         "signature": [
-          "(newFilters?: any[] | undefined, oldFilters?: any[] | undefined) => boolean"
+          "(newFilters?: ",
+          "Filter",
+          "[] | undefined, oldFilters?: ",
+          "Filter",
+          "[] | undefined) => boolean"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37762,7 +40024,8 @@
             "label": "newFilters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/only_disabled.d.ts",
             "deprecated": false
@@ -37775,7 +40038,8 @@
             "label": "oldFilters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/only_disabled.d.ts",
             "deprecated": false
@@ -37793,7 +40057,10 @@
         "label": "pinFilter",
         "description": [],
         "signature": [
-          "(filter: any) => any"
+          "(filter: ",
+          "Filter",
+          ") => ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -37803,12 +40070,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -37999,7 +40270,11 @@
         "label": "toggleFilterDisabled",
         "description": [],
         "signature": [
-          "(filter: any) => { meta: { disabled: boolean; alias: string | null; negate: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }; $state?: { store: any; } | undefined; query?: any; }"
+          "(filter: ",
+          "Filter",
+          ") => { meta: { disabled: boolean; alias: string | null; negate: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }; $state?: { store: ",
+          "FilterStateStore",
+          "; } | undefined; query?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -38009,12 +40284,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -38032,7 +40311,11 @@
         "label": "toggleFilterNegated",
         "description": [],
         "signature": [
-          "(filter: any) => { meta: { negate: boolean; alias: string | null; disabled: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }; $state?: { store: any; } | undefined; query?: any; }"
+          "(filter: ",
+          "Filter",
+          ") => { meta: { negate: boolean; alias: string | null; disabled: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }; $state?: { store: ",
+          "FilterStateStore",
+          "; } | undefined; query?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -38042,12 +40325,16 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filter",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "{ $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; }"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/meta_filter.d.ts",
             "deprecated": false
@@ -38065,7 +40352,11 @@
         "label": "uniqFilters",
         "description": [],
         "signature": [
-          "(filters: any[], comparatorOptions?: any) => any[]"
+          "(filters: ",
+          "Filter",
+          "[], comparatorOptions?: any) => ",
+          "Filter",
+          "[]"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -38080,7 +40371,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[]"
+              "Filter",
+              "[]"
             ],
             "path": "node_modules/@kbn/es-query/target_types/filters/helpers/uniq_filters.d.ts",
             "deprecated": false
@@ -38462,108 +40754,6 @@
     "misc": [
       {
         "parentPluginId": "data",
-        "id": "def-common.buildEmptyFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "buildEmptyFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.buildExistsFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "buildExistsFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.buildPhraseFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "buildPhraseFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.buildPhrasesFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "buildPhrasesFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.buildQueryFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "buildQueryFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.buildRangeFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "buildRangeFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
         "id": "def-common.CSV_FORMULA_CHARS",
         "type": "Array",
         "tags": [],
@@ -38600,7 +40790,8 @@
         "label": "CustomFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { query: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -38665,7 +40856,10 @@
         "label": "ExistsFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "FilterMeta",
+          "; exists?: { field: string; } | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -38703,7 +40897,11 @@
         "label": "Filter",
         "description": [],
         "signature": [
-          "any"
+          "{ $state?: { store: ",
+          "FilterStateStore",
+          "; } | undefined; meta: ",
+          "FilterMeta",
+          "; query?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -40453,7 +42651,7 @@
         "label": "FilterMeta",
         "description": [],
         "signature": [
-          "any"
+          "{ alias: string | null; disabled: boolean; negate: boolean; controlledBy?: string | undefined; index?: string | undefined; isMultiIndex?: boolean | undefined; type?: string | undefined; key?: string | undefined; params?: any; value?: string | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -40479,7 +42677,10 @@
         "label": "GeoBoundingBoxFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "GeoBoundingBoxFilterMeta",
+          "; geo_bounding_box: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -40496,7 +42697,10 @@
         "label": "GeoPolygonFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "GeoPolygonFilterMeta",
+          "; geo_polygon: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -40547,40 +42751,6 @@
       },
       {
         "parentPluginId": "data",
-        "id": "def-common.getPhraseFilterField",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "getPhraseFilterField",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.getPhraseFilterValue",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "getPhraseFilterValue",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
         "id": "def-common.IFieldSubType",
         "type": "Type",
         "tags": [
@@ -40617,159 +42787,6 @@
         ],
         "path": "src/plugins/data/common/constants.ts",
         "deprecated": false,
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isExistsFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isExistsFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isGeoBoundingBoxFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isGeoBoundingBoxFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isGeoPolygonFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isGeoPolygonFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isMatchAllFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isMatchAllFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isMissingFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isMissingFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isPhraseFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isPhraseFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isPhrasesFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isPhrasesFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isQueryStringFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isQueryStringFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "data",
-        "id": "def-common.isRangeFilter",
-        "type": "Any",
-        "tags": [
-          "deprecated"
-        ],
-        "label": "isRangeFilter",
-        "description": [],
-        "signature": [
-          "any"
-        ],
-        "path": "src/plugins/data/common/es_query/index.ts",
-        "deprecated": true,
-        "references": [],
         "initialIsOpen": false
       },
       {
@@ -41118,7 +43135,10 @@
         "label": "MatchAllFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "MatchAllFilterMeta",
+          "; match_all: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -41144,7 +43164,10 @@
         "label": "MissingFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "FilterMeta",
+          "; missing: { field: string; }; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -41161,7 +43184,10 @@
         "label": "PhraseFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "PhraseFilterMeta",
+          "; script?: { script: { source?: string | undefined; lang?: \"painless\" | \"expression\" | \"mustache\" | \"java\" | undefined; params: { [key: string]: PhraseFilterValue; }; }; } | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -41178,11 +43204,28 @@
         "label": "PhrasesFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & { meta: ",
+          "PhrasesFilterMeta",
+          "; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
         "references": [],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "data",
+        "id": "def-common.Query",
+        "type": "Type",
+        "tags": [],
+        "label": "Query",
+        "description": [],
+        "signature": [
+          "{ query: string | { [key: string]: any; }; language: string; }"
+        ],
+        "path": "node_modules/@kbn/es-query/target_types/filters/build_filters/types.d.ts",
+        "deprecated": false,
         "initialIsOpen": false
       },
       {
@@ -41195,7 +43238,14 @@
         "label": "RangeFilter",
         "description": [],
         "signature": [
-          "any"
+          "Filter",
+          " & ",
+          "EsRangeFilter",
+          " & { meta: ",
+          "RangeFilterMeta",
+          "; script?: { script: { params: any; lang: ",
+          "ScriptLanguage",
+          "; source: string; }; } | undefined; match_all?: any; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -41221,7 +43271,10 @@
         "label": "RangeFilterMeta",
         "description": [],
         "signature": [
-          "any"
+          "FilterMeta",
+          " & { params: ",
+          "RangeFilterParams",
+          "; field?: string | undefined; formattedValue?: string | undefined; }"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,
@@ -41238,7 +43291,7 @@
         "label": "RangeFilterParams",
         "description": [],
         "signature": [
-          "any"
+          "RangeFilterParams"
         ],
         "path": "src/plugins/data/common/es_query/index.ts",
         "deprecated": true,

--- a/api_docs/data.mdx
+++ b/api_docs/data.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Client
 

--- a/api_docs/data.mdx
+++ b/api_docs/data.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Client
 

--- a/api_docs/data_autocomplete.json
+++ b/api_docs/data_autocomplete.json
@@ -381,6 +381,28 @@
         ],
         "path": "src/plugins/data/public/autocomplete/providers/query_suggestion_provider.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-public.args",
+            "type": "Object",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "data",
+                "scope": "public",
+                "docId": "kibDataAutocompletePluginApi",
+                "section": "def-public.QuerySuggestionGetFnArgs",
+                "text": "QuerySuggestionGetFnArgs"
+              }
+            ],
+            "path": "src/plugins/data/public/autocomplete/providers/query_suggestion_provider.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/data_autocomplete.mdx
+++ b/api_docs/data_autocomplete.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Client
 

--- a/api_docs/data_autocomplete.mdx
+++ b/api_docs/data_autocomplete.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Client
 

--- a/api_docs/data_field_formats.json
+++ b/api_docs/data_field_formats.json
@@ -3598,6 +3598,32 @@
         ],
         "path": "src/plugins/data/common/field_formats/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.key",
+            "type": "string",
+            "tags": [],
+            "label": "key",
+            "description": [],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.defaultOverride",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "defaultOverride",
+            "description": [],
+            "signature": [
+              "T | undefined"
+            ],
+            "path": "src/plugins/data/common/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/data_field_formats.mdx
+++ b/api_docs/data_field_formats.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Client
 

--- a/api_docs/data_field_formats.mdx
+++ b/api_docs/data_field_formats.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Client
 

--- a/api_docs/data_index_patterns.json
+++ b/api_docs/data_index_patterns.json
@@ -5712,7 +5712,67 @@
               ") | undefined"
             ],
             "path": "src/plugins/data/common/index_patterns/fields/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.IFieldType.toSpec.$1.options",
+                "type": "Object",
+                "tags": [],
+                "label": "options",
+                "description": [],
+                "path": "src/plugins/data/common/index_patterns/fields/types.ts",
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "data",
+                    "id": "def-common.IFieldType.toSpec.$1.options.getFormatterForField",
+                    "type": "Function",
+                    "tags": [],
+                    "label": "getFormatterForField",
+                    "description": [],
+                    "signature": [
+                      "((field: ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.IFieldType",
+                        "text": "IFieldType"
+                      },
+                      " | ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.IndexPatternField",
+                        "text": "IndexPatternField"
+                      },
+                      " | ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataIndexPatternsPluginApi",
+                        "section": "def-common.FieldSpec",
+                        "text": "FieldSpec"
+                      },
+                      ") => ",
+                      {
+                        "pluginId": "data",
+                        "scope": "common",
+                        "docId": "kibDataFieldFormatsPluginApi",
+                        "section": "def-common.FieldFormat",
+                        "text": "FieldFormat"
+                      },
+                      ") | undefined"
+                    ],
+                    "path": "src/plugins/data/common/index_patterns/fields/types.ts",
+                    "deprecated": false
+                  }
+                ]
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -5741,18 +5801,6 @@
         "deprecated": true,
         "references": [
           {
-            "plugin": "savedObjects",
-            "path": "src/plugins/saved_objects/public/types.ts"
-          },
-          {
-            "plugin": "savedObjects",
-            "path": "src/plugins/saved_objects/public/types.ts"
-          },
-          {
-            "plugin": "savedObjects",
-            "path": "src/plugins/saved_objects/public/types.ts"
-          },
-          {
             "plugin": "observability",
             "path": "x-pack/plugins/observability/public/components/shared/exploratory_view/types.ts"
           },
@@ -6471,14 +6519,6 @@
           {
             "plugin": "observability",
             "path": "x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/utils.ts"
-          },
-          {
-            "plugin": "maps",
-            "path": "x-pack/plugins/maps/public/embeddable/types.ts"
-          },
-          {
-            "plugin": "maps",
-            "path": "x-pack/plugins/maps/public/embeddable/types.ts"
           },
           {
             "plugin": "ml",
@@ -6741,7 +6781,46 @@
               ") | undefined"
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.IIndexPattern.getFormatterForField.$1",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.IFieldType",
+                    "text": "IFieldType"
+                  },
+                  " | ",
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.IndexPatternField",
+                    "text": "IndexPatternField"
+                  },
+                  " | ",
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.FieldSpec",
+                    "text": "FieldSpec"
+                  }
+                ],
+                "path": "src/plugins/data/common/index_patterns/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -7211,11 +7290,10 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.options",
+                "id": "def-common.IIndexPatternsApiClient.getFieldsForTimePattern.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -7230,9 +7308,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -7254,11 +7334,10 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.options",
+                "id": "def-common.IIndexPatternsApiClient.getFieldsForWildcard.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -7273,9 +7352,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -7780,11 +7861,10 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.options",
+                "id": "def-common.SavedObjectsClientCommon.find.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -7799,9 +7879,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -7817,29 +7899,37 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.type",
+                "id": "def-common.SavedObjectsClientCommon.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.id",
+                "id": "def-common.SavedObjectsClientCommon.get.$2",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -7855,55 +7945,65 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.type",
+                "id": "def-common.SavedObjectsClientCommon.update.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.id",
+                "id": "def-common.SavedObjectsClientCommon.update.$2",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.attributes",
+                "id": "def-common.SavedObjectsClientCommon.update.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "attributes",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.options",
+                "id": "def-common.SavedObjectsClientCommon.update.$4",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -7919,45 +8019,51 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.type",
+                "id": "def-common.SavedObjectsClientCommon.create.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.attributes",
+                "id": "def-common.SavedObjectsClientCommon.create.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "attributes",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.options",
+                "id": "def-common.SavedObjectsClientCommon.create.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -7971,29 +8077,37 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.type",
+                "id": "def-common.SavedObjectsClientCommon.delete.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.id",
+                "id": "def-common.SavedObjectsClientCommon.delete.$2",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8160,19 +8274,23 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.UiSettingsCommon.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -8186,8 +8304,8 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -8201,21 +8319,24 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.UiSettingsCommon.set.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.value",
+                "id": "def-common.UiSettingsCommon.set.$2",
                 "type": "Any",
                 "tags": [],
                 "label": "value",
@@ -8224,9 +8345,11 @@
                   "any"
                 ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -8240,19 +8363,23 @@
             ],
             "path": "src/plugins/data/common/index_patterns/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.UiSettingsCommon.remove.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/index_patterns/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8585,6 +8712,41 @@
         ],
         "path": "src/plugins/data/common/index_patterns/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.error",
+            "type": "Object",
+            "tags": [],
+            "label": "error",
+            "description": [],
+            "signature": [
+              "Error"
+            ],
+            "path": "src/plugins/data/common/index_patterns/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.toastInputFields",
+            "type": "Object",
+            "tags": [],
+            "label": "toastInputFields",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "public",
+                "docId": "kibCorePluginApi",
+                "section": "def-public.ErrorToastOptions",
+                "text": "ErrorToastOptions"
+              }
+            ],
+            "path": "src/plugins/data/common/index_patterns/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -8607,6 +8769,40 @@
         ],
         "path": "src/plugins/data/common/index_patterns/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.toastInputFields",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "toastInputFields",
+            "description": [],
+            "signature": [
+              "Pick<",
+              "Toast",
+              ", \"children\" | \"onClick\" | \"onChange\" | \"color\" | \"onKeyDown\" | \"defaultChecked\" | \"defaultValue\" | \"suppressContentEditableWarning\" | \"suppressHydrationWarning\" | \"accessKey\" | \"className\" | \"contentEditable\" | \"contextMenu\" | \"dir\" | \"draggable\" | \"hidden\" | \"lang\" | \"placeholder\" | \"slot\" | \"spellCheck\" | \"style\" | \"tabIndex\" | \"translate\" | \"radioGroup\" | \"role\" | \"about\" | \"datatype\" | \"inlist\" | \"prefix\" | \"property\" | \"resource\" | \"typeof\" | \"vocab\" | \"autoCapitalize\" | \"autoCorrect\" | \"autoSave\" | \"itemProp\" | \"itemScope\" | \"itemType\" | \"itemID\" | \"itemRef\" | \"results\" | \"security\" | \"unselectable\" | \"inputMode\" | \"is\" | \"aria-activedescendant\" | \"aria-atomic\" | \"aria-autocomplete\" | \"aria-busy\" | \"aria-checked\" | \"aria-colcount\" | \"aria-colindex\" | \"aria-colspan\" | \"aria-controls\" | \"aria-current\" | \"aria-describedby\" | \"aria-details\" | \"aria-disabled\" | \"aria-dropeffect\" | \"aria-errormessage\" | \"aria-expanded\" | \"aria-flowto\" | \"aria-grabbed\" | \"aria-haspopup\" | \"aria-hidden\" | \"aria-invalid\" | \"aria-keyshortcuts\" | \"aria-label\" | \"aria-labelledby\" | \"aria-level\" | \"aria-live\" | \"aria-modal\" | \"aria-multiline\" | \"aria-multiselectable\" | \"aria-orientation\" | \"aria-owns\" | \"aria-placeholder\" | \"aria-posinset\" | \"aria-pressed\" | \"aria-readonly\" | \"aria-relevant\" | \"aria-required\" | \"aria-roledescription\" | \"aria-rowcount\" | \"aria-rowindex\" | \"aria-rowspan\" | \"aria-selected\" | \"aria-setsize\" | \"aria-sort\" | \"aria-valuemax\" | \"aria-valuemin\" | \"aria-valuenow\" | \"aria-valuetext\" | \"dangerouslySetInnerHTML\" | \"onCopy\" | \"onCopyCapture\" | \"onCut\" | \"onCutCapture\" | \"onPaste\" | \"onPasteCapture\" | \"onCompositionEnd\" | \"onCompositionEndCapture\" | \"onCompositionStart\" | \"onCompositionStartCapture\" | \"onCompositionUpdate\" | \"onCompositionUpdateCapture\" | \"onFocus\" | \"onFocusCapture\" | \"onBlur\" | \"onBlurCapture\" | \"onChangeCapture\" | \"onBeforeInput\" | \"onBeforeInputCapture\" | \"onInput\" | \"onInputCapture\" | \"onReset\" | \"onResetCapture\" | \"onSubmit\" | \"onSubmitCapture\" | \"onInvalid\" | \"onInvalidCapture\" | \"onLoad\" | \"onLoadCapture\" | \"onError\" | \"onErrorCapture\" | \"onKeyDownCapture\" | \"onKeyPress\" | \"onKeyPressCapture\" | \"onKeyUp\" | \"onKeyUpCapture\" | \"onAbort\" | \"onAbortCapture\" | \"onCanPlay\" | \"onCanPlayCapture\" | \"onCanPlayThrough\" | \"onCanPlayThroughCapture\" | \"onDurationChange\" | \"onDurationChangeCapture\" | \"onEmptied\" | \"onEmptiedCapture\" | \"onEncrypted\" | \"onEncryptedCapture\" | \"onEnded\" | \"onEndedCapture\" | \"onLoadedData\" | \"onLoadedDataCapture\" | \"onLoadedMetadata\" | \"onLoadedMetadataCapture\" | \"onLoadStart\" | \"onLoadStartCapture\" | \"onPause\" | \"onPauseCapture\" | \"onPlay\" | \"onPlayCapture\" | \"onPlaying\" | \"onPlayingCapture\" | \"onProgress\" | \"onProgressCapture\" | \"onRateChange\" | \"onRateChangeCapture\" | \"onSeeked\" | \"onSeekedCapture\" | \"onSeeking\" | \"onSeekingCapture\" | \"onStalled\" | \"onStalledCapture\" | \"onSuspend\" | \"onSuspendCapture\" | \"onTimeUpdate\" | \"onTimeUpdateCapture\" | \"onVolumeChange\" | \"onVolumeChangeCapture\" | \"onWaiting\" | \"onWaitingCapture\" | \"onAuxClick\" | \"onAuxClickCapture\" | \"onClickCapture\" | \"onContextMenu\" | \"onContextMenuCapture\" | \"onDoubleClick\" | \"onDoubleClickCapture\" | \"onDrag\" | \"onDragCapture\" | \"onDragEnd\" | \"onDragEndCapture\" | \"onDragEnter\" | \"onDragEnterCapture\" | \"onDragExit\" | \"onDragExitCapture\" | \"onDragLeave\" | \"onDragLeaveCapture\" | \"onDragOver\" | \"onDragOverCapture\" | \"onDragStart\" | \"onDragStartCapture\" | \"onDrop\" | \"onDropCapture\" | \"onMouseDown\" | \"onMouseDownCapture\" | \"onMouseEnter\" | \"onMouseLeave\" | \"onMouseMove\" | \"onMouseMoveCapture\" | \"onMouseOut\" | \"onMouseOutCapture\" | \"onMouseOver\" | \"onMouseOverCapture\" | \"onMouseUp\" | \"onMouseUpCapture\" | \"onSelect\" | \"onSelectCapture\" | \"onTouchCancel\" | \"onTouchCancelCapture\" | \"onTouchEnd\" | \"onTouchEndCapture\" | \"onTouchMove\" | \"onTouchMoveCapture\" | \"onTouchStart\" | \"onTouchStartCapture\" | \"onPointerDown\" | \"onPointerDownCapture\" | \"onPointerMove\" | \"onPointerMoveCapture\" | \"onPointerUp\" | \"onPointerUpCapture\" | \"onPointerCancel\" | \"onPointerCancelCapture\" | \"onPointerEnter\" | \"onPointerEnterCapture\" | \"onPointerLeave\" | \"onPointerLeaveCapture\" | \"onPointerOver\" | \"onPointerOverCapture\" | \"onPointerOut\" | \"onPointerOutCapture\" | \"onGotPointerCapture\" | \"onGotPointerCaptureCapture\" | \"onLostPointerCapture\" | \"onLostPointerCaptureCapture\" | \"onScroll\" | \"onScrollCapture\" | \"onWheel\" | \"onWheelCapture\" | \"onAnimationStart\" | \"onAnimationStartCapture\" | \"onAnimationEnd\" | \"onAnimationEndCapture\" | \"onAnimationIteration\" | \"onAnimationIterationCapture\" | \"onTransitionEnd\" | \"onTransitionEndCapture\" | \"toastLifeTimeMs\" | \"iconType\" | \"onClose\" | \"data-test-subj\"> & { title?: string | ",
+              {
+                "pluginId": "core",
+                "scope": "public",
+                "docId": "kibCorePluginApi",
+                "section": "def-public.MountPoint",
+                "text": "MountPoint"
+              },
+              "<HTMLElement> | undefined; text?: string | ",
+              {
+                "pluginId": "core",
+                "scope": "public",
+                "docId": "kibCorePluginApi",
+                "section": "def-public.MountPoint",
+                "text": "MountPoint"
+              },
+              "<HTMLElement> | undefined; }"
+            ],
+            "path": "src/plugins/data/common/index_patterns/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/data_index_patterns.mdx
+++ b/api_docs/data_index_patterns.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Server
 

--- a/api_docs/data_index_patterns.mdx
+++ b/api_docs/data_index_patterns.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Server
 

--- a/api_docs/data_query.json
+++ b/api_docs/data_query.json
@@ -82,7 +82,9 @@
             "label": "getFilters",
             "description": [],
             "signature": [
-              "() => any[]"
+              "() => ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -97,7 +99,9 @@
             "label": "getAppFilters",
             "description": [],
             "signature": [
-              "() => any[]"
+              "() => ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -112,7 +116,9 @@
             "label": "getGlobalFilters",
             "description": [],
             "signature": [
-              "() => any[]"
+              "() => ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -177,7 +183,11 @@
             "label": "addFilters",
             "description": [],
             "signature": [
-              "(filters: any, pinFilterStatus?: boolean) => void"
+              "(filters: ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[], pinFilterStatus?: boolean) => void"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -185,12 +195,15 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.FilterManager.addFilters.$1",
-                "type": "Any",
+                "type": "CompoundType",
                 "tags": [],
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter",
+                  " | ",
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
                 "deprecated": false,
@@ -221,7 +234,9 @@
             "label": "setFilters",
             "description": [],
             "signature": [
-              "(newFilters: any[], pinFilterStatus?: boolean) => void"
+              "(newFilters: ",
+              "Filter",
+              "[], pinFilterStatus?: boolean) => void"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -234,7 +249,8 @@
                 "label": "newFilters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
                 "deprecated": false,
@@ -267,7 +283,9 @@
               "\nSets new global filters and leaves app filters untouched,\nRemoves app filters for which there is a duplicate within new global filters"
             ],
             "signature": [
-              "(newGlobalFilters: any[]) => void"
+              "(newGlobalFilters: ",
+              "Filter",
+              "[]) => void"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -280,7 +298,8 @@
                 "label": "newGlobalFilters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
                 "deprecated": false,
@@ -299,7 +318,9 @@
               "\nSets new app filters and leaves global filters untouched,\nRemoves app filters for which there is a duplicate within new global filters"
             ],
             "signature": [
-              "(newAppFilters: any[]) => void"
+              "(newAppFilters: ",
+              "Filter",
+              "[]) => void"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -312,7 +333,8 @@
                 "label": "newAppFilters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
                 "deprecated": false,
@@ -329,7 +351,9 @@
             "label": "removeFilter",
             "description": [],
             "signature": [
-              "(filter: any) => void"
+              "(filter: ",
+              "Filter",
+              ") => void"
             ],
             "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
             "deprecated": false,
@@ -337,12 +361,12 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.FilterManager.removeFilter.$1",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "filter",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Filter"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
                 "deprecated": false,
@@ -374,7 +398,9 @@
             "label": "setFiltersStore",
             "description": [],
             "signature": [
-              "(filters: any[], store: ",
+              "(filters: ",
+              "Filter",
+              "[], store: ",
               "FilterStateStore",
               ", shouldOverrideStore?: boolean) => void"
             ],
@@ -389,7 +415,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "src/plugins/data/public/query/filter_manager/filter_manager.ts",
                 "deprecated": false,
@@ -678,7 +705,9 @@
             "section": "def-public.QueryState",
             "text": "QueryState"
           },
-          ">({ timefilter: { timefilter }, filterManager, queryString, state$, }: Pick<{ addToQueryLog: (appName: string, { language, query }: any) => void; filterManager: ",
+          ">({ timefilter: { timefilter }, filterManager, queryString, state$, }: Pick<{ addToQueryLog: (appName: string, { language, query }: ",
+          "Query",
+          ") => void; filterManager: ",
           {
             "pluginId": "data",
             "scope": "public",
@@ -734,7 +763,11 @@
           },
           " | undefined) => { bool: { must: ",
           "DslQuery",
-          "[]; filter: any[]; should: never[]; must_not: any[]; }; }; } | { filterManager: ",
+          "[]; filter: ",
+          "Filter",
+          "[]; should: never[]; must_not: ",
+          "Filter",
+          "[]; }; }; } | { filterManager: ",
           {
             "pluginId": "data",
             "scope": "public",
@@ -787,7 +820,9 @@
             "label": "{\n    timefilter: { timefilter },\n    filterManager,\n    queryString,\n    state$,\n  }",
             "description": [],
             "signature": [
-              "Pick<{ addToQueryLog: (appName: string, { language, query }: any) => void; filterManager: ",
+              "Pick<{ addToQueryLog: (appName: string, { language, query }: ",
+              "Query",
+              ") => void; filterManager: ",
               {
                 "pluginId": "data",
                 "scope": "public",
@@ -843,7 +878,11 @@
               },
               " | undefined) => { bool: { must: ",
               "DslQuery",
-              "[]; filter: any[]; should: never[]; must_not: any[]; }; }; } | { filterManager: ",
+              "[]; filter: ",
+              "Filter",
+              "[]; should: never[]; must_not: ",
+              "Filter",
+              "[]; }; }; } | { filterManager: ",
               {
                 "pluginId": "data",
                 "scope": "public",
@@ -1034,7 +1073,11 @@
         "label": "extractTimeRange",
         "description": [],
         "signature": [
-          "(filters: any[], timeFieldName: string | undefined) => { restOfFilters: any[]; timeRange?: ",
+          "(filters: ",
+          "Filter",
+          "[], timeFieldName: string | undefined) => { restOfFilters: ",
+          "Filter",
+          "[]; timeRange?: ",
           {
             "pluginId": "data",
             "scope": "common",
@@ -1055,7 +1098,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[]"
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/public/query/timefilter/lib/extract_time_filter.ts",
             "deprecated": false,
@@ -1105,7 +1149,9 @@
             "section": "def-common.IFieldType",
             "text": "IFieldType"
           },
-          ", values: any, operation: string, index: string) => any[]"
+          ", values: any, operation: string, index: string) => ",
+          "Filter",
+          "[]"
         ],
         "path": "src/plugins/data/public/query/filter_manager/lib/generate_filters.ts",
         "deprecated": false,
@@ -1252,7 +1298,9 @@
         "label": "getDisplayValueFromFilter",
         "description": [],
         "signature": [
-          "(filter: any, indexPatterns: ",
+          "(filter: ",
+          "Filter",
+          ", indexPatterns: ",
           {
             "pluginId": "data",
             "scope": "common",
@@ -1268,12 +1316,12 @@
           {
             "parentPluginId": "data",
             "id": "def-public.getDisplayValueFromFilter.$1",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "filter",
             "description": [],
             "signature": [
-              "any"
+              "Filter"
             ],
             "path": "src/plugins/data/public/query/filter_manager/lib/get_display_value.ts",
             "deprecated": false,
@@ -1314,7 +1362,9 @@
           "\nHelper to setup syncing of global data with the URL"
         ],
         "signature": [
-          "(query: Pick<{ addToQueryLog: (appName: string, { language, query }: any) => void; filterManager: ",
+          "(query: Pick<{ addToQueryLog: (appName: string, { language, query }: ",
+          "Query",
+          ") => void; filterManager: ",
           {
             "pluginId": "data",
             "scope": "public",
@@ -1370,7 +1420,11 @@
           },
           " | undefined) => { bool: { must: ",
           "DslQuery",
-          "[]; filter: any[]; should: never[]; must_not: any[]; }; }; } | { filterManager: ",
+          "[]; filter: ",
+          "Filter",
+          "[]; should: never[]; must_not: ",
+          "Filter",
+          "[]; }; }; } | { filterManager: ",
           {
             "pluginId": "data",
             "scope": "public",
@@ -1421,7 +1475,9 @@
             "label": "query",
             "description": [],
             "signature": [
-              "Pick<{ addToQueryLog: (appName: string, { language, query }: any) => void; filterManager: ",
+              "Pick<{ addToQueryLog: (appName: string, { language, query }: ",
+              "Query",
+              ") => void; filterManager: ",
               {
                 "pluginId": "data",
                 "scope": "public",
@@ -1477,7 +1533,11 @@
               },
               " | undefined) => { bool: { must: ",
               "DslQuery",
-              "[]; filter: any[]; should: never[]; must_not: any[]; }; }; } | { filterManager: ",
+              "[]; filter: ",
+              "Filter",
+              "[]; should: never[]; must_not: ",
+              "Filter",
+              "[]; }; }; } | { filterManager: ",
               {
                 "pluginId": "data",
                 "scope": "public",
@@ -1601,7 +1661,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/data/public/query/state_sync/types.ts",
             "deprecated": false
@@ -1609,12 +1670,13 @@
           {
             "parentPluginId": "data",
             "id": "def-public.QueryState.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/data/public/query/state_sync/types.ts",
             "deprecated": false
@@ -2002,7 +2064,9 @@
         "label": "QueryStart",
         "description": [],
         "signature": [
-          "{ addToQueryLog: (appName: string, { language, query }: any) => void; filterManager: ",
+          "{ addToQueryLog: (appName: string, { language, query }: ",
+          "Query",
+          ") => void; filterManager: ",
           {
             "pluginId": "data",
             "scope": "public",
@@ -2058,7 +2122,11 @@
           },
           " | undefined) => { bool: { must: ",
           "DslQuery",
-          "[]; filter: any[]; should: never[]; must_not: any[]; }; }; }"
+          "[]; filter: ",
+          "Filter",
+          "[]; should: never[]; must_not: ",
+          "Filter",
+          "[]; }; }; }"
         ],
         "path": "src/plugins/data/public/query/query_service.ts",
         "deprecated": false,
@@ -2175,7 +2243,9 @@
             "section": "def-common.TimeRange",
             "text": "TimeRange"
           },
-          " | undefined) => any; getBounds: () => ",
+          " | undefined) => ",
+          "RangeFilter",
+          " | undefined; getBounds: () => ",
           {
             "pluginId": "data",
             "scope": "common",
@@ -2440,7 +2510,9 @@
             "section": "def-common.TimeRange",
             "text": "TimeRange"
           },
-          ", options: { forceNow?: Date | undefined; fieldName?: string | undefined; } | undefined) => any"
+          ", options: { forceNow?: Date | undefined; fieldName?: string | undefined; } | undefined) => ",
+          "RangeFilter",
+          " | undefined"
         ],
         "path": "src/plugins/data/common/query/timefilter/get_time.ts",
         "deprecated": false,
@@ -2536,7 +2608,8 @@
         "label": "isQuery",
         "description": [],
         "signature": [
-          "(x: unknown) => x is any"
+          "(x: unknown) => x is ",
+          "Query"
         ],
         "path": "src/plugins/data/common/query/is_query.ts",
         "deprecated": false,

--- a/api_docs/data_query.json
+++ b/api_docs/data_query.json
@@ -1739,11 +1739,10 @@
             ],
             "path": "src/plugins/data/public/query/saved_query/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.attributes",
+                "id": "def-public.SavedQueryService.saveQuery.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "attributes",
@@ -1752,22 +1751,33 @@
                   "SavedQueryAttributes"
                 ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-public.config",
+                "id": "def-public.SavedQueryService.saveQuery.$2.config",
                 "type": "Object",
                 "tags": [],
                 "label": "config",
                 "description": [],
-                "signature": [
-                  "{ overwrite: boolean; } | undefined"
-                ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "data",
+                    "id": "def-public.SavedQueryService.saveQuery.$2.config.overwrite",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "overwrite",
+                    "description": [],
+                    "path": "src/plugins/data/public/query/saved_query/types.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1789,8 +1799,8 @@
             ],
             "path": "src/plugins/data/public/query/saved_query/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1812,11 +1822,10 @@
             ],
             "path": "src/plugins/data/public/query/saved_query/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.searchText",
+                "id": "def-public.SavedQueryService.findSavedQueries.$1",
                 "type": "string",
                 "tags": [],
                 "label": "searchText",
@@ -1825,11 +1834,12 @@
                   "string | undefined"
                 ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "data",
-                "id": "def-public.perPage",
+                "id": "def-public.SavedQueryService.findSavedQueries.$2",
                 "type": "number",
                 "tags": [],
                 "label": "perPage",
@@ -1838,11 +1848,12 @@
                   "number | undefined"
                 ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "data",
-                "id": "def-public.activePage",
+                "id": "def-public.SavedQueryService.findSavedQueries.$3",
                 "type": "number",
                 "tags": [],
                 "label": "activePage",
@@ -1851,9 +1862,11 @@
                   "number | undefined"
                 ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1875,19 +1888,23 @@
             ],
             "path": "src/plugins/data/public/query/saved_query/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.id",
+                "id": "def-public.SavedQueryService.getSavedQuery.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1901,19 +1918,23 @@
             ],
             "path": "src/plugins/data/public/query/saved_query/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.id",
+                "id": "def-public.SavedQueryService.deleteSavedQuery.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/public/query/saved_query/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1927,8 +1948,8 @@
             ],
             "path": "src/plugins/data/public/query/saved_query/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1948,6 +1969,8 @@
         ],
         "path": "src/plugins/data/public/query/timefilter/lib/auto_refresh_loop.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {

--- a/api_docs/data_query.mdx
+++ b/api_docs/data_query.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Client
 

--- a/api_docs/data_query.mdx
+++ b/api_docs/data_query.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Client
 

--- a/api_docs/data_search.json
+++ b/api_docs/data_search.json
@@ -1055,11 +1055,10 @@
             ],
             "path": "src/plugins/data/public/search/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-public.e",
+                "id": "def-public.ISearchStart.showError.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "e",
@@ -1068,9 +1067,11 @@
                   "Error"
                 ],
                 "path": "src/plugins/data/public/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1681,8 +1682,8 @@
             ],
             "path": "src/plugins/data/public/search/session/session_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -1727,8 +1728,8 @@
             ],
             "path": "src/plugins/data/public/search/session/session_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2788,11 +2789,10 @@
             ],
             "path": "src/plugins/data/server/search/session/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-server.core",
+                "id": "def-server.ISearchSessionService.asScopedProvider.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "core",
@@ -2807,9 +2807,11 @@
                   }
                 ],
                 "path": "src/plugins/data/server/search/session/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2891,21 +2893,24 @@
             ],
             "path": "src/plugins/data/server/search/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-server.name",
+                "id": "def-server.ISearchSetup.registerSearchStrategy.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-server.strategy",
+                "id": "def-server.ISearchSetup.registerSearchStrategy.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "strategy",
@@ -2921,9 +2926,11 @@
                   "<SearchStrategyRequest, SearchStrategyResponse>"
                 ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -3043,11 +3050,10 @@
             ],
             "path": "src/plugins/data/server/search/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-server.name",
+                "id": "def-server.ISearchStart.getSearchStrategy.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
@@ -3056,9 +3062,11 @@
                   "string | undefined"
                 ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -3087,11 +3095,10 @@
             ],
             "path": "src/plugins/data/server/search/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-server.request",
+                "id": "def-server.ISearchStart.asScoped.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "request",
@@ -3107,9 +3114,11 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -3195,11 +3204,10 @@
             ],
             "path": "src/plugins/data/server/search/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-server.request",
+                "id": "def-server.ISearchStrategy.search.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "request",
@@ -3208,11 +3216,12 @@
                   "SearchStrategyRequest"
                 ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-server.options",
+                "id": "def-server.ISearchStrategy.search.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -3227,11 +3236,12 @@
                   }
                 ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-server.deps",
+                "id": "def-server.ISearchStrategy.search.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "deps",
@@ -3246,9 +3256,11 @@
                   }
                 ],
                 "path": "src/plugins/data/server/search/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -3277,7 +3289,64 @@
               ") => Promise<void>) | undefined"
             ],
             "path": "src/plugins/data/server/search/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.cancel.$1",
+                "type": "string",
+                "tags": [],
+                "label": "id",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.cancel.$2",
+                "type": "Object",
+                "tags": [],
+                "label": "options",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataSearchPluginApi",
+                    "section": "def-common.ISearchOptions",
+                    "text": "ISearchOptions"
+                  }
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.cancel.$3",
+                "type": "Object",
+                "tags": [],
+                "label": "deps",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "server",
+                    "docId": "kibDataSearchPluginApi",
+                    "section": "def-server.SearchStrategyDependencies",
+                    "text": "SearchStrategyDependencies"
+                  }
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -3306,7 +3375,78 @@
               ") => Promise<void>) | undefined"
             ],
             "path": "src/plugins/data/server/search/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.extend.$1",
+                "type": "string",
+                "tags": [],
+                "label": "id",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.extend.$2",
+                "type": "string",
+                "tags": [],
+                "label": "keepAlive",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.extend.$3",
+                "type": "Object",
+                "tags": [],
+                "label": "options",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataSearchPluginApi",
+                    "section": "def-common.ISearchOptions",
+                    "text": "ISearchOptions"
+                  }
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-server.ISearchStrategy.extend.$4",
+                "type": "Object",
+                "tags": [],
+                "label": "deps",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "server",
+                    "docId": "kibDataSearchPluginApi",
+                    "section": "def-server.SearchStrategyDependencies",
+                    "text": "SearchStrategyDependencies"
+                  }
+                ],
+                "path": "src/plugins/data/server/search/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -11782,11 +11922,10 @@
                 ],
                 "path": "src/plugins/data/common/search/expressions/esdsl.ts",
                 "deprecated": false,
-                "returnComment": [],
                 "children": [
                   {
                     "parentPluginId": "data",
-                    "id": "def-common.getKibanaRequest",
+                    "id": "def-common.getEsdslFn.$1.getStartDependencies.getStartDependencies.$1",
                     "type": "Any",
                     "tags": [],
                     "label": "getKibanaRequest",
@@ -11795,9 +11934,11 @@
                       "any"
                     ],
                     "path": "src/plugins/data/common/search/expressions/esdsl.ts",
-                    "deprecated": false
+                    "deprecated": false,
+                    "isRequired": true
                   }
-                ]
+                ],
+                "returnComment": []
               }
             ]
           }
@@ -11856,19 +11997,23 @@
                 ],
                 "path": "src/plugins/data/common/search/aggs/buckets/filter.ts",
                 "deprecated": false,
-                "returnComment": [],
                 "children": [
                   {
                     "parentPluginId": "data",
-                    "id": "def-common.key",
+                    "id": "def-common.getFilterBucketAgg.$1.getConfig.getConfig.$1",
                     "type": "string",
                     "tags": [],
                     "label": "key",
                     "description": [],
+                    "signature": [
+                      "string"
+                    ],
                     "path": "src/plugins/data/common/search/aggs/buckets/filter.ts",
-                    "deprecated": false
+                    "deprecated": false,
+                    "isRequired": true
                   }
-                ]
+                ],
+                "returnComment": []
               }
             ]
           }
@@ -19101,7 +19246,52 @@
               "((aggConfig: TAggConfig, key: any, params?: any) => any) | undefined"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_type.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.createFilter.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "aggConfig",
+                "description": [],
+                "signature": [
+                  "TAggConfig"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.createFilter.$2",
+                "type": "Any",
+                "tags": [],
+                "label": "key",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.createFilter.$3",
+                "type": "Any",
+                "tags": [],
+                "label": "params",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19280,7 +19470,9 @@
               "(() => any) | undefined"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_type.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19314,7 +19506,24 @@
               "<Record<string, any>>) | undefined"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_type.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getSerializedFormat.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "agg",
+                "description": [],
+                "signature": [
+                  "TAggConfig"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19327,7 +19536,38 @@
               "((agg: TAggConfig, bucket: any) => any) | undefined"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_type.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getValue.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "agg",
+                "description": [],
+                "signature": [
+                  "TAggConfig"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getValue.$2",
+                "type": "Any",
+                "tags": [],
+                "label": "bucket",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19340,7 +19580,52 @@
               "((bucket: any, key: any, agg: TAggConfig) => any) | undefined"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_type.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getKey.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "bucket",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getKey.$2",
+                "type": "Any",
+                "tags": [],
+                "label": "key",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getKey.$3",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "agg",
+                "description": [],
+                "signature": [
+                  "TAggConfig"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19353,7 +19638,24 @@
               "((agg: TAggConfig) => string) | undefined"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_type.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-common.AggTypeConfig.getValueBucketPath.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "agg",
+                "description": [],
+                "signature": [
+                  "TAggConfig"
+                ],
+                "path": "src/plugins/data/common/search/aggs/agg_type.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -19576,8 +19878,8 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/date_histogram.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19591,19 +19893,23 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/date_histogram.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.DateHistogramBucketAggDependencies.getConfig.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/search/aggs/buckets/date_histogram.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -19669,8 +19975,8 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/date_range.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -19684,19 +19990,23 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/date_range.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.DateRangeBucketAggDependencies.getConfig.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/search/aggs/buckets/date_range.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -19922,24 +20232,24 @@
             ],
             "path": "src/plugins/data/common/search/search_source/fetch/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.request",
+                "id": "def-common.FetchHandlers.onResponse.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "request",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/data/common/search/search_source/fetch/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.response",
+                "id": "def-common.FetchHandlers.onResponse.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "response",
@@ -19955,9 +20265,11 @@
                   "<any>"
                 ],
                 "path": "src/plugins/data/common/search/search_source/fetch/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -19984,19 +20296,23 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/filters.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.FiltersBucketAggDependencies.getConfig.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/search/aggs/buckets/filters.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -20023,19 +20339,23 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/histogram.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.key",
+                "id": "def-common.HistogramBucketAggDependencies.getConfig.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/search/aggs/buckets/histogram.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -20256,11 +20576,10 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/histogram.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.bounds",
+                "id": "def-common.IBucketHistogramAggConfig.setAutoBounds.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "bounds",
@@ -20275,9 +20594,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/search/aggs/buckets/histogram.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -20298,8 +20619,8 @@
             ],
             "path": "src/plugins/data/common/search/aggs/buckets/histogram.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -21124,11 +21445,10 @@
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.fields",
+                "id": "def-common.ISearchStartSearchSource.create.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "fields",
@@ -21144,9 +21464,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/data/common/search/search_source/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -21170,8 +21492,8 @@
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -21209,21 +21531,24 @@
             ],
             "path": "src/plugins/data/common/search/aggs/metrics/std_deviation.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.customLabel",
+                "id": "def-common.IStdDevAggConfig.keyedDetails.$1",
                 "type": "string",
                 "tags": [],
                 "label": "customLabel",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/data/common/search/aggs/metrics/std_deviation.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "data",
-                "id": "def-common.fieldDisplayName",
+                "id": "def-common.IStdDevAggConfig.keyedDetails.$2",
                 "type": "string",
                 "tags": [],
                 "label": "fieldDisplayName",
@@ -21232,9 +21557,11 @@
                   "string | undefined"
                 ],
                 "path": "src/plugins/data/common/search/aggs/metrics/std_deviation.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -21248,8 +21575,8 @@
             ],
             "path": "src/plugins/data/common/search/aggs/metrics/std_deviation.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -21484,11 +21811,10 @@
             ],
             "path": "src/plugins/data/common/search/aggs/param_types/optioned.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "data",
-                "id": "def-common.agg",
+                "id": "def-common.OptionedValueProp.isCompatible.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "agg",
@@ -21503,9 +21829,11 @@
                   }
                 ],
                 "path": "src/plugins/data/common/search/aggs/param_types/optioned.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -25673,6 +26001,39 @@
         ],
         "path": "src/plugins/data/common/search/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.id",
+            "type": "string",
+            "tags": [],
+            "label": "id",
+            "description": [],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.options",
+            "type": "Object",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "data",
+                "scope": "common",
+                "docId": "kibDataSearchPluginApi",
+                "section": "def-common.ISearchOptions",
+                "text": "ISearchOptions"
+              },
+              " | undefined"
+            ],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -25695,6 +26056,49 @@
         ],
         "path": "src/plugins/data/common/search/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.id",
+            "type": "string",
+            "tags": [],
+            "label": "id",
+            "description": [],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.keepAlive",
+            "type": "string",
+            "tags": [],
+            "label": "keepAlive",
+            "description": [],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.options",
+            "type": "Object",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "data",
+                "scope": "common",
+                "docId": "kibDataSearchPluginApi",
+                "section": "def-common.ISearchOptions",
+                "text": "ISearchOptions"
+              },
+              " | undefined"
+            ],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -25751,6 +26155,42 @@
         ],
         "path": "src/plugins/data/common/search/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "data",
+            "id": "def-common.request",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              "SearchStrategyRequest"
+            ],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "data",
+            "id": "def-common.options",
+            "type": "Object",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "data",
+                "scope": "common",
+                "docId": "kibDataSearchPluginApi",
+                "section": "def-common.ISearchOptions",
+                "text": "ISearchOptions"
+              },
+              " | undefined"
+            ],
+            "path": "src/plugins/data/common/search/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/data_search.json
+++ b/api_docs/data_search.json
@@ -5906,7 +5906,9 @@
             "label": "getSearchSourceTimeFilter",
             "description": [],
             "signature": [
-              "(forceNow?: Date | undefined) => any[]"
+              "(forceNow?: Date | undefined) => ",
+              "RangeFilter",
+              "[] | { meta: { index: string | undefined; params: {}; alias: string; disabled: boolean; negate: boolean; }; query: { bool: { should: { bool: { filter: { range: { [x: string]: { gte: string; lte: string; }; }; }[]; }; }[]; minimum_should_match: number; }; }; }[]"
             ],
             "path": "src/plugins/data/common/search/aggs/agg_configs.ts",
             "deprecated": false,
@@ -11172,7 +11174,11 @@
         "label": "filtersToAst",
         "description": [],
         "signature": [
-          "(filters: any) => ",
+          "(filters: ",
+          "Filter",
+          " | ",
+          "Filter",
+          "[]) => ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -11188,12 +11194,15 @@
           {
             "parentPluginId": "data",
             "id": "def-common.filtersToAst.$1",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "filters",
             "description": [],
             "signature": [
-              "any"
+              "Filter",
+              " | ",
+              "Filter",
+              "[]"
             ],
             "path": "src/plugins/data/common/search/expressions/filters_to_ast.ts",
             "deprecated": false,
@@ -14330,7 +14339,9 @@
         "label": "queryToAst",
         "description": [],
         "signature": [
-          "(query: any) => ",
+          "(query: ",
+          "Query",
+          ") => ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -14345,12 +14356,12 @@
           {
             "parentPluginId": "data",
             "id": "def-common.queryToAst.$1",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [],
             "signature": [
-              "any"
+              "Query"
             ],
             "path": "src/plugins/data/common/search/expressions/query_to_ast.ts",
             "deprecated": false,
@@ -14840,7 +14851,17 @@
                 "section": "def-common.GeoPoint",
                 "text": "GeoPoint"
               },
-              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: any; }, \"filter\" | \"geo_bounding_box\"> & Pick<{ geo_bounding_box?: ({ type: \"geo_bounding_box\"; } & GeoBox) | ({ type: \"geo_bounding_box\"; } & { top_left: ",
+              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: ",
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.ExpressionValueBoxed",
+                "text": "ExpressionValueBoxed"
+              },
+              "<\"kibana_query\", ",
+              "Query",
+              "> | undefined; }, \"filter\" | \"geo_bounding_box\"> & Pick<{ geo_bounding_box?: ({ type: \"geo_bounding_box\"; } & GeoBox) | ({ type: \"geo_bounding_box\"; } & { top_left: ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -14872,7 +14893,17 @@
                 "section": "def-common.GeoPoint",
                 "text": "GeoPoint"
               },
-              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: any; }, never>, \"enabled\" | \"id\" | \"filter\" | \"customLabel\" | \"schema\" | \"geo_bounding_box\" | \"json\" | \"timeShift\">, ",
+              "; }) | ({ type: \"geo_bounding_box\"; } & WellKnownText) | undefined; filter?: ",
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.ExpressionValueBoxed",
+                "text": "ExpressionValueBoxed"
+              },
+              "<\"kibana_query\", ",
+              "Query",
+              "> | undefined; }, never>, \"enabled\" | \"id\" | \"filter\" | \"customLabel\" | \"schema\" | \"geo_bounding_box\" | \"json\" | \"timeShift\">, ",
               "AggExpressionType",
               ", ",
               {
@@ -21887,12 +21918,12 @@
           {
             "parentPluginId": "data",
             "id": "def-common.QueryFilter.input",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "input",
             "description": [],
             "signature": [
-              "any"
+              "{ query: string | { [key: string]: any; }; language: string; }"
             ],
             "path": "src/plugins/data/common/search/expressions/query_filter.ts",
             "deprecated": false
@@ -22742,14 +22773,15 @@
           {
             "parentPluginId": "data",
             "id": "def-common.SearchSourceFields.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [
               "\n{@link Query}"
             ],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false
@@ -22757,14 +22789,21 @@
           {
             "parentPluginId": "data",
             "id": "def-common.SearchSourceFields.filter",
-            "type": "Any",
+            "type": "CompoundType",
             "tags": [],
             "label": "filter",
             "description": [
               "\n{@link Filter}"
             ],
             "signature": [
-              "any"
+              "Filter",
+              " | ",
+              "Filter",
+              "[] | (() => ",
+              "Filter",
+              " | ",
+              "Filter",
+              "[] | undefined) | undefined"
             ],
             "path": "src/plugins/data/common/search/search_source/types.ts",
             "deprecated": false
@@ -24460,7 +24499,13 @@
         "label": "ExecutionContextSearch",
         "description": [],
         "signature": [
-          "{ filters?: any[] | undefined; query?: any; timeRange?: ",
+          "{ filters?: ",
+          "Filter",
+          "[] | undefined; query?: ",
+          "Query",
+          " | ",
+          "Query",
+          "[] | undefined; timeRange?: ",
           {
             "pluginId": "data",
             "scope": "common",
@@ -24615,7 +24660,17 @@
             "section": "def-common.ExpressionFunctionDefinition",
             "text": "ExpressionFunctionDefinition"
           },
-          "<\"existsFilter\", null, Arguments, any, ",
+          "<\"existsFilter\", null, Arguments, ",
+          {
+            "pluginId": "expressions",
+            "scope": "common",
+            "docId": "kibExpressionsPluginApi",
+            "section": "def-common.ExpressionValueBoxed",
+            "text": "ExpressionValueBoxed"
+          },
+          "<\"kibana_filter\", ",
+          "Filter",
+          ">, ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -25067,7 +25122,17 @@
             "section": "def-common.ExpressionFunctionDefinition",
             "text": "ExpressionFunctionDefinition"
           },
-          "<\"kibanaFilter\", null, Arguments, any, ",
+          "<\"kibanaFilter\", null, Arguments, ",
+          {
+            "pluginId": "expressions",
+            "scope": "common",
+            "docId": "kibExpressionsPluginApi",
+            "section": "def-common.ExpressionValueBoxed",
+            "text": "ExpressionValueBoxed"
+          },
+          "<\"kibana_filter\", ",
+          "Filter",
+          ">, ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -25169,7 +25234,17 @@
             "section": "def-common.ExpressionFunctionDefinition",
             "text": "ExpressionFunctionDefinition"
           },
-          "<\"kql\", null, Arguments, any, ",
+          "<\"kql\", null, Arguments, ",
+          {
+            "pluginId": "expressions",
+            "scope": "common",
+            "docId": "kibExpressionsPluginApi",
+            "section": "def-common.ExpressionValueBoxed",
+            "text": "ExpressionValueBoxed"
+          },
+          "<\"kibana_query\", ",
+          "Query",
+          ">, ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -25208,7 +25283,17 @@
             "section": "def-common.ExpressionFunctionDefinition",
             "text": "ExpressionFunctionDefinition"
           },
-          "<\"lucene\", null, Arguments, any, ",
+          "<\"lucene\", null, Arguments, ",
+          {
+            "pluginId": "expressions",
+            "scope": "common",
+            "docId": "kibExpressionsPluginApi",
+            "section": "def-common.ExpressionValueBoxed",
+            "text": "ExpressionValueBoxed"
+          },
+          "<\"kibana_query\", ",
+          "Query",
+          ">, ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -25310,7 +25395,17 @@
             "section": "def-common.ExpressionFunctionDefinition",
             "text": "ExpressionFunctionDefinition"
           },
-          "<\"rangeFilter\", null, Arguments, any, ",
+          "<\"rangeFilter\", null, Arguments, ",
+          {
+            "pluginId": "expressions",
+            "scope": "common",
+            "docId": "kibExpressionsPluginApi",
+            "section": "def-common.ExpressionValueBoxed",
+            "text": "ExpressionValueBoxed"
+          },
+          "<\"kibana_filter\", ",
+          "Filter",
+          ">, ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -25451,7 +25546,17 @@
             "section": "def-common.ExpressionFunctionDefinition",
             "text": "ExpressionFunctionDefinition"
           },
-          "<\"rangeFilter\", null, Arguments, any, ",
+          "<\"rangeFilter\", null, Arguments, ",
+          {
+            "pluginId": "expressions",
+            "scope": "common",
+            "docId": "kibExpressionsPluginApi",
+            "section": "def-common.ExpressionValueBoxed",
+            "text": "ExpressionValueBoxed"
+          },
+          "<\"kibana_filter\", ",
+          "Filter",
+          ">, ",
           {
             "pluginId": "expressions",
             "scope": "common",
@@ -26482,7 +26587,8 @@
         "label": "KibanaFilter",
         "description": [],
         "signature": [
-          "any"
+          "{ type: \"kibana_filter\"; } & ",
+          "Filter"
         ],
         "path": "src/plugins/data/common/search/expressions/kibana_context_type.ts",
         "deprecated": false,
@@ -26496,7 +26602,8 @@
         "label": "KibanaQueryOutput",
         "description": [],
         "signature": [
-          "any"
+          "{ type: \"kibana_query\"; } & ",
+          "Query"
         ],
         "path": "src/plugins/data/common/search/expressions/kibana_context_type.ts",
         "deprecated": false,
@@ -27227,6 +27334,9 @@
             "tags": [],
             "label": "type",
             "description": [],
+            "signature": [
+              "\"kibana_filter\""
+            ],
             "path": "src/plugins/data/common/search/expressions/exists_filter.ts",
             "deprecated": false
           },
@@ -27369,7 +27479,11 @@
             "label": "fn",
             "description": [],
             "signature": [
-              "(input: null, args: Arguments) => any"
+              "(input: null, args: Arguments) => { $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; type: \"kibana_filter\"; }"
             ],
             "path": "src/plugins/data/common/search/expressions/exists_filter.ts",
             "deprecated": false,
@@ -29118,6 +29232,9 @@
             "tags": [],
             "label": "type",
             "description": [],
+            "signature": [
+              "\"kibana_filter\""
+            ],
             "path": "src/plugins/data/common/search/expressions/kibana_filter.ts",
             "deprecated": false
           },
@@ -29666,6 +29783,9 @@
             "tags": [],
             "label": "type",
             "description": [],
+            "signature": [
+              "\"kibana_query\""
+            ],
             "path": "src/plugins/data/common/search/expressions/kql.ts",
             "deprecated": false
           },
@@ -29773,7 +29893,7 @@
             "label": "fn",
             "description": [],
             "signature": [
-              "(input: null, args: Arguments) => { type: string; language: string; query: string; }"
+              "(input: null, args: Arguments) => { type: \"kibana_query\"; language: string; query: string; }"
             ],
             "path": "src/plugins/data/common/search/expressions/kql.ts",
             "deprecated": false,
@@ -29842,6 +29962,9 @@
             "tags": [],
             "label": "type",
             "description": [],
+            "signature": [
+              "\"kibana_query\""
+            ],
             "path": "src/plugins/data/common/search/expressions/lucene.ts",
             "deprecated": false
           },
@@ -29949,7 +30072,7 @@
             "label": "fn",
             "description": [],
             "signature": [
-              "(input: null, args: Arguments) => { type: string; language: string; query: any; }"
+              "(input: null, args: Arguments) => { type: \"kibana_query\"; language: string; query: any; }"
             ],
             "path": "src/plugins/data/common/search/expressions/lucene.ts",
             "deprecated": false,
@@ -30477,6 +30600,9 @@
             "tags": [],
             "label": "type",
             "description": [],
+            "signature": [
+              "\"kibana_filter\""
+            ],
             "path": "src/plugins/data/common/search/expressions/phrase_filter.ts",
             "deprecated": false
           },
@@ -30680,7 +30806,11 @@
             "label": "fn",
             "description": [],
             "signature": [
-              "(input: null, args: Arguments) => any"
+              "(input: null, args: Arguments) => { $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; type: \"kibana_filter\"; }"
             ],
             "path": "src/plugins/data/common/search/expressions/phrase_filter.ts",
             "deprecated": false,
@@ -30979,6 +31109,9 @@
             "tags": [],
             "label": "type",
             "description": [],
+            "signature": [
+              "\"kibana_filter\""
+            ],
             "path": "src/plugins/data/common/search/expressions/range_filter.ts",
             "deprecated": false
           },
@@ -31169,7 +31302,11 @@
             "label": "fn",
             "description": [],
             "signature": [
-              "(input: null, args: Arguments) => any"
+              "(input: null, args: Arguments) => { $state?: { store: ",
+              "FilterStateStore",
+              "; } | undefined; meta: ",
+              "FilterMeta",
+              "; query?: any; type: \"kibana_filter\"; }"
             ],
             "path": "src/plugins/data/common/search/expressions/range_filter.ts",
             "deprecated": false,

--- a/api_docs/data_search.mdx
+++ b/api_docs/data_search.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Client
 

--- a/api_docs/data_search.mdx
+++ b/api_docs/data_search.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Client
 

--- a/api_docs/data_ui.json
+++ b/api_docs/data_ui.json
@@ -150,12 +150,12 @@
           {
             "parentPluginId": "data",
             "id": "def-public.QueryStringInputProps.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [],
             "signature": [
-              "any"
+              "{ query: string | { [key: string]: any; }; language: string; }"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
             "deprecated": false
@@ -288,7 +288,9 @@
             "label": "onChange",
             "description": [],
             "signature": [
-              "((query: any) => void) | undefined"
+              "((query: ",
+              "Query",
+              ") => void) | undefined"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
             "deprecated": false,
@@ -296,12 +298,12 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.QueryStringInputProps.onChange.$1",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "query",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Query"
                 ],
                 "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
                 "deprecated": false,
@@ -348,7 +350,9 @@
             "label": "onSubmit",
             "description": [],
             "signature": [
-              "((query: any) => void) | undefined"
+              "((query: ",
+              "Query",
+              ") => void) | undefined"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
             "deprecated": false,
@@ -356,12 +360,12 @@
               {
                 "parentPluginId": "data",
                 "id": "def-public.QueryStringInputProps.onSubmit.$1",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "query",
                 "description": [],
                 "signature": [
-                  "any"
+                  "Query"
                 ],
                 "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
                 "deprecated": false,

--- a/api_docs/data_ui.json
+++ b/api_docs/data_ui.json
@@ -276,7 +276,9 @@
               "(() => void) | undefined"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -289,7 +291,24 @@
               "((query: any) => void) | undefined"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.QueryStringInputProps.onChange.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "query",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -302,7 +321,24 @@
               "((isFocused: boolean) => void) | undefined"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.QueryStringInputProps.onChangeQueryInputFocus.$1",
+                "type": "boolean",
+                "tags": [],
+                "label": "isFocused",
+                "description": [],
+                "signature": [
+                  "boolean"
+                ],
+                "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",
@@ -315,7 +351,24 @@
               "((query: any) => void) | undefined"
             ],
             "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "data",
+                "id": "def-public.QueryStringInputProps.onSubmit.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "query",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/data/public/ui/query_string_input/query_string_input.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "data",

--- a/api_docs/data_ui.mdx
+++ b/api_docs/data_ui.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3870 | 151 | 3322 | 63 |
+| 3920 | 158 | 3372 | 63 |
 
 ## Client
 

--- a/api_docs/data_ui.mdx
+++ b/api_docs/data_ui.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 3920 | 158 | 3372 | 63 |
+| 3994 | 85 | 3446 | 63 |
 
 ## Client
 

--- a/api_docs/data_visualizer.json
+++ b/api_docs/data_visualizer.json
@@ -230,6 +230,35 @@
         ],
         "path": "x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "dataVisualizer",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "dataVisualizer",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -252,6 +281,35 @@
         ],
         "path": "x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "dataVisualizer",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "dataVisualizer",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/data_visualizer.mdx
+++ b/api_docs/data_visualizer.mdx
@@ -18,7 +18,7 @@ Contact [Machine Learning UI](https://github.com/orgs/elastic/teams/ml-ui) for q
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 104 | 3 | 104 | 0 |
+| 108 | 5 | 108 | 0 |
 
 ## Client
 

--- a/api_docs/deprecations_by_api.mdx
+++ b/api_docs/deprecations_by_api.mdx
@@ -14,17 +14,14 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 | <DocLink id="kibDataPluginApi" section="def-public.castEsToKbnFieldTypeName" text="castEsToKbnFieldTypeName"/> | indexPatternFieldEditor, savedObjectsManagement | 8.0 |
 | <DocLink id="kibDataPluginApi" section="def-common.castEsToKbnFieldTypeName" text="castEsToKbnFieldTypeName"/> | indexPatternFieldEditor, savedObjectsManagement | 8.0 |
 | <DocLink id="kibDataPluginApi" section="def-server.castEsToKbnFieldTypeName" text="castEsToKbnFieldTypeName"/> | indexPatternFieldEditor, savedObjectsManagement | 8.0 |
-| <DocLink id="kibCorePluginApi" section="def-server.ILegacyCustomClusterClient" text="ILegacyCustomClusterClient"/> | indexManagement | 7.16 |
-| <DocLink id="kibCorePluginApi" section="def-server.LegacyScopedClusterClient" text="LegacyScopedClusterClient"/> | indexManagement | 7.16 |
-| <DocLink id="kibCorePluginApi" section="def-server.ILegacyScopedClusterClient" text="ILegacyScopedClusterClient"/> | indexManagement, globalSearch | 7.16 |
-| <DocLink id="kibCorePluginApi" section="def-server.LegacyAPICaller" text="LegacyAPICaller"/> | crossClusterReplication, indexLifecycleManagement | 7.16 |
-| <DocLink id="kibDataPluginApi" section="def-public.IIndexPattern" text="IIndexPattern"/> | savedObjects, observability, timelines, infra, ml, securitySolution, maps, stackAlerts, transform | - |
-| <DocLink id="kibDataPluginApi" section="def-common.IIndexPattern" text="IIndexPattern"/> | savedObjects, observability, timelines, infra, ml, securitySolution, maps, stackAlerts, transform | - |
+| <DocLink id="kibCorePluginApi" section="def-server.ILegacyScopedClusterClient" text="ILegacyScopedClusterClient"/> | globalSearch | 7.16 |
+| <DocLink id="kibDataPluginApi" section="def-public.IIndexPattern" text="IIndexPattern"/> | observability, timelines, infra, ml, securitySolution, stackAlerts, transform | - |
 | <DocLink id="kibDataPluginApi" section="def-public.esFilters" text="esFilters"/> | discover, visualizations, dashboard, lens, observability, maps, canvas, dashboardEnhanced, discoverEnhanced, securitySolution | - |
 | <DocLink id="kibDataPluginApi" section="def-public.ExistsFilter" text="ExistsFilter"/> | observability | - |
 | <DocLink id="kibDataPluginApi" section="def-public.Filter" text="Filter"/> | canvas, discover, visualizations, dashboard, lens, observability, timelines, maps, infra, dashboardEnhanced, discoverEnhanced, securitySolution, urlDrilldown, lists, ml, visTypeTimeseries | - |
 | <DocLink id="kibDataPluginApi" section="def-common.Filter" text="Filter"/> | canvas, discover, visualizations, dashboard, lens, observability, timelines, maps, infra, dashboardEnhanced, discoverEnhanced, securitySolution, urlDrilldown, lists, ml, visTypeTimeseries | - |
 | <DocLink id="kibDataPluginApi" section="def-common.ExistsFilter" text="ExistsFilter"/> | observability | - |
+| <DocLink id="kibDataPluginApi" section="def-common.IIndexPattern" text="IIndexPattern"/> | observability, timelines, infra, ml, securitySolution, stackAlerts, transform | - |
 | <DocLink id="kibDataPluginApi" section="def-server.Filter" text="Filter"/> | canvas, discover, visualizations, dashboard, lens, observability, timelines, maps, infra, dashboardEnhanced, discoverEnhanced, securitySolution, urlDrilldown, lists, ml, visTypeTimeseries | - |
 | <DocLink id="kibDataPluginApi" section="def-public.IFieldSubType" text="IFieldSubType"/> | timelines | - |
 | <DocLink id="kibDataPluginApi" section="def-public.esKuery" text="esKuery"/> | fleet, lens, timelines, infra, dataVisualizer, ml, apm, securitySolution, stackAlerts, transform, uptime | - |

--- a/api_docs/deprecations_by_plugin.mdx
+++ b/api_docs/deprecations_by_plugin.mdx
@@ -177,16 +177,6 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 
 
 
-## crossClusterReplication
-
-| Deprecated API | Reference location(s) | Remove By |
-| ---------------|-----------|-----------|
-| <DocLink id="kibCorePluginApi" section="def-server.LegacyAPICaller" text="LegacyAPICaller"/> | [plugin.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/cross_cluster_replication/server/plugin.ts#:~:text=LegacyAPICaller), [plugin.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/cross_cluster_replication/server/plugin.ts#:~:text=LegacyAPICaller) | 7.16 |
-
-
-
 ## dashboard
 
 | Deprecated API | Reference location(s) | Remove By |
@@ -572,38 +562,6 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 
 
 
-## indexLifecycleManagement
-
-| Deprecated API | Reference location(s) | Remove By |
-| ---------------|-----------|-----------|
-| <DocLink id="kibCorePluginApi" section="def-server.LegacyAPICaller" text="LegacyAPICaller"/> | [plugin.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_lifecycle_management/server/plugin.ts#:~:text=LegacyAPICaller), [plugin.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_lifecycle_management/server/plugin.ts#:~:text=LegacyAPICaller) | 7.16 |
-
-
-
-## indexManagement
-
-| Deprecated API | Reference location(s) | Remove By |
-| ---------------|-----------|-----------|
-| <DocLink id="kibCorePluginApi" section="def-server.ILegacyCustomClusterClient" text="ILegacyCustomClusterClient"/> | [plugin.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/plugin.ts#:~:text=ILegacyCustomClusterClient), [plugin.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/plugin.ts#:~:text=ILegacyCustomClusterClient) | 7.16 |
-| <DocLink id="kibCorePluginApi" section="def-server.LegacyScopedClusterClient" text="LegacyScopedClusterClient"/> | [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/types.ts#:~:text=LegacyScopedClusterClient), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/types.ts#:~:text=LegacyScopedClusterClient), [types.d.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/target/types/server/types.d.ts#:~:text=LegacyScopedClusterClient), [types.d.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/target/types/server/types.d.ts#:~:text=LegacyScopedClusterClient) | 7.16 |
-| <DocLink id="kibCorePluginApi" section="def-server.ILegacyScopedClusterClient" text="ILegacyScopedClusterClient"/> | [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/types.ts#:~:text=ILegacyScopedClusterClient), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/types.ts#:~:text=ILegacyScopedClusterClient), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/server/types.ts#:~:text=ILegacyScopedClusterClient), [types.d.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/target/types/server/types.d.ts#:~:text=ILegacyScopedClusterClient), [types.d.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/target/types/server/types.d.ts#:~:text=ILegacyScopedClusterClient), [types.d.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/index_management/target/types/server/types.d.ts#:~:text=ILegacyScopedClusterClient) | 7.16 |
-
-
-
 ## indexPatternFieldEditor
 
 | Deprecated API | Reference location(s) | Remove By |
@@ -829,9 +787,6 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 
 | Deprecated API | Reference location(s) | Remove By |
 | ---------------|-----------|-----------|
-| <DocLink id="kibDataPluginApi" section="def-public.IIndexPattern" text="IIndexPattern"/> | [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/embeddable/types.ts#:~:text=IIndexPattern), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/embeddable/types.ts#:~:text=IIndexPattern) | - |
 | <DocLink id="kibDataPluginApi" section="def-public.IFieldType" text="IFieldType"/> | [es_doc_field.ts
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/classes/fields/es_doc_field.ts#:~:text=IFieldType), [es_doc_field.ts
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/classes/fields/es_doc_field.ts#:~:text=IFieldType), [es_source.ts
@@ -887,9 +842,6 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/index_pattern_util.ts#:~:text=IFieldType), [index_pattern_util.ts
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/index_pattern_util.ts#:~:text=IFieldType), [index_pattern_util.ts
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/index_pattern_util.ts#:~:text=IFieldType)+ 84 more | - |
-| <DocLink id="kibDataPluginApi" section="def-common.IIndexPattern" text="IIndexPattern"/> | [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/embeddable/types.ts#:~:text=IIndexPattern), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/embeddable/types.ts#:~:text=IIndexPattern) | - |
 | <DocLink id="kibDataPluginApi" section="def-server.IFieldType" text="IFieldType"/> | [es_doc_field.ts
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/classes/fields/es_doc_field.ts#:~:text=IFieldType), [es_doc_field.ts
             ](https://github.com/elastic/kibana/tree/master/x-pack/plugins/maps/public/classes/fields/es_doc_field.ts#:~:text=IFieldType), [es_source.ts
@@ -1075,21 +1027,6 @@ warning: This document is auto-generated and is meant to be viewed inside our ex
 | <DocLink id="kibSavedObjectsPluginApi" section="def-public.SavedObjectSaveModal" text="SavedObjectSaveModal"/> | [saved_object_save_modal_dashboard.tsx
             ](https://github.com/elastic/kibana/tree/master/src/plugins/presentation_util/public/components/saved_object_save_modal_dashboard.tsx#:~:text=SavedObjectSaveModal), [saved_object_save_modal_dashboard.tsx
             ](https://github.com/elastic/kibana/tree/master/src/plugins/presentation_util/public/components/saved_object_save_modal_dashboard.tsx#:~:text=SavedObjectSaveModal) | - |
-
-
-
-## savedObjects
-
-| Deprecated API | Reference location(s) | Remove By |
-| ---------------|-----------|-----------|
-| <DocLink id="kibDataPluginApi" section="def-public.IIndexPattern" text="IIndexPattern"/> | [types.ts
-            ](https://github.com/elastic/kibana/tree/master/src/plugins/saved_objects/public/types.ts#:~:text=IIndexPattern), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/src/plugins/saved_objects/public/types.ts#:~:text=IIndexPattern), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/src/plugins/saved_objects/public/types.ts#:~:text=IIndexPattern) | - |
-| <DocLink id="kibDataPluginApi" section="def-common.IIndexPattern" text="IIndexPattern"/> | [types.ts
-            ](https://github.com/elastic/kibana/tree/master/src/plugins/saved_objects/public/types.ts#:~:text=IIndexPattern), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/src/plugins/saved_objects/public/types.ts#:~:text=IIndexPattern), [types.ts
-            ](https://github.com/elastic/kibana/tree/master/src/plugins/saved_objects/public/types.ts#:~:text=IIndexPattern) | - |
 
 
 

--- a/api_docs/dev_tools.json
+++ b/api_docs/dev_tools.json
@@ -178,11 +178,10 @@
           ],
           "path": "src/plugins/dev_tools/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "devTools",
-              "id": "def-public.devTool",
+              "id": "def-public.DevToolsSetup.register.$1",
               "type": "CompoundType",
               "tags": [],
               "label": "devTool",
@@ -190,14 +189,14 @@
                 "The dev tools descriptor"
               ],
               "signature": [
-                "Pick<",
-                "DevToolApp",
-                ", \"title\" | \"id\" | \"order\" | \"mount\" | \"tooltipContent\" | \"enableRouting\"> & { disabled?: boolean | undefined; }"
+                "CreateDevToolArgs"
               ],
               "path": "src/plugins/dev_tools/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/discover.json
+++ b/api_docs/discover.json
@@ -686,8 +686,8 @@
             ],
             "path": "src/plugins/discover/public/saved_searches/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "discover",
@@ -709,11 +709,10 @@
             ],
             "path": "src/plugins/discover/public/saved_searches/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "discover",
-                "id": "def-public.saveOptions",
+                "id": "def-public.SavedSearch.save.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "saveOptions",
@@ -728,9 +727,11 @@
                   }
                 ],
                 "path": "src/plugins/discover/public/saved_searches/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "discover",
@@ -804,19 +805,23 @@
             ],
             "path": "src/plugins/discover/public/saved_searches/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "discover",
-                "id": "def-public.id",
+                "id": "def-public.SavedSearchLoader.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/discover/public/saved_searches/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "discover",
@@ -830,19 +835,23 @@
             ],
             "path": "src/plugins/discover/public/saved_searches/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "discover",
-                "id": "def-public.id",
+                "id": "def-public.SavedSearchLoader.urlFor.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/discover/public/saved_searches/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/discover.json
+++ b/api_docs/discover.json
@@ -181,7 +181,8 @@
               "\nOptionally apply filters."
             ],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/discover/public/locator.ts",
             "deprecated": false
@@ -189,14 +190,15 @@
           {
             "parentPluginId": "discover",
             "id": "def-public.DiscoverAppLocatorParams.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [
               "\nOptionally set a query."
             ],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/discover/public/locator.ts",
             "deprecated": false
@@ -396,7 +398,8 @@
               "\nOptionally apply filters."
             ],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/discover/public/url_generator.ts",
             "deprecated": false
@@ -404,14 +407,15 @@
           {
             "parentPluginId": "discover",
             "id": "def-public.DiscoverUrlGeneratorState.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [
               "\nOptionally set a query. NOTE: if given and used in conjunction with `dashboardId`, and the\nsaved dashboard has a query saved with it, this will _replace_ that query."
             ],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/discover/public/url_generator.ts",
             "deprecated": false
@@ -899,12 +903,13 @@
           {
             "parentPluginId": "discover",
             "id": "def-public.SearchInput.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/discover/public/application/embeddable/types.ts",
             "deprecated": false
@@ -917,7 +922,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/discover/public/application/embeddable/types.ts",
             "deprecated": false

--- a/api_docs/discover.mdx
+++ b/api_docs/discover.mdx
@@ -18,7 +18,7 @@ Contact [Kibana App](https://github.com/orgs/elastic/teams/kibana-app) for quest
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 81 | 3 | 55 | 6 |
+| 81 | 0 | 55 | 6 |
 
 ## Client
 

--- a/api_docs/embeddable.json
+++ b/api_docs/embeddable.json
@@ -5797,8 +5797,8 @@
             ],
             "path": "src/plugins/embeddable/public/lib/embeddables/embeddable_factory.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "embeddable",
@@ -7783,11 +7783,10 @@
             ],
             "path": "src/plugins/embeddable/public/lib/reference_or_value_embeddable/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "embeddable",
-                "id": "def-public.input",
+                "id": "def-public.ReferenceOrValueEmbeddable.inputIsRefType.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "input",
@@ -7796,9 +7795,11 @@
                   "ValTypeInput | RefTypeInput"
                 ],
                 "path": "src/plugins/embeddable/public/lib/reference_or_value_embeddable/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "embeddable",
@@ -7814,8 +7815,8 @@
             ],
             "path": "src/plugins/embeddable/public/lib/reference_or_value_embeddable/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "embeddable",
@@ -7831,8 +7832,8 @@
             ],
             "path": "src/plugins/embeddable/public/lib/reference_or_value_embeddable/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8139,6 +8140,35 @@
         ],
         "path": "src/plugins/embeddable/public/plugin.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "embeddable",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "embeddable",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -8419,52 +8449,46 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.id",
+              "id": "def-public.EmbeddableSetup.registerEmbeddableFactory.$1",
               "type": "string",
               "tags": [],
               "label": "id",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.factory",
+              "id": "def-public.EmbeddableSetup.registerEmbeddableFactory.$2",
               "type": "CompoundType",
               "tags": [],
               "label": "factory",
               "description": [],
               "signature": [
-                "Pick<",
                 {
                   "pluginId": "embeddable",
                   "scope": "public",
                   "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.EmbeddableFactory",
-                  "text": "EmbeddableFactory"
+                  "section": "def-public.EmbeddableFactoryDefinition",
+                  "text": "EmbeddableFactoryDefinition"
                 },
                 "<I, O, E, ",
                 "SavedObjectAttributes",
-                ">, \"type\" | \"create\" | \"isEditable\" | \"getDisplayName\"> & Partial<Pick<",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.EmbeddableFactory",
-                  "text": "EmbeddableFactory"
-                },
-                "<I, O, E, ",
-                "SavedObjectAttributes",
-                ">, \"createFromSavedObject\" | \"isContainerType\" | \"getExplicitInput\" | \"savedObjectMetaData\" | \"canCreateNew\" | \"getDefaultInput\" | \"telemetry\" | \"extract\" | \"inject\" | \"migrations\" | \"grouping\" | \"getIconType\" | \"getDescription\">>"
+                ">"
               ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -8494,11 +8518,10 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.enhancement",
+              "id": "def-public.EmbeddableSetup.registerEnhancement.$1",
               "type": "Object",
               "tags": [],
               "label": "enhancement",
@@ -8522,9 +8545,11 @@
                 ">"
               ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -8540,90 +8565,23 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.customProvider",
+              "id": "def-public.EmbeddableSetup.setCustomEmbeddableFactoryProvider.$1",
               "type": "Function",
               "tags": [],
               "label": "customProvider",
               "description": [],
               "signature": [
-                "<I extends ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "common",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-common.EmbeddableInput",
-                  "text": "EmbeddableInput"
-                },
-                " = ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "common",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-common.EmbeddableInput",
-                  "text": "EmbeddableInput"
-                },
-                ", O extends ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.EmbeddableOutput",
-                  "text": "EmbeddableOutput"
-                },
-                " = ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.EmbeddableOutput",
-                  "text": "EmbeddableOutput"
-                },
-                ", E extends ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.IEmbeddable",
-                  "text": "IEmbeddable"
-                },
-                "<I, O> = ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.IEmbeddable",
-                  "text": "IEmbeddable"
-                },
-                "<I, O>, T extends ",
-                "SavedObjectAttributes",
-                " = ",
-                "SavedObjectAttributes",
-                ">(def: ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.EmbeddableFactoryDefinition",
-                  "text": "EmbeddableFactoryDefinition"
-                },
-                "<I, O, E, T>) => ",
-                {
-                  "pluginId": "embeddable",
-                  "scope": "public",
-                  "docId": "kibEmbeddablePluginApi",
-                  "section": "def-public.EmbeddableFactory",
-                  "text": "EmbeddableFactory"
-                },
-                "<I, O, E, T>"
+                "EmbeddableFactoryProvider"
               ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -8735,19 +8693,23 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.embeddableFactoryId",
+              "id": "def-public.EmbeddableStart.getEmbeddableFactory.$1",
               "type": "string",
               "tags": [],
               "label": "embeddableFactoryId",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -8811,8 +8773,8 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -8907,11 +8869,10 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.storage",
+              "id": "def-public.EmbeddableStart.getStateTransfer.$1",
               "type": "Object",
               "tags": [],
               "label": "storage",
@@ -8927,9 +8888,11 @@
                 " | undefined"
               ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": false
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -8985,21 +8948,24 @@
           ],
           "path": "src/plugins/embeddable/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.type",
+              "id": "def-public.EmbeddableStart.getAttributeService.$1",
               "type": "string",
               "tags": [],
               "label": "type",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "embeddable",
-              "id": "def-public.options",
+              "id": "def-public.EmbeddableStart.getAttributeService.$2",
               "type": "Object",
               "tags": [],
               "label": "options",
@@ -9009,9 +8975,11 @@
                 "<A>"
               ],
               "path": "src/plugins/embeddable/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",
@@ -9172,11 +9140,10 @@
           ],
           "path": "src/plugins/embeddable/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-server.factory",
+              "id": "def-server.EmbeddableSetup.registerEmbeddableFactory.$1",
               "type": "Object",
               "tags": [],
               "label": "factory",
@@ -9200,9 +9167,11 @@
                 ">"
               ],
               "path": "src/plugins/embeddable/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -9232,11 +9201,10 @@
           ],
           "path": "src/plugins/embeddable/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "embeddable",
-              "id": "def-server.enhancement",
+              "id": "def-server.EmbeddableSetup.registerEnhancement.$1",
               "type": "Object",
               "tags": [],
               "label": "enhancement",
@@ -9260,9 +9228,11 @@
                 ">"
               ],
               "path": "src/plugins/embeddable/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "embeddable",
@@ -9283,8 +9253,8 @@
           ],
           "path": "src/plugins/embeddable/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -9822,19 +9792,23 @@
             ],
             "path": "src/plugins/embeddable/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "embeddable",
-                "id": "def-common.embeddableFactoryId",
+                "id": "def-common.CommonEmbeddableStartContract.getEmbeddableFactory.$1",
                 "type": "string",
                 "tags": [],
                 "label": "embeddableFactoryId",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/embeddable/common/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "embeddable",
@@ -9848,19 +9822,23 @@
             ],
             "path": "src/plugins/embeddable/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "embeddable",
-                "id": "def-common.enhancementId",
+                "id": "def-common.CommonEmbeddableStartContract.getEnhancement.$1",
                 "type": "string",
                 "tags": [],
                 "label": "enhancementId",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/embeddable/common/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -10073,6 +10051,40 @@
         ],
         "path": "src/plugins/embeddable/common/lib/migrate.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "embeddable",
+            "id": "def-common.state",
+            "type": "Object",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "{ [key: string]: ",
+              {
+                "pluginId": "kibanaUtils",
+                "scope": "common",
+                "docId": "kibKibanaUtilsPluginApi",
+                "section": "def-common.Serializable",
+                "text": "Serializable"
+              },
+              "; }"
+            ],
+            "path": "src/plugins/embeddable/common/lib/migrate.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "embeddable",
+            "id": "def-common.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "path": "src/plugins/embeddable/common/lib/migrate.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/embeddable.mdx
+++ b/api_docs/embeddable.mdx
@@ -18,7 +18,7 @@ import embeddableObj from './embeddable.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 456 | 4 | 384 | 3 |
+| 460 | 5 | 388 | 3 |
 
 ## Client
 

--- a/api_docs/encrypted_saved_objects.json
+++ b/api_docs/encrypted_saved_objects.json
@@ -155,31 +155,38 @@
             ],
             "path": "x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "encryptedSavedObjects",
-                "id": "def-server.type",
+                "id": "def-server.EncryptedSavedObjectsClient.getDecryptedAsInternalUser.$1",
                 "type": "string",
                 "tags": [],
                 "label": "type",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "encryptedSavedObjects",
-                "id": "def-server.id",
+                "id": "def-server.EncryptedSavedObjectsClient.getDecryptedAsInternalUser.$2",
                 "type": "string",
                 "tags": [],
                 "label": "id",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "encryptedSavedObjects",
-                "id": "def-server.options",
+                "id": "def-server.EncryptedSavedObjectsClient.getDecryptedAsInternalUser.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -195,9 +202,11 @@
                   " | undefined"
                 ],
                 "path": "x-pack/plugins/encrypted_saved_objects/server/saved_objects/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -294,6 +303,37 @@
         ],
         "path": "x-pack/plugins/encrypted_saved_objects/server/create_migration.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "encryptedSavedObjects",
+            "id": "def-server.encryptedDoc",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "encryptedDoc",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectUnsanitizedDoc",
+                "text": "SavedObjectUnsanitizedDoc"
+              },
+              "<InputAttributes> | ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectUnsanitizedDoc",
+                "text": "SavedObjectUnsanitizedDoc"
+              },
+              "<MigratedAttributes>"
+            ],
+            "path": "x-pack/plugins/encrypted_saved_objects/server/create_migration.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -340,11 +380,10 @@
           ],
           "path": "x-pack/plugins/encrypted_saved_objects/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "encryptedSavedObjects",
-              "id": "def-server.typeRegistration",
+              "id": "def-server.EncryptedSavedObjectsPluginSetup.registerType.$1",
               "type": "Object",
               "tags": [],
               "label": "typeRegistration",
@@ -359,9 +398,11 @@
                 }
               ],
               "path": "x-pack/plugins/encrypted_saved_objects/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "encryptedSavedObjects",
@@ -421,11 +462,10 @@
           ],
           "path": "x-pack/plugins/encrypted_saved_objects/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "encryptedSavedObjects",
-              "id": "def-server.error",
+              "id": "def-server.EncryptedSavedObjectsPluginStart.isEncryptionError.$1",
               "type": "Object",
               "tags": [],
               "label": "error",
@@ -434,9 +474,11 @@
                 "Error"
               ],
               "path": "x-pack/plugins/encrypted_saved_objects/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "encryptedSavedObjects",

--- a/api_docs/encrypted_saved_objects.mdx
+++ b/api_docs/encrypted_saved_objects.mdx
@@ -18,7 +18,7 @@ Contact [Platform Security](https://github.com/orgs/elastic/teams/kibana-securit
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 28 | 0 | 26 | 4 |
+| 29 | 0 | 27 | 4 |
 
 ## Server
 

--- a/api_docs/es_ui_shared.json
+++ b/api_docs/es_ui_shared.json
@@ -1065,7 +1065,24 @@
               "((data: any) => any) | undefined"
             ],
             "path": "src/plugins/es_ui_shared/public/request/use_request.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "esUiShared",
+                "id": "def-public.UseRequestConfig.deserializer.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "data",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/es_ui_shared/public/request/use_request.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1148,8 +1165,8 @@
             ],
             "path": "src/plugins/es_ui_shared/public/request/use_request.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1191,6 +1208,29 @@
         ],
         "path": "src/plugins/es_ui_shared/public/components/json_editor/use_json.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "esUiShared",
+            "id": "def-public.arg",
+            "type": "Object",
+            "tags": [],
+            "label": "arg",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "esUiShared",
+                "scope": "public",
+                "docId": "kibEsUiSharedPluginApi",
+                "section": "def-public.JsonEditorState",
+                "text": "JsonEditorState"
+              },
+              "<T>"
+            ],
+            "path": "src/plugins/es_ui_shared/public/components/json_editor/use_json.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -1357,37 +1397,6 @@
               "EsErrorHandlerParams"
             ],
             "path": "src/plugins/es_ui_shared/__packages_do_not_import__/errors/handle_es_error.ts",
-            "deprecated": false,
-            "isRequired": true
-          }
-        ],
-        "returnComment": [],
-        "initialIsOpen": false
-      },
-      {
-        "parentPluginId": "esUiShared",
-        "id": "def-server.isEsError",
-        "type": "Function",
-        "tags": [],
-        "label": "isEsError",
-        "description": [],
-        "signature": [
-          "(err: RequestError) => boolean"
-        ],
-        "path": "src/plugins/es_ui_shared/__packages_do_not_import__/errors/is_es_error.ts",
-        "deprecated": false,
-        "children": [
-          {
-            "parentPluginId": "esUiShared",
-            "id": "def-server.isEsError.$1",
-            "type": "Object",
-            "tags": [],
-            "label": "err",
-            "description": [],
-            "signature": [
-              "RequestError"
-            ],
-            "path": "src/plugins/es_ui_shared/__packages_do_not_import__/errors/is_es_error.ts",
             "deprecated": false,
             "isRequired": true
           }

--- a/api_docs/es_ui_shared.mdx
+++ b/api_docs/es_ui_shared.mdx
@@ -18,7 +18,7 @@ import esUiSharedObj from './es_ui_shared.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 92 | 4 | 90 | 1 |
+| 92 | 5 | 90 | 1 |
 
 ## Client
 

--- a/api_docs/expression_repeat_image.json
+++ b/api_docs/expression_repeat_image.json
@@ -355,6 +355,8 @@
         ],
         "path": "src/plugins/expression_repeat_image/common/types/expression_functions.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {

--- a/api_docs/expression_shape.json
+++ b/api_docs/expression_shape.json
@@ -596,8 +596,8 @@
             ],
             "path": "src/plugins/expression_shape/public/components/reusable/types.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -896,6 +896,8 @@
         ],
         "path": "src/plugins/expression_shape/common/types/expression_functions.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -1408,6 +1410,8 @@
         ],
         "path": "src/plugins/expression_shape/common/types/expression_functions.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {

--- a/api_docs/expressions.json
+++ b/api_docs/expressions.json
@@ -6404,8 +6404,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -6489,8 +6489,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -6513,7 +6513,9 @@
               "<unknown, unknown, unknown, any>) | undefined"
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -6528,7 +6530,9 @@
               "(() => boolean) | undefined"
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -6552,8 +6556,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -6921,13 +6925,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
-            "returnComment": [
-              "`ExpressionAstFunctionBuilder[]`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.fnName",
+                "id": "def-public.ExpressionAstExpressionBuilder.findFunction.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "fnName",
@@ -6945,8 +6946,12 @@
                   "<FnDef>[\"name\"]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_expression.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`ExpressionAstFunctionBuilder[]`"
             ]
           },
           {
@@ -6972,10 +6977,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`ExpressionAstExpression`"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "expressions",
@@ -6993,10 +6998,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`string`"
-            ],
-            "children": []
+            ]
           }
         ],
         "initialIsOpen": false
@@ -7097,13 +7102,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionAstFunctionBuilder.addArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -7114,11 +7116,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.value",
+                "id": "def-public.ExpressionAstFunctionBuilder.addArgument.$2",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "value",
@@ -7136,8 +7139,12 @@
                   " | FunctionArgs<FnDef>[A]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -7164,13 +7171,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`ExpressionAstFunctionBuilderArgument[] | undefined`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionAstFunctionBuilder.getArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -7181,8 +7185,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`ExpressionAstFunctionBuilderArgument[] | undefined`"
             ]
           },
           {
@@ -7209,13 +7217,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionAstFunctionBuilder.replaceArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -7226,11 +7231,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.value",
+                "id": "def-public.ExpressionAstFunctionBuilder.replaceArgument.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "value",
@@ -7249,8 +7255,12 @@
                   " | FunctionArgs<FnDef>[A])[]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -7269,13 +7279,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionAstFunctionBuilder.removeArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -7286,8 +7293,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -7313,10 +7324,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`ExpressionAstFunction`"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "expressions",
@@ -7334,10 +7345,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`string`"
-            ],
-            "children": []
+            ]
           }
         ],
         "initialIsOpen": false
@@ -8236,7 +8247,9 @@
               "(() => Error | undefined) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8272,11 +8285,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.domNode",
+                "id": "def-public.ExpressionRenderDefinition.render.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "domNode",
@@ -8285,11 +8297,12 @@
                   "HTMLElement"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.config",
+                "id": "def-public.ExpressionRenderDefinition.render.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "config",
@@ -8298,11 +8311,12 @@
                   "Config"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.handlers",
+                "id": "def-public.ExpressionRenderDefinition.render.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "handlers",
@@ -8317,9 +8331,11 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8443,19 +8459,23 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionsServiceStart.getFunction.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8479,19 +8499,23 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionsServiceStart.getRenderer.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8515,19 +8539,23 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.name",
+                "id": "def-public.ExpressionsServiceStart.getType.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8593,11 +8621,10 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.ast",
+                "id": "def-public.ExpressionsServiceStart.run.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "ast",
@@ -8613,11 +8640,12 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.input",
+                "id": "def-public.ExpressionsServiceStart.run.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "input",
@@ -8626,11 +8654,12 @@
                   "Input"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.params",
+                "id": "def-public.ExpressionsServiceStart.run.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "params",
@@ -8646,9 +8675,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8688,11 +8719,10 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.ast",
+                "id": "def-public.ExpressionsServiceStart.execute.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "ast",
@@ -8708,11 +8738,12 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.input",
+                "id": "def-public.ExpressionsServiceStart.execute.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "input",
@@ -8721,11 +8752,12 @@
                   "Input"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.params",
+                "id": "def-public.ExpressionsServiceStart.execute.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "params",
@@ -8741,9 +8773,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8766,8 +8800,8 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -8818,7 +8852,24 @@
               "((type: any) => void | Error) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ExpressionTypeDefinition.validate.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8831,7 +8882,24 @@
               "((type: Value) => SerializedType) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ExpressionTypeDefinition.serialize.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "Value"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -8844,7 +8912,24 @@
               "((type: SerializedType) => Value) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ExpressionTypeDefinition.deserialize.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "SerializedType"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9288,8 +9373,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9303,11 +9388,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.fn",
+                "id": "def-public.IInterpreterRenderHandlers.onDestroy.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "fn",
@@ -9316,9 +9400,11 @@
                   "() => void"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9332,8 +9418,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9347,11 +9433,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.params",
+                "id": "def-public.IInterpreterRenderHandlers.update.$1",
                 "type": "Any",
                 "tags": [],
                 "label": "params",
@@ -9360,9 +9445,11 @@
                   "any"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9376,11 +9463,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-public.event",
+                "id": "def-public.IInterpreterRenderHandlers.event.$1",
                 "type": "Any",
                 "tags": [],
                 "label": "event",
@@ -9389,9 +9475,11 @@
                   "any"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9404,7 +9492,24 @@
               "((event: any) => Promise<boolean>) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.IInterpreterRenderHandlers.hasCompatibleActions.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "event",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/expressions/common/expression_renderers/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9425,8 +9530,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9440,8 +9545,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9746,7 +9851,45 @@
               " | null | undefined) => React.ReactElement<any, string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)> | React.ReactElement<any, string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)>[]) | undefined"
             ],
             "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ReactExpressionRendererProps.renderError.$1",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "message",
+                "description": [],
+                "signature": [
+                  "string | null | undefined"
+                ],
+                "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
+                "deprecated": false,
+                "isRequired": false
+              },
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ReactExpressionRendererProps.renderError.$2",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "error",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "expressions",
+                    "scope": "public",
+                    "docId": "kibExpressionsPluginApi",
+                    "section": "def-public.ExpressionRenderError",
+                    "text": "ExpressionRenderError"
+                  },
+                  " | null | undefined"
+                ],
+                "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
+                "deprecated": false,
+                "isRequired": false
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9780,7 +9923,30 @@
               ") => void) | undefined"
             ],
             "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ReactExpressionRendererProps.onEvent.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "event",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "expressions",
+                    "scope": "public",
+                    "docId": "kibExpressionsPluginApi",
+                    "section": "def-public.ExpressionRendererEvent",
+                    "text": "ExpressionRendererEvent"
+                  }
+                ],
+                "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -9793,7 +9959,52 @@
               "(<TData, TInspectorAdapters>(data: TData, adapters?: TInspectorAdapters | undefined, partial?: boolean | undefined) => void) | undefined"
             ],
             "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ReactExpressionRendererProps.onData$.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "data",
+                "description": [],
+                "signature": [
+                  "TData"
+                ],
+                "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ReactExpressionRendererProps.onData$.$2",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "adapters",
+                "description": [],
+                "signature": [
+                  "TInspectorAdapters | undefined"
+                ],
+                "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
+                "deprecated": false,
+                "isRequired": false
+              },
+              {
+                "parentPluginId": "expressions",
+                "id": "def-public.ReactExpressionRendererProps.onData$.$3",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "partial",
+                "description": [],
+                "signature": [
+                  "boolean | undefined"
+                ],
+                "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
+                "deprecated": false,
+                "isRequired": false
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -10304,6 +10515,35 @@
         ],
         "path": "src/plugins/expressions/public/react_expression_renderer.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "expressions",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "expressions",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10346,6 +10586,35 @@
         ],
         "path": "src/plugins/expressions/common/expression_types/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "expressions",
+            "id": "def-public.input",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "input",
+            "description": [],
+            "signature": [
+              "I"
+            ],
+            "path": "src/plugins/expressions/common/expression_types/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "expressions",
+            "id": "def-public.availableTypes",
+            "type": "Object",
+            "tags": [],
+            "label": "availableTypes",
+            "description": [],
+            "signature": [
+              "{ [x: string]: any; }"
+            ],
+            "path": "src/plugins/expressions/common/expression_types/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -15898,8 +16167,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -15983,8 +16252,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -16007,7 +16276,9 @@
               "<unknown, unknown, unknown, any>) | undefined"
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -16022,7 +16293,9 @@
               "(() => boolean) | undefined"
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -16046,8 +16319,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -16415,13 +16688,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
-            "returnComment": [
-              "`ExpressionAstFunctionBuilder[]`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.fnName",
+                "id": "def-server.ExpressionAstExpressionBuilder.findFunction.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "fnName",
@@ -16439,8 +16709,12 @@
                   "<FnDef>[\"name\"]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_expression.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`ExpressionAstFunctionBuilder[]`"
             ]
           },
           {
@@ -16466,10 +16740,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`ExpressionAstExpression`"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "expressions",
@@ -16487,10 +16761,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`string`"
-            ],
-            "children": []
+            ]
           }
         ],
         "initialIsOpen": false
@@ -16591,13 +16865,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.name",
+                "id": "def-server.ExpressionAstFunctionBuilder.addArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -16608,11 +16879,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.value",
+                "id": "def-server.ExpressionAstFunctionBuilder.addArgument.$2",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "value",
@@ -16630,8 +16902,12 @@
                   " | FunctionArgs<FnDef>[A]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -16658,13 +16934,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`ExpressionAstFunctionBuilderArgument[] | undefined`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.name",
+                "id": "def-server.ExpressionAstFunctionBuilder.getArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -16675,8 +16948,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`ExpressionAstFunctionBuilderArgument[] | undefined`"
             ]
           },
           {
@@ -16703,13 +16980,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.name",
+                "id": "def-server.ExpressionAstFunctionBuilder.replaceArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -16720,11 +16994,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.value",
+                "id": "def-server.ExpressionAstFunctionBuilder.replaceArgument.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "value",
@@ -16743,8 +17018,12 @@
                   " | FunctionArgs<FnDef>[A])[]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -16763,13 +17042,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.name",
+                "id": "def-server.ExpressionAstFunctionBuilder.removeArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -16780,8 +17056,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -16807,10 +17087,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`ExpressionAstFunction`"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "expressions",
@@ -16828,10 +17108,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`string`"
-            ],
-            "children": []
+            ]
           }
         ],
         "initialIsOpen": false
@@ -17701,7 +17981,9 @@
               "(() => Error | undefined) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -17737,11 +18019,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.domNode",
+                "id": "def-server.ExpressionRenderDefinition.render.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "domNode",
@@ -17750,11 +18031,12 @@
                   "HTMLElement"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.config",
+                "id": "def-server.ExpressionRenderDefinition.render.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "config",
@@ -17763,11 +18045,12 @@
                   "Config"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.handlers",
+                "id": "def-server.ExpressionRenderDefinition.render.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "handlers",
@@ -17782,9 +18065,11 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -17835,7 +18120,24 @@
               "((type: any) => void | Error) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-server.ExpressionTypeDefinition.validate.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -17848,7 +18150,24 @@
               "((type: Value) => SerializedType) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-server.ExpressionTypeDefinition.serialize.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "Value"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -17861,7 +18180,24 @@
               "((type: SerializedType) => Value) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-server.ExpressionTypeDefinition.deserialize.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "SerializedType"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18043,8 +18379,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18058,11 +18394,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.fn",
+                "id": "def-server.IInterpreterRenderHandlers.onDestroy.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "fn",
@@ -18071,9 +18406,11 @@
                   "() => void"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18087,8 +18424,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18102,11 +18439,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.params",
+                "id": "def-server.IInterpreterRenderHandlers.update.$1",
                 "type": "Any",
                 "tags": [],
                 "label": "params",
@@ -18115,9 +18451,11 @@
                   "any"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18131,11 +18469,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-server.event",
+                "id": "def-server.IInterpreterRenderHandlers.event.$1",
                 "type": "Any",
                 "tags": [],
                 "label": "event",
@@ -18144,9 +18481,11 @@
                   "any"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18159,7 +18498,24 @@
               "((event: any) => Promise<boolean>) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-server.IInterpreterRenderHandlers.hasCompatibleActions.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "event",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/expressions/common/expression_renderers/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18180,8 +18536,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18195,8 +18551,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -18906,6 +19262,35 @@
         ],
         "path": "src/plugins/expressions/common/expression_types/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "expressions",
+            "id": "def-server.input",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "input",
+            "description": [],
+            "signature": [
+              "I"
+            ],
+            "path": "src/plugins/expressions/common/expression_types/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "expressions",
+            "id": "def-server.availableTypes",
+            "type": "Object",
+            "tags": [],
+            "label": "availableTypes",
+            "description": [],
+            "signature": [
+              "{ [x: string]: any; }"
+            ],
+            "path": "src/plugins/expressions/common/expression_types/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -26585,8 +26970,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -26670,8 +27055,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -26694,7 +27079,9 @@
               "<unknown, unknown, unknown, any>) | undefined"
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -26709,7 +27096,9 @@
               "(() => boolean) | undefined"
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -26733,8 +27122,8 @@
             ],
             "path": "src/plugins/expressions/common/execution/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -26872,11 +27261,10 @@
             ],
             "path": "src/plugins/expressions/common/execution/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutionPureTransitions.start.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -26892,9 +27280,11 @@
                   "<Output>"
                 ],
                 "path": "src/plugins/expressions/common/execution/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -26924,11 +27314,10 @@
             ],
             "path": "src/plugins/expressions/common/execution/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutionPureTransitions.setResult.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -26944,9 +27333,11 @@
                   "<Output>"
                 ],
                 "path": "src/plugins/expressions/common/execution/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -26976,11 +27367,10 @@
             ],
             "path": "src/plugins/expressions/common/execution/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutionPureTransitions.setError.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -26996,9 +27386,11 @@
                   "<Output>"
                 ],
                 "path": "src/plugins/expressions/common/execution/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -27190,11 +27582,10 @@
             ],
             "path": "src/plugins/expressions/common/executor/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutorPureSelectors.getFunction.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -27210,9 +27601,11 @@
                   "<Record<string, unknown>>"
                 ],
                 "path": "src/plugins/expressions/common/executor/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -27242,11 +27635,10 @@
             ],
             "path": "src/plugins/expressions/common/executor/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutorPureSelectors.getType.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -27262,9 +27654,11 @@
                   "<Record<string, unknown>>"
                 ],
                 "path": "src/plugins/expressions/common/executor/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -27286,11 +27680,10 @@
             ],
             "path": "src/plugins/expressions/common/executor/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutorPureSelectors.getContext.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -27306,9 +27699,11 @@
                   "<Record<string, unknown>>"
                 ],
                 "path": "src/plugins/expressions/common/executor/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -27359,11 +27754,10 @@
             ],
             "path": "src/plugins/expressions/common/executor/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutorPureTransitions.addFunction.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -27379,9 +27773,11 @@
                   "<Record<string, unknown>>"
                 ],
                 "path": "src/plugins/expressions/common/executor/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -27419,11 +27815,10 @@
             ],
             "path": "src/plugins/expressions/common/executor/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutorPureTransitions.addType.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -27439,9 +27834,11 @@
                   "<Record<string, unknown>>"
                 ],
                 "path": "src/plugins/expressions/common/executor/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -27471,11 +27868,10 @@
             ],
             "path": "src/plugins/expressions/common/executor/container.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.state",
+                "id": "def-common.ExecutorPureTransitions.extendContext.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "state",
@@ -27491,9 +27887,11 @@
                   "<Record<string, unknown>>"
                 ],
                 "path": "src/plugins/expressions/common/executor/container.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -27679,13 +28077,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
-            "returnComment": [
-              "`ExpressionAstFunctionBuilder[]`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.fnName",
+                "id": "def-common.ExpressionAstExpressionBuilder.findFunction.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "fnName",
@@ -27703,8 +28098,12 @@
                   "<FnDef>[\"name\"]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_expression.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`ExpressionAstFunctionBuilder[]`"
             ]
           },
           {
@@ -27730,10 +28129,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`ExpressionAstExpression`"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "expressions",
@@ -27751,10 +28150,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_expression.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`string`"
-            ],
-            "children": []
+            ]
           }
         ],
         "initialIsOpen": false
@@ -27855,13 +28254,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionAstFunctionBuilder.addArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -27872,11 +28268,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.value",
+                "id": "def-common.ExpressionAstFunctionBuilder.addArgument.$2",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "value",
@@ -27894,8 +28291,12 @@
                   " | FunctionArgs<FnDef>[A]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -27922,13 +28323,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`ExpressionAstFunctionBuilderArgument[] | undefined`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionAstFunctionBuilder.getArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -27939,8 +28337,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`ExpressionAstFunctionBuilderArgument[] | undefined`"
             ]
           },
           {
@@ -27967,13 +28369,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionAstFunctionBuilder.replaceArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -27984,11 +28383,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.value",
+                "id": "def-common.ExpressionAstFunctionBuilder.replaceArgument.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "value",
@@ -28007,8 +28407,12 @@
                   " | FunctionArgs<FnDef>[A])[]"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -28027,13 +28431,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
-            "returnComment": [
-              "`this`"
-            ],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionAstFunctionBuilder.removeArgument.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "name",
@@ -28044,8 +28445,12 @@
                   "A"
                 ],
                 "path": "src/plugins/expressions/common/ast/build_function.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "`this`"
             ]
           },
           {
@@ -28071,10 +28476,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`ExpressionAstFunction`"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "expressions",
@@ -28092,10 +28497,10 @@
             ],
             "path": "src/plugins/expressions/common/ast/build_function.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "`string`"
-            ],
-            "children": []
+            ]
           }
         ],
         "initialIsOpen": false
@@ -29142,7 +29547,9 @@
               "(() => Error | undefined) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29178,11 +29585,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.domNode",
+                "id": "def-common.ExpressionRenderDefinition.render.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "domNode",
@@ -29191,11 +29597,12 @@
                   "HTMLElement"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.config",
+                "id": "def-common.ExpressionRenderDefinition.render.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "config",
@@ -29204,11 +29611,12 @@
                   "Config"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.handlers",
+                "id": "def-common.ExpressionRenderDefinition.render.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "handlers",
@@ -29223,9 +29631,11 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -29317,19 +29727,23 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionsServiceStart.getFunction.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29353,19 +29767,23 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionsServiceStart.getRenderer.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29389,19 +29807,23 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.name",
+                "id": "def-common.ExpressionsServiceStart.getType.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29467,11 +29889,10 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.ast",
+                "id": "def-common.ExpressionsServiceStart.run.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "ast",
@@ -29487,11 +29908,12 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.input",
+                "id": "def-common.ExpressionsServiceStart.run.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "input",
@@ -29500,11 +29922,12 @@
                   "Input"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.params",
+                "id": "def-common.ExpressionsServiceStart.run.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "params",
@@ -29520,9 +29943,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29562,11 +29987,10 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.ast",
+                "id": "def-common.ExpressionsServiceStart.execute.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "ast",
@@ -29582,11 +30006,12 @@
                   }
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.input",
+                "id": "def-common.ExpressionsServiceStart.execute.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "input",
@@ -29595,11 +30020,12 @@
                   "Input"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.params",
+                "id": "def-common.ExpressionsServiceStart.execute.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "params",
@@ -29615,9 +30041,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/expressions/common/service/expressions_services.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29640,8 +30068,8 @@
             ],
             "path": "src/plugins/expressions/common/service/expressions_services.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -29692,7 +30120,24 @@
               "((type: any) => void | Error) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-common.ExpressionTypeDefinition.validate.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29705,7 +30150,24 @@
               "((type: Value) => SerializedType) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-common.ExpressionTypeDefinition.serialize.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "Value"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29718,7 +30180,24 @@
               "((type: SerializedType) => Value) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-common.ExpressionTypeDefinition.deserialize.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "type",
+                "description": [],
+                "signature": [
+                  "SerializedType"
+                ],
+                "path": "src/plugins/expressions/common/expression_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29900,8 +30379,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29915,11 +30394,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.fn",
+                "id": "def-common.IInterpreterRenderHandlers.onDestroy.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "fn",
@@ -29928,9 +30406,11 @@
                   "() => void"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29944,8 +30424,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29959,11 +30439,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.params",
+                "id": "def-common.IInterpreterRenderHandlers.update.$1",
                 "type": "Any",
                 "tags": [],
                 "label": "params",
@@ -29972,9 +30451,11 @@
                   "any"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -29988,11 +30469,10 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "expressions",
-                "id": "def-common.event",
+                "id": "def-common.IInterpreterRenderHandlers.event.$1",
                 "type": "Any",
                 "tags": [],
                 "label": "event",
@@ -30001,9 +30481,11 @@
                   "any"
                 ],
                 "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -30016,7 +30498,24 @@
               "((event: any) => Promise<boolean>) | undefined"
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "expressions",
+                "id": "def-common.IInterpreterRenderHandlers.hasCompatibleActions.$1",
+                "type": "Any",
+                "tags": [],
+                "label": "event",
+                "description": [],
+                "signature": [
+                  "any"
+                ],
+                "path": "src/plugins/expressions/common/expression_renderers/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -30037,8 +30536,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -30052,8 +30551,8 @@
             ],
             "path": "src/plugins/expressions/common/expression_renderers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "expressions",
@@ -31829,6 +32328,35 @@
         ],
         "path": "src/plugins/expressions/common/expression_types/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "expressions",
+            "id": "def-common.input",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "input",
+            "description": [],
+            "signature": [
+              "I"
+            ],
+            "path": "src/plugins/expressions/common/expression_types/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "expressions",
+            "id": "def-common.availableTypes",
+            "type": "Object",
+            "tags": [],
+            "label": "availableTypes",
+            "description": [],
+            "signature": [
+              "{ [x: string]: any; }"
+            ],
+            "path": "src/plugins/expressions/common/expression_types/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/expressions.mdx
+++ b/api_docs/expressions.mdx
@@ -18,7 +18,7 @@ import expressionsObj from './expressions.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 2004 | 58 | 1569 | 5 |
+| 2030 | 65 | 1595 | 5 |
 
 ## Client
 

--- a/api_docs/features.json
+++ b/api_docs/features.json
@@ -2143,7 +2143,23 @@
                   "(licenseType: \"basic\" | \"standard\" | \"gold\" | \"platinum\" | \"enterprise\" | \"trial\") => boolean | undefined"
                 ],
                 "path": "x-pack/plugins/features/server/feature_privilege_iterator/sub_feature_privilege_iterator.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "features",
+                    "id": "def-server.licenseType",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "licenseType",
+                    "description": [],
+                    "signature": [
+                      "\"basic\" | \"standard\" | \"gold\" | \"platinum\" | \"enterprise\" | \"trial\""
+                    ],
+                    "path": "x-pack/plugins/features/server/feature_privilege_iterator/sub_feature_privilege_iterator.ts",
+                    "deprecated": false
+                  }
+                ]
               }
             ]
           }

--- a/api_docs/features.mdx
+++ b/api_docs/features.mdx
@@ -18,7 +18,7 @@ import featuresObj from './features.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 215 | 0 | 97 | 2 |
+| 216 | 0 | 98 | 2 |
 
 ## Client
 

--- a/api_docs/file_upload.json
+++ b/api_docs/file_upload.json
@@ -102,11 +102,10 @@
             ],
             "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "fileUpload",
-                "id": "def-public.geojsonFile",
+                "id": "def-public.FileUploadComponentProps.onFileSelect.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "geojsonFile",
@@ -115,29 +114,39 @@
                   "GeoJSON.FeatureCollection<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>"
                 ],
                 "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "fileUpload",
-                "id": "def-public.name",
+                "id": "def-public.FileUploadComponentProps.onFileSelect.$2",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "fileUpload",
-                "id": "def-public.previewCoverage",
+                "id": "def-public.FileUploadComponentProps.onFileSelect.$3",
                 "type": "number",
                 "tags": [],
                 "label": "previewCoverage",
                 "description": [],
+                "signature": [
+                  "number"
+                ],
                 "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -151,8 +160,8 @@
             ],
             "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -166,8 +175,8 @@
             ],
             "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -181,8 +190,8 @@
             ],
             "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -204,11 +213,10 @@
             ],
             "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "fileUpload",
-                "id": "def-public.results",
+                "id": "def-public.FileUploadComponentProps.onUploadComplete.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "results",
@@ -223,9 +231,11 @@
                   }
                 ],
                 "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -239,8 +249,8 @@
             ],
             "path": "x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -791,21 +801,24 @@
             ],
             "path": "x-pack/plugins/file_upload/public/components/geojson_upload_form/index_name_form.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "fileUpload",
-                "id": "def-public.name",
+                "id": "def-public.Props.onIndexNameChange.$1",
                 "type": "string",
                 "tags": [],
                 "label": "name",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/file_upload/public/components/geojson_upload_form/index_name_form.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "fileUpload",
-                "id": "def-public.error",
+                "id": "def-public.Props.onIndexNameChange.$2",
                 "type": "string",
                 "tags": [],
                 "label": "error",
@@ -814,9 +827,11 @@
                   "string | undefined"
                 ],
                 "path": "x-pack/plugins/file_upload/public/components/geojson_upload_form/index_name_form.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -830,8 +845,8 @@
             ],
             "path": "x-pack/plugins/file_upload/public/components/geojson_upload_form/index_name_form.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "fileUpload",
@@ -845,8 +860,8 @@
             ],
             "path": "x-pack/plugins/file_upload/public/components/geojson_upload_form/index_name_form.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/fleet.json
+++ b/api_docs/fleet.json
@@ -962,30 +962,54 @@
             ],
             "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "fleet",
-                "id": "def-public.opts",
+                "id": "def-public.PackagePolicyCreateExtensionComponentProps.onChange.$1.opts",
                 "type": "Object",
                 "tags": [],
                 "label": "opts",
                 "description": [],
-                "signature": [
-                  "{ isValid: boolean; updatedPolicy: ",
-                  {
-                    "pluginId": "fleet",
-                    "scope": "common",
-                    "docId": "kibFleetPluginApi",
-                    "section": "def-common.NewPackagePolicy",
-                    "text": "NewPackagePolicy"
-                  },
-                  "; }"
-                ],
                 "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "fleet",
+                    "id": "def-public.PackagePolicyCreateExtensionComponentProps.onChange.$1.opts.isValid",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "isValid",
+                    "description": [
+                      "is current form state is valid"
+                    ],
+                    "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "fleet",
+                    "id": "def-public.PackagePolicyCreateExtensionComponentProps.onChange.$1.opts.updatedPolicy",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "updatedPolicy",
+                    "description": [
+                      "The updated Integration Policy to be merged back and included in the API call"
+                    ],
+                    "signature": [
+                      {
+                        "pluginId": "fleet",
+                        "scope": "common",
+                        "docId": "kibFleetPluginApi",
+                        "section": "def-common.NewPackagePolicy",
+                        "text": "NewPackagePolicy"
+                      }
+                    ],
+                    "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1163,30 +1187,131 @@
             ],
             "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "fleet",
-                "id": "def-public.opts",
+                "id": "def-public.PackagePolicyEditExtensionComponentProps.onChange.$1.opts",
                 "type": "Object",
                 "tags": [],
                 "label": "opts",
                 "description": [],
-                "signature": [
-                  "{ isValid: boolean; updatedPolicy: Partial<",
-                  {
-                    "pluginId": "fleet",
-                    "scope": "common",
-                    "docId": "kibFleetPluginApi",
-                    "section": "def-common.NewPackagePolicy",
-                    "text": "NewPackagePolicy"
-                  },
-                  ">; }"
-                ],
                 "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "fleet",
+                    "id": "def-public.PackagePolicyEditExtensionComponentProps.onChange.$1.opts.isValid",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "isValid",
+                    "description": [
+                      "is current form state is valid"
+                    ],
+                    "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "fleet",
+                    "id": "def-public.PackagePolicyEditExtensionComponentProps.onChange.$1.opts.updatedPolicy",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "updatedPolicy",
+                    "description": [
+                      "The updated Integration Policy to be merged back and included in the API call"
+                    ],
+                    "signature": [
+                      "{ name?: string | undefined; description?: string | undefined; namespace?: string | undefined; enabled?: boolean | undefined; policy_id?: string | undefined; output_id?: string | undefined; package?: ",
+                      {
+                        "pluginId": "fleet",
+                        "scope": "common",
+                        "docId": "kibFleetPluginApi",
+                        "section": "def-common.PackagePolicyPackage",
+                        "text": "PackagePolicyPackage"
+                      },
+                      " | undefined; inputs?: ",
+                      {
+                        "pluginId": "fleet",
+                        "scope": "common",
+                        "docId": "kibFleetPluginApi",
+                        "section": "def-common.NewPackagePolicyInput",
+                        "text": "NewPackagePolicyInput"
+                      },
+                      "[] | undefined; vars?: Record<string, ",
+                      {
+                        "pluginId": "fleet",
+                        "scope": "common",
+                        "docId": "kibFleetPluginApi",
+                        "section": "def-common.PackagePolicyConfigRecordEntry",
+                        "text": "PackagePolicyConfigRecordEntry"
+                      },
+                      "> | undefined; }"
+                    ],
+                    "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "fleet",
+        "id": "def-public.PackagePolicyEditTabsExtension",
+        "type": "Interface",
+        "tags": [],
+        "label": "PackagePolicyEditTabsExtension",
+        "description": [
+          "Extension point registration contract for Integration Policy Edit tabs views"
+        ],
+        "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+        "deprecated": false,
+        "children": [
+          {
+            "parentPluginId": "fleet",
+            "id": "def-public.PackagePolicyEditTabsExtension.package",
+            "type": "string",
+            "tags": [],
+            "label": "package",
+            "description": [],
+            "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "fleet",
+            "id": "def-public.PackagePolicyEditTabsExtension.view",
+            "type": "string",
+            "tags": [],
+            "label": "view",
+            "description": [],
+            "signature": [
+              "\"package-policy-edit-tabs\""
+            ],
+            "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "fleet",
+            "id": "def-public.PackagePolicyEditTabsExtension.tabs",
+            "type": "Array",
+            "tags": [],
+            "label": "tabs",
+            "description": [],
+            "signature": [
+              "{ title: string; Component: React.LazyExoticComponent<React.ComponentType<",
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.PackagePolicyEditExtensionComponentProps",
+                "text": "PackagePolicyEditExtensionComponentProps"
+              },
+              ">>; }[]"
+            ],
+            "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+            "deprecated": false
           }
         ],
         "initialIsOpen": false
@@ -1394,6 +1519,14 @@
             "pluginId": "fleet",
             "scope": "public",
             "docId": "kibFleetPluginApi",
+            "section": "def-public.PackagePolicyEditTabsExtension",
+            "text": "PackagePolicyEditTabsExtension"
+          },
+          " | ",
+          {
+            "pluginId": "fleet",
+            "scope": "public",
+            "docId": "kibFleetPluginApi",
             "section": "def-public.PackageCustomExtension",
             "text": "PackageCustomExtension"
           },
@@ -1448,6 +1581,68 @@
         ],
         "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "fleet",
+            "id": "def-public.extensionPoint",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "extensionPoint",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.PackagePolicyEditExtension",
+                "text": "PackagePolicyEditExtension"
+              },
+              " | ",
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.PackagePolicyEditTabsExtension",
+                "text": "PackagePolicyEditTabsExtension"
+              },
+              " | ",
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.PackageCustomExtension",
+                "text": "PackageCustomExtension"
+              },
+              " | ",
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.PackagePolicyCreateExtension",
+                "text": "PackagePolicyCreateExtension"
+              },
+              " | ",
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.PackageAssetsExtension",
+                "text": "PackageAssetsExtension"
+              },
+              " | ",
+              {
+                "pluginId": "fleet",
+                "scope": "public",
+                "docId": "kibFleetPluginApi",
+                "section": "def-public.AgentEnrollmentFlyoutFinalStepExtension",
+                "text": "AgentEnrollmentFlyoutFinalStepExtension"
+              }
+            ],
+            "path": "x-pack/plugins/fleet/public/types/ui_extensions.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -2086,6 +2281,14 @@
                   "pluginId": "fleet",
                   "scope": "public",
                   "docId": "kibFleetPluginApi",
+                  "section": "def-public.PackagePolicyEditTabsExtension",
+                  "text": "PackagePolicyEditTabsExtension"
+                },
+                " | ",
+                {
+                  "pluginId": "fleet",
+                  "scope": "public",
+                  "docId": "kibFleetPluginApi",
                   "section": "def-public.PackageCustomExtension",
                   "text": "PackageCustomExtension"
                 },
@@ -2131,8 +2334,8 @@
           ],
           "path": "x-pack/plugins/fleet/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",
@@ -5079,8 +5282,8 @@
           ],
           "path": "x-pack/plugins/fleet/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "fleet",
@@ -5195,86 +5398,29 @@
           ],
           "path": "x-pack/plugins/fleet/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "fleet",
-              "id": "def-server.args",
+              "id": "def-server.FleetStartContract.registerExternalCallback.$1",
               "type": "CompoundType",
               "tags": [],
               "label": "args",
               "description": [],
               "signature": [
-                "[\"packagePolicyCreate\", (newPackagePolicy: ",
                 {
                   "pluginId": "fleet",
-                  "scope": "common",
-                  "docId": "kibFleetPluginApi",
-                  "section": "def-common.NewPackagePolicy",
-                  "text": "NewPackagePolicy"
-                },
-                ", context: ",
-                {
-                  "pluginId": "core",
                   "scope": "server",
-                  "docId": "kibCorePluginApi",
-                  "section": "def-server.RequestHandlerContext",
-                  "text": "RequestHandlerContext"
-                },
-                ", request: ",
-                {
-                  "pluginId": "core",
-                  "scope": "server",
-                  "docId": "kibCoreHttpPluginApi",
-                  "section": "def-server.KibanaRequest",
-                  "text": "KibanaRequest"
-                },
-                "<unknown, unknown, unknown, any>) => Promise<",
-                {
-                  "pluginId": "fleet",
-                  "scope": "common",
                   "docId": "kibFleetPluginApi",
-                  "section": "def-common.NewPackagePolicy",
-                  "text": "NewPackagePolicy"
-                },
-                ">] | [\"packagePolicyUpdate\", (newPackagePolicy: ",
-                {
-                  "pluginId": "fleet",
-                  "scope": "common",
-                  "docId": "kibFleetPluginApi",
-                  "section": "def-common.UpdatePackagePolicy",
-                  "text": "UpdatePackagePolicy"
-                },
-                ", context: ",
-                {
-                  "pluginId": "core",
-                  "scope": "server",
-                  "docId": "kibCorePluginApi",
-                  "section": "def-server.RequestHandlerContext",
-                  "text": "RequestHandlerContext"
-                },
-                ", request: ",
-                {
-                  "pluginId": "core",
-                  "scope": "server",
-                  "docId": "kibCoreHttpPluginApi",
-                  "section": "def-server.KibanaRequest",
-                  "text": "KibanaRequest"
-                },
-                "<unknown, unknown, unknown, any>) => Promise<",
-                {
-                  "pluginId": "fleet",
-                  "scope": "common",
-                  "docId": "kibFleetPluginApi",
-                  "section": "def-common.UpdatePackagePolicy",
-                  "text": "UpdatePackagePolicy"
-                },
-                ">]"
+                  "section": "def-server.ExternalCallback",
+                  "text": "ExternalCallback"
+                }
               ],
               "path": "x-pack/plugins/fleet/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "fleet",
@@ -5291,19 +5437,23 @@
           ],
           "path": "x-pack/plugins/fleet/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "fleet",
-              "id": "def-server.packageName",
+              "id": "def-server.FleetStartContract.createArtifactsClient.$1",
               "type": "string",
               "tags": [],
               "label": "packageName",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "x-pack/plugins/fleet/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",

--- a/api_docs/fleet.mdx
+++ b/api_docs/fleet.mdx
@@ -18,7 +18,7 @@ import fleetObj from './fleet.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 1140 | 15 | 1045 | 8 |
+| 1149 | 15 | 1049 | 8 |
 
 ## Client
 

--- a/api_docs/global_search.json
+++ b/api_docs/global_search.json
@@ -398,8 +398,8 @@
             ],
             "path": "x-pack/plugins/global_search/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -948,11 +948,10 @@
             ],
             "path": "x-pack/plugins/global_search/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "globalSearch",
-                "id": "def-server.context",
+                "id": "def-server.GlobalSearchResultProvider.getSearchableTypes.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "context",
@@ -967,9 +966,11 @@
                   }
                 ],
                 "path": "x-pack/plugins/global_search/server/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1066,8 +1067,8 @@
             ],
             "path": "x-pack/plugins/global_search/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/home.json
+++ b/api_docs/home.json
@@ -241,7 +241,9 @@
               "(() => boolean) | undefined"
             ],
             "path": "src/plugins/home/public/services/feature_catalogue/feature_catalogue_registry.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "home",
@@ -461,6 +463,35 @@
         ],
         "path": "src/plugins/home/public/services/tutorials/tutorial_service.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "home",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "home",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -475,6 +506,35 @@
         ],
         "path": "src/plugins/home/public/services/tutorials/tutorial_service.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "home",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "home",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -489,6 +549,35 @@
         ],
         "path": "src/plugins/home/public/services/tutorials/tutorial_service.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "home",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "home",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -951,6 +1040,8 @@
         ],
         "path": "src/plugins/home/server/services/sample_data/lib/sample_dataset_registry_types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -967,6 +1058,22 @@
         ],
         "path": "src/plugins/home/server/services/tutorials/lib/tutorials_registry_types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "home",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "TutorialContext"
+            ],
+            "path": "src/plugins/home/server/services/tutorials/lib/tutorials_registry_types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/home.mdx
+++ b/api_docs/home.mdx
@@ -18,7 +18,7 @@ import homeObj from './home.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 94 | 0 | 70 | 5 |
+| 101 | 3 | 77 | 5 |
 
 ## Client
 

--- a/api_docs/index_pattern_field_editor.json
+++ b/api_docs/index_pattern_field_editor.json
@@ -314,22 +314,34 @@
             ],
             "path": "src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "indexPatternFieldEditor",
-                "id": "def-public.newParams",
+                "id": "def-public.FormatEditorProps.onChange.$1.newParams",
                 "type": "Object",
                 "tags": [],
                 "label": "newParams",
                 "description": [],
-                "signature": [
-                  "{ [key: string]: any; }"
-                ],
                 "path": "src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "indexPatternFieldEditor",
+                    "id": "def-public.FormatEditorProps.onChange.$1.newParams.Unnamed",
+                    "type": "Any",
+                    "tags": [],
+                    "label": "Unnamed",
+                    "description": [],
+                    "signature": [
+                      "any"
+                    ],
+                    "path": "src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/types.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "indexPatternFieldEditor",
@@ -405,7 +417,24 @@
               "((fieldNames: string[]) => void) | undefined"
             ],
             "path": "src/plugins/index_pattern_field_editor/public/open_delete_modal.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "indexPatternFieldEditor",
+                "id": "def-public.OpenFieldDeleteModalOptions.onDelete.$1",
+                "type": "Array",
+                "tags": [],
+                "label": "fieldNames",
+                "description": [],
+                "signature": [
+                  "string[]"
+                ],
+                "path": "src/plugins/index_pattern_field_editor/public/open_delete_modal.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "indexPatternFieldEditor",
@@ -473,7 +502,30 @@
               ") => void) | undefined"
             ],
             "path": "src/plugins/index_pattern_field_editor/public/open_editor.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "indexPatternFieldEditor",
+                "id": "def-public.OpenFieldEditorOptions.onSave.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "field",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "data",
+                    "scope": "common",
+                    "docId": "kibDataIndexPatternsPluginApi",
+                    "section": "def-common.IndexPatternField",
+                    "text": "IndexPatternField"
+                  }
+                ],
+                "path": "src/plugins/index_pattern_field_editor/public/open_editor.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "indexPatternFieldEditor",
@@ -548,6 +600,8 @@
         ],
         "path": "src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/index_pattern_field_editor.mdx
+++ b/api_docs/index_pattern_field_editor.mdx
@@ -18,7 +18,7 @@ Contact [App Services](https://github.com/orgs/elastic/teams/kibana-app-services
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 41 | 1 | 36 | 3 |
+| 44 | 2 | 39 | 3 |
 
 ## Client
 

--- a/api_docs/infra.json
+++ b/api_docs/infra.json
@@ -358,21 +358,24 @@
           ],
           "path": "x-pack/plugins/infra/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "infra",
-              "id": "def-server.sourceId",
+              "id": "def-server.InfraPluginSetup.defineInternalSourceConfiguration.$1",
               "type": "string",
               "tags": [],
               "label": "sourceId",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "x-pack/plugins/infra/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "infra",
-              "id": "def-server.sourceProperties",
+              "id": "def-server.InfraPluginSetup.defineInternalSourceConfiguration.$2",
               "type": "Object",
               "tags": [],
               "label": "sourceProperties",
@@ -381,9 +384,11 @@
                 "InfraStaticSourceConfiguration"
               ],
               "path": "x-pack/plugins/infra/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/inspector.json
+++ b/api_docs/inspector.json
@@ -881,7 +881,30 @@
               ") => boolean) | undefined"
             ],
             "path": "src/plugins/inspector/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "inspector",
+                "id": "def-public.InspectorViewDescription.shouldShow.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "adapters",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "inspector",
+                    "scope": "common",
+                    "docId": "kibInspectorPluginApi",
+                    "section": "def-common.Adapters",
+                    "text": "Adapters"
+                  }
+                ],
+                "path": "src/plugins/inspector/public/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "inspector",
@@ -1181,13 +1204,10 @@
           ],
           "path": "src/plugins/inspector/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [
-            "True, if a call to `open` with the same adapters\nwould have shown the inspector panel, false otherwise."
-          ],
           "children": [
             {
               "parentPluginId": "inspector",
-              "id": "def-public.adapters",
+              "id": "def-public.Start.isAvailable.$1",
               "type": "Object",
               "tags": [],
               "label": "adapters",
@@ -1205,8 +1225,12 @@
                 " | undefined"
               ],
               "path": "src/plugins/inspector/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": false
             }
+          ],
+          "returnComment": [
+            "True, if a call to `open` with the same adapters\nwould have shown the inspector panel, false otherwise."
           ]
         },
         {
@@ -1249,13 +1273,10 @@
           ],
           "path": "src/plugins/inspector/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [
-            "The session instance for the opened inspector."
-          ],
           "children": [
             {
               "parentPluginId": "inspector",
-              "id": "def-public.adapters",
+              "id": "def-public.Start.open.$1",
               "type": "Object",
               "tags": [],
               "label": "adapters",
@@ -1272,11 +1293,12 @@
                 }
               ],
               "path": "src/plugins/inspector/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "inspector",
-              "id": "def-public.options",
+              "id": "def-public.Start.open.$2",
               "type": "Object",
               "tags": [],
               "label": "options",
@@ -1294,8 +1316,12 @@
                 " | undefined"
               ],
               "path": "src/plugins/inspector/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": false
             }
+          ],
+          "returnComment": [
+            "The session instance for the opened inspector."
           ]
         }
       ],

--- a/api_docs/inspector.mdx
+++ b/api_docs/inspector.mdx
@@ -18,7 +18,7 @@ import inspectorObj from './inspector.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 101 | 6 | 78 | 4 |
+| 102 | 6 | 79 | 4 |
 
 ## Client
 

--- a/api_docs/kibana_legacy.json
+++ b/api_docs/kibana_legacy.json
@@ -919,7 +919,24 @@
               "((...args: any[]) => void) | undefined"
             ],
             "path": "src/plugins/kibana_legacy/public/angular/angular_config.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "kibanaLegacy",
+                "id": "def-public.RouteConfiguration.resolveRedirectTo.$1",
+                "type": "Array",
+                "tags": [],
+                "label": "args",
+                "description": [],
+                "signature": [
+                  "any[]"
+                ],
+                "path": "src/plugins/kibana_legacy/public/angular/angular_config.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaLegacy",
@@ -999,7 +1016,24 @@
               "[]) | undefined"
             ],
             "path": "src/plugins/kibana_legacy/public/angular/angular_config.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "kibanaLegacy",
+                "id": "def-public.RouteConfiguration.k7Breadcrumbs.$1",
+                "type": "Array",
+                "tags": [],
+                "label": "args",
+                "description": [],
+                "signature": [
+                  "any[]"
+                ],
+                "path": "src/plugins/kibana_legacy/public/angular/angular_config.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaLegacy",
@@ -1060,6 +1094,38 @@
         ],
         "path": "src/plugins/kibana_legacy/public/utils/private.d.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaLegacy",
+            "id": "def-public.provider",
+            "type": "Function",
+            "tags": [],
+            "label": "provider",
+            "description": [],
+            "signature": [
+              "(...injectable: any[]) => T"
+            ],
+            "path": "src/plugins/kibana_legacy/public/utils/private.d.ts",
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "kibanaLegacy",
+                "id": "def-public.injectable",
+                "type": "Array",
+                "tags": [],
+                "label": "injectable",
+                "description": [],
+                "signature": [
+                  "any[]"
+                ],
+                "path": "src/plugins/kibana_legacy/public/utils/private.d.ts",
+                "deprecated": false
+              }
+            ]
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/kibana_legacy.mdx
+++ b/api_docs/kibana_legacy.mdx
@@ -18,7 +18,7 @@ Contact [Kibana App](https://github.com/orgs/elastic/teams/kibana-app) for quest
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 66 | 3 | 62 | 1 |
+| 70 | 3 | 66 | 1 |
 
 ## Client
 

--- a/api_docs/kibana_react.json
+++ b/api_docs/kibana_react.json
@@ -892,6 +892,35 @@
         ],
         "path": "src/plugins/kibana_react/public/context/context.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-public.props",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "P & { children?: React.ReactNode; }"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-public.context",
+            "type": "Any",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "any"
+            ],
+            "path": "node_modules/@types/react/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1835,8 +1864,8 @@
             ],
             "path": "src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1992,7 +2021,9 @@
               "(() => void) | undefined"
             ],
             "path": "src/plugins/kibana_react/public/field_button/field_button.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaReact",
@@ -2381,24 +2412,24 @@
             ],
             "path": "src/plugins/kibana_react/public/overlays/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaReact",
-                "id": "def-public.node",
+                "id": "def-public.KibanaReactOverlays.openFlyout.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "node",
                 "description": [],
                 "signature": [
-                  "string | number | boolean | {} | React.ReactElement<any, string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)> | React.ReactNodeArray | React.ReactPortal | null | undefined"
+                  "React.ReactNode"
                 ],
                 "path": "src/plugins/kibana_react/public/overlays/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "kibanaReact",
-                "id": "def-public.options",
+                "id": "def-public.KibanaReactOverlays.openFlyout.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -2414,9 +2445,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/kibana_react/public/overlays/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaReact",
@@ -2445,24 +2478,24 @@
             ],
             "path": "src/plugins/kibana_react/public/overlays/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaReact",
-                "id": "def-public.node",
+                "id": "def-public.KibanaReactOverlays.openModal.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "node",
                 "description": [],
                 "signature": [
-                  "string | number | boolean | {} | React.ReactElement<any, string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)> | React.ReactNodeArray | React.ReactPortal | null | undefined"
+                  "React.ReactNode"
                 ],
                 "path": "src/plugins/kibana_react/public/overlays/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "kibanaReact",
-                "id": "def-public.options",
+                "id": "def-public.KibanaReactOverlays.openModal.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -2478,9 +2511,11 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/kibana_react/public/overlays/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -3199,7 +3234,25 @@
               ".IStandaloneCodeEditor) => void) | undefined"
             ],
             "path": "src/plugins/kibana_react/public/url_template_editor/url_template_editor.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "kibanaReact",
+                "id": "def-public.UrlTemplateEditorProps.onEditor.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "editor",
+                "description": [],
+                "signature": [
+                  "editor",
+                  ".IStandaloneCodeEditor"
+                ],
+                "path": "src/plugins/kibana_react/public/url_template_editor/url_template_editor.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaReact",
@@ -4198,6 +4251,43 @@
         ],
         "path": "src/plugins/kibana_react/common/eui_styled_components.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-common.first",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "first",
+            "description": [],
+            "signature": [
+              "CSSObject",
+              " | ",
+              "InterpolationFunction",
+              "<",
+              "ThemedStyledProps",
+              "<P, T>> | TemplateStringsArray"
+            ],
+            "path": "node_modules/@types/styled-components/ts3.7/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-common.interpolations",
+            "type": "Array",
+            "tags": [],
+            "label": "interpolations",
+            "description": [],
+            "signature": [
+              "Interpolation",
+              "<",
+              "ThemedStyledProps",
+              "<P, T>>[]"
+            ],
+            "path": "node_modules/@types/styled-components/ts3.7/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -4374,6 +4464,37 @@
         ],
         "path": "src/plugins/kibana_react/common/eui_styled_components.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-common.strings",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "strings",
+            "description": [],
+            "signature": [
+              "TemplateStringsArray | ",
+              "CSSKeyframes"
+            ],
+            "path": "node_modules/@types/styled-components/ts3.7/index.d.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-common.interpolations",
+            "type": "Array",
+            "tags": [],
+            "label": "interpolations",
+            "description": [],
+            "signature": [
+              "SimpleInterpolation",
+              "[]"
+            ],
+            "path": "node_modules/@types/styled-components/ts3.7/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -4404,6 +4525,22 @@
         ],
         "path": "src/plugins/kibana_react/common/eui_styled_components.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaReact",
+            "id": "def-common.component",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "component",
+            "description": [],
+            "signature": [
+              "React.ComponentProps<C> extends { theme?: T | undefined; } ? C : never"
+            ],
+            "path": "node_modules/@types/styled-components/ts3.7/index.d.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/kibana_react.mdx
+++ b/api_docs/kibana_react.mdx
@@ -18,7 +18,7 @@ import kibanaReactObj from './kibana_react.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 258 | 5 | 228 | 4 |
+| 266 | 6 | 236 | 4 |
 
 ## Client
 

--- a/api_docs/kibana_utils.json
+++ b/api_docs/kibana_utils.json
@@ -1673,7 +1673,24 @@
                   "((error: Error) => void) | undefined"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.createKbnUrlStateStorage.$1.useHashfalsehistoryonGetErroronSetError.onGetError.$1",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "error",
+                    "description": [],
+                    "signature": [
+                      "Error"
+                    ],
+                    "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
+                    "deprecated": false,
+                    "isRequired": true
+                  }
+                ],
+                "returnComment": []
               },
               {
                 "parentPluginId": "kibanaUtils",
@@ -1686,7 +1703,24 @@
                   "((error: Error) => void) | undefined"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.createKbnUrlStateStorage.$1.useHashfalsehistoryonGetErroronSetError.onSetError.$1",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "error",
+                    "description": [],
+                    "signature": [
+                      "Error"
+                    ],
+                    "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
+                    "deprecated": false,
+                    "isRequired": true
+                  }
+                ],
+                "returnComment": []
               }
             ]
           }
@@ -2015,7 +2049,9 @@
                   "<any>) | undefined"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_management/url/kbn_url_tracker.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [],
+                "returnComment": []
               },
               {
                 "parentPluginId": "kibanaUtils",
@@ -2045,7 +2081,26 @@
                   "((pathname: string) => boolean) | undefined"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_management/url/kbn_url_tracker.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.createKbnUrlTracker.$1.baseUrldefaultSubUrlstorageKeystateParamsnavLinkUpdater$toastNotificationshistorygetHistorystorageshouldTrackUrlUpdatereturntrueonBeforeNavLinkSavednewNavLinknewNavLink.shouldTrackUrlUpdate.$1",
+                    "type": "string",
+                    "tags": [],
+                    "label": "pathname",
+                    "description": [
+                      "A location's pathname which comes to history listener"
+                    ],
+                    "signature": [
+                      "string"
+                    ],
+                    "path": "src/plugins/kibana_utils/public/state_management/url/kbn_url_tracker.ts",
+                    "deprecated": false,
+                    "isRequired": true
+                  }
+                ],
+                "returnComment": []
               },
               {
                 "parentPluginId": "kibanaUtils",
@@ -2060,7 +2115,24 @@
                   "((newNavLink: string) => string) | undefined"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_management/url/kbn_url_tracker.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.createKbnUrlTracker.$1.baseUrldefaultSubUrlstorageKeystateParamsnavLinkUpdater$toastNotificationshistorygetHistorystorageshouldTrackUrlUpdatereturntrueonBeforeNavLinkSavednewNavLinknewNavLink.onBeforeNavLinkSaved.$1",
+                    "type": "string",
+                    "tags": [],
+                    "label": "newNavLink",
+                    "description": [],
+                    "signature": [
+                      "string"
+                    ],
+                    "path": "src/plugins/kibana_utils/public/state_management/url/kbn_url_tracker.ts",
+                    "deprecated": false,
+                    "isRequired": true
+                  }
+                ],
+                "returnComment": []
               }
             ]
           }
@@ -3513,7 +3585,30 @@
                   ") => void) | undefined"
                 ],
                 "path": "src/plugins/kibana_utils/public/history/redirect_when_missing.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.redirectWhenMissing.$1.historynavigateToAppbasePathmappingtoastNotificationsonBeforeRedirect.onBeforeRedirect.$1",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "error",
+                    "description": [],
+                    "signature": [
+                      {
+                        "pluginId": "kibanaUtils",
+                        "scope": "common",
+                        "docId": "kibKibanaUtilsPluginApi",
+                        "section": "def-common.SavedObjectNotFound",
+                        "text": "SavedObjectNotFound"
+                      }
+                    ],
+                    "path": "src/plugins/kibana_utils/public/history/redirect_when_missing.tsx",
+                    "deprecated": false,
+                    "isRequired": true
+                  }
+                ],
+                "returnComment": []
               }
             ]
           }
@@ -4260,10 +4355,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "current state"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4279,11 +4374,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.state",
+                "id": "def-public.BaseStateContainer.set.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -4294,9 +4388,11 @@
                   "State"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4368,11 +4464,10 @@
             ],
             "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.config",
+                "id": "def-public.CollectConfigProps.onConfig.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "config",
@@ -4381,9 +4476,11 @@
                   "Config"
                 ],
                 "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4439,11 +4536,10 @@
             ],
             "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.context",
+                "id": "def-public.Configurable.createConfig.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "context",
@@ -4452,9 +4548,11 @@
                   "Context"
                 ],
                 "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4470,11 +4568,10 @@
             ],
             "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.config",
+                "id": "def-public.Configurable.isConfigValid.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "config",
@@ -4483,11 +4580,12 @@
                   "Config"
                 ],
                 "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.context",
+                "id": "def-public.Configurable.isConfigValid.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "context",
@@ -4496,9 +4594,11 @@
                   "Context"
                 ],
                 "path": "src/plugins/kibana_utils/public/ui/configurable.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4561,7 +4661,24 @@
               "(<T>(state: T) => T) | undefined"
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/create_state_container.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "kibanaUtils",
+                "id": "def-public.CreateStateContainerOptions.freeze.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  "T"
+                ],
+                "path": "src/plugins/kibana_utils/common/state_containers/create_state_container.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -4601,21 +4718,24 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IKbnUrlStateStorage.set.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.state",
+                "id": "def-public.IKbnUrlStateStorage.set.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -4624,22 +4744,33 @@
                   "State"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.opts",
+                "id": "def-public.IKbnUrlStateStorage.set.$3.opts",
                 "type": "Object",
                 "tags": [],
                 "label": "opts",
                 "description": [],
-                "signature": [
-                  "{ replace: boolean; } | undefined"
-                ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.IKbnUrlStateStorage.set.$3.opts.replace",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "replace",
+                    "description": [],
+                    "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4653,19 +4784,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IKbnUrlStateStorage.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4681,19 +4816,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IKbnUrlStateStorage.change$.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4709,8 +4848,8 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4772,11 +4911,10 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.state",
+                "id": "def-public.INullableBaseStateContainer.set.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "state",
@@ -4785,9 +4923,11 @@
                   "State | null"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_sync/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -4827,21 +4967,24 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.ISessionStorageStateStorage.set.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.state",
+                "id": "def-public.ISessionStorageStateStorage.set.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -4850,9 +4993,11 @@
                   "State"
                 ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -4866,19 +5011,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.ISessionStorageStateStorage.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_session_storage_state_storage.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -4989,19 +5138,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IStorage.getItem.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5015,21 +5168,24 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IStorage.setItem.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.value",
+                "id": "def-public.IStorage.setItem.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "value",
@@ -5038,9 +5194,11 @@
                   "T"
                 ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5054,19 +5212,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IStorage.removeItem.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5080,8 +5242,8 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -5118,19 +5280,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IStorageWrapper.get.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5144,21 +5310,24 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IStorageWrapper.set.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.value",
+                "id": "def-public.IStorageWrapper.set.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "value",
@@ -5167,9 +5336,11 @@
                   "T"
                 ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5183,19 +5354,23 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.key",
+                "id": "def-public.IStorageWrapper.remove.$1",
                 "type": "string",
                 "tags": [],
                 "label": "key",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/kibana_utils/public/storage/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5209,8 +5384,8 @@
             ],
             "path": "src/plugins/kibana_utils/public/storage/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -5370,8 +5545,8 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5438,24 +5613,30 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.nextReducer",
+                "id": "def-public.ReduxLikeStateContainer.replaceReducer.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "nextReducer",
                 "description": [],
                 "signature": [
-                  "(state: State, action: ",
-                  "TransitionDescription",
-                  "<string, any[]>) => State"
+                  {
+                    "pluginId": "kibanaUtils",
+                    "scope": "common",
+                    "docId": "kibKibanaUtilsPluginApi",
+                    "section": "def-common.Reducer",
+                    "text": "Reducer"
+                  },
+                  "<State>"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5471,11 +5652,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.action",
+                "id": "def-public.ReduxLikeStateContainer.dispatch.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "action",
@@ -5485,9 +5665,11 @@
                   "<string, any[]>"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5509,42 +5691,30 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.middleware",
+                "id": "def-public.ReduxLikeStateContainer.addMiddleware.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "middleware",
                 "description": [],
                 "signature": [
-                  "(store: Pick<",
                   {
                     "pluginId": "kibanaUtils",
                     "scope": "common",
                     "docId": "kibKibanaUtilsPluginApi",
-                    "section": "def-common.ReduxLikeStateContainer",
-                    "text": "ReduxLikeStateContainer"
+                    "section": "def-common.Middleware",
+                    "text": "Middleware"
                   },
-                  "<State, any, {}>, \"getState\" | \"dispatch\">) => (next: (action: ",
-                  "TransitionDescription",
-                  "<string, any[]>) => any) => ",
-                  {
-                    "pluginId": "kibanaUtils",
-                    "scope": "common",
-                    "docId": "kibKibanaUtilsPluginApi",
-                    "section": "def-common.Dispatch",
-                    "text": "Dispatch"
-                  },
-                  "<",
-                  "TransitionDescription",
-                  "<string, any[]>>"
+                  "<State>"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -5558,11 +5728,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-public.listener",
+                "id": "def-public.ReduxLikeStateContainer.subscribe.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "listener",
@@ -5571,9 +5740,11 @@
                   "(state: State) => void"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -5844,6 +6015,35 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.previous",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "previous",
+            "description": [],
+            "signature": [
+              "Result"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.current",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "current",
+            "description": [],
+            "signature": [
+              "Result"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -5868,6 +6068,38 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.mapStateToProp",
+            "type": "Function",
+            "tags": [],
+            "label": "mapStateToProp",
+            "description": [],
+            "signature": [
+              "(state: State) => Pick<Props, StatePropKeys>"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "kibanaUtils",
+                "id": "def-public.state",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  "State"
+                ],
+                "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+                "deprecated": false
+              }
+            ]
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -5884,6 +6116,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.action",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "action",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -5906,6 +6154,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -5922,6 +6186,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -5936,6 +6216,8 @@
         ],
         "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -5952,6 +6234,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -5988,6 +6286,24 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.store",
+            "type": "Object",
+            "tags": [],
+            "label": "store",
+            "description": [],
+            "signature": [
+              "{ getState: () => State; dispatch: (action: ",
+              "TransitionDescription",
+              "<string, any[]>) => void; }"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6010,6 +6326,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6067,6 +6399,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.args",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              "Args"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6085,6 +6433,36 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.action",
+            "type": "Object",
+            "tags": [],
+            "label": "action",
+            "description": [],
+            "signature": [
+              "TransitionDescription",
+              "<string, any[]>"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6099,6 +6477,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.args",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              "Args"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6113,6 +6507,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-public.value",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "value",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -6143,6 +6553,8 @@
         ],
         "path": "src/plugins/kibana_utils/public/core/create_start_service_getter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -6157,6 +6569,8 @@
         ],
         "path": "src/plugins/kibana_utils/public/state_sync/state_sync.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -6171,6 +6585,8 @@
         ],
         "path": "src/plugins/kibana_utils/public/state_sync/state_sync.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -6195,6 +6611,8 @@
         ],
         "path": "src/plugins/kibana_utils/common/ui/ui_component.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -6296,7 +6714,33 @@
                   "(val: string, pctEncodeSpaces?: boolean | undefined) => string"
                 ],
                 "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.val",
+                    "type": "string",
+                    "tags": [],
+                    "label": "val",
+                    "description": [],
+                    "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-public.pctEncodeSpaces",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "pctEncodeSpaces",
+                    "description": [],
+                    "signature": [
+                      "boolean | undefined"
+                    ],
+                    "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
+                    "deprecated": false
+                  }
+                ]
               },
               {
                 "parentPluginId": "kibanaUtils",
@@ -7213,6 +7657,8 @@
         ],
         "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -7227,6 +7673,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-server.value",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "value",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],
@@ -7284,7 +7746,33 @@
                   "(val: string, pctEncodeSpaces?: boolean | undefined) => string"
                 ],
                 "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-server.val",
+                    "type": "string",
+                    "tags": [],
+                    "label": "val",
+                    "description": [],
+                    "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-server.pctEncodeSpaces",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "pctEncodeSpaces",
+                    "description": [],
+                    "signature": [
+                      "boolean | undefined"
+                    ],
+                    "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
+                    "deprecated": false
+                  }
+                ]
               },
               {
                 "parentPluginId": "kibanaUtils",
@@ -8975,10 +9463,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
+            "children": [],
             "returnComment": [
               "current state"
-            ],
-            "children": []
+            ]
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -8994,11 +9482,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.state",
+                "id": "def-common.BaseStateContainer.set.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -9009,9 +9496,11 @@
                   "State"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -9057,7 +9546,24 @@
               "(<T>(state: T) => T) | undefined"
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/create_state_container.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "kibanaUtils",
+                "id": "def-common.CreateStateContainerOptions.freeze.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  "T"
+                ],
+                "path": "src/plugins/kibana_utils/common/state_containers/create_state_container.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -9156,13 +9662,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
             "deprecated": false,
-            "returnComment": [
-              "A new stats object augmented with new telemetry information."
-            ],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.state",
+                "id": "def-common.PersistableState.telemetry.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -9173,11 +9676,12 @@
                   "P"
                 ],
                 "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.stats",
+                "id": "def-common.PersistableState.telemetry.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "stats",
@@ -9185,11 +9689,15 @@
                   "Stats object containing the stats which were already\ncollected. This `stats` object shall not be mutated in-line."
                 ],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "A new stats object augmented with new telemetry information."
             ]
           },
           {
@@ -9208,13 +9716,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
             "deprecated": false,
-            "returnComment": [
-              "Persistable state object with references injected."
-            ],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.state",
+                "id": "def-common.PersistableState.inject.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -9225,11 +9730,12 @@
                   "P"
                 ],
                 "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.references",
+                "id": "def-common.PersistableState.inject.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "references",
@@ -9241,8 +9747,12 @@
                   "[]"
                 ],
                 "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "Persistable state object with references injected."
             ]
           },
           {
@@ -9261,13 +9771,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
             "deprecated": false,
-            "returnComment": [
-              "Persistable state object with references extracted and a list of\nreferences."
-            ],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.state",
+                "id": "def-common.PersistableState.extract.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "state",
@@ -9278,8 +9785,12 @@
                   "P"
                 ],
                 "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "Persistable state object with references extracted and a list of\nreferences."
             ]
           },
           {
@@ -9502,7 +10013,43 @@
               ">) => P) | undefined"
             ],
             "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "kibanaUtils",
+                "id": "def-common.PersistableStateService.migrateToLatest.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "state",
+                "description": [
+                  "The persistable state serializable state object."
+                ],
+                "signature": [
+                  {
+                    "pluginId": "kibanaUtils",
+                    "scope": "common",
+                    "docId": "kibKibanaUtilsPluginApi",
+                    "section": "def-common.VersionedState",
+                    "text": "VersionedState"
+                  },
+                  "<",
+                  {
+                    "pluginId": "kibanaUtils",
+                    "scope": "common",
+                    "docId": "kibKibanaUtilsPluginApi",
+                    "section": "def-common.SerializableState",
+                    "text": "SerializableState"
+                  },
+                  ">"
+                ],
+                "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": [
+              "A serializable state object migrated to the latest state."
+            ]
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -9525,8 +10072,8 @@
             ],
             "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -9573,8 +10120,8 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -9641,24 +10188,30 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.nextReducer",
+                "id": "def-common.ReduxLikeStateContainer.replaceReducer.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "nextReducer",
                 "description": [],
                 "signature": [
-                  "(state: State, action: ",
-                  "TransitionDescription",
-                  "<string, any[]>) => State"
+                  {
+                    "pluginId": "kibanaUtils",
+                    "scope": "common",
+                    "docId": "kibKibanaUtilsPluginApi",
+                    "section": "def-common.Reducer",
+                    "text": "Reducer"
+                  },
+                  "<State>"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -9674,11 +10227,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.action",
+                "id": "def-common.ReduxLikeStateContainer.dispatch.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "action",
@@ -9688,9 +10240,11 @@
                   "<string, any[]>"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -9712,42 +10266,30 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.middleware",
+                "id": "def-common.ReduxLikeStateContainer.addMiddleware.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "middleware",
                 "description": [],
                 "signature": [
-                  "(store: Pick<",
                   {
                     "pluginId": "kibanaUtils",
                     "scope": "common",
                     "docId": "kibKibanaUtilsPluginApi",
-                    "section": "def-common.ReduxLikeStateContainer",
-                    "text": "ReduxLikeStateContainer"
+                    "section": "def-common.Middleware",
+                    "text": "Middleware"
                   },
-                  "<State, any, {}>, \"getState\" | \"dispatch\">) => (next: (action: ",
-                  "TransitionDescription",
-                  "<string, any[]>) => any) => ",
-                  {
-                    "pluginId": "kibanaUtils",
-                    "scope": "common",
-                    "docId": "kibKibanaUtilsPluginApi",
-                    "section": "def-common.Dispatch",
-                    "text": "Dispatch"
-                  },
-                  "<",
-                  "TransitionDescription",
-                  "<string, any[]>>"
+                  "<State>"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "kibanaUtils",
@@ -9761,11 +10303,10 @@
             ],
             "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "kibanaUtils",
-                "id": "def-common.listener",
+                "id": "def-common.ReduxLikeStateContainer.subscribe.$1",
                 "type": "Function",
                 "tags": [],
                 "label": "listener",
@@ -9774,9 +10315,11 @@
                   "(state: State) => void"
                 ],
                 "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -10033,6 +10576,35 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.previous",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "previous",
+            "description": [],
+            "signature": [
+              "Result"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.current",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "current",
+            "description": [],
+            "signature": [
+              "Result"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10057,6 +10629,38 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.mapStateToProp",
+            "type": "Function",
+            "tags": [],
+            "label": "mapStateToProp",
+            "description": [],
+            "signature": [
+              "(state: State) => Pick<Props, StatePropKeys>"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "kibanaUtils",
+                "id": "def-common.state",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  "State"
+                ],
+                "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+                "deprecated": false
+              }
+            ]
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10073,6 +10677,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.action",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "action",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10095,6 +10715,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10111,6 +10747,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10125,6 +10777,8 @@
         ],
         "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -10141,6 +10795,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10177,6 +10847,24 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.store",
+            "type": "Object",
+            "tags": [],
+            "label": "store",
+            "description": [],
+            "signature": [
+              "{ getState: () => State; dispatch: (action: ",
+              "TransitionDescription",
+              "<string, any[]>) => void; }"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10191,6 +10879,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "FromVersion"
+            ],
+            "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10274,6 +10978,40 @@
         ],
         "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Object",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "{ [key: string]: ",
+              {
+                "pluginId": "kibanaUtils",
+                "scope": "common",
+                "docId": "kibKibanaUtilsPluginApi",
+                "section": "def-common.Serializable",
+                "text": "Serializable"
+              },
+              "; }"
+            ],
+            "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "path": "src/plugins/kibana_utils/common/persistable_state/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10296,6 +11034,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10353,6 +11107,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.args",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              "Args"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10371,6 +11141,36 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.state",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "state",
+            "description": [],
+            "signature": [
+              "State"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.action",
+            "type": "Object",
+            "tags": [],
+            "label": "action",
+            "description": [],
+            "signature": [
+              "TransitionDescription",
+              "<string, any[]>"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10385,6 +11185,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.args",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              "Args"
+            ],
+            "path": "src/plugins/kibana_utils/common/state_containers/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10475,6 +11291,22 @@
         ],
         "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "kibanaUtils",
+            "id": "def-common.value",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "value",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/plugins/kibana_utils/common/create_getter_setter.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -10499,6 +11331,8 @@
         ],
         "path": "src/plugins/kibana_utils/common/ui/ui_component.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -10580,7 +11414,33 @@
                   "(val: string, pctEncodeSpaces?: boolean | undefined) => string"
                 ],
                 "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
-                "deprecated": false
+                "deprecated": false,
+                "returnComment": [],
+                "children": [
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-common.val",
+                    "type": "string",
+                    "tags": [],
+                    "label": "val",
+                    "description": [],
+                    "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "kibanaUtils",
+                    "id": "def-common.pctEncodeSpaces",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "pctEncodeSpaces",
+                    "description": [],
+                    "signature": [
+                      "boolean | undefined"
+                    ],
+                    "path": "src/plugins/kibana_utils/common/url/encode_uri_query.ts",
+                    "deprecated": false
+                  }
+                ]
               },
               {
                 "parentPluginId": "kibanaUtils",

--- a/api_docs/kibana_utils.mdx
+++ b/api_docs/kibana_utils.mdx
@@ -18,7 +18,7 @@ import kibanaUtilsObj from './kibana_utils.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 551 | 3 | 359 | 8 |
+| 600 | 3 | 406 | 8 |
 
 ## Client
 

--- a/api_docs/lens.json
+++ b/api_docs/lens.json
@@ -3465,7 +3465,8 @@
             "section": "def-common.PersistableFilter",
             "text": "PersistableFilter"
           },
-          " extends any"
+          " extends ",
+          "Filter"
         ],
         "path": "x-pack/plugins/lens/common/types.ts",
         "deprecated": false,
@@ -3507,7 +3508,8 @@
             "section": "def-common.PersistableFilterMeta",
             "text": "PersistableFilterMeta"
           },
-          " extends any"
+          " extends ",
+          "FilterMeta"
         ],
         "path": "x-pack/plugins/lens/common/types.ts",
         "deprecated": false,

--- a/api_docs/lens.json
+++ b/api_docs/lens.json
@@ -627,26 +627,30 @@
             ],
             "path": "x-pack/plugins/lens/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "lens",
-                "id": "def-public.input",
+                "id": "def-public.LensPublicStart.navigateToPrefilledEditor.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "input",
                 "description": [],
                 "signature": [
-                  "LensByValueInput",
-                  " | ",
-                  "LensByReferenceInput"
+                  {
+                    "pluginId": "lens",
+                    "scope": "public",
+                    "docId": "kibLensPluginApi",
+                    "section": "def-public.LensEmbeddableInput",
+                    "text": "LensEmbeddableInput"
+                  }
                 ],
                 "path": "x-pack/plugins/lens/public/plugin.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "lens",
-                "id": "def-public.openInNewTab",
+                "id": "def-public.LensPublicStart.navigateToPrefilledEditor.$2",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "openInNewTab",
@@ -655,9 +659,11 @@
                   "boolean | undefined"
                 ],
                 "path": "x-pack/plugins/lens/public/plugin.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "lens",
@@ -673,8 +679,8 @@
             ],
             "path": "x-pack/plugins/lens/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "lens",
@@ -692,8 +698,8 @@
             ],
             "path": "x-pack/plugins/lens/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -3637,6 +3643,29 @@
         ],
         "path": "x-pack/plugins/lens/common/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "lens",
+            "id": "def-common.mapping",
+            "type": "Object",
+            "tags": [],
+            "label": "mapping",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "expressions",
+                "scope": "common",
+                "docId": "kibExpressionsPluginApi",
+                "section": "def-common.SerializedFieldFormat",
+                "text": "SerializedFieldFormat"
+              },
+              "<Record<string, any>> | undefined"
+            ],
+            "path": "x-pack/plugins/lens/common/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/lens.mdx
+++ b/api_docs/lens.mdx
@@ -18,7 +18,7 @@ Contact [Kibana App](https://github.com/orgs/elastic/teams/kibana-app) for quest
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 207 | 0 | 191 | 23 |
+| 208 | 0 | 192 | 23 |
 
 ## Client
 

--- a/api_docs/licensing.json
+++ b/api_docs/licensing.json
@@ -143,8 +143,8 @@
             ],
             "path": "x-pack/plugins/licensing/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "licensing",
@@ -175,8 +175,8 @@
             ],
             "path": "x-pack/plugins/licensing/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "licensing",
@@ -764,11 +764,7 @@
             },
             {
               "plugin": "reporting",
-              "path": "x-pack/plugins/reporting/public/share_context_menu/register_csv_reporting.tsx"
-            },
-            {
-              "plugin": "reporting",
-              "path": "x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx"
+              "path": "x-pack/plugins/reporting/public/share_context_menu/index.ts"
             },
             {
               "plugin": "reporting",
@@ -1849,8 +1845,8 @@
             ],
             "path": "x-pack/plugins/licensing/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "licensing",
@@ -1881,8 +1877,8 @@
             ],
             "path": "x-pack/plugins/licensing/common/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "licensing",
@@ -2409,6 +2405,22 @@
         ],
         "path": "x-pack/plugins/licensing/server/wrap_route_with_license_check.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "licensing",
+            "id": "def-server.license",
+            "type": "Object",
+            "tags": [],
+            "label": "license",
+            "description": [],
+            "signature": [
+              "ILicense"
+            ],
+            "path": "x-pack/plugins/licensing/server/wrap_route_with_license_check.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -2739,11 +2751,10 @@
           ],
           "path": "x-pack/plugins/licensing/server/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "licensing",
-              "id": "def-server.clusterClient",
+              "id": "def-server.LicensingPluginStart.createLicensePoller.$1",
               "type": "Object",
               "tags": [],
               "label": "clusterClient",
@@ -2758,19 +2769,25 @@
                 }
               ],
               "path": "x-pack/plugins/licensing/server/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "licensing",
-              "id": "def-server.pollingFrequency",
+              "id": "def-server.LicensingPluginStart.createLicensePoller.$2",
               "type": "number",
               "tags": [],
               "label": "pollingFrequency",
               "description": [],
+              "signature": [
+                "number"
+              ],
               "path": "x-pack/plugins/licensing/server/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "licensing",

--- a/api_docs/licensing.mdx
+++ b/api_docs/licensing.mdx
@@ -18,7 +18,7 @@ import licensingObj from './licensing.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 117 | 0 | 42 | 8 |
+| 118 | 0 | 43 | 8 |
 
 ## Client
 

--- a/api_docs/lists.json
+++ b/api_docs/lists.json
@@ -2551,8 +2551,8 @@
             ],
             "path": "x-pack/plugins/lists/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "lists",
@@ -2573,8 +2573,8 @@
             ],
             "path": "x-pack/plugins/lists/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/management.json
+++ b/api_docs/management.json
@@ -499,11 +499,10 @@
             ],
             "path": "src/plugins/management/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "management",
-                "id": "def-public.crumbs",
+                "id": "def-public.ManagementAppMountParams.setBreadcrumbs.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "crumbs",
@@ -513,9 +512,11 @@
                   "[]"
                 ],
                 "path": "src/plugins/management/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "management",

--- a/api_docs/maps.json
+++ b/api_docs/maps.json
@@ -373,7 +373,9 @@
             "label": "_getFilters",
             "description": [],
             "signature": [
-              "() => any[]"
+              "() => ",
+              "Filter",
+              "[]"
             ],
             "path": "x-pack/plugins/maps/public/embeddable/map_embeddable.tsx",
             "deprecated": false,
@@ -608,7 +610,9 @@
             "label": "addFilters",
             "description": [],
             "signature": [
-              "(filters: any[], actionId?: string) => Promise<void>"
+              "(filters: ",
+              "Filter",
+              "[], actionId?: string) => Promise<void>"
             ],
             "path": "x-pack/plugins/maps/public/embeddable/map_embeddable.tsx",
             "deprecated": false,
@@ -621,7 +625,8 @@
                 "label": "filters",
                 "description": [],
                 "signature": [
-                  "any[]"
+                  "Filter",
+                  "[]"
                 ],
                 "path": "x-pack/plugins/maps/public/embeddable/map_embeddable.tsx",
                 "deprecated": false,
@@ -822,7 +827,9 @@
             "label": "addFilters",
             "description": [],
             "signature": [
-              "((filters: any[], actionId: string) => Promise<void>) | null"
+              "((filters: ",
+              "Filter",
+              "[], actionId: string) => Promise<void>) | null"
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
             "deprecated": false

--- a/api_docs/maps.json
+++ b/api_docs/maps.json
@@ -839,8 +839,8 @@
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "maps",
@@ -875,7 +875,9 @@
               "<object>) | undefined"
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "maps",
@@ -896,7 +898,9 @@
               "<object>[]>) | undefined"
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "maps",
@@ -910,19 +914,23 @@
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "maps",
-                "id": "def-public.layerId",
+                "id": "def-public.RenderTooltipContentParams.getLayerName.$1",
                 "type": "string",
                 "tags": [],
                 "label": "layerId",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "maps",
@@ -948,22 +956,57 @@
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "maps",
-                "id": "def-public.__0",
+                "id": "def-public.RenderTooltipContentParams.loadFeatureProperties.$1.layerIdfeatureIdmbProperties",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{\n    layerId,\n    featureId,\n    mbProperties,\n  }",
                 "description": [],
-                "signature": [
-                  "{ layerId: string; featureId?: string | number | undefined; mbProperties: GeoJSON.GeoJsonProperties; }"
-                ],
                 "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "maps",
+                    "id": "def-public.RenderTooltipContentParams.loadFeatureProperties.$1.layerIdfeatureIdmbProperties.layerId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "layerId",
+                    "description": [],
+                    "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "maps",
+                    "id": "def-public.RenderTooltipContentParams.loadFeatureProperties.$1.layerIdfeatureIdmbProperties.featureId",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "featureId",
+                    "description": [],
+                    "signature": [
+                      "string | number | undefined"
+                    ],
+                    "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "maps",
+                    "id": "def-public.RenderTooltipContentParams.loadFeatureProperties.$1.layerIdfeatureIdmbProperties.mbProperties",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "mbProperties",
+                    "description": [],
+                    "signature": [
+                      "{ [name: string]: any; } | null"
+                    ],
+                    "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "maps",
@@ -977,22 +1020,44 @@
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "maps",
-                "id": "def-public.__0",
+                "id": "def-public.RenderTooltipContentParams.loadFeatureGeometry.$1.layerIdfeatureId",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{\n    layerId,\n    featureId,\n  }",
                 "description": [],
-                "signature": [
-                  "{ layerId: string; featureId?: string | number | undefined; }"
-                ],
                 "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "maps",
+                    "id": "def-public.RenderTooltipContentParams.loadFeatureGeometry.$1.layerIdfeatureId.layerId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "layerId",
+                    "description": [],
+                    "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "maps",
+                    "id": "def-public.RenderTooltipContentParams.loadFeatureGeometry.$1.layerIdfeatureId.featureId",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "featureId",
+                    "description": [],
+                    "signature": [
+                      "string | number | undefined"
+                    ],
+                    "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "maps",
@@ -1013,7 +1078,58 @@
               ") => void) | undefined"
             ],
             "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "maps",
+                "id": "def-public.RenderTooltipContentParams.onSingleValueTrigger.$1",
+                "type": "string",
+                "tags": [],
+                "label": "actionId",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "maps",
+                "id": "def-public.RenderTooltipContentParams.onSingleValueTrigger.$2",
+                "type": "string",
+                "tags": [],
+                "label": "key",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "maps",
+                "id": "def-public.RenderTooltipContentParams.onSingleValueTrigger.$3",
+                "type": "CompoundType",
+                "tags": [],
+                "label": "value",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "maps",
+                    "scope": "common",
+                    "docId": "kibMapsPluginApi",
+                    "section": "def-common.RawValue",
+                    "text": "RawValue"
+                  }
+                ],
+                "path": "x-pack/plugins/maps/public/classes/tooltips/tooltip_property.ts",
+                "deprecated": false,
+                "isRequired": false
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1110,8 +1226,8 @@
             "pluginId": "data",
             "scope": "common",
             "docId": "kibDataIndexPatternsPluginApi",
-            "section": "def-common.IIndexPattern",
-            "text": "IIndexPattern"
+            "section": "def-common.IndexPattern",
+            "text": "IndexPattern"
           },
           "[]; }"
         ],
@@ -2359,6 +2475,22 @@
         ],
         "path": "x-pack/plugins/maps/common/constants.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "maps",
+            "id": "def-common.value",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "value",
+            "description": [],
+            "signature": [
+              "string | number | boolean | string[] | null | undefined"
+            ],
+            "path": "x-pack/plugins/maps/common/constants.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/maps.mdx
+++ b/api_docs/maps.mdx
@@ -18,7 +18,7 @@ import mapsObj from './maps.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 204 | 2 | 203 | 11 |
+| 213 | 2 | 212 | 11 |
 
 ## Client
 

--- a/api_docs/maps_ems.json
+++ b/api_docs/maps_ems.json
@@ -783,8 +783,8 @@
           ],
           "path": "src/plugins/maps_ems/public/index.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/ml.json
+++ b/api_docs/ml.json
@@ -1247,6 +1247,24 @@
         ],
         "path": "x-pack/plugins/ml/public/application/components/data_grid/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "ml",
+            "id": "def-public.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ rowIndex: number; columnId: string; setCellProps: (props: ",
+              "CommonProps",
+              " & React.HTMLAttributes<HTMLDivElement>) => void; }"
+            ],
+            "path": "x-pack/plugins/ml/public/application/components/data_grid/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/ml.mdx
+++ b/api_docs/ml.mdx
@@ -18,7 +18,7 @@ Contact [Machine Learning UI](https://github.com/orgs/elastic/teams/ml-ui) for q
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 278 | 10 | 274 | 33 |
+| 279 | 10 | 275 | 33 |
 
 ## Client
 

--- a/api_docs/monitoring.json
+++ b/api_docs/monitoring.json
@@ -34,8 +34,8 @@
             ],
             "path": "x-pack/plugins/monitoring/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "monitoring",
@@ -49,8 +49,8 @@
             ],
             "path": "x-pack/plugins/monitoring/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "monitoring",
@@ -72,32 +72,29 @@
             ],
             "path": "x-pack/plugins/monitoring/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "monitoring",
-                "id": "def-server.esClient",
+                "id": "def-server.IBulkUploader.start.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "esClient",
                 "description": [],
                 "signature": [
-                  "Pick<",
-                  "KibanaClient",
-                  ", \"get\" | \"delete\" | \"create\" | \"index\" | \"update\" | \"closePointInTime\" | \"count\" | \"search\" | \"security\" | \"eql\" | \"on\" | \"off\" | \"transform\" | \"helpers\" | \"emit\" | \"once\" | \"asyncSearch\" | \"autoscaling\" | \"bulk\" | \"cat\" | \"ccr\" | \"clearScroll\" | \"cluster\" | \"danglingIndices\" | \"dataFrameTransformDeprecated\" | \"deleteByQuery\" | \"deleteByQueryRethrottle\" | \"deleteScript\" | \"enrich\" | \"exists\" | \"existsSource\" | \"explain\" | \"features\" | \"fieldCaps\" | \"fleet\" | \"getScript\" | \"getScriptContext\" | \"getScriptLanguages\" | \"getSource\" | \"graph\" | \"ilm\" | \"indices\" | \"info\" | \"ingest\" | \"license\" | \"logstash\" | \"mget\" | \"migration\" | \"ml\" | \"monitoring\" | \"msearch\" | \"msearchTemplate\" | \"mtermvectors\" | \"nodes\" | \"openPointInTime\" | \"ping\" | \"putScript\" | \"rankEval\" | \"reindex\" | \"reindexRethrottle\" | \"renderSearchTemplate\" | \"rollup\" | \"scriptsPainlessExecute\" | \"scroll\" | \"searchShards\" | \"searchTemplate\" | \"searchableSnapshots\" | \"shutdown\" | \"slm\" | \"snapshot\" | \"sql\" | \"ssl\" | \"tasks\" | \"termsEnum\" | \"termvectors\" | \"textStructure\" | \"updateByQuery\" | \"updateByQueryRethrottle\" | \"watcher\" | \"xpack\"> & { transport: { request(params: ",
-                  "TransportRequestParams",
-                  ", options?: ",
-                  "TransportRequestOptions",
-                  " | undefined): ",
-                  "TransportRequestPromise",
-                  "<",
-                  "ApiResponse",
-                  "<Record<string, any>, unknown>>; }; }"
+                  {
+                    "pluginId": "core",
+                    "scope": "server",
+                    "docId": "kibCorePluginApi",
+                    "section": "def-server.ElasticsearchClient",
+                    "text": "ElasticsearchClient"
+                  }
                 ],
                 "path": "x-pack/plugins/monitoring/server/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "monitoring",
@@ -111,8 +108,8 @@
             ],
             "path": "x-pack/plugins/monitoring/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/observability.json
+++ b/api_docs/observability.json
@@ -1479,29 +1479,37 @@
             ],
             "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "observability",
-                "id": "def-public.by",
+                "id": "def-public.MetricsFetchDataResponse.sort.$1",
                 "type": "string",
                 "tags": [],
                 "label": "by",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "observability",
-                "id": "def-public.direction",
+                "id": "def-public.MetricsFetchDataResponse.sort.$2",
                 "type": "string",
                 "tags": [],
                 "label": "direction",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "observability",
@@ -2834,6 +2842,28 @@
         ],
         "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "observability",
+            "id": "def-public.fetchDataParams",
+            "type": "Object",
+            "tags": [],
+            "label": "fetchDataParams",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "observability",
+                "scope": "public",
+                "docId": "kibObservabilityPluginApi",
+                "section": "def-public.FetchDataParams",
+                "text": "FetchDataParams"
+              }
+            ],
+            "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -2864,6 +2894,29 @@
         ],
         "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "observability",
+            "id": "def-public.params",
+            "type": "Object",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "observability",
+                "scope": "public",
+                "docId": "kibObservabilityPluginApi",
+                "section": "def-public.HasDataParams",
+                "text": "HasDataParams"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/plugins/observability/public/typings/fetch_overview_data/index.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -2930,6 +2983,24 @@
         ],
         "path": "x-pack/plugins/observability/public/rules/create_observability_rule_type_registry.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "observability",
+            "id": "def-public.options",
+            "type": "Object",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              "{ fields: OutputOf<",
+              "Optional",
+              "<{ readonly \"kibana.rac.alert.owner\": { readonly type: \"keyword\"; }; readonly \"kibana.rac.alert.producer\": { readonly type: \"keyword\"; }; readonly \"kibana.space_ids\": { readonly type: \"keyword\"; readonly array: true; }; readonly \"kibana.rac.alert.uuid\": { readonly type: \"keyword\"; }; readonly \"kibana.rac.alert.id\": { readonly type: \"keyword\"; }; readonly \"kibana.rac.alert.start\": { readonly type: \"date\"; }; readonly \"kibana.rac.alert.end\": { readonly type: \"date\"; }; readonly \"kibana.rac.alert.duration.us\": { readonly type: \"long\"; }; readonly \"kibana.rac.alert.severity.level\": { readonly type: \"keyword\"; }; readonly \"kibana.rac.alert.severity.value\": { readonly type: \"long\"; }; readonly \"kibana.rac.alert.status\": { readonly type: \"keyword\"; }; readonly \"kibana.rac.alert.evaluation.threshold\": { readonly type: \"scaled_float\"; readonly scaling_factor: 100; }; readonly \"kibana.rac.alert.evaluation.value\": { readonly type: \"scaled_float\"; readonly scaling_factor: 100; }; readonly \"kibana.rac.alert.reason\": { readonly type: \"keyword\"; }; readonly tags: { readonly type: \"keyword\"; readonly array: true; readonly required: false; }; readonly '@timestamp': { readonly type: \"date\"; readonly array: false; readonly required: true; }; readonly 'event.kind': { readonly type: \"keyword\"; readonly array: false; readonly required: false; }; readonly 'event.action': { readonly type: \"keyword\"; readonly array: false; readonly required: false; }; readonly 'rule.uuid': { readonly type: \"keyword\"; readonly array: false; readonly required: false; }; readonly 'rule.id': { readonly type: \"keyword\"; readonly array: false; readonly required: false; }; readonly 'rule.name': { readonly type: \"keyword\"; readonly array: false; readonly required: false; }; readonly 'rule.category': { readonly type: \"keyword\"; readonly array: false; readonly required: false; }; }, \"tags\" | \"event.kind\" | \"event.action\" | \"rule.uuid\" | \"rule.id\" | \"rule.name\" | \"rule.category\" | \"kibana.rac.alert.producer\" | \"kibana.rac.alert.owner\" | \"kibana.rac.alert.id\" | \"kibana.rac.alert.uuid\" | \"kibana.rac.alert.start\" | \"kibana.rac.alert.end\" | \"kibana.rac.alert.duration.us\" | \"kibana.rac.alert.severity.level\" | \"kibana.rac.alert.severity.value\" | \"kibana.rac.alert.status\" | \"kibana.rac.alert.evaluation.threshold\" | \"kibana.rac.alert.evaluation.value\" | \"kibana.rac.alert.reason\" | \"kibana.space_ids\">> & Record<string, any>; formatters: { asDuration: (value: number | null | undefined, { defaultValue, extended }?: FormatterOptions) => string; asPercent: (numerator: number | null | undefined, denominator: number | undefined, fallbackResult?: string) => string; }; }"
+            ],
+            "path": "x-pack/plugins/observability/public/rules/create_observability_rule_type_registry.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -3051,6 +3122,22 @@
         ],
         "path": "x-pack/plugins/observability/public/hooks/use_track_metric.tsx",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "observability",
+            "id": "def-public.__0",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "TrackOptions & { metric: string; }"
+            ],
+            "path": "x-pack/plugins/observability/public/hooks/use_track_metric.tsx",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/observability.mdx
+++ b/api_docs/observability.mdx
@@ -18,7 +18,7 @@ Contact Observability UI for questions regarding this plugin.
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 219 | 0 | 219 | 10 |
+| 223 | 0 | 223 | 10 |
 
 ## Client
 

--- a/api_docs/presentation_util.json
+++ b/api_docs/presentation_util.json
@@ -1454,8 +1454,8 @@
             ],
             "path": "src/plugins/presentation_util/public/services/capabilities.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1469,8 +1469,8 @@
             ],
             "path": "src/plugins/presentation_util/public/services/capabilities.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1484,8 +1484,8 @@
             ],
             "path": "src/plugins/presentation_util/public/services/capabilities.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1499,8 +1499,8 @@
             ],
             "path": "src/plugins/presentation_util/public/services/capabilities.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1537,21 +1537,24 @@
             ],
             "path": "src/plugins/presentation_util/public/services/dashboards.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.query",
+                "id": "def-public.PresentationDashboardsService.findDashboards.$1",
                 "type": "string",
                 "tags": [],
                 "label": "query",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/presentation_util/public/services/dashboards.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.fields",
+                "id": "def-public.PresentationDashboardsService.findDashboards.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "fields",
@@ -1560,9 +1563,11 @@
                   "string[]"
                 ],
                 "path": "src/plugins/presentation_util/public/services/dashboards.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1586,19 +1591,23 @@
             ],
             "path": "src/plugins/presentation_util/public/services/dashboards.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.title",
+                "id": "def-public.PresentationDashboardsService.findDashboardsByTitle.$1",
                 "type": "string",
                 "tags": [],
                 "label": "title",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/presentation_util/public/services/dashboards.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1625,11 +1634,10 @@
             ],
             "path": "src/plugins/presentation_util/public/services/labs.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.id",
+                "id": "def-public.PresentationLabsService.isProjectEnabled.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
@@ -1638,9 +1646,11 @@
                   "\"labs:dashboard:deferBelowFold\""
                 ],
                 "path": "src/plugins/presentation_util/public/services/labs.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1654,8 +1664,8 @@
             ],
             "path": "src/plugins/presentation_util/public/services/labs.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1676,11 +1686,10 @@
             ],
             "path": "src/plugins/presentation_util/public/services/labs.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.id",
+                "id": "def-public.PresentationLabsService.getProject.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
@@ -1689,9 +1698,11 @@
                   "\"labs:dashboard:deferBelowFold\""
                 ],
                 "path": "src/plugins/presentation_util/public/services/labs.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1713,11 +1724,10 @@
             ],
             "path": "src/plugins/presentation_util/public/services/labs.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.solutions",
+                "id": "def-public.PresentationLabsService.getProjects.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "solutions",
@@ -1726,9 +1736,11 @@
                   "(\"dashboard\" | \"canvas\" | \"presentation\")[] | undefined"
                 ],
                 "path": "src/plugins/presentation_util/public/services/labs.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1742,11 +1754,10 @@
             ],
             "path": "src/plugins/presentation_util/public/services/labs.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.id",
+                "id": "def-public.PresentationLabsService.setProjectStatus.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
@@ -1755,11 +1766,12 @@
                   "\"labs:dashboard:deferBelowFold\""
                 ],
                 "path": "src/plugins/presentation_util/public/services/labs.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.env",
+                "id": "def-public.PresentationLabsService.setProjectStatus.$2",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "env",
@@ -1768,19 +1780,25 @@
                   "\"kibana\" | \"browser\" | \"session\""
                 ],
                 "path": "src/plugins/presentation_util/public/services/labs.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.status",
+                "id": "def-public.PresentationLabsService.setProjectStatus.$3",
                 "type": "boolean",
                 "tags": [],
                 "label": "status",
                 "description": [],
+                "signature": [
+                  "boolean"
+                ],
                 "path": "src/plugins/presentation_util/public/services/labs.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1794,8 +1812,8 @@
             ],
             "path": "src/plugins/presentation_util/public/services/labs.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1844,8 +1862,8 @@
             ],
             "path": "src/plugins/presentation_util/public/components/solution_toolbar/items/quick_group.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1918,8 +1936,8 @@
             ],
             "path": "src/plugins/presentation_util/public/components/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -1941,11 +1959,10 @@
             ],
             "path": "src/plugins/presentation_util/public/components/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "presentationUtil",
-                "id": "def-public.props",
+                "id": "def-public.SaveModalDashboardProps.onSave.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "props",
@@ -1961,9 +1978,11 @@
                   " & { dashboardId: string | null; addToLibrary: boolean; }"
                 ],
                 "path": "src/plugins/presentation_util/public/components/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "presentationUtil",
@@ -2028,6 +2047,29 @@
         ],
         "path": "src/plugins/presentation_util/public/services/create/factory.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "presentationUtil",
+            "id": "def-public.params",
+            "type": "Object",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "presentationUtil",
+                "scope": "public",
+                "docId": "kibPresentationUtilPluginApi",
+                "section": "def-public.KibanaPluginServiceParams",
+                "text": "KibanaPluginServiceParams"
+              },
+              "<Start>"
+            ],
+            "path": "src/plugins/presentation_util/public/services/create/factory.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -2044,6 +2086,22 @@
         ],
         "path": "src/plugins/presentation_util/public/services/create/factory.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "presentationUtil",
+            "id": "def-public.params",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              "Parameters"
+            ],
+            "path": "src/plugins/presentation_util/public/services/create/factory.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/presentation_util.mdx
+++ b/api_docs/presentation_util.mdx
@@ -18,7 +18,7 @@ import presentationUtilObj from './presentation_util.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 176 | 3 | 149 | 5 |
+| 178 | 3 | 151 | 5 |
 
 ## Client
 

--- a/api_docs/reporting.json
+++ b/api_docs/reporting.json
@@ -54,6 +54,40 @@
                 "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
                 "deprecated": false,
                 "isRequired": true
+              },
+              {
+                "parentPluginId": "reporting",
+                "id": "def-public.ReportingAPIClient.Unnamed.$2",
+                "type": "Object",
+                "tags": [],
+                "label": "uiSettings",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "core",
+                    "scope": "public",
+                    "docId": "kibCorePluginApi",
+                    "section": "def-public.IUiSettingsClient",
+                    "text": "IUiSettingsClient"
+                  }
+                ],
+                "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "reporting",
+                "id": "def-public.ReportingAPIClient.Unnamed.$3",
+                "type": "string",
+                "tags": [],
+                "label": "kibanaVersion",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
+                "deprecated": false,
+                "isRequired": true
               }
             ],
             "returnComment": []
@@ -311,7 +345,9 @@
             "label": "getReportingJobPath",
             "description": [],
             "signature": [
-              "(exportType: string, jobParams: JobParams) => string"
+              "(exportType: string, jobParams: ",
+              "BaseParams",
+              ") => string"
             ],
             "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
             "deprecated": false,
@@ -338,7 +374,7 @@
                 "label": "jobParams",
                 "description": [],
                 "signature": [
-                  "JobParams"
+                  "BaseParams"
                 ],
                 "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
                 "deprecated": false,
@@ -355,7 +391,9 @@
             "label": "createReportingJob",
             "description": [],
             "signature": [
-              "(exportType: string, jobParams: any) => Promise<",
+              "(exportType: string, jobParams: ",
+              "BaseParams",
+              ") => Promise<",
               "Job",
               ">"
             ],
@@ -379,12 +417,77 @@
               {
                 "parentPluginId": "reporting",
                 "id": "def-public.ReportingAPIClient.createReportingJob.$2",
-                "type": "Any",
+                "type": "Object",
                 "tags": [],
                 "label": "jobParams",
                 "description": [],
                 "signature": [
-                  "any"
+                  "BaseParams"
+                ],
+                "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
+          },
+          {
+            "parentPluginId": "reporting",
+            "id": "def-public.ReportingAPIClient.createImmediateReport",
+            "type": "Function",
+            "tags": [],
+            "label": "createImmediateReport",
+            "description": [],
+            "signature": [
+              "(baseParams: ",
+              "BaseParams",
+              ") => Promise<any>"
+            ],
+            "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "reporting",
+                "id": "def-public.ReportingAPIClient.createImmediateReport.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "baseParams",
+                "description": [],
+                "signature": [
+                  "BaseParams"
+                ],
+                "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
+          },
+          {
+            "parentPluginId": "reporting",
+            "id": "def-public.ReportingAPIClient.getDecoratedJobParams",
+            "type": "Function",
+            "tags": [],
+            "label": "getDecoratedJobParams",
+            "description": [],
+            "signature": [
+              "<T extends Pick<",
+              "BaseParams",
+              ", \"title\" | \"objectType\" | \"layout\">>(baseParams: T) => ",
+              "BaseParams"
+            ],
+            "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "reporting",
+                "id": "def-public.ReportingAPIClient.getDecoratedJobParams.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "baseParams",
+                "description": [],
+                "signature": [
+                  "T"
                 ],
                 "path": "x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts",
                 "deprecated": false,
@@ -869,6 +972,21 @@
                 "isRequired": true
               }
             ],
+            "returnComment": []
+          },
+          {
+            "parentPluginId": "reporting",
+            "id": "def-server.ReportingCore.getKibanaVersion",
+            "type": "Function",
+            "tags": [],
+            "label": "getKibanaVersion",
+            "description": [],
+            "signature": [
+              "() => string"
+            ],
+            "path": "x-pack/plugins/reporting/server/core.ts",
+            "deprecated": false,
+            "children": [],
             "returnComment": []
           },
           {
@@ -2138,8 +2256,8 @@
           ],
           "path": "x-pack/plugins/reporting/server/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",

--- a/api_docs/reporting.mdx
+++ b/api_docs/reporting.mdx
@@ -18,7 +18,7 @@ Contact [Kibana Reporting Services](https://github.com/orgs/elastic/teams/kibana
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 133 | 1 | 132 | 14 |
+| 140 | 0 | 139 | 15 |
 
 ## Client
 

--- a/api_docs/rule_registry.json
+++ b/api_docs/rule_registry.json
@@ -792,8 +792,8 @@
             ],
             "path": "x-pack/plugins/rule_registry/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -915,6 +915,22 @@
         ],
         "path": "x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type_factory.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "ruleRegistry",
+            "id": "def-server.alert",
+            "type": "Object",
+            "tags": [],
+            "label": "alert",
+            "description": [],
+            "signature": [
+              "{ id: string; fields: Record<string, unknown>; }"
+            ],
+            "path": "x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type_factory.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -939,6 +955,46 @@
         ],
         "path": "x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "ruleRegistry",
+            "id": "def-server.options",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "options",
+            "description": [],
+            "signature": [
+              "Pick<",
+              {
+                "pluginId": "alerting",
+                "scope": "server",
+                "docId": "kibAlertingPluginApi",
+                "section": "def-server.AlertExecutorOptions",
+                "text": "AlertExecutorOptions"
+              },
+              "<Params, State, InstanceState, InstanceContext, ActionGroupIds>, \"name\" | \"params\" | \"tags\" | \"spaceId\" | \"rule\" | \"createdBy\" | \"updatedBy\" | \"previousStartedAt\" | \"state\" | \"alertId\" | \"namespace\" | \"startedAt\"> & { services: ",
+              {
+                "pluginId": "alerting",
+                "scope": "server",
+                "docId": "kibAlertingPluginApi",
+                "section": "def-server.AlertServices",
+                "text": "AlertServices"
+              },
+              "<InstanceState, InstanceContext, ActionGroupIds> & ",
+              {
+                "pluginId": "ruleRegistry",
+                "scope": "server",
+                "docId": "kibRuleRegistryPluginApi",
+                "section": "def-server.LifecycleAlertServices",
+                "text": "LifecycleAlertServices"
+              },
+              "<InstanceState, InstanceContext, ActionGroupIds>; }"
+            ],
+            "path": "x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1029,11 +1085,10 @@
           ],
           "path": "x-pack/plugins/rule_registry/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "ruleRegistry",
-              "id": "def-server.req",
+              "id": "def-server.RuleRegistryPluginStartContract.getRacClientWithRequest.$1",
               "type": "Object",
               "tags": [],
               "label": "req",
@@ -1049,9 +1104,11 @@
                 "<unknown, unknown, unknown, any>"
               ],
               "path": "x-pack/plugins/rule_registry/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "ruleRegistry",

--- a/api_docs/rule_registry.mdx
+++ b/api_docs/rule_registry.mdx
@@ -18,7 +18,7 @@ import ruleRegistryObj from './rule_registry.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 60 | 0 | 60 | 9 |
+| 62 | 0 | 62 | 9 |
 
 ## Server
 

--- a/api_docs/runtime_fields.json
+++ b/api_docs/runtime_fields.json
@@ -200,11 +200,10 @@
             ],
             "path": "x-pack/plugins/runtime_fields/public/components/runtime_field_editor_flyout_content/runtime_field_editor_flyout_content.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "runtimeFields",
-                "id": "def-public.field",
+                "id": "def-public.Props.onSave.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "field",
@@ -219,9 +218,11 @@
                   }
                 ],
                 "path": "x-pack/plugins/runtime_fields/public/components/runtime_field_editor_flyout_content/runtime_field_editor_flyout_content.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "runtimeFields",
@@ -237,8 +238,8 @@
             ],
             "path": "x-pack/plugins/runtime_fields/public/components/runtime_field_editor_flyout_content/runtime_field_editor_flyout_content.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "runtimeFields",

--- a/api_docs/saved_objects.json
+++ b/api_docs/saved_objects.json
@@ -1884,8 +1884,8 @@
             ],
             "path": "src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -1934,7 +1934,24 @@
               "((appId: string) => string | undefined) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "savedObjects",
+                "id": "def-public.OriginSaveModalProps.getAppNameFromId.$1",
+                "type": "string",
+                "tags": [],
+                "label": "appId",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -1997,8 +2014,8 @@
             ],
             "path": "src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2041,11 +2058,10 @@
             ],
             "path": "src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjects",
-                "id": "def-public.props",
+                "id": "def-public.OriginSaveModalProps.onSave.$1",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "props",
@@ -2061,9 +2077,11 @@
                   " & { returnToOrigin: boolean; }"
                 ],
                 "path": "src/plugins/saved_objects/public/save_modal/saved_object_save_modal_origin.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2198,8 +2216,8 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2234,22 +2252,23 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjects",
-                "id": "def-public.resp",
+                "id": "def-public.SavedObject.applyESResp.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "resp",
                 "description": [],
                 "signature": [
-                  "{ [x: string]: any; }"
+                  "Record<string, any>"
                 ],
                 "path": "src/plugins/saved_objects/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2275,11 +2294,10 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjects",
-                "id": "def-public.opts",
+                "id": "def-public.SavedObject.creationOpts.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "opts",
@@ -2288,9 +2306,11 @@
                   "SavedObjectCreationOpts"
                 ],
                 "path": "src/plugins/saved_objects/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2316,7 +2336,9 @@
               "(() => Promise<{}>) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2330,8 +2352,8 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2345,8 +2367,8 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2360,8 +2382,8 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2375,8 +2397,8 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2391,13 +2413,30 @@
                 "pluginId": "data",
                 "scope": "common",
                 "docId": "kibDataIndexPatternsPluginApi",
-                "section": "def-common.IIndexPattern",
-                "text": "IIndexPattern"
+                "section": "def-common.IndexPattern",
+                "text": "IndexPattern"
               },
               " | null>) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "savedObjects",
+                "id": "def-public.SavedObject.hydrateIndexPattern.$1",
+                "type": "string",
+                "tags": [],
+                "label": "id",
+                "description": [],
+                "signature": [
+                  "string | undefined"
+                ],
+                "path": "src/plugins/saved_objects/public/types.ts",
+                "deprecated": false,
+                "isRequired": false
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2431,7 +2470,9 @@
               ">) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2455,8 +2496,8 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2501,11 +2542,10 @@
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjects",
-                "id": "def-public.saveOptions",
+                "id": "def-public.SavedObject.save.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "saveOptions",
@@ -2520,9 +2560,11 @@
                   }
                 ],
                 "path": "src/plugins/saved_objects/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2639,7 +2681,30 @@
               ">) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "savedObjects",
+                "id": "def-public.SavedObjectConfig.afterESResp.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "savedObject",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "savedObjects",
+                    "scope": "public",
+                    "docId": "kibSavedObjectsPluginApi",
+                    "section": "def-public.SavedObject",
+                    "text": "SavedObject"
+                  }
+                ],
+                "path": "src/plugins/saved_objects/public/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2669,7 +2734,24 @@
               ") | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "savedObjects",
+                "id": "def-public.SavedObjectConfig.extractReferences.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "opts",
+                "description": [],
+                "signature": [
+                  "SavedObjectAttributesAndRefs"
+                ],
+                "path": "src/plugins/saved_objects/public/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2692,7 +2774,39 @@
               "[]) => void) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "savedObjects",
+                "id": "def-public.SavedObjectConfig.injectReferences.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "object",
+                "description": [],
+                "signature": [
+                  "T"
+                ],
+                "path": "src/plugins/saved_objects/public/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "savedObjects",
+                "id": "def-public.SavedObjectConfig.injectReferences.$2",
+                "type": "Array",
+                "tags": [],
+                "label": "references",
+                "description": [],
+                "signature": [
+                  "SavedObjectReference",
+                  "[]"
+                ],
+                "path": "src/plugins/saved_objects/public/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2718,7 +2832,9 @@
               "(() => void) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2732,8 +2848,8 @@
                 "pluginId": "data",
                 "scope": "common",
                 "docId": "kibDataIndexPatternsPluginApi",
-                "section": "def-common.IIndexPattern",
-                "text": "IIndexPattern"
+                "section": "def-common.IndexPattern",
+                "text": "IndexPattern"
               },
               " | undefined"
             ],
@@ -2875,11 +2991,10 @@
             ],
             "path": "src/plugins/saved_objects/public/saved_object/decorators/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjects",
-                "id": "def-public.config",
+                "id": "def-public.SavedObjectDecorator.decorateConfig.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "config",
@@ -2894,9 +3009,11 @@
                   }
                 ],
                 "path": "src/plugins/saved_objects/public/saved_object/decorators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -2912,11 +3029,10 @@
             ],
             "path": "src/plugins/saved_objects/public/saved_object/decorators/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjects",
-                "id": "def-public.object",
+                "id": "def-public.SavedObjectDecorator.decorateObject.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "object",
@@ -2925,9 +3041,11 @@
                   "T"
                 ],
                 "path": "src/plugins/saved_objects/public/saved_object/decorators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -3363,7 +3481,9 @@
               "(() => void) | undefined"
             ],
             "path": "src/plugins/saved_objects/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjects",
@@ -3507,6 +3627,22 @@
         ],
         "path": "src/plugins/saved_objects/public/saved_object/decorators/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "savedObjects",
+            "id": "def-public.services",
+            "type": "Object",
+            "tags": [],
+            "label": "services",
+            "description": [],
+            "signature": [
+              "SavedObjectKibanaServices"
+            ],
+            "path": "src/plugins/saved_objects/public/saved_object/decorators/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -3644,11 +3780,10 @@
           ],
           "path": "src/plugins/saved_objects/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "savedObjects",
-              "id": "def-public.config",
+              "id": "def-public.SavedObjectSetup.registerDecorator.$1",
               "type": "Object",
               "tags": [],
               "label": "config",
@@ -3664,9 +3799,11 @@
                 "<any>"
               ],
               "path": "src/plugins/saved_objects/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/saved_objects.mdx
+++ b/api_docs/saved_objects.mdx
@@ -18,7 +18,7 @@ import savedObjectsObj from './saved_objects.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 213 | 3 | 199 | 5 |
+| 220 | 3 | 206 | 5 |
 
 ## Client
 

--- a/api_docs/saved_objects_management.json
+++ b/api_docs/saved_objects_management.json
@@ -710,11 +710,10 @@
             ],
             "path": "src/plugins/saved_objects_management/public/services/action_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjectsManagement",
-                "id": "def-public.action",
+                "id": "def-public.SavedObjectsManagementActionServiceSetup.register.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "action",
@@ -729,9 +728,11 @@
                   }
                 ],
                 "path": "src/plugins/saved_objects_management/public/services/action_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -760,19 +761,23 @@
             ],
             "path": "src/plugins/saved_objects_management/public/services/action_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjectsManagement",
-                "id": "def-public.actionId",
+                "id": "def-public.SavedObjectsManagementActionServiceStart.has.$1",
                 "type": "string",
                 "tags": [],
                 "label": "actionId",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/saved_objects_management/public/services/action_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "savedObjectsManagement",
@@ -796,8 +801,8 @@
             ],
             "path": "src/plugins/saved_objects_management/public/services/action_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -906,11 +911,10 @@
             ],
             "path": "src/plugins/saved_objects_management/public/services/column_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjectsManagement",
-                "id": "def-public.column",
+                "id": "def-public.SavedObjectsManagementColumnServiceSetup.register.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "column",
@@ -926,9 +930,11 @@
                   "<unknown>"
                 ],
                 "path": "src/plugins/saved_objects_management/public/services/column_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -965,8 +971,8 @@
             ],
             "path": "src/plugins/saved_objects_management/public/services/column_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/saved_objects_tagging_oss.json
+++ b/api_docs/saved_objects_tagging_oss.json
@@ -253,11 +253,10 @@
             ],
             "path": "src/plugins/saved_objects_tagging_oss/public/api.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjectsTaggingOss",
-                "id": "def-public.ids",
+                "id": "def-public.SavedObjectSaveModalTagSelectorComponentProps.onTagsSelected.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "ids",
@@ -266,9 +265,11 @@
                   "string[]"
                 ],
                 "path": "src/plugins/saved_objects_tagging_oss/public/api.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1037,11 +1038,10 @@
             ],
             "path": "src/plugins/saved_objects_tagging_oss/public/api.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "savedObjectsTaggingOss",
-                "id": "def-public.ids",
+                "id": "def-public.TagSelectorComponentProps.onTagsSelected.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "ids",
@@ -1050,9 +1050,11 @@
                   "string[]"
                 ],
                 "path": "src/plugins/saved_objects_tagging_oss/public/api.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1087,6 +1089,28 @@
         ],
         "path": "src/plugins/saved_objects_tagging_oss/public/api.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "savedObjectsTaggingOss",
+            "id": "def-public.object",
+            "type": "Object",
+            "tags": [],
+            "label": "object",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "savedObjects",
+                "scope": "public",
+                "docId": "kibSavedObjectsPluginApi",
+                "section": "def-public.SavedObject",
+                "text": "SavedObject"
+              }
+            ],
+            "path": "src/plugins/saved_objects_tagging_oss/public/api.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/saved_objects_tagging_oss.mdx
+++ b/api_docs/saved_objects_tagging_oss.mdx
@@ -18,7 +18,7 @@ import savedObjectsTaggingOssObj from './saved_objects_tagging_oss.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 89 | 3 | 50 | 0 |
+| 90 | 3 | 51 | 0 |
 
 ## Client
 

--- a/api_docs/screenshot_mode.json
+++ b/api_docs/screenshot_mode.json
@@ -232,8 +232,8 @@
           ],
           "path": "src/plugins/screenshot_mode/server/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/security.json
+++ b/api_docs/security.json
@@ -119,8 +119,8 @@
             ],
             "path": "x-pack/plugins/security/public/authentication/authentication_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "security",
@@ -136,8 +136,8 @@
             ],
             "path": "x-pack/plugins/security/public/authentication/authentication_service.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -446,8 +446,8 @@
             ],
             "path": "x-pack/plugins/security/public/nav_control/nav_control_service.tsx",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "security",
@@ -471,11 +471,10 @@
             ],
             "path": "x-pack/plugins/security/public/nav_control/nav_control_service.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "security",
-                "id": "def-public.newUserMenuLink",
+                "id": "def-public.SecurityNavControlServiceStart.addUserMenuLinks.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "newUserMenuLink",
@@ -491,9 +490,11 @@
                   "[]"
                 ],
                 "path": "x-pack/plugins/security/public/nav_control/nav_control_service.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -808,11 +809,10 @@
             ],
             "path": "x-pack/plugins/security/server/audit/audit_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "security",
-                "id": "def-server.event",
+                "id": "def-server.AuditLogger.log.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "event",
@@ -828,9 +828,11 @@
                   " | undefined"
                 ],
                 "path": "x-pack/plugins/security/server/audit/audit_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -872,11 +874,10 @@
             ],
             "path": "x-pack/plugins/security/server/audit/audit_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "security",
-                "id": "def-server.request",
+                "id": "def-server.AuditServiceSetup.asScoped.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "request",
@@ -892,9 +893,11 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "x-pack/plugins/security/server/audit/audit_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "security",
@@ -915,11 +918,10 @@
             ],
             "path": "x-pack/plugins/security/server/audit/audit_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "security",
-                "id": "def-server.id",
+                "id": "def-server.AuditServiceSetup.getLogger.$1",
                 "type": "string",
                 "tags": [],
                 "label": "id",
@@ -928,9 +930,11 @@
                   "string | undefined"
                 ],
                 "path": "x-pack/plugins/security/server/audit/audit_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1147,11 +1151,10 @@
             ],
             "path": "x-pack/plugins/security/server/authentication/authentication_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "security",
-                "id": "def-server.request",
+                "id": "def-server.AuthenticationServiceStart.getCurrentUser.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "request",
@@ -1167,9 +1170,11 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "x-pack/plugins/security/server/authentication/authentication_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1494,31 +1499,38 @@
             ],
             "path": "x-pack/plugins/security/server/audit/audit_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "security",
-                "id": "def-server.eventType",
+                "id": "def-server.LegacyAuditLogger.log.$1",
                 "type": "string",
                 "tags": [],
                 "label": "eventType",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/security/server/audit/audit_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "security",
-                "id": "def-server.message",
+                "id": "def-server.LegacyAuditLogger.log.$2",
                 "type": "string",
                 "tags": [],
                 "label": "message",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/security/server/audit/audit_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "security",
-                "id": "def-server.data",
+                "id": "def-server.LegacyAuditLogger.log.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "data",
@@ -1527,9 +1539,11 @@
                   "Record<string, any> | undefined"
                 ],
                 "path": "x-pack/plugins/security/server/audit/audit_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/security_oss.json
+++ b/api_docs/security_oss.json
@@ -126,11 +126,10 @@
           ],
           "path": "src/plugins/security_oss/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "securityOss",
-              "id": "def-server.provider",
+              "id": "def-server.SecurityOssPluginSetup.setAnonymousAccessServiceProvider.$1",
               "type": "Function",
               "tags": [],
               "label": "provider",
@@ -140,9 +139,11 @@
                 "AnonymousAccessService"
               ],
               "path": "src/plugins/security_oss/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/security_solution.json
+++ b/api_docs/security_solution.json
@@ -16518,7 +16518,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
             "deprecated": false

--- a/api_docs/security_solution.json
+++ b/api_docs/security_solution.json
@@ -349,8 +349,8 @@
           ],
           "path": "x-pack/plugins/security_solution/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -707,8 +707,8 @@
             ],
             "path": "x-pack/plugins/security_solution/server/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1079,8 +1079,8 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -1195,7 +1195,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -1208,7 +1210,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -1264,7 +1268,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2627,21 +2633,24 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.columnName",
+                "id": "def-common.ColumnRenderer.isInstance.$1",
                 "type": "string",
                 "tags": [],
                 "label": "columnName",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.data",
+                "id": "def-common.ColumnRenderer.isInstance.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "data",
@@ -2657,9 +2666,11 @@
                   "[]"
                 ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -2681,30 +2692,115 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.__0",
+                "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{\n    columnName,\n    eventId,\n    field,\n    timelineId,\n    truncate,\n    values,\n    linkValues,\n  }",
                 "description": [],
-                "signature": [
-                  "{ columnName: string; eventId: string; field: ",
-                  {
-                    "pluginId": "timelines",
-                    "scope": "common",
-                    "docId": "kibTimelinesPluginApi",
-                    "section": "def-common.ColumnHeaderOptions",
-                    "text": "ColumnHeaderOptions"
-                  },
-                  "; timelineId: string; truncate?: boolean | undefined; values: string[] | null | undefined; linkValues?: string[] | null | undefined; }"
-                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.columnName",
+                    "type": "string",
+                    "tags": [],
+                    "label": "columnName",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.eventId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "eventId",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.field",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "field",
+                    "description": [],
+                    "signature": [
+                      "Pick<",
+                      "EuiDataGridColumn",
+                      ", \"id\" | \"display\" | \"displayAsText\" | \"initialWidth\"> & { aggregatable?: boolean | undefined; category?: string | undefined; columnHeaderType: ",
+                      {
+                        "pluginId": "timelines",
+                        "scope": "common",
+                        "docId": "kibTimelinesPluginApi",
+                        "section": "def-common.ColumnHeaderType",
+                        "text": "ColumnHeaderType"
+                      },
+                      "; description?: string | undefined; example?: string | undefined; format?: string | undefined; linkField?: string | undefined; placeholder?: string | undefined; subType?: ",
+                      "IFieldSubType",
+                      " | undefined; type?: string | undefined; }"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.timelineId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "timelineId",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.truncate",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "truncate",
+                    "description": [],
+                    "signature": [
+                      "boolean | undefined"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.values",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "values",
+                    "description": [],
+                    "signature": [
+                      "string[] | null | undefined"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.linkValues",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "linkValues",
+                    "description": [],
+                    "signature": [
+                      "string[] | null | undefined"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -4973,22 +5069,31 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.__0",
+                "id": "def-common.HeaderActionProps.onSelectAll.$1.isSelected",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{ isSelected }",
                 "description": [],
-                "signature": [
-                  "{ isSelected: boolean; }"
-                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.HeaderActionProps.onSelectAll.$1.isSelected.isSelected",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "isSelected",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -9265,11 +9370,10 @@
             ],
             "path": "x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.options",
+                "id": "def-common.MatrixHistogramSchema.buildDsl.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "options",
@@ -9284,9 +9388,11 @@
                   }
                 ],
                 "path": "x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -9335,7 +9441,45 @@
               "[]) | undefined"
             ],
             "path": "x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "securitySolution",
+                "id": "def-common.MatrixHistogramSchema.parser.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "data",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "securitySolution",
+                    "scope": "common",
+                    "docId": "kibSecuritySolutionPluginApi",
+                    "section": "def-common.MatrixHistogramParseData",
+                    "text": "MatrixHistogramParseData"
+                  },
+                  "<U>"
+                ],
+                "path": "x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "securitySolution",
+                "id": "def-common.MatrixHistogramSchema.parser.$2",
+                "type": "string",
+                "tags": [],
+                "label": "keyBucket",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -14320,11 +14464,10 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.data",
+                "id": "def-common.RowRenderer.isInstance.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "data",
@@ -14333,9 +14476,11 @@
                   "Ecs"
                 ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "securitySolution",
@@ -14359,32 +14504,75 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "securitySolution",
-                "id": "def-common.__0",
+                "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{\n    browserFields,\n    data,\n    isDraggable,\n    timelineId,\n  }",
                 "description": [],
-                "signature": [
-                  "{ browserFields: Readonly<Record<string, Partial<",
-                  {
-                    "pluginId": "timelines",
-                    "scope": "common",
-                    "docId": "kibTimelinesPluginApi",
-                    "section": "def-common.BrowserField",
-                    "text": "BrowserField"
-                  },
-                  ">>>; data: ",
-                  "Ecs",
-                  "; isDraggable: boolean; timelineId: string; }"
-                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.browserFields",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "browserFields",
+                    "description": [],
+                    "signature": [
+                      "{ readonly [x: string]: Partial<",
+                      {
+                        "pluginId": "timelines",
+                        "scope": "common",
+                        "docId": "kibTimelinesPluginApi",
+                        "section": "def-common.BrowserField",
+                        "text": "BrowserField"
+                      },
+                      ">; }"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.data",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "data",
+                    "description": [],
+                    "signature": [
+                      "Ecs"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.isDraggable",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "isDraggable",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "securitySolution",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.timelineId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "timelineId",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -19902,6 +20090,19 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.nextPage",
+            "type": "number",
+            "tags": [],
+            "label": "nextPage",
+            "description": [],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19916,6 +20117,19 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.columnId",
+            "type": "string",
+            "tags": [],
+            "label": "columnId",
+            "description": [],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19930,6 +20144,22 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ columnId: string; delta: number; }"
+            ],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19954,6 +20184,30 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.sorted",
+            "type": "Object",
+            "tags": [],
+            "label": "sorted",
+            "description": [],
+            "signature": [
+              "{ columnId: string; sortDirection: ",
+              {
+                "pluginId": "securitySolution",
+                "scope": "common",
+                "docId": "kibSecuritySolutionPluginApi",
+                "section": "def-common.SortDirection",
+                "text": "SortDirection"
+              },
+              "; }"
+            ],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19976,6 +20230,30 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.sorted",
+            "type": "Array",
+            "tags": [],
+            "label": "sorted",
+            "description": [],
+            "signature": [
+              "{ columnId: string; sortDirection: ",
+              {
+                "pluginId": "securitySolution",
+                "scope": "common",
+                "docId": "kibSecuritySolutionPluginApi",
+                "section": "def-common.SortDirection",
+                "text": "SortDirection"
+              },
+              "; }[]"
+            ],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -19992,6 +20270,19 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.eventId",
+            "type": "string",
+            "tags": [],
+            "label": "eventId",
+            "description": [],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -20008,6 +20299,22 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ eventIds: string[]; isSelected: boolean; }"
+            ],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -20024,6 +20331,22 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ isSelected: boolean; }"
+            ],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -20040,6 +20363,19 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.eventId",
+            "type": "string",
+            "tags": [],
+            "label": "eventId",
+            "description": [],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -20064,6 +20400,29 @@
         ],
         "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "securitySolution",
+            "id": "def-common.columns",
+            "type": "Array",
+            "tags": [],
+            "label": "columns",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "timelines",
+                "scope": "common",
+                "docId": "kibTimelinesPluginApi",
+                "section": "def-common.ColumnHeaderOptions",
+                "text": "ColumnHeaderOptions"
+              },
+              "[]"
+            ],
+            "path": "x-pack/plugins/security_solution/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/security_solution.mdx
+++ b/api_docs/security_solution.mdx
@@ -18,7 +18,7 @@ import securitySolutionObj from './security_solution.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 1298 | 8 | 1247 | 27 |
+| 1322 | 8 | 1271 | 27 |
 
 ## Client
 

--- a/api_docs/share.json
+++ b/api_docs/share.json
@@ -852,11 +852,10 @@
             ],
             "path": "src/plugins/share/common/url_service/locators/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "share",
-                "id": "def-public.params",
+                "id": "def-public.LocatorPublic.useUrl.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "params",
@@ -865,11 +864,12 @@
                   "P"
                 ],
                 "path": "src/plugins/share/common/url_service/locators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "share",
-                "id": "def-public.getUrlParams",
+                "id": "def-public.LocatorPublic.useUrl.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "getUrlParams",
@@ -879,11 +879,12 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/share/common/url_service/locators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "share",
-                "id": "def-public.deps",
+                "id": "def-public.LocatorPublic.useUrl.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "deps",
@@ -892,9 +893,11 @@
                   "React.DependencyList | undefined"
                 ],
                 "path": "src/plugins/share/common/url_service/locators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -979,8 +982,8 @@
             ],
             "path": "src/plugins/share/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "share",
@@ -995,7 +998,24 @@
               ") => boolean) | undefined"
             ],
             "path": "src/plugins/share/public/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "share",
+                "id": "def-public.ShareContext.showPublicUrlSwitch.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "anonymousUserCapabilities",
+                "description": [],
+                "signature": [
+                  "Capabilities"
+                ],
+                "path": "src/plugins/share/public/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1141,11 +1161,10 @@
             ],
             "path": "src/plugins/share/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "share",
-                "id": "def-public.context",
+                "id": "def-public.ShareMenuProvider.getShareMenuItems.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "context",
@@ -1160,9 +1179,11 @@
                   }
                 ],
                 "path": "src/plugins/share/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -1449,7 +1470,31 @@
               "[Id][\"State\"]) => Promise<string>) | undefined"
             ],
             "path": "src/plugins/share/public/url_generators/url_generator_definition.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "share",
+                "id": "def-public.UrlGeneratorsDefinition.createUrl.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "share",
+                    "scope": "public",
+                    "docId": "kibSharePluginApi",
+                    "section": "def-public.UrlGeneratorStateMapping",
+                    "text": "UrlGeneratorStateMapping"
+                  },
+                  "[Id][\"State\"]"
+                ],
+                "path": "src/plugins/share/public/url_generators/url_generator_definition.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "share",
@@ -1499,7 +1544,31 @@
               "[Id][\"MigratedId\"]; }>) | undefined"
             ],
             "path": "src/plugins/share/public/url_generators/url_generator_definition.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "share",
+                "id": "def-public.UrlGeneratorsDefinition.migrate.$1",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "state",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "share",
+                    "scope": "public",
+                    "docId": "kibSharePluginApi",
+                    "section": "def-public.UrlGeneratorStateMapping",
+                    "text": "UrlGeneratorStateMapping"
+                  },
+                  "[Id][\"State\"]"
+                ],
+                "path": "src/plugins/share/public/url_generators/url_generator_definition.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -2172,11 +2241,10 @@
             ],
             "path": "src/plugins/share/common/url_service/locators/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "share",
-                "id": "def-common.params",
+                "id": "def-common.LocatorPublic.useUrl.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "params",
@@ -2185,11 +2253,12 @@
                   "P"
                 ],
                 "path": "src/plugins/share/common/url_service/locators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "share",
-                "id": "def-common.getUrlParams",
+                "id": "def-common.LocatorPublic.useUrl.$2",
                 "type": "Object",
                 "tags": [],
                 "label": "getUrlParams",
@@ -2199,11 +2268,12 @@
                   " | undefined"
                 ],
                 "path": "src/plugins/share/common/url_service/locators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               },
               {
                 "parentPluginId": "share",
-                "id": "def-common.deps",
+                "id": "def-common.LocatorPublic.useUrl.$3",
                 "type": "Object",
                 "tags": [],
                 "label": "deps",
@@ -2212,9 +2282,11 @@
                   "React.DependencyList | undefined"
                 ],
                 "path": "src/plugins/share/common/url_service/locators/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/share.mdx
+++ b/api_docs/share.mdx
@@ -18,7 +18,7 @@ import shareObj from './share.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 123 | 1 | 83 | 8 |
+| 126 | 1 | 86 | 8 |
 
 ## Client
 

--- a/api_docs/spaces.json
+++ b/api_docs/spaces.json
@@ -1394,11 +1394,10 @@
             ],
             "path": "x-pack/plugins/spaces/server/spaces_service/spaces_service.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "spaces",
-                "id": "def-server.request",
+                "id": "def-server.SpacesServiceStart.createSpacesClient.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "request",
@@ -1416,9 +1415,11 @@
                   "<unknown, unknown, unknown, any>"
                 ],
                 "path": "x-pack/plugins/spaces/server/spaces_service/spaces_service.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "spaces",
@@ -1705,6 +1706,48 @@
         ],
         "path": "x-pack/plugins/spaces/server/spaces_client/spaces_client_service.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "spaces",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "x-pack/plugins/spaces/server/spaces_client/spaces_client_service.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "spaces",
+            "id": "def-server.savedObjectsStart",
+            "type": "Object",
+            "tags": [],
+            "label": "savedObjectsStart",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectsServiceStart",
+                "text": "SavedObjectsServiceStart"
+              }
+            ],
+            "path": "x-pack/plugins/spaces/server/spaces_client/spaces_client_service.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1746,6 +1789,48 @@
         ],
         "path": "x-pack/plugins/spaces/server/spaces_client/spaces_client_service.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "spaces",
+            "id": "def-server.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any>"
+            ],
+            "path": "x-pack/plugins/spaces/server/spaces_client/spaces_client_service.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "spaces",
+            "id": "def-server.baseClient",
+            "type": "Object",
+            "tags": [],
+            "label": "baseClient",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "spaces",
+                "scope": "server",
+                "docId": "kibSpacesPluginApi",
+                "section": "def-server.ISpacesClient",
+                "text": "ISpacesClient"
+              }
+            ],
+            "path": "x-pack/plugins/spaces/server/spaces_client/spaces_client_service.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/spaces.mdx
+++ b/api_docs/spaces.mdx
@@ -18,7 +18,7 @@ Contact [Platform Security](https://github.com/orgs/elastic/teams/kibana-securit
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 106 | 0 | 0 | 0 |
+| 110 | 0 | 4 | 0 |
 
 ## Client
 

--- a/api_docs/spaces_oss.json
+++ b/api_docs/spaces_oss.json
@@ -191,7 +191,52 @@
               "((objects: { type: string; id: string; }[], spacesToAdd: string[], spacesToRemove: string[]) => Promise<void>) | undefined"
             ],
             "path": "src/plugins/spaces_oss/public/api.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "spacesOss",
+                "id": "def-public.ShareToSpaceFlyoutProps.changeSpacesHandler.$1",
+                "type": "Array",
+                "tags": [],
+                "label": "objects",
+                "description": [],
+                "signature": [
+                  "{ type: string; id: string; }[]"
+                ],
+                "path": "src/plugins/spaces_oss/public/api.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "spacesOss",
+                "id": "def-public.ShareToSpaceFlyoutProps.changeSpacesHandler.$2",
+                "type": "Array",
+                "tags": [],
+                "label": "spacesToAdd",
+                "description": [],
+                "signature": [
+                  "string[]"
+                ],
+                "path": "src/plugins/spaces_oss/public/api.ts",
+                "deprecated": false,
+                "isRequired": true
+              },
+              {
+                "parentPluginId": "spacesOss",
+                "id": "def-public.ShareToSpaceFlyoutProps.changeSpacesHandler.$3",
+                "type": "Array",
+                "tags": [],
+                "label": "spacesToRemove",
+                "description": [],
+                "signature": [
+                  "string[]"
+                ],
+                "path": "src/plugins/spaces_oss/public/api.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "spacesOss",
@@ -206,7 +251,24 @@
               "((updatedObjects: { type: string; id: string; }[]) => void) | undefined"
             ],
             "path": "src/plugins/spaces_oss/public/api.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "spacesOss",
+                "id": "def-public.ShareToSpaceFlyoutProps.onUpdate.$1",
+                "type": "Array",
+                "tags": [],
+                "label": "updatedObjects",
+                "description": [],
+                "signature": [
+                  "{ type: string; id: string; }[]"
+                ],
+                "path": "src/plugins/spaces_oss/public/api.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "spacesOss",
@@ -221,7 +283,9 @@
               "(() => void) | undefined"
             ],
             "path": "src/plugins/spaces_oss/public/api.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -610,23 +674,26 @@
             ],
             "path": "src/plugins/spaces_oss/public/api.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "spacesOss",
-                "id": "def-public.path",
+                "id": "def-public.SpacesApiUi.redirectLegacyUrl.$1",
                 "type": "string",
                 "tags": [],
                 "label": "path",
                 "description": [
                   "The path to use for the new URL, optionally including `search` and/or `hash` URL components."
                 ],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/spaces_oss/public/api.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "spacesOss",
-                "id": "def-public.objectNoun",
+                "id": "def-public.SpacesApiUi.redirectLegacyUrl.$2",
                 "type": "string",
                 "tags": [],
                 "label": "objectNoun",
@@ -637,9 +704,11 @@
                   "string | undefined"
                 ],
                 "path": "src/plugins/spaces_oss/public/api.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -982,6 +1051,22 @@
         ],
         "path": "src/plugins/spaces_oss/public/api.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "spacesOss",
+            "id": "def-public.props",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "props",
+            "description": [],
+            "signature": [
+              "T"
+            ],
+            "path": "src/plugins/spaces_oss/public/api.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/spaces_oss.mdx
+++ b/api_docs/spaces_oss.mdx
@@ -18,7 +18,7 @@ Contact [Platform Security](https://github.com/orgs/elastic/teams/kibana-securit
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 72 | 0 | 5 | 0 |
+| 77 | 0 | 10 | 0 |
 
 ## Client
 

--- a/api_docs/task_manager.json
+++ b/api_docs/task_manager.json
@@ -883,6 +883,28 @@
         ],
         "path": "x-pack/plugins/task_manager/server/task.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "taskManager",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "taskManager",
+                "scope": "server",
+                "docId": "kibTaskManagerPluginApi",
+                "section": "def-server.RunContext",
+                "text": "RunContext"
+              }
+            ],
+            "path": "x-pack/plugins/task_manager/server/task.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       }
     ],

--- a/api_docs/task_manager.mdx
+++ b/api_docs/task_manager.mdx
@@ -18,7 +18,7 @@ import taskManagerObj from './task_manager.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 52 | 0 | 25 | 8 |
+| 53 | 0 | 26 | 8 |
 
 ## Server
 

--- a/api_docs/telemetry.json
+++ b/api_docs/telemetry.json
@@ -165,8 +165,8 @@
             ],
             "path": "src/plugins/telemetry/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "telemetry",
@@ -194,8 +194,8 @@
             ],
             "path": "src/plugins/telemetry/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "telemetry",
@@ -211,8 +211,8 @@
             ],
             "path": "src/plugins/telemetry/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "telemetry",
@@ -228,8 +228,8 @@
             ],
             "path": "src/plugins/telemetry/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "telemetry",
@@ -245,21 +245,25 @@
             ],
             "path": "src/plugins/telemetry/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "telemetry",
-                "id": "def-public.optedIn",
+                "id": "def-public.TelemetryServicePublicApis.setOptIn.$1",
                 "type": "boolean",
                 "tags": [],
                 "label": "optedIn",
                 "description": [
                   "Whether the user is opting-in (`true`) or out (`false`)."
                 ],
+                "signature": [
+                  "boolean"
+                ],
                 "path": "src/plugins/telemetry/public/plugin.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -661,8 +665,8 @@
           ],
           "path": "src/plugins/telemetry/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -694,8 +698,8 @@
           ],
           "path": "src/plugins/telemetry/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",

--- a/api_docs/telemetry_collection_manager.json
+++ b/api_docs/telemetry_collection_manager.json
@@ -533,6 +533,47 @@
         ],
         "path": "src/plugins/telemetry_collection_manager/server/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "telemetryCollectionManager",
+            "id": "def-server.config",
+            "type": "Object",
+            "tags": [],
+            "label": "config",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "telemetryCollectionManager",
+                "scope": "server",
+                "docId": "kibTelemetryCollectionManagerPluginApi",
+                "section": "def-server.StatsCollectionConfig",
+                "text": "StatsCollectionConfig"
+              }
+            ],
+            "path": "src/plugins/telemetry_collection_manager/server/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "telemetryCollectionManager",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "telemetryCollectionManager",
+                "scope": "server",
+                "docId": "kibTelemetryCollectionManagerPluginApi",
+                "section": "def-server.StatsCollectionContext",
+                "text": "StatsCollectionContext"
+              }
+            ],
+            "path": "src/plugins/telemetry_collection_manager/server/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -571,6 +612,67 @@
         ],
         "path": "src/plugins/telemetry_collection_manager/server/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "telemetryCollectionManager",
+            "id": "def-server.clustersDetails",
+            "type": "Array",
+            "tags": [],
+            "label": "clustersDetails",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "telemetryCollectionManager",
+                "scope": "server",
+                "docId": "kibTelemetryCollectionManagerPluginApi",
+                "section": "def-server.ClusterDetails",
+                "text": "ClusterDetails"
+              },
+              "[]"
+            ],
+            "path": "src/plugins/telemetry_collection_manager/server/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "telemetryCollectionManager",
+            "id": "def-server.config",
+            "type": "Object",
+            "tags": [],
+            "label": "config",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "telemetryCollectionManager",
+                "scope": "server",
+                "docId": "kibTelemetryCollectionManagerPluginApi",
+                "section": "def-server.StatsCollectionConfig",
+                "text": "StatsCollectionConfig"
+              }
+            ],
+            "path": "src/plugins/telemetry_collection_manager/server/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "telemetryCollectionManager",
+            "id": "def-server.context",
+            "type": "Object",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "telemetryCollectionManager",
+                "scope": "server",
+                "docId": "kibTelemetryCollectionManagerPluginApi",
+                "section": "def-server.StatsCollectionContext",
+                "text": "StatsCollectionContext"
+              }
+            ],
+            "path": "src/plugins/telemetry_collection_manager/server/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -617,11 +719,10 @@
           ],
           "path": "src/plugins/telemetry_collection_manager/server/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "telemetryCollectionManager",
-              "id": "def-server.collectionConfig",
+              "id": "def-server.TelemetryCollectionManagerPluginSetup.setCollectionStrategy.$1",
               "type": "Object",
               "tags": [],
               "label": "collectionConfig",
@@ -631,9 +732,11 @@
                 "<T>"
               ],
               "path": "src/plugins/telemetry_collection_manager/server/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "telemetryCollectionManager",

--- a/api_docs/telemetry_collection_manager.mdx
+++ b/api_docs/telemetry_collection_manager.mdx
@@ -18,7 +18,7 @@ import telemetryCollectionManagerObj from './telemetry_collection_manager.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 29 | 0 | 29 | 4 |
+| 34 | 0 | 34 | 4 |
 
 ## Server
 

--- a/api_docs/telemetry_management_section.json
+++ b/api_docs/telemetry_management_section.json
@@ -191,19 +191,23 @@
           ],
           "path": "src/plugins/telemetry_management_section/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "telemetryManagementSection",
-              "id": "def-public.enabled",
+              "id": "def-public.TelemetryManagementSectionPluginSetup.toggleSecuritySolutionExample.$1",
               "type": "boolean",
               "tags": [],
               "label": "enabled",
               "description": [],
+              "signature": [
+                "boolean"
+              ],
               "path": "src/plugins/telemetry_management_section/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/timelines.json
+++ b/api_docs/timelines.json
@@ -458,11 +458,10 @@
                 ],
                 "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
                 "deprecated": false,
-                "returnComment": [],
                 "children": [
                   {
                     "parentPluginId": "timelines",
-                    "id": "def-public.containerElement",
+                    "id": "def-public.getTableSkipFocus.$1.containerElementgetFocusedCellshiftKeytableHasFocustableClassName.tableHasFocus.$1",
                     "type": "CompoundType",
                     "tags": [],
                     "label": "containerElement",
@@ -471,9 +470,11 @@
                       "HTMLElement | null"
                     ],
                     "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
-                    "deprecated": false
+                    "deprecated": false,
+                    "isRequired": false
                   }
-                ]
+                ],
+                "returnComment": []
               },
               {
                 "parentPluginId": "timelines",
@@ -567,8 +568,8 @@
                 ],
                 "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
                 "deprecated": false,
-                "returnComment": [],
-                "children": []
+                "children": [],
+                "returnComment": []
               },
               {
                 "parentPluginId": "timelines",
@@ -582,8 +583,8 @@
                 ],
                 "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
                 "deprecated": false,
-                "returnComment": [],
-                "children": []
+                "children": [],
+                "returnComment": []
               },
               {
                 "parentPluginId": "timelines",
@@ -1496,6 +1497,22 @@
         ],
         "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-public.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ newFocusedColumn: HTMLDivElement | null; newFocusedColumnAriaColindex: number | null; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1624,8 +1641,8 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1645,22 +1662,24 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "timelines",
-              "id": "def-public.props",
+              "id": "def-public.TimelinesUIStart.getTGrid.$1",
               "type": "Uncategorized",
               "tags": [],
               "label": "props",
               "description": [],
               "signature": [
-                "T extends \"standalone\" ? TGridStandaloneCompProps : T extends \"embedded\" ? TGridIntegratedCompProps : TGridIntegratedCompProps"
+                "GetTGridProps",
+                "<T>"
               ],
               "path": "x-pack/plugins/timelines/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1674,8 +1693,8 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1693,11 +1712,10 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "timelines",
-              "id": "def-public.props",
+              "id": "def-public.TimelinesUIStart.getLoadingPanel.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1706,9 +1724,11 @@
                 "LoadingPanelProps"
               ],
               "path": "x-pack/plugins/timelines/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1726,11 +1746,10 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "timelines",
-              "id": "def-public.props",
+              "id": "def-public.TimelinesUIStart.getLastUpdated.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1739,9 +1758,11 @@
                 "LastUpdatedAtProps"
               ],
               "path": "x-pack/plugins/timelines/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1752,31 +1773,30 @@
           "description": [],
           "signature": [
             "(props: ",
-            "FieldBrowserWrappedProps",
+            "FieldBrowserProps",
             ") => React.ReactElement<",
-            "FieldBrowserWrappedProps",
+            "FieldBrowserProps",
             ">"
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "timelines",
-              "id": "def-public.props",
-              "type": "CompoundType",
+              "id": "def-public.TimelinesUIStart.getFieldBrowser.$1",
+              "type": "Object",
               "tags": [],
               "label": "props",
               "description": [],
               "signature": [
-                "Pick<",
-                "FieldBrowserProps",
-                ", \"timelineId\" | \"columnHeaders\" | \"browserFields\" | \"isEventViewer\" | \"onFieldSelected\"> & { width?: number | undefined; height?: number | undefined; }"
+                "FieldBrowserProps"
               ],
               "path": "x-pack/plugins/timelines/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1793,8 +1813,8 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1810,8 +1830,8 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1828,8 +1848,8 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
-          "children": []
+          "children": [],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1847,11 +1867,10 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "timelines",
-              "id": "def-public.store",
+              "id": "def-public.TimelinesUIStart.setTGridEmbeddedStore.$1",
               "type": "Object",
               "tags": [],
               "label": "store",
@@ -1863,9 +1882,11 @@
                 ">"
               ],
               "path": "x-pack/plugins/timelines/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "timelines",
@@ -1883,11 +1904,10 @@
           ],
           "path": "x-pack/plugins/timelines/public/types.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "timelines",
-              "id": "def-public.props",
+              "id": "def-public.TimelinesUIStart.getAddToCaseAction.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
@@ -1896,9 +1916,11 @@
                 "AddToCaseActionProps"
               ],
               "path": "x-pack/plugins/timelines/public/types.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",
@@ -3204,11 +3226,10 @@
                 ],
                 "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
                 "deprecated": false,
-                "returnComment": [],
                 "children": [
                   {
                     "parentPluginId": "timelines",
-                    "id": "def-common.containerElement",
+                    "id": "def-common.getTableSkipFocus.$1.containerElementgetFocusedCellshiftKeytableHasFocustableClassName.tableHasFocus.$1",
                     "type": "CompoundType",
                     "tags": [],
                     "label": "containerElement",
@@ -3217,9 +3238,11 @@
                       "HTMLElement | null"
                     ],
                     "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
-                    "deprecated": false
+                    "deprecated": false,
+                    "isRequired": false
                   }
-                ]
+                ],
+                "returnComment": []
               },
               {
                 "parentPluginId": "timelines",
@@ -3327,8 +3350,8 @@
                 ],
                 "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
                 "deprecated": false,
-                "returnComment": [],
-                "children": []
+                "children": [],
+                "returnComment": []
               },
               {
                 "parentPluginId": "timelines",
@@ -3342,8 +3365,8 @@
                 ],
                 "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
                 "deprecated": false,
-                "returnComment": [],
-                "children": []
+                "children": [],
+                "returnComment": []
               },
               {
                 "parentPluginId": "timelines",
@@ -4753,8 +4776,8 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "timelines",
@@ -4869,7 +4892,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "timelines",
@@ -4882,7 +4907,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "timelines",
@@ -4938,7 +4965,9 @@
               "(() => void) | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -5541,21 +5570,24 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "timelines",
-                "id": "def-common.columnName",
+                "id": "def-common.ColumnRenderer.isInstance.$1",
                 "type": "string",
                 "tags": [],
                 "label": "columnName",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "timelines",
-                "id": "def-common.data",
+                "id": "def-common.ColumnRenderer.isInstance.$2",
                 "type": "Array",
                 "tags": [],
                 "label": "data",
@@ -5571,9 +5603,11 @@
                   "[]"
                 ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "timelines",
@@ -5595,30 +5629,115 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "timelines",
-                "id": "def-common.__0",
+                "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{\n    columnName,\n    eventId,\n    field,\n    timelineId,\n    truncate,\n    values,\n    linkValues,\n  }",
                 "description": [],
-                "signature": [
-                  "{ columnName: string; eventId: string; field: ",
-                  {
-                    "pluginId": "timelines",
-                    "scope": "common",
-                    "docId": "kibTimelinesPluginApi",
-                    "section": "def-common.ColumnHeaderOptions",
-                    "text": "ColumnHeaderOptions"
-                  },
-                  "; timelineId: string; truncate?: boolean | undefined; values: string[] | null | undefined; linkValues?: string[] | null | undefined; }"
-                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.columnName",
+                    "type": "string",
+                    "tags": [],
+                    "label": "columnName",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.eventId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "eventId",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.field",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "field",
+                    "description": [],
+                    "signature": [
+                      "Pick<",
+                      "EuiDataGridColumn",
+                      ", \"id\" | \"display\" | \"displayAsText\" | \"initialWidth\"> & { aggregatable?: boolean | undefined; category?: string | undefined; columnHeaderType: ",
+                      {
+                        "pluginId": "timelines",
+                        "scope": "common",
+                        "docId": "kibTimelinesPluginApi",
+                        "section": "def-common.ColumnHeaderType",
+                        "text": "ColumnHeaderType"
+                      },
+                      "; description?: string | undefined; example?: string | undefined; format?: string | undefined; linkField?: string | undefined; placeholder?: string | undefined; subType?: ",
+                      "IFieldSubType",
+                      " | undefined; type?: string | undefined; }"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.timelineId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "timelineId",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.truncate",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "truncate",
+                    "description": [],
+                    "signature": [
+                      "boolean | undefined"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.values",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "values",
+                    "description": [],
+                    "signature": [
+                      "string[] | null | undefined"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.ColumnRenderer.renderColumn.$1.columnNameeventIdfieldtimelineIdtruncatevalueslinkValues.linkValues",
+                    "type": "CompoundType",
+                    "tags": [],
+                    "label": "linkValues",
+                    "description": [],
+                    "signature": [
+                      "string[] | null | undefined"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/columns/index.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -7575,22 +7694,31 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "timelines",
-                "id": "def-common.__0",
+                "id": "def-common.HeaderActionProps.onSelectAll.$1.isSelected",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{ isSelected }",
                 "description": [],
-                "signature": [
-                  "{ isSelected: boolean; }"
-                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.HeaderActionProps.onSelectAll.$1.isSelected.isSelected",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "isSelected",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/actions/index.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "timelines",
@@ -8556,11 +8684,10 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "timelines",
-                "id": "def-common.data",
+                "id": "def-common.RowRenderer.isInstance.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "data",
@@ -8569,9 +8696,11 @@
                   "Ecs"
                 ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "timelines",
@@ -8595,32 +8724,75 @@
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "timelines",
-                "id": "def-common.__0",
+                "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId",
                 "type": "Object",
                 "tags": [],
-                "label": "__0",
+                "label": "{\n    browserFields,\n    data,\n    isDraggable,\n    timelineId,\n  }",
                 "description": [],
-                "signature": [
-                  "{ browserFields: Readonly<Record<string, Partial<",
-                  {
-                    "pluginId": "timelines",
-                    "scope": "common",
-                    "docId": "kibTimelinesPluginApi",
-                    "section": "def-common.BrowserField",
-                    "text": "BrowserField"
-                  },
-                  ">>>; data: ",
-                  "Ecs",
-                  "; isDraggable: boolean; timelineId: string; }"
-                ],
                 "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
-                "deprecated": false
+                "deprecated": false,
+                "children": [
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.browserFields",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "browserFields",
+                    "description": [],
+                    "signature": [
+                      "{ readonly [x: string]: Partial<",
+                      {
+                        "pluginId": "timelines",
+                        "scope": "common",
+                        "docId": "kibTimelinesPluginApi",
+                        "section": "def-common.BrowserField",
+                        "text": "BrowserField"
+                      },
+                      ">; }"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.data",
+                    "type": "Object",
+                    "tags": [],
+                    "label": "data",
+                    "description": [],
+                    "signature": [
+                      "Ecs"
+                    ],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.isDraggable",
+                    "type": "boolean",
+                    "tags": [],
+                    "label": "isDraggable",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  },
+                  {
+                    "parentPluginId": "timelines",
+                    "id": "def-common.RowRenderer.renderRow.$1.browserFieldsdataisDraggabletimelineId.timelineId",
+                    "type": "string",
+                    "tags": [],
+                    "label": "timelineId",
+                    "description": [],
+                    "path": "x-pack/plugins/timelines/common/types/timeline/rows/index.ts",
+                    "deprecated": false
+                  }
+                ]
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -12148,6 +12320,22 @@
         ],
         "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ containerElement: HTMLElement | null; tableClassName: string; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12316,6 +12504,19 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.nextPage",
+            "type": "number",
+            "tags": [],
+            "label": "nextPage",
+            "description": [],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12330,6 +12531,22 @@
         ],
         "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ newFocusedColumn: HTMLDivElement | null; newFocusedColumnAriaColindex: number | null; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/utils/accessibility/helpers.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12344,6 +12561,19 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.columnId",
+            "type": "string",
+            "tags": [],
+            "label": "columnId",
+            "description": [],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12358,6 +12588,22 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ columnId: string; delta: number; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12382,6 +12628,30 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.sorted",
+            "type": "Object",
+            "tags": [],
+            "label": "sorted",
+            "description": [],
+            "signature": [
+              "{ columnId: string; sortDirection: ",
+              {
+                "pluginId": "securitySolution",
+                "scope": "common",
+                "docId": "kibSecuritySolutionPluginApi",
+                "section": "def-common.SortDirection",
+                "text": "SortDirection"
+              },
+              "; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12404,6 +12674,30 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.sorted",
+            "type": "Array",
+            "tags": [],
+            "label": "sorted",
+            "description": [],
+            "signature": [
+              "{ columnId: string; sortDirection: ",
+              {
+                "pluginId": "securitySolution",
+                "scope": "common",
+                "docId": "kibSecuritySolutionPluginApi",
+                "section": "def-common.SortDirection",
+                "text": "SortDirection"
+              },
+              "; }[]"
+            ],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12420,6 +12714,19 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.eventId",
+            "type": "string",
+            "tags": [],
+            "label": "eventId",
+            "description": [],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12436,6 +12743,22 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ eventIds: string[]; isSelected: boolean; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12452,6 +12775,22 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.__0",
+            "type": "Object",
+            "tags": [],
+            "label": "__0",
+            "description": [],
+            "signature": [
+              "{ isSelected: boolean; }"
+            ],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12468,6 +12807,19 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.eventId",
+            "type": "string",
+            "tags": [],
+            "label": "eventId",
+            "description": [],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -12492,6 +12844,29 @@
         ],
         "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "timelines",
+            "id": "def-common.columns",
+            "type": "Array",
+            "tags": [],
+            "label": "columns",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "timelines",
+                "scope": "common",
+                "docId": "kibTimelinesPluginApi",
+                "section": "def-common.ColumnHeaderOptions",
+                "text": "ColumnHeaderOptions"
+              },
+              "[]"
+            ],
+            "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {

--- a/api_docs/timelines.json
+++ b/api_docs/timelines.json
@@ -1531,7 +1531,9 @@
             "section": "def-common.ColumnHeaderOptions",
             "text": "ColumnHeaderOptions"
           },
-          "[]; filters?: any[] | undefined; title: string; id: string; sort: ",
+          "[]; filters?: ",
+          "Filter",
+          "[] | undefined; title: string; id: string; sort: ",
           {
             "pluginId": "timelines",
             "scope": "common",
@@ -10609,7 +10611,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "x-pack/plugins/timelines/common/types/timeline/store.ts",
             "deprecated": false

--- a/api_docs/timelines.mdx
+++ b/api_docs/timelines.mdx
@@ -18,7 +18,7 @@ import timelinesObj from './timelines.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 889 | 6 | 770 | 26 |
+| 914 | 6 | 795 | 25 |
 
 ## Client
 

--- a/api_docs/triggers_actions_ui.json
+++ b/api_docs/triggers_actions_ui.json
@@ -1154,11 +1154,10 @@
             ],
             "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "triggersActionsUi",
-                "id": "def-public.alertParams",
+                "id": "def-public.AlertTypeModel.validate.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "alertParams",
@@ -1167,9 +1166,11 @@
                   "Params"
                 ],
                 "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "triggersActionsUi",
@@ -1312,11 +1313,10 @@
             ],
             "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "triggersActionsUi",
-                "id": "def-public.property",
+                "id": "def-public.AlertTypeParamsExpressionProps.setAlertParams.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "property",
@@ -1325,11 +1325,12 @@
                   "Key"
                 ],
                 "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "triggersActionsUi",
-                "id": "def-public.value",
+                "id": "def-public.AlertTypeParamsExpressionProps.setAlertParams.$2",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "value",
@@ -1338,9 +1339,11 @@
                   "Params[Key] | undefined"
                 ],
                 "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "triggersActionsUi",
@@ -1362,11 +1365,10 @@
             ],
             "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "triggersActionsUi",
-                "id": "def-public.key",
+                "id": "def-public.AlertTypeParamsExpressionProps.setAlertProperty.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "key",
@@ -1375,11 +1377,12 @@
                   "Prop"
                 ],
                 "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               },
               {
                 "parentPluginId": "triggersActionsUi",
-                "id": "def-public.value",
+                "id": "def-public.AlertTypeParamsExpressionProps.setAlertProperty.$2",
                 "type": "CompoundType",
                 "tags": [],
                 "label": "value",
@@ -1396,9 +1399,11 @@
                   "<Params>, \"enabled\" | \"id\" | \"name\" | \"params\" | \"actions\" | \"throttle\" | \"tags\" | \"alertTypeId\" | \"consumer\" | \"schedule\" | \"scheduledTaskId\" | \"createdBy\" | \"updatedBy\" | \"createdAt\" | \"updatedAt\" | \"apiKeyOwner\" | \"notifyWhen\" | \"muteAll\" | \"mutedInstanceIds\" | \"executionStatus\">[Prop] | null"
                 ],
                 "path": "x-pack/plugins/triggers_actions_ui/public/types.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": false
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "triggersActionsUi",
@@ -1803,11 +1808,10 @@
             ],
             "path": "x-pack/plugins/triggers_actions_ui/public/application/app.tsx",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "triggersActionsUi",
-                "id": "def-public.crumbs",
+                "id": "def-public.TriggersAndActionsUiServices.setBreadcrumbs.$1",
                 "type": "Array",
                 "tags": [],
                 "label": "crumbs",
@@ -1817,9 +1821,11 @@
                   "[]"
                 ],
                 "path": "x-pack/plugins/triggers_actions_ui/public/application/app.tsx",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "triggersActionsUi",
@@ -3117,46 +3123,25 @@
           ],
           "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "triggersActionsUi",
-              "id": "def-public.props",
+              "id": "def-public.TriggersAndActionsUIPublicPluginStart.getAddConnectorFlyout.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
               "description": [],
               "signature": [
-                "{ onClose: () => void; consumer?: string | undefined; actionTypes?: ",
-                {
-                  "pluginId": "actions",
-                  "scope": "common",
-                  "docId": "kibActionsPluginApi",
-                  "section": "def-common.ActionType",
-                  "text": "ActionType"
-                },
-                "[] | undefined; onTestConnector?: ((connector: ",
-                {
-                  "pluginId": "triggersActionsUi",
-                  "scope": "public",
-                  "docId": "kibTriggersActionsUiPluginApi",
-                  "section": "def-public.ActionConnector",
-                  "text": "ActionConnector"
-                },
-                "<Record<string, unknown>, Record<string, unknown>>) => void) | undefined; reloadConnectors?: (() => Promise<void | ",
-                {
-                  "pluginId": "triggersActionsUi",
-                  "scope": "public",
-                  "docId": "kibTriggersActionsUiPluginApi",
-                  "section": "def-public.ActionConnector",
-                  "text": "ActionConnector"
-                },
-                "<Record<string, unknown>, Record<string, unknown>>[]>) | undefined; }"
+                "Pick<",
+                "ConnectorAddFlyoutProps",
+                ", \"onClose\" | \"consumer\" | \"actionTypes\" | \"onTestConnector\" | \"reloadConnectors\">"
               ],
               "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "triggersActionsUi",
@@ -3174,40 +3159,25 @@
           ],
           "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "triggersActionsUi",
-              "id": "def-public.props",
+              "id": "def-public.TriggersAndActionsUIPublicPluginStart.getEditConnectorFlyout.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
               "description": [],
               "signature": [
-                "{ onClose: () => void; consumer?: string | undefined; reloadConnectors?: (() => Promise<void | ",
-                {
-                  "pluginId": "triggersActionsUi",
-                  "scope": "public",
-                  "docId": "kibTriggersActionsUiPluginApi",
-                  "section": "def-public.ActionConnector",
-                  "text": "ActionConnector"
-                },
-                "<Record<string, unknown>, Record<string, unknown>>[]>) | undefined; initialConnector: ",
-                {
-                  "pluginId": "triggersActionsUi",
-                  "scope": "public",
-                  "docId": "kibTriggersActionsUiPluginApi",
-                  "section": "def-public.ActionConnector",
-                  "text": "ActionConnector"
-                },
-                "<Record<string, unknown>, Record<string, unknown>>; tab?: ",
-                "EditConectorTabs",
-                " | undefined; }"
+                "Pick<",
+                "ConnectorEditFlyoutProps",
+                ", \"onClose\" | \"consumer\" | \"reloadConnectors\" | \"initialConnector\" | \"tab\">"
               ],
               "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "triggersActionsUi",
@@ -3225,38 +3195,25 @@
           ],
           "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "triggersActionsUi",
-              "id": "def-public.props",
+              "id": "def-public.TriggersAndActionsUIPublicPluginStart.getAddAlertFlyout.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
               "description": [],
               "signature": [
-                "{ onClose: (reason: ",
-                {
-                  "pluginId": "triggersActionsUi",
-                  "scope": "public",
-                  "docId": "kibTriggersActionsUiPluginApi",
-                  "section": "def-public.AlertFlyoutCloseReason",
-                  "text": "AlertFlyoutCloseReason"
-                },
-                ") => void; metadata?: Record<string, any> | undefined; onSave?: (() => Promise<void>) | undefined; alertTypeId?: string | undefined; consumer: string; canChangeTrigger?: boolean | undefined; initialValues?: Partial<Pick<",
-                {
-                  "pluginId": "alerting",
-                  "scope": "common",
-                  "docId": "kibAlertingPluginApi",
-                  "section": "def-common.Alert",
-                  "text": "Alert"
-                },
-                "<Record<string, unknown>>, \"enabled\" | \"id\" | \"name\" | \"params\" | \"actions\" | \"throttle\" | \"tags\" | \"alertTypeId\" | \"consumer\" | \"schedule\" | \"scheduledTaskId\" | \"createdBy\" | \"updatedBy\" | \"createdAt\" | \"updatedAt\" | \"apiKeyOwner\" | \"notifyWhen\" | \"muteAll\" | \"mutedInstanceIds\" | \"executionStatus\">> | undefined; reloadAlerts?: (() => Promise<void>) | undefined; }"
+                "Pick<",
+                "AlertAddProps",
+                "<Record<string, any>>, \"onClose\" | \"metadata\" | \"onSave\" | \"alertTypeId\" | \"consumer\" | \"canChangeTrigger\" | \"initialValues\" | \"reloadAlerts\">"
               ],
               "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "triggersActionsUi",
@@ -3274,38 +3231,25 @@
           ],
           "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "triggersActionsUi",
-              "id": "def-public.props",
+              "id": "def-public.TriggersAndActionsUIPublicPluginStart.getEditAlertFlyout.$1",
               "type": "Object",
               "tags": [],
               "label": "props",
               "description": [],
               "signature": [
-                "{ onClose: (reason: ",
-                {
-                  "pluginId": "triggersActionsUi",
-                  "scope": "public",
-                  "docId": "kibTriggersActionsUiPluginApi",
-                  "section": "def-public.AlertFlyoutCloseReason",
-                  "text": "AlertFlyoutCloseReason"
-                },
-                ") => void; metadata?: Record<string, any> | undefined; onSave?: (() => Promise<void>) | undefined; reloadAlerts?: (() => Promise<void>) | undefined; initialAlert: Pick<",
-                {
-                  "pluginId": "alerting",
-                  "scope": "common",
-                  "docId": "kibAlertingPluginApi",
-                  "section": "def-common.Alert",
-                  "text": "Alert"
-                },
-                "<Record<string, unknown>>, \"enabled\" | \"id\" | \"name\" | \"params\" | \"actions\" | \"throttle\" | \"tags\" | \"alertTypeId\" | \"consumer\" | \"schedule\" | \"scheduledTaskId\" | \"createdBy\" | \"updatedBy\" | \"createdAt\" | \"updatedAt\" | \"apiKeyOwner\" | \"notifyWhen\" | \"muteAll\" | \"mutedInstanceIds\" | \"executionStatus\">; }"
+                "Pick<",
+                "AlertEditProps",
+                "<Record<string, any>>, \"onClose\" | \"metadata\" | \"onSave\" | \"reloadAlerts\" | \"initialAlert\">"
               ],
               "path": "x-pack/plugins/triggers_actions_ui/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",

--- a/api_docs/triggers_actions_ui.mdx
+++ b/api_docs/triggers_actions_ui.mdx
@@ -18,7 +18,7 @@ import triggersActionsUiObj from './triggers_actions_ui.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 237 | 1 | 228 | 19 |
+| 237 | 1 | 228 | 18 |
 
 ## Client
 

--- a/api_docs/ui_actions_enhanced.json
+++ b/api_docs/ui_actions_enhanced.json
@@ -2749,8 +2749,8 @@
             ],
             "path": "x-pack/plugins/ui_actions_enhanced/public/drilldowns/drilldown_definition.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "uiActionsEnhanced",
@@ -3160,11 +3160,10 @@
             ],
             "path": "x-pack/plugins/ui_actions_enhanced/public/dynamic_actions/dynamic_action_manager.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "uiActionsEnhanced",
-                "id": "def-public.context",
+                "id": "def-public.DynamicActionManagerParams.isCompatible.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "context",
@@ -3173,9 +3172,11 @@
                   "C"
                 ],
                 "path": "x-pack/plugins/ui_actions_enhanced/public/dynamic_actions/dynamic_action_manager.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -3983,11 +3984,10 @@
           ],
           "path": "x-pack/plugins/ui_actions_enhanced/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "uiActionsEnhanced",
-              "id": "def-server.definition",
+              "id": "def-server.SetupContract.registerActionFactory.$1",
               "type": "Object",
               "tags": [],
               "label": "definition",
@@ -4011,9 +4011,11 @@
                 ">"
               ],
               "path": "x-pack/plugins/ui_actions_enhanced/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/url_forwarding.json
+++ b/api_docs/url_forwarding.json
@@ -217,19 +217,23 @@
             ],
             "path": "src/plugins/url_forwarding/public/plugin.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "urlForwarding",
-                "id": "def-public.legacyPath",
+                "id": "def-public.ForwardDefinition.rewritePath.$1",
                 "type": "string",
                 "tags": [],
                 "label": "legacyPath",
                 "description": [],
+                "signature": [
+                  "string"
+                ],
                 "path": "src/plugins/url_forwarding/public/plugin.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false

--- a/api_docs/usage_collection.json
+++ b/api_docs/usage_collection.json
@@ -145,39 +145,38 @@
           ],
           "path": "src/plugins/usage_collection/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.appName",
+              "id": "def-public.UsageCollectionSetup.reportUiCounter.$1",
               "type": "string",
               "tags": [],
               "label": "appName",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.type",
+              "id": "def-public.UsageCollectionSetup.reportUiCounter.$2",
               "type": "CompoundType",
               "tags": [],
               "label": "type",
               "description": [],
               "signature": [
-                "METRIC_TYPE",
-                ".COUNT | ",
-                "METRIC_TYPE",
-                ".LOADED | ",
-                "METRIC_TYPE",
-                ".CLICK"
+                "UiCounterMetricType"
               ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.eventNames",
+              "id": "def-public.UsageCollectionSetup.reportUiCounter.$3",
               "type": "CompoundType",
               "tags": [],
               "label": "eventNames",
@@ -186,11 +185,12 @@
                 "string | string[]"
               ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.count",
+              "id": "def-public.UsageCollectionSetup.reportUiCounter.$4",
               "type": "number",
               "tags": [],
               "label": "count",
@@ -199,9 +199,11 @@
                 "number | undefined"
               ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": false
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",
@@ -235,39 +237,38 @@
           ],
           "path": "src/plugins/usage_collection/public/plugin.tsx",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.appName",
+              "id": "def-public.UsageCollectionStart.reportUiCounter.$1",
               "type": "string",
               "tags": [],
               "label": "appName",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.type",
+              "id": "def-public.UsageCollectionStart.reportUiCounter.$2",
               "type": "CompoundType",
               "tags": [],
               "label": "type",
               "description": [],
               "signature": [
-                "METRIC_TYPE",
-                ".COUNT | ",
-                "METRIC_TYPE",
-                ".LOADED | ",
-                "METRIC_TYPE",
-                ".CLICK"
+                "UiCounterMetricType"
               ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.eventNames",
+              "id": "def-public.UsageCollectionStart.reportUiCounter.$3",
               "type": "CompoundType",
               "tags": [],
               "label": "eventNames",
@@ -276,11 +277,12 @@
                 "string | string[]"
               ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "usageCollection",
-              "id": "def-public.count",
+              "id": "def-public.UsageCollectionStart.reportUiCounter.$4",
               "type": "number",
               "tags": [],
               "label": "count",
@@ -289,9 +291,11 @@
                 "number | undefined"
               ],
               "path": "src/plugins/usage_collection/public/plugin.tsx",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": false
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "start",
@@ -553,11 +557,10 @@
             ],
             "path": "src/plugins/usage_collection/server/usage_counters/usage_counter.ts",
             "deprecated": false,
-            "returnComment": [],
             "children": [
               {
                 "parentPluginId": "usageCollection",
-                "id": "def-server.params",
+                "id": "def-server.IUsageCounter.incrementCounter.$1",
                 "type": "Object",
                 "tags": [],
                 "label": "params",
@@ -572,9 +575,11 @@
                   }
                 ],
                 "path": "src/plugins/usage_collection/server/usage_counters/usage_counter.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
-            ]
+            ],
+            "returnComment": []
           }
         ],
         "initialIsOpen": false
@@ -742,6 +747,46 @@
         ],
         "path": "src/plugins/usage_collection/server/collector/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "usageCollection",
+            "id": "def-server.context",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "context",
+            "description": [],
+            "signature": [
+              "{ esClient: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCorePluginApi",
+                "section": "def-server.ElasticsearchClient",
+                "text": "ElasticsearchClient"
+              },
+              "; soClient: Pick<",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreSavedObjectsPluginApi",
+                "section": "def-server.SavedObjectsClient",
+                "text": "SavedObjectsClient"
+              },
+              ", \"get\" | \"delete\" | \"create\" | \"bulkCreate\" | \"checkConflicts\" | \"find\" | \"bulkGet\" | \"resolve\" | \"update\" | \"collectMultiNamespaceReferences\" | \"updateObjectsSpaces\" | \"bulkUpdate\" | \"removeReferencesTo\" | \"openPointInTimeForType\" | \"closePointInTime\" | \"createPointInTimeFinder\" | \"errors\">; } & (WithKibanaRequest extends true ? { kibanaRequest?: ",
+              {
+                "pluginId": "core",
+                "scope": "server",
+                "docId": "kibCoreHttpPluginApi",
+                "section": "def-server.KibanaRequest",
+                "text": "KibanaRequest"
+              },
+              "<unknown, unknown, unknown, any> | undefined; } : {})"
+            ],
+            "path": "src/plugins/usage_collection/server/collector/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -963,19 +1008,23 @@
           ],
           "path": "src/plugins/usage_collection/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-server.type",
+              "id": "def-server.UsageCollectionSetup.createUsageCounter.$1",
               "type": "string",
               "tags": [],
               "label": "type",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/usage_collection/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "usageCollection",
@@ -999,19 +1048,23 @@
           ],
           "path": "src/plugins/usage_collection/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-server.type",
+              "id": "def-server.UsageCollectionSetup.getUsageCounterByType.$1",
               "type": "string",
               "tags": [],
               "label": "type",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/usage_collection/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "usageCollection",
@@ -1043,62 +1096,30 @@
           ],
           "path": "src/plugins/usage_collection/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-server.options",
+              "id": "def-server.UsageCollectionSetup.makeUsageCollector.$1",
               "type": "CompoundType",
               "tags": [],
               "label": "options",
               "description": [],
               "signature": [
-                "{ type: string; isReady: () => boolean | Promise<boolean>; schema?: ",
                 {
                   "pluginId": "usageCollection",
                   "scope": "server",
                   "docId": "kibUsageCollectionPluginApi",
-                  "section": "def-server.MakeSchemaFrom",
-                  "text": "MakeSchemaFrom"
+                  "section": "def-server.UsageCollectorOptions",
+                  "text": "UsageCollectorOptions"
                 },
-                "<TFetchReturn> | undefined; fetch: ",
-                {
-                  "pluginId": "usageCollection",
-                  "scope": "server",
-                  "docId": "kibUsageCollectionPluginApi",
-                  "section": "def-server.CollectorFetchMethod",
-                  "text": "CollectorFetchMethod"
-                },
-                "<WithKibanaRequest, TFetchReturn, ExtraOptions>; } & ExtraOptions & (WithKibanaRequest extends true ? { extendFetchContext: ",
-                {
-                  "pluginId": "usageCollection",
-                  "scope": "server",
-                  "docId": "kibUsageCollectionPluginApi",
-                  "section": "def-server.CollectorOptionsFetchExtendedContext",
-                  "text": "CollectorOptionsFetchExtendedContext"
-                },
-                "<WithKibanaRequest>; } : { extendFetchContext?: ",
-                {
-                  "pluginId": "usageCollection",
-                  "scope": "server",
-                  "docId": "kibUsageCollectionPluginApi",
-                  "section": "def-server.CollectorOptionsFetchExtendedContext",
-                  "text": "CollectorOptionsFetchExtendedContext"
-                },
-                "<WithKibanaRequest> | undefined; }) & Required<Pick<",
-                {
-                  "pluginId": "usageCollection",
-                  "scope": "server",
-                  "docId": "kibUsageCollectionPluginApi",
-                  "section": "def-server.CollectorOptions",
-                  "text": "CollectorOptions"
-                },
-                "<TFetchReturn, boolean, {}>, \"schema\">>"
+                "<TFetchReturn, WithKibanaRequest, ExtraOptions>"
               ],
               "path": "src/plugins/usage_collection/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "usageCollection",
@@ -1122,11 +1143,10 @@
           ],
           "path": "src/plugins/usage_collection/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-server.collector",
+              "id": "def-server.UsageCollectionSetup.registerCollector.$1",
               "type": "Object",
               "tags": [],
               "label": "collector",
@@ -1142,9 +1162,11 @@
                 "<TFetchReturn, ExtraOptions>"
               ],
               "path": "src/plugins/usage_collection/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "usageCollection",
@@ -1168,19 +1190,23 @@
           ],
           "path": "src/plugins/usage_collection/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "usageCollection",
-              "id": "def-server.type",
+              "id": "def-server.UsageCollectionSetup.getCollectorByType.$1",
               "type": "string",
               "tags": [],
               "label": "type",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/usage_collection/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/usage_collection.mdx
+++ b/api_docs/usage_collection.mdx
@@ -18,7 +18,7 @@ import usageCollectionObj from './usage_collection.json';
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 57 | 0 | 16 | 2 |
+| 58 | 0 | 17 | 2 |
 
 ## Client
 

--- a/api_docs/vis_type_timeseries.json
+++ b/api_docs/vis_type_timeseries.json
@@ -135,11 +135,10 @@
           ],
           "path": "src/plugins/vis_type_timeseries/server/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "visTypeTimeseries",
-              "id": "def-server.requestContext",
+              "id": "def-server.VisTypeTimeseriesSetup.getVisData.$1",
               "type": "Object",
               "tags": [],
               "label": "requestContext",
@@ -148,11 +147,12 @@
                 "DataRequestHandlerContext"
               ],
               "path": "src/plugins/vis_type_timeseries/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "visTypeTimeseries",
-              "id": "def-server.fakeRequest",
+              "id": "def-server.VisTypeTimeseriesSetup.getVisData.$2",
               "type": "Object",
               "tags": [],
               "label": "fakeRequest",
@@ -168,11 +168,12 @@
                 "<unknown, unknown, unknown, any>"
               ],
               "path": "src/plugins/vis_type_timeseries/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "visTypeTimeseries",
-              "id": "def-server.options",
+              "id": "def-server.VisTypeTimeseriesSetup.getVisData.$3",
               "type": "Any",
               "tags": [],
               "label": "options",
@@ -181,9 +182,11 @@
                 "any"
               ],
               "path": "src/plugins/vis_type_timeseries/server/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         }
       ],
       "lifecycle": "setup",

--- a/api_docs/visualizations.json
+++ b/api_docs/visualizations.json
@@ -2802,7 +2802,9 @@
               "(() => string[]) | undefined"
             ],
             "path": "src/plugins/visualizations/public/vis_types/vis_type_alias_registry.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "visualizations",
@@ -2932,7 +2934,31 @@
               " | undefined) => string[]) | undefined"
             ],
             "path": "src/plugins/visualizations/public/vis_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "visualizations",
+                "id": "def-public.VisTypeDefinition.getSupportedTriggers.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "params",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "visualizations",
+                    "scope": "common",
+                    "docId": "kibVisualizationsPluginApi",
+                    "section": "def-common.VisParams",
+                    "text": "VisParams"
+                  },
+                  " | undefined"
+                ],
+                "path": "src/plugins/visualizations/public/vis_types/types.ts",
+                "deprecated": false,
+                "isRequired": false
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "visualizations",
@@ -2971,7 +2997,30 @@
               "[]>) | undefined"
             ],
             "path": "src/plugins/visualizations/public/vis_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "visualizations",
+                "id": "def-public.VisTypeDefinition.getUsedIndexPattern.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "visParams",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "visualizations",
+                    "scope": "common",
+                    "docId": "kibVisualizationsPluginApi",
+                    "section": "def-common.VisParams",
+                    "text": "VisParams"
+                  }
+                ],
+                "path": "src/plugins/visualizations/public/vis_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "visualizations",
@@ -3157,7 +3206,39 @@
               ">) => React.ReactNode) | undefined"
             ],
             "path": "src/plugins/visualizations/public/vis_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "visualizations",
+                "id": "def-public.VisTypeDefinition.getInfoMessage.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "vis",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "visualizations",
+                    "scope": "public",
+                    "docId": "kibVisualizationsPluginApi",
+                    "section": "def-public.Vis",
+                    "text": "Vis"
+                  },
+                  "<",
+                  {
+                    "pluginId": "visualizations",
+                    "scope": "common",
+                    "docId": "kibVisualizationsPluginApi",
+                    "section": "def-common.VisParams",
+                    "text": "VisParams"
+                  },
+                  ">"
+                ],
+                "path": "src/plugins/visualizations/public/vis_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "visualizations",
@@ -3275,7 +3356,31 @@
               "<TVisParams>>) | undefined"
             ],
             "path": "src/plugins/visualizations/public/vis_types/types.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "visualizations",
+                "id": "def-public.VisTypeDefinition.setup.$1",
+                "type": "Object",
+                "tags": [],
+                "label": "vis",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "visualizations",
+                    "scope": "public",
+                    "docId": "kibVisualizationsPluginApi",
+                    "section": "def-public.Vis",
+                    "text": "Vis"
+                  },
+                  "<TVisParams>"
+                ],
+                "path": "src/plugins/visualizations/public/vis_types/types.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "visualizations",
@@ -3461,7 +3566,9 @@
               "(() => string[]) | undefined"
             ],
             "path": "src/plugins/visualizations/public/vis_types/vis_type_alias_registry.ts",
-            "deprecated": false
+            "deprecated": false,
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "visualizations",
@@ -3729,6 +3836,48 @@
         ],
         "path": "src/plugins/visualizations/public/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "visualizations",
+            "id": "def-public.vis",
+            "type": "Object",
+            "tags": [],
+            "label": "vis",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "visualizations",
+                "scope": "public",
+                "docId": "kibVisualizationsPluginApi",
+                "section": "def-public.Vis",
+                "text": "Vis"
+              },
+              "<TVisParams>"
+            ],
+            "path": "src/plugins/visualizations/public/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "visualizations",
+            "id": "def-public.params",
+            "type": "Object",
+            "tags": [],
+            "label": "params",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "visualizations",
+                "scope": "public",
+                "docId": "kibVisualizationsPluginApi",
+                "section": "def-public.VisToExpressionAstParams",
+                "text": "VisToExpressionAstParams"
+              }
+            ],
+            "path": "src/plugins/visualizations/public/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -4370,21 +4519,24 @@
           ],
           "path": "src/plugins/visualizations/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "visualizations",
-              "id": "def-public.visType",
+              "id": "def-public.VisualizationsStart.createVis.$1",
               "type": "string",
               "tags": [],
               "label": "visType",
               "description": [],
+              "signature": [
+                "string"
+              ],
               "path": "src/plugins/visualizations/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "visualizations",
-              "id": "def-public.visState",
+              "id": "def-public.VisualizationsStart.createVis.$2",
               "type": "Object",
               "tags": [],
               "label": "visState",
@@ -4408,9 +4560,11 @@
                 ">"
               ],
               "path": "src/plugins/visualizations/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "visualizations",

--- a/api_docs/visualizations.json
+++ b/api_docs/visualizations.json
@@ -2613,7 +2613,9 @@
                 "section": "def-common.TimeRange",
                 "text": "TimeRange"
               },
-              " | undefined) => any; getBounds: () => ",
+              " | undefined) => ",
+              "RangeFilter",
+              " | undefined; getBounds: () => ",
               {
                 "pluginId": "data",
                 "scope": "common",
@@ -3709,12 +3711,13 @@
           {
             "parentPluginId": "visualizations",
             "id": "def-public.VisualizeInput.query",
-            "type": "Any",
+            "type": "Object",
             "tags": [],
             "label": "query",
             "description": [],
             "signature": [
-              "any"
+              "Query",
+              " | undefined"
             ],
             "path": "src/plugins/visualizations/public/embeddable/visualize_embeddable.ts",
             "deprecated": false
@@ -3727,7 +3730,8 @@
             "label": "filters",
             "description": [],
             "signature": [
-              "any[] | undefined"
+              "Filter",
+              "[] | undefined"
             ],
             "path": "src/plugins/visualizations/public/embeddable/visualize_embeddable.ts",
             "deprecated": false

--- a/api_docs/visualizations.mdx
+++ b/api_docs/visualizations.mdx
@@ -18,7 +18,7 @@ Contact [Kibana App](https://github.com/orgs/elastic/teams/kibana-app) for quest
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 257 | 14 | 239 | 12 |
+| 263 | 14 | 245 | 12 |
 
 ## Client
 

--- a/api_docs/visualizations.mdx
+++ b/api_docs/visualizations.mdx
@@ -18,7 +18,7 @@ Contact [Kibana App](https://github.com/orgs/elastic/teams/kibana-app) for quest
 
 | Public API count  | Any count | Items lacking comments | Missing exports | 
 |-------------------|-----------|------------------------|-----------------|
-| 263 | 14 | 245 | 12 |
+| 263 | 13 | 245 | 12 |
 
 ## Client
 

--- a/packages/kbn-docs-utils/src/api_docs/build_api_declarations/buid_api_declaration.test.ts
+++ b/packages/kbn-docs-utils/src/api_docs/build_api_declarations/buid_api_declaration.test.ts
@@ -84,7 +84,7 @@ it('Test Interface Kind doc def', () => {
 
   expect(def.type).toBe(TypeKind.InterfaceKind);
   expect(def.children).toBeDefined();
-  expect(def.children!.length).toBe(3);
+  expect(def.children!.length).toBe(6);
 });
 
 it('Test union export', () => {

--- a/packages/kbn-docs-utils/src/api_docs/build_api_declarations/build_function_type_dec.ts
+++ b/packages/kbn-docs-utils/src/api_docs/build_api_declarations/build_function_type_dec.ts
@@ -5,46 +5,35 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
-import {
-  FunctionDeclaration,
-  MethodDeclaration,
-  ConstructorDeclaration,
-  Node,
-  MethodSignature,
-} from 'ts-morph';
+import { PropertySignature } from 'ts-morph';
 
 import { ToolingLog, KibanaPlatformPlugin } from '@kbn/dev-utils';
+import { FunctionTypeNode } from 'ts-morph';
 import { buildApiDecsForParameters } from './build_parameter_decs';
 import { AnchorLink, ApiDeclaration, TypeKind } from '../types';
 import { getJSDocReturnTagComment, getJSDocs } from './js_doc_utils';
 import { buildBasicApiDeclaration } from './build_basic_api_declaration';
 
 /**
- * Takes the various function-like node declaration types and converts them into an ApiDeclaration.
- * @param node
- * @param plugins
- * @param anchorLink
- * @param log
+ * Takes the various function-type node declaration types and converts them into an ApiDeclaration.
  */
-export function buildFunctionDec({
+export function buildFunctionTypeDec({
   node,
+  typeNode,
   plugins,
   anchorLink,
   currentPluginId,
   log,
   captureReferences,
 }: {
-  node: FunctionDeclaration | MethodDeclaration | ConstructorDeclaration | MethodSignature;
+  node: PropertySignature;
+  typeNode: FunctionTypeNode;
   plugins: KibanaPlatformPlugin[];
   anchorLink: AnchorLink;
   currentPluginId: string;
   log: ToolingLog;
   captureReferences: boolean;
 }): ApiDeclaration {
-  const label = Node.isConstructorDeclaration(node)
-    ? 'Constructor'
-    : node.getName() || '(WARN: Missing name)';
   const fn = {
     ...buildBasicApiDeclaration({
       currentPluginId,
@@ -53,11 +42,11 @@ export function buildFunctionDec({
       captureReferences,
       plugins,
       log,
-      apiName: label,
+      apiName: node.getName(),
     }),
     type: TypeKind.FunctionKind,
     children: buildApiDecsForParameters(
-      node.getParameters(),
+      typeNode.getParameters(),
       plugins,
       anchorLink,
       currentPluginId,

--- a/packages/kbn-docs-utils/src/api_docs/build_api_declarations/build_variable_dec.ts
+++ b/packages/kbn-docs-utils/src/api_docs/build_api_declarations/build_variable_dec.ts
@@ -46,7 +46,6 @@ export function buildVariableDec(
   captureReferences: boolean
 ): ApiDeclaration {
   const initializer = node.getInitializer();
-
   if (initializer && Node.isObjectLiteralExpression(initializer)) {
     // Recursively list object properties as children.
     return {
@@ -90,6 +89,7 @@ export function buildVariableDec(
     );
   }
 
+  // Without this the test "Property on interface pointing to generic function type exported with link" will fail.
   if (node.getType().getCallSignatures().length > 0) {
     if (node.getType().getCallSignatures().length > 1) {
       log.warning(`Not handling more than one call signature for node ${node.getName()}`);

--- a/packages/kbn-docs-utils/src/api_docs/mdx/split_apis_by_folder.test.ts
+++ b/packages/kbn-docs-utils/src/api_docs/mdx/split_apis_by_folder.test.ts
@@ -38,7 +38,7 @@ beforeAll(() => {
 });
 
 test('foo service has all exports', () => {
-  expect(doc?.client.length).toBe(35);
+  expect(doc?.client.length).toBe(36);
   const split = splitApisByFolder(doc);
   expect(split.length).toBe(2);
 
@@ -47,5 +47,5 @@ test('foo service has all exports', () => {
 
   expect(fooDoc?.common.length).toBe(1);
   expect(fooDoc?.client.length).toBe(2);
-  expect(mainDoc?.client.length).toBe(33);
+  expect(mainDoc?.client.length).toBe(34);
 });

--- a/packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts
+++ b/packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts
@@ -8,7 +8,7 @@
 
 /* eslint-disable max-classes-per-file */
 
-import { ImAType } from './types';
+import { FnTypeWithGeneric, ImAType } from './types';
 
 /**
  * @internal
@@ -88,9 +88,25 @@ export interface ExampleInterface extends AnotherInterface<string> {
   aFnWithGen: <T>(t: T) => void;
 
   /**
+   * Add coverage for this bug report: https://github.com/elastic/kibana/issues/107145
+   */
+  anOptionalFn?: (foo: string) => string;
+
+  /**
    * These are not coming back properly.
    */
   aFn(): void;
+
+  /**
+   * This one is slightly different than the above `aFnWithGen`. The generic is part of the type, not the function (it's before the = sign).
+   * Ideally, we can still capture the children.
+   */
+  fnTypeWithGeneric: FnTypeWithGeneric<string>;
+
+  /**
+   * Optional code path is different than others.
+   */
+  fnTypeWithGenericThatIsOptional?: FnTypeWithGeneric<string>;
 }
 
 /**

--- a/packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts
+++ b/packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts
@@ -26,6 +26,14 @@ export type ImAType = string | number | TypeWithGeneric<string> | FooType | ImAC
 export type FnWithGeneric = <T>(t: T) => TypeWithGeneric<T>;
 
 /**
+ * Ever so slightly different than above. Users of this type must specify the generic.
+ *
+ * @param t something!
+ * @return something!
+ */
+export type FnTypeWithGeneric<T> = (t: T, p: MyProps) => TypeWithGeneric<T>;
+
+/**
  * Comments on enums.
  */
 export enum DayOfWeek {

--- a/packages/kbn-docs-utils/src/api_docs/tests/snapshots/plugin_a.json
+++ b/packages/kbn-docs-utils/src/api_docs/tests/snapshots/plugin_a.json
@@ -416,22 +416,31 @@
                 ],
                 "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
                 "deprecated": false,
-                "returnComment": [],
                 "children": [
                   {
                     "parentPluginId": "pluginA",
-                    "id": "def-public.foo",
+                    "id": "def-public.crazyFunction.$2.fn.fn.$1.foo",
                     "type": "Object",
                     "tags": [],
                     "label": "foo",
                     "description": [],
-                    "signature": [
-                      "{ param: string; }"
-                    ],
                     "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
-                    "deprecated": false
+                    "deprecated": false,
+                    "children": [
+                      {
+                        "parentPluginId": "pluginA",
+                        "id": "def-public.crazyFunction.$2.fn.fn.$1.foo.param",
+                        "type": "string",
+                        "tags": [],
+                        "label": "param",
+                        "description": [],
+                        "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
+                        "deprecated": false
+                      }
+                    ]
                   }
-                ]
+                ],
+                "returnComment": []
               }
             ]
           },
@@ -732,8 +741,8 @@
             ],
             "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
             "deprecated": false,
-            "returnComment": [],
-            "children": []
+            "children": [],
+            "returnComment": []
           },
           {
             "parentPluginId": "pluginA",
@@ -749,13 +758,10 @@
             ],
             "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
             "deprecated": false,
-            "returnComment": [
-              "nothing!"
-            ],
             "children": [
               {
                 "parentPluginId": "pluginA",
-                "id": "def-public.t",
+                "id": "def-public.ExampleInterface.aFnWithGen.$1",
                 "type": "Uncategorized",
                 "tags": [],
                 "label": "t",
@@ -766,9 +772,45 @@
                   "T"
                 ],
                 "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
-                "deprecated": false
+                "deprecated": false,
+                "isRequired": true
               }
+            ],
+            "returnComment": [
+              "nothing!"
             ]
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.ExampleInterface.anOptionalFn",
+            "type": "Function",
+            "tags": [],
+            "label": "anOptionalFn",
+            "description": [
+              "\nAdd coverage for this bug report: https://github.com/elastic/kibana/issues/107145"
+            ],
+            "signature": [
+              "((foo: string) => string) | undefined"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
+            "deprecated": false,
+            "children": [
+              {
+                "parentPluginId": "pluginA",
+                "id": "def-public.ExampleInterface.anOptionalFn.$1",
+                "type": "string",
+                "tags": [],
+                "label": "foo",
+                "description": [],
+                "signature": [
+                  "string"
+                ],
+                "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
+                "deprecated": false,
+                "isRequired": true
+              }
+            ],
+            "returnComment": []
           },
           {
             "parentPluginId": "pluginA",
@@ -786,6 +828,94 @@
             "deprecated": false,
             "children": [],
             "returnComment": []
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.ExampleInterface.fnTypeWithGeneric",
+            "type": "Function",
+            "tags": [],
+            "label": "fnTypeWithGeneric",
+            "description": [
+              "\nThis one is slightly different than the above `aFnWithGen`. The generic is part of the type, not the function (it's before the = sign).\nIdeally, we can still capture the children."
+            ],
+            "signature": [
+              "(t: string, p: ",
+              {
+                "pluginId": "pluginA",
+                "scope": "public",
+                "docId": "kibPluginAPluginApi",
+                "section": "def-public.MyProps",
+                "text": "MyProps"
+              },
+              ") => ",
+              {
+                "pluginId": "pluginA",
+                "scope": "public",
+                "docId": "kibPluginAPluginApi",
+                "section": "def-public.TypeWithGeneric",
+                "text": "TypeWithGeneric"
+              },
+              "<string>"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
+            "deprecated": false,
+            "returnComment": [],
+            "children": [
+              {
+                "parentPluginId": "pluginA",
+                "id": "def-public.t",
+                "type": "Uncategorized",
+                "tags": [],
+                "label": "t",
+                "description": [],
+                "signature": [
+                  "T"
+                ],
+                "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
+                "deprecated": false
+              },
+              {
+                "parentPluginId": "pluginA",
+                "id": "def-public.p",
+                "type": "Object",
+                "tags": [],
+                "label": "p",
+                "description": [],
+                "signature": [
+                  {
+                    "pluginId": "pluginA",
+                    "scope": "public",
+                    "docId": "kibPluginAPluginApi",
+                    "section": "def-public.MyProps",
+                    "text": "MyProps"
+                  }
+                ],
+                "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
+                "deprecated": false
+              }
+            ]
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.ExampleInterface.fnTypeWithGenericThatIsOptional",
+            "type": "Function",
+            "tags": [],
+            "label": "fnTypeWithGenericThatIsOptional",
+            "description": [
+              "\nOptional code path is different than others."
+            ],
+            "signature": [
+              {
+                "pluginId": "pluginA",
+                "scope": "public",
+                "docId": "kibPluginAPluginApi",
+                "section": "def-public.FnTypeWithGeneric",
+                "text": "FnTypeWithGeneric"
+              },
+              "<string> | undefined"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/classes.ts",
+            "deprecated": false
           }
         ],
         "initialIsOpen": false
@@ -1074,6 +1204,8 @@
         ],
         "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       },
       {
@@ -1131,6 +1263,79 @@
       },
       {
         "parentPluginId": "pluginA",
+        "id": "def-public.FnTypeWithGeneric",
+        "type": "Type",
+        "tags": [
+          "return"
+        ],
+        "label": "FnTypeWithGeneric",
+        "description": [
+          "\nEver so slightly different than above. Users of this type must specify the generic.\n"
+        ],
+        "signature": [
+          "(t: T, p: ",
+          {
+            "pluginId": "pluginA",
+            "scope": "public",
+            "docId": "kibPluginAPluginApi",
+            "section": "def-public.MyProps",
+            "text": "MyProps"
+          },
+          ") => ",
+          {
+            "pluginId": "pluginA",
+            "scope": "public",
+            "docId": "kibPluginAPluginApi",
+            "section": "def-public.TypeWithGeneric",
+            "text": "TypeWithGeneric"
+          },
+          "<T>"
+        ],
+        "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
+        "deprecated": false,
+        "returnComment": [
+          "something!"
+        ],
+        "children": [
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.t",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "t",
+            "description": [
+              "something!"
+            ],
+            "signature": [
+              "T"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.p",
+            "type": "Object",
+            "tags": [],
+            "label": "p",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "pluginA",
+                "scope": "public",
+                "docId": "kibPluginAPluginApi",
+                "section": "def-public.MyProps",
+                "text": "MyProps"
+              }
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
+            "deprecated": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "pluginA",
         "id": "def-public.FnWithGeneric",
         "type": "Type",
         "tags": [],
@@ -1151,6 +1356,24 @@
         ],
         "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.t",
+            "type": "Uncategorized",
+            "tags": [],
+            "label": "t",
+            "description": [
+              "This is a generic T type. It can be anything."
+            ],
+            "signature": [
+              "T"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/types.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1309,6 +1532,94 @@
         ],
         "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.a",
+            "type": "string",
+            "tags": [],
+            "label": "a",
+            "description": [],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.b",
+            "type": "number",
+            "tags": [],
+            "label": "b",
+            "description": [],
+            "signature": [
+              "number | undefined"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.c",
+            "type": "Array",
+            "tags": [],
+            "label": "c",
+            "description": [],
+            "signature": [
+              "string[]"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.d",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "d",
+            "description": [],
+            "signature": [
+              "string | number | ",
+              {
+                "pluginId": "pluginA",
+                "scope": "public",
+                "docId": "kibPluginAFooPluginApi",
+                "section": "def-public.FooType",
+                "text": "FooType"
+              },
+              " | ",
+              {
+                "pluginId": "pluginA",
+                "scope": "public",
+                "docId": "kibPluginAPluginApi",
+                "section": "def-public.TypeWithGeneric",
+                "text": "TypeWithGeneric"
+              },
+              "<string> | ",
+              {
+                "pluginId": "pluginA",
+                "scope": "common",
+                "docId": "kibPluginAPluginApi",
+                "section": "def-common.ImACommonType",
+                "text": "ImACommonType"
+              }
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
+            "deprecated": false
+          },
+          {
+            "parentPluginId": "pluginA",
+            "id": "def-public.e",
+            "type": "string",
+            "tags": [],
+            "label": "e",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/fns.ts",
+            "deprecated": false
+          }
+        ],
         "initialIsOpen": false
       },
       {
@@ -1738,13 +2049,10 @@
           ],
           "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [
-            "the id of the search service."
-          ],
           "children": [
             {
               "parentPluginId": "pluginA",
-              "id": "def-public.searchSpec",
+              "id": "def-public.Setup.getSearchService.$1",
               "type": "Object",
               "tags": [],
               "label": "searchSpec",
@@ -1761,8 +2069,12 @@
                 }
               ],
               "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             }
+          ],
+          "returnComment": [
+            "the id of the search service."
           ]
         },
         {
@@ -1779,24 +2091,41 @@
           ],
           "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "pluginA",
-              "id": "def-public.searchSpec",
+              "id": "def-public.Setup.getSearchService2.$1.searchSpec",
               "type": "Object",
               "tags": [],
               "label": "searchSpec",
-              "description": [
-                "Provide the settings neccessary to create a new Search Service"
-              ],
-              "signature": [
-                "{ username: string; password: string; }"
-              ],
+              "description": [],
               "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "children": [
+                {
+                  "parentPluginId": "pluginA",
+                  "id": "def-public.Setup.getSearchService2.$1.searchSpec.username",
+                  "type": "string",
+                  "tags": [],
+                  "label": "username",
+                  "description": [],
+                  "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
+                  "deprecated": false
+                },
+                {
+                  "parentPluginId": "pluginA",
+                  "id": "def-public.Setup.getSearchService2.$1.searchSpec.password",
+                  "type": "string",
+                  "tags": [],
+                  "label": "password",
+                  "description": [],
+                  "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
+                  "deprecated": false
+                }
+              ]
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "pluginA",
@@ -1815,48 +2144,63 @@
           "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
           "deprecated": true,
           "references": [],
-          "returnComment": [],
           "children": [
             {
               "parentPluginId": "pluginA",
-              "id": "def-public.thingOne",
+              "id": "def-public.Setup.doTheThing.$1",
               "type": "number",
               "tags": [],
               "label": "thingOne",
               "description": [
                 "Thing one comment"
               ],
+              "signature": [
+                "number"
+              ],
               "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "pluginA",
-              "id": "def-public.thingTwo",
+              "id": "def-public.Setup.doTheThing.$2",
               "type": "string",
               "tags": [],
               "label": "thingTwo",
               "description": [
                 "ThingTwo comment"
               ],
+              "signature": [
+                "string"
+              ],
               "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "isRequired": true
             },
             {
               "parentPluginId": "pluginA",
-              "id": "def-public.thingThree",
+              "id": "def-public.Setup.doTheThing.$3.thingThree",
               "type": "Object",
               "tags": [],
               "label": "thingThree",
-              "description": [
-                "Thing three is an object with a nested var"
-              ],
-              "signature": [
-                "{ nestedVar: number; }"
-              ],
+              "description": [],
               "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "children": [
+                {
+                  "parentPluginId": "pluginA",
+                  "id": "def-public.Setup.doTheThing.$3.thingThree.nestedVar",
+                  "type": "number",
+                  "tags": [],
+                  "label": "nestedVar",
+                  "description": [],
+                  "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
+                  "deprecated": false
+                }
+              ]
             }
-          ]
+          ],
+          "returnComment": []
         },
         {
           "parentPluginId": "pluginA",
@@ -1872,25 +2216,60 @@
           ],
           "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
           "deprecated": false,
-          "returnComment": [
-            "It's hard to tell but I think this returns a function that returns an object with a\nproperty that is a function that returns a string. Whoa."
-          ],
           "children": [
             {
               "parentPluginId": "pluginA",
-              "id": "def-public.obj",
+              "id": "def-public.Setup.fnWithInlineParams.$1.obj",
               "type": "Object",
               "tags": [],
               "label": "obj",
-              "description": [
-                "A funky parameter."
-              ],
-              "signature": [
-                "{ fn: (foo: { param: string; }) => number; }"
-              ],
+              "description": [],
               "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
-              "deprecated": false
+              "deprecated": false,
+              "children": [
+                {
+                  "parentPluginId": "pluginA",
+                  "id": "def-public.Setup.fnWithInlineParams.$1.obj.fn",
+                  "type": "Function",
+                  "tags": [],
+                  "label": "fn",
+                  "description": [],
+                  "signature": [
+                    "(foo: { param: string; }) => number"
+                  ],
+                  "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
+                  "deprecated": false,
+                  "children": [
+                    {
+                      "parentPluginId": "pluginA",
+                      "id": "def-public.Setup.fnWithInlineParams.$1.obj.fn.$1.foo",
+                      "type": "Object",
+                      "tags": [],
+                      "label": "foo",
+                      "description": [],
+                      "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
+                      "deprecated": false,
+                      "children": [
+                        {
+                          "parentPluginId": "pluginA",
+                          "id": "def-public.Setup.fnWithInlineParams.$1.obj.fn.$1.foo.param",
+                          "type": "string",
+                          "tags": [],
+                          "label": "param",
+                          "description": [],
+                          "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
+                          "deprecated": false
+                        }
+                      ]
+                    }
+                  ],
+                  "returnComment": []
+                }
+              ]
             }
+          ],
+          "returnComment": [
+            "It's hard to tell but I think this returns a function that returns an object with a\nproperty that is a function that returns a string. Whoa."
           ]
         },
         {
@@ -1934,10 +2313,10 @@
           ],
           "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/plugin.ts",
           "deprecated": false,
+          "children": [],
           "returnComment": [
             "The currently selected {@link SearchLanguage}"
-          ],
-          "children": []
+          ]
         }
       ],
       "lifecycle": "start",

--- a/packages/kbn-docs-utils/src/api_docs/tests/snapshots/plugin_a_foo.json
+++ b/packages/kbn-docs-utils/src/api_docs/tests/snapshots/plugin_a_foo.json
@@ -35,6 +35,8 @@
         ],
         "path": "packages/kbn-docs-utils/src/api_docs/tests/__fixtures__/src/plugin_a/public/foo/index.ts",
         "deprecated": false,
+        "returnComment": [],
+        "children": [],
         "initialIsOpen": false
       }
     ],


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/107145 and added a test to catch it.

In fixing this, I made a change that had unintended consequences but tests still passed, so I added some additional tests to catch those issues and ended up fixing a couple other things as well. There is one known issue with this and I mention it at the end of this test:

```ts

  it('Property on interface pointing to generic function type exported with link', () => {
    const exampleInterface = doc.client.find((c) => c.label === 'ExampleInterface');
    expect(exampleInterface).toBeDefined();

    const fn = exampleInterface?.children?.find((c) => c.label === 'fnTypeWithGeneric');
    expect(fn).toBeDefined();

    // `fnTypeWithGeneric` is defined as:
    //  fnTypeWithGeneric: FnTypeWithGeneric<string>;
    // and `GenericTypeFn` is defined as:
    // type FnTypeWithGeneric<T> = (t: T, p: MyProps) => TypeWithGeneric<T>;
    // In get_signature.ts, we use the `TypeFormatFlags.InTypeAlias` flag which ends up expanding the type
    // to be a function, and thus this doesn't show up as a single referenced type with no kids. If we ever fixed that,
    // it would be find to change expectations here to be no children and TypeKind instead of FunctionKind.
    expect(fn?.children).toBeDefined();
    expect(fn?.type).toBe(TypeKind.FunctionKind);
    expect(fn?.signature).toBeDefined();
    expect(linkCount(fn!.signature!)).toBe(2);
    expect(fn?.children?.length).toBe(2);

    // This will fail! It actually shows up as Uncategorized. It would be some effort to get it to show up as string, which may involve
    // trying to fix the above issue so it's not expanded.
    // expect(fn?.children[0]!.type).toBe(TypeKind.StringKind);
  });

```

 It's a rather small bug that I'm pretty sure already existed, so not going to try to fix in this PR as I couldn't find any easy way after a day's investigation..


Unfortunately the change seems to have caused a lot of unimportant reordering of the json blobs.