### PR TITLE
[dev-utils/run] support --info flag when default log level changed

### DIFF
--- a/packages/kbn-dev-utils/src/run/flags.ts
+++ b/packages/kbn-dev-utils/src/run/flags.ts
@@ -9,6 +9,7 @@
 import getopts from 'getopts';
 
 import { RunOptions } from './run';
+import { LOG_LEVEL_FLAGS, DEFAULT_LOG_LEVEL } from '../tooling_log/log_levels';
 
 export interface Flags {
   verbose: boolean;
@@ -52,12 +53,18 @@ export function mergeFlagOptions(global: FlagOptions = {}, local: FlagOptions = 
   };
 }
 
-export function getFlags(argv: string[], flagOptions: RunOptions['flags'] = {}): Flags {
+export function getFlags(
+  argv: string[],
+  flagOptions: RunOptions['flags'] = {},
+  defaultLogLevel: string = DEFAULT_LOG_LEVEL
+): Flags {
   const unexpectedNames = new Set<string>();
+
+  const logLevelFlags = LOG_LEVEL_FLAGS.map((f) => f.name).filter((f) => f !== defaultLogLevel);
 
   const { verbose, quiet, silent, debug, help, _, ...others } = getopts(argv, {
     string: flagOptions.string,
-    boolean: [...(flagOptions.boolean || []), 'verbose', 'quiet', 'silent', 'debug', 'help'],
+    boolean: [...(flagOptions.boolean || []), ...logLevelFlags, 'help'],
     alias: {
       ...flagOptions.alias,
       v: 'verbose',

--- a/packages/kbn-dev-utils/src/run/help.ts
+++ b/packages/kbn-dev-utils/src/run/help.ts
@@ -13,13 +13,10 @@ import 'core-js/features/string/repeat';
 import dedent from 'dedent';
 
 import { Command } from './run_with_commands';
+import { getLogLevelFlagsHelp } from '../tooling_log/log_levels';
 
 const DEFAULT_GLOBAL_USAGE = `node ${Path.relative(process.cwd(), process.argv[1])}`;
 export const GLOBAL_FLAGS = dedent`
-  --verbose, -v      Log verbosely
-  --debug            Log debug messages (less than verbose)
-  --quiet            Only log errors
-  --silent           Don't log anything
   --help             Show this message
 `;
 
@@ -39,12 +36,18 @@ export function getHelp({
   description,
   usage,
   flagHelp,
+  defaultLogLevel,
 }: {
   description?: string;
   usage?: string;
   flagHelp?: string;
+  defaultLogLevel?: string;
 }) {
-  const optionHelp = joinAndTrimLines(dedent(flagHelp || ''), GLOBAL_FLAGS);
+  const optionHelp = joinAndTrimLines(
+    dedent(flagHelp || ''),
+    getLogLevelFlagsHelp(defaultLogLevel),
+    GLOBAL_FLAGS
+  );
 
   return `
   ${dedent(usage || '') || DEFAULT_GLOBAL_USAGE}

--- a/packages/kbn-dev-utils/src/run/run.ts
+++ b/packages/kbn-dev-utils/src/run/run.ts
@@ -31,11 +31,12 @@ export interface RunOptions {
 }
 
 export async function run(fn: RunFn, options: RunOptions = {}) {
-  const flags = getFlags(process.argv.slice(2), options.flags);
+  const flags = getFlags(process.argv.slice(2), options.flags, options.log?.defaultLevel);
   const helpText = getHelp({
     description: options.description,
     usage: options.usage,
     flagHelp: options.flags?.help,
+    defaultLogLevel: options.log?.defaultLevel,
   });
 
   const log = new ToolingLog({

--- a/packages/kbn-dev-utils/src/tooling_log/log_levels.ts
+++ b/packages/kbn-dev-utils/src/tooling_log/log_levels.ts
@@ -7,6 +7,7 @@
  */
 
 const LEVELS = ['silent', 'error', 'warning', 'success', 'info', 'debug', 'verbose'] as const;
+export const DEFAULT_LOG_LEVEL = 'info' as const;
 export type LogLevel = typeof LEVELS[number];
 
 export function pickLevelFromFlags(
@@ -15,9 +16,39 @@ export function pickLevelFromFlags(
 ) {
   if (flags.verbose) return 'verbose';
   if (flags.debug) return 'debug';
+  if (flags.info) return 'info';
   if (flags.quiet) return 'error';
   if (flags.silent) return 'silent';
-  return options.default || 'info';
+  return options.default || DEFAULT_LOG_LEVEL;
+}
+
+export const LOG_LEVEL_FLAGS = [
+  {
+    name: 'verbose',
+    help: '--verbose, -v      Log verbosely',
+  },
+  {
+    name: 'info',
+    help: "--info             Don't log debug messages",
+  },
+  {
+    name: 'debug',
+    help: '--debug            Log debug messages (less than verbose)',
+  },
+  {
+    name: 'quiet',
+    help: '--quiet            Only log errors',
+  },
+  {
+    name: 'silent',
+    help: "--silent           Don't log anything",
+  },
+];
+
+export function getLogLevelFlagsHelp(defaultLogLevel: string = DEFAULT_LOG_LEVEL) {
+  return LOG_LEVEL_FLAGS.filter(({ name }) => name !== defaultLogLevel)
+    .map(({ help }) => help)
+    .join('\n');
 }
 
 export type ParsedLogLevel = ReturnType<typeof parseLogLevel>;

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8769,20 +8769,51 @@ module.exports = (chalk, temporary) => {
  * Side Public License, v 1.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.parseLogLevel = exports.pickLevelFromFlags = void 0;
+exports.parseLogLevel = exports.getLogLevelFlagsHelp = exports.LOG_LEVEL_FLAGS = exports.pickLevelFromFlags = exports.DEFAULT_LOG_LEVEL = void 0;
 const LEVELS = ['silent', 'error', 'warning', 'success', 'info', 'debug', 'verbose'];
+exports.DEFAULT_LOG_LEVEL = 'info';
 function pickLevelFromFlags(flags, options = {}) {
     if (flags.verbose)
         return 'verbose';
     if (flags.debug)
         return 'debug';
+    if (flags.info)
+        return 'info';
     if (flags.quiet)
         return 'error';
     if (flags.silent)
         return 'silent';
-    return options.default || 'info';
+    return options.default || exports.DEFAULT_LOG_LEVEL;
 }
 exports.pickLevelFromFlags = pickLevelFromFlags;
+exports.LOG_LEVEL_FLAGS = [
+    {
+        name: 'verbose',
+        help: '--verbose, -v      Log verbosely',
+    },
+    {
+        name: 'info',
+        help: "--info             Don't log debug messages",
+    },
+    {
+        name: 'debug',
+        help: '--debug            Log debug messages (less than verbose)',
+    },
+    {
+        name: 'quiet',
+        help: '--quiet            Only log errors',
+    },
+    {
+        name: 'silent',
+        help: "--silent           Don't log anything",
+    },
+];
+function getLogLevelFlagsHelp(defaultLogLevel = exports.DEFAULT_LOG_LEVEL) {
+    return exports.LOG_LEVEL_FLAGS.filter(({ name }) => name !== defaultLogLevel)
+        .map(({ help }) => help)
+        .join('\n');
+}
+exports.getLogLevelFlagsHelp = getLogLevelFlagsHelp;
 function parseLogLevel(name) {
     const i = LEVELS.indexOf(name);
     if (i === -1) {

--- a/test/scripts/checks/type_check_plugin_public_api_docs.sh
+++ b/test/scripts/checks/type_check_plugin_public_api_docs.sh
@@ -7,8 +7,7 @@ checks-reporter-with-killswitch "Build TS Refs" \
     --ignore-type-failures \
     --clean \
     --no-cache \
-    --force \
-    --debug
+    --force
 
 checks-reporter-with-killswitch "Check Types" \
   node scripts/type_check


### PR DESCRIPTION
When the default log level is customized the `--debug` flag (or whatever the new default log level is) is useless, so this PR makes the log level flags update based on the default log level, including a `--info` flag which can be used to set the log level back to "info".