### PR TITLE
[Security Solution] add transform failed warning banner on endpoints …

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -7,6 +7,7 @@
 
 import type { TransformConfigSchema } from './transforms/types';
 import { ENABLE_CASE_CONNECTOR } from '../../cases/common';
+import { metadataTransformPattern } from './endpoint/constants';
 
 export const APP_ID = 'securitySolution';
 export const SERVER_APP_ID = 'siem';
@@ -309,3 +310,5 @@ export const showAllOthersBucket: string[] = [
  * than use it from here.
  */
 export const ELASTIC_NAME = 'estc';
+
+export const TRANSFORM_STATS_URL = `/api/transform/transforms/${metadataTransformPattern}-*/_stats`;

--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -10,6 +10,7 @@ export const alertsIndexPattern = 'logs-endpoint.alerts-*';
 export const metadataIndexPattern = 'metrics-endpoint.metadata-*';
 export const metadataCurrentIndexPattern = 'metrics-endpoint.metadata_current_*';
 export const metadataTransformPrefix = 'endpoint.metadata_current-default';
+export const metadataTransformPattern = 'endpoint.metadata_current-*';
 export const policyIndexPattern = 'metrics-endpoint.policy-*';
 export const telemetryIndexPattern = 'metrics-endpoint.telemetry-*';
 export const LIMITED_CONCURRENCY_ENDPOINT_ROUTE_TAG = 'endpoint:limited-concurrency';

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
@@ -37,6 +37,8 @@ import {
   PendingActionsHttpMockInterface,
   pendingActionsHttpMock,
 } from '../../../common/lib/endpoint_pending_actions/mocks';
+import { TRANSFORM_STATS_URL } from '../../../../common/constants';
+import { TransformStatsResponse, TRANSFORM_STATE } from './types';
 
 type EndpointMetadataHttpMocksInterface = ResponseProvidersInterface<{
   metadataList: () => HostResultList;
@@ -232,11 +234,32 @@ export const fleetApisHttpMock = composeHttpHandlerMocks<FleetApisHttpMockInterf
   fleetGetCheckPermissionsHttpMock,
 ]);
 
+type TransformHttpMocksInterface = ResponseProvidersInterface<{
+  metadataTransformStats: () => TransformStatsResponse;
+}>;
+export const failedTransformStateMock = {
+  count: 1,
+  transforms: [
+    {
+      state: TRANSFORM_STATE.FAILED,
+    },
+  ],
+};
+export const transformsHttpMocks = httpHandlerMockFactory<TransformHttpMocksInterface>([
+  {
+    id: 'metadataTransformStats',
+    path: TRANSFORM_STATS_URL,
+    method: 'get',
+    handler: () => failedTransformStateMock,
+  },
+]);
+
 type EndpointPageHttpMockInterface = EndpointMetadataHttpMocksInterface &
   EndpointPolicyResponseHttpMockInterface &
   EndpointActivityLogHttpMockInterface &
   FleetApisHttpMockInterface &
-  PendingActionsHttpMockInterface;
+  PendingActionsHttpMockInterface &
+  TransformHttpMocksInterface;
 /**
  * HTTP Mocks that support the Endpoint List and Details page
  */
@@ -246,4 +269,5 @@ export const endpointPageHttpMock = composeHttpHandlerMocks<EndpointPageHttpMock
   endpointActivityLogHttpMock,
   fleetApisHttpMock,
   pendingActionsHttpMock,
+  transformsHttpMocks,
 ]);

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/action.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/action.ts
@@ -173,6 +173,12 @@ export interface EndpointDetailsActivityLogUpdateIsInvalidDateRange {
   };
 }
 
+export type LoadMetadataTransformStats = Action<'loadMetadataTransformStats'>;
+
+export type MetadataTransformStatsChanged = Action<'metadataTransformStatsChanged'> & {
+  payload: EndpointState['metadataTransformStats'];
+};
+
 export type EndpointAction =
   | ServerReturnedEndpointList
   | ServerFailedToReturnEndpointList
@@ -202,4 +208,6 @@ export type EndpointAction =
   | ServerFailedToReturnEndpointsTotal
   | EndpointIsolationRequest
   | EndpointIsolationRequestStateChange
-  | EndpointPendingActionsStateChanged;
+  | EndpointPendingActionsStateChanged
+  | LoadMetadataTransformStats
+  | MetadataTransformStatsChanged;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/builders.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/builders.ts
@@ -59,5 +59,6 @@ export const initialEndpointPageState = (): Immutable<EndpointState> => {
     hostStatus: undefined,
     isolationRequestState: createUninitialisedResourceState(),
     endpointPendingActions: createLoadedResourceState(new Map()),
+    metadataTransformStats: createUninitialisedResourceState(),
   };
 };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
@@ -12,6 +12,7 @@ import { mockEndpointResultList } from './mock_endpoint_result_list';
 import { EndpointAction } from './action';
 import { endpointListReducer } from './reducer';
 import { DEFAULT_POLL_INTERVAL } from '../../../common/constants';
+import { createUninitialisedResourceState } from '../../../state';
 
 describe('EndpointList store concerns', () => {
   let store: Store<EndpointState>;
@@ -87,6 +88,7 @@ describe('EndpointList store concerns', () => {
           data: new Map(),
           type: 'LoadedResourceState',
         },
+        metadataTransformStats: createUninitialisedResourceState(),
       });
     });
 

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
@@ -36,8 +36,16 @@ import {
   detailsData,
   getIsEndpointPackageInfoUninitialized,
   getIsOnEndpointDetailsActivityLog,
+  getMetadataTransformStats,
+  isMetadataTransformStatsLoading,
 } from './selectors';
-import { AgentIdsPendingActions, EndpointState, PolicyIds } from '../types';
+import {
+  AgentIdsPendingActions,
+  EndpointState,
+  PolicyIds,
+  TransformStats,
+  TransformStatsResponse,
+} from '../types';
 import {
   sendGetEndpointSpecificPackagePolicies,
   sendGetEndpointSecurityPackage,
@@ -64,6 +72,7 @@ import { resolvePathVariables } from '../../../../common/utils/resolve_path_vari
 import { EndpointPackageInfoStateChanged } from './action';
 import { fetchPendingActionsByAgentId } from '../../../../common/lib/endpoint_pending_actions';
 import { getIsInvalidDateRange } from '../utils';
+import { TRANSFORM_STATS_URL } from '../../../../../common/constants';
 
 type EndpointPageStore = ImmutableMiddlewareAPI<EndpointState, AppAction>;
 
@@ -494,6 +503,10 @@ export const endpointMiddlewareFactory: ImmutableMiddlewareFactory<EndpointState
     if (action.type === 'endpointIsolationRequest') {
       return handleIsolateEndpointHost(store, action);
     }
+
+    if (action.type === 'loadMetadataTransformStats') {
+      return handleLoadMetadataTransformStats(coreStart.http, store);
+    }
   };
 };
 
@@ -716,3 +729,35 @@ const loadEndpointsPendingActions = async ({
     logError(error);
   }
 };
+
+export async function handleLoadMetadataTransformStats(http: HttpStart, store: EndpointPageStore) {
+  const { getState, dispatch } = store;
+
+  if (!http || !getState || !dispatch) {
+    return;
+  }
+
+  const state = getState();
+  if (isMetadataTransformStatsLoading(state)) return;
+
+  dispatch({
+    type: 'metadataTransformStatsChanged',
+    // ts error to be fixed when AsyncResourceState is refactored (#830)
+    // @ts-expect-error
+    payload: createLoadingResourceState<TransformStats[]>(getMetadataTransformStats(state)),
+  });
+
+  try {
+    const transformStatsResponse: TransformStatsResponse = await http.get(TRANSFORM_STATS_URL);
+
+    dispatch({
+      type: 'metadataTransformStatsChanged',
+      payload: createLoadedResourceState<TransformStats[]>(transformStatsResponse.transforms),
+    });
+  } catch (error) {
+    dispatch({
+      type: 'metadataTransformStatsChanged',
+      payload: createFailedResourceState<TransformStats[]>(error),
+    });
+  }
+}

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/mock_endpoint_result_list.ts
@@ -30,6 +30,8 @@ import {
 import { GetPolicyListResponse } from '../../policy/types';
 import { pendingActionsResponseMock } from '../../../../common/lib/endpoint_pending_actions/mocks';
 import { ACTION_STATUS_ROUTE } from '../../../../../common/endpoint/constants';
+import { TRANSFORM_STATS_URL } from '../../../../../common/constants';
+import { TransformStats, TransformStatsResponse } from '../types';
 
 const generator = new EndpointDocGenerator('seed');
 
@@ -87,6 +89,7 @@ const endpointListApiPathHandlerMocks = ({
   policyResponse = generator.generatePolicyResponse(),
   agentPolicy = generator.generateAgentPolicy(),
   totalAgentsUsingEndpoint = 0,
+  transforms = [],
 }: {
   /** route handlers will be setup for each individual host in this array */
   endpointsResults?: HostResultList['hosts'];
@@ -95,6 +98,7 @@ const endpointListApiPathHandlerMocks = ({
   policyResponse?: HostPolicyResponse;
   agentPolicy?: GetAgentPoliciesResponseItem;
   totalAgentsUsingEndpoint?: number;
+  transforms?: TransformStats[];
 } = {}) => {
   const apiHandlers = {
     // endpoint package info
@@ -158,6 +162,11 @@ const endpointListApiPathHandlerMocks = ({
     [ACTION_STATUS_ROUTE]: (): PendingActionsResponse => {
       return pendingActionsResponseMock();
     },
+
+    [TRANSFORM_STATS_URL]: (): TransformStatsResponse => ({
+      count: transforms.length,
+      transforms,
+    }),
   };
 
   // Build a GET route handler for each endpoint details based on the list of Endpoints passed on input

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
@@ -9,6 +9,7 @@ import {
   EndpointDetailsActivityLogChanged,
   EndpointPackageInfoStateChanged,
   EndpointPendingActionsStateChanged,
+  MetadataTransformStatsChanged,
 } from './action';
 import {
   isOnEndpointPage,
@@ -81,6 +82,14 @@ const handleEndpointPackageInfoStateChanged: CaseReducer<EndpointPackageInfoStat
     endpointPackageInfo: action.payload,
   };
 };
+
+const handleMetadataTransformStatsChanged: CaseReducer<MetadataTransformStatsChanged> = (
+  state,
+  action
+) => ({
+  ...state,
+  metadataTransformStats: action.payload,
+});
 
 /* eslint-disable-next-line complexity */
 export const endpointListReducer: StateReducer = (state = initialEndpointPageState(), action) => {
@@ -390,6 +399,8 @@ export const endpointListReducer: StateReducer = (state = initialEndpointPageSta
       },
       endpointsExist: true,
     };
+  } else if (action.type === 'metadataTransformStatsChanged') {
+    return handleMetadataTransformStatsChanged(state, action);
   }
 
   return state;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/selectors.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/selectors.ts
@@ -453,3 +453,12 @@ export const getEndpointHostIsolationStatusPropsCallback: (
     };
   }
 );
+
+export const getMetadataTransformStats = (state: Immutable<EndpointState>) =>
+  state.metadataTransformStats;
+
+export const metadataTransformStats = (state: Immutable<EndpointState>) =>
+  isLoadedResourceState(state.metadataTransformStats) ? state.metadataTransformStats.data : [];
+
+export const isMetadataTransformStatsLoading = (state: Immutable<EndpointState>) =>
+  isLoadingResourceState(state.metadataTransformStats);

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
@@ -106,6 +106,8 @@ export interface EndpointState {
    * states other than Loaded
    */
   endpointPendingActions: AsyncResourceState<AgentIdsPendingActions>;
+  // Metadata transform stats to checking transform state
+  metadataTransformStats: AsyncResourceState<TransformStats[]>;
 }
 
 export type AgentIdsPendingActions = Map<string, EndpointPendingActions['pending_actions']>;
@@ -133,4 +135,76 @@ export interface EndpointIndexUIQueryParams {
   show?: 'policy_response' | 'activity_log' | 'details' | 'isolate' | 'unisolate';
   /** Query text from search bar*/
   admin_query?: string;
+}
+
+export const TRANSFORM_STATE = {
+  ABORTING: 'aborting',
+  FAILED: 'failed',
+  INDEXING: 'indexing',
+  STARTED: 'started',
+  STOPPED: 'stopped',
+  STOPPING: 'stopping',
+  WAITING: 'waiting',
+};
+
+export const WARNING_TRANSFORM_STATES = new Set([
+  TRANSFORM_STATE.ABORTING,
+  TRANSFORM_STATE.FAILED,
+  TRANSFORM_STATE.STOPPED,
+  TRANSFORM_STATE.STOPPING,
+]);
+
+const transformStates = Object.values(TRANSFORM_STATE);
+export type TransformState = typeof transformStates[number];
+
+export interface TransformStats {
+  id: string;
+  checkpointing: {
+    last: {
+      checkpoint: number;
+      timestamp_millis?: number;
+    };
+    next?: {
+      checkpoint: number;
+      checkpoint_progress?: {
+        total_docs: number;
+        docs_remaining: number;
+        percent_complete: number;
+      };
+    };
+    operations_behind: number;
+  };
+  node?: {
+    id: string;
+    name: string;
+    ephemeral_id: string;
+    transport_address: string;
+    attributes: Record<string, unknown>;
+  };
+  stats: {
+    delete_time_in_ms: number;
+    documents_deleted: number;
+    documents_indexed: number;
+    documents_processed: number;
+    index_failures: number;
+    index_time_in_ms: number;
+    index_total: number;
+    pages_processed: number;
+    search_failures: number;
+    search_time_in_ms: number;
+    search_total: number;
+    trigger_count: number;
+    processing_time_in_ms: number;
+    processing_total: number;
+    exponential_avg_checkpoint_duration_ms: number;
+    exponential_avg_documents_indexed: number;
+    exponential_avg_documents_processed: number;
+  };
+  reason?: string;
+  state: TransformState;
+}
+
+export interface TransformStatsResponse {
+  count: number;
+  transforms: TransformStats[];
 }

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback, memo, useContext } from 'react';
+import React, { useMemo, useCallback, memo, useContext, useEffect, useState } from 'react';
 import {
   EuiHorizontalRule,
   EuiBasicTable,
@@ -57,8 +57,12 @@ import { useKibana } from '../../../../../../../../src/plugins/kibana_react/publ
 import { LinkToApp } from '../../../../common/components/endpoint/link_to_app';
 import { TableRowActions } from './components/table_row_actions';
 import { EndpointAgentStatus } from './components/endpoint_agent_status';
+import { CallOut } from '../../../../common/components/callouts';
+import { WARNING_TRANSFORM_STATES } from '../types';
+import { metadataTransformPrefix } from '../../../../../common/endpoint/constants';
 
 const MAX_PAGINATED_ITEM = 9999;
+const TRANSFORM_URL = '/data/transform';
 
 const EndpointListNavLink = memo<{
   name: string;
@@ -120,12 +124,33 @@ export const EndpointList = () => {
     areEndpointsEnrolling,
     agentsWithEndpointsTotalError,
     endpointsTotalError,
+    metadataTransformStats,
   } = useEndpointSelector(selector);
   const { search } = useFormatUrl(SecurityPageName.administration);
   const { getAppUrl } = useAppUrl();
   const dispatch = useDispatch<(a: EndpointAction) => void>();
   // cap ability to page at 10k records. (max_result_window)
   const maxPageCount = totalItemCount > MAX_PAGINATED_ITEM ? MAX_PAGINATED_ITEM : totalItemCount;
+  const [showTransformFailedCallout, setShowTransformFailedCallout] = useState(false);
+
+  useEffect(() => {
+    if (!endpointsExist || !listData?.length) {
+      return;
+    }
+
+    dispatch({ type: 'loadMetadataTransformStats' });
+  }, [endpointsExist, listData.length, dispatch]);
+
+  useEffect(() => {
+    const hasFailure = metadataTransformStats.some((transform) =>
+      WARNING_TRANSFORM_STATES.has(transform?.state)
+    );
+    setShowTransformFailedCallout(hasFailure);
+  }, [metadataTransformStats]);
+
+  const closeTransformFailedCallout = useCallback(() => {
+    setShowTransformFailedCallout(false);
+  }, []);
 
   const paginationSetup = useMemo(() => {
     return {
@@ -494,6 +519,76 @@ export const EndpointList = () => {
     return endpointsExist && !patternsError;
   }, [endpointsExist, patternsError]);
 
+  const transformFailedCalloutDescription = useMemo(
+    () => (
+      <>
+        <FormattedMessage
+          id="xpack.securitySolution.endpoint.list.transformFailed.message"
+          defaultMessage="A required transform, {transformId}, is currently failing. Most of the time this can be fixed by {transformsPage}. For additional help, please visit the {docsPage}"
+          values={{
+            transformId: metadataTransformStats[0]?.id || metadataTransformPrefix,
+            transformsPage: (
+              <LinkToApp
+                data-test-subj="failed-transform-restart-link"
+                appId="management"
+                appPath={TRANSFORM_URL}
+              >
+                <FormattedMessage
+                  id="xpack.securitySolution.endpoint.list.transformFailed.restartLink"
+                  defaultMessage="restarting the transform"
+                />
+              </LinkToApp>
+            ),
+            docsPage: (
+              <EuiLink
+                data-test-subj="failed-transform-docs-link"
+                href={services?.docLinks?.links.transforms.guide}
+                target="_blank"
+              >
+                <FormattedMessage
+                  id="xpack.securitySolution.endpoint.list.transformFailed.docsLink"
+                  defaultMessage="troubleshooting documentation"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+        <EuiSpacer size="s" />
+      </>
+    ),
+    [metadataTransformStats, services?.docLinks?.links.transforms.guide]
+  );
+
+  const transformFailedCallout = useMemo(() => {
+    if (!showTransformFailedCallout) {
+      return;
+    }
+
+    return (
+      <>
+        <CallOut
+          message={{
+            id: 'endpoints-list-transform-failed',
+            type: 'warning',
+            title: i18n.translate('xpack.securitySolution.endpoint.list.transformFailed.title', {
+              defaultMessage: 'Required transform failed',
+            }),
+            description: transformFailedCalloutDescription,
+          }}
+          dismissButtonText={i18n.translate(
+            'xpack.securitySolution.endpoint.list.transformFailed.dismiss',
+            {
+              defaultMessage: 'Dismiss',
+            }
+          )}
+          onDismiss={closeTransformFailedCallout}
+          showDismissButton={true}
+        />
+        <EuiSpacer size="m" />
+      </>
+    );
+  }, [showTransformFailedCallout, closeTransformFailedCallout, transformFailedCalloutDescription]);
+
   return (
     <AdministrationListPage
       data-test-subj="endpointPage"
@@ -544,6 +639,7 @@ export const EndpointList = () => {
             <EuiSpacer size="m" />
           </>
         )}
+        {transformFailedCallout}
         <EuiFlexGroup>
           {shouldShowKQLBar && (
             <EuiFlexItem>


### PR DESCRIPTION
## Summary

Add failed metadata transform banner to endpoint list page.
![Screen Shot 2021-08-02 at 3 49 12 PM](https://user-images.githubusercontent.com/11009772/127922169-14c79345-12e3-4c54-b7a9-a6290c5bfdf0.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))