### PR TITLE
POC: Sharing Saved Objects developer guide steps

### DIFF
--- a/x-pack/plugins/notes_test/common/constants.ts
+++ b/x-pack/plugins/notes_test/common/constants.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const NOTE_OBJ_TYPE = 'note';
+export const VIEW_NOTE_PATH = 'viewNote';

--- a/x-pack/plugins/notes_test/common/index.ts
+++ b/x-pack/plugins/notes_test/common/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './constants';
+export * from './types';

--- a/x-pack/plugins/notes_test/common/types.ts
+++ b/x-pack/plugins/notes_test/common/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface NoteAttributes {
+  subject: string;
+  text: string;
+  createdAt: Date;
+}

--- a/x-pack/plugins/notes_test/kibana.json
+++ b/x-pack/plugins/notes_test/kibana.json
@@ -1,0 +1,10 @@
+{
+  "id": "notesTest",
+  "owner": { "name": "Platform Security", "githubTeam": "kibana-security" },
+  "version": "0.0.1",
+  "kibanaVersion": "kibana",
+  "server": true,
+  "ui": true,
+  "requiredPlugins": [],
+  "optionalPlugins": []
+}

--- a/x-pack/plugins/notes_test/kibana.json
+++ b/x-pack/plugins/notes_test/kibana.json
@@ -6,5 +6,5 @@
   "server": true,
   "ui": true,
   "requiredPlugins": [],
-  "optionalPlugins": []
+  "optionalPlugins": ["spaces"]
 }

--- a/x-pack/plugins/notes_test/public/app.tsx
+++ b/x-pack/plugins/notes_test/public/app.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Router, Switch, Route } from 'react-router-dom';
+
+import type { AppMountParameters } from 'src/core/public';
+import { VIEW_NOTE_PATH } from '../common';
+import { NotesList } from './notes_list';
+import type { Services } from './services';
+import { ViewNote } from './view_note';
+
+interface RenderParams {
+  services: Services;
+  appMountParams: AppMountParameters;
+}
+
+export const renderApp = ({ services, appMountParams }: RenderParams) => {
+  const { element, history } = appMountParams;
+
+  ReactDOM.render(
+    <Router history={history}>
+      <Switch>
+        <Route path={`/${VIEW_NOTE_PATH}/:noteId`}>
+          <ViewNote services={services} />
+        </Route>
+        <Route path="/" exact>
+          <NotesList services={services} />
+        </Route>
+      </Switch>
+    </Router>,
+    element
+  );
+
+  return () => ReactDOM.unmountComponentAtNode(element);
+};

--- a/x-pack/plugins/notes_test/public/app.tsx
+++ b/x-pack/plugins/notes_test/public/app.tsx
@@ -9,7 +9,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Switch, Route } from 'react-router-dom';
 
-import type { AppMountParameters } from 'src/core/public';
+import type { AppMountParameters, HttpStart } from 'src/core/public';
+import type { SpacesPluginStart } from '../../spaces/public';
 import { VIEW_NOTE_PATH } from '../common';
 import { NotesList } from './notes_list';
 import type { Services } from './services';
@@ -18,16 +19,18 @@ import { ViewNote } from './view_note';
 interface RenderParams {
   services: Services;
   appMountParams: AppMountParameters;
+  http: HttpStart;
+  spacesApi?: SpacesPluginStart;
 }
 
-export const renderApp = ({ services, appMountParams }: RenderParams) => {
+export const renderApp = ({ services, appMountParams, http, spacesApi }: RenderParams) => {
   const { element, history } = appMountParams;
 
   ReactDOM.render(
     <Router history={history}>
       <Switch>
         <Route path={`/${VIEW_NOTE_PATH}/:noteId`}>
-          <ViewNote services={services} />
+          <ViewNote services={services} http={http} spacesApi={spacesApi} />
         </Route>
         <Route path="/" exact>
           <NotesList services={services} />

--- a/x-pack/plugins/notes_test/public/create_note_form.tsx
+++ b/x-pack/plugins/notes_test/public/create_note_form.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { EuiButton, EuiFieldText, EuiForm, EuiFormRow, EuiText, EuiTextArea } from '@elastic/eui';
+
+import type { Services } from './services';
+
+interface Props {
+  services: Services;
+  onAfterCreate: () => void;
+}
+
+export function CreateNoteForm({ services, onAfterCreate }: Props) {
+  const [subject, setSubject] = useState<string>('');
+  const [text, setText] = useState<string>('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+
+  const saveNote = useCallback(async () => {
+    if (isSaving) return;
+    setIsSaving(true);
+
+    if (!subject || !text) {
+      setIsInvalid(true);
+    } else {
+      setIsInvalid(false);
+      await services.createNote(subject, text);
+      setSubject('');
+      setText('');
+      services.addSuccessToast('Note created!');
+      onAfterCreate();
+    }
+
+    setIsSaving(false);
+  }, [subject, text, services, isSaving, onAfterCreate]);
+
+  return (
+    <>
+      <EuiForm isInvalid={isInvalid} error="Subject and body text are required">
+        <EuiFormRow>
+          <EuiText>Create a new note</EuiText>
+        </EuiFormRow>
+        <EuiFormRow>
+          <EuiFieldText
+            placeholder="Subject"
+            value={subject}
+            onChange={(event) => setSubject(event.target.value)}
+          />
+        </EuiFormRow>
+        <EuiFormRow>
+          <EuiTextArea
+            placeholder="Body text"
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+          />
+        </EuiFormRow>
+        <EuiFormRow>
+          <EuiButton onClick={saveNote}>Save</EuiButton>
+        </EuiFormRow>
+      </EuiForm>
+    </>
+  );
+}

--- a/x-pack/plugins/notes_test/public/index.ts
+++ b/x-pack/plugins/notes_test/public/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginInitializer } from 'src/core/public';
+import { NotesTestPlugin } from './plugin';
+
+export const plugin: PluginInitializer<{}, {}> = () => new NotesTestPlugin();

--- a/x-pack/plugins/notes_test/public/notes_list.tsx
+++ b/x-pack/plugins/notes_test/public/notes_list.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  EuiInMemoryTable,
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentHeader,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { Link } from 'react-router-dom';
+
+import type { SimpleSavedObject } from 'src/core/public';
+import type { NoteAttributes } from '../common';
+import { VIEW_NOTE_PATH } from '../common';
+import { CreateNoteForm } from './create_note_form';
+import type { Services } from './services';
+
+interface Props {
+  services: Services;
+}
+
+type NoteObject = SimpleSavedObject<NoteAttributes>;
+
+export function NotesList({ services }: Props) {
+  const { findAllNotes } = services;
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const [notes, setNotes] = useState<NoteObject[]>([]);
+
+  const fetchNotes = useCallback(async () => {
+    if (isFetching) return;
+    setIsFetching(true);
+
+    const response = await findAllNotes();
+    setNotes(response);
+
+    setIsFetching(false);
+  }, [isFetching, findAllNotes, setNotes]);
+
+  useEffect(() => {
+    fetchNotes();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <EuiPage>
+      <EuiPageBody>
+        <EuiPageContent>
+          <EuiPageContentHeader>
+            <EuiText>
+              <h1>Notes</h1>
+            </EuiText>
+          </EuiPageContentHeader>
+          {notes.length ? (
+            <>
+              <EuiInMemoryTable<NoteObject>
+                items={notes}
+                columns={[
+                  {
+                    field: 'attributes.subject',
+                    name: 'Subject',
+                    render: (value, record) => {
+                      const { id, attributes } = record;
+                      return <Link to={`${VIEW_NOTE_PATH}/${id}`}>{attributes.subject}</Link>;
+                    },
+                  },
+                  {
+                    field: 'attributes.createdAt',
+                    name: 'Created at',
+                    dataType: 'date',
+                  },
+                ]}
+                pagination={false}
+                sorting={{ sort: { field: 'attributes.createdAt', direction: 'desc' } }}
+              />
+              <EuiSpacer />
+            </>
+          ) : null}
+          <CreateNoteForm services={services} onAfterCreate={() => fetchNotes()} />
+        </EuiPageContent>
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/x-pack/plugins/notes_test/public/plugin.tsx
+++ b/x-pack/plugins/notes_test/public/plugin.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, Plugin, CoreSetup, AppMountParameters } from 'src/core/public';
+import { getServices } from './services';
+
+export class NotesTestPlugin implements Plugin<{}, {}, {}, {}> {
+  public setup(core: CoreSetup) {
+    core.application.register({
+      id: 'notesTest',
+      title: 'Notes test',
+      async mount(appMountParams: AppMountParameters) {
+        const [coreStart] = await core.getStartServices();
+        const services = getServices(coreStart);
+        const { renderApp } = await import('./app');
+        return renderApp({ services, appMountParams });
+      },
+    });
+
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/plugins/notes_test/public/plugin.tsx
+++ b/x-pack/plugins/notes_test/public/plugin.tsx
@@ -6,18 +6,25 @@
  */
 
 import type { CoreStart, Plugin, CoreSetup, AppMountParameters } from 'src/core/public';
+import type { SpacesPluginStart } from '../../spaces/public';
 import { getServices } from './services';
 
-export class NotesTestPlugin implements Plugin<{}, {}, {}, {}> {
-  public setup(core: CoreSetup) {
+interface PluginStartDeps {
+  spaces?: SpacesPluginStart;
+}
+
+export class NotesTestPlugin implements Plugin<{}, {}, {}, PluginStartDeps> {
+  public setup(core: CoreSetup<PluginStartDeps>) {
     core.application.register({
       id: 'notesTest',
       title: 'Notes test',
       async mount(appMountParams: AppMountParameters) {
-        const [coreStart] = await core.getStartServices();
+        const [coreStart, pluginStartDeps] = await core.getStartServices();
         const services = getServices(coreStart);
+        const { http } = coreStart;
+        const { spaces: spacesApi } = pluginStartDeps;
         const { renderApp } = await import('./app');
-        return renderApp({ services, appMountParams });
+        return renderApp({ services, appMountParams, http, spacesApi });
       },
     });
 

--- a/x-pack/plugins/notes_test/public/services.ts
+++ b/x-pack/plugins/notes_test/public/services.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CoreStart, SimpleSavedObject } from 'src/core/public';
+import type { CoreStart, ResolvedSimpleSavedObject, SimpleSavedObject } from 'src/core/public';
 
 import type { NoteAttributes } from '../common';
 import { NOTE_OBJ_TYPE } from '../common';
@@ -13,7 +13,7 @@ import { NOTE_OBJ_TYPE } from '../common';
 export interface Services {
   createNote: (subject: string, text: string) => Promise<void>;
   findAllNotes: () => Promise<Array<SimpleSavedObject<NoteAttributes>>>;
-  getNoteById: (id: string) => Promise<SimpleSavedObject<NoteAttributes>>;
+  getNoteById: (id: string) => Promise<ResolvedSimpleSavedObject<NoteAttributes>>;
   addSuccessToast: (message: string) => void;
 }
 
@@ -33,8 +33,8 @@ export function getServices(core: CoreStart): Services {
       return findResult.savedObjects;
     },
     getNoteById: async (id: string) => {
-      const savedObject = await savedObjectsClient.get<NoteAttributes>(NOTE_OBJ_TYPE, id);
-      return savedObject;
+      const resolveResult = await savedObjectsClient.resolve<NoteAttributes>(NOTE_OBJ_TYPE, id);
+      return resolveResult;
     },
     addSuccessToast: (message: string) => core.notifications.toasts.addSuccess(message),
   };

--- a/x-pack/plugins/notes_test/public/services.ts
+++ b/x-pack/plugins/notes_test/public/services.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, SimpleSavedObject } from 'src/core/public';
+
+import type { NoteAttributes } from '../common';
+import { NOTE_OBJ_TYPE } from '../common';
+
+export interface Services {
+  createNote: (subject: string, text: string) => Promise<void>;
+  findAllNotes: () => Promise<Array<SimpleSavedObject<NoteAttributes>>>;
+  getNoteById: (id: string) => Promise<SimpleSavedObject<NoteAttributes>>;
+  addSuccessToast: (message: string) => void;
+}
+
+export function getServices(core: CoreStart): Services {
+  const savedObjectsClient = core.savedObjects.client;
+
+  return {
+    createNote: async (subject: string, text: string) => {
+      const attributes = { subject, text, createdAt: new Date() };
+      await savedObjectsClient.create<NoteAttributes>(NOTE_OBJ_TYPE, attributes);
+    },
+    findAllNotes: async () => {
+      const findResult = await savedObjectsClient.find<NoteAttributes>({
+        type: NOTE_OBJ_TYPE,
+        perPage: 100,
+      });
+      return findResult.savedObjects;
+    },
+    getNoteById: async (id: string) => {
+      const savedObject = await savedObjectsClient.get<NoteAttributes>(NOTE_OBJ_TYPE, id);
+      return savedObject;
+    },
+    addSuccessToast: (message: string) => core.notifications.toasts.addSuccess(message),
+  };
+}

--- a/x-pack/plugins/notes_test/public/view_note.tsx
+++ b/x-pack/plugins/notes_test/public/view_note.tsx
@@ -17,7 +17,7 @@ import {
 } from '@elastic/eui';
 import { Link, useParams } from 'react-router-dom';
 
-import type { SimpleSavedObject } from 'src/core/public';
+import type { ResolvedSimpleSavedObject } from 'src/core/public';
 import type { NoteAttributes } from '../common';
 import type { Services } from './services';
 
@@ -28,16 +28,17 @@ interface Props {
   services: Services;
 }
 
-type NoteObject = SimpleSavedObject<NoteAttributes>;
+type ResolvedNote = ResolvedSimpleSavedObject<NoteAttributes>;
 
 export function ViewNote({ services }: Props) {
   const { noteId } = useParams<Params>();
-  const [note, setNote] = useState<NoteObject | null>(null);
+  const [resolvedNote, setResolvedNote] = useState<ResolvedNote | null>(null);
+  const note = resolvedNote?.saved_object;
 
   const fetchNote = async () => {
-    const savedObject = await services.getNoteById(noteId);
+    const resolveResult = await services.getNoteById(noteId);
 
-    setNote(savedObject);
+    setResolvedNote(resolveResult);
   };
 
   useEffect(() => {

--- a/x-pack/plugins/notes_test/public/view_note.tsx
+++ b/x-pack/plugins/notes_test/public/view_note.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiLoadingSpinner,
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentHeader,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { Link, useParams } from 'react-router-dom';
+
+import type { SimpleSavedObject } from 'src/core/public';
+import type { NoteAttributes } from '../common';
+import type { Services } from './services';
+
+interface Params {
+  noteId: string;
+}
+interface Props {
+  services: Services;
+}
+
+type NoteObject = SimpleSavedObject<NoteAttributes>;
+
+export function ViewNote({ services }: Props) {
+  const { noteId } = useParams<Params>();
+  const [note, setNote] = useState<NoteObject | null>(null);
+
+  const fetchNote = async () => {
+    const savedObject = await services.getNoteById(noteId);
+
+    setNote(savedObject);
+  };
+
+  useEffect(() => {
+    fetchNote();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [noteId]);
+
+  return (
+    <EuiPage>
+      <EuiPageBody>
+        <EuiPageContent>
+          <EuiPageContentHeader>
+            <EuiText>
+              <h1>View note</h1>
+            </EuiText>
+          </EuiPageContentHeader>
+          {note ? (
+            <>
+              <EuiText>
+                <h2>{note.attributes.subject}</h2>
+                <p>{note.attributes.createdAt}</p>
+                <pre>
+                  <code>{note.attributes.text}</code>
+                </pre>
+              </EuiText>
+              <EuiSpacer />
+            </>
+          ) : (
+            <EuiLoadingSpinner />
+          )}
+          <Link to="/">Back to notes list</Link>
+        </EuiPageContent>
+      </EuiPageBody>
+    </EuiPage>
+  );
+}

--- a/x-pack/plugins/notes_test/public/view_note.tsx
+++ b/x-pack/plugins/notes_test/public/view_note.tsx
@@ -17,8 +17,10 @@ import {
 } from '@elastic/eui';
 import { Link, useParams } from 'react-router-dom';
 
-import type { ResolvedSimpleSavedObject } from 'src/core/public';
+import type { HttpStart, ResolvedSimpleSavedObject } from 'src/core/public';
+import type { SpacesPluginStart } from '../../spaces/public';
 import type { NoteAttributes } from '../common';
+import { VIEW_NOTE_PATH } from '../common';
 import type { Services } from './services';
 
 interface Params {
@@ -26,17 +28,28 @@ interface Params {
 }
 interface Props {
   services: Services;
+  http: HttpStart;
+  spacesApi?: SpacesPluginStart;
 }
 
 type ResolvedNote = ResolvedSimpleSavedObject<NoteAttributes>;
+const OBJECT_NOUN = 'note';
 
-export function ViewNote({ services }: Props) {
+export function ViewNote({ services, http, spacesApi }: Props) {
   const { noteId } = useParams<Params>();
   const [resolvedNote, setResolvedNote] = useState<ResolvedNote | null>(null);
   const note = resolvedNote?.saved_object;
 
   const fetchNote = async () => {
     const resolveResult = await services.getNoteById(noteId);
+
+    if (spacesApi && resolveResult.outcome === 'aliasMatch') {
+      // We found this object by a legacy URL alias from its old ID; redirect the user to the page with its new ID, preserving any URL hash
+      const newObjectId = resolveResult.alias_target_id!; // This is always defined if outcome === 'aliasMatch'
+      const newPath = `/${VIEW_NOTE_PATH}/${newObjectId}${window.location.hash}`; // Use the *local* path within this app (do not include the "/app/appId" prefix)
+      await spacesApi.ui.redirectLegacyUrl(newPath, OBJECT_NOUN);
+      return;
+    }
 
     setResolvedNote(resolveResult);
   };
@@ -46,10 +59,37 @@ export function ViewNote({ services }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [noteId]);
 
+  const getLegacyUrlConflictCallout = () => {
+    // This function returns a callout component *if* we have encountered a "legacy URL conflict" scenario
+    if (spacesApi && resolvedNote) {
+      if (resolvedNote.outcome === 'conflict') {
+        // We have resolved to one object, but another object has a legacy URL alias associated with this ID/page. We should display a
+        // callout with a warning for the user, and provide a way for them to navigate to the other object.
+        const currentObjectId = resolvedNote.saved_object.id;
+        const otherObjectId = resolvedNote.alias_target_id!; // This is always defined if outcome === 'conflict'
+        const otherObjectPath = `/${VIEW_NOTE_PATH}/${otherObjectId}${window.location.hash}`; // Use the *local* path within this app (do not include the "/app/appId" prefix)
+        return (
+          <>
+            {spacesApi.ui.components.getLegacyUrlConflict({
+              objectNoun: OBJECT_NOUN,
+              currentObjectId,
+              otherObjectId,
+              otherObjectPath,
+            })}
+            <EuiSpacer />
+          </>
+        );
+      }
+    }
+    return null;
+  };
+
   return (
     <EuiPage>
       <EuiPageBody>
         <EuiPageContent>
+          {/* If we have a legacy URL conflict callout to display, show it at the top of the page */}
+          {getLegacyUrlConflictCallout()}
           <EuiPageContentHeader>
             <EuiText>
               <h1>View note</h1>

--- a/x-pack/plugins/notes_test/server/index.ts
+++ b/x-pack/plugins/notes_test/server/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginInitializer } from 'src/core/server';
+
+import { NotesTestPlugin } from './plugin';
+
+export const plugin: PluginInitializer<{}, {}> = () => new NotesTestPlugin();

--- a/x-pack/plugins/notes_test/server/plugin.ts
+++ b/x-pack/plugins/notes_test/server/plugin.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Plugin, CoreSetup, CoreStart } from 'src/core/server';
+import { registerSavedObject } from './saved_objects';
+
+export class NotesTestPlugin implements Plugin<{}, {}> {
+  public setup(core: CoreSetup) {
+    registerSavedObject(core.savedObjects);
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/plugins/notes_test/server/saved_objects.ts
+++ b/x-pack/plugins/notes_test/server/saved_objects.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsServiceSetup, SavedObjectsType } from 'src/core/server';
+import type { NoteAttributes } from '../common';
+import { NOTE_OBJ_TYPE } from '../common';
+
+export function registerSavedObject(savedObjects: SavedObjectsServiceSetup) {
+  savedObjects.registerType(noteSavedObjectType);
+}
+
+const noteSavedObjectType: SavedObjectsType<NoteAttributes> = {
+  name: NOTE_OBJ_TYPE,
+  hidden: false,
+  management: {
+    importableAndExportable: true,
+    icon: 'document',
+    getTitle: ({ attributes }) => attributes.subject,
+  },
+  mappings: { dynamic: false, properties: {} },
+  namespaceType: 'single',
+};

--- a/x-pack/plugins/notes_test/server/saved_objects.ts
+++ b/x-pack/plugins/notes_test/server/saved_objects.ts
@@ -22,5 +22,6 @@ const noteSavedObjectType: SavedObjectsType<NoteAttributes> = {
     getTitle: ({ attributes }) => attributes.subject,
   },
   mappings: { dynamic: false, properties: {} },
-  namespaceType: 'single',
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
 };

--- a/x-pack/plugins/notes_test/tsconfig.json
+++ b/x-pack/plugins/notes_test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./target/types",
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["common/**/*", "public/**/*", "server/**/*"],
+  "references": [
+    { "path": "../../../src/core/tsconfig.json" },
+  ]
+}

--- a/x-pack/plugins/notes_test/tsconfig.json
+++ b/x-pack/plugins/notes_test/tsconfig.json
@@ -10,5 +10,6 @@
   "include": ["common/**/*", "public/**/*", "server/**/*"],
   "references": [
     { "path": "../../../src/core/tsconfig.json" },
+    { "path": "../spaces/tsconfig.json" },
   ]
 }


### PR DESCRIPTION
[skip-ci]

This PR is a proof-of-concept. It is designed to be a companion for the [Sharing Saved Objects developer guide](https://www.elastic.co/guide/en/kibana/master/sharing-saved-objects.html) (added in #107099).

## Example steps <a href="#user-content-example-steps" id="example-steps">#</a>

The proof-of-concept adds a new example plugin called Notes Test (added in a084bf0). This plugin registers an isolated "note" saved object type (`namespaceType: 'single'`). The subsequent commits walk through the steps of the developer guide to convert the "note" objects to become share-capable.

* Initial commit: 30b8fe6
* Step 1: (not covered in this POC)
* Step 2: c02076e
* Step 3: 5b1a467
* Step 4: 2fd4c42
* Step 5: (not covered in this POC)

## Using the example plugin

Open Kibana and use the main navigation pane to view the Notes Test app. You can use this page to view a table of notes or create a new note. You can click an existing note to view its body text.

![notes-test](https://user-images.githubusercontent.com/5295965/129046288-8abf269d-40ab-4079-9a45-ba74ac390c74.gif)