### PR TITLE
[7.x]  [Lens] make the datatable content selectable (#106982)

### DIFF
--- a/x-pack/plugins/lens/public/visualization_container.scss
+++ b/x-pack/plugins/lens/public/visualization_container.scss
@@ -1,6 +1,7 @@
 .lnsVisualizationContainer {
   @include euiScrollBar;
   overflow: auto;
+  user-select: text;
 }
 
 .lnsExpressionRenderer {


### PR DESCRIPTION
Backports the following commits to 7.x:
 -  [Lens] make the datatable content selectable (#106982)