### PR TITLE
[7.13] [Reporting CSV] Fix scroll ID bug for deprecated csv export (#106892)

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/csv/execute_job.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv/execute_job.test.ts
@@ -175,7 +175,7 @@ describe('CSV Execute Job', function () {
       );
 
       expect(mockEsClient.scroll).toHaveBeenCalledWith(
-        expect.objectContaining({ scroll_id: scrollId })
+        expect.objectContaining({ body: { scroll_id: scrollId } })
       );
     });
 
@@ -261,7 +261,7 @@ describe('CSV Execute Job', function () {
       );
 
       expect(mockEsClient.clearScroll).toHaveBeenCalledWith(
-        expect.objectContaining({ scroll_id: lastScrollId })
+        expect.objectContaining({ body: { scroll_id: lastScrollId } })
       );
     });
 
@@ -295,7 +295,7 @@ describe('CSV Execute Job', function () {
       );
 
       expect(mockEsClient.clearScroll).toHaveBeenCalledWith(
-        expect.objectContaining({ scroll_id: lastScrollId })
+        expect.objectContaining({ body: { scroll_id: lastScrollId } })
       );
     });
   });
@@ -754,7 +754,7 @@ describe('CSV Execute Job', function () {
 
       expect(mockEsClient.clearScroll).toHaveBeenCalledWith(
         expect.objectContaining({
-          scroll_id: scrollId,
+          body: { scroll_id: scrollId },
         })
       );
     });
@@ -1151,7 +1151,7 @@ describe('CSV Execute Job', function () {
       await runTask('job123', jobParams, cancellationToken);
 
       expect(mockEsClient.scroll).toHaveBeenCalledWith(
-        expect.objectContaining({ scroll: scrollDuration })
+        expect.objectContaining({ body: { scroll: scrollDuration, scroll_id: 'scrollId' } })
       );
     });
   });

--- a/x-pack/plugins/reporting/server/export_types/csv/generate_csv/hit_iterator.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv/generate_csv/hit_iterator.ts
@@ -60,12 +60,14 @@ export function createHitIterator(logger: LevelLogger) {
       );
     }
 
-    async function scroll(scrollId: string | undefined) {
+    async function scroll(scrollId: string) {
       logger.debug('executing scroll request');
       return parseResponse(
         await elasticsearchClient.scroll({
-          scroll_id: scrollId,
-          scroll: scrollSettings.duration,
+          body: {
+            scroll_id: scrollId,
+            scroll: scrollSettings.duration,
+          },
         })
       );
     }
@@ -74,7 +76,7 @@ export function createHitIterator(logger: LevelLogger) {
       logger.debug('executing clearScroll request');
       try {
         await elasticsearchClient.clearScroll({
-          scroll_id: scrollId,
+          body: { scroll_id: scrollId },
         });
       } catch (err) {
         // Do not throw the error, as the job can still be completed successfully


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [Reporting CSV] Fix scroll ID bug for deprecated csv export (#106892)