### PR TITLE
[canvas] Create Labs Service; remove legacy service

### DIFF
--- a/x-pack/plugins/canvas/public/services/index.ts
+++ b/x-pack/plugins/canvas/public/services/index.ts
@@ -8,9 +8,11 @@
 export * from './legacy';
 
 import { PluginServices } from '../../../../../src/plugins/presentation_util/public';
+
+import { CanvasCustomElementService } from './custom_element';
 import { CanvasEmbeddablesService } from './embeddables';
 import { CanvasExpressionsService } from './expressions';
-import { CanvasCustomElementService } from './custom_element';
+import { CanvasLabsService } from './labs';
 import { CanvasNavLinkService } from './nav_link';
 import { CanvasNotifyService } from './notify';
 import { CanvasPlatformService } from './platform';
@@ -21,6 +23,7 @@ export interface CanvasPluginServices {
   customElement: CanvasCustomElementService;
   embeddables: CanvasEmbeddablesService;
   expressions: CanvasExpressionsService;
+  labs: CanvasLabsService;
   navLink: CanvasNavLinkService;
   notify: CanvasNotifyService;
   platform: CanvasPlatformService;
@@ -30,12 +33,13 @@ export interface CanvasPluginServices {
 
 export const pluginServices = new PluginServices<CanvasPluginServices>();
 
-export const useEmbeddablesService = () =>
-  (() => pluginServices.getHooks().embeddables.useService())();
 export const useCustomElementService = () =>
   (() => pluginServices.getHooks().customElement.useService())();
+export const useEmbeddablesService = () =>
+  (() => pluginServices.getHooks().embeddables.useService())();
 export const useExpressionsService = () =>
   (() => pluginServices.getHooks().expressions.useService())();
+export const useLabsService = () => (() => pluginServices.getHooks().labs.useService())();
 export const useNavLinkService = () => (() => pluginServices.getHooks().navLink.useService())();
 export const useNotifyService = () => (() => pluginServices.getHooks().notify.useService())();
 export const usePlatformService = () => (() => pluginServices.getHooks().platform.useService())();

--- a/x-pack/plugins/canvas/public/services/kibana/index.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/index.ts
@@ -17,6 +17,7 @@ import { CanvasStartDeps } from '../../plugin';
 import { customElementServiceFactory } from './custom_element';
 import { embeddablesServiceFactory } from './embeddables';
 import { expressionsServiceFactory } from './expressions';
+import { labsServiceFactory } from './labs';
 import { navLinkServiceFactory } from './nav_link';
 import { notifyServiceFactory } from './notify';
 import { platformServiceFactory } from './platform';
@@ -26,6 +27,7 @@ import { workpadServiceFactory } from './workpad';
 export { customElementServiceFactory } from './custom_element';
 export { embeddablesServiceFactory } from './embeddables';
 export { expressionsServiceFactory } from './expressions';
+export { labsServiceFactory } from './labs';
 export { notifyServiceFactory } from './notify';
 export { platformServiceFactory } from './platform';
 export { reportingServiceFactory } from './reporting';
@@ -38,6 +40,7 @@ export const pluginServiceProviders: PluginServiceProviders<
   customElement: new PluginServiceProvider(customElementServiceFactory),
   embeddables: new PluginServiceProvider(embeddablesServiceFactory),
   expressions: new PluginServiceProvider(expressionsServiceFactory),
+  labs: new PluginServiceProvider(labsServiceFactory),
   navLink: new PluginServiceProvider(navLinkServiceFactory),
   notify: new PluginServiceProvider(notifyServiceFactory),
   platform: new PluginServiceProvider(platformServiceFactory),

--- a/x-pack/plugins/canvas/public/services/kibana/labs.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/labs.ts
@@ -6,23 +6,19 @@
  */
 
 import {
+  KibanaPluginServiceFactory,
   projectIDs,
-  PresentationLabsService,
 } from '../../../../../../src/plugins/presentation_util/public';
-
-import { CanvasServiceFactory } from '.';
 import { UI_SETTINGS } from '../../../common';
-export interface CanvasLabsService extends PresentationLabsService {
-  projectIDs: typeof projectIDs;
-  isLabsEnabled: () => boolean;
-}
+import { CanvasStartDeps } from '../../plugin';
+import { CanvasLabsService } from '../labs';
 
-export const labsServiceFactory: CanvasServiceFactory<CanvasLabsService> = async (
-  _coreSetup,
-  coreStart,
-  _setupPlugins,
-  startPlugins
-) => ({
+export type CanvasLabsServiceFactory = KibanaPluginServiceFactory<
+  CanvasLabsService,
+  CanvasStartDeps
+>;
+
+export const labsServiceFactory: CanvasLabsServiceFactory = ({ startPlugins, coreStart }) => ({
   projectIDs,
   isLabsEnabled: () => coreStart.uiSettings.get(UI_SETTINGS.ENABLE_LABS_UI),
   ...startPlugins.presentationUtil.labsService,

--- a/x-pack/plugins/canvas/public/services/labs.ts
+++ b/x-pack/plugins/canvas/public/services/labs.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  projectIDs,
+  PresentationLabsService,
+} from '../../../../../src/plugins/presentation_util/public';
+
+export interface CanvasLabsService extends PresentationLabsService {
+  projectIDs: typeof projectIDs;
+  isLabsEnabled: () => boolean;
+}

--- a/x-pack/plugins/canvas/public/services/legacy/context.tsx
+++ b/x-pack/plugins/canvas/public/services/legacy/context.tsx
@@ -26,7 +26,6 @@ const defaultContextValue = {
 export const ServicesContext = createContext<CanvasServices>(defaultContextValue as CanvasServices);
 
 export const useServices = () => useContext(ServicesContext);
-export const useLabsService = () => useServices().labs;
 export const withServices = <Props extends WithServicesProps>(type: ComponentType<Props>) => {
   const EnhancedType: FC<Props> = (props) =>
     createElement(type, { ...props, services: useServices() });
@@ -40,7 +39,6 @@ export const LegacyServicesProvider: FC<{
   const specifiedProviders: CanvasServiceProviders = { ...services, ...providers };
   const value = {
     search: specifiedProviders.search.getService(),
-    labs: specifiedProviders.labs.getService(),
   };
   return <ServicesContext.Provider value={value}>{children}</ServicesContext.Provider>;
 };

--- a/x-pack/plugins/canvas/public/services/legacy/index.ts
+++ b/x-pack/plugins/canvas/public/services/legacy/index.ts
@@ -9,7 +9,6 @@ import { BehaviorSubject } from 'rxjs';
 import { CoreSetup, CoreStart, AppUpdater } from '../../../../../../src/core/public';
 import { CanvasSetupDeps, CanvasStartDeps } from '../../plugin';
 import { searchServiceFactory } from './search';
-import { labsServiceFactory } from './labs';
 
 export { SearchService } from './search';
 export { ExpressionsService } from '../../../../../../src/plugins/expressions/common';
@@ -68,14 +67,12 @@ export type ServiceFromProvider<P> = P extends CanvasServiceProvider<infer T> ? 
 
 export const services = {
   search: new CanvasServiceProvider(searchServiceFactory),
-  labs: new CanvasServiceProvider(labsServiceFactory),
 };
 
 export type CanvasServiceProviders = typeof services;
 
 export interface CanvasServices {
   search: ServiceFromProvider<typeof services.search>;
-  labs: ServiceFromProvider<typeof services.labs>;
 }
 
 export const startLegacyServices = async (

--- a/x-pack/plugins/canvas/public/services/legacy/stubs/index.ts
+++ b/x-pack/plugins/canvas/public/services/legacy/stubs/index.ts
@@ -6,12 +6,10 @@
  */
 
 import { CanvasServices, services } from '../';
-import { labsService } from './labs';
 import { searchService } from './search';
 
 export const stubs: CanvasServices = {
   search: searchService,
-  labs: labsService,
 };
 
 export const startServices = async (providedServices: Partial<CanvasServices> = {}) => {

--- a/x-pack/plugins/canvas/public/services/stubs/index.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/index.ts
@@ -17,6 +17,7 @@ import { CanvasPluginServices } from '..';
 import { customElementServiceFactory } from './custom_element';
 import { embeddablesServiceFactory } from './embeddables';
 import { expressionsServiceFactory } from './expressions';
+import { labsServiceFactory } from './labs';
 import { navLinkServiceFactory } from './nav_link';
 import { notifyServiceFactory } from './notify';
 import { platformServiceFactory } from './platform';
@@ -25,6 +26,7 @@ import { workpadServiceFactory } from './workpad';
 
 export { customElementServiceFactory } from './custom_element';
 export { expressionsServiceFactory } from './expressions';
+export { labsServiceFactory } from './labs';
 export { navLinkServiceFactory } from './nav_link';
 export { notifyServiceFactory } from './notify';
 export { platformServiceFactory } from './platform';
@@ -35,6 +37,7 @@ export const pluginServiceProviders: PluginServiceProviders<CanvasPluginServices
   customElement: new PluginServiceProvider(customElementServiceFactory),
   embeddables: new PluginServiceProvider(embeddablesServiceFactory),
   expressions: new PluginServiceProvider(expressionsServiceFactory),
+  labs: new PluginServiceProvider(labsServiceFactory),
   navLink: new PluginServiceProvider(navLinkServiceFactory),
   notify: new PluginServiceProvider(notifyServiceFactory),
   platform: new PluginServiceProvider(platformServiceFactory),

--- a/x-pack/plugins/canvas/public/services/stubs/labs.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/labs.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { projectIDs } from '../../../../../../../src/plugins/presentation_util/public';
+import {
+  PluginServiceFactory,
+  projectIDs,
+} from '../../../../../../src/plugins/presentation_util/public';
 import { CanvasLabsService } from '../labs';
+
+type CanvasLabsServiceFactory = PluginServiceFactory<CanvasLabsService>;
 
 const noop = (..._args: any[]): any => {};
 
-export const labsService: CanvasLabsService = {
+export const labsServiceFactory: CanvasLabsServiceFactory = () => ({
   getProject: noop,
   getProjects: noop,
   getProjectIDs: () => projectIDs,
@@ -19,4 +24,4 @@ export const labsService: CanvasLabsService = {
   projectIDs,
   reset: noop,
   setProjectStatus: noop,
-};
+});


### PR DESCRIPTION
> Reviewable portion of https://github.com/elastic/kibana/pull/103202

## Summary

This PR creates a Canvas-specific Labs Service based on the Services Abstraction API and removes the legacy service.  This service basically adds the ability to know if the Labs UI is enabled to the Presentation Util labs service.

## What is this?

In https://github.com/elastic/kibana/pull/88112 the Presentation Team created a Service Abstraction API which allows any of our solutions to uniformly (and safely) create abstractions between external services and the means by which we use them.  It also provides a standard method for "swapping" service implementations at "start" time, (e.g. Kibana setup/start, or Storybook start, or Jest setup, etc).  That means, for example, Storybook Controls can give arguments to the services to adjust mocks on-the-fly from the Storybook application.

> For more information, check out [the docs](https://github.com/elastic/kibana/tree/master/src/plugins/presentation_util#plugin-services-toolkit).

Canvas already had a rough service abstraction layer that was a bit rigid, but was also unsafe: the singleton providing services was defined as a _module-level constant_.  This means it exists and can be accessed outside the setup/start lifecycle of a Kibana plugin. 😞 

This forthcoming collection of PRs moves each individual service abstraction to our "official" API and removes the legacy service.  This makes it easier to review and test each service.