### PR TITLE
[7.x] Fix typo in ReasonFound test (#102690)

### DIFF
--- a/x-pack/plugins/monitoring/public/components/no_data/reasons/reason_found.test.js
+++ b/x-pack/plugins/monitoring/public/components/no_data/reasons/reason_found.test.js
@@ -58,7 +58,7 @@ describe('ReasonFound', () => {
           data: 'false',
           context: 'fakeContext',
         }}
-        enabled={enabler}
+        enabler={enabler}
       />
     );
     expect(component).toMatchSnapshot();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo in ReasonFound test (#102690)