### PR TITLE
Disable reporting for all "oss: false" integration tests

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/integration_tests/migration.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/migration.test.ts
@@ -95,12 +95,6 @@ describe('migration v2', () => {
             },
           ],
         },
-        // reporting loads headless browser, that prevents nodejs process from exiting.
-        xpack: {
-          reporting: {
-            enabled: false,
-          },
-        },
       },
       {
         oss,

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7.7.2_xpack_100k.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7.7.2_xpack_100k.test.ts
@@ -24,8 +24,7 @@ async function removeLogFile() {
   await unlink(logFilePath).catch(() => void 0);
 }
 
-// FLAKY: https://github.com/elastic/kibana/issues/96895
-describe.skip('migration from 7.7.2-xpack with 100k objects', () => {
+describe('migration from 7.7.2-xpack with 100k objects', () => {
   let esServer: kbnTestServer.TestElasticsearchUtils;
   let root: Root;
   let coreStart: InternalCoreStart;

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7_13_0_failed_action_tasks.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/migration_7_13_0_failed_action_tasks.test.ts
@@ -133,12 +133,6 @@ function createRoot() {
           },
         ],
       },
-      xpack: {
-        reporting: {
-          // browser install causes issues with Jest
-          enabled: false,
-        },
-      },
     },
     {
       oss: false,

--- a/src/core/test_helpers/kbn_server.ts
+++ b/src/core/test_helpers/kbn_server.ts
@@ -105,6 +105,17 @@ export function createRootWithCorePlugins(settings = {}, cliArgs: Partial<CliArg
       username: kibanaServerTestUser.username,
       password: kibanaServerTestUser.password,
     },
+    // createRootWithSettings sets default value to "true", so undefined should be threatened as "true".
+    ...(cliArgs.oss === false
+      ? {
+          // reporting loads headless browser, that prevents nodejs process from exiting and causes test flakiness
+          xpack: {
+            reporting: {
+              enabled: false,
+            },
+          },
+        }
+      : {}),
   };
 
   return createRootWithSettings(


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/96895
Considering that we should run tests against the default dist that includes `x-pack` folder, I'd say that the right solution is to disable the loading Chromium binary on CI https://github.com/elastic/kibana/issues/102919