### PR TITLE
[7.x] [Vislib] Removes the angular import (#106968)

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/lib/binder.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/binder.ts
@@ -8,7 +8,6 @@
 
 import d3 from 'd3';
 import $ from 'jquery';
-import { IScope } from 'angular';
 
 export interface Emitter {
   on: (...args: any[]) => void;
@@ -19,13 +18,6 @@ export interface Emitter {
 
 export class Binder {
   private disposal: Array<() => void> = [];
-
-  constructor($scope: IScope) {
-    // support auto-binding to $scope objects
-    if ($scope) {
-      $scope.$on('$destroy', () => this.destroy());
-    }
-  }
 
   public on(emitter: Emitter, ...args: any[]) {
     const on = emitter.on || emitter.addListener;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Vislib] Removes the angular import (#106968)