### PR TITLE
[7.x] use IndexPattern instead of IIndexPattern (#107225)

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -30,7 +30,7 @@ import {
   esFilters,
   FilterManager,
   IFieldType,
-  IIndexPattern,
+  IndexPattern,
   Query,
 } from '../../../../../src/plugins/data/public';
 import { TopNavMenuData } from '../../../../../src/plugins/navigation/public';
@@ -182,7 +182,7 @@ describe('Lens App', () => {
 
   it('updates global filters with store state', async () => {
     const services = makeDefaultServices(sessionIdSubject);
-    const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+    const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
     const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
     const pinnedFilter = esFilters.buildExistsFilter(pinnedField, indexPattern);
     services.data.query.filterManager.getFilters = jest.fn().mockImplementation(() => {
@@ -634,7 +634,7 @@ describe('Lens App', () => {
       });
 
       it('saves app filters and does not save pinned filters', async () => {
-        const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+        const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
         const field = ({ name: 'myfield' } as unknown) as IFieldType;
         const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
         const unpinned = esFilters.buildExistsFilter(field, indexPattern);
@@ -816,7 +816,7 @@ describe('Lens App', () => {
 
     it('updates the filters when the user changes them', async () => {
       const { instance, services, lensStore } = await mountWith({});
-      const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+      const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
       const field = ({ name: 'myfield' } as unknown) as IFieldType;
       expect(lensStore.getState()).toEqual({
         lens: expect.objectContaining({
@@ -871,7 +871,7 @@ describe('Lens App', () => {
           searchSessionId: `sessionId-3`,
         }),
       });
-      const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+      const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
       const field = ({ name: 'myfield' } as unknown) as IFieldType;
       act(() =>
         services.data.query.filterManager.setFilters([
@@ -1006,7 +1006,7 @@ describe('Lens App', () => {
           query: { query: 'new', language: 'lucene' },
         })
       );
-      const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+      const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
       const field = ({ name: 'myfield' } as unknown) as IFieldType;
       const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
       const unpinned = esFilters.buildExistsFilter(field, indexPattern);
@@ -1063,7 +1063,7 @@ describe('Lens App', () => {
           query: { query: 'new', language: 'lucene' },
         })
       );
-      const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+      const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
       const field = ({ name: 'myfield' } as unknown) as IFieldType;
       const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
       const unpinned = esFilters.buildExistsFilter(field, indexPattern);

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../mocks';
 import { act } from 'react-dom/test-utils';
 import { ReactExpressionRendererType } from '../../../../../../src/plugins/expressions/public';
-import { esFilters, IFieldType, IIndexPattern } from '../../../../../../src/plugins/data/public';
+import { esFilters, IFieldType, IndexPattern } from '../../../../../../src/plugins/data/public';
 import { SuggestionPanel, SuggestionPanelProps } from './suggestion_panel';
 import { getSuggestions, Suggestion } from './suggestion_helpers';
 import { EuiIcon, EuiPanel, EuiToolTip } from '@elastic/eui';
@@ -291,7 +291,7 @@ describe('suggestion_panel', () => {
     (mockVisualization.toPreviewExpression as jest.Mock).mockReturnValueOnce('test | expression');
     mockDatasource.toExpression.mockReturnValue('datasource_expression');
 
-    const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+    const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
     const field = ({ name: 'myfield' } as unknown) as IFieldType;
 
     mountWithProvider(

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -28,7 +28,7 @@ import { ReactWrapper } from 'enzyme';
 import { DragDrop, ChildDragDropProvider } from '../../../drag_drop';
 import { fromExpression } from '@kbn/interpreter/common';
 import { coreMock } from 'src/core/public/mocks';
-import { esFilters, IFieldType, IIndexPattern } from '../../../../../../../src/plugins/data/public';
+import { esFilters, IFieldType, IndexPattern } from '../../../../../../../src/plugins/data/public';
 import { UiActionsStart } from '../../../../../../../src/plugins/ui_actions/public';
 import { uiActionsPluginMock } from '../../../../../../../src/plugins/ui_actions/public/mocks';
 import { TriggerContract } from '../../../../../../../src/plugins/ui_actions/public/triggers';
@@ -443,7 +443,7 @@ describe('workspace_panel', () => {
 
     expect(expressionRendererMock).toHaveBeenCalledTimes(1);
 
-    const indexPattern = ({ id: 'index1' } as unknown) as IIndexPattern;
+    const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
     const field = ({ name: 'myfield' } as unknown) as IFieldType;
 
     await act(async () => {

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -12,7 +12,6 @@ import type { ExecutionContextServiceStart } from 'src/core/public';
 import {
   ExecutionContextSearch,
   Filter,
-  IIndexPattern,
   Query,
   TimefilterContract,
   TimeRange,
@@ -83,7 +82,7 @@ export type LensByReferenceInput = SavedObjectEmbeddableInput & LensBaseEmbeddab
 export type LensEmbeddableInput = LensByValueInput | LensByReferenceInput;
 
 export interface LensEmbeddableOutput extends EmbeddableOutput {
-  indexPatterns?: IIndexPattern[];
+  indexPatterns?: IndexPattern[];
 }
 
 export interface LensEmbeddableDeps {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
@@ -40,7 +40,7 @@ import { trackUiEvent } from '../lens_ui_telemetry';
 import { loadIndexPatterns, syncExistingFields } from './loader';
 import { fieldExists } from './pure_helpers';
 import { Loader } from '../loader';
-import { esQuery, IIndexPattern } from '../../../../../src/plugins/data/public';
+import { esQuery } from '../../../../../src/plugins/data/public';
 import { IndexPatternFieldEditorStart } from '../../../../../src/plugins/index_pattern_field_editor/public';
 import { VISUALIZE_GEO_FIELD_TRIGGER } from '../../../../../src/plugins/ui_actions/public';
 
@@ -94,7 +94,7 @@ const fieldTypeNames: Record<DataType, string> = {
 // Wrapper around esQuery.buildEsQuery, handling errors (e.g. because a query can't be parsed) by
 // returning a query dsl object not matching anything
 function buildSafeEsQuery(
-  indexPattern: IIndexPattern,
+  indexPattern: IndexPattern,
   query: Query,
   filters: Filter[],
   queryConfig: EsQueryConfig
@@ -164,7 +164,7 @@ export function IndexPatternDataPanel({
     }));
 
   const dslQuery = buildSafeEsQuery(
-    indexPatterns[currentIndexPatternId] as IIndexPattern,
+    indexPatterns[currentIndexPatternId],
     query,
     filters,
     esQuery.getEsQueryConfig(core.uiSettings)

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -44,7 +44,6 @@ import {
   ES_FIELD_TYPES,
   Filter,
   esQuery,
-  IIndexPattern,
 } from '../../../../../src/plugins/data/public';
 import { FieldButton } from '../../../../../src/plugins/kibana_react/public';
 import { ChartsPluginSetup } from '../../../../../src/plugins/charts/public';
@@ -169,7 +168,7 @@ export const InnerFieldItem = function InnerFieldItem(props: FieldItemProps) {
       .post(`/api/lens/index_stats/${indexPattern.id}/field`, {
         body: JSON.stringify({
           dslQuery: esQuery.buildEsQuery(
-            indexPattern as IIndexPattern,
+            indexPattern,
             query,
             filters,
             esQuery.getEsQueryConfig(core.uiSettings)

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -19,11 +19,7 @@ import {
 import { uniq } from 'lodash';
 import { CoreStart } from 'kibana/public';
 import { FieldStatsResponse } from '../../../../../common';
-import {
-  AggFunctionsMapping,
-  esQuery,
-  IIndexPattern,
-} from '../../../../../../../../src/plugins/data/public';
+import { AggFunctionsMapping, esQuery } from '../../../../../../../../src/plugins/data/public';
 import { buildExpressionFunction } from '../../../../../../../../src/plugins/expressions/public';
 import { updateColumnParam, isReferenced } from '../../layer_helpers';
 import { DataType, FramePublicAPI } from '../../../../types';
@@ -99,7 +95,7 @@ function getDisallowedTermsMessage(
               body: JSON.stringify({
                 fieldName,
                 dslQuery: esQuery.buildEsQuery(
-                  indexPattern as IIndexPattern,
+                  indexPattern,
                   frame.query,
                   frame.filters,
                   esQuery.getEsQueryConfig(core.uiSettings)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - use IndexPattern instead of IIndexPattern (#107225)