### PR TITLE
[APM] Adds custom tabs with new UI extension point 'package-policy-edit-tabs'

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -31,6 +31,11 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
   packageInfo?: PackageInfo;
   integrationInfo?: RegistryPolicyTemplate;
   'data-test-subj'?: string;
+  tabs?: Array<{
+    title: string;
+    isSelected: boolean;
+    onClick: React.ReactEventHandler;
+  }>;
 }> = memo(
   ({
     from,
@@ -41,6 +46,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
     integrationInfo,
     children,
     'data-test-subj': dataTestSubj,
+    tabs = [],
   }) => {
     const pageTitle = useMemo(() => {
       if (
@@ -184,6 +190,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
         rightColumn={rightColumn}
         rightColumnGrow={false}
         data-test-subj={dataTestSubj}
+        tabs={tabs.map(({ title, ...rest }) => ({ name: title, ...rest }))}
       >
         {children}
       </WithHeaderLayout>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -332,30 +332,58 @@ export const EditPackagePolicyForm = memo<{
     }
   };
 
+  const extensionView = useUIExtension(packagePolicy.package?.name ?? '', 'package-policy-edit');
+  const extensionTabsView = useUIExtension(
+    packagePolicy.package?.name ?? '',
+    'package-policy-edit-tabs'
+  );
+  const tabsViews = extensionTabsView?.tabs ?? [];
+  const [selectedTab, setSelectedTab] = useState(0);
+
   const layoutProps = {
     from,
     cancelUrl,
     agentPolicy,
     packageInfo,
+    tabs: tabsViews.length
+      ? [
+          {
+            title: i18n.translate('xpack.fleet.editPackagePolicy.settingsTabName', {
+              defaultMessage: 'Settings',
+            }),
+            isSelected: selectedTab === 0,
+            onClick: () => {
+              setSelectedTab(0);
+            },
+          },
+          ...tabsViews.map(({ title }, index) => ({
+            title,
+            isSelected: selectedTab === index + 1,
+            onClick: () => {
+              setSelectedTab(index + 1);
+            },
+          })),
+        ]
+      : [],
   };
-
-  const extensionView = useUIExtension(packagePolicy.package?.name ?? '', 'package-policy-edit');
 
   const configurePackage = useMemo(
     () =>
       agentPolicy && packageInfo ? (
         <>
-          <StepDefinePackagePolicy
-            agentPolicy={agentPolicy}
-            packageInfo={packageInfo}
-            packagePolicy={packagePolicy}
-            updatePackagePolicy={updatePackagePolicy}
-            validationResults={validationResults!}
-            submitAttempted={formState === 'INVALID'}
-          />
+          {selectedTab === 0 && (
+            <StepDefinePackagePolicy
+              agentPolicy={agentPolicy}
+              packageInfo={packageInfo}
+              packagePolicy={packagePolicy}
+              updatePackagePolicy={updatePackagePolicy}
+              validationResults={validationResults!}
+              submitAttempted={formState === 'INVALID'}
+            />
+          )}
 
           {/* Only show the out-of-box configuration step if a UI extension is NOT registered */}
-          {!extensionView && (
+          {!extensionView && selectedTab === 0 && (
             <StepConfigurePackagePolicy
               packageInfo={packageInfo}
               packagePolicy={packagePolicy}
@@ -370,11 +398,19 @@ export const EditPackagePolicyForm = memo<{
             packagePolicy.package?.name &&
             originalPackagePolicy && (
               <ExtensionWrapper>
-                <extensionView.Component
-                  policy={originalPackagePolicy}
-                  newPolicy={packagePolicy}
-                  onChange={handleExtensionViewOnChange}
-                />
+                {selectedTab === 0 ? (
+                  <extensionView.Component
+                    policy={originalPackagePolicy}
+                    newPolicy={packagePolicy}
+                    onChange={handleExtensionViewOnChange}
+                  />
+                ) : (
+                  React.createElement(tabsViews[selectedTab - 1].Component, {
+                    policy: originalPackagePolicy,
+                    newPolicy: packagePolicy,
+                    onChange: handleExtensionViewOnChange,
+                  })
+                )}
               </ExtensionWrapper>
             )}
         </>
@@ -389,6 +425,7 @@ export const EditPackagePolicyForm = memo<{
       originalPackagePolicy,
       extensionView,
       handleExtensionViewOnChange,
+      selectedTab,
     ]
   );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -337,7 +337,7 @@ export const EditPackagePolicyForm = memo<{
     packagePolicy.package?.name ?? '',
     'package-policy-edit-tabs'
   );
-  const tabsViews = extensionTabsView?.tabs ?? [];
+  const tabsViews = extensionTabsView?.tabs;
   const [selectedTab, setSelectedTab] = useState(0);
 
   const layoutProps = {
@@ -345,7 +345,7 @@ export const EditPackagePolicyForm = memo<{
     cancelUrl,
     agentPolicy,
     packageInfo,
-    tabs: tabsViews.length
+    tabs: tabsViews?.length
       ? [
           {
             title: i18n.translate('xpack.fleet.editPackagePolicy.settingsTabName', {
@@ -398,18 +398,18 @@ export const EditPackagePolicyForm = memo<{
             packagePolicy.package?.name &&
             originalPackagePolicy && (
               <ExtensionWrapper>
-                {selectedTab === 0 ? (
-                  <extensionView.Component
-                    policy={originalPackagePolicy}
-                    newPolicy={packagePolicy}
-                    onChange={handleExtensionViewOnChange}
-                  />
-                ) : (
+                {selectedTab > 0 && tabsViews ? (
                   React.createElement(tabsViews[selectedTab - 1].Component, {
                     policy: originalPackagePolicy,
                     newPolicy: packagePolicy,
                     onChange: handleExtensionViewOnChange,
                   })
+                ) : (
+                  <extensionView.Component
+                    policy={originalPackagePolicy}
+                    newPolicy={packagePolicy}
+                    onChange={handleExtensionViewOnChange}
+                  />
                 )}
               </ExtensionWrapper>
             )}
@@ -426,6 +426,7 @@ export const EditPackagePolicyForm = memo<{
       extensionView,
       handleExtensionViewOnChange,
       selectedTab,
+      tabsViews,
     ]
   );
 

--- a/x-pack/plugins/fleet/public/types/ui_extensions.ts
+++ b/x-pack/plugins/fleet/public/types/ui_extensions.ts
@@ -52,6 +52,16 @@ export interface PackagePolicyEditExtension {
   Component: LazyExoticComponent<PackagePolicyEditExtensionComponent>;
 }
 
+/** Extension point registration contract for Integration Policy Edit tabs views */
+export interface PackagePolicyEditTabsExtension {
+  package: string;
+  view: 'package-policy-edit-tabs';
+  tabs: Array<{
+    title: EuiStepProps['title'];
+    Component: LazyExoticComponent<PackagePolicyEditExtensionComponent>;
+  }>;
+}
+
 /**
  * UI Component Extension is used on the pages displaying the ability to Create an
  * Integration Policy
@@ -120,6 +130,7 @@ export interface AgentEnrollmentFlyoutFinalStepExtension {
 /** Fleet UI Extension Point */
 export type UIExtensionPoint =
   | PackagePolicyEditExtension
+  | PackagePolicyEditTabsExtension
   | PackageCustomExtension
   | PackagePolicyCreateExtension
   | PackageAssetsExtension


### PR DESCRIPTION
Related to #106440.

Adds a new UI extension point `'package-policy-edit-tabs'` to organize custom integration settings into additional tabs in the Edit Integration Settings page. It  renders the component when the tab is selected. It's the same behavior as `package-policy-edit` extensions (which will continue to customize the base settings).

![fleet-policy-edit-tabs-extension](https://user-images.githubusercontent.com/1967266/127877218-016e1c7a-3b15-45c3-8f16-e790a8c6daea.gif)
