### PR TITLE
[App Search] Crawler Overview: Migrate Crawl Requests Table, Add Domains Table empty state

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -304,6 +304,7 @@ describe('AddDomainLogic', () => {
           http.post.mockReturnValueOnce(
             Promise.resolve({
               domains: [],
+              crawl_requests: [],
             })
           );
 
@@ -312,6 +313,7 @@ describe('AddDomainLogic', () => {
 
           expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith({
             domains: [],
+            crawlRequests: [],
           });
         });
 
@@ -328,6 +330,7 @@ describe('AddDomainLogic', () => {
                   name: 'https://swiftype.co/site-search',
                 },
               ],
+              crawl_requests: [],
             })
           );
           jest.spyOn(AddDomainLogic.actions, 'onSubmitNewDomainSuccess');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/add_domain_logic.test.ts
@@ -304,7 +304,6 @@ describe('AddDomainLogic', () => {
           http.post.mockReturnValueOnce(
             Promise.resolve({
               domains: [],
-              crawl_requests: [],
             })
           );
 
@@ -313,7 +312,6 @@ describe('AddDomainLogic', () => {
 
           expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith({
             domains: [],
-            crawlRequests: [],
           });
         });
 
@@ -330,7 +328,6 @@ describe('AddDomainLogic', () => {
                   name: 'https://swiftype.co/site-search',
                 },
               ],
-              crawl_requests: [],
             })
           );
           jest.spyOn(AddDomainLogic.actions, 'onSubmitNewDomainSuccess');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -56,7 +56,7 @@ const values: { domains: CrawlerDomain[]; crawlRequests: CrawlRequest[] } = {
   ],
 };
 
-describe('DomainsTable', () => {
+describe('CrawlRequestsTable', () => {
   let wrapper: ShallowWrapper;
   let tableContent: string;
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__/kea_logic';
+import '../../../__mocks__/engine_logic.mock';
+
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiBasicTable, EuiEmptyPrompt } from '@elastic/eui';
+
+import { mountWithIntl } from '../../../../test_helpers';
+
+import {
+  CrawlerDomain,
+  CrawlerPolicies,
+  CrawlerRules,
+  CrawlerStatus,
+  CrawlRequest,
+} from '../types';
+
+import { CrawlRequestsTable } from './crawl_requests_table';
+
+const values: { domains: CrawlerDomain[]; crawlRequests: CrawlRequest[] } = {
+  // CrawlerOverviewLogic
+  domains: [
+    {
+      id: '507f1f77bcf86cd799439011',
+      createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      url: 'elastic.co',
+      documentCount: 13,
+      sitemaps: [],
+      entryPoints: [],
+      crawlRules: [],
+      defaultCrawlRule: {
+        id: '-',
+        policy: CrawlerPolicies.allow,
+        rule: CrawlerRules.regex,
+        pattern: '.*',
+      },
+    },
+  ],
+  crawlRequests: [
+    {
+      id: '618d0e66abe97bc688328900',
+      status: CrawlerStatus.Pending,
+      createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      beganAt: null,
+      completedAt: null,
+    },
+  ],
+};
+
+describe('DomainsTable', () => {
+  let wrapper: ShallowWrapper;
+  let tableContent: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('columns', () => {
+    beforeAll(() => {
+      setMockValues(values);
+      wrapper = shallow(<CrawlRequestsTable />);
+      tableContent = mountWithIntl(<CrawlRequestsTable />)
+        .find(EuiBasicTable)
+        .text();
+    });
+
+    it('renders an id column', () => {
+      expect(tableContent).toContain('618d0e66abe97bc688328900');
+    });
+
+    it('renders a created at column', () => {
+      expect(tableContent).toContain('Created');
+      expect(tableContent).toContain('Aug 31, 2020');
+    });
+
+    it('renders a status column', () => {
+      expect(tableContent).toContain('Status');
+      expect(tableContent).toContain('Pending');
+    });
+  });
+
+  describe('no items message', () => {
+    it('displays an empty prompt when there are no crawl requests', () => {
+      setMockValues({
+        ...values,
+        crawlRequests: [],
+      });
+
+      wrapper = shallow(<CrawlRequestsTable />);
+
+      expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -97,7 +97,7 @@ describe('CrawlRequestsTable', () => {
 
       wrapper = shallow(<CrawlRequestsTable />);
 
-      expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+      expect(wrapper.find(EuiBasicTable).dive().find(EuiEmptyPrompt)).toHaveLength(1);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -55,32 +55,35 @@ const columns: Array<EuiTableFieldDataColumnType<CrawlRequest>> = [
 export const CrawlRequestsTable: React.FC = () => {
   const { crawlRequests } = useValues(CrawlerOverviewLogic);
 
-  if (crawlRequests.length === 0) {
-    return (
-      <EuiEmptyPrompt
-        iconType="tableDensityExpanded"
-        title={
-          <h3>
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.title',
-              {
-                defaultMessage: 'No recent crawl requests',
-              }
-            )}
-          </h3>
-        }
-        body={
-          <p>
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.body',
-              {
-                defaultMessage: "You haven't started any crawls yet.",
-              }
-            )}
-          </p>
-        }
-      />
-    );
-  }
-  return <EuiBasicTable columns={columns} items={crawlRequests} />;
+  return (
+    <EuiBasicTable
+      columns={columns}
+      items={crawlRequests}
+      noItemsMessage={
+        <EuiEmptyPrompt
+          iconType="tableDensityExpanded"
+          title={
+            <h3>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.title',
+                {
+                  defaultMessage: 'No recent crawl requests',
+                }
+              )}
+            </h3>
+          }
+          body={
+            <p>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.body',
+                {
+                  defaultMessage: "You haven't started any crawls yet.",
+                }
+              )}
+            </p>
+          }
+        />
+      }
+    />
+  );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiBasicTable, EuiEmptyPrompt, EuiTableFieldDataColumnType } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { CrawlerOverviewLogic } from '../crawler_overview_logic';
+import { CrawlRequest, readableCrawlerStatuses } from '../types';
+
+import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
+
+const columns: Array<EuiTableFieldDataColumnType<CrawlRequest>> = [
+  {
+    field: 'id',
+    name: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.domainURL',
+      {
+        defaultMessage: 'Request ID',
+      }
+    ),
+  },
+  {
+    field: 'createdAt',
+    name: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.created',
+      {
+        defaultMessage: 'Created',
+      }
+    ),
+    render: (createdAt: CrawlRequest['createdAt']) => (
+      <CustomFormattedTimestamp timestamp={createdAt} />
+    ),
+  },
+  {
+    field: 'status',
+    name: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.status',
+      {
+        defaultMessage: 'Status',
+      }
+    ),
+    render: (status: CrawlRequest['status']) => readableCrawlerStatuses[status],
+  },
+];
+
+export const CrawlRequestsTable: React.FC = () => {
+  const { crawlRequests } = useValues(CrawlerOverviewLogic);
+
+  if (crawlRequests.length === 0) {
+    return (
+      <EuiEmptyPrompt
+        iconType="tableDensityExpanded"
+        title={
+          <h3>
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.title',
+              {
+                defaultMessage: 'No recent crawl requests',
+              }
+            )}
+          </h3>
+        }
+        body={
+          <p>
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.body',
+              {
+                defaultMessage: "You haven't started any crawls yet.",
+              }
+            )}
+          </p>
+        }
+      />
+    );
+  }
+  return <EuiBasicTable columns={columns} items={crawlRequests} />;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -14,6 +14,8 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { AddDomainForm } from './components/add_domain/add_domain_form';
+import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
@@ -94,15 +96,15 @@ describe('CrawlerOverview', () => {
     expect(mockActions.fetchCrawlerData).toHaveBeenCalledTimes(1);
   });
 
-  // TODO update below line to 'hides the domain and crawl request tables when there are no domains, and no crawl requests' after empty state is added
-  it('shows domain table and hides the crawl request table when there are no domains, and no crawl requests', () => {
+  it('hides the domain and crawl request tables when there are no domains, and no crawl requests', () => {
     setMockValues({ ...mockValues, domains: [], crawlRequests: [] });
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
-    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
-    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(0);
+    expect(wrapper.find(DomainsTable)).toHaveLength(0);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(0);
   });
 
@@ -111,21 +113,22 @@ describe('CrawlerOverview', () => {
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(0);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(0);
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 
-  // TODO update below line to 'hides the domain table and shows the crawl request tables when there are crawl requests but no domains' after empty state is added
-  it('shows the domain and the crawl request tables when there are crawl requests, but no domains', () => {
+  it('hides the domain table and shows the crawl request tables when there are crawl requests but no domains', () => {
     setMockValues({ ...mockValues, domains: [] });
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
-    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
-    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(0);
+    expect(wrapper.find(DomainsTable)).toHaveLength(0);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 
@@ -134,7 +137,8 @@ describe('CrawlerOverview', () => {
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(0);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(0);
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -11,12 +11,64 @@ import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
+import {
+  CrawlerDomainFromServer,
+  CrawlerPolicies,
+  CrawlerRules,
+  CrawlerStatus,
+  CrawlRequestFromServer,
+} from './types';
+
+const domains: CrawlerDomainFromServer[] = [
+  {
+    id: 'x',
+    name: 'moviedatabase.com',
+    document_count: 13,
+    created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    sitemaps: [],
+    entry_points: [],
+    crawl_rules: [],
+    default_crawl_rule: {
+      id: '-',
+      policy: CrawlerPolicies.allow,
+      rule: CrawlerRules.regex,
+      pattern: '.*',
+    },
+  },
+  {
+    id: 'y',
+    name: 'swiftype.com',
+    last_visited_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    document_count: 40,
+    created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    sitemaps: [],
+    entry_points: [],
+    crawl_rules: [],
+  },
+];
+
+const crawlRequests: CrawlRequestFromServer[] = [
+  {
+    id: 'a',
+    status: CrawlerStatus.Canceled,
+    created_at: 'Mon, 31 Aug 2020 11:00:00 +0000',
+    began_at: 'Mon, 31 Aug 2020 12:00:00 +0000',
+    completed_at: 'Mon, 31 Aug 2020 13:00:00 +0000',
+  },
+  {
+    id: 'b',
+    status: CrawlerStatus.Success,
+    created_at: 'Mon, 31 Aug 2020 14:00:00 +0000',
+    began_at: 'Mon, 31 Aug 2020 15:00:00 +0000',
+    completed_at: 'Mon, 31 Aug 2020 16:00:00 +0000',
+  },
+];
 
 describe('CrawlerOverview', () => {
   const mockActions = {
@@ -25,29 +77,66 @@ describe('CrawlerOverview', () => {
 
   const mockValues = {
     dataLoading: false,
-    domains: [],
+    domains,
+    crawlRequests,
   };
-
-  let wrapper: ShallowWrapper;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    setMockValues(mockValues);
     setMockActions(mockActions);
-    wrapper = shallow(<CrawlerOverview />);
   });
 
   it('calls fetchCrawlerData on page load', () => {
+    setMockValues(mockValues);
+
+    shallow(<CrawlerOverview />);
+
     expect(mockActions.fetchCrawlerData).toHaveBeenCalledTimes(1);
   });
 
-  it('renders', () => {
-    expect(wrapper.find(DomainsTable)).toHaveLength(1);
+  // TODO update below line to 'hides the domain and crawl request tables when there are no domains, and no crawl requests' after empty state is added
+  it('shows domain table and hides the crawl request table when there are no domains, and no crawl requests', () => {
+    setMockValues({ ...mockValues, domains: [], crawlRequests: [] });
 
-    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+    const wrapper = shallow(<CrawlerOverview />);
 
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(0);
+  });
+
+  it('shows the domain and the crawl request tables when there are domains, but no crawl requests', () => {
+    setMockValues({ ...mockValues, crawlRequests: [] });
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
+    expect(wrapper.find(DomainsTable)).toHaveLength(1);
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+  });
 
-    // TODO test for empty state after it is built in a future PR
+  // TODO update below line to 'hides the domain table and shows the crawl request tables when there are crawl requests but no domains' after empty state is added
+  it('shows the domain and the crawl request tables when there are crawl requests, but no domains', () => {
+    setMockValues({ ...mockValues, domains: [] });
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+  });
+
+  it('shows the domain and the crawl request tableswhen there are crawl requests and domains', () => {
+    setMockValues(mockValues);
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
+    expect(wrapper.find(DomainsTable)).toHaveLength(1);
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
 
@@ -43,7 +44,7 @@ describe('CrawlerOverview', () => {
   it('renders', () => {
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
 
-    // TODO test for CrawlRequestsTable after it is built in a future PR
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
 
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -132,7 +132,7 @@ describe('CrawlerOverview', () => {
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 
-  it('shows the domain and the crawl request tableswhen there are crawl requests and domains', () => {
+  it('shows the domain and the crawl request tables when there are crawl requests and domains', () => {
     setMockValues(mockValues);
 
     const wrapper = shallow(<CrawlerOverview />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -12,7 +12,6 @@ import { useActions, useValues } from 'kea';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
 
 import { DOCS_PREFIX } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -12,12 +12,15 @@ import { useActions, useValues } from 'kea';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { DOCS_PREFIX } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { AddDomainForm } from './components/add_domain/add_domain_form';
+import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
@@ -38,22 +41,59 @@ export const CrawlerOverview: React.FC = () => {
       pageHeader={{ pageTitle: CRAWLER_TITLE }}
       isLoading={dataLoading}
     >
-      <EuiFlexGroup direction="row" alignItems="stretch">
-        <EuiFlexItem>
+      {domains.length > 0 ? (
+        <>
+          <EuiFlexGroup direction="row" alignItems="stretch">
+            <EuiFlexItem>
+              <EuiTitle size="s">
+                <h3>
+                  {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTitle', {
+                    defaultMessage: 'Domains',
+                  })}
+                </h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <AddDomainFlyout />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
+          <DomainsTable />
+        </>
+      ) : (
+        <>
           <EuiTitle size="s">
             <h3>
-              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTitle', {
-                defaultMessage: 'Domains',
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.empty.title', {
+                defaultMessage: 'Add a domain to get started',
               })}
             </h3>
           </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <AddDomainFlyout />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <DomainsTable />
+          <EuiText>
+            <p>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.empty.description', {
+                defaultMessage:
+                  "Easily index your website's content. To get started, enter your domain name, provide optional entry points and crawl rules, and we will handle the rest.",
+              })}{' '}
+              <EuiLink external target="_blank" href={`${DOCS_PREFIX}/web-crawler.html`}>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.empty.crawlerDocumentationLinkDescription',
+                  {
+                    defaultMessage: 'Learn more about the web crawler',
+                  }
+                )}
+              </EuiLink>
+            </p>
+          </EuiText>
+          <AddDomainForm />
+          <EuiSpacer />
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <AddDomainFormSubmitButton />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
       {(crawlRequests.length > 0 || domains.length > 0) && (
         <>
           <EuiSpacer size="xl" />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -108,7 +108,7 @@ export const CrawlerOverview: React.FC = () => {
             <p>
               {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
                 defaultMessage:
-                  "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
+                  "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces.",
               })}{' '}
               <EuiLink
                 href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -9,14 +9,16 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
+import { DOCS_PREFIX } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
@@ -52,6 +54,37 @@ export const CrawlerOverview: React.FC = () => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <DomainsTable />
+      <EuiSpacer size="m" />
+      <EuiTitle size="s">
+        <h3>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
+            defaultMessage: 'Recent Crawl Requests',
+          })}
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="xs" />
+      <EuiText color="subdued" size="s">
+        <p>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
+            defaultMessage:
+              "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
+          })}{' '}
+          <EuiLink
+            href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}
+            target="_blank"
+            external
+          >
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.configurationDocumentationLinkDescription',
+              {
+                defaultMessage: 'Learn more about configuring crawler logs in Kibana',
+              }
+            )}
+          </EuiLink>
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <CrawlRequestsTable />
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -99,7 +99,7 @@ export const CrawlerOverview: React.FC = () => {
           <EuiTitle size="s">
             <h3>
               {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
-                defaultMessage: 'Recent Crawl Requests',
+                defaultMessage: 'Recent crawl requests',
               })}
             </h3>
           </EuiTitle>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -24,7 +24,7 @@ import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
 
 export const CrawlerOverview: React.FC = () => {
-  const { dataLoading } = useValues(CrawlerOverviewLogic);
+  const { crawlRequests, dataLoading, domains } = useValues(CrawlerOverviewLogic);
 
   const { fetchCrawlerData } = useActions(CrawlerOverviewLogic);
 
@@ -54,37 +54,41 @@ export const CrawlerOverview: React.FC = () => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <DomainsTable />
-      <EuiSpacer size="m" />
-      <EuiTitle size="s">
-        <h3>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
-            defaultMessage: 'Recent Crawl Requests',
-          })}
-        </h3>
-      </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText color="subdued" size="s">
-        <p>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
-            defaultMessage:
-              "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
-          })}{' '}
-          <EuiLink
-            href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}
-            target="_blank"
-            external
-          >
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.crawler.configurationDocumentationLinkDescription',
-              {
-                defaultMessage: 'Learn more about configuring crawler logs in Kibana',
-              }
-            )}
-          </EuiLink>
-        </p>
-      </EuiText>
-      <EuiSpacer size="m" />
-      <CrawlRequestsTable />
+      {(crawlRequests.length > 0 || domains.length > 0) && (
+        <>
+          <EuiSpacer size="xl" />
+          <EuiTitle size="s">
+            <h3>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
+                defaultMessage: 'Recent Crawl Requests',
+              })}
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="xs" />
+          <EuiText color="subdued" size="s">
+            <p>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
+                defaultMessage:
+                  "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
+              })}{' '}
+              <EuiLink
+                href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}
+                target="_blank"
+                external
+              >
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.configurationDocumentationLinkDescription',
+                  {
+                    defaultMessage: 'Learn more about configuring crawler logs in Kibana',
+                  }
+                )}
+              </EuiLink>
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+          <CrawlRequestsTable />
+        </>
+      )}
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -45,11 +45,11 @@ export const CrawlerOverview: React.FC = () => {
           <EuiFlexGroup direction="row" alignItems="stretch">
             <EuiFlexItem>
               <EuiTitle size="s">
-                <h3>
+                <h2>
                   {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTitle', {
                     defaultMessage: 'Domains',
                   })}
-                </h3>
+                </h2>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -62,11 +62,11 @@ export const CrawlerOverview: React.FC = () => {
       ) : (
         <>
           <EuiTitle size="s">
-            <h3>
+            <h2>
               {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.empty.title', {
                 defaultMessage: 'Add a domain to get started',
               })}
-            </h3>
+            </h2>
           </EuiTitle>
           <EuiText>
             <p>
@@ -97,11 +97,11 @@ export const CrawlerOverview: React.FC = () => {
         <>
           <EuiSpacer size="xl" />
           <EuiTitle size="s">
-            <h3>
+            <h2>
               {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
                 defaultMessage: 'Recent crawl requests',
               })}
-            </h3>
+            </h2>
           </EuiTitle>
           <EuiSpacer size="xs" />
           <EuiText color="subdued" size="s">

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -16,14 +16,17 @@ import { nextTick } from '@kbn/test/jest';
 
 import { CrawlerOverviewLogic, CrawlerOverviewValues } from './crawler_overview_logic';
 import {
+  CrawlerData,
   CrawlerDataFromServer,
   CrawlerDomain,
   CrawlerPolicies,
   CrawlerRules,
   CrawlerStatus,
+  CrawlRequest,
+  CrawlRequestFromServer,
   CrawlRule,
 } from './types';
-import { crawlerDataServerToClient } from './utils';
+import { crawlerDataServerToClient, crawlRequestServerToClient } from './utils';
 
 const DEFAULT_VALUES: CrawlerOverviewValues = {
   crawlRequests: [],
@@ -38,7 +41,7 @@ const DEFAULT_CRAWL_RULE: CrawlRule = {
   pattern: '.*',
 };
 
-const MOCK_SERVER_DATA: CrawlerDataFromServer = {
+const MOCK_SERVER_CRAWLER_DATA: CrawlerDataFromServer = {
   domains: [
     {
       id: '507f1f77bcf86cd799439011',
@@ -50,18 +53,22 @@ const MOCK_SERVER_DATA: CrawlerDataFromServer = {
       crawl_rules: [],
     },
   ],
-  crawl_requests: [
-    {
-      id: '618d0e66abe97bc688328900',
-      status: CrawlerStatus.Pending,
-      created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
-      began_at: null,
-      completed_at: null,
-    },
-  ],
 };
 
-const MOCK_CLIENT_DATA = crawlerDataServerToClient(MOCK_SERVER_DATA);
+const MOCK_SERVER_CRAWL_REQUESTS_DATA: CrawlRequestFromServer[] = [
+  {
+    id: '618d0e66abe97bc688328900',
+    status: CrawlerStatus.Pending,
+    created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    began_at: null,
+    completed_at: null,
+  },
+];
+
+const MOCK_CLIENT_CRAWLER_DATA = crawlerDataServerToClient(MOCK_SERVER_CRAWLER_DATA);
+const MOCK_CLIENT_CRAWL_REQUESTS_DATA = MOCK_SERVER_CRAWL_REQUESTS_DATA.map(
+  crawlRequestServerToClient
+);
 
 describe('CrawlerOverviewLogic', () => {
   const { mount } = new LogicMounter(CrawlerOverviewLogic);
@@ -79,7 +86,7 @@ describe('CrawlerOverviewLogic', () => {
 
   describe('actions', () => {
     describe('onReceiveCrawlerData', () => {
-      const crawlerData = {
+      const crawlerData: CrawlerData = {
         domains: [
           {
             id: '507f1f77bcf86cd799439011',
@@ -90,15 +97,6 @@ describe('CrawlerOverviewLogic', () => {
             entryPoints: [],
             crawlRules: [],
             defaultCrawlRule: DEFAULT_CRAWL_RULE,
-          },
-        ],
-        crawlRequests: [
-          {
-            id: '618d0e66abe97bc688328900',
-            status: CrawlerStatus.Pending,
-            createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
-            beganAt: null,
-            completedAt: null,
           },
         ],
       };
@@ -115,25 +113,68 @@ describe('CrawlerOverviewLogic', () => {
         expect(CrawlerOverviewLogic.values.dataLoading).toEqual(false);
       });
     });
+
+    describe('onReceiveCrawlRequests', () => {
+      const crawlRequests: CrawlRequest[] = [
+        {
+          id: '618d0e66abe97bc688328900',
+          status: CrawlerStatus.Pending,
+          createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+          beganAt: null,
+          completedAt: null,
+        },
+      ];
+
+      beforeEach(() => {
+        CrawlerOverviewLogic.actions.onReceiveCrawlRequests(crawlRequests);
+      });
+
+      it('should set the crawl requests', () => {
+        expect(CrawlerOverviewLogic.values.crawlRequests).toEqual(crawlRequests);
+      });
+    });
   });
 
   describe('listeners', () => {
     describe('fetchCrawlerData', () => {
-      it('calls onReceiveCrawlerData with retrieved data that has been converted from server to client', async () => {
+      it('updates logic with data that has been converted from server to client', async () => {
         jest.spyOn(CrawlerOverviewLogic.actions, 'onReceiveCrawlerData');
+        // TODO this spyOn should be removed when crawl request polling is added
+        jest.spyOn(CrawlerOverviewLogic.actions, 'onReceiveCrawlRequests');
 
-        http.get.mockReturnValue(Promise.resolve(MOCK_SERVER_DATA));
+        // TODO this first mock for MOCK_SERVER_CRAWL_REQUESTS_DATA should be removed when crawl request polling is added
+        http.get.mockReturnValueOnce(Promise.resolve(MOCK_SERVER_CRAWL_REQUESTS_DATA));
+        http.get.mockReturnValueOnce(Promise.resolve(MOCK_SERVER_CRAWLER_DATA));
         CrawlerOverviewLogic.actions.fetchCrawlerData();
         await nextTick();
 
-        expect(http.get).toHaveBeenCalledWith('/api/app_search/engines/some-engine/crawler');
+        expect(http.get).toHaveBeenNthCalledWith(
+          1,
+          '/api/app_search/engines/some-engine/crawler/crawl_requests'
+        );
+        expect(CrawlerOverviewLogic.actions.onReceiveCrawlRequests).toHaveBeenCalledWith(
+          MOCK_CLIENT_CRAWL_REQUESTS_DATA
+        );
+
+        expect(http.get).toHaveBeenNthCalledWith(2, '/api/app_search/engines/some-engine/crawler');
         expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith(
-          MOCK_CLIENT_DATA
+          MOCK_CLIENT_CRAWLER_DATA
         );
       });
 
-      it('calls flashApiErrors when there is an error', async () => {
-        http.get.mockReturnValue(Promise.reject('error'));
+      // TODO this test should be removed when crawl request polling is added
+      it('calls flashApiErrors when there is an error on the request for crawl results', async () => {
+        http.get.mockReturnValueOnce(Promise.reject('error'));
+        CrawlerOverviewLogic.actions.fetchCrawlerData();
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+
+      it('calls flashApiErrors when there is an error on the request for crawler data', async () => {
+        // TODO this first mock for MOCK_SERVER_CRAWL_REQUESTS_DATA should be removed when crawl request polling is added
+        http.get.mockReturnValueOnce(Promise.resolve(MOCK_SERVER_CRAWL_REQUESTS_DATA));
+        http.get.mockReturnValueOnce(Promise.reject('error'));
         CrawlerOverviewLogic.actions.fetchCrawlerData();
         await nextTick();
 
@@ -145,7 +186,7 @@ describe('CrawlerOverviewLogic', () => {
       it('calls onReceiveCrawlerData with retrieved data that has been converted from server to client', async () => {
         jest.spyOn(CrawlerOverviewLogic.actions, 'onReceiveCrawlerData');
 
-        http.delete.mockReturnValue(Promise.resolve(MOCK_SERVER_DATA));
+        http.delete.mockReturnValue(Promise.resolve(MOCK_SERVER_CRAWLER_DATA));
         CrawlerOverviewLogic.actions.deleteDomain({ id: '1234' } as CrawlerDomain);
         await nextTick();
 
@@ -156,7 +197,7 @@ describe('CrawlerOverviewLogic', () => {
           }
         );
         expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith(
-          MOCK_CLIENT_DATA
+          MOCK_CLIENT_CRAWLER_DATA
         );
         expect(flashSuccessToast).toHaveBeenCalled();
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -14,17 +14,19 @@ import '../../__mocks__/engine_logic.mock';
 
 import { nextTick } from '@kbn/test/jest';
 
-import { CrawlerOverviewLogic } from './crawler_overview_logic';
+import { CrawlerOverviewLogic, CrawlerOverviewValues } from './crawler_overview_logic';
 import {
   CrawlerDataFromServer,
   CrawlerDomain,
   CrawlerPolicies,
   CrawlerRules,
+  CrawlerStatus,
   CrawlRule,
 } from './types';
 import { crawlerDataServerToClient } from './utils';
 
-const DEFAULT_VALUES = {
+const DEFAULT_VALUES: CrawlerOverviewValues = {
+  crawlRequests: [],
   dataLoading: true,
   domains: [],
 };
@@ -46,6 +48,15 @@ const MOCK_SERVER_DATA: CrawlerDataFromServer = {
       sitemaps: [],
       entry_points: [],
       crawl_rules: [],
+    },
+  ],
+  crawl_requests: [
+    {
+      id: '618d0e66abe97bc688328900',
+      status: CrawlerStatus.Pending,
+      created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      began_at: null,
+      completed_at: null,
     },
   ],
 };
@@ -79,6 +90,15 @@ describe('CrawlerOverviewLogic', () => {
             entryPoints: [],
             crawlRules: [],
             defaultCrawlRule: DEFAULT_CRAWL_RULE,
+          },
+        ],
+        crawlRequests: [
+          {
+            id: '618d0e66abe97bc688328900',
+            status: CrawlerStatus.Pending,
+            createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+            beganAt: null,
+            completedAt: null,
           },
         ],
       };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
@@ -14,7 +14,7 @@ import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_message
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlerData, CrawlerDomain } from './types';
+import { CrawlerData, CrawlerDomain, CrawlRequest } from './types';
 import { crawlerDataServerToClient } from './utils';
 
 export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
@@ -28,7 +28,8 @@ export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
     }
   );
 
-interface CrawlerOverviewValues {
+export interface CrawlerOverviewValues {
+  crawlRequests: CrawlRequest[];
   dataLoading: boolean;
   domains: CrawlerDomain[];
 }
@@ -59,6 +60,12 @@ export const CrawlerOverviewLogic = kea<
       [],
       {
         onReceiveCrawlerData: (_, { data: { domains } }) => domains,
+      },
+    ],
+    crawlRequests: [
+      [],
+      {
+        onReceiveCrawlerData: (_, { data: { crawlRequests } }) => crawlRequests,
       },
     ],
   },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
+
 export enum CrawlerPolicies {
   allow = 'allow',
   deny = 'deny',
@@ -60,10 +62,12 @@ export interface CrawlerDomainFromServer {
 
 export interface CrawlerData {
   domains: CrawlerDomain[];
+  crawlRequests: CrawlRequest[];
 }
 
 export interface CrawlerDataFromServer {
   domains: CrawlerDomainFromServer[];
+  crawl_requests: CrawlRequestFromServer[];
 }
 
 export interface CrawlerDomainValidationResultFromServer {
@@ -101,3 +105,75 @@ export type CrawlerDomainValidationStepName =
   | 'networkConnectivity'
   | 'indexingRestrictions'
   | 'contentVerification';
+// See SharedTogo::Crawler::Status for details on how these are generated
+export enum CrawlerStatus {
+  Pending = 'pending',
+  Suspended = 'suspended',
+  Starting = 'starting',
+  Running = 'running',
+  Suspending = 'suspending',
+  Canceling = 'canceling',
+  Success = 'success',
+  Failed = 'failed',
+  Canceled = 'canceled',
+  Skipped = 'skipped',
+}
+
+export interface CrawlRequestFromServer {
+  id: string;
+  status: CrawlerStatus;
+  created_at: string;
+  began_at: string | null;
+  completed_at: string | null;
+}
+
+export interface CrawlRequest {
+  id: string;
+  status: CrawlerStatus;
+  createdAt: string;
+  beganAt: string | null;
+  completedAt: string | null;
+}
+
+export const readableCrawlerStatuses: { [key in CrawlerStatus]: string } = {
+  [CrawlerStatus.Pending]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.pending',
+    { defaultMessage: 'Pending' }
+  ),
+  [CrawlerStatus.Suspended]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.suspended',
+    { defaultMessage: 'Suspended' }
+  ),
+  [CrawlerStatus.Starting]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.starting',
+    { defaultMessage: 'Starting' }
+  ),
+  [CrawlerStatus.Running]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.running',
+    { defaultMessage: 'Running' }
+  ),
+  [CrawlerStatus.Suspending]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.suspending',
+    { defaultMessage: 'Suspending' }
+  ),
+  [CrawlerStatus.Canceling]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.canceling',
+    { defaultMessage: 'Canceling' }
+  ),
+  [CrawlerStatus.Success]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.success',
+    { defaultMessage: 'Success' }
+  ),
+  [CrawlerStatus.Failed]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.failed',
+    { defaultMessage: 'Failed' }
+  ),
+  [CrawlerStatus.Canceled]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.canceled',
+    { defaultMessage: 'Canceled' }
+  ),
+  [CrawlerStatus.Skipped]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.skipped',
+    { defaultMessage: 'Skipped' }
+  ),
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -62,12 +62,10 @@ export interface CrawlerDomainFromServer {
 
 export interface CrawlerData {
   domains: CrawlerDomain[];
-  crawlRequests: CrawlRequest[];
 }
 
 export interface CrawlerDataFromServer {
   domains: CrawlerDomainFromServer[];
-  crawl_requests: CrawlRequestFromServer[];
 }
 
 export interface CrawlerDomainValidationResultFromServer {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
@@ -160,15 +160,47 @@ describe('crawlerDataServerToClient', () => {
   });
 
   it('converts all domains from the server form to their client form', () => {
-    expect(output.domains).toHaveLength(2);
-    expect(output.domains[0]).toEqual(crawlerDomainServerToClient(domains[0]));
-    expect(output.domains[1]).toEqual(crawlerDomainServerToClient(domains[1]));
+    expect(output.domains).toEqual([
+      {
+        id: 'x',
+        url: 'moviedatabase.com',
+        documentCount: 13,
+        createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+        sitemaps: [],
+        entryPoints: [],
+        crawlRules: [],
+        defaultCrawlRule: DEFAULT_CRAWL_RULE,
+      },
+      {
+        id: 'y',
+        url: 'swiftype.com',
+        lastCrawl: 'Mon, 31 Aug 2020 17:00:00 +0000',
+        documentCount: 40,
+        createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+        sitemaps: [],
+        entryPoints: [],
+        crawlRules: [],
+      },
+    ]);
   });
 
   it('converts all crawl requests from the server form to their client form', () => {
-    expect(output.crawlRequests).toHaveLength(2);
-    expect(output.crawlRequests[0]).toEqual(crawlRequestServerToClient(crawlRequests[0]));
-    expect(output.crawlRequests[1]).toEqual(crawlRequestServerToClient(crawlRequests[1]));
+    expect(output.crawlRequests).toEqual([
+      {
+        id: 'a',
+        status: CrawlerStatus.Canceled,
+        createdAt: 'Mon, 31 Aug 2020 11:00:00 +0000',
+        beganAt: 'Mon, 31 Aug 2020 12:00:00 +0000',
+        completedAt: 'Mon, 31 Aug 2020 13:00:00 +0000',
+      },
+      {
+        id: 'b',
+        status: CrawlerStatus.Success,
+        createdAt: 'Mon, 31 Aug 2020 14:00:00 +0000',
+        beganAt: 'Mon, 31 Aug 2020 15:00:00 +0000',
+        completedAt: 'Mon, 31 Aug 2020 16:00:00 +0000',
+      },
+    ]);
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
@@ -135,23 +135,6 @@ describe('crawlerDataServerToClient', () => {
     },
   ];
 
-  const crawlRequests: CrawlRequestFromServer[] = [
-    {
-      id: 'a',
-      status: CrawlerStatus.Canceled,
-      created_at: 'Mon, 31 Aug 2020 11:00:00 +0000',
-      began_at: 'Mon, 31 Aug 2020 12:00:00 +0000',
-      completed_at: 'Mon, 31 Aug 2020 13:00:00 +0000',
-    },
-    {
-      id: 'b',
-      status: CrawlerStatus.Success,
-      created_at: 'Mon, 31 Aug 2020 14:00:00 +0000',
-      began_at: 'Mon, 31 Aug 2020 15:00:00 +0000',
-      completed_at: 'Mon, 31 Aug 2020 16:00:00 +0000',
-    },
-  ];
-
   beforeAll(() => {
     output = crawlerDataServerToClient({
       domains,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
@@ -155,7 +155,6 @@ describe('crawlerDataServerToClient', () => {
   beforeAll(() => {
     output = crawlerDataServerToClient({
       domains,
-      crawl_requests: crawlRequests,
     });
   });
 
@@ -180,25 +179,6 @@ describe('crawlerDataServerToClient', () => {
         sitemaps: [],
         entryPoints: [],
         crawlRules: [],
-      },
-    ]);
-  });
-
-  it('converts all crawl requests from the server form to their client form', () => {
-    expect(output.crawlRequests).toEqual([
-      {
-        id: 'a',
-        status: CrawlerStatus.Canceled,
-        createdAt: 'Mon, 31 Aug 2020 11:00:00 +0000',
-        beganAt: 'Mon, 31 Aug 2020 12:00:00 +0000',
-        completedAt: 'Mon, 31 Aug 2020 13:00:00 +0000',
-      },
-      {
-        id: 'b',
-        status: CrawlerStatus.Success,
-        createdAt: 'Mon, 31 Aug 2020 14:00:00 +0000',
-        beganAt: 'Mon, 31 Aug 2020 15:00:00 +0000',
-        completedAt: 'Mon, 31 Aug 2020 16:00:00 +0000',
       },
     ]);
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -12,6 +12,8 @@ import {
   CrawlerDataFromServer,
   CrawlerDomainValidationResultFromServer,
   CrawlerDomainValidationStep,
+  CrawlRequestFromServer,
+  CrawlRequest,
 } from './types';
 
 export function crawlerDomainServerToClient(payload: CrawlerDomainFromServer): CrawlerDomain {
@@ -48,11 +50,30 @@ export function crawlerDomainServerToClient(payload: CrawlerDomainFromServer): C
   return clientPayload;
 }
 
+export function crawlRequestServerToClient(crawlRequest: CrawlRequestFromServer): CrawlRequest {
+  const {
+    id,
+    status,
+    created_at: createdAt,
+    began_at: beganAt,
+    completed_at: completedAt,
+  } = crawlRequest;
+
+  return {
+    id,
+    status,
+    createdAt,
+    beganAt,
+    completedAt,
+  };
+}
+
 export function crawlerDataServerToClient(payload: CrawlerDataFromServer): CrawlerData {
-  const { domains } = payload;
+  const { domains, crawl_requests: crawlRequests } = payload;
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
+    crawlRequests: crawlRequests.map((crawlRequest) => crawlRequestServerToClient(crawlRequest)),
   };
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -69,11 +69,10 @@ export function crawlRequestServerToClient(crawlRequest: CrawlRequestFromServer)
 }
 
 export function crawlerDataServerToClient(payload: CrawlerDataFromServer): CrawlerData {
-  const { domains, crawl_requests: crawlRequests } = payload;
+  const { domains } = payload;
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
-    crawlRequests: crawlRequests.map((crawlRequest) => crawlRequestServerToClient(crawlRequest)),
   };
 }
 

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -43,6 +43,39 @@ describe('crawler routes', () => {
     });
   });
 
+  describe('GET /api/app_search/engines/{name}/crawler/crawl_requests', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/engines/{name}/crawler/crawl_requests',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/engines/:name/crawler/crawl_requests',
+      });
+    });
+
+    it('validates correctly with name', () => {
+      const request = { params: { name: 'some-engine' } };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without name', () => {
+      const request = { params: {} };
+      mockRouter.shouldThrow(request);
+    });
+  });
+
   describe('POST /api/app_search/engines/{name}/crawler/domains', () => {
     let mockRouter: MockRouter;
 

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -27,6 +27,20 @@ export function registerCrawlerRoutes({
     })
   );
 
+  router.get(
+    {
+      path: '/api/app_search/engines/{name}/crawler/crawl_requests',
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/engines/:name/crawler/crawl_requests',
+    })
+  );
+
   router.post(
     {
       path: '/api/app_search/engines/{name}/crawler/domains',


### PR DESCRIPTION
## Summary

- Migrates the existing `CrawlRequestsTable` from our standalone UX into Kibana.  
- Adds an empty state to the existing Domains table

## Notes

1. I combined these because adding the empty state was trivial. I was already refactoring the tests, so I figured I should just add in the correct tests rather than keep all the TODO statements.  I'm sorry if this is confusing!  It may help to follow along [commit-by-commit ](https://github.com/elastic/kibana/pull/107436/commits)
2. It can be helpful to [hide whitespace](https://github.com/elastic/kibana/pull/107436/files?diff=split&w=1) on React PRs

## Screenshots 

![Screen Shot 2021-08-03 at 8 00 50 AM](https://user-images.githubusercontent.com/2479295/128017085-3bb222a2-7f69-4b7e-961c-580cd9d6f0ca.png)

![Screen Shot 2021-08-03 at 7 59 48 AM](https://user-images.githubusercontent.com/2479295/128017091-7e32469e-63b9-4292-992f-c3e18d70768a.png)

![Screen Shot 2021-08-03 at 7 59 32 AM](https://user-images.githubusercontent.com/2479295/128017093-a90d30f2-8545-4cc9-ba40-054d5e75dbfe.png)


## Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

