### PR TITLE
[maps] fix More than 2 maps embeddables with geo-shape layers results in empty layers for 3+

### DIFF
--- a/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.test.js
+++ b/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.test.js
@@ -273,11 +273,11 @@ describe('hitsToGeoJson', () => {
     it('Should not modify results of flattenHit', () => {
       const geoFieldName = 'location';
       const cachedProperities = {
-        [geoFieldName]: '20,100'
+        [geoFieldName]: '20,100',
       };
-      const cachedFlattenHit = (hit) => {
+      const cachedFlattenHit = () => {
         return cachedProperities;
-      }
+      };
       const hits = [
         {
           _source: {
@@ -285,8 +285,9 @@ describe('hitsToGeoJson', () => {
           },
         },
       ];
-      hitsToGeoJson(hits, cachedFlattenHit, geoFieldName, 'geo_point', []);
+      const geojson = hitsToGeoJson(hits, cachedFlattenHit, geoFieldName, 'geo_point', []);
       expect(cachedProperities.hasOwnProperty('location')).toBe(true);
+      expect(geojson.features[0].properties).toEqual({});
     });
   });
 });

--- a/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.test.js
+++ b/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.test.js
@@ -269,6 +269,25 @@ describe('hitsToGeoJson', () => {
         type: 'Point',
       });
     });
+
+    it('Should not modify results of flattenHit', () => {
+      const geoFieldName = 'location';
+      const cachedProperities = {
+        [geoFieldName]: '20,100'
+      };
+      const cachedFlattenHit = (hit) => {
+        return cachedProperities;
+      }
+      const hits = [
+        {
+          _source: {
+            [geoFieldName]: '20,100',
+          },
+        },
+      ];
+      hitsToGeoJson(hits, cachedFlattenHit, geoFieldName, 'geo_point', []);
+      expect(cachedProperities.hasOwnProperty('location')).toBe(true);
+    });
   });
 });
 

--- a/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.ts
+++ b/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.ts
@@ -80,7 +80,7 @@ export function hitsToGeoJson(
   const tmpGeometriesAccumulator: Geometry[] = [];
 
   for (let i = 0; i < hits.length; i++) {
-    const properties = flattenHit(hits[i]);
+    const properties = { ...flattenHit(hits[i]) };
 
     tmpGeometriesAccumulator.length = 0; // truncate accumulator
 

--- a/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.ts
+++ b/x-pack/plugins/maps/common/elasticsearch_util/elasticsearch_geo_utils.ts
@@ -80,6 +80,8 @@ export function hitsToGeoJson(
   const tmpGeometriesAccumulator: Geometry[] = [];
 
   for (let i = 0; i < hits.length; i++) {
+    // flattenHit returns value from cache. Create new object to avoid modifying flattenHit cache.
+    // not doing deep copy because copying coordinates can be very expensive for complex geometries.
     const properties = { ...flattenHit(hits[i]) };
 
     tmpGeometriesAccumulator.length = 0; // truncate accumulator


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/107293

On the surface, it appeared that [indexPattern.flattenHit(hit)](https://github.com/elastic/kibana/blob/7.14/x-pack/plugins/maps/public/classes/sources/es_search_source/es_search_source.tsx#L461) returned objects with missing properties from the flatten hit cache. Upon further investigation, the reason why the cache was missing properties was that Maps was deleting the geometry property and this deletion occur on the object instance from flatten_hit cache. The fix is to expand the results of flattenHit so that changes made by Maps do not pollute the flatten_hit cache.