### PR TITLE
[DOCS] Removes tags from 6.8.18 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -110,8 +110,6 @@ Review important information about the {kib} 6.x.x releases.
 [[release-notes-6.8.18]]
 == {kib} 6.8.18
 
-coming::[6.8.18]
-
 For information about the {kib} 6.8.18 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

Removes coming tag from the 6.8.18 release notes.