### PR TITLE
[DOCS] Removes tag from what's new

### DIFF
--- a/docs/index-extra-title-page.html
+++ b/docs/index-extra-title-page.html
@@ -6,6 +6,9 @@
   <p>
     <a href="https://www.elastic.co/guide/en/kibana/7.14/whats-new.html"><b>What's new</b></a
     >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
+      href="https://www.elastic.co/guide/en/kibana/7.14/release-notes-7.14.0.html"
+      ><b>Release notes</b></a
+    >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
       href="https://www.elastic.co/videos/training-how-to-stack"
       ><b>How-to videos</b></a
     >

--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,8 +1,6 @@
 [[whats-new]]
 == What's new in {minor-version}
 
-coming::[7.14.0]
-
 Here are the highlights of what's new and improved in {minor-version}.
 For detailed information about this release,
 check out the <<release-notes, release notes>>.


### PR DESCRIPTION
## Summary

This PR:

- Adds a link to the Release notes on the landing page
- Removes the coming tag from What's new