### PR TITLE
[7.x] [DOCS] Removes coming tag from 7.14 release notes (#107470)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -64,8 +64,6 @@ Review important information about the {kib} 7.x releases.
 [[release-notes-7.14.0]]
 == {kib} 7.14.0
 
-coming::[7.14.0]
-
 For information about the {kib} 7.14.0 release, review the following information.
 
 [float]


### PR DESCRIPTION
Backports the following into 7.x:

- [DOCS] Removes coming tag from 7.14 release notes (#107470)