### PR TITLE
[App Search] Migrate CrawlerStatusIndicator and CrawlerStatusBanner

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__/kea_logic';
+import '../../../__mocks__/engine_logic.mock';
+
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiBasicTable, EuiEmptyPrompt } from '@elastic/eui';
+
+import { mountWithIntl } from '../../../../test_helpers';
+
+import {
+  CrawlerDomain,
+  CrawlerPolicies,
+  CrawlerRules,
+  CrawlerStatus,
+  CrawlRequest,
+} from '../types';
+
+import { CrawlRequestsTable } from './crawl_requests_table';
+
+const values: { domains: CrawlerDomain[]; crawlRequests: CrawlRequest[] } = {
+  // CrawlerOverviewLogic
+  domains: [
+    {
+      id: '507f1f77bcf86cd799439011',
+      createdOn: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      url: 'elastic.co',
+      documentCount: 13,
+      sitemaps: [],
+      entryPoints: [],
+      crawlRules: [],
+      defaultCrawlRule: {
+        id: '-',
+        policy: CrawlerPolicies.allow,
+        rule: CrawlerRules.regex,
+        pattern: '.*',
+      },
+    },
+  ],
+  crawlRequests: [
+    {
+      id: '618d0e66abe97bc688328900',
+      status: CrawlerStatus.Pending,
+      createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      beganAt: null,
+      completedAt: null,
+    },
+  ],
+};
+
+describe('DomainsTable', () => {
+  let wrapper: ShallowWrapper;
+  let tableContent: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('columns', () => {
+    beforeAll(() => {
+      setMockValues(values);
+      wrapper = shallow(<CrawlRequestsTable />);
+      tableContent = mountWithIntl(<CrawlRequestsTable />)
+        .find(EuiBasicTable)
+        .text();
+    });
+
+    it('renders an id column', () => {
+      expect(tableContent).toContain('618d0e66abe97bc688328900');
+    });
+
+    it('renders a created at column', () => {
+      expect(tableContent).toContain('Created');
+      expect(tableContent).toContain('Aug 31, 2020');
+    });
+
+    it('renders a status column', () => {
+      expect(tableContent).toContain('Status');
+      expect(tableContent).toContain('Pending');
+    });
+  });
+
+  describe('no items message', () => {
+    it('displays an empty prompt when there are no crawl requests', () => {
+      setMockValues({
+        ...values,
+        crawlRequests: [],
+      });
+
+      wrapper = shallow(<CrawlRequestsTable />);
+
+      expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiBasicTable, EuiEmptyPrompt, EuiTableFieldDataColumnType } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { CrawlerOverviewLogic } from '../crawler_overview_logic';
+import { CrawlRequest, readableCrawlerStatuses } from '../types';
+
+import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
+
+const columns: Array<EuiTableFieldDataColumnType<CrawlRequest>> = [
+  {
+    field: 'id',
+    name: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.domainURL',
+      {
+        defaultMessage: 'Request ID',
+      }
+    ),
+  },
+  {
+    field: 'createdAt',
+    name: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.created',
+      {
+        defaultMessage: 'Created',
+      }
+    ),
+    render: (createdAt: CrawlRequest['createdAt']) => (
+      <CustomFormattedTimestamp timestamp={createdAt} />
+    ),
+  },
+  {
+    field: 'status',
+    name: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.status',
+      {
+        defaultMessage: 'Status',
+      }
+    ),
+    render: (status: CrawlRequest['status']) => readableCrawlerStatuses[status],
+  },
+];
+
+export const CrawlRequestsTable: React.FC = () => {
+  const { crawlRequests } = useValues(CrawlerOverviewLogic);
+
+  if (crawlRequests.length === 0) {
+    return (
+      <EuiEmptyPrompt
+        iconType="tableDensityExpanded"
+        title={
+          <h3>
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.title',
+              {
+                defaultMessage: 'No recent crawl requests',
+              }
+            )}
+          </h3>
+        }
+        body={
+          <p>
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.body',
+              {
+                defaultMessage: "You haven't started any crawls yet.",
+              }
+            )}
+          </p>
+        }
+      />
+    );
+  }
+  return <EuiBasicTable columns={columns} items={crawlRequests} />;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_banner.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_banner.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockValues } from '../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { CrawlerStatus } from '../types';
+
+import { CrawlerStatusBanner } from './crawler_status_banner';
+
+describe('CrawlerStatusBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  [(CrawlerStatus.Starting, CrawlerStatus.Running, CrawlerStatus.Canceling)].forEach((status) => {
+    describe(`when the status is ${status}`, () => {
+      it('renders an appropriate CrawlerStatusBanner', () => {
+        setMockValues({
+          mostRecentCrawlRequestStatus: status,
+        });
+
+        const wrapper = shallow(<CrawlerStatusBanner />);
+
+        expect(wrapper.prop('data-test-subj')).toMatch(
+          new RegExp(`CrawlerStatusBanner${status}`, 'i')
+        );
+      });
+    });
+  });
+
+  [
+    CrawlerStatus.Success,
+    CrawlerStatus.Failed,
+    CrawlerStatus.Canceled,
+    CrawlerStatus.Pending,
+    CrawlerStatus.Suspended,
+    CrawlerStatus.Suspending,
+  ].forEach((status) => {
+    describe(`when the status is ${status}`, () => {
+      it('renders an appropriate CrawlerStatusBanner', () => {
+        setMockValues({
+          mostRecentCrawlRequestStatus: status,
+        });
+
+        const wrapper = shallow(<CrawlerStatusBanner />);
+
+        expect(wrapper.exists()).toBe(false);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_banner.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_banner.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiCallOut } from '@elastic/eui';
+
+import { CrawlerOverviewLogic } from '../crawler_overview_logic';
+import { CrawlerStatus } from '../types';
+
+export const CrawlerStatusBanner: React.FC = () => {
+  const { mostRecentCrawlRequestStatus } = useValues(CrawlerOverviewLogic);
+  if (
+    mostRecentCrawlRequestStatus === CrawlerStatus.Running ||
+    mostRecentCrawlRequestStatus === CrawlerStatus.Starting ||
+    mostRecentCrawlRequestStatus === CrawlerStatus.Canceling
+  ) {
+    return (
+      <EuiCallOut
+        iconType="iInCircle"
+        title="Changes you make now won't take effect until the start of your next crawl."
+      />
+    );
+  }
+  return null;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/crawler_status_indicator.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/crawler_status_indicator.test.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setMockActions, setMockValues } from '../../../../../__mocks__/kea_logic';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiButton } from '@elastic/eui';
+
+import { CrawlerDomain, CrawlerStatus } from '../../types';
+
+import { CrawlerStatusIndicator } from './crawler_status_indicator';
+import { StopCrawlPopoverContextMenu } from './stop_crawl_popover_context_menu';
+
+const MOCK_VALUES = {
+  domains: [{}, {}] as CrawlerDomain[],
+  mostRecentCrawlRequestStatus: CrawlerStatus.Success,
+};
+
+const MOCK_ACTIONS = {
+  startCrawl: jest.fn(),
+  stopCrawl: jest.fn(),
+};
+
+describe('CrawlerStatusIndicator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockActions(MOCK_ACTIONS);
+  });
+
+  describe('when status is not a valid status', () => {
+    it('is disabled', () => {
+      // this tests a codepath that should be impossible to reach, status should always be a CrawlerStatus
+      // but we use a switch statement and need to test the default case for this to recieve 100% coverage
+      setMockValues({
+        ...MOCK_VALUES,
+        mostRecentCrawlRequestStatus: null,
+      });
+
+      const wrapper = shallow(<CrawlerStatusIndicator />);
+      expect(wrapper.is(EuiButton)).toEqual(true);
+      expect(wrapper.text()).toContain('Start a crawl');
+      expect(wrapper.prop('disabled')).toEqual(true);
+    });
+  });
+
+  describe('when there are no domains', () => {
+    it('is disabled', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        domains: [],
+      });
+
+      const wrapper = shallow(<CrawlerStatusIndicator />);
+      expect(wrapper.is(EuiButton)).toEqual(true);
+      expect(wrapper.text()).toContain('Start a crawl');
+      expect(wrapper.prop('disabled')).toEqual(true);
+    });
+  });
+
+  describe('when the status is success', () => {
+    it('renders an CrawlerStatusIndicator with a start crawl button', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        mostRecentCrawlRequestStatus: CrawlerStatus.Success,
+      });
+
+      const wrapper = shallow(<CrawlerStatusIndicator />);
+      expect(wrapper.is(EuiButton)).toEqual(true);
+      expect(wrapper.text()).toContain('Start a crawl');
+      expect(wrapper.prop('onClick').toEqual(MOCK_ACTIONS.startCrawl));
+    });
+  });
+
+  [CrawlerStatus.Failed, CrawlerStatus.Canceled].forEach((status) => {
+    describe(`when the status is ready for retry: ${status}`, () => {
+      it('renders an CrawlerStatusIndicator with a retry crawl button', () => {
+        setMockValues({
+          ...MOCK_VALUES,
+          mostRecentCrawlRequestStatus: status,
+        });
+
+        const wrapper = shallow(<CrawlerStatusIndicator />);
+        expect(wrapper.is(EuiButton)).toEqual(true);
+        expect(wrapper.text()).toContain('Retry crawl');
+        expect(wrapper.prop('onClick').toEqual(MOCK_ACTIONS.startCrawl));
+      });
+    });
+  });
+
+  [CrawlerStatus.Pending, CrawlerStatus.Suspended].forEach((status) => {
+    describe(`when the status is ${status}`, () => {
+      it('renders an CrawlerStatusIndicator with a pending indicator', () => {
+        setMockValues({
+          ...MOCK_VALUES,
+          mostRecentCrawlRequestStatus: status,
+        });
+
+        const wrapper = shallow(<CrawlerStatusIndicator />);
+        expect(wrapper.is(EuiButton)).toEqual(true);
+        expect(wrapper.text()).toContain('Pending...');
+      });
+    });
+  });
+
+  describe('when the status is Starting', () => {
+    it('renders an appropriate CrawlerStatusIndicator', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        mostRecentCrawlRequestStatus: CrawlerStatus.Starting,
+      });
+
+      const wrapper = shallow(<CrawlerStatusIndicator />);
+      expect(wrapper.is(EuiButton)).toEqual(true);
+      expect(wrapper.text()).toContain('Starting...');
+    });
+  });
+
+  describe('when the status is Running', () => {
+    it('renders an appropriate CrawlerStatusIndicator', () => {
+      setMockValues({
+        ...MOCK_VALUES,
+        mostRecentCrawlRequestStatus: CrawlerStatus.Running,
+      });
+
+      const wrapper = shallow(<CrawlerStatusIndicator />);
+      expect(wrapper.is(StopCrawlPopoverContextMenu)).toEqual(true);
+      expect(wrapper.prop('stopCrawl').toEqual(MOCK_ACTIONS.stopCrawl));
+    });
+  });
+
+  [CrawlerStatus.Canceling, CrawlerStatus.Suspending].forEach((status) => {
+    describe(`when the status is ${status}`, () => {
+      it('renders an CrawlerStatusIndicator with a stopping indicator', () => {
+        setMockValues({
+          ...MOCK_VALUES,
+          mostRecentCrawlRequestStatus: status,
+        });
+
+        const wrapper = shallow(<CrawlerStatusIndicator />);
+        expect(wrapper.is(EuiButton)).toEqual(true);
+        expect(wrapper.text()).toContain('Starting...');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/crawler_status_indicator.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/crawler_status_indicator.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiButton } from '@elastic/eui';
+
+import { CrawlerOverviewLogic } from '../../crawler_overview_logic';
+import { CrawlerStatus } from '../../types';
+
+import { StopCrawlPopoverContextMenu } from './stop_crawl_popover_context_menu';
+
+export const CrawlerStatusIndicator: React.FC = () => {
+  const { domains, mostRecentCrawlRequestStatus } = useValues(CrawlerOverviewLogic);
+  const { startCrawl, stopCrawl } = useActions(CrawlerOverviewLogic);
+
+  const disabledButton = <EuiButton disabled>Start a Crawl</EuiButton>;
+
+  if (domains.length === 0) {
+    return disabledButton;
+  }
+
+  switch (mostRecentCrawlRequestStatus) {
+    case CrawlerStatus.Success:
+      return (
+        <EuiButton fill onClick={startCrawl}>
+          Start a Crawl
+        </EuiButton>
+      );
+    case CrawlerStatus.Failed:
+    case CrawlerStatus.Canceled:
+      return (
+        <EuiButton fill onClick={startCrawl}>
+          Retry Crawl
+        </EuiButton>
+      );
+    case CrawlerStatus.Pending:
+    case CrawlerStatus.Suspended:
+      return (
+        <EuiButton disabled isLoading>
+          Pending...
+        </EuiButton>
+      );
+    case CrawlerStatus.Starting:
+      return <EuiButton isLoading>Starting...</EuiButton>;
+    case CrawlerStatus.Running:
+      return <StopCrawlPopoverContextMenu stopCrawl={stopCrawl} />;
+    case CrawlerStatus.Canceling:
+    case CrawlerStatus.Suspending:
+      return (
+        <EuiButton isLoading fill>
+          Stopping...
+        </EuiButton>
+      );
+    default:
+      // We should never get here
+      return disabledButton;
+  }
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/stop_crawl_popover_context_menu.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/stop_crawl_popover_context_menu.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiButton, EuiContextMenuItem, EuiContextMenuPanel } from '@elastic/eui';
+
+import { rerender } from '../../../../../test_helpers';
+
+import { StopCrawlPopoverContextMenu } from './stop_crawl_popover_context_menu';
+
+const stopCrawl = jest.fn();
+
+describe('StopCrawlsPopoverContextMenu', () => {
+  it('is initially closed', () => {
+    const wrapper = shallow(<StopCrawlPopoverContextMenu stopCrawl={stopCrawl} />);
+    expect(wrapper.find(EuiContextMenuPanel)).toHaveLength(0);
+  });
+
+  it('can be opened to stop crawls', () => {
+    const wrapper = shallow(<StopCrawlPopoverContextMenu stopCrawl={stopCrawl} />);
+    wrapper.find(EuiButton).simulate('click');
+    rerender(wrapper);
+    wrapper.find(EuiContextMenuPanel).dive().find(EuiContextMenuItem).simulate('click');
+    expect(stopCrawl).toHaveBeenCalled();
+    rerender(wrapper);
+    expect(wrapper.find(EuiContextMenuPanel)).toHaveLength(0);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/stop_crawl_popover_context_menu.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/stop_crawl_popover_context_menu.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import {
+  EuiButton,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPopover,
+} from '@elastic/eui';
+
+interface StopCrawlPopoverContextMenuProps {
+  stopCrawl(): void;
+}
+
+export const StopCrawlPopoverContextMenu: React.FC<StopCrawlPopoverContextMenuProps> = ({
+  stopCrawl,
+  ...rest
+}) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+
+  const togglePopover = () => setPopover(!isPopoverOpen);
+
+  const closePopover = () => setPopover(false);
+
+  return (
+    <EuiPopover
+      {...rest}
+      button={
+        <EuiButton
+          iconType="arrowDown"
+          iconSide="right"
+          onClick={togglePopover}
+          className="crawlInProgressButton"
+        >
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiLoadingSpinner size="m" />
+            </EuiFlexItem>
+            <EuiFlexItem>Crawling...</EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiButton>
+      }
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenuPanel
+        items={[
+          <EuiContextMenuItem
+            key="cancel crawl"
+            icon="cross"
+            onClick={() => {
+              closePopover();
+              stopCrawl();
+            }}
+          >
+            Cancel Crawl
+          </EuiContextMenuItem>,
+        ]}
+      />
+    </EuiPopover>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -14,6 +14,8 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { AddDomainForm } from './components/add_domain/add_domain_form';
+import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
@@ -94,15 +96,15 @@ describe('CrawlerOverview', () => {
     expect(mockActions.fetchCrawlerData).toHaveBeenCalledTimes(1);
   });
 
-  // TODO update below line to 'hides the domain and crawl request tables when there are no domains, and no crawl requests' after empty state is added
-  it('shows domain table and hides the crawl request table when there are no domains, and no crawl requests', () => {
+  it('hides the domain and crawl request tables when there are no domains, and no crawl requests', () => {
     setMockValues({ ...mockValues, domains: [], crawlRequests: [] });
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
-    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
-    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(0);
+    expect(wrapper.find(DomainsTable)).toHaveLength(0);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(0);
   });
 
@@ -111,21 +113,22 @@ describe('CrawlerOverview', () => {
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(0);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(0);
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 
-  // TODO update below line to 'hides the domain table and shows the crawl request tables when there are crawl requests but no domains' after empty state is added
-  it('shows the domain and the crawl request tables when there are crawl requests, but no domains', () => {
+  it('hides the domain table and shows the crawl request tables when there are crawl requests but no domains', () => {
     setMockValues({ ...mockValues, domains: [] });
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
-    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
-    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(1);
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(0);
+    expect(wrapper.find(DomainsTable)).toHaveLength(0);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 
@@ -134,7 +137,8 @@ describe('CrawlerOverview', () => {
 
     const wrapper = shallow(<CrawlerOverview />);
 
-    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainForm)).toHaveLength(0);
+    expect(wrapper.find(AddDomainFormSubmitButton)).toHaveLength(0);
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -11,12 +11,64 @@ import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
+import {
+  CrawlerDomainFromServer,
+  CrawlerPolicies,
+  CrawlerRules,
+  CrawlerStatus,
+  CrawlRequestFromServer,
+} from './types';
+
+const domains: CrawlerDomainFromServer[] = [
+  {
+    id: 'x',
+    name: 'moviedatabase.com',
+    document_count: 13,
+    created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    sitemaps: [],
+    entry_points: [],
+    crawl_rules: [],
+    default_crawl_rule: {
+      id: '-',
+      policy: CrawlerPolicies.allow,
+      rule: CrawlerRules.regex,
+      pattern: '.*',
+    },
+  },
+  {
+    id: 'y',
+    name: 'swiftype.com',
+    last_visited_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    document_count: 40,
+    created_on: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    sitemaps: [],
+    entry_points: [],
+    crawl_rules: [],
+  },
+];
+
+const crawlRequests: CrawlRequestFromServer[] = [
+  {
+    id: 'a',
+    status: CrawlerStatus.Canceled,
+    created_at: 'Mon, 31 Aug 2020 11:00:00 +0000',
+    began_at: 'Mon, 31 Aug 2020 12:00:00 +0000',
+    completed_at: 'Mon, 31 Aug 2020 13:00:00 +0000',
+  },
+  {
+    id: 'b',
+    status: CrawlerStatus.Success,
+    created_at: 'Mon, 31 Aug 2020 14:00:00 +0000',
+    began_at: 'Mon, 31 Aug 2020 15:00:00 +0000',
+    completed_at: 'Mon, 31 Aug 2020 16:00:00 +0000',
+  },
+];
 
 describe('CrawlerOverview', () => {
   const mockActions = {
@@ -25,29 +77,66 @@ describe('CrawlerOverview', () => {
 
   const mockValues = {
     dataLoading: false,
-    domains: [],
+    domains,
+    crawlRequests,
   };
-
-  let wrapper: ShallowWrapper;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    setMockValues(mockValues);
     setMockActions(mockActions);
-    wrapper = shallow(<CrawlerOverview />);
   });
 
   it('calls fetchCrawlerData on page load', () => {
+    setMockValues(mockValues);
+
+    shallow(<CrawlerOverview />);
+
     expect(mockActions.fetchCrawlerData).toHaveBeenCalledTimes(1);
   });
 
-  it('renders', () => {
-    expect(wrapper.find(DomainsTable)).toHaveLength(1);
+  // TODO update below line to 'hides the domain and crawl request tables when there are no domains, and no crawl requests' after empty state is added
+  it('shows domain table and hides the crawl request table when there are no domains, and no crawl requests', () => {
+    setMockValues({ ...mockValues, domains: [], crawlRequests: [] });
 
-    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+    const wrapper = shallow(<CrawlerOverview />);
 
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(0);
+  });
+
+  it('shows the domain and the crawl request tables when there are domains, but no crawl requests', () => {
+    setMockValues({ ...mockValues, crawlRequests: [] });
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
+    expect(wrapper.find(DomainsTable)).toHaveLength(1);
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+  });
 
-    // TODO test for empty state after it is built in a future PR
+  // TODO update below line to 'hides the domain table and shows the crawl request tables when there are crawl requests but no domains' after empty state is added
+  it('shows the domain and the crawl request tables when there are crawl requests, but no domains', () => {
+    setMockValues({ ...mockValues, domains: [] });
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(1); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(DomainsTable)).toHaveLength(1); // TODO this should be 0 after empty state is added
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+  });
+
+  it('shows the domain and the crawl request tableswhen there are crawl requests and domains', () => {
+    setMockValues(mockValues);
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    // expect(wrapper.find(AddDomainForm)).toHaveLength(0); // TODO uncomment this after empty state is added
+    expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
+    expect(wrapper.find(DomainsTable)).toHaveLength(1);
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -75,6 +75,7 @@ const crawlRequests: CrawlRequestFromServer[] = [
 describe('CrawlerOverview', () => {
   const mockActions = {
     fetchCrawlerData: jest.fn(),
+    getLatestCrawlRequests: jest.fn(),
   };
 
   const mockValues = {
@@ -88,12 +89,13 @@ describe('CrawlerOverview', () => {
     setMockActions(mockActions);
   });
 
-  it('calls fetchCrawlerData on page load', () => {
+  it('calls fetchCrawlerData and starts polling on page load', () => {
     setMockValues(mockValues);
 
     shallow(<CrawlerOverview />);
 
     expect(mockActions.fetchCrawlerData).toHaveBeenCalledTimes(1);
+    expect(mockActions.getLatestCrawlRequests).toHaveBeenCalledWith(false);
   });
 
   it('hides the domain and crawl request tables when there are no domains, and no crawl requests', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CrawlerOverview } from './crawler_overview';
 
@@ -43,7 +44,7 @@ describe('CrawlerOverview', () => {
   it('renders', () => {
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
 
-    // TODO test for CrawlRequestsTable after it is built in a future PR
+    expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
 
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -12,7 +12,6 @@ import { useActions, useValues } from 'kea';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
 
 import { DOCS_PREFIX } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -12,12 +12,15 @@ import { useActions, useValues } from 'kea';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { DOCS_PREFIX } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { AddDomainForm } from './components/add_domain/add_domain_form';
+import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
@@ -38,22 +41,59 @@ export const CrawlerOverview: React.FC = () => {
       pageHeader={{ pageTitle: CRAWLER_TITLE }}
       isLoading={dataLoading}
     >
-      <EuiFlexGroup direction="row" alignItems="stretch">
-        <EuiFlexItem>
+      {domains.length > 0 ? (
+        <>
+          <EuiFlexGroup direction="row" alignItems="stretch">
+            <EuiFlexItem>
+              <EuiTitle size="s">
+                <h3>
+                  {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTitle', {
+                    defaultMessage: 'Domains',
+                  })}
+                </h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <AddDomainFlyout />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
+          <DomainsTable />
+        </>
+      ) : (
+        <>
           <EuiTitle size="s">
             <h3>
-              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.domainsTitle', {
-                defaultMessage: 'Domains',
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.empty.title', {
+                defaultMessage: 'Add a domain to get started',
               })}
             </h3>
           </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <AddDomainFlyout />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <DomainsTable />
+          <EuiText>
+            <p>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.empty.description', {
+                defaultMessage:
+                  "Easily index your website's content. To get started, enter your domain name, provide optional entry points and crawl rules, and we will handle the rest.",
+              })}{' '}
+              <EuiLink external target="_blank" href={`${DOCS_PREFIX}/web-crawler.html`}>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.empty.crawlerDocumentationLinkDescription',
+                  {
+                    defaultMessage: 'Learn more about the web crawler',
+                  }
+                )}
+              </EuiLink>
+            </p>
+          </EuiText>
+          <AddDomainForm />
+          <EuiSpacer />
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <AddDomainFormSubmitButton />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      )}
       {(crawlRequests.length > 0 || domains.length > 0) && (
         <>
           <EuiSpacer size="xl" />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -24,20 +24,25 @@ import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
+import { CrawlerStatusIndicator } from './components/crawler_status_indicator/crawler_status_indicator';
 
 export const CrawlerOverview: React.FC = () => {
-  const { crawlRequests, dataLoading, domains } = useValues(CrawlerOverviewLogic);
+  const { crawlRequests, dataLoading, domains, mostRecentCrawlRequestStatus} = useValues(CrawlerOverviewLogic);
 
-  const { fetchCrawlerData } = useActions(CrawlerOverviewLogic);
+  const { fetchCrawlerData, getLatestCrawlRequests } = useActions(CrawlerOverviewLogic);
 
   useEffect(() => {
     fetchCrawlerData();
+    getLatestCrawlRequests(false);
   }, []);
 
   return (
     <AppSearchPageTemplate
       pageChrome={getEngineBreadcrumbs([CRAWLER_TITLE])}
-      pageHeader={{ pageTitle: CRAWLER_TITLE }}
+      pageHeader={{ pageTitle: CRAWLER_TITLE
+      rightSideItems: [
+        <CrawlerStatusIndicator status={mostRecentCrawlRequestStatus}/>
+      ]}}
       isLoading={dataLoading}
     >
       {domains.length > 0 ? (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -9,14 +9,16 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
+import { DOCS_PREFIX } from '../../routes';
 import { getEngineBreadcrumbs } from '../engine';
 import { AppSearchPageTemplate } from '../layout';
 
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
+import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { DomainsTable } from './components/domains_table';
 import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
@@ -52,6 +54,37 @@ export const CrawlerOverview: React.FC = () => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <DomainsTable />
+      <EuiSpacer size="m" />
+      <EuiTitle size="s">
+        <h3>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
+            defaultMessage: 'Recent Crawl Requests',
+          })}
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="xs" />
+      <EuiText color="subdued" size="s">
+        <p>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
+            defaultMessage:
+              "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
+          })}{' '}
+          <EuiLink
+            href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}
+            target="_blank"
+            external
+          >
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.configurationDocumentationLinkDescription',
+              {
+                defaultMessage: 'Learn more about configuring crawler logs in Kibana',
+              }
+            )}
+          </EuiLink>
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <CrawlRequestsTable />
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -24,7 +24,7 @@ import { CRAWLER_TITLE } from './constants';
 import { CrawlerOverviewLogic } from './crawler_overview_logic';
 
 export const CrawlerOverview: React.FC = () => {
-  const { dataLoading } = useValues(CrawlerOverviewLogic);
+  const { crawlRequests, dataLoading, domains } = useValues(CrawlerOverviewLogic);
 
   const { fetchCrawlerData } = useActions(CrawlerOverviewLogic);
 
@@ -54,37 +54,41 @@ export const CrawlerOverview: React.FC = () => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       <DomainsTable />
-      <EuiSpacer size="m" />
-      <EuiTitle size="s">
-        <h3>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
-            defaultMessage: 'Recent Crawl Requests',
-          })}
-        </h3>
-      </EuiTitle>
-      <EuiSpacer size="xs" />
-      <EuiText color="subdued" size="s">
-        <p>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
-            defaultMessage:
-              "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
-          })}{' '}
-          <EuiLink
-            href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}
-            target="_blank"
-            external
-          >
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.crawler.configurationDocumentationLinkDescription',
-              {
-                defaultMessage: 'Learn more about configuring crawler logs in Kibana',
-              }
-            )}
-          </EuiLink>
-        </p>
-      </EuiText>
-      <EuiSpacer size="m" />
-      <CrawlRequestsTable />
+      {(crawlRequests.length > 0 || domains.length > 0) && (
+        <>
+          <EuiSpacer size="xl" />
+          <EuiTitle size="s">
+            <h3>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTitle', {
+                defaultMessage: 'Recent Crawl Requests',
+              })}
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="xs" />
+          <EuiText color="subdued" size="s">
+            <p>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlRequestsDescription', {
+                defaultMessage:
+                  "Recent crawl requests are logged here. Using the request ID of each crawl, you can track progress and examine crawl events in Kibana's Discover or Logs user interfaces. ",
+              })}{' '}
+              <EuiLink
+                href={`${DOCS_PREFIX}/view-web-crawler-events-logs.html`}
+                target="_blank"
+                external
+              >
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.configurationDocumentationLinkDescription',
+                  {
+                    defaultMessage: 'Learn more about configuring crawler logs in Kibana',
+                  }
+                )}
+              </EuiLink>
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+          <CrawlRequestsTable />
+        </>
+      )}
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -30,6 +30,7 @@ const DEFAULT_VALUES: CrawlerOverviewValues = {
   dataLoading: true,
   domains: [],
   mostRecentCrawlRequestStatus: CrawlerStatus.Success,
+  timeoutId: null,
 };
 
 const DEFAULT_CRAWL_RULE: CrawlRule = {
@@ -168,6 +169,26 @@ describe('CrawlerOverviewLogic', () => {
         await nextTick();
 
         expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+
+    describe('startCrawl', () => {
+      describe('on success', () => {
+        it('starts polling for crawl requests', () => {});
+      });
+
+      describe('on failure', () => {
+        it('flashes an error', () => {});
+      });
+    });
+
+    describe('stopCrawl', () => {
+      describe('on success', () => {
+        it('starts polling for crawl requests', () => {});
+      });
+
+      describe('on failure', () => {
+        it('flashes an error', () => {});
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -14,17 +14,19 @@ import '../../__mocks__/engine_logic.mock';
 
 import { nextTick } from '@kbn/test/jest';
 
-import { CrawlerOverviewLogic } from './crawler_overview_logic';
+import { CrawlerOverviewLogic, CrawlerOverviewValues } from './crawler_overview_logic';
 import {
   CrawlerDataFromServer,
   CrawlerDomain,
   CrawlerPolicies,
   CrawlerRules,
+  CrawlerStatus,
   CrawlRule,
 } from './types';
 import { crawlerDataServerToClient } from './utils';
 
-const DEFAULT_VALUES = {
+const DEFAULT_VALUES: CrawlerOverviewValues = {
+  crawlRequests: [],
   dataLoading: true,
   domains: [],
 };
@@ -46,6 +48,15 @@ const MOCK_SERVER_DATA: CrawlerDataFromServer = {
       sitemaps: [],
       entry_points: [],
       crawl_rules: [],
+    },
+  ],
+  crawl_requests: [
+    {
+      id: '618d0e66abe97bc688328900',
+      status: CrawlerStatus.Pending,
+      created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      began_at: null,
+      completed_at: null,
     },
   ],
 };
@@ -79,6 +90,15 @@ describe('CrawlerOverviewLogic', () => {
             entryPoints: [],
             crawlRules: [],
             defaultCrawlRule: DEFAULT_CRAWL_RULE,
+          },
+        ],
+        crawlRequests: [
+          {
+            id: '618d0e66abe97bc688328900',
+            status: CrawlerStatus.Pending,
+            createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+            beganAt: null,
+            completedAt: null,
           },
         ],
       };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_VALUES: CrawlerOverviewValues = {
   crawlRequests: [],
   dataLoading: true,
   domains: [],
+  mostRecentCrawlRequestStatus: CrawlerStatus.Success,
 };
 
 const DEFAULT_CRAWL_RULE: CrawlRule = {
@@ -167,6 +168,77 @@ describe('CrawlerOverviewLogic', () => {
         await nextTick();
 
         expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('mostRecentCrawlRequestStatus', () => {
+      it('is Success when there are no crawl requests', () => {
+        mount({
+          crawlRequests: [],
+        });
+
+        expect(CrawlerOverviewLogic.values.mostRecentCrawlRequestStatus).toEqual(
+          CrawlerStatus.Success
+        );
+      });
+
+      it('is Success when there are only crawl requests', () => {
+        mount({
+          crawlRequests: [
+            {
+              id: '2',
+              status: CrawlerStatus.Skipped,
+              createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+              beganAt: null,
+              completedAt: null,
+            },
+            {
+              id: '1',
+              status: CrawlerStatus.Skipped,
+              createdAt: 'Mon, 30 Aug 2020 17:00:00 +0000',
+              beganAt: null,
+              completedAt: null,
+            },
+          ],
+        });
+
+        expect(CrawlerOverviewLogic.values.mostRecentCrawlRequestStatus).toEqual(
+          CrawlerStatus.Success
+        );
+      });
+
+      it('is the first non-skipped crawl request status', () => {
+        mount({
+          crawlRequests: [
+            {
+              id: '3',
+              status: CrawlerStatus.Skipped,
+              createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+              beganAt: null,
+              completedAt: null,
+            },
+            {
+              id: '2',
+              status: CrawlerStatus.Failed,
+              createdAt: 'Mon, 30 Aug 2020 17:00:00 +0000',
+              beganAt: null,
+              completedAt: null,
+            },
+            {
+              id: '1',
+              status: CrawlerStatus.Success,
+              createdAt: 'Mon, 29 Aug 2020 17:00:00 +0000',
+              beganAt: null,
+              completedAt: null,
+            },
+          ],
+        });
+
+        expect(CrawlerOverviewLogic.values.mostRecentCrawlRequestStatus).toEqual(
+          CrawlerStatus.Failed
+        );
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
@@ -14,7 +14,7 @@ import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_message
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlerData, CrawlerDomain } from './types';
+import { CrawlerData, CrawlerDomain, CrawlRequest } from './types';
 import { crawlerDataServerToClient } from './utils';
 
 export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
@@ -28,7 +28,8 @@ export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
     }
   );
 
-interface CrawlerOverviewValues {
+export interface CrawlerOverviewValues {
+  crawlRequests: CrawlRequest[];
   dataLoading: boolean;
   domains: CrawlerDomain[];
 }
@@ -59,6 +60,12 @@ export const CrawlerOverviewLogic = kea<
       [],
       {
         onReceiveCrawlerData: (_, { data: { domains } }) => domains,
+      },
+    ],
+    crawlRequests: [
+      [],
+      {
+        onReceiveCrawlerData: (_, { data: { crawlRequests } }) => crawlRequests,
       },
     ],
   },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
@@ -14,7 +14,7 @@ import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_message
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlerData, CrawlerDomain, CrawlRequest } from './types';
+import { CrawlerData, CrawlerDomain, CrawlerStatus, CrawlRequest } from './types';
 import { crawlerDataServerToClient } from './utils';
 
 export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
@@ -32,6 +32,7 @@ export interface CrawlerOverviewValues {
   crawlRequests: CrawlRequest[];
   dataLoading: boolean;
   domains: CrawlerDomain[];
+  mostRecentCrawlRequestStatus: CrawlerStatus;
 }
 
 interface CrawlerOverviewActions {
@@ -69,6 +70,20 @@ export const CrawlerOverviewLogic = kea<
       },
     ],
   },
+  selectors: ({ selectors }) => ({
+    mostRecentCrawlRequestStatus: [
+      () => [selectors.crawlRequests],
+      (crawlRequests: CrawlerOverviewValues['crawlRequests']) => {
+        const eligibleCrawlRequests = crawlRequests.filter(
+          (req) => req.status !== CrawlerStatus.Skipped
+        );
+        if (eligibleCrawlRequests.length === 0) {
+          return CrawlerStatus.Success;
+        }
+        return eligibleCrawlRequests[0].status;
+      },
+    ],
+  }),
   listeners: ({ actions }) => ({
     fetchCrawlerData: async () => {
       const { http } = HttpLogic.values;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
@@ -14,8 +14,14 @@ import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_message
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlerData, CrawlerDomain, CrawlerStatus, CrawlRequest } from './types';
-import { crawlerDataServerToClient } from './utils';
+import {
+  CrawlerData,
+  CrawlerDomain,
+  CrawlerStatus,
+  CrawlRequest,
+  CrawlRequestFromServer,
+} from './types';
+import { crawlerDataServerToClient, crawlRequestServerToClient } from './utils';
 
 export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
   i18n.translate(
@@ -28,17 +34,28 @@ export const DELETE_DOMAIN_MESSAGE = (domainUrl: string) =>
     }
   );
 
+const POLLING_DURATION = 1000;
+const POLLING_DURATION_ON_FAILURE = 5000;
+
 export interface CrawlerOverviewValues {
   crawlRequests: CrawlRequest[];
   dataLoading: boolean;
   domains: CrawlerDomain[];
   mostRecentCrawlRequestStatus: CrawlerStatus;
+  timeoutId: NodeJS.Timeout | null;
 }
 
 interface CrawlerOverviewActions {
+  clearTimeoutId(): void;
+  createNewTimeoutForCrawlRequests(timeoutId: number): { timeoutId: number };
   deleteDomain(domain: CrawlerDomain): { domain: CrawlerDomain };
   fetchCrawlerData(): void;
+  getLatestCrawlRequests(refreshData?: boolean): { refreshData?: boolean };
+  onCreatedNewTimeout(timeoutId: NodeJS.Timeout): { timeoutId: NodeJS.Timeout };
   onReceiveCrawlerData(data: CrawlerData): { data: CrawlerData };
+  onRecieveCrawlRequests(crawlRequests: CrawlRequest[]): { crawlRequests: CrawlRequest[] };
+  startCrawl(): void;
+  stopCrawl(): void;
 }
 
 export const CrawlerOverviewLogic = kea<
@@ -46,9 +63,15 @@ export const CrawlerOverviewLogic = kea<
 >({
   path: ['enterprise_search', 'app_search', 'crawler', 'crawler_overview'],
   actions: {
+    clearTimeoutId: true,
     deleteDomain: (domain) => ({ domain }),
     fetchCrawlerData: true,
+    getLatestCrawlRequests: (timeoutId) => ({ timeoutId }),
+    onCreatedNewTimeout: (timeoutId) => ({ timeoutId }),
     onReceiveCrawlerData: (data) => ({ data }),
+    onRecieveCrawlRequests: (crawlRequests) => ({ crawlRequests }),
+    startCrawl: () => null,
+    stopCrawl: () => null,
   },
   reducers: {
     dataLoading: [
@@ -67,6 +90,14 @@ export const CrawlerOverviewLogic = kea<
       [],
       {
         onReceiveCrawlerData: (_, { data: { crawlRequests } }) => crawlRequests,
+        onRecieveCrawlRequests: (_, { crawlRequests }) => crawlRequests,
+      },
+    ],
+    timeoutId: [
+      null,
+      {
+        clearTimeoutId: () => null,
+        onCreatedNewTimeout: (_, { timeoutId }) => timeoutId,
       },
     ],
   },
@@ -84,7 +115,7 @@ export const CrawlerOverviewLogic = kea<
       },
     ],
   }),
-  listeners: ({ actions }) => ({
+  listeners: ({ actions, values }) => ({
     fetchCrawlerData: async () => {
       const { http } = HttpLogic.values;
       const { engineName } = EngineLogic.values;
@@ -115,6 +146,79 @@ export const CrawlerOverviewLogic = kea<
         flashSuccessToast(DELETE_DOMAIN_MESSAGE(domain.url));
       } catch (e) {
         flashAPIErrors(e);
+      }
+    },
+    startCrawl: async () => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        await http.post(`/api/as/v0/engines/${engineName}/crawler/crawl_requests`);
+        actions.getLatestCrawlRequests();
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+    stopCrawl: async () => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        await http.post(`/api/as/v0/engines/${engineName}/crawler/crawl_requests/cancel`);
+        actions.getLatestCrawlRequests();
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+    createNewTimeoutForCrawlRequests: ({ timeoutId }) => {
+      if (values.timeoutId) {
+        clearTimeout(values.timeoutId);
+      }
+
+      const timeoutIdId = setTimeout(() => {
+        actions.getLatestCrawlRequests();
+      }, timeoutId);
+
+      actions.onCreatedNewTimeout(timeoutIdId);
+    },
+    getLatestCrawlRequests: async ({ refreshData = true }) => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const crawlRequestsFromServer: CrawlRequestFromServer[] = await http.get(
+          `/api/as/v0/engines/${engineName}/crawler/crawl_requests`
+        );
+        const crawlRequests = crawlRequestsFromServer.map(crawlRequestServerToClient);
+        actions.onRecieveCrawlRequests(crawlRequests);
+        if (
+          [
+            CrawlerStatus.Pending,
+            CrawlerStatus.Starting,
+            CrawlerStatus.Running,
+            CrawlerStatus.Canceling,
+          ].includes(crawlRequests[0]?.status)
+        ) {
+          actions.createNewTimeoutForCrawlRequests(POLLING_DURATION);
+        } else if (
+          [CrawlerStatus.Success, CrawlerStatus.Failed, CrawlerStatus.Canceled].includes(
+            crawlRequests[0]?.status
+          )
+        ) {
+          actions.clearTimeoutId();
+          if (refreshData) {
+            actions.fetchCrawlerData();
+          }
+        }
+      } catch (e) {
+        actions.createNewTimeoutForCrawlRequests(POLLING_DURATION_ON_FAILURE);
+      }
+    },
+  }),
+  events: ({ values }) => ({
+    beforeUnmount: () => {
+      if (values.timeoutId) {
+        clearTimeout(values.timeoutId);
       }
     },
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
+
 export enum CrawlerPolicies {
   allow = 'allow',
   deny = 'deny',
@@ -60,10 +62,12 @@ export interface CrawlerDomainFromServer {
 
 export interface CrawlerData {
   domains: CrawlerDomain[];
+  crawlRequests: CrawlRequest[];
 }
 
 export interface CrawlerDataFromServer {
   domains: CrawlerDomainFromServer[];
+  crawl_requests: CrawlRequestFromServer[];
 }
 
 export interface CrawlerDomainValidationResultFromServer {
@@ -101,3 +105,75 @@ export type CrawlerDomainValidationStepName =
   | 'networkConnectivity'
   | 'indexingRestrictions'
   | 'contentVerification';
+// See SharedTogo::Crawler::Status for details on how these are generated
+export enum CrawlerStatus {
+  Pending = 'pending',
+  Suspended = 'suspended',
+  Starting = 'starting',
+  Running = 'running',
+  Suspending = 'suspending',
+  Canceling = 'canceling',
+  Success = 'success',
+  Failed = 'failed',
+  Canceled = 'canceled',
+  Skipped = 'skipped',
+}
+
+export interface CrawlRequestFromServer {
+  id: string;
+  status: CrawlerStatus;
+  created_at: string;
+  began_at: string | null;
+  completed_at: string | null;
+}
+
+export interface CrawlRequest {
+  id: string;
+  status: CrawlerStatus;
+  createdAt: string;
+  beganAt: string | null;
+  completedAt: string | null;
+}
+
+export const readableCrawlerStatuses: { [key in CrawlerStatus]: string } = {
+  [CrawlerStatus.Pending]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.pending',
+    { defaultMessage: 'Pending' }
+  ),
+  [CrawlerStatus.Suspended]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.suspended',
+    { defaultMessage: 'Suspended' }
+  ),
+  [CrawlerStatus.Starting]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.starting',
+    { defaultMessage: 'Starting' }
+  ),
+  [CrawlerStatus.Running]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.running',
+    { defaultMessage: 'Running' }
+  ),
+  [CrawlerStatus.Suspending]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.suspending',
+    { defaultMessage: 'Suspending' }
+  ),
+  [CrawlerStatus.Canceling]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.canceling',
+    { defaultMessage: 'Canceling' }
+  ),
+  [CrawlerStatus.Success]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.success',
+    { defaultMessage: 'Success' }
+  ),
+  [CrawlerStatus.Failed]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.failed',
+    { defaultMessage: 'Failed' }
+  ),
+  [CrawlerStatus.Canceled]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.canceled',
+    { defaultMessage: 'Canceled' }
+  ),
+  [CrawlerStatus.Skipped]: i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlerStatusOptions.skipped',
+    { defaultMessage: 'Skipped' }
+  ),
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -12,6 +12,8 @@ import {
   CrawlerDataFromServer,
   CrawlerDomainValidationResultFromServer,
   CrawlerDomainValidationStep,
+  CrawlRequestFromServer,
+  CrawlRequest,
 } from './types';
 
 export function crawlerDomainServerToClient(payload: CrawlerDomainFromServer): CrawlerDomain {
@@ -48,11 +50,30 @@ export function crawlerDomainServerToClient(payload: CrawlerDomainFromServer): C
   return clientPayload;
 }
 
+export function crawlRequestServerToClient(crawlRequest: CrawlRequestFromServer): CrawlRequest {
+  const {
+    id,
+    status,
+    created_at: createdAt,
+    began_at: beganAt,
+    completed_at: completedAt,
+  } = crawlRequest;
+
+  return {
+    id,
+    status,
+    createdAt,
+    beganAt,
+    completedAt,
+  };
+}
+
 export function crawlerDataServerToClient(payload: CrawlerDataFromServer): CrawlerData {
-  const { domains } = payload;
+  const { domains, crawl_requests: crawlRequests } = payload;
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
+    crawlRequests: crawlRequests.map((crawlRequest) => crawlRequestServerToClient(crawlRequest)),
   };
 }
 


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
