### PR TITLE
[Fleet] Remove references to legacy Elasticsearch types

### DIFF
--- a/x-pack/plugins/fleet/server/errors/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/errors/handlers.test.ts
@@ -6,7 +6,6 @@
  */
 
 import Boom from '@hapi/boom';
-import { errors } from 'elasticsearch';
 import { httpServerMock } from 'src/core/server/mocks';
 
 import { createAppContextStartContractMock } from '../mocks';
@@ -20,7 +19,6 @@ import {
   defaultIngestErrorHandler,
 } from './index';
 
-const LegacyESErrors = errors as Record<string, any>;
 type ITestEsErrorsFnParams = [errorCode: string, error: any, expectedMessage: string];
 
 describe('defaultIngestErrorHandler', () => {
@@ -54,36 +52,6 @@ describe('defaultIngestErrorHandler', () => {
     expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
     expect(mockContract.logger?.error).toHaveBeenCalledWith(expectedMessage);
   }
-
-  describe('use the HTTP error status code provided by LegacyESErrors', () => {
-    const statusCodes = Object.keys(LegacyESErrors).filter((key) => /^\d+$/.test(key));
-    const errorCodes = statusCodes.filter((key) => parseInt(key, 10) >= 400);
-    const casesWithPathResponse: ITestEsErrorsFnParams[] = errorCodes.map((errorCode) => [
-      errorCode,
-      new LegacyESErrors[errorCode]('the root message', {
-        path: '/path/to/call',
-        response: 'response is here',
-      }),
-      'the root message response from /path/to/call: response is here',
-    ]);
-    const casesWithOtherMeta: ITestEsErrorsFnParams[] = errorCodes.map((errorCode) => [
-      errorCode,
-      new LegacyESErrors[errorCode]('the root message', {
-        other: '/path/to/call',
-        props: 'response is here',
-      }),
-      'the root message',
-    ]);
-    const casesWithoutMeta: ITestEsErrorsFnParams[] = errorCodes.map((errorCode) => [
-      errorCode,
-      new LegacyESErrors[errorCode]('some message'),
-      'some message',
-    ]);
-
-    test.each(casesWithPathResponse)('%d - with path & response', testEsErrorsFn);
-    test.each(casesWithOtherMeta)('%d - with other metadata', testEsErrorsFn);
-    test.each(casesWithoutMeta)('%d - without metadata', testEsErrorsFn);
-  });
 
   describe('IngestManagerError', () => {
     it('502: RegistryError', async () => {

--- a/x-pack/plugins/fleet/server/errors/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/errors/handlers.test.ts
@@ -19,8 +19,6 @@ import {
   defaultIngestErrorHandler,
 } from './index';
 
-type ITestEsErrorsFnParams = [errorCode: string, error: any, expectedMessage: string];
-
 describe('defaultIngestErrorHandler', () => {
   let mockContract: ReturnType<typeof createAppContextStartContractMock>;
   beforeEach(async () => {
@@ -33,25 +31,6 @@ describe('defaultIngestErrorHandler', () => {
     jest.clearAllMocks();
     appContextService.stop();
   });
-
-  async function testEsErrorsFn(...args: ITestEsErrorsFnParams) {
-    const [, error, expectedMessage] = args;
-    jest.clearAllMocks();
-    const response = httpServerMock.createResponseFactory();
-    await defaultIngestErrorHandler({ error, response });
-
-    // response
-    expect(response.ok).toHaveBeenCalledTimes(0);
-    expect(response.customError).toHaveBeenCalledTimes(1);
-    expect(response.customError).toHaveBeenCalledWith({
-      statusCode: error.status,
-      body: { message: expectedMessage },
-    });
-
-    // logging
-    expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
-    expect(mockContract.logger?.error).toHaveBeenCalledWith(expectedMessage);
-  }
 
   describe('IngestManagerError', () => {
     it('502: RegistryError', async () => {

--- a/x-pack/plugins/fleet/server/errors/handlers.ts
+++ b/x-pack/plugins/fleet/server/errors/handlers.ts
@@ -7,7 +7,6 @@
 
 import type Boom from '@hapi/boom';
 import { isBoom } from '@hapi/boom';
-import { errors as LegacyESErrors } from 'elasticsearch';
 
 import type {
   IKibanaResponse,
@@ -40,26 +39,6 @@ interface IngestErrorHandlerParams {
 // unsure if this is correct. would prefer to use something "official"
 // this type is based on BadRequest values observed while debugging https://github.com/elastic/kibana/issues/75862
 
-interface LegacyESClientError {
-  message: string;
-  stack: string;
-  status: number;
-  displayName: string;
-  path?: string;
-  query?: string | undefined;
-  body?: {
-    error: {
-      type: string;
-    };
-    status: number;
-  };
-  statusCode?: number;
-  response?: string;
-}
-export const isLegacyESClientError = (error: any): error is LegacyESClientError => {
-  return error instanceof LegacyESErrors._Abstract;
-};
-
 const getHTTPResponseCode = (error: IngestManagerError): number => {
   if (error instanceof RegistryError) {
     return 502; // Bad Gateway
@@ -84,23 +63,6 @@ const getHTTPResponseCode = (error: IngestManagerError): number => {
 
 export function ingestErrorToResponseOptions(error: IngestErrorHandlerParams['error']) {
   const logger = appContextService.getLogger();
-  if (isLegacyESClientError(error)) {
-    // there was a problem communicating with ES (e.g. via `callCluster`)
-    // only log the message
-    const message =
-      error?.path && error?.response
-        ? // if possible, return the failing endpoint and its response
-          `${error.message} response from ${error.path}: ${error.response}`
-        : error.message;
-
-    logger.error(message);
-
-    return {
-      statusCode: error?.statusCode || error.status,
-      body: { message },
-    };
-  }
-
   // our "expected" errors
   if (error instanceof IngestManagerError) {
     // only log the message

--- a/x-pack/plugins/fleet/server/errors/index.ts
+++ b/x-pack/plugins/fleet/server/errors/index.ts
@@ -8,11 +8,7 @@
 /* eslint-disable max-classes-per-file */
 import { isESClientError } from './utils';
 
-export {
-  defaultIngestErrorHandler,
-  ingestErrorToResponseOptions,
-  isLegacyESClientError,
-} from './handlers';
+export { defaultIngestErrorHandler, ingestErrorToResponseOptions } from './handlers';
 
 export { isESClientError } from './utils';
 


### PR DESCRIPTION
## Summary

Closes #107179

Remove references to `elasticsearch` module in Fleet.

The non-legacy `elasticsearch/types` module does not export these legacy errors, and I based this PR off of another one linked in the top-level tracking issue (#83910) for this cleanup in which the security team removed references to these legacy errors in their tests: #107135.