### PR TITLE
[7.x] [actions] change cloud icon usage for the customHostSettings connector settings  (#107481)

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -117,13 +117,13 @@ xpack.actions.customHostSettings:
   The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
 
 | `xpack.actions.customHostSettings[n]`
-`.ssl.rejectUnauthorized` {ess-icon}
+`.ssl.rejectUnauthorized`
   | Deprecated. Use <<action-config-custom-host-verification-mode,`xpack.actions.customHostSettings.ssl.verificationMode`>> instead. A boolean value indicating whether to bypass server certificate validation.
   Overrides the general `xpack.actions.rejectUnauthorized` configuration
   for requests made for this hostname/port.
 
 |[[action-config-custom-host-verification-mode]] `xpack.actions.customHostSettings[n]`
-`.ssl.verificationMode`
+`.ssl.verificationMode` {ess-icon}
   | Controls the verification of the server certificate that {hosted-ems} receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. 
  Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. <<elasticsearch-ssl-verificationMode,Equivalent {kib} setting>>. Overrides the general `xpack.actions.ssl.verificationMode` configuration
   for requests made for this hostname/port.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [actions] change cloud icon usage for the customHostSettings connector settings  (#107481)