### PR TITLE
chore(NA): moving @kbn/server-route-repository to babel transpiler

### DIFF
--- a/packages/kbn-server-route-repository/.babelrc
+++ b/packages/kbn-server-route-repository/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-server-route-repository/BUILD.bazel
+++ b/packages/kbn-server-route-repository/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-server-route-repository"
 PKG_REQUIRE_NAME = "@kbn/server-route-repository"
@@ -25,7 +26,7 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md"
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-config-schema",
   "//packages/kbn-io-ts-utils",
   "@npm//@hapi/boom",
@@ -36,12 +37,20 @@ SRC_DEPS = [
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-config-schema",
+  "//packages/kbn-io-ts-utils",
+  "@npm//@hapi/boom",
+  "@npm//utility-types",
   "@npm//@types/jest",
   "@npm//@types/lodash",
   "@npm//@types/node",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -52,14 +61,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -68,7 +78,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-server-route-repository/BUILD.bazel
+++ b/packages/kbn-server-route-repository/BUILD.bazel
@@ -31,7 +31,6 @@ RUNTIME_DEPS = [
   "//packages/kbn-io-ts-utils",
   "@npm//@hapi/boom",
   "@npm//fp-ts",
-  "@npm//io-ts",
   "@npm//lodash",
   "@npm//utility-types"
 ]
@@ -40,6 +39,7 @@ TYPES_DEPS = [
   "//packages/kbn-config-schema",
   "//packages/kbn-io-ts-utils",
   "@npm//@hapi/boom",
+  "@npm//fp-ts",
   "@npm//utility-types",
   "@npm//@types/jest",
   "@npm//@types/lodash",

--- a/packages/kbn-server-route-repository/package.json
+++ b/packages/kbn-server-route-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kbn/server-route-repository",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true

--- a/packages/kbn-server-route-repository/tsconfig.json
+++ b/packages/kbn-server-route-repository/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "./target",
-    "stripInternal": false,
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "./target_types",
+    "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-server-route-repository/src",
+    "stripInternal": false,
     "types": [
       "jest",
       "node"
@@ -15,6 +17,6 @@
     "noUnusedLocals": false
   },
   "include": [
-    "./src/**/*.ts"
+    "src/**/*.ts"
   ]
 }

--- a/x-pack/plugins/apm/public/services/rest/createCallApmApi.ts
+++ b/x-pack/plugins/apm/public/services/rest/createCallApmApi.ts
@@ -10,12 +10,14 @@ import * as t from 'io-ts';
 import type {
   ClientRequestParamsOf,
   EndpointOf,
+  formatRequest as formatRequestType,
   ReturnOf,
   RouteRepositoryClient,
   ServerRouteRepository,
   ServerRoute,
 } from '@kbn/server-route-repository';
-import { formatRequest } from '@kbn/server-route-repository';
+// @ts-expect-error
+import { formatRequest } from '@kbn/server-route-repository/target_node/format_request';
 import { FetchOptions } from '../../../common/fetch_options';
 import { callApi } from './callApi';
 import type {
@@ -81,7 +83,10 @@ export function createCallApmApi(core: CoreStart | CoreSetup) {
       params?: Partial<Record<string, any>>;
     };
 
-    const { method, pathname } = formatRequest(endpoint, params?.path);
+    const { method, pathname } = formatRequest(
+      endpoint,
+      params?.path
+    ) as ReturnType<typeof formatRequestType>;
 
     return callApi(core, {
       ...opts,

--- a/x-pack/plugins/apm/public/services/rest/createCallApmApi.ts
+++ b/x-pack/plugins/apm/public/services/rest/createCallApmApi.ts
@@ -15,7 +15,7 @@ import type {
   ServerRouteRepository,
   ServerRoute,
 } from '@kbn/server-route-repository';
-import { formatRequest } from '@kbn/server-route-repository/target/format_request';
+import { formatRequest } from '@kbn/server-route-repository';
 import { FetchOptions } from '../../../common/fetch_options';
 import { callApi } from './callApi';
 import type {

--- a/x-pack/plugins/apm/public/services/rest/createCallApmApi.ts
+++ b/x-pack/plugins/apm/public/services/rest/createCallApmApi.ts
@@ -16,7 +16,10 @@ import type {
   ServerRouteRepository,
   ServerRoute,
 } from '@kbn/server-route-repository';
-// @ts-expect-error
+// @ts-expect-error cannot find module or correspondent type declarations
+// The code and types are at separated folders on @kbn/server-route-repository
+// so in order to do targeted imports they must me imported separately, and
+// an error is expected here
 import { formatRequest } from '@kbn/server-route-repository/target_node/format_request';
 import { FetchOptions } from '../../../common/fetch_options';
 import { callApi } from './callApi';

--- a/x-pack/plugins/apm/server/routes/register_routes/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/register_routes/index.test.ts
@@ -7,7 +7,7 @@
 
 import { jsonRt } from '@kbn/io-ts-utils';
 import { createServerRouteRepository } from '@kbn/server-route-repository';
-import { ServerRoute } from '@kbn/server-route-repository/target/typings';
+import { ServerRoute } from '@kbn/server-route-repository';
 import * as t from 'io-ts';
 import { CoreSetup, Logger } from 'src/core/server';
 import { APMConfig } from '../..';

--- a/x-pack/plugins/observability/public/services/call_observability_api/index.ts
+++ b/x-pack/plugins/observability/public/services/call_observability_api/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { formatRequest } from '@kbn/server-route-repository/target/format_request';
+import { formatRequest } from '@kbn/server-route-repository';
 import type { HttpSetup } from 'kibana/public';
 import type { AbstractObservabilityClient, ObservabilityClient } from './types';
 

--- a/x-pack/plugins/observability/public/services/call_observability_api/index.ts
+++ b/x-pack/plugins/observability/public/services/call_observability_api/index.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { formatRequest } from '@kbn/server-route-repository';
+// @ts-expect-error
+import { formatRequest } from '@kbn/server-route-repository/target_node/format_request';
+import type { formatRequest as formatRequestType } from '@kbn/server-route-repository/target_types/format_request';
 import type { HttpSetup } from 'kibana/public';
 import type { AbstractObservabilityClient, ObservabilityClient } from './types';
 
@@ -17,7 +19,9 @@ export function createCallObservabilityApi(http: HttpSetup) {
   const client: AbstractObservabilityClient = (options) => {
     const { params: { path, body, query } = {}, endpoint, ...rest } = options;
 
-    const { method, pathname } = formatRequest(endpoint, path);
+    const { method, pathname } = formatRequest(endpoint, path) as ReturnType<
+      typeof formatRequestType
+    >;
 
     return http[method](pathname, {
       ...rest,


### PR DESCRIPTION
One step forward on #69706

That PR moves the @kbn/server-route-repository from using tsc compiler to babel transpiler to produce the js outputs.