### PR TITLE
chore(NA): moving @kbn/server-http-tools to babel transpiler

### DIFF
--- a/packages/kbn-server-http-tools/.babelrc
+++ b/packages/kbn-server-http-tools/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-server-http-tools/BUILD.bazel
+++ b/packages/kbn-server-http-tools/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-server-http-tools"
 PKG_REQUIRE_NAME = "@kbn/server-http-tools"
@@ -25,7 +26,7 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md"
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-config-schema",
   "//packages/kbn-crypto",
   "@npm//@hapi/hapi",
@@ -36,13 +37,24 @@ SRC_DEPS = [
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-config-schema",
+  "//packages/kbn-crypto",
+  "@npm//@hapi/hapi",
+  "@npm//@hapi/hoek",
+  "@npm//joi",
+  "@npm//moment",
   "@npm//@types/hapi__hapi",
+  "@npm//@types/jest",
   "@npm//@types/joi",
   "@npm//@types/node",
   "@npm//@types/uuid",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -53,14 +65,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -69,7 +82,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-server-http-tools/package.json
+++ b/packages/kbn-server-http-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kbn/server-http-tools",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true

--- a/packages/kbn-server-http-tools/tsconfig.json
+++ b/packages/kbn-server-http-tools/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "./target",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "./target",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-server-http-tools/src",


### PR DESCRIPTION
One step forward on #69706

That PR moves the @kbn/server-http-tools from using tsc compiler to babel transpiler to produce the js outputs.