### PR TITLE
chore(NA): moving @kbn/babel-code-parser to babel transpiler

### DIFF
--- a/packages/kbn-babel-code-parser/BUILD.bazel
+++ b/packages/kbn-babel-code-parser/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
-load("@npm//@babel/cli:index.bzl", "babel")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-babel-code-parser"
 PKG_REQUIRE_NAME = "@kbn/babel-code-parser"
@@ -25,35 +25,23 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-babel-preset",
   "@npm//@babel/parser",
   "@npm//@babel/traverse",
   "@npm//lodash",
 ]
 
-babel(
-  name = "target",
-  data = DEPS + [
-      ":srcs",
-      ".babelrc",
-  ],
-  output_dir = True,
-  # the following arg paths includes $(execpath) as babel runs on the sandbox root
-  args = [
-      "./%s/src" % package_name(),
-      "--config-file",
-      "./%s/.babelrc" % package_name(),
-      "--out-dir",
-      "$(@D)",
-      "--quiet"
-  ],
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
 )
 
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":target"],
+  deps = RUNTIME_DEPS + [":target_node"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-babel-code-parser/BUILD.bazel
+++ b/packages/kbn-babel-code-parser/BUILD.bazel
@@ -26,7 +26,6 @@ NPM_MODULE_EXTRA_FILES = [
 ]
 
 RUNTIME_DEPS = [
-  "//packages/kbn-babel-preset",
   "@npm//@babel/parser",
   "@npm//@babel/traverse",
   "@npm//lodash",

--- a/packages/kbn-babel-code-parser/package.json
+++ b/packages/kbn-babel-code-parser/package.json
@@ -3,7 +3,7 @@
   "description": "babel code parser for Kibana",
   "private": true,
   "version": "1.0.0",
-  "main": "./target/index.js",
+  "main": "./target_node/index.js",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
One step forward on #69706

That PR moves the @kbn/babel-code-parser from using babel rule to use the new jsts_transpiler one.