### PR TITLE
[DOCS] Remove redundant attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,8 +4,6 @@
 :include-xpack:  true
 :lang:           en
 :kib-repo-dir:   {kibana-root}/docs
-:blog-ref:       https://www.elastic.co/blog/
-:wikipedia:      https://en.wikipedia.org/wiki
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 


### PR DESCRIPTION
## Summary

Removes redundant attributes that are already defined (with the same values) in https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc
