### PR TITLE
[7.x][DOCS] Remove redundant attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,8 +4,6 @@
 :include-xpack:  true
 :lang:           en
 :kib-repo-dir:   {kibana-root}/docs
-:blog-ref:       https://www.elastic.co/blog/
-:wikipedia:      https://en.wikipedia.org/wiki
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
@@ -15,7 +13,6 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 :es-docker-image: {es-docker-repo}:{version}
 :blob:           {kib-repo}blob/{branch}/
 :security-ref:   https://www.elastic.co/community/security/
-:kibana-ref-all: https://www.elastic.co/guide/en/kibana
 
 include::{docs-root}/shared/attributes.asciidoc[]
 


### PR DESCRIPTION
## Summary

Backports https://github.com/elastic/kibana/pull/107583
Also removes `kibana-ref-all`, which was added to the shared attributes in https://github.com/elastic/docs/pull/2169