### PR TITLE
[DOCS] Updates file data visualizer details

### DIFF
--- a/docs/maps/import-geospatial-data.asciidoc
+++ b/docs/maps/import-geospatial-data.asciidoc
@@ -27,6 +27,7 @@ To upload CSV files in {kib} with the *{file-data-viz}*, you must have
 privileges to upload GeoJSON files and:
 
 * The `manage_pipeline` or `manage_ingest_pipelines` cluster privilege
+* The `manage` index privilege for destination indices
 * The `read` {kib} privilege for *{ml-app}* or the `all` {kib}
 privilege for *Discover*
 

--- a/docs/maps/import-geospatial-data.asciidoc
+++ b/docs/maps/import-geospatial-data.asciidoc
@@ -27,7 +27,7 @@ To upload CSV files in {kib} with the *{file-data-viz}*, you must have privilege
 
 * The `manage_pipeline` cluster privilege.
 * The `read` {kib} privilege for *Machine Learning*.
-* The `machine_learning_admin` or `machine_learning_user` role.
+* The `monitor` or `monitor_text_structure` cluster privileges
 
 
 [discrete]

--- a/docs/maps/import-geospatial-data.asciidoc
+++ b/docs/maps/import-geospatial-data.asciidoc
@@ -19,15 +19,16 @@ spaces in **{stack-manage-app}** in {kib}. For more information, see
 To upload GeoJSON files in {kib} with *Maps*, you must have:
 
 * The `all` {kib} privilege for *Maps*.
-* The `all` {kib} privilege for *Index Pattern Management*.
+* The `all` {kib} privilege for *{ipm-app}*.
 * The `create` and `create_index` index privileges for destination indices.
 * To use the index in *Maps*, you must also have the `read` and `view_index_metadata` index privileges for destination indices.
 
-To upload CSV files in {kib} with the *{file-data-viz}*, you must have privileges to upload GeoJSON files and:
+To upload CSV files in {kib} with the *{file-data-viz}*, you must have
+privileges to upload GeoJSON files and:
 
-* The `manage_pipeline` cluster privilege.
-* The `read` {kib} privilege for *Machine Learning*.
-* The `monitor` or `monitor_text_structure` cluster privileges
+* The `manage_pipeline` or `manage_ingest_pipelines` cluster privilege
+* The `read` {kib} privilege for *{ml-app}* or the `all` {kib}
+privilege for *Discover*
 
 
 [discrete]

--- a/docs/maps/import-geospatial-data.asciidoc
+++ b/docs/maps/import-geospatial-data.asciidoc
@@ -19,17 +19,15 @@ spaces in **{stack-manage-app}** in {kib}. For more information, see
 To upload GeoJSON files in {kib} with *Maps*, you must have:
 
 * The `all` {kib} privilege for *Maps*.
-* The `all` {kib} privilege for *{ipm-app}*.
+* The `all` {kib} privilege for *Index Pattern Management*.
 * The `create` and `create_index` index privileges for destination indices.
 * To use the index in *Maps*, you must also have the `read` and `view_index_metadata` index privileges for destination indices.
 
-To upload CSV files in {kib} with the *{file-data-viz}*, you must have
-privileges to upload GeoJSON files and:
+To upload CSV files in {kib} with the *{file-data-viz}*, you must have privileges to upload GeoJSON files and:
 
-* The `manage_pipeline` or `manage_ingest_pipelines` cluster privilege
-* The `manage` index privilege for destination indices
-* The `read` {kib} privilege for *{ml-app}* or the `all` {kib}
-privilege for *Discover*
+* The `manage_pipeline` cluster privilege.
+* The `read` {kib} privilege for *Machine Learning*.
+* The `machine_learning_admin` or `machine_learning_user` role.
 
 
 [discrete]

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -53,8 +53,8 @@ NOTE: This feature is not intended for use as part of a repeated production
 process, but rather for the initial exploration of your data.
 
 You can upload a file up to 100 MB. This value is configurable up to 1 GB in
-<<kibana-ml-settings, Advanced Settings>>. To upload a file with geospatial data,
-refer to <<import-geospatial-data,Import geospatial data>>.
+<<fileupload-maxfilesize,Advanced Settings>>. To upload a file with geospatial
+data, refer to <<import-geospatial-data,Import geospatial data>>.
 
 [role="screenshot"]
 image::images/add-data-fv.png[Uploading a file in {kib}]

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -54,21 +54,18 @@ refer to <<import-geospatial-data, Import geospatial data>>.
 image::images/add-data-fv.png[{file-data-viz}]
 
 The {stack-security-features} provide roles and privileges that control which
-users can upload files. To upload files in {kib} with the *{file-data-viz}*, you
-must have the following privileges:
+users can upload files. To upload files in {kib}, you must have the following
+privileges:
 
-* `all` {kib} privileges for the {ml-features} in the appropriate spaces.
-Alternatively, `read` {kib} privileges for the {ml-features} and `all` {kib}
-privileges for the index pattern management feature
-* `manage_pipeline` cluster privilege
-* `monitor` or `monitor_text_structure` cluster privileges
-* `create`, `create_index`, and `read` index privileges for destination
+* `all` {kib} privileges for *Discover* or *{ml-app}* in the appropriate spaces.
+Alternatively, `read` {kib} privileges for *{ml-app}* and `all` {kib}
+privileges for *{ipm-app}*
+* `manage_pipeline` or `manage_ingest_pipelines` cluster privilege
+* `create`, `create_index`, and `read` index privileges for the destination
 indices
 
 You can manage your roles, privileges, and
-spaces in **{stack-manage-app}** in {kib}. For more information, see
-{ref}/security-privileges.html[Security privileges],
-<<kibana-privileges, {kib} privileges>>, and
+spaces in **{stack-manage-app}** in {kib}. For more information, refer to
 <<xpack-kibana-role-management, {kib} role management>>.
 
 NOTE: This feature is not intended for use as part of a

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -57,15 +57,13 @@ The {stack-security-features} provide roles and privileges that control which
 users can upload files. To upload files in {kib}, you must have the following
 privileges:
 
-* `all` {kib} privileges for *Discover* or *{ml-app}* in the appropriate spaces.
-Alternatively, `read` {kib} privileges for *{ml-app}* and `all` {kib}
-privileges for *{ipm-app}*
+* `all` {kib} privileges for *Discover* or *{ml-app}* in the appropriate spaces
 * `manage_pipeline` or `manage_ingest_pipelines` cluster privilege
-* `create`, `create_index`, and `read` index privileges for the destination
-indices
+* `create`, `create_index`, `manage`, and `read` index privileges for the
+destination indices
 
-You can manage your roles, privileges, and
-spaces in **{stack-manage-app}** in {kib}. For more information, refer to
+You can manage your roles, privileges, and spaces in **{stack-manage-app}** in
+{kib}. For more information, refer to
 <<xpack-kibana-role-management, {kib} role management>>.
 
 NOTE: This feature is not intended for use as part of a

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -46,14 +46,30 @@ image::images/add-data-fleet.png[Add data using Fleet]
 [[upload-data-kibana]]
 === Upload a file
 
-experimental[] If your data is in a CSV, JSON, or log file, you can upload it using the {file-data-viz}. You can upload a file up to 100 MB. This value is configurable up to 1 GB in
+If your data is in a CSV, JSON, or log file, you can upload it using the {file-data-viz}. You can upload a file up to 100 MB. This value is configurable up to 1 GB in
 <<kibana-ml-settings, Advanced Settings>>. To upload a file with geospatial data,
 refer to <<import-geospatial-data, Import geospatial data>>.
 
 [role="screenshot"]
-image::images/add-data-fv.png[File Data Visualizer]
+image::images/add-data-fv.png[{file-data-viz}]
 
+The {stack-security-features} provide roles and privileges that control which
+users can upload files. To upload files in {kib} with the *{file-data-viz}*, you
+must have the following privileges:
 
+* `all` {kib} privileges for the {ml-features} in the appropriate spaces.
+Alternatively, `read` {kib} privileges for the {ml-features} and `all` {kib}
+privileges for the index pattern management feature
+* `manage_pipeline` cluster privilege
+* `monitor` or `monitor_text_structure` cluster privileges
+* `create`, `create_index`, and `read` index privileges for destination
+indices
+
+You can manage your roles, privileges, and
+spaces in **{stack-manage-app}** in {kib}. For more information, see
+{ref}/security-privileges.html[Security privileges],
+<<kibana-privileges, {kib} privileges>>, and
+<<xpack-kibana-role-management, {kib} role management>>.
 
 NOTE: This feature is not intended for use as part of a
 repeated production process, but rather for the initial exploration of your data.

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -46,29 +46,30 @@ image::images/add-data-fleet.png[Add data using Fleet]
 [[upload-data-kibana]]
 === Upload a file
 
-If your data is in a CSV, JSON, or log file, you can upload it using the {file-data-viz}. You can upload a file up to 100 MB. This value is configurable up to 1 GB in
+If you have a log file or delimited CSV, TSV, or JSON file, you can upload it,
+view its fields and metrics, and optionally import it into {es}.
+
+NOTE: This feature is not intended for use as part of a repeated production
+process, but rather for the initial exploration of your data.
+
+You can upload a file up to 100 MB. This value is configurable up to 1 GB in
 <<kibana-ml-settings, Advanced Settings>>. To upload a file with geospatial data,
-refer to <<import-geospatial-data, Import geospatial data>>.
+refer to <<import-geospatial-data,Import geospatial data>>.
 
 [role="screenshot"]
-image::images/add-data-fv.png[{file-data-viz}]
+image::images/add-data-fv.png[Uploading a file in {kib}]
 
 The {stack-security-features} provide roles and privileges that control which
-users can upload files. To upload files in {kib}, you must have the following
-privileges:
+users can upload files. To upload a file in {kib} and import it into an {es}
+index, you'll need:
 
-* `all` {kib} privileges for *Discover* or *{ml-app}* in the appropriate spaces
+* `all` {kib} privileges for *Discover*
 * `manage_pipeline` or `manage_ingest_pipelines` cluster privilege
-* `create`, `create_index`, `manage`, and `read` index privileges for the
-destination indices
+* `create`, `create_index`, `manage`, and `read` index privileges for the index
 
 You can manage your roles, privileges, and spaces in **{stack-manage-app}** in
 {kib}. For more information, refer to
-<<xpack-kibana-role-management, {kib} role management>>.
-
-NOTE: This feature is not intended for use as part of a
-repeated production process, but rather for the initial exploration of your data.
-
+<<xpack-kibana-role-management,{kib} role management>>.
 
 [discrete]
 === Additional options for loading your data

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -17,7 +17,7 @@ if your data is stored in {es} and contains a time field, you can use the
 [role="screenshot"]
 image::user/ml/images/ml-data-visualizer-sample.jpg[{data-viz} for sample flight data]
 
-experimental[] You can also upload a CSV, NDJSON, or log file. The *{data-viz}*
+You can also upload a CSV, NDJSON, or log file. The *{data-viz}*
 identifies the file format and field mappings. You can then optionally import
 that data into an {es} index. To change the default file size limit, see
 <<kibana-general-settings, fileUpload:maxFileSize advanced settings>>.


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/104075, https://github.com/elastic/kibana/pull/101169, https://github.com/elastic/stack-docs/pull/1719

This PR removes the "experimental" indicator from the file data visualizer information in the Kibana Guide. It also updates the security requirements in the [Add data](https://www.elastic.co/guide/en/kibana/master/connect-to-elasticsearch.html) page.

The matching updates to the [Import geospatial data](https://www.elastic.co/guide/en/kibana/master/import-geospatial-data.html) page are accomplished in https://github.com/elastic/kibana/pull/107985

### Preview

* https://kibana_107609.docs-preview.app.elstc.co/guide/en/kibana/master/connect-to-elasticsearch.html#upload-data-kibana