### PR TITLE
[APM] always prefer url over transaction.page.url

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Summary/TransactionSummary.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Summary/TransactionSummary.tsx
@@ -11,7 +11,6 @@ import { Summary } from './';
 import { TimestampTooltip } from '../TimestampTooltip';
 import { DurationSummaryItem } from './DurationSummaryItem';
 import { ErrorCountSummaryItemBadge } from './error_count_summary_item_badge';
-import { isRumAgentName } from '../../../../common/agent_name';
 import { HttpInfoSummaryItem } from './http_info_summary_item';
 import { TransactionResultSummaryItem } from './TransactionResultSummaryItem';
 import { UserAgentSummaryItem } from './UserAgentSummaryItem';
@@ -24,10 +23,7 @@ interface Props {
 
 function getTransactionResultSummaryItem(transaction: Transaction) {
   const result = transaction.transaction.result;
-  const isRumAgent = isRumAgentName(transaction.agent.name);
-  const url = isRumAgent
-    ? transaction.transaction.page?.url
-    : transaction.url?.full;
+  const url = transaction.url?.full || transaction.transaction?.page?.url;
 
   if (url) {
     const method = transaction.http?.request?.method;


### PR DESCRIPTION
## Summary

Since 7.9.0, APM Server has been copying the `transaction.page.url` value to the ECS `url` field. We should still use `transaction.page.url` if it exists and `url` does not (i.e. for very old docs), but we should stop expecting it in newly written documents.

Closes #107493

### Checklist

~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~ (Couldn't find any existing test, doesn't seem worthwhile to add one.)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)