### PR TITLE
[7.x] [APM] Add throughput, error rate charts to backend detail page (#107379)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_detail_dependencies_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_detail_dependencies_table.tsx
@@ -58,11 +58,11 @@ export function BackendDetailDependenciesTable() {
           path: {
             backendName,
           },
-          query: { start, end, environment, numBuckets: 20, offset },
+          query: { start, end, environment, numBuckets: 20, offset, kuery },
         },
       });
     },
-    [start, end, environment, offset, backendName]
+    [start, end, environment, offset, backendName, kuery]
   );
 
   const dependencies =

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_error_rate_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_error_rate_chart.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
-import { getDurationFormatter } from '../../../../common/utils/formatters';
+import { asPercent } from '../../../../common/utils/formatters';
 import { useApmBackendContext } from '../../../context/apm_backend/use_apm_backend_context';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useComparison } from '../../../hooks/use_comparison';
@@ -15,12 +15,12 @@ import { useTimeRange } from '../../../hooks/use_time_range';
 import { Coordinate, TimeSeries } from '../../../../typings/timeseries';
 import { TimeseriesChart } from '../../shared/charts/timeseries_chart';
 import { useTheme } from '../../../hooks/use_theme';
-import {
-  getMaxY,
-  getResponseTimeTickFormatter,
-} from '../../shared/charts/transaction_charts/helper';
 
-export function BackendLatencyChart({ height }: { height: number }) {
+function yLabelFormat(y?: number | null) {
+  return asPercent(y || 0, 1);
+}
+
+export function BackendErrorRateChart({ height }: { height: number }) {
   const { backendName } = useApmBackendContext();
 
   const theme = useTheme();
@@ -40,7 +40,7 @@ export function BackendLatencyChart({ height }: { height: number }) {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/charts/latency',
+        endpoint: 'GET /api/apm/backends/{backendName}/charts/error_rate',
         params: {
           path: {
             backendName,
@@ -65,9 +65,9 @@ export function BackendLatencyChart({ height }: { height: number }) {
       specs.push({
         data: data.currentTimeseries,
         type: 'linemark',
-        color: theme.eui.euiColorVis1,
-        title: i18n.translate('xpack.apm.backendLatencyChart.chartTitle', {
-          defaultMessage: 'Latency',
+        color: theme.eui.euiColorVis7,
+        title: i18n.translate('xpack.apm.backendErrorRateChart.chartTitle', {
+          defaultMessage: 'Error rate',
         }),
       });
     }
@@ -78,26 +78,23 @@ export function BackendLatencyChart({ height }: { height: number }) {
         type: 'area',
         color: theme.eui.euiColorMediumShade,
         title: i18n.translate(
-          'xpack.apm.backendLatencyChart.previousPeriodLabel',
+          'xpack.apm.backendErrorRateChart.previousPeriodLabel',
           { defaultMessage: 'Previous period' }
         ),
       });
     }
 
     return specs;
-  }, [data, theme.eui.euiColorVis1, theme.eui.euiColorMediumShade]);
-
-  const maxY = getMaxY(timeseries);
-  const latencyFormatter = getDurationFormatter(maxY);
+  }, [data, theme.eui.euiColorVis7, theme.eui.euiColorMediumShade]);
 
   return (
     <TimeseriesChart
       height={height}
       fetchStatus={status}
-      id="latencyChart"
+      id="errorRateChart"
       customTheme={comparisonChartTheme}
       timeseries={timeseries}
-      yLabelFormat={getResponseTimeTickFormatter(latencyFormatter)}
+      yLabelFormat={yLabelFormat}
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_throughput_chart.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
-import { getDurationFormatter } from '../../../../common/utils/formatters';
+import { asTransactionRate } from '../../../../common/utils/formatters';
 import { useApmBackendContext } from '../../../context/apm_backend/use_apm_backend_context';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useComparison } from '../../../hooks/use_comparison';
@@ -15,12 +15,8 @@ import { useTimeRange } from '../../../hooks/use_time_range';
 import { Coordinate, TimeSeries } from '../../../../typings/timeseries';
 import { TimeseriesChart } from '../../shared/charts/timeseries_chart';
 import { useTheme } from '../../../hooks/use_theme';
-import {
-  getMaxY,
-  getResponseTimeTickFormatter,
-} from '../../shared/charts/transaction_charts/helper';
 
-export function BackendLatencyChart({ height }: { height: number }) {
+export function BackendThroughputChart({ height }: { height: number }) {
   const { backendName } = useApmBackendContext();
 
   const theme = useTheme();
@@ -40,7 +36,7 @@ export function BackendLatencyChart({ height }: { height: number }) {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/charts/latency',
+        endpoint: 'GET /api/apm/backends/{backendName}/charts/throughput',
         params: {
           path: {
             backendName,
@@ -65,9 +61,9 @@ export function BackendLatencyChart({ height }: { height: number }) {
       specs.push({
         data: data.currentTimeseries,
         type: 'linemark',
-        color: theme.eui.euiColorVis1,
-        title: i18n.translate('xpack.apm.backendLatencyChart.chartTitle', {
-          defaultMessage: 'Latency',
+        color: theme.eui.euiColorVis0,
+        title: i18n.translate('xpack.apm.backendThroughputChart.chartTitle', {
+          defaultMessage: 'Throughput',
         }),
       });
     }
@@ -78,26 +74,23 @@ export function BackendLatencyChart({ height }: { height: number }) {
         type: 'area',
         color: theme.eui.euiColorMediumShade,
         title: i18n.translate(
-          'xpack.apm.backendLatencyChart.previousPeriodLabel',
+          'xpack.apm.backendThroughputChart.previousPeriodLabel',
           { defaultMessage: 'Previous period' }
         ),
       });
     }
 
     return specs;
-  }, [data, theme.eui.euiColorVis1, theme.eui.euiColorMediumShade]);
-
-  const maxY = getMaxY(timeseries);
-  const latencyFormatter = getDurationFormatter(maxY);
+  }, [data, theme.eui.euiColorVis0, theme.eui.euiColorMediumShade]);
 
   return (
     <TimeseriesChart
       height={height}
       fetchStatus={status}
-      id="latencyChart"
+      id="throughputChart"
       customTheme={comparisonChartTheme}
       timeseries={timeseries}
-      yLabelFormat={getResponseTimeTickFormatter(latencyFormatter)}
+      yLabelFormat={asTransactionRate}
     />
   );
 }

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/index.tsx
@@ -9,16 +9,20 @@ import { EuiPanel } from '@elastic/eui';
 import { EuiFlexGroup } from '@elastic/eui';
 import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
+import { EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { ApmBackendContextProvider } from '../../../context/apm_backend/apm_backend_context';
 import { useBreadcrumb } from '../../../context/breadcrumbs/use_breadcrumb';
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../hooks/use_apm_router';
-import { ApmMainTemplate } from '../../routing/templates/apm_main_template';
 import { SearchBar } from '../../shared/search_bar';
 import { BackendLatencyChart } from './backend_latency_chart';
 import { BackendInventoryTitle } from '../../routing/home';
 import { BackendDetailDependenciesTable } from './backend_detail_dependencies_table';
+import { BackendThroughputChart } from './backend_throughput_chart';
+import { BackendErrorRateChart } from './backend_error_rate_chart';
+import { BackendDetailTemplate } from '../../routing/templates/backend_detail_template';
 
 export function BackendDetailOverview() {
   const {
@@ -43,21 +47,55 @@ export function BackendDetailOverview() {
   ]);
 
   return (
-    <ApmMainTemplate pageTitle={backendName}>
-      <ApmBackendContextProvider>
+    <ApmBackendContextProvider>
+      <BackendDetailTemplate title={backendName}>
         <SearchBar showTimeComparison />
         <ChartPointerEventContextProvider>
-          <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexGroup direction="row" gutterSize="s">
             <EuiFlexItem>
               <EuiPanel hasBorder={true}>
+                <EuiTitle size="xs">
+                  <h2>
+                    {i18n.translate(
+                      'xpack.apm.backendDetailLatencyChartTitle',
+                      { defaultMessage: 'Latency' }
+                    )}
+                  </h2>
+                </EuiTitle>
                 <BackendLatencyChart height={200} />
+              </EuiPanel>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiPanel hasBorder={true}>
+                <EuiTitle size="xs">
+                  <h2>
+                    {i18n.translate(
+                      'xpack.apm.backendDetailThroughputChartTitle',
+                      { defaultMessage: 'Throughput' }
+                    )}
+                  </h2>
+                </EuiTitle>
+                <BackendThroughputChart height={200} />
+              </EuiPanel>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiPanel hasBorder={true}>
+                <EuiTitle size="xs">
+                  <h2>
+                    {i18n.translate(
+                      'xpack.apm.backendDetailErrorRateChartTitle',
+                      { defaultMessage: 'Error rate' }
+                    )}
+                  </h2>
+                </EuiTitle>
+                <BackendErrorRateChart height={200} />
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
         </ChartPointerEventContextProvider>
         <EuiSpacer size="m" />
         <BackendDetailDependenciesTable />
-      </ApmBackendContextProvider>
-    </ApmMainTemplate>
+      </BackendDetailTemplate>
+    </ApmBackendContextProvider>
   );
 }

--- a/x-pack/plugins/apm/public/components/routing/templates/backend_detail_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/backend_detail_template.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import React from 'react';
+import { useApmBackendContext } from '../../../context/apm_backend/use_apm_backend_context';
+import { ApmMainTemplate } from './apm_main_template';
+import { SpanIcon } from '../../shared/span_icon';
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function BackendDetailTemplate({ title, children }: Props) {
+  const {
+    backendName,
+    metadata: { data },
+  } = useApmBackendContext();
+
+  const metadata = data?.metadata;
+
+  return (
+    <ApmMainTemplate
+      pageHeader={{
+        pageTitle: (
+          <EuiFlexGroup alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="l">
+                <h1>{backendName}</h1>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <SpanIcon
+                type={metadata?.spanType}
+                subtype={metadata?.spanSubtype}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
+      }}
+    >
+      {children}
+    </ApmMainTemplate>
+  );
+}

--- a/x-pack/plugins/apm/server/lib/backends/get_error_rate_charts_for_backend.ts
+++ b/x-pack/plugins/apm/server/lib/backends/get_error_rate_charts_for_backend.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EventOutcome } from '../../../common/event_outcome';
+import {
+  EVENT_OUTCOME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
+} from '../../../common/elasticsearch_fieldnames';
+import { environmentQuery } from '../../../common/utils/environment_query';
+import { kqlQuery, rangeQuery } from '../../../../observability/server';
+import { ProcessorEvent } from '../../../common/processor_event';
+import { Setup } from '../helpers/setup_request';
+import { getMetricsDateHistogramParams } from '../helpers/metrics';
+import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
+
+export async function getErrorRateChartsForBackend({
+  backendName,
+  setup,
+  start,
+  end,
+  environment,
+  kuery,
+  offset,
+}: {
+  backendName: string;
+  setup: Setup;
+  start: number;
+  end: number;
+  environment?: string;
+  kuery?: string;
+  offset?: string;
+}) {
+  const { apmEventClient } = setup;
+
+  const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
+    start,
+    end,
+    offset,
+  });
+
+  const response = await apmEventClient.search('get_error_rate_for_backend', {
+    apm: {
+      events: [ProcessorEvent.metric],
+    },
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            ...environmentQuery(environment),
+            ...kqlQuery(kuery),
+            ...rangeQuery(startWithOffset, endWithOffset),
+            { term: { [SPAN_DESTINATION_SERVICE_RESOURCE]: backendName } },
+            {
+              terms: {
+                [EVENT_OUTCOME]: [EventOutcome.success, EventOutcome.failure],
+              },
+            },
+          ],
+        },
+      },
+      aggs: {
+        timeseries: {
+          date_histogram: getMetricsDateHistogramParams({
+            start: startWithOffset,
+            end: endWithOffset,
+            metricsInterval: 60,
+          }),
+          aggs: {
+            failures: {
+              filter: {
+                term: {
+                  [EVENT_OUTCOME]: EventOutcome.failure,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return (
+    response.aggregations?.timeseries.buckets.map((bucket) => {
+      const totalCount = bucket.doc_count;
+      const failureCount = bucket.failures.doc_count;
+
+      return {
+        x: bucket.key + offsetInMs,
+        y: failureCount / totalCount,
+      };
+    }) ?? []
+  );
+}

--- a/x-pack/plugins/apm/server/lib/backends/get_metadata_for_backend.ts
+++ b/x-pack/plugins/apm/server/lib/backends/get_metadata_for_backend.ts
@@ -51,7 +51,7 @@ export async function getMetadataForBackend({
   const sample = maybe(sampleResponse.hits.hits[0])?._source;
 
   return {
-    'span.type': sample?.span.type,
-    'span.subtype': sample?.span.subtype,
+    spanType: sample?.span.type,
+    spanSubtype: sample?.span.subtype,
   };
 }

--- a/x-pack/plugins/apm/server/lib/backends/get_throughput_charts_for_backend.ts
+++ b/x-pack/plugins/apm/server/lib/backends/get_throughput_charts_for_backend.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../common/elasticsearch_fieldnames';
+import { environmentQuery } from '../../../common/utils/environment_query';
+import { kqlQuery, rangeQuery } from '../../../../observability/server';
+import { ProcessorEvent } from '../../../common/processor_event';
+import { Setup } from '../helpers/setup_request';
+import { getMetricsDateHistogramParams } from '../helpers/metrics';
+import { getOffsetInMs } from '../../../common/utils/get_offset_in_ms';
+
+export async function getThroughputChartsForBackend({
+  backendName,
+  setup,
+  start,
+  end,
+  environment,
+  kuery,
+  offset,
+}: {
+  backendName: string;
+  setup: Setup;
+  start: number;
+  end: number;
+  environment?: string;
+  kuery?: string;
+  offset?: string;
+}) {
+  const { apmEventClient } = setup;
+
+  const { offsetInMs, startWithOffset, endWithOffset } = getOffsetInMs({
+    start,
+    end,
+    offset,
+  });
+
+  const response = await apmEventClient.search('get_throughput_for_backend', {
+    apm: {
+      events: [ProcessorEvent.metric],
+    },
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            ...environmentQuery(environment),
+            ...kqlQuery(kuery),
+            ...rangeQuery(startWithOffset, endWithOffset),
+            { term: { [SPAN_DESTINATION_SERVICE_RESOURCE]: backendName } },
+          ],
+        },
+      },
+      aggs: {
+        timeseries: {
+          date_histogram: getMetricsDateHistogramParams({
+            start: startWithOffset,
+            end: endWithOffset,
+            metricsInterval: 60,
+          }),
+          aggs: {
+            throughput: {
+              rate: {},
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return (
+    response.aggregations?.timeseries.buckets.map((bucket) => {
+      return {
+        x: bucket.key + offsetInMs,
+        y: bucket.throughput.value,
+      };
+    }) ?? []
+  );
+}

--- a/x-pack/plugins/apm/server/lib/backends/get_upstream_services_for_backend.ts
+++ b/x-pack/plugins/apm/server/lib/backends/get_upstream_services_for_backend.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { kqlQuery } from '../../../../observability/server';
 import { SPAN_DESTINATION_SERVICE_RESOURCE } from '../../../common/elasticsearch_fieldnames';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { getConnectionStats } from '../connections/get_connection_stats';
@@ -17,6 +18,7 @@ export async function getUpstreamServicesForBackend({
   end,
   backendName,
   numBuckets,
+  kuery,
   environment,
   offset,
 }: {
@@ -25,6 +27,7 @@ export async function getUpstreamServicesForBackend({
   end: number;
   backendName: string;
   numBuckets: number;
+  kuery?: string;
   environment?: string;
   offset?: string;
 }) {
@@ -35,6 +38,7 @@ export async function getUpstreamServicesForBackend({
     filter: [
       { term: { [SPAN_DESTINATION_SERVICE_RESOURCE]: backendName } },
       ...environmentQuery(environment),
+      ...kqlQuery(kuery),
     ],
     collapseBy: 'upstream',
     numBuckets,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Add throughput, error rate charts to backend detail page (#107379)