### PR TITLE
[Cases] Fix connector's icon bug

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.test.tsx
@@ -7,20 +7,27 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { AllCasesGeneric } from './all_cases_generic';
+import { act } from 'react-dom/test-utils';
 
+import { AllCasesGeneric } from './all_cases_generic';
 import { TestProviders } from '../../common/mock';
 import { useGetTags } from '../../containers/use_get_tags';
 import { useGetReporters } from '../../containers/use_get_reporters';
 import { useGetActionLicense } from '../../containers/use_get_action_license';
+import { useConnectors } from '../../containers/configure/use_connectors';
+import { useKibana } from '../../common/lib/kibana';
 import { StatusAll } from '../../containers/types';
 import { CaseStatuses, SECURITY_SOLUTION_OWNER } from '../../../common';
-import { act } from 'react-dom/test-utils';
+import { connectorsMock } from '../../containers/mock';
+import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
+import { triggersActionsUiMock } from '../../../../triggers_actions_ui/public/mocks';
 
 jest.mock('../../containers/use_get_reporters');
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/use_get_action_license');
+jest.mock('../../containers/configure/use_connectors');
 jest.mock('../../containers/api');
+jest.mock('../../common/lib/kibana');
 
 const createCaseNavigation = { href: '', onClick: jest.fn() };
 
@@ -34,26 +41,34 @@ const alertDataMock = {
   alertId: 'alert-id',
   owner: SECURITY_SOLUTION_OWNER,
 };
+
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
+const useConnectorsMock = useConnectors as jest.Mock;
+const mockTriggersActionsUiService = triggersActionsUiMock.createStart();
+
 jest.mock('../../common/lib/kibana', () => {
   const originalModule = jest.requireActual('../../common/lib/kibana');
   return {
     ...originalModule,
     useKibana: () => ({
       services: {
-        triggersActionsUi: {
-          actionTypeRegistry: {
-            get: jest.fn().mockReturnValue({
-              actionTypeTitle: '.jira',
-              iconClass: 'logoSecurity',
-            }),
-          },
-        },
+        triggersActionsUi: mockTriggersActionsUiService,
       },
     }),
   };
 });
 
 describe('AllCasesGeneric ', () => {
+  const { createMockActionTypeModel } = actionTypeRegistryMock;
+
+  beforeAll(() => {
+    connectorsMock.forEach((connector) =>
+      useKibanaMock().services.triggersActionsUi.actionTypeRegistry.register(
+        createMockActionTypeModel({ id: connector.actionTypeId, iconClass: 'logoSecurity' })
+      )
+    );
+  });
+
   beforeEach(() => {
     jest.resetAllMocks();
     (useGetTags as jest.Mock).mockReturnValue({ tags: ['coke', 'pepsi'], fetchTags: jest.fn() });
@@ -68,6 +83,7 @@ describe('AllCasesGeneric ', () => {
       actionLicense: null,
       isLoading: false,
     });
+    useConnectorsMock.mockImplementation(() => ({ connectors: connectorsMock, loading: false }));
   });
 
   it('renders the first available status when hiddenStatus is given', () =>

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx
@@ -37,6 +37,7 @@ import { CasesTableFilters } from './table_filters';
 import { EuiBasicTableOnChange } from './types';
 
 import { CasesTable } from './table';
+import { useConnectors } from '../../containers/configure/use_connectors';
 
 const ProgressLoader = styled(EuiProgress)`
   ${({ $isShow }: { $isShow: boolean }) =>
@@ -103,6 +104,7 @@ export const AllCasesGeneric = React.memo<AllCasesGenericProps>(
 
     // Post Comment to Case
     const { postComment, isLoading: isCommentUpdating } = usePostComment();
+    const { connectors } = useConnectors({ toastPermissionsErrors: false });
 
     const sorting = useMemo(
       () => ({
@@ -203,6 +205,7 @@ export const AllCasesGeneric = React.memo<AllCasesGenericProps>(
       refreshCases,
       showActions,
       userCanCrud,
+      connectors,
     });
 
     const itemIdToExpandedRowMap = useMemo(

--- a/x-pack/plugins/cases/public/components/all_cases/columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.test.tsx
@@ -10,51 +10,67 @@ import { mount } from 'enzyme';
 
 import '../../common/mock/match_media';
 import { ExternalServiceColumn } from './columns';
-
 import { useGetCasesMockState } from '../../containers/mock';
+import { useKibana } from '../../common/lib/kibana';
+import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
+import { connectors } from '../configure_cases/__mock__';
 
-jest.mock('../../common/lib/kibana', () => {
-  const originalModule = jest.requireActual('../../common/lib/kibana');
-  return {
-    ...originalModule,
-    useKibana: () => ({
-      services: {
-        triggersActionsUi: {
-          actionTypeRegistry: {
-            get: jest.fn().mockReturnValue({
-              actionTypeTitle: '.jira',
-              iconClass: 'logoSecurity',
-            }),
-          },
-        },
-      },
-    }),
-  };
-});
+jest.mock('../../common/lib/kibana');
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 describe('ExternalServiceColumn ', () => {
+  const { createMockActionTypeModel } = actionTypeRegistryMock;
+
+  beforeAll(() => {
+    connectors.forEach((connector) =>
+      useKibanaMock().services.triggersActionsUi.actionTypeRegistry.register(
+        createMockActionTypeModel({ id: connector.actionTypeId, iconClass: 'logoSecurity' })
+      )
+    );
+  });
+
   it('Not pushed render', () => {
     const wrapper = mount(
-      <ExternalServiceColumn {...{ theCase: useGetCasesMockState.data.cases[0] }} />
+      <ExternalServiceColumn theCase={useGetCasesMockState.data.cases[0]} connectors={connectors} />
     );
     expect(
       wrapper.find(`[data-test-subj="case-table-column-external-notPushed"]`).last().exists()
     ).toBeTruthy();
   });
+
   it('Up to date', () => {
     const wrapper = mount(
-      <ExternalServiceColumn {...{ theCase: useGetCasesMockState.data.cases[1] }} />
+      <ExternalServiceColumn theCase={useGetCasesMockState.data.cases[1]} connectors={connectors} />
     );
     expect(
       wrapper.find(`[data-test-subj="case-table-column-external-upToDate"]`).last().exists()
     ).toBeTruthy();
   });
+
   it('Needs update', () => {
     const wrapper = mount(
-      <ExternalServiceColumn {...{ theCase: useGetCasesMockState.data.cases[2] }} />
+      <ExternalServiceColumn theCase={useGetCasesMockState.data.cases[2]} connectors={connectors} />
     );
     expect(
       wrapper.find(`[data-test-subj="case-table-column-external-requiresUpdate"]`).last().exists()
     ).toBeTruthy();
+  });
+
+  it('it does not throw when accessing the icon if the connector type is not registered', () => {
+    // If the component throws the test will fail
+    mount(
+      <ExternalServiceColumn
+        theCase={useGetCasesMockState.data.cases[2]}
+        connectors={[
+          {
+            id: 'none',
+            actionTypeId: '.none',
+            name: 'None',
+            config: {},
+            isPreconfigured: false,
+          },
+        ]}
+      />
+    );
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.test.tsx
@@ -58,19 +58,21 @@ describe('ExternalServiceColumn ', () => {
 
   it('it does not throw when accessing the icon if the connector type is not registered', () => {
     // If the component throws the test will fail
-    mount(
-      <ExternalServiceColumn
-        theCase={useGetCasesMockState.data.cases[2]}
-        connectors={[
-          {
-            id: 'none',
-            actionTypeId: '.none',
-            name: 'None',
-            config: {},
-            isPreconfigured: false,
-          },
-        ]}
-      />
-    );
+    expect(() =>
+      mount(
+        <ExternalServiceColumn
+          theCase={useGetCasesMockState.data.cases[2]}
+          connectors={[
+            {
+              id: 'none',
+              actionTypeId: '.none',
+              name: 'None',
+              config: {},
+              isPreconfigured: false,
+            },
+          ]}
+        />
+      )
+    ).not.toThrowError();
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.tsx
@@ -21,7 +21,14 @@ import {
 import { RIGHT_ALIGNMENT } from '@elastic/eui/lib/services';
 import styled from 'styled-components';
 
-import { CaseStatuses, CaseType, DeleteCase, Case, SubCase } from '../../../common';
+import {
+  CaseStatuses,
+  CaseType,
+  DeleteCase,
+  Case,
+  SubCase,
+  ActionConnector,
+} from '../../../common';
 import { getEmptyTagValue } from '../empty_value';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
 import { CaseDetailsHrefSchema, CaseDetailsLink, CasesNavigation } from '../links';
@@ -35,6 +42,7 @@ import { ConfirmDeleteCaseModal } from '../confirm_delete_case';
 import { useKibana } from '../../common/lib/kibana';
 import { StatusContextMenu } from '../case_action_bar/status_context_menu';
 import { TruncatedText } from '../truncated_text';
+import { getConnectorIcon } from '../utils';
 
 export type CasesColumns =
   | EuiTableActionsColumnType<Case>
@@ -66,6 +74,7 @@ export interface GetCasesColumn {
   refreshCases?: (a?: boolean) => void;
   showActions: boolean;
   userCanCrud: boolean;
+  connectors?: ActionConnector[];
 }
 export const useCasesColumns = ({
   caseDetailsNavigation,
@@ -77,6 +86,7 @@ export const useCasesColumns = ({
   refreshCases,
   showActions,
   userCanCrud,
+  connectors = [],
 }: GetCasesColumn): CasesColumns[] => {
   // Delete case
   const {
@@ -266,7 +276,7 @@ export const useCasesColumns = ({
       name: i18n.EXTERNAL_INCIDENT,
       render: (theCase: Case) => {
         if (theCase.id != null) {
-          return <ExternalServiceColumn theCase={theCase} />;
+          return <ExternalServiceColumn theCase={theCase} connectors={connectors} />;
         }
         return getEmptyTagValue();
       },
@@ -325,6 +335,7 @@ export const useCasesColumns = ({
 
 interface Props {
   theCase: Case;
+  connectors: ActionConnector[];
 }
 
 const IconWrapper = styled.span`
@@ -335,26 +346,31 @@ const IconWrapper = styled.span`
     width: 20px !important;
   }
 `;
-export const ExternalServiceColumn: React.FC<Props> = ({ theCase }) => {
+
+export const ExternalServiceColumn: React.FC<Props> = ({ theCase, connectors }) => {
   const { triggersActionsUi } = useKibana().services;
 
   if (theCase.externalService == null) {
     return renderStringField(i18n.NOT_PUSHED, `case-table-column-external-notPushed`);
   }
 
+  const lastPushedConnector: ActionConnector | undefined = connectors.find(
+    (connector) => connector.id === theCase.externalService?.connectorId
+  );
   const lastCaseUpdate = theCase.updatedAt != null ? new Date(theCase.updatedAt) : null;
   const lastCasePush =
     theCase.externalService?.pushedAt != null ? new Date(theCase.externalService?.pushedAt) : null;
   const hasDataToPush =
     lastCasePush === null ||
     (lastCaseUpdate != null && lastCasePush.getTime() < lastCaseUpdate?.getTime());
+
   return (
     <p>
       <IconWrapper>
         <EuiIcon
           size="original"
           title={theCase.externalService?.connectorName}
-          type={triggersActionsUi.actionTypeRegistry.get(theCase.connector.type)?.iconClass ?? ''}
+          type={getConnectorIcon(triggersActionsUi, lastPushedConnector?.actionTypeId ?? '')}
         />
       </IconWrapper>
       <EuiLink

--- a/x-pack/plugins/cases/public/components/all_cases/columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.tsx
@@ -370,7 +370,7 @@ export const ExternalServiceColumn: React.FC<Props> = ({ theCase, connectors }) 
         <EuiIcon
           size="original"
           title={theCase.externalService?.connectorName}
-          type={getConnectorIcon(triggersActionsUi, lastPushedConnector?.actionTypeId ?? '')}
+          type={getConnectorIcon(triggersActionsUi, lastPushedConnector?.actionTypeId)}
         />
       </IconWrapper>
       <EuiLink

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.test.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.test.tsx
@@ -225,76 +225,24 @@ describe('ConnectorsDropdown', () => {
   });
 
   test('it does not throw when accessing the icon if the connector type is not registered', () => {
-    const newWrapper = mount(
-      <ConnectorsDropdown
-        {...props}
-        connectors={[
-          {
-            id: 'none',
-            actionTypeId: '.none',
-            name: 'None',
-            config: {},
-            isPreconfigured: false,
-          },
-        ]}
-      />,
-      {
-        wrappingComponent: TestProviders,
-      }
-    );
-
-    const selectProps = newWrapper.find(EuiSuperSelect).props();
-    expect(selectProps.options).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "data-test-subj": "dropdown-connector-no-connector",
-          "inputDisplay": <EuiFlexGroup
-            alignItems="center"
-            gutterSize="none"
-            responsive={false}
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <Styled(EuiIcon)
-                size="m"
-                type="minusInCircle"
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <span
-                data-test-subj="dropdown-connector-no-connector"
-              >
-                No connector selected
-              </span>
-            </EuiFlexItem>
-          </EuiFlexGroup>,
-          "value": "none",
-        },
-        Object {
-          "data-test-subj": "dropdown-connector-none",
-          "inputDisplay": <EuiFlexGroup
-            alignItems="center"
-            gutterSize="none"
-            responsive={false}
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <Styled(EuiIcon)
-                size="m"
-                type=""
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <span>
-                None
-              </span>
-            </EuiFlexItem>
-          </EuiFlexGroup>,
-          "value": "none",
-        },
-      ]
-    `);
+    expect(() =>
+      mount(
+        <ConnectorsDropdown
+          {...props}
+          connectors={[
+            {
+              id: 'none',
+              actionTypeId: '.none',
+              name: 'None',
+              config: {},
+              isPreconfigured: false,
+            },
+          ]}
+        />,
+        {
+          wrappingComponent: TestProviders,
+        }
+      )
+    ).not.toThrowError();
   });
 });

--- a/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/connectors_dropdown.tsx
@@ -13,6 +13,7 @@ import { ConnectorTypes } from '../../../common';
 import { ActionConnector } from '../../containers/configure/types';
 import * as i18n from './translations';
 import { useKibana } from '../../common/lib/kibana';
+import { getConnectorIcon } from '../utils';
 
 export interface Props {
   connectors: ActionConnector[];
@@ -81,10 +82,7 @@ const ConnectorsDropdownComponent: React.FC<Props> = ({
               <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
                 <EuiFlexItem grow={false}>
                   <EuiIconExtended
-                    type={
-                      triggersActionsUi.actionTypeRegistry.get(connector.actionTypeId)?.iconClass ??
-                      ''
-                    }
+                    type={getConnectorIcon(triggersActionsUi, connector.actionTypeId)}
                     size={ICON_SIZE}
                   />
                 </EuiFlexItem>

--- a/x-pack/plugins/cases/public/components/connectors/card.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/card.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { ConnectorTypes } from '../../../common';
+import { useKibana } from '../../common/lib/kibana';
+import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
+import { connectors } from '../configure_cases/__mock__';
+import { ConnectorCard } from './card';
+
+jest.mock('../../common/lib/kibana');
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
+
+describe('ConnectorCard ', () => {
+  const { createMockActionTypeModel } = actionTypeRegistryMock;
+
+  beforeAll(() => {
+    connectors.forEach((connector) =>
+      useKibanaMock().services.triggersActionsUi.actionTypeRegistry.register(
+        createMockActionTypeModel({ id: connector.actionTypeId, iconClass: 'logoSecurity' })
+      )
+    );
+  });
+
+  it('it does not throw when accessing the icon if the connector type is not registered', () => {
+    // If the component throws the test will fail
+    mount(
+      <ConnectorCard
+        connectorType={ConnectorTypes.none}
+        title="None"
+        listItems={[]}
+        isLoading={false}
+      />
+    );
+  });
+});

--- a/x-pack/plugins/cases/public/components/connectors/card.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/card.test.tsx
@@ -29,14 +29,15 @@ describe('ConnectorCard ', () => {
   });
 
   it('it does not throw when accessing the icon if the connector type is not registered', () => {
-    // If the component throws the test will fail
-    mount(
-      <ConnectorCard
-        connectorType={ConnectorTypes.none}
-        title="None"
-        listItems={[]}
-        isLoading={false}
-      />
-    );
+    expect(() =>
+      mount(
+        <ConnectorCard
+          connectorType={ConnectorTypes.none}
+          title="None"
+          listItems={[]}
+          isLoading={false}
+        />
+      )
+    ).not.toThrowError();
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/card.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/card.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 
 import { ConnectorTypes } from '../../../common';
 import { useKibana } from '../../common/lib/kibana';
+import { getConnectorIcon } from '../utils';
 
 interface ConnectorCardProps {
   connectorType: ConnectorTypes;
@@ -47,16 +48,13 @@ const ConnectorCardDisplay: React.FC<ConnectorCardProps> = ({
     ),
     [listItems]
   );
+
   const icon = useMemo(
-    () => (
-      <EuiIcon
-        size="xl"
-        type={triggersActionsUi.actionTypeRegistry.get(`${connectorType}`)?.iconClass ?? ''}
-      />
-    ),
+    () => <EuiIcon size="xl" type={getConnectorIcon(triggersActionsUi, connectorType)} />,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [connectorType]
   );
+
   return (
     <>
       {isLoading && <EuiLoadingSpinner data-test-subj="connector-card-loading" />}

--- a/x-pack/plugins/cases/public/components/create/connector.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/connector.test.tsx
@@ -21,20 +21,18 @@ import { schema, FormProps } from './schema';
 import { TestProviders } from '../../common/mock';
 import { useCaseConfigure } from '../../containers/configure/use_configure';
 import { useCaseConfigureResponse } from '../configure_cases/__mock__';
+import { triggersActionsUiMock } from '../../../../triggers_actions_ui/public/mocks';
+import { actionTypeRegistryMock } from '../../../../triggers_actions_ui/public/application/action_type_registry.mock';
+import { useKibana } from '../../common/lib/kibana';
+
+const mockTriggersActionsUiService = triggersActionsUiMock.createStart();
 
 jest.mock('../../common/lib/kibana', () => ({
   useKibana: () => ({
     services: {
       notifications: {},
       http: {},
-      triggersActionsUi: {
-        actionTypeRegistry: {
-          get: jest.fn().mockReturnValue({
-            actionTypeTitle: 'test',
-            iconClass: 'logoSecurity',
-          }),
-        },
-      },
+      triggersActionsUi: mockTriggersActionsUiService,
     },
   }),
 }));
@@ -48,6 +46,7 @@ const useGetIncidentTypesMock = useGetIncidentTypes as jest.Mock;
 const useGetSeverityMock = useGetSeverity as jest.Mock;
 const useGetChoicesMock = useGetChoices as jest.Mock;
 const useCaseConfigureMock = useCaseConfigure as jest.Mock;
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 const useGetIncidentTypesResponse = {
   isLoading: false,
@@ -86,6 +85,16 @@ describe('Connector', () => {
 
     return <Form form={form}>{children}</Form>;
   };
+
+  const { createMockActionTypeModel } = actionTypeRegistryMock;
+
+  beforeAll(() => {
+    connectorsMock.forEach((connector) =>
+      useKibanaMock().services.triggersActionsUi.actionTypeRegistry.register(
+        createMockActionTypeModel({ id: connector.actionTypeId, iconClass: 'logoSecurity' })
+      )
+    );
+  });
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/x-pack/plugins/cases/public/components/utils.test.ts
+++ b/x-pack/plugins/cases/public/components/utils.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { actionTypeRegistryMock } from '../../../triggers_actions_ui/public/application/action_type_registry.mock';
+import { triggersActionsUiMock } from '../../../triggers_actions_ui/public/mocks';
+import { getConnectorIcon } from './utils';
+
+describe('Utils', () => {
+  describe('getConnectorIcon', () => {
+    const { createMockActionTypeModel } = actionTypeRegistryMock;
+    const mockTriggersActionsUiService = triggersActionsUiMock.createStart();
+    mockTriggersActionsUiService.actionTypeRegistry.register(
+      createMockActionTypeModel({ id: '.test', iconClass: 'test' })
+    );
+
+    it('it returns the correct icon class', () => {
+      expect(getConnectorIcon(mockTriggersActionsUiService, '.test')).toBe('test');
+    });
+
+    it('it returns an empty string if the type is undefined', () => {
+      expect(getConnectorIcon(mockTriggersActionsUiService)).toBe('');
+    });
+
+    it('it returns an empty string if the type is not registered', () => {
+      expect(getConnectorIcon(mockTriggersActionsUiService, '.not-registered')).toBe('');
+    });
+
+    it('it returns an empty string if it throws', () => {
+      mockTriggersActionsUiService.actionTypeRegistry.get = () => {
+        throw new Error();
+      };
+
+      expect(getConnectorIcon(mockTriggersActionsUiService, '.not-registered')).toBe('');
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/components/utils.ts
+++ b/x-pack/plugins/cases/public/components/utils.ts
@@ -46,15 +46,25 @@ export const getConnectorsFormValidators = ({
 
 export const getConnectorIcon = (
   triggersActionsUi: StartPlugins['triggersActionsUi'],
-  type: string
+  type?: string
 ): IconType => {
   /**
    * triggersActionsUi.actionTypeRegistry.get will throw an error if the type is not registered.
    * This will break Kibana if not handled properly.
    */
-  if (triggersActionsUi.actionTypeRegistry.has(type)) {
-    return triggersActionsUi.actionTypeRegistry.get(type).iconClass;
+  const emptyResponse = '';
+
+  if (type == null) {
+    return emptyResponse;
   }
 
-  return '';
+  try {
+    if (triggersActionsUi.actionTypeRegistry.has(type)) {
+      return triggersActionsUi.actionTypeRegistry.get(type).iconClass;
+    }
+  } catch {
+    return emptyResponse;
+  }
+
+  return emptyResponse;
 };

--- a/x-pack/plugins/cases/public/components/utils.ts
+++ b/x-pack/plugins/cases/public/components/utils.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import { IconType } from '@elastic/eui';
 import { ConnectorTypes } from '../../common';
 import { FieldConfig, ValidationConfig } from '../common/shared_imports';
+import { StartPlugins } from '../types';
 import { connectorValidator as swimlaneConnectorValidator } from './connectors/swimlane/validator';
 import { CaseActionConnector } from './types';
 
@@ -41,3 +43,18 @@ export const getConnectorsFormValidators = ({
     },
   ],
 });
+
+export const getConnectorIcon = (
+  triggersActionsUi: StartPlugins['triggersActionsUi'],
+  type: string
+): IconType => {
+  /**
+   * triggersActionsUi.actionTypeRegistry.get will throw an error if the type is not registered.
+   * This will break Kibana if not handled properly.
+   */
+  if (triggersActionsUi.actionTypeRegistry.has(type)) {
+    return triggersActionsUi.actionTypeRegistry.get(type).iconClass;
+  }
+
+  return '';
+};


### PR DESCRIPTION
## Summary

The `triggersActionsUi` provides access to the `actionTypeRegistry`. Cases use the `actionTypeRegistry` to get the icon of the connector. If the type of the connector is not registered to the `actionTypeRegistry` an error will be thrown if you try to get the action type from the registry. The error is not being handled properly by Cases leading to broken Kibana. 

Steps to reproduce:

1. Create a case.
2. Push it to an external service like Jira.
3. Change the connector to none.
4. Go back to the All cases page.

You should see the following error:

<img width="1179" alt="Screenshot 2021-08-04 at 2 31 00 PM" src="https://user-images.githubusercontent.com/7871006/128173543-99a25ab9-2931-433f-a963-9ebe92871ec0.png">

Also, the connector icon being shown on the All cases page is wrong. The page shows the icon of the connector that is selected for the particular case and that of the last pushed connector.

Steps to reproduce:

1. Create a case.
2. Push it to SN.
3. Change the connector to Jira.
4. Go back to the All cases page.

You should see the Jira icon instead of the SN icon. Example:

<img width="220" alt="Screenshot 2021-08-04 at 2 37 00 PM" src="https://user-images.githubusercontent.com/7871006/128174630-cc87f5a1-474c-49c4-8b2e-409ecb6662a3.png">

This PR fixes both bugs.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
