### PR TITLE
[Cases] Fix config bug

### DIFF
--- a/x-pack/plugins/cases/kibana.json
+++ b/x-pack/plugins/cases/kibana.json
@@ -1,7 +1,7 @@
 {
   "configPath":[
-     "cases",
-     "xpack"
+     "xpack",
+     "cases"
   ],
   "description":"The Case management system in Kibana",
   "extraPublicDirs":[


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/102707 broke the config path by alphabetized the items in the `configPath` array. This will cause the following error if the `xpack.cases.enabled` config has been set.

```
[fatal][root] CriticalError: Unknown configuration key(s): "xpack.cases.enabled". Check for spelling errors and ensure that expected plugins are installed.
    at ensureValidConfiguration (/Users/laxmana/workspace/kibana/src/core/server/config/ensure_valid_configuration.ts:36:11)
    at Server.preboot (/Users/laxmana/workspace/kibana/src/core/server/server.ts:144:5)
    at Root.preboot (/Users/laxmana/workspace/kibana/src/core/server/root/index.ts:42:14)
    at bootstrap (/Users/laxmana/workspace/kibana/src/core/server/bootstrap.ts:84:25)
    at Command.<anonymous> (/Users/laxmana/workspace/kibana/src/cli/serve/serve.js:258:5) {
  code: 'InvalidConfig',
  processExitCode: 64,
  cause: undefined
}

 FATAL  Error: Unknown configuration key(s): "xpack.cases.enabled". Check for spelling errors and ensure that expected plugins are installed.
```

The bug will affect **only** users that have set the `xpack.cases.enabled`. Cases are enabled by default. To bypass the problem the users have to convert `xpack.cases.enabled` to `cases.xpack.enabled`.

This PR fixes this issue for `7.14.1` by reverting the path back to `xpack.cases.enabled`.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
