### PR TITLE
Revert "fixes the provider name flexibility"

### DIFF
--- a/x-pack/plugins/security_solution/cypress/tasks/login.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/login.ts
@@ -205,11 +205,6 @@ const credentialsProvidedByEnvironment = (): boolean =>
  * Kibana's `/internal/security/login` endpoint, bypassing the login page (for speed).
  */
 const loginViaEnvironmentCredentials = () => {
-  const providerName =
-    Cypress.env('protocol') === 'http' || Cypress.config().baseUrl!.includes('staging')
-      ? 'basic'
-      : 'cloud-basic';
-
   cy.log(
     `Authenticating via environment credentials from the \`CYPRESS_${ELASTICSEARCH_USERNAME}\` and \`CYPRESS_${ELASTICSEARCH_PASSWORD}\` environment variables`
   );
@@ -218,7 +213,7 @@ const loginViaEnvironmentCredentials = () => {
   cy.request({
     body: {
       providerType: 'basic',
-      providerName,
+      providerName: 'basic',
       currentURL: '/',
       params: {
         username: Cypress.env(ELASTICSEARCH_USERNAME),


### PR DESCRIPTION
The heuristic to select provider name `cloud-basic` breaks the CCS
integration tests, where protocol is https, and actually is not needed in
any of the automated tests.

For a better solution we need @MadameSheema to be back from PTO.

This partially reverts commit 9f2d9d4d54ad89f3c6dee85d79af0e323633e0d5.