### PR TITLE
[Stack Monitoring] update docs for changes in stack monitoring rules

### DIFF
--- a/docs/user/monitoring/kibana-alerts.asciidoc
+++ b/docs/user/monitoring/kibana-alerts.asciidoc
@@ -11,8 +11,7 @@ specific needs.
 [role="screenshot"]
 image::user/monitoring/images/monitoring-kibana-alerting-notification.png["{kib} alerting notifications in {stack-monitor-app}"]
 
-When you open *{stack-monitor-app}*, you will be ask to create these rules 
-They are initially configured to detect and notify on various 
+When you open *{stack-monitor-app}*, you will be ask to create these rules. They are initially configured to detect and notify on various 
 conditions across your monitored clusters. You can view notifications for: *Cluster health*, *Resource utilization*, and *Errors and exceptions* for {es}
 in real time.
 
@@ -23,8 +22,9 @@ been recreated as rules in {kib} {alert-features}. For this reason, the existing
 The default action for all {stack-monitor-app} rules is to write to {kib} logs 
 and display a notification in the UI.
 
-To review and modify all available rules, click *Enter setup mode* on the 
-*Cluster overview* page.
+To see and modify existing Stack Monitoring rules, click *Enter setup mode* on the 
+*Cluster overview* page. To manage all rules or to remove a rule, open the main menu, then click *Stack Management > Rules and Connectors*.
+Here you can also create multiple new Stack Monitoring rules of the same type.
 
 [discrete]
 [[kibana-alerts-cpu-threshold]]

--- a/docs/user/monitoring/kibana-alerts.asciidoc
+++ b/docs/user/monitoring/kibana-alerts.asciidoc
@@ -11,7 +11,7 @@ specific needs.
 [role="screenshot"]
 image::user/monitoring/images/monitoring-kibana-alerting-notification.png["{kib} alerting notifications in {stack-monitor-app}"]
 
-When you open *{stack-monitor-app}*, you will be ask to create these rules. They are initially configured to detect and notify on various 
+When you open *{stack-monitor-app}*, you will be asked to create these rules. They are initially configured to detect and notify on various 
 conditions across your monitored clusters. You can view notifications for: *Cluster health*, *Resource utilization*, and *Errors and exceptions* for {es}
 in real time.
 

--- a/docs/user/monitoring/kibana-alerts.asciidoc
+++ b/docs/user/monitoring/kibana-alerts.asciidoc
@@ -11,7 +11,7 @@ specific needs.
 [role="screenshot"]
 image::user/monitoring/images/monitoring-kibana-alerting-notification.png["{kib} alerting notifications in {stack-monitor-app}"]
 
-When you open *{stack-monitor-app}*, you will be asked to create these rules. They are initially configured to detect and notify on various 
+When you open *{stack-monitor-app}* for the first time, you will be asked to acknowledge the creation of these default rules. They are initially configured to detect and notify on various 
 conditions across your monitored clusters. You can view notifications for: *Cluster health*, *Resource utilization*, and *Errors and exceptions* for {es}
 in real time.
 
@@ -22,9 +22,8 @@ been recreated as rules in {kib} {alert-features}. For this reason, the existing
 The default action for all {stack-monitor-app} rules is to write to {kib} logs 
 and display a notification in the UI.
 
-To see and modify existing Stack Monitoring rules, click *Enter setup mode* on the 
-*Cluster overview* page. To manage all rules or to remove a rule, open the main menu, then click *Stack Management > Rules and Connectors*.
-Here you can also create multiple new Stack Monitoring rules of the same type.
+To review and modify existing *{stack-monitor-app}* rules, click *Enter setup mode* on the *Cluster overview* page.
+Alternatively, to manage all rules, including create and delete functionality go to *Stack Management > Rules and Connectors*.
 
 [discrete]
 [[kibana-alerts-cpu-threshold]]


### PR DESCRIPTION
Update docs for changes in https://github.com/elastic/kibana/pull/106457.

- Stack Monitoring rules can now have multiples of one type of rule
- Stack Monitoring rules can now be removed