### PR TITLE
[Metrics UI] Fix metric threshold preview regression

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -96,8 +96,6 @@ export const evaluateAlert = <Params extends EvaluatedAlertParams = EvaluatedAle
   );
 };
 
-const MINIMUM_BUCKETS = 5;
-
 const getMetric: (
   esClient: ElasticsearchClient,
   params: MetricExpressionParams,
@@ -127,10 +125,10 @@ const getMetric: (
     .startOf(timeUnit)
     .valueOf();
 
-  // We need enough data for 5 buckets worth of data. We also need
-  // to convert the intervalAsSeconds to milliseconds.
-  // TODO: We only need to get 5 buckets for the rate query, so this logic should move there.
-  const minimumFrom = to - intervalAsMS * MINIMUM_BUCKETS;
+  // Rate aggregations need 5 buckets worth of data
+  const minimumBuckets = aggType === Aggregators.RATE ? 5 : 1;
+
+  const minimumFrom = to - intervalAsMS * minimumBuckets;
 
   const from = roundTimestamp(
     timeframe && timeframe.start <= minimumFrom ? timeframe.start : minimumFrom,

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
@@ -64,4 +64,30 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
       );
     });
   });
+
+  describe('when passed a timeframe of 1 hour', () => {
+    const testTimeframe = {
+      start: moment().subtract(1, 'hour').valueOf(),
+      end: moment().valueOf(),
+    };
+    const searchBodyWithoutGroupBy = getElasticsearchMetricQuery(
+      expressionParams,
+      timefield,
+      testTimeframe
+    );
+    const searchBodyWithGroupBy = getElasticsearchMetricQuery(
+      expressionParams,
+      timefield,
+      testTimeframe,
+      groupBy
+    );
+    test("generates 1 hour's worth of buckets", () => {
+      // @ts-ignore
+      expect(searchBodyWithoutGroupBy.aggs.aggregatedIntervals.date_range.ranges.length).toBe(60);
+      expect(
+        // @ts-ignore
+        searchBodyWithGroupBy.aggs.groupings.aggs.aggregatedIntervals.date_range.ranges.length
+      ).toBe(60);
+    });
+  });
 });

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -76,12 +76,13 @@ export const getElasticsearchMetricQuery = (
           aggregatedIntervals: {
             date_range: {
               field: timefield,
-              ranges: [
-                {
-                  from: to - intervalAsMS - deliveryDelay,
-                  to: to - deliveryDelay,
-                },
-              ],
+              // Generate an array of buckets, starting at `from` and ending at `to`
+              // This is usually only necessary for alert previews or rate aggs. Most alert evaluations
+              // will generate only one bucket from this logic.
+              ranges: Array.from(Array(Math.floor((to - from) / intervalAsMS)), (_, i) => ({
+                from: from + intervalAsMS * i - deliveryDelay,
+                to: from + intervalAsMS * (i + 1) - deliveryDelay,
+              })),
             },
             aggregations,
           },


### PR DESCRIPTION
## Summary

Fixes #107672 

Metric threshold alert previews will now generate enough buckets to look back an hour/day/etc., instead of just generating one bucket..

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

