### PR TITLE
[package testing] Create target dir before copying artifacts

### DIFF
--- a/test/scripts/jenkins_xpack_package_deb.sh
+++ b/test/scripts/jenkins_xpack_package_deb.sh
@@ -4,6 +4,7 @@ set -e
 
 source src/dev/ci_setup/setup_env.sh
 
+mkdir -p target
 gsutil -q -m cp "gs://ci-artifacts.kibana.dev/package-testing/$GIT_COMMIT/kibana-*.deb" ./target
 
 export VAGRANT_CWD=test/package

--- a/test/scripts/jenkins_xpack_package_docker.sh
+++ b/test/scripts/jenkins_xpack_package_docker.sh
@@ -4,6 +4,7 @@ set -e
 
 source src/dev/ci_setup/setup_env.sh
 
+mkdir -p target
 gsutil -q -m cp "gs://ci-artifacts.kibana.dev/package-testing/$GIT_COMMIT/kibana-[0-9]*-docker-image.tar.gz" ./target
 
 export VAGRANT_CWD=test/package

--- a/test/scripts/jenkins_xpack_package_rpm.sh
+++ b/test/scripts/jenkins_xpack_package_rpm.sh
@@ -4,6 +4,7 @@ set -e
 
 source src/dev/ci_setup/setup_env.sh
 
+mkdir -p target
 gsutil -q -m cp "gs://ci-artifacts.kibana.dev/package-testing/$GIT_COMMIT/kibana-*.rpm" ./target
 
 export VAGRANT_CWD=test/package


### PR DESCRIPTION
gsutil requires a directory to exist before copying artifacts in.
Prior to https://github.com/elastic/kibana/pull/107217, a
.bootstrap-cache file was written, providing the directory for these
writes.  Now that we're no longer writing this file, we need to ensure
it exists.

