### PR TITLE
[7.x] [Alerting UI] Added visual indicator when enable switched click is processed on the server side. (#107272)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/alert_details.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/alert_details.tsx
@@ -21,6 +21,7 @@ import {
   EuiSpacer,
   EuiButtonEmpty,
   EuiButton,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { AlertExecutionStatusErrorReasons } from '../../../../../../alerting/common';
@@ -99,6 +100,8 @@ export const AlertDetails: React.FunctionComponent<AlertDetailsProps> = ({
   const alertActions = alert.actions;
   const uniqueActions = Array.from(new Set(alertActions.map((item: any) => item.actionTypeId)));
   const [isEnabled, setIsEnabled] = useState<boolean>(alert.enabled);
+  const [isEnabledUpdating, setIsEnabledUpdating] = useState<boolean>(false);
+  const [isMutedUpdating, setIsMutedUpdating] = useState<boolean>(false);
   const [isMuted, setIsMuted] = useState<boolean>(alert.muteAll);
   const [editFlyoutVisible, setEditFlyoutVisibility] = useState<boolean>(false);
   const [dissmissAlertErrors, setDissmissAlertErrors] = useState<boolean>(false);
@@ -218,54 +221,92 @@ export const AlertDetails: React.FunctionComponent<AlertDetailsProps> = ({
             <EuiSpacer />
             <EuiFlexGroup justifyContent="flexEnd" wrap responsive={false} gutterSize="m">
               <EuiFlexItem grow={false}>
-                <EuiSwitch
-                  name="enable"
-                  disabled={!canSaveAlert || !alertType.enabledInLicense}
-                  checked={isEnabled}
-                  data-test-subj="enableSwitch"
-                  onChange={async () => {
-                    if (isEnabled) {
-                      setIsEnabled(false);
-                      await disableAlert(alert);
-                      // Reset dismiss if previously clicked
-                      setDissmissAlertErrors(false);
-                    } else {
-                      setIsEnabled(true);
-                      await enableAlert(alert);
+                {isEnabledUpdating ? (
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiLoadingSpinner data-test-subj="enableSpinner" size="m" />
+                    </EuiFlexItem>
+
+                    <EuiFlexItem>
+                      <EuiText size="s">
+                        <FormattedMessage
+                          id="xpack.triggersActionsUI.sections.alertDetails.collapsedItemActons.enableLoadingTitle"
+                          defaultMessage="Enable"
+                        />
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ) : (
+                  <EuiSwitch
+                    name="enable"
+                    disabled={!canSaveAlert || !alertType.enabledInLicense}
+                    checked={isEnabled}
+                    data-test-subj="enableSwitch"
+                    onChange={async () => {
+                      setIsEnabledUpdating(true);
+                      if (isEnabled) {
+                        setIsEnabled(false);
+                        await disableAlert(alert);
+                        // Reset dismiss if previously clicked
+                        setDissmissAlertErrors(false);
+                      } else {
+                        setIsEnabled(true);
+                        await enableAlert(alert);
+                      }
+                      requestRefresh();
+                      setIsEnabledUpdating(false);
+                    }}
+                    label={
+                      <FormattedMessage
+                        id="xpack.triggersActionsUI.sections.alertDetails.collapsedItemActons.enableTitle"
+                        defaultMessage="Enable"
+                      />
                     }
-                    requestRefresh();
-                  }}
-                  label={
-                    <FormattedMessage
-                      id="xpack.triggersActionsUI.sections.alertDetails.collapsedItemActons.enableTitle"
-                      defaultMessage="Enable"
-                    />
-                  }
-                />
+                  />
+                )}
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiSwitch
-                  name="mute"
-                  checked={isMuted}
-                  disabled={!canSaveAlert || !isEnabled || !alertType.enabledInLicense}
-                  data-test-subj="muteSwitch"
-                  onChange={async () => {
-                    if (isMuted) {
-                      setIsMuted(false);
-                      await unmuteAlert(alert);
-                    } else {
-                      setIsMuted(true);
-                      await muteAlert(alert);
+                {isMutedUpdating ? (
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiLoadingSpinner size="m" />
+                    </EuiFlexItem>
+
+                    <EuiFlexItem>
+                      <EuiText size="s">
+                        <FormattedMessage
+                          id="xpack.triggersActionsUI.sections.alertDetails.collapsedItemActons.muteLoadingTitle"
+                          defaultMessage="Mute"
+                        />
+                      </EuiText>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                ) : (
+                  <EuiSwitch
+                    name="mute"
+                    checked={isMuted}
+                    disabled={!canSaveAlert || !isEnabled || !alertType.enabledInLicense}
+                    data-test-subj="muteSwitch"
+                    onChange={async () => {
+                      setIsMutedUpdating(true);
+                      if (isMuted) {
+                        setIsMuted(false);
+                        await unmuteAlert(alert);
+                      } else {
+                        setIsMuted(true);
+                        await muteAlert(alert);
+                      }
+                      requestRefresh();
+                      setIsMutedUpdating(false);
+                    }}
+                    label={
+                      <FormattedMessage
+                        id="xpack.triggersActionsUI.sections.alertDetails.collapsedItemActons.muteTitle"
+                        defaultMessage="Mute"
+                      />
                     }
-                    requestRefresh();
-                  }}
-                  label={
-                    <FormattedMessage
-                      id="xpack.triggersActionsUI.sections.alertDetails.collapsedItemActons.muteTitle"
-                      defaultMessage="Mute"
-                    />
-                  }
-                />
+                  />
+                )}
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/alert_instances.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/alert_instances.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import moment, { Duration } from 'moment';
 import { i18n } from '@kbn/i18n';
-import { EuiBasicTable, EuiHealth, EuiSpacer, EuiSwitch, EuiToolTip } from '@elastic/eui';
+import { EuiBasicTable, EuiHealth, EuiSpacer, EuiToolTip } from '@elastic/eui';
 // @ts-ignore
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '@elastic/eui/lib/services';
 import { padStart, chunk } from 'lodash';
@@ -26,6 +26,7 @@ import {
 } from '../../common/components/with_bulk_alert_api_operations';
 import { DEFAULT_SEARCH_PAGE_SIZE } from '../../../constants';
 import './alert_instances.scss';
+import { RuleMutedSwitch } from './rule_muted_switch';
 
 type AlertInstancesProps = {
   alert: Alert;
@@ -112,17 +113,11 @@ export const alertInstancesTableColumns = (
     ),
     render: (alertInstance: AlertInstanceListItem) => {
       return (
-        <>
-          <EuiSwitch
-            label="mute"
-            showLabel={false}
-            compressed={true}
-            checked={alertInstance.isMuted}
-            disabled={readOnly}
-            data-test-subj={`muteAlertInstanceButton_${alertInstance.instance}`}
-            onChange={() => onMuteAction(alertInstance)}
-          />
-        </>
+        <RuleMutedSwitch
+          disabled={readOnly}
+          onMuteAction={async () => await onMuteAction(alertInstance)}
+          alertInstance={alertInstance}
+        />
       );
     },
     sortable: false,

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/rule_muted_switch.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/rule_muted_switch.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiSwitch, EuiLoadingSpinner } from '@elastic/eui';
+
+import { AlertInstanceListItem } from './alert_instances';
+
+interface ComponentOpts {
+  alertInstance: AlertInstanceListItem;
+  onMuteAction: (instance: AlertInstanceListItem) => Promise<void>;
+  disabled: boolean;
+}
+
+export const RuleMutedSwitch: React.FunctionComponent<ComponentOpts> = ({
+  alertInstance,
+  onMuteAction,
+  disabled,
+}: ComponentOpts) => {
+  const [isMuted, setIsMuted] = useState<boolean>(alertInstance?.isMuted);
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+
+  return isUpdating ? (
+    <EuiLoadingSpinner size="m" />
+  ) : (
+    <EuiSwitch
+      name="mute"
+      disabled={disabled}
+      compressed={true}
+      checked={isMuted}
+      onChange={async () => {
+        setIsUpdating(true);
+        await onMuteAction(alertInstance);
+        setIsMuted(!isMuted);
+        setIsUpdating(false);
+      }}
+      data-test-subj={`muteAlertInstanceButton_${alertInstance.instance}`}
+      showLabel={false}
+      label="mute"
+    />
+  );
+};

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/rule_enabled_switch.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/rule_enabled_switch.tsx
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { asyncScheduler } from 'rxjs';
-import React, { useEffect, useState } from 'react';
-import { EuiSwitch } from '@elastic/eui';
+import React, { useState, useEffect } from 'react';
+import { EuiSwitch, EuiLoadingSpinner } from '@elastic/eui';
 
 import { Alert, AlertTableItem } from '../../../../types';
 
@@ -28,8 +27,11 @@ export const RuleEnabledSwitch: React.FunctionComponent<ComponentOpts> = ({
   useEffect(() => {
     setIsEnabled(item.enabled);
   }, [item.enabled]);
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
 
-  return (
+  return isUpdating ? (
+    <EuiLoadingSpinner data-test-subj="enableSpinner" size="m" />
+  ) : (
     <EuiSwitch
       name="enable"
       disabled={!item.isEditable || !item.enabledInLicense}
@@ -37,16 +39,16 @@ export const RuleEnabledSwitch: React.FunctionComponent<ComponentOpts> = ({
       checked={isEnabled}
       data-test-subj="enableSwitch"
       onChange={async () => {
-        const enabled = isEnabled;
-        asyncScheduler.schedule(async () => {
-          if (enabled) {
-            await disableAlert({ ...item, enabled });
-          } else {
-            await enableAlert({ ...item, enabled });
-          }
-          onAlertChanged();
-        }, 10);
+        setIsUpdating(true);
+        const enabled = item.enabled;
+        if (enabled) {
+          await disableAlert({ ...item, enabled });
+        } else {
+          await enableAlert({ ...item, enabled });
+        }
         setIsEnabled(!isEnabled);
+        setIsUpdating(false);
+        onAlertChanged();
       }}
       label=""
     />


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Alerting UI] Added visual indicator when enable switched click is processed on the server side. (#107272)