### PR TITLE
[7.14] chore(NA): moving @kbn/telemetry-tools to babel transpiler (#107540)

### DIFF
--- a/packages/kbn-telemetry-tools/.babelrc
+++ b/packages/kbn-telemetry-tools/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-telemetry-tools/BUILD.bazel
+++ b/packages/kbn-telemetry-tools/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-telemetry-tools"
 PKG_REQUIRE_NAME = "@kbn/telemetry-tools"
@@ -28,28 +29,30 @@ NPM_MODULE_EXTRA_FILES = [
   "GUIDELINE.md",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-dev-utils",
   "//packages/kbn-utility-types",
   "@npm//glob",
   "@npm//listr",
   "@npm//normalize-path",
-  "@npm//tslib",
 ]
 
 TYPES_DEPS = [
-  "@npm//@types/flot",
+  "//packages/kbn-dev-utils",
+  "//packages/kbn-utility-types",
   "@npm//@types/glob",
   "@npm//@types/jest",
   "@npm//@types/listr",
   "@npm//@types/lodash",
   "@npm//@types/node",
   "@npm//@types/normalize-path",
-  "@npm//@types/testing-library__jest-dom",
-  "@npm//resize-observer-polyfill"
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -60,14 +63,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -76,7 +80,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-telemetry-tools/package.json
+++ b/packages/kbn-telemetry-tools/package.json
@@ -2,8 +2,8 @@
   "name": "@kbn/telemetry-tools",
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "private": true,
   "kibana": {
     "devOnly": true

--- a/packages/kbn-telemetry-tools/tsconfig.json
+++ b/packages/kbn-telemetry-tools/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "./target",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "isolatedModules": true,
+    "outDir": "./target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-telemetry-tools/src",
-    "isolatedModules": true,
     "types": [
       "jest",
       "node"


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/telemetry-tools to babel transpiler (#107540)