### PR TITLE
use kbnArchiver and test_user with minimal role in x-pack/test/functional/apps/rollup_job/tsvb.js 

### DIFF
--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -465,6 +465,17 @@ export default async function ({ readConfigFile }) {
           ],
         },
 
+        test_rollup_reader: {
+          elasticsearch: {
+            indices: [
+              {
+                names: ['rollup-*'],
+                privileges: ['read', 'view_index_metadata'],
+              },
+            ],
+          },
+        },
+
         //Kibana feature privilege isn't specific to advancedSetting. It can be anything. https://github.com/elastic/kibana/issues/35965
         test_api_keys: {
           elasticsearch: {

--- a/x-pack/test/functional/fixtures/kbn_archiver/rollup/rollup.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/rollup/rollup.json
@@ -1,0 +1,39 @@
+{
+  "attributes": {
+    "accessibility:disableAnimations": true,
+    "buildNum": 9007199254740991,
+    "dateFormat:tz": "UTC",
+    "defaultIndex": "rollup",
+    "visualization:visualize:legacyChartsLibrary": true,
+    "visualization:visualize:legacyPieChartsLibrary": true
+  },
+  "coreMigrationVersion": "7.15.0",
+  "id": "7.15.0",
+  "migrationVersion": {
+    "config": "7.13.0"
+  },
+  "references": [],
+  "type": "config",
+  "updated_at": "2021-08-04T23:35:47.992Z",
+  "version": "WzQwLDFd"
+}
+
+{
+  "attributes": {
+    "fieldAttrs": "{}",
+    "fields": "[]",
+    "runtimeFieldMap": "{}",
+    "timeFieldName": "@timestamp.date_histogram.timestamp",
+    "title": "rollup*",
+    "typeMeta": "{}"
+  },
+  "coreMigrationVersion": "7.15.0",
+  "id": "rollup",
+  "migrationVersion": {
+    "index-pattern": "7.11.0"
+  },
+  "references": [],
+  "type": "index-pattern",
+  "updated_at": "2021-08-04T23:22:14.902Z",
+  "version": "WzIyLDFd"
+}


### PR DESCRIPTION
-  part of #102552
-  part of  https://github.com/elastic/kibana/issues/84970

- Migrate esArchiver to use kbnArchiver for the `tsvb rollup_job test`
- Conversion of superuser to `test_user` with minimum privileges for functional tsvb test