### PR TITLE
[APM] Invalidate trackPageview on route change

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/track_pageview.tsx
+++ b/x-pack/plugins/apm/public/components/routing/track_pageview.tsx
@@ -11,8 +11,8 @@ import { useTrackPageview } from '../../../../observability/public';
 export function TrackPageview({ children }: { children: React.ReactElement }) {
   const routePath = useRoutePath();
 
-  useTrackPageview({ app: 'apm', path: routePath });
-  useTrackPageview({ app: 'apm', path: routePath, delay: 15000 });
+  useTrackPageview({ app: 'apm', path: routePath }, [routePath]);
+  useTrackPageview({ app: 'apm', path: routePath, delay: 15000 }, [routePath]);
 
   return children;
 }


### PR DESCRIPTION
Closes #107728.

Adds an effect dependency to `useTrackPageview` to make sure it is invalidated on route change.