### PR TITLE
Realign cypress/ccs_integration with cypress/integration

### DIFF
--- a/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { CELL_TEXT, JSON_LINES, TABLE_ROWS } from '../../screens/alerts_details';
+import { ALERT_FLYOUT, CELL_TEXT, JSON_LINES, TABLE_ROWS } from '../../screens/alerts_details';
 
 import {
   expandFirstAlert,
@@ -45,12 +45,15 @@ describe('Alert details with unmapped fields', () => {
     openJsonView();
     scrollJsonViewToBottom();
 
-    cy.get(JSON_LINES).then((elements) => {
-      const length = elements.length;
-      cy.wrap(elements)
-        .eq(length - expectedUnmappedField.line)
-        .should('have.text', expectedUnmappedField.text);
-    });
+    cy.get(ALERT_FLYOUT)
+      .find(JSON_LINES)
+      .then((elements) => {
+        const length = elements.length;
+        cy.wrap(elements)
+          .eq(length - expectedUnmappedField.line)
+          .invoke('text')
+          .should('include', expectedUnmappedField.text);
+      });
   });
 
   it('Displays the unmapped field on the table', () => {
@@ -61,8 +64,8 @@ describe('Alert details with unmapped fields', () => {
     };
 
     openTable();
-
-    cy.get(TABLE_ROWS)
+    cy.get(ALERT_FLYOUT)
+      .find(TABLE_ROWS)
       .eq(expectedUnmmappedField.row)
       .within(() => {
         cy.get(CELL_TEXT).eq(2).should('have.text', expectedUnmmappedField.field);


### PR DESCRIPTION
cypress/ccs_integration is a subset/fork of cypress/integration and already tends to be left behind.

Situation is expected to improve once proper signaling of failing tests is reported to #security-solution-slack-testing.

For the moment, let's keep aligning manually.