### PR TITLE
[security solution] Add behaviour protection for mac and linux

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v7_15_0.test.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v7_15_0.test.ts
@@ -18,6 +18,12 @@ describe('7.15.0 Endpoint Package Policy migration', () => {
     windowsPopup = {},
     windowsMalware = {},
     windowsRansomware = {},
+    macBehavior = {},
+    macMalware = {},
+    macPopup = {},
+    linuxBehavior = {},
+    linuxMalware = {},
+    linuxPopup = {},
   }) => {
     return {
       id: 'mock-saved-object-id',
@@ -53,6 +59,16 @@ describe('7.15.0 Endpoint Package Policy migration', () => {
                     ...windowsBehavior,
                     ...windowsPopup,
                   },
+                  mac: {
+                    ...macMalware,
+                    ...macBehavior,
+                    ...macPopup,
+                  },
+                  linux: {
+                    ...linuxMalware,
+                    ...linuxBehavior,
+                    ...linuxPopup,
+                  },
                 },
               },
             },
@@ -63,7 +79,7 @@ describe('7.15.0 Endpoint Package Policy migration', () => {
     };
   };
 
-  it('adds windows memory and behavior protection alongside malware and ramsomware', () => {
+  it('adds windows memory protection, and windows, mac and linux behavior protection alongside malware and ramsomware', () => {
     const initialDoc = policyDoc({
       windowsMalware: { malware: { mode: 'off' } },
       windowsRansomware: { ransomware: { mode: 'off', supported: true } },
@@ -74,6 +90,24 @@ describe('7.15.0 Endpoint Package Policy migration', () => {
             enabled: true,
           },
           ransomware: {
+            message: '',
+            enabled: true,
+          },
+        },
+      },
+      macMalware: { malware: { mode: 'off' } },
+      macPopup: {
+        popup: {
+          malware: {
+            message: '',
+            enabled: true,
+          },
+        },
+      },
+      linuxMalware: { malware: { mode: 'off' } },
+      linuxPopup: {
+        popup: {
+          malware: {
             message: '',
             enabled: true,
           },
@@ -101,6 +135,36 @@ describe('7.15.0 Endpoint Package Policy migration', () => {
           memory_protection: {
             message: '',
             enabled: false,
+          },
+          // new behavior popup setup
+          behavior_protection: {
+            message: '',
+            enabled: false,
+          },
+        },
+      },
+      macMalware: { malware: { mode: 'off' } },
+      macBehavior: { behavior_protection: { mode: 'off', supported: true } },
+      macPopup: {
+        popup: {
+          malware: {
+            message: '',
+            enabled: true,
+          },
+          // new behavior popup setup
+          behavior_protection: {
+            message: '',
+            enabled: false,
+          },
+        },
+      },
+      linuxMalware: { malware: { mode: 'off' } },
+      linuxBehavior: { behavior_protection: { mode: 'off', supported: true } },
+      linuxPopup: {
+        popup: {
+          malware: {
+            message: '',
+            enabled: true,
           },
           // new behavior popup setup
           behavior_protection: {

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v7_15_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v7_15_0.ts
@@ -49,6 +49,10 @@ export const migratePackagePolicyToV7150: SavedObjectMigrationFn<PackagePolicy, 
     policy.windows.popup.memory_protection = memoryPopup;
     policy.windows.behavior_protection = behavior;
     policy.windows.popup.behavior_protection = behaviorPopup;
+    policy.mac.behavior_protection = behavior;
+    policy.mac.popup.behavior_protection = behaviorPopup;
+    policy.linux.behavior_protection = behavior;
+    policy.linux.popup.behavior_protection = behaviorPopup;
   }
 
   return updatedPackagePolicyDoc;

--- a/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
@@ -71,8 +71,16 @@ export const policyFactory = (): PolicyConfig => {
       malware: {
         mode: ProtectionModes.prevent,
       },
+      behavior_protection: {
+        mode: ProtectionModes.prevent,
+        supported: true,
+      },
       popup: {
         malware: {
+          message: '',
+          enabled: true,
+        },
+        behavior_protection: {
           message: '',
           enabled: true,
         },
@@ -90,8 +98,16 @@ export const policyFactory = (): PolicyConfig => {
       malware: {
         mode: ProtectionModes.prevent,
       },
+      behavior_protection: {
+        mode: ProtectionModes.prevent,
+        supported: true,
+      },
       popup: {
         malware: {
+          message: '',
+          enabled: true,
+        },
+        behavior_protection: {
           message: '',
           enabled: true,
         },
@@ -147,21 +163,37 @@ export const policyFactoryWithoutPaidFeatures = (
     },
     mac: {
       ...policy.mac,
+      behavior_protection: {
+        mode: ProtectionModes.off,
+        supported: false,
+      },
       popup: {
         ...policy.mac.popup,
         malware: {
           message: '',
           enabled: true,
         },
+        behavior_protection: {
+          message: '',
+          enabled: false,
+        },
       },
     },
     linux: {
       ...policy.linux,
+      behavior_protection: {
+        mode: ProtectionModes.off,
+        supported: false,
+      },
       popup: {
         ...policy.linux.popup,
         malware: {
           message: '',
           enabled: true,
+        },
+        behavior_protection: {
+          message: '',
+          enabled: false,
         },
       },
     },
@@ -186,6 +218,20 @@ export const policyFactoryWithSupportedFeatures = (
         ...policy.windows.memory_protection,
         supported: true,
       },
+      behavior_protection: {
+        ...policy.windows.behavior_protection,
+        supported: true,
+      },
+    },
+    mac: {
+      ...policy.mac,
+      behavior_protection: {
+        ...policy.windows.behavior_protection,
+        supported: true,
+      },
+    },
+    linux: {
+      ...policy.linux,
       behavior_protection: {
         ...policy.windows.behavior_protection,
         supported: true,

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -900,8 +900,13 @@ export interface PolicyConfig {
       network: boolean;
     };
     malware: ProtectionFields;
+    behavior_protection: ProtectionFields & SupportedFields;
     popup: {
       malware: {
+        message: string;
+        enabled: boolean;
+      };
+      behavior_protection: {
         message: string;
         enabled: boolean;
       };
@@ -918,8 +923,13 @@ export interface PolicyConfig {
       network: boolean;
     };
     malware: ProtectionFields;
+    behavior_protection: ProtectionFields & SupportedFields;
     popup: {
       malware: {
+        message: string;
+        enabled: boolean;
+      };
+      behavior_protection: {
         message: string;
         enabled: boolean;
       };
@@ -951,11 +961,17 @@ export interface UIPolicyConfig {
   /**
    * Mac-specific policy configuration that is supported via the UI
    */
-  mac: Pick<PolicyConfig['mac'], 'malware' | 'events' | 'popup' | 'advanced'>;
+  mac: Pick<
+    PolicyConfig['mac'],
+    'malware' | 'events' | 'popup' | 'advanced' | 'behavior_protection'
+  >;
   /**
    * Linux-specific policy configuration that is supported via the UI
    */
-  linux: Pick<PolicyConfig['linux'], 'malware' | 'events' | 'popup' | 'advanced'>;
+  linux: Pick<
+    PolicyConfig['linux'],
+    'malware' | 'events' | 'popup' | 'advanced' | 'behavior_protection'
+  >;
 }
 
 /** Policy:  Protection fields */

--- a/x-pack/plugins/security_solution/common/license/policy_config.test.ts
+++ b/x-pack/plugins/security_solution/common/license/policy_config.test.ts
@@ -86,6 +86,10 @@ describe('policy_config and licenses', () => {
       // behavior protection
       policy.windows.behavior_protection.mode = ProtectionModes.prevent;
       policy.windows.behavior_protection.supported = true;
+      policy.mac.behavior_protection.mode = ProtectionModes.prevent;
+      policy.mac.behavior_protection.supported = true;
+      policy.linux.behavior_protection.mode = ProtectionModes.prevent;
+      policy.linux.behavior_protection.supported = true;
 
       const valid = isEndpointPolicyValidForLicense(policy, Platinum);
       expect(valid).toBeTruthy();
@@ -102,6 +106,10 @@ describe('policy_config and licenses', () => {
       // behavior protection
       policy.windows.popup.behavior_protection.enabled = true;
       policy.windows.behavior_protection.supported = true;
+      policy.mac.popup.behavior_protection.enabled = true;
+      policy.mac.behavior_protection.supported = true;
+      policy.linux.popup.behavior_protection.enabled = true;
+      policy.linux.behavior_protection.supported = true;
       const valid = isEndpointPolicyValidForLicense(policy, Platinum);
       expect(valid).toBeTruthy();
     });
@@ -187,6 +195,8 @@ describe('policy_config and licenses', () => {
       it('blocks behavior_protection to be turned on for Gold and below licenses', () => {
         const policy = policyFactoryWithoutPaidFeatures();
         policy.windows.behavior_protection.mode = ProtectionModes.prevent;
+        policy.mac.behavior_protection.mode = ProtectionModes.prevent;
+        policy.linux.behavior_protection.mode = ProtectionModes.prevent;
 
         let valid = isEndpointPolicyValidForLicense(policy, Gold);
         expect(valid).toBeFalsy();
@@ -197,6 +207,8 @@ describe('policy_config and licenses', () => {
       it('blocks behavior_protection notification to be turned on for Gold and below licenses', () => {
         const policy = policyFactoryWithoutPaidFeatures();
         policy.windows.popup.behavior_protection.enabled = true;
+        policy.mac.popup.behavior_protection.enabled = true;
+        policy.linux.popup.behavior_protection.enabled = true;
         let valid = isEndpointPolicyValidForLicense(policy, Gold);
         expect(valid).toBeFalsy();
 
@@ -207,6 +219,8 @@ describe('policy_config and licenses', () => {
       it('allows behavior_protection notification message changes with a Platinum license', () => {
         const policy = policyFactory();
         policy.windows.popup.behavior_protection.message = 'BOOM';
+        policy.mac.popup.behavior_protection.message = 'BOOM';
+        policy.linux.popup.behavior_protection.message = 'BOOM';
         const valid = isEndpointPolicyValidForLicense(policy, Platinum);
         expect(valid).toBeTruthy();
       });
@@ -214,6 +228,8 @@ describe('policy_config and licenses', () => {
       it('blocks behavior_protection notification message changes for Gold and below licenses', () => {
         const policy = policyFactory();
         policy.windows.popup.behavior_protection.message = 'BOOM';
+        policy.mac.popup.behavior_protection.message = 'BOOM';
+        policy.linux.popup.behavior_protection.message = 'BOOM';
         let valid = isEndpointPolicyValidForLicense(policy, Gold);
         expect(valid).toBeFalsy();
 
@@ -275,11 +291,23 @@ describe('policy_config and licenses', () => {
       policy.windows.behavior_protection.mode = ProtectionModes.detect;
       policy.windows.popup.behavior_protection.enabled = false;
       policy.windows.popup.behavior_protection.message = popupMessage;
+      policy.mac.behavior_protection.mode = ProtectionModes.detect;
+      policy.mac.popup.behavior_protection.enabled = false;
+      policy.mac.popup.behavior_protection.message = popupMessage;
+      policy.linux.behavior_protection.mode = ProtectionModes.detect;
+      policy.linux.popup.behavior_protection.enabled = false;
+      policy.linux.popup.behavior_protection.message = popupMessage;
 
       const retPolicy = unsetPolicyFeaturesAccordingToLicenseLevel(policy, Platinum);
       expect(retPolicy.windows.behavior_protection.mode).toEqual(ProtectionModes.detect);
       expect(retPolicy.windows.popup.behavior_protection.enabled).toBeFalsy();
       expect(retPolicy.windows.popup.behavior_protection.message).toEqual(popupMessage);
+      expect(retPolicy.mac.behavior_protection.mode).toEqual(ProtectionModes.detect);
+      expect(retPolicy.mac.popup.behavior_protection.enabled).toBeFalsy();
+      expect(retPolicy.mac.popup.behavior_protection.message).toEqual(popupMessage);
+      expect(retPolicy.linux.behavior_protection.mode).toEqual(ProtectionModes.detect);
+      expect(retPolicy.linux.popup.behavior_protection.enabled).toBeFalsy();
+      expect(retPolicy.linux.popup.behavior_protection.message).toEqual(popupMessage);
     });
 
     it('resets Platinum-paid fields for lower license tiers', () => {
@@ -349,6 +377,8 @@ describe('policy_config and licenses', () => {
       const policy = policyFactory(); // what we will modify, and should be reset
       const popupMessage = 'WOOP WOOP';
       policy.windows.popup.behavior_protection.message = popupMessage;
+      policy.mac.popup.behavior_protection.message = popupMessage;
+      policy.linux.popup.behavior_protection.message = popupMessage;
 
       const retPolicy = unsetPolicyFeaturesAccordingToLicenseLevel(policy, Gold);
 
@@ -363,6 +393,30 @@ describe('policy_config and licenses', () => {
       // need to invert the test, since it could be either value
       expect(['', DefaultPolicyNotificationMessage]).toContain(
         retPolicy.windows.popup.behavior_protection.message
+      );
+
+      expect(retPolicy.mac.behavior_protection.mode).toEqual(defaults.mac.behavior_protection.mode);
+      expect(retPolicy.mac.popup.behavior_protection.enabled).toEqual(
+        defaults.mac.popup.behavior_protection.enabled
+      );
+      expect(retPolicy.mac.popup.behavior_protection.message).not.toEqual(popupMessage);
+
+      // need to invert the test, since it could be either value
+      expect(['', DefaultPolicyNotificationMessage]).toContain(
+        retPolicy.mac.popup.behavior_protection.message
+      );
+
+      expect(retPolicy.linux.behavior_protection.mode).toEqual(
+        defaults.linux.behavior_protection.mode
+      );
+      expect(retPolicy.linux.popup.behavior_protection.enabled).toEqual(
+        defaults.linux.popup.behavior_protection.enabled
+      );
+      expect(retPolicy.linux.popup.behavior_protection.message).not.toEqual(popupMessage);
+
+      // need to invert the test, since it could be either value
+      expect(['', DefaultPolicyNotificationMessage]).toContain(
+        retPolicy.linux.popup.behavior_protection.message
       );
     });
 
@@ -413,11 +467,19 @@ describe('policy_config and licenses', () => {
       const defaults = policyFactoryWithoutPaidFeatures(); // reference
       const policy = policyFactory(); // what we will modify, and should be reset
       policy.windows.behavior_protection.supported = true;
+      policy.mac.behavior_protection.supported = true;
+      policy.linux.behavior_protection.supported = true;
 
       const retPolicy = unsetPolicyFeaturesAccordingToLicenseLevel(policy, Gold);
 
       expect(retPolicy.windows.behavior_protection.supported).toEqual(
         defaults.windows.behavior_protection.supported
+      );
+      expect(retPolicy.mac.behavior_protection.supported).toEqual(
+        defaults.mac.behavior_protection.supported
+      );
+      expect(retPolicy.linux.behavior_protection.supported).toEqual(
+        defaults.linux.behavior_protection.supported
       );
     });
 
@@ -425,11 +487,19 @@ describe('policy_config and licenses', () => {
       const defaults = policyFactoryWithSupportedFeatures(); // reference
       const policy = policyFactory(); // what we will modify, and should be reset
       policy.windows.behavior_protection.supported = false;
+      policy.mac.behavior_protection.supported = false;
+      policy.linux.behavior_protection.supported = false;
 
       const retPolicy = unsetPolicyFeaturesAccordingToLicenseLevel(policy, Platinum);
 
       expect(retPolicy.windows.behavior_protection.supported).toEqual(
         defaults.windows.behavior_protection.supported
+      );
+      expect(retPolicy.mac.behavior_protection.supported).toEqual(
+        defaults.mac.behavior_protection.supported
+      );
+      expect(retPolicy.linux.behavior_protection.supported).toEqual(
+        defaults.linux.behavior_protection.supported
       );
     });
   });

--- a/x-pack/plugins/security_solution/common/license/policy_config.ts
+++ b/x-pack/plugins/security_solution/common/license/policy_config.ts
@@ -129,7 +129,9 @@ function isEndpointBehaviorPolicyValidForLicense(policy: PolicyConfig, license: 
     // only platinum or higher may enable behavior protection
     if (
       policy.windows.behavior_protection.supported !==
-      defaults.windows.behavior_protection.supported
+        defaults.windows.behavior_protection.supported ||
+      policy.mac.behavior_protection.supported !== defaults.mac.behavior_protection.supported ||
+      policy.linux.behavior_protection.supported !== defaults.linux.behavior_protection.supported
     ) {
       return false;
     }
@@ -139,29 +141,44 @@ function isEndpointBehaviorPolicyValidForLicense(policy: PolicyConfig, license: 
   const defaults = policyFactoryWithoutPaidFeatures();
 
   // only platinum or higher may enable behavior_protection
-  if (policy.windows.behavior_protection.mode !== defaults.windows.behavior_protection.mode) {
+  if (
+    policy.windows.behavior_protection.mode !== defaults.windows.behavior_protection.mode ||
+    policy.mac.behavior_protection.mode !== defaults.mac.behavior_protection.mode ||
+    policy.linux.behavior_protection.mode !== defaults.linux.behavior_protection.mode
+  ) {
     return false;
   }
 
   // only platinum or higher may enable behavior_protection notification
   if (
     policy.windows.popup.behavior_protection.enabled !==
-    defaults.windows.popup.behavior_protection.enabled
+      defaults.windows.popup.behavior_protection.enabled ||
+    policy.mac.popup.behavior_protection.enabled !==
+      defaults.mac.popup.behavior_protection.enabled ||
+    policy.linux.popup.behavior_protection.enabled !==
+      defaults.linux.popup.behavior_protection.enabled
   ) {
     return false;
   }
 
   // Only Platinum or higher may change the behavior_protection message (which can be blank or what Endpoint defaults)
   if (
-    policy.windows.popup.behavior_protection.message !== '' &&
-    policy.windows.popup.behavior_protection.message !== DefaultPolicyNotificationMessage
+    (policy.windows.popup.behavior_protection.message !== '' &&
+      policy.windows.popup.behavior_protection.message !== DefaultPolicyNotificationMessage) ||
+    (policy.mac.popup.behavior_protection.message !== '' &&
+      policy.mac.popup.behavior_protection.message !== DefaultPolicyNotificationMessage) ||
+    (policy.linux.popup.behavior_protection.message !== '' &&
+      policy.linux.popup.behavior_protection.message !== DefaultPolicyNotificationMessage)
   ) {
     return false;
   }
 
   // only platinum or higher may enable behavior_protection
   if (
-    policy.windows.behavior_protection.supported !== defaults.windows.behavior_protection.supported
+    policy.windows.behavior_protection.supported !==
+      defaults.windows.behavior_protection.supported ||
+    policy.mac.behavior_protection.supported !== defaults.mac.behavior_protection.supported ||
+    policy.linux.behavior_protection.supported !== defaults.linux.behavior_protection.supported
   ) {
     return false;
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
@@ -313,9 +313,14 @@ describe('policy details: ', () => {
                   mac: {
                     events: { process: true, file: true, network: true },
                     malware: { mode: 'prevent' },
+                    behavior_protection: { mode: 'off', supported: false },
                     popup: {
                       malware: {
                         enabled: true,
+                        message: '',
+                      },
+                      behavior_protection: {
+                        enabled: false,
                         message: '',
                       },
                     },
@@ -325,9 +330,14 @@ describe('policy details: ', () => {
                     events: { process: true, file: true, network: true },
                     logging: { file: 'info' },
                     malware: { mode: 'prevent' },
+                    behavior_protection: { mode: 'off', supported: false },
                     popup: {
                       malware: {
                         enabled: true,
+                        message: '',
+                      },
+                      behavior_protection: {
+                        enabled: false,
                         message: '',
                       },
                     },

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware.ts
@@ -56,6 +56,14 @@ export const policyDetailsMiddlewareFactory: ImmutableMiddlewareFactory<PolicyDe
         ) {
           policyItem.inputs[0].config.policy.value.windows.popup.behavior_protection.message = DefaultPolicyNotificationMessage;
         }
+        if (policyItem.inputs[0].config.policy.value.mac.popup.behavior_protection.message === '') {
+          policyItem.inputs[0].config.policy.value.mac.popup.behavior_protection.message = DefaultPolicyNotificationMessage;
+        }
+        if (
+          policyItem.inputs[0].config.policy.value.linux.popup.behavior_protection.message === ''
+        ) {
+          policyItem.inputs[0].config.policy.value.linux.popup.behavior_protection.message = DefaultPolicyNotificationMessage;
+        }
       } catch (error) {
         dispatch({
           type: 'serverFailedToReturnPolicyDetailsData',

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/selectors.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/selectors.ts
@@ -194,12 +194,14 @@ export const policyConfig: (s: PolicyDetailsState) => UIPolicyConfig = createSel
         advanced: mac.advanced,
         events: mac.events,
         malware: mac.malware,
+        behavior_protection: windows.behavior_protection,
         popup: mac.popup,
       },
       linux: {
         advanced: linux.advanced,
         events: linux.events,
         malware: linux.malware,
+        behavior_protection: windows.behavior_protection,
         popup: linux.popup,
       },
     };

--- a/x-pack/plugins/security_solution/public/management/pages/policy/types.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/types.ts
@@ -137,8 +137,8 @@ export type PolicyProtection =
       UIPolicyConfig['windows'],
       'malware' | 'ransomware' | 'memory_protection' | 'behavior_protection'
     >
-  | keyof Pick<UIPolicyConfig['mac'], 'malware'>
-  | keyof Pick<UIPolicyConfig['linux'], 'malware'>;
+  | keyof Pick<UIPolicyConfig['mac'], 'malware' | 'behavior_protection'>
+  | keyof Pick<UIPolicyConfig['linux'], 'malware' | 'behavior_protection'>;
 
 export type MacPolicyProtection = keyof Pick<UIPolicyConfig['mac'], 'malware'>;
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/protections/behavior.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/protections/behavior.tsx
@@ -30,7 +30,7 @@ export const BehaviorProtection = React.memo(() => {
       type={i18n.translate('xpack.securitySolution.endpoint.policy.details.behavior_protection', {
         defaultMessage: 'Behavior Protection',
       })}
-      supportedOss={[OperatingSystem.WINDOWS]}
+      supportedOss={[OperatingSystem.WINDOWS, OperatingSystem.MAC, OperatingSystem.LINUX]}
       dataTestSubj="behaviorProtectionsForm"
       rightCorner={<ProtectionSwitch protection={protection} osList={OSes} />}
     >

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/protections/behavior.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/protections/behavior.tsx
@@ -23,7 +23,7 @@ import { SecurityPageName } from '../../../../../../app/types';
  *  which will configure for all relevant OSes.
  */
 export const BehaviorProtection = React.memo(() => {
-  const OSes: Immutable<BehaviorProtectionOSes[]> = [OS.windows];
+  const OSes: Immutable<BehaviorProtectionOSes[]> = [OS.windows, OS.mac, OS.linux];
   const protection = 'behavior_protection';
   return (
     <ConfigForm

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -299,8 +299,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 logging: { file: 'info' },
                 advanced: { agent: { connection_delay: 'true' } },
                 malware: { mode: 'prevent' },
+                behavior_protection: { mode: 'prevent', supported: true },
                 popup: {
                   malware: {
+                    enabled: true,
+                    message: 'Elastic Security {action} {filename}',
+                  },
+                  behavior_protection: {
                     enabled: true,
                     message: 'Elastic Security {action} {filename}',
                   },
@@ -310,8 +315,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 events: { file: false, network: true, process: true },
                 logging: { file: 'info' },
                 malware: { mode: 'prevent' },
+                behavior_protection: { mode: 'prevent', supported: true },
                 popup: {
                   malware: {
+                    enabled: true,
+                    message: 'Elastic Security {action} {filename}',
+                  },
+                  behavior_protection: {
                     enabled: true,
                     message: 'Elastic Security {action} {filename}',
                   },
@@ -513,8 +523,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 logging: { file: 'info' },
                 advanced: { agent: { connection_delay: 'true' } },
                 malware: { mode: 'prevent' },
+                behavior_protection: { mode: 'prevent', supported: true },
                 popup: {
                   malware: {
+                    enabled: true,
+                    message: 'Elastic Security {action} {filename}',
+                  },
+                  behavior_protection: {
                     enabled: true,
                     message: 'Elastic Security {action} {filename}',
                   },
@@ -524,8 +539,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 events: { file: true, network: true, process: true },
                 logging: { file: 'info' },
                 malware: { mode: 'prevent' },
+                behavior_protection: { mode: 'prevent', supported: true },
                 popup: {
                   malware: {
+                    enabled: true,
+                    message: 'Elastic Security {action} {filename}',
+                  },
+                  behavior_protection: {
                     enabled: true,
                     message: 'Elastic Security {action} {filename}',
                   },
@@ -724,8 +744,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 events: { file: true, network: true, process: true },
                 logging: { file: 'info' },
                 malware: { mode: 'prevent' },
+                behavior_protection: { mode: 'prevent', supported: true },
                 popup: {
                   malware: {
+                    enabled: true,
+                    message: 'Elastic Security {action} {filename}',
+                  },
+                  behavior_protection: {
                     enabled: true,
                     message: 'Elastic Security {action} {filename}',
                   },
@@ -735,8 +760,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                 events: { file: true, network: true, process: true },
                 logging: { file: 'info' },
                 malware: { mode: 'prevent' },
+                behavior_protection: { mode: 'prevent', supported: true },
                 popup: {
                   malware: {
+                    enabled: true,
+                    message: 'Elastic Security {action} {filename}',
+                  },
+                  behavior_protection: {
                     enabled: true,
                     message: 'Elastic Security {action} {filename}',
                   },


### PR DESCRIPTION
## Summary

Adds mac and linux support for the behavior protection added for windows only [here](https://github.com/elastic/kibana/pull/106247)

Includes:

- Functional tests update
- License change checks and tests
- Data migrations

![image](https://user-images.githubusercontent.com/227916/128356485-35752df8-2749-4142-a709-4d59a3ea9fe3.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
