### PR TITLE
[scripts/build_ts_refs] when using `--clean` initialize caches

### DIFF
--- a/src/dev/typescript/build_ts_refs_cli.ts
+++ b/src/dev/typescript/build_ts_refs_cli.ts
@@ -41,7 +41,7 @@ export async function runBuildRefsCli() {
       const cacheEnabled = process.env.BUILD_TS_REFS_CACHE_ENABLE !== 'false' && !!flags.cache;
       const doCapture = process.env.BUILD_TS_REFS_CACHE_CAPTURE === 'true';
       const doClean = !!flags.clean || doCapture;
-      const doInitCache = cacheEnabled && !doClean;
+      const doInitCache = cacheEnabled && !doCapture;
 
       if (doClean) {
         log.info('deleting', outDirs.length, 'ts output directories');


### PR DESCRIPTION
The `--clean` flag is supposed to tell the `build_ts_refs` script to delete the existing TS output dirs and build from scratch, but at some point I decided that it should also disable the cache, which feels like a bad decision now. Building without cache is an extremely slow process that most people shouldn't need to do, in the case their local cache is corrupted, which happens, we should have a way to run `scripts/build_ts_refs` with clean caches (ignoring local changes) and a way to build from a totally clean state without caches. This is now accomplished by running:

 - delete the TS output dirs, restore them from the latest cache, and run `tsc` to make sure they're updated with local changes:
	```
	node scripts/build_ts_refs --clean
	```

 - delete the TS output dirs and then run `tsc` to regenerate them ([used in CI](https://github.com/elastic/kibana/blob/8c5daca64c79ef47b57cbc55105f1dde185a1b02/test/scripts/checks/type_check_plugin_public_api_docs.sh#L5-L10)):
	```
	node scripts/build_ts_refs --clean --no-cache
	```