### PR TITLE
[Discover] Fix classic table usage in discover context

### DIFF
--- a/src/plugins/discover/public/application/angular/doc_table/create_doc_table_react.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/create_doc_table_react.tsx
@@ -23,13 +23,13 @@ export interface DocTableLegacyProps {
   onFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
   rows: estypes.SearchHit[];
   indexPattern: IndexPattern;
-  minimumVisibleRows?: number;
+  minimumVisibleRows: number;
   onAddColumn?: (column: string) => void;
-  onBackToTop: () => void;
+  onBackToTop?: () => void;
   onSort?: (sort: string[][]) => void;
   onMoveColumn?: (columns: string, newIdx: number) => void;
   onRemoveColumn?: (column: string) => void;
-  sampleSize: number;
+  sampleSize?: number;
   sort?: string[][];
   useNewFieldsApi?: boolean;
 }
@@ -102,7 +102,7 @@ export function DocTableLegacy(renderProps: DocTableLegacyProps) {
   const ref = useRef<HTMLDivElement>(null);
   const scope = useRef<AngularScope | undefined>();
   const [rows, setRows] = useState(renderProps.rows);
-  const [minimumVisibleRows, setMinimumVisibleRows] = useState(50);
+  const [minimumVisibleRows, setMinimumVisibleRows] = useState(renderProps.minimumVisibleRows);
   const onSkipBottomButtonClick = useCallback(async () => {
     // delay scrolling to after the rows have been rendered
     const bottomMarker = document.getElementById('discoverBottomMarker');
@@ -119,9 +119,9 @@ export function DocTableLegacy(renderProps: DocTableLegacyProps) {
   }, [setMinimumVisibleRows, renderProps.rows]);
 
   useEffect(() => {
-    setMinimumVisibleRows(50);
+    setMinimumVisibleRows(renderProps.minimumVisibleRows);
     setRows(renderProps.rows);
-  }, [renderProps.rows, setMinimumVisibleRows]);
+  }, [renderProps.rows, setMinimumVisibleRows, renderProps.minimumVisibleRows]);
 
   useEffect(() => {
     if (ref && ref.current && !scope.current) {
@@ -146,7 +146,7 @@ export function DocTableLegacy(renderProps: DocTableLegacyProps) {
     <div>
       <SkipBottomButton onClick={onSkipBottomButtonClick} />
       <div ref={ref} />
-      {renderProps.rows.length === renderProps.sampleSize ? (
+      {renderProps.onBackToTop && renderProps.rows.length === renderProps.sampleSize ? (
         <div
           className="dscTable__footer"
           data-test-subj="discoverDocTableFooter"

--- a/src/plugins/discover/public/application/apps/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/layout/discover_documents.tsx
@@ -145,6 +145,7 @@ function DiscoverDocumentsComponent({
           <DocTableLegacyMemoized
             columns={columns}
             indexPattern={indexPattern}
+            minimumVisibleRows={50}
             rows={rows}
             sort={state.sort || []}
             searchDescription={savedSearch.description}

--- a/src/plugins/discover/public/application/components/context_app/context_app_content.tsx
+++ b/src/plugins/discover/public/application/components/context_app/context_app_content.tsx
@@ -125,7 +125,6 @@ export function ContextAppContent({
   };
 
   const legacyDocTableProps = () => {
-    // @ts-expect-error doesn't implement full DocTableLegacyProps interface
     return {
       columns,
       indexPattern,


### PR DESCRIPTION
## Summary

WIP

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
