### PR TITLE
Fix default route link on kibana homepage

### DIFF
--- a/src/plugins/kibana_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
+++ b/src/plugins/kibana_react/public/overview_page/overview_page_footer/overview_page_footer.tsx
@@ -50,7 +50,9 @@ export const OverviewPageFooter: FC<Props> = ({
         iconType="home"
         size="xs"
         onClick={(event: MouseEvent) => {
-          application.navigateToUrl(addBasePath('/app/management/kibana/settings#defaultRoute'));
+          application.navigateToUrl(
+            addBasePath('/app/management/kibana/settings?query=default+route')
+          );
           if (onChangeDefaultRoute) {
             onChangeDefaultRoute(event);
           }


### PR DESCRIPTION
## Summary

The link to changing the default route for the homepage had the wrong URL pattern.

![image](https://user-images.githubusercontent.com/324519/128411226-15292576-5898-41e6-964b-dc04022430b4.png)


