### PR TITLE
[ML] Data Frame Analytics wizard: ensure cloning retains hyperparameters and results field is correct

### DIFF
--- a/x-pack/plugins/ml/common/types/data_frame_analytics.ts
+++ b/x-pack/plugins/ml/common/types/data_frame_analytics.ts
@@ -143,3 +143,31 @@ export interface AnalyticsMapReturnType {
   details: Record<string, any>; // transform, job, or index details
   error: null | any;
 }
+
+export interface FeatureProcessor {
+  frequency_encoding: {
+    feature_name: string;
+    field: string;
+    frequency_map: Record<string, any>;
+  };
+  multi_encoding: {
+    processors: any[];
+  };
+  n_gram_encoding: {
+    feature_prefix?: string;
+    field: string;
+    length?: number;
+    n_grams: number[];
+    start?: number;
+  };
+  one_hot_encoding: {
+    field: string;
+    hot_map: string;
+  };
+  target_mean_encoding: {
+    default_value: number;
+    feature_name: string;
+    field: string;
+    target_map: Record<string, any>;
+  };
+}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
@@ -308,7 +308,12 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
             values: { defaultValue: DEFAULT_RESULTS_FIELD },
           })}
           checked={useResultsFieldDefault === true}
-          onChange={() => setUseResultsFieldDefault(!useResultsFieldDefault)}
+          onChange={() => {
+            if (!useResultsFieldDefault === true) {
+              setFormState({ resultsField: undefined });
+            }
+            setUseResultsFieldDefault(!useResultsFieldDefault);
+          }}
           data-test-subj="mlAnalyticsCreateJobWizardUseResultsFieldDefault"
         />
       </EuiFormRow>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_clone/clone_action_name.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_clone/clone_action_name.tsx
@@ -133,6 +133,9 @@ const getAnalyticsJobMeta = (config: CloneDataFrameAnalyticsConfig): AnalyticsJo
               optional: true,
               formKey: 'etaGrowthRatePerTree',
             },
+            feature_processors: {
+              optional: true,
+            },
             max_optimization_rounds_per_hyperparameter: {
               optional: true,
               formKey: 'maxOptimizationRoundsPerHyperparameter',
@@ -233,6 +236,9 @@ const getAnalyticsJobMeta = (config: CloneDataFrameAnalyticsConfig): AnalyticsJo
               defaultValue: 'mse',
             },
             loss_function_parameter: {
+              optional: true,
+            },
+            feature_processors: {
               optional: true,
             },
             early_stopping_enabled: {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
@@ -61,12 +61,13 @@ export interface State {
     destinationIndexNameEmpty: boolean;
     destinationIndexNameValid: boolean;
     destinationIndexPatternTitleExists: boolean;
-    earlyStoppingEnabled: undefined | boolean;
     downsampleFactor: undefined | number;
+    earlyStoppingEnabled: undefined | boolean;
     eta: undefined | number;
     etaGrowthRatePerTree: undefined | number;
     featureBagFraction: undefined | number;
     featureInfluenceThreshold: undefined | number;
+    featureProcessors: undefined | Array<Record<string, any>>;
     gamma: undefined | number;
     includes: string[];
     jobId: DataFrameAnalyticsId;
@@ -78,6 +79,8 @@ export interface State {
     jobConfigQuery: any;
     jobConfigQueryString: string | undefined;
     lambda: number | undefined;
+    lossFunction: string | undefined;
+    lossFunctionParameter: number | undefined;
     loadingFieldOptions: boolean;
     maxNumThreads: undefined | number;
     maxOptimizationRoundsPerHyperparameter: undefined | number;
@@ -147,6 +150,7 @@ export const getInitialState = (): State => ({
     etaGrowthRatePerTree: undefined,
     featureBagFraction: undefined,
     featureInfluenceThreshold: undefined,
+    featureProcessors: undefined,
     gamma: undefined,
     includes: [],
     jobId: '',
@@ -158,6 +162,8 @@ export const getInitialState = (): State => ({
     jobConfigQuery: defaultSearchQuery,
     jobConfigQueryString: undefined,
     lambda: undefined,
+    lossFunction: undefined,
+    lossFunctionParameter: undefined,
     loadingFieldOptions: false,
     maxNumThreads: DEFAULT_MAX_NUM_THREADS,
     maxOptimizationRoundsPerHyperparameter: undefined,
@@ -268,8 +274,15 @@ export const getJobConfigFromFormState = (
       formState.featureBagFraction && {
         feature_bag_fraction: formState.featureBagFraction,
       },
+      formState.featureProcessors && {
+        feature_processors: formState.featureProcessors,
+      },
       formState.gamma && { gamma: formState.gamma },
       formState.lambda && { lambda: formState.lambda },
+      formState.lossFunction && { loss_function: formState.lossFunction },
+      formState.lossFunctionParameter && {
+        loss_function_parameter: formState.lossFunctionParameter,
+      },
       formState.maxOptimizationRoundsPerHyperparameter && {
         max_optimization_rounds_per_hyperparameter:
           formState.maxOptimizationRoundsPerHyperparameter,

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
@@ -17,6 +17,7 @@ import {
   DataFrameAnalyticsConfig,
   DataFrameAnalyticsId,
   DataFrameAnalysisConfigType,
+  FeatureProcessor,
 } from '../../../../../../../common/types/data_frame_analytics';
 import { isClassificationAnalysis } from '../../../../../../../common/util/analytics_utils';
 import { ANALYSIS_CONFIG_TYPE } from '../../../../../../../common/constants/data_frame_analytics';
@@ -67,7 +68,7 @@ export interface State {
     etaGrowthRatePerTree: undefined | number;
     featureBagFraction: undefined | number;
     featureInfluenceThreshold: undefined | number;
-    featureProcessors: undefined | Array<Record<string, any>>;
+    featureProcessors: undefined | FeatureProcessor[];
     gamma: undefined | number;
     includes: string[];
     jobId: DataFrameAnalyticsId;


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/106981
Fixes: https://github.com/elastic/kibana/issues/104609

This PR 
- ensures all DFA job hyperparameters, including `loss_function`, (listed in https://www.elastic.co/guide/en/elasticsearch/reference/7.14/put-dfanalytics.html) are carried over on cloning
- ensures results field is updated to use default if 'Use default' switch is enabled.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


