### PR TITLE
[7.14] Disable Product check in @elastic/elasticsearch-js (#107642)

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@elastic/apm-rum-react": "^1.2.11",
     "@elastic/charts": "32.0.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@7.14.0-canary.6",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@7.14.0-canary.7",
     "@elastic/ems-client": "7.14.0",
     "@elastic/eui": "34.5.2",
     "@elastic/filesaver": "1.1.2",

--- a/packages/kbn-es/src/utils/native_realm.js
+++ b/packages/kbn-es/src/utils/native_realm.js
@@ -11,6 +11,23 @@ const chalk = require('chalk');
 
 const { log: defaultLog } = require('./log');
 
+/**
+ * Hack to skip the Product Check performed by the Elasticsearch-js client.
+ * We noticed a couple of bugs that may need to be fixed before taking full
+ * advantage of this feature.
+ *
+ * The bugs are detailed in this issue: https://github.com/elastic/kibana/issues/105557
+ *
+ * The hack is copied from the test/utils in the elasticsearch-js repo
+ * (https://github.com/elastic/elasticsearch-js/blob/master/test/utils/index.js#L45-L56)
+ */
+function skipProductCheck(client) {
+  const tSymbol = Object.getOwnPropertySymbols(client.transport || client).filter(
+    (symbol) => symbol.description === 'product check'
+  )[0];
+  (client.transport || client)[tSymbol] = 2;
+}
+
 exports.NativeRealm = class NativeRealm {
   constructor({ elasticPassword, port, log = defaultLog, ssl = false, caCert }) {
     this._client = new Client({
@@ -22,6 +39,8 @@ exports.NativeRealm = class NativeRealm {
           }
         : undefined,
     });
+    // TODO: @elastic/es-clients I had to disable the product check here because the client is getting 404 while ES is initializing, but the requests here auto retry them.
+    skipProductCheck(this._client);
     this._elasticPassword = elasticPassword;
     this._log = log;
   }

--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -22,6 +22,12 @@ export const configureClient = (
   const client = new Client(clientOptions);
   addLogging(client, logger.get('query', type));
 
+  // ------------------------------------------------------------------------ //
+  // Hack to disable the "Product check" while the bugs in                    //
+  // https://github.com/elastic/kibana/issues/105557 are handled.             //
+  skipProductCheck(client);
+  // ------------------------------------------------------------------------ //
+
   return client;
 };
 
@@ -78,3 +84,21 @@ const addLogging = (client: Client, logger: Logger) => {
     }
   });
 };
+
+/**
+ * Hack to skip the Product Check performed by the Elasticsearch-js client.
+ * We noticed a couple of bugs that may need to be fixed before taking full
+ * advantage of this feature.
+ *
+ * The bugs are detailed in this issue: https://github.com/elastic/kibana/issues/105557
+ *
+ * The hack is copied from the test/utils in the elasticsearch-js repo
+ * (https://github.com/elastic/elasticsearch-js/blob/master/test/utils/index.js#L45-L56)
+ */
+function skipProductCheck(client: Client) {
+  const tSymbol = Object.getOwnPropertySymbols(client.transport || client).filter(
+    (symbol) => symbol.description === 'product check'
+  )[0];
+  // @ts-expect-error `tSymbol` is missing in the index signature of Transport
+  (client.transport || client)[tSymbol] = 2;
+}

--- a/src/setup_node_env/exit_on_warning.js
+++ b/src/setup_node_env/exit_on_warning.js
@@ -29,6 +29,14 @@ var IGNORE_WARNINGS = [
     file: '/node_modules/supertest/node_modules/superagent/lib/node/index.js',
     line: 418,
   },
+  {
+    // TODO: @elastic/es-clients - The new client will attempt a Product check and it will `process.emitWarning`
+    //  that the security features are blocking such check.
+    //  Such emit is causing Node.js to crash unless we explicitly catch it.
+    //  We need to discard that warning
+    message:
+      'The client is unable to verify that the server is Elasticsearch due to security privileges on the server side. Some functionality may not be compatible if the server is running an unsupported product.',
+  },
 ];
 
 if (process.noProcessWarnings !== true) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,10 +1403,10 @@
   dependencies:
     "@elastic/ecs-helpers" "^1.1.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@7.14.0-canary.6":
-  version "7.14.0-canary.6"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-7.14.0-canary.6.tgz#29ae3f53708e94d7efbd9d1a228f6b9f83f03645"
-  integrity sha512-Se4ClajPQn5T3h6vil4Jvje+ic29kD3boM1AfOEWhNieGz48JMJSxNX31OiaD0Q7MsVLVKd6Xx0rXqzgMXDd1A==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@7.14.0-canary.7":
+  version "7.14.0-canary.7"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-7.14.0-canary.7.tgz#c14a4c80a5d9584fbcb2d6b73da141e313a75b88"
+  integrity sha512-Vk3Q9NcTJhFvkGgHh4sbqdcUysjh9eZgjAtoXRwlXCgULwDsxFpAPeb/+HZjlW9BWCPjEVbo2vgEvU8/9cXjxg==
   dependencies:
     debug "^4.3.1"
     hpagent "^0.1.1"


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Disable Product check in @elastic/elasticsearch-js (#107642)