### PR TITLE
[ML] Data Frame Analytics: add evaluation quality metrics to Classification exploration view

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/common/analytics.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/common/analytics.ts
@@ -65,7 +65,7 @@ export interface LoadExploreDataArg {
   searchQuery: SavedSearchQuery;
 }
 
-export interface MetricItem {
+export interface ClassificationMetricItem {
   className: string;
   accuracy?: number;
   recall?: number;

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/common/analytics.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/common/analytics.ts
@@ -65,6 +65,12 @@ export interface LoadExploreDataArg {
   searchQuery: SavedSearchQuery;
 }
 
+export interface MetricItem {
+  className: string;
+  accuracy?: number;
+  recall?: number;
+}
+
 export const SEARCH_SIZE = 1000;
 
 export const TRAINING_PERCENT_MIN = 1;

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/_classification_exploration.scss
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/_classification_exploration.scss
@@ -41,3 +41,9 @@ $labelColumnWidth: 80px;
     text-transform: none;
   }
 }
+
+.mlDataFrameAnalyticsClassification__evaluationMetrics {
+  width: 80%;
+  padding-left: 10%;
+  padding-right: 10%;
+}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/_classification_exploration.scss
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/_classification_exploration.scss
@@ -43,7 +43,5 @@ $labelColumnWidth: 80px;
 }
 
 .mlDataFrameAnalyticsClassification__evaluationMetrics {
-  width: 80%;
-  padding-left: 10%;
-  padding-right: 10%;
+  width: 60%;
 }

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluate_panel.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluate_panel.tsx
@@ -34,6 +34,7 @@ import { ResultsSearchQuery } from '../../../../common/analytics';
 
 import { ExpandableSection, HEADER_ITEMS_LOADING } from '../expandable_section';
 import { EvaluateStat } from './evaluate_stat';
+import { EvaluationQualityMetricsTable } from './evaluation_quality_metrics_table';
 
 import { getRocCurveChartVegaLiteSpec } from './get_roc_curve_chart_vega_lite_spec';
 
@@ -120,6 +121,7 @@ export const EvaluatePanel: FC<EvaluatePanelProps> = ({ jobConfig, jobStatus, se
     error: errorConfusionMatrix,
     isLoading: isLoadingConfusionMatrix,
     overallAccuracy,
+    evaluationMetricsItems,
   } = useConfusionMatrix(jobConfig, searchQuery);
 
   useEffect(() => {
@@ -365,46 +367,57 @@ export const EvaluatePanel: FC<EvaluatePanelProps> = ({ jobConfig, jobStatus, se
             ) : null}
             {/* Accuracy and Recall */}
             <EuiSpacer size="xl" />
-            <EuiFlexGroup gutterSize="l">
+            <EuiFlexGroup
+              direction="column"
+              justifyContent="center"
+              className="mlDataFrameAnalyticsClassification__evaluationMetrics"
+            >
               <EuiFlexItem grow={false}>
-                <EvaluateStat
-                  dataTestSubj={'mlDFAEvaluateSectionOverallAccuracyStat'}
-                  title={overallAccuracy}
-                  isLoading={isLoadingConfusionMatrix}
-                  description={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyStat',
-                    {
-                      defaultMessage: 'Overall accuracy',
-                    }
-                  )}
-                  tooltipContent={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyTooltip',
-                    {
-                      defaultMessage:
-                        'The ratio of the number of correct class predictions to the total number of predictions.',
-                    }
-                  )}
-                />
+                <EuiFlexGroup gutterSize="l">
+                  <EuiFlexItem grow={false}>
+                    <EvaluateStat
+                      dataTestSubj={'mlDFAEvaluateSectionOverallAccuracyStat'}
+                      title={overallAccuracy}
+                      isLoading={isLoadingConfusionMatrix}
+                      description={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyStat',
+                        {
+                          defaultMessage: 'Overall accuracy',
+                        }
+                      )}
+                      tooltipContent={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyTooltip',
+                        {
+                          defaultMessage:
+                            'The ratio of the number of correct class predictions to the total number of predictions.',
+                        }
+                      )}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EvaluateStat
+                      dataTestSubj={'mlDFAEvaluateSectionAvgRecallStat'}
+                      title={avgRecall}
+                      isLoading={isLoadingConfusionMatrix}
+                      description={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionMeanRecallStat',
+                        {
+                          defaultMessage: 'Mean recall',
+                        }
+                      )}
+                      tooltipContent={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionAvgRecallTooltip',
+                        {
+                          defaultMessage:
+                            'Mean recall shows how many of the data points that are actual class members were identified correctly as class members.',
+                        }
+                      )}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EvaluateStat
-                  dataTestSubj={'mlDFAEvaluateSectionAvgRecallStat'}
-                  title={avgRecall}
-                  isLoading={isLoadingConfusionMatrix}
-                  description={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionMeanRecallStat',
-                    {
-                      defaultMessage: 'Mean recall',
-                    }
-                  )}
-                  tooltipContent={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionAvgRecallTooltip',
-                    {
-                      defaultMessage:
-                        'Mean recall shows how many of the data points that are actual class members were identified correctly as class members.',
-                    }
-                  )}
-                />
+                <EvaluationQualityMetricsTable evaluationMetricsItems={evaluationMetricsItems} />
               </EuiFlexItem>
             </EuiFlexGroup>
             {/* AUC ROC Chart */}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluate_panel.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluate_panel.tsx
@@ -86,6 +86,13 @@ const trainingDatasetHelpText = i18n.translate(
   }
 );
 
+const evaluationQualityMetricsHelpText = i18n.translate(
+  'xpack.ml.dataframe.analytics.classificationExploration.evaluationQualityMetricsHelpText',
+  {
+    defaultMessage: 'Evaluation quality metrics',
+  }
+);
+
 function getHelpText(dataSubsetTitle: string): string {
   let helpText = entireDatasetHelpText;
   if (dataSubsetTitle === SUBSET_TITLE.TESTING) {
@@ -367,6 +374,10 @@ export const EvaluatePanel: FC<EvaluatePanelProps> = ({ jobConfig, jobStatus, se
             ) : null}
             {/* Accuracy and Recall */}
             <EuiSpacer size="xl" />
+            <EuiTitle size="xxs">
+              <span>{evaluationQualityMetricsHelpText}</span>
+            </EuiTitle>
+            <EuiSpacer size="s" />
             <EuiFlexGroup
               direction="column"
               justifyContent="center"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
@@ -63,8 +63,8 @@ export const EvaluationQualityMetricsTable: FC<{
         <EuiInMemoryTable<ClassificationMetricItem>
           items={evaluationMetricsItems}
           columns={columns}
-          pagination={true}
-          sorting={true}
+          pagination
+          sorting
         />
       </EuiPanel>
     </EuiAccordion>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 import { EuiAccordion, EuiInMemoryTable, EuiPanel } from '@elastic/eui';
 
-import { MetricItem } from '../../../common/analytics';
+import { MetricItem } from '../../../../common/analytics';
 
 const columns = [
   {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
+
+import { EuiAccordion, EuiInMemoryTable, EuiPanel } from '@elastic/eui';
+
+const columns = [
+  {
+    field: 'className',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyClassColumn',
+      {
+        defaultMessage: 'Class',
+      }
+    ),
+    sortable: true,
+    truncateText: true,
+  },
+  {
+    field: 'recall',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyRecallColumn',
+      {
+        defaultMessage: 'Recall',
+      }
+    ),
+    render: (value: number) => Math.round(value * 1000) / 1000,
+  },
+  {
+    field: 'accuracy',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyAccuracyColumn',
+      {
+        defaultMessage: 'Accuracy',
+      }
+    ),
+    render: (value: number) => Math.round(value * 1000) / 1000,
+  },
+];
+
+interface MetricItem {
+  className: string;
+  accuracy?: number;
+  recall?: number;
+}
+
+export const EvaluationQualityMetricsTable: FC<{ evaluationMetricsItems: MetricItem[] }> = ({
+  evaluationMetricsItems,
+}) => (
+  <>
+    <EuiAccordion
+      id="recall-and-accuracy"
+      buttonContent={
+        <FormattedMessage
+          id="xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionRecallAndAccuracy"
+          defaultMessage="Per class recall and accuracy"
+        />
+      }
+    >
+      <EuiPanel>
+        <EuiInMemoryTable<MetricItem>
+          items={evaluationMetricsItems}
+          columns={columns}
+          pagination={true}
+          sorting={true}
+        />
+      </EuiPanel>
+    </EuiAccordion>
+  </>
+);

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 import { EuiAccordion, EuiInMemoryTable, EuiPanel } from '@elastic/eui';
 
-import { MetricItem } from '../../../../common/analytics';
+import { ClassificationMetricItem } from '../../../../common/analytics';
 
 const columns = [
   {
@@ -25,16 +25,6 @@ const columns = [
     truncateText: true,
   },
   {
-    field: 'recall',
-    name: i18n.translate(
-      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyRecallColumn',
-      {
-        defaultMessage: 'Recall',
-      }
-    ),
-    render: (value: number) => Math.round(value * 1000) / 1000,
-  },
-  {
     field: 'accuracy',
     name: i18n.translate(
       'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyAccuracyColumn',
@@ -44,11 +34,21 @@ const columns = [
     ),
     render: (value: number) => Math.round(value * 1000) / 1000,
   },
+  {
+    field: 'recall',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyRecallColumn',
+      {
+        defaultMessage: 'Recall',
+      }
+    ),
+    render: (value: number) => Math.round(value * 1000) / 1000,
+  },
 ];
 
-export const EvaluationQualityMetricsTable: FC<{ evaluationMetricsItems: MetricItem[] }> = ({
-  evaluationMetricsItems,
-}) => (
+export const EvaluationQualityMetricsTable: FC<{
+  evaluationMetricsItems: ClassificationMetricItem[];
+}> = ({ evaluationMetricsItems }) => (
   <>
     <EuiAccordion
       id="recall-and-accuracy"
@@ -60,7 +60,7 @@ export const EvaluationQualityMetricsTable: FC<{ evaluationMetricsItems: MetricI
       }
     >
       <EuiPanel>
-        <EuiInMemoryTable<MetricItem>
+        <EuiInMemoryTable<ClassificationMetricItem>
           items={evaluationMetricsItems}
           columns={columns}
           pagination={true}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
@@ -8,8 +8,9 @@
 import React, { FC } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
-
 import { EuiAccordion, EuiInMemoryTable, EuiPanel } from '@elastic/eui';
+
+import { MetricItem } from '../../../common/analytics';
 
 const columns = [
   {
@@ -44,12 +45,6 @@ const columns = [
     render: (value: number) => Math.round(value * 1000) / 1000,
   },
 ];
-
-interface MetricItem {
-  className: string;
-  accuracy?: number;
-  recall?: number;
-}
 
 export const EvaluationQualityMetricsTable: FC<{ evaluationMetricsItems: MetricItem[] }> = ({
   evaluationMetricsItems,

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/use_confusion_matrix.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/use_confusion_matrix.ts
@@ -65,7 +65,9 @@ export const useConfusionMatrix = (
   const [confusionMatrixData, setConfusionMatrixData] = useState<ConfusionMatrix[]>([]);
   const [overallAccuracy, setOverallAccuracy] = useState<null | number>(null);
   const [avgRecall, setAvgRecall] = useState<null | number>(null);
-  const [evaluationMetricsItems, setEvalutaionMetricsItems] = useState<any>([]);
+  const [evaluationMetricsItems, setEvaluationMetricsItems] = useState<ClassificationMetricItem[]>(
+    []
+  );
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [docsCount, setDocsCount] = useState<null | number>(null);
   const [error, setError] = useState<null | string>(null);
@@ -115,7 +117,7 @@ export const useConfusionMatrix = (
         setConfusionMatrixData(confusionMatrix || []);
         setAvgRecall(evalData.eval?.classification?.recall?.avg_recall || null);
         setOverallAccuracy(evalData.eval?.classification?.accuracy?.overall_accuracy || null);
-        setEvalutaionMetricsItems(getEvalutionMetricsItems(evalData.eval?.classification));
+        setEvaluationMetricsItems(getEvalutionMetricsItems(evalData.eval?.classification));
         setIsLoading(false);
       } else {
         setIsLoading(false);

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/use_confusion_matrix.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/use_confusion_matrix.ts
@@ -13,6 +13,7 @@ import {
   ConfusionMatrix,
   ResultsSearchQuery,
   ANALYSIS_CONFIG_TYPE,
+  MetricItem,
 } from '../../../../common/analytics';
 import { isKeywordAndTextType } from '../../../../common/fields';
 
@@ -25,12 +26,6 @@ import {
 } from '../../../../common';
 
 import { isTrainingFilter } from './is_training_filter';
-
-interface MetricItem {
-  className: string;
-  accuracy?: number;
-  recall?: number;
-}
 
 function getEvalutionMetricsItems(evalMetrics?: ClassificationEvaluateResponse['classification']) {
   if (evalMetrics === undefined) return [];

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/use_confusion_matrix.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/use_confusion_matrix.ts
@@ -13,7 +13,7 @@ import {
   ConfusionMatrix,
   ResultsSearchQuery,
   ANALYSIS_CONFIG_TYPE,
-  MetricItem,
+  ClassificationMetricItem,
 } from '../../../../common/analytics';
 import { isKeywordAndTextType } from '../../../../common/fields';
 
@@ -39,7 +39,7 @@ function getEvalutionMetricsItems(evalMetrics?: ClassificationEvaluateResponse['
       accuracy: accuracyMetric.value,
     };
     return acc;
-  }, {} as Record<string, MetricItem>);
+  }, {} as Record<string, ClassificationMetricItem>);
 
   recallMetrics.forEach((recallMetric) => {
     if (metricsMap[recallMetric.class_name] !== undefined) {


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/kibana/issues/96329

This PR adds per class accuracy and recall metrics for classification jobs exploration page.

An expandable section with a table showing the per class accuracy and recall metrics has been created in the model evaluation section.

![image](https://user-images.githubusercontent.com/6446462/129063108-860d655f-648f-4e5a-b216-03cc684ca4d2.png)


![image](https://user-images.githubusercontent.com/6446462/129063067-66728539-b95d-42f2-bb4c-5d639a9b600d.png)





### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))



#
