### PR TITLE
[Lens][Accessibility] Take into account background color for non opaque colors

### DIFF
--- a/x-pack/plugins/lens/public/shared_components/coloring/utils.test.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/utils.test.ts
@@ -405,4 +405,15 @@ describe('getContrastColor', () => {
     expect(getContrastColor('#fff', true)).toBe('#000000');
     expect(getContrastColor('#fff', false)).toBe('#000000');
   });
+
+  it('should take into account background color if the primary color is opaque', () => {
+    expect(getContrastColor('rgba(0,0,0,0)', true)).toBe('#ffffff');
+    expect(getContrastColor('rgba(0,0,0,0)', false)).toBe('#000000');
+    expect(getContrastColor('#00000000', true)).toBe('#ffffff');
+    expect(getContrastColor('#00000000', false)).toBe('#000000');
+    expect(getContrastColor('#ffffff00', true)).toBe('#ffffff');
+    expect(getContrastColor('#ffffff00', false)).toBe('#000000');
+    expect(getContrastColor('rgba(255,255,255,0)', true)).toBe('#ffffff');
+    expect(getContrastColor('rgba(255,255,255,0)', false)).toBe('#000000');
+  });
 });

--- a/x-pack/plugins/lens/public/shared_components/coloring/utils.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/utils.ts
@@ -294,7 +294,12 @@ export function getColorStops(
 export function getContrastColor(color: string, isDarkTheme: boolean) {
   const darkColor = isDarkTheme ? euiDarkVars.euiColorInk : euiLightVars.euiColorInk;
   const lightColor = isDarkTheme ? euiDarkVars.euiColorGhost : euiLightVars.euiColorGhost;
-  return isColorDark(...chroma(color).rgb()) ? lightColor : darkColor;
+  const backgroundColor = isDarkTheme
+    ? euiDarkVars.euiPageBackgroundColor
+    : euiLightVars.euiPageBackgroundColor;
+  const finalColor =
+    chroma(color).alpha() < 1 ? chroma.blend(backgroundColor, color, 'overlay') : chroma(color);
+  return isColorDark(...finalColor.rgb()) ? lightColor : darkColor;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #106593 

Color contrast now takes into account also EUI background color when computing final text color for the datatable dynamic coloring.

![a11y_test_color](https://user-images.githubusercontent.com/924948/128692893-1badfc93-0950-4d32-a2d3-c9b3e124f11e.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)