### PR TITLE
[Logs UI] Change orientation of the ML setup form

### DIFF
--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_indices_form.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_indices_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
+import { EuiTitle, EuiText, EuiFormRow, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React, { useCallback } from 'react';
@@ -54,44 +54,47 @@ export const AnalysisSetupIndicesForm: React.FunctionComponent<{
   const isInvalid = validationErrors.length > 0;
 
   return (
-    <EuiDescribedFormGroup
-      title={
-        <h3>
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <EuiTitle size="xs">
+          <h3>
+            <FormattedMessage
+              id="xpack.infra.analysisSetup.indicesSelectionTitle"
+              defaultMessage="Choose indices"
+            />
+          </h3>
+        </EuiTitle>
+        <EuiText size="s" color="subdued">
           <FormattedMessage
-            id="xpack.infra.analysisSetup.indicesSelectionTitle"
-            defaultMessage="Choose indices"
+            id="xpack.infra.analysisSetup.indicesSelectionDescription"
+            defaultMessage="By default, Machine Learning analyzes log messages in all log indices configured for the source. You can choose to only analyze a subset of the index names. Every selected index name must match at least one index with log entries. You can also choose to only include a certain subset of datasets. Note that the dataset filter applies to all selected indices."
           />
-        </h3>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.analysisSetup.indicesSelectionDescription"
-          defaultMessage="By default, Machine Learning analyzes log messages in all log indices configured for the source. You can choose to only analyze a subset of the index names. Every selected index name must match at least one index with log entries. You can also choose to only include a certain subset of datasets. Note that the dataset filter applies to all selected indices."
-        />
-      }
-    >
-      <LoadingOverlayWrapper isLoading={isValidating}>
-        <EuiFormRow
-          fullWidth
-          isInvalid={isInvalid}
-          label={indicesSelectionLabel}
-          labelType="legend"
-        >
-          <>
-            {indices.map((index) => (
-              <IndexSetupRow
-                index={index}
-                isDisabled={disabled}
-                key={index.name}
-                onChangeIsSelected={changeIsIndexSelected}
-                onChangeDatasetFilter={changeDatasetFilter}
-                previousQualityWarnings={previousQualityWarnings}
-              />
-            ))}
-          </>
-        </EuiFormRow>
-      </LoadingOverlayWrapper>
-    </EuiDescribedFormGroup>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <LoadingOverlayWrapper isLoading={isValidating}>
+          <EuiFormRow
+            fullWidth
+            isInvalid={isInvalid}
+            label={indicesSelectionLabel}
+            labelType="legend"
+          >
+            <>
+              {indices.map((index) => (
+                <IndexSetupRow
+                  index={index}
+                  isDisabled={disabled}
+                  key={index.name}
+                  onChangeIsSelected={changeIsIndexSelected}
+                  onChangeDatasetFilter={changeDatasetFilter}
+                  previousQualityWarnings={previousQualityWarnings}
+                />
+              ))}
+            </>
+          </EuiFormRow>
+        </LoadingOverlayWrapper>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_indices_form.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_indices_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiDescribedFormGroup, EuiFormRow, EuiSpacer } from '@elastic/eui';
+import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React, { useCallback } from 'react';
@@ -79,17 +79,14 @@ export const AnalysisSetupIndicesForm: React.FunctionComponent<{
         >
           <>
             {indices.map((index) => (
-              <>
-                <IndexSetupRow
-                  index={index}
-                  isDisabled={disabled}
-                  key={index.name}
-                  onChangeIsSelected={changeIsIndexSelected}
-                  onChangeDatasetFilter={changeDatasetFilter}
-                  previousQualityWarnings={previousQualityWarnings}
-                />
-                <EuiSpacer />
-              </>
+              <IndexSetupRow
+                index={index}
+                isDisabled={disabled}
+                key={index.name}
+                onChangeIsSelected={changeIsIndexSelected}
+                onChangeDatasetFilter={changeDatasetFilter}
+                previousQualityWarnings={previousQualityWarnings}
+              />
             ))}
           </>
         </EuiFormRow>

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_indices_form.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_indices_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
+import { EuiDescribedFormGroup, EuiFormRow, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React, { useCallback } from 'react';
@@ -79,14 +79,17 @@ export const AnalysisSetupIndicesForm: React.FunctionComponent<{
         >
           <>
             {indices.map((index) => (
-              <IndexSetupRow
-                index={index}
-                isDisabled={disabled}
-                key={index.name}
-                onChangeIsSelected={changeIsIndexSelected}
-                onChangeDatasetFilter={changeDatasetFilter}
-                previousQualityWarnings={previousQualityWarnings}
-              />
+              <>
+                <IndexSetupRow
+                  index={index}
+                  isDisabled={disabled}
+                  key={index.name}
+                  onChangeIsSelected={changeIsIndexSelected}
+                  onChangeDatasetFilter={changeDatasetFilter}
+                  previousQualityWarnings={previousQualityWarnings}
+                />
+                <EuiSpacer />
+              </>
             ))}
           </>
         </EuiFormRow>

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_timerange_form.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/analysis_setup_timerange_form.tsx
@@ -6,8 +6,10 @@
  */
 
 import {
-  EuiDescribedFormGroup,
+  EuiTitle,
+  EuiText,
   EuiFlexGroup,
+  EuiFlexItem,
   EuiFormControlLayout,
   EuiFormRow,
 } from '@elastic/eui';
@@ -80,70 +82,75 @@ export const AnalysisSetupTimerangeForm: React.FunctionComponent<{
   );
 
   return (
-    <EuiDescribedFormGroup
-      title={
-        <h3>
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <EuiTitle size="xs">
+          <h3>
+            <FormattedMessage
+              id="xpack.infra.analysisSetup.timeRangeTitle"
+              defaultMessage="Choose a time range"
+            />
+          </h3>
+        </EuiTitle>
+        <EuiText size="s" color="subdued">
           <FormattedMessage
-            id="xpack.infra.analysisSetup.timeRangeTitle"
-            defaultMessage="Choose a time range"
+            id="xpack.infra.analysisSetup.timeRangeDescription"
+            defaultMessage="By default, Machine Learning analyzes log messages in your log indices no older than four weeks, and continues indefinitely. You can specify a different date to begin, to end, or both."
           />
-        </h3>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.analysisSetup.timeRangeDescription"
-          defaultMessage="By default, Machine Learning analyzes log messages in your log indices no older than four weeks, and continues indefinitely. You can specify a different date to begin, to end, or both."
-        />
-      }
-    >
-      <EuiFormRow
-        error={startTimeValidationErrorMessages}
-        fullWidth
-        isInvalid={startTimeValidationErrorMessages.length > 0}
-        label={startTimeLabel}
-      >
-        <EuiFlexGroup gutterSize="s">
-          <EuiFormControlLayout
-            clear={startTime && !disabled ? { onClick: () => setStartTime(undefined) } : undefined}
-            isDisabled={disabled}
-          >
-            <FixedDatePicker
-              disabled={disabled}
-              showTimeSelect
-              selected={startTimeValue}
-              onChange={(date) => setStartTime(selectedDateToParam(date))}
-              placeholder={startTimeDefaultDescription}
-              maxDate={now}
-            />
-          </EuiFormControlLayout>
-        </EuiFlexGroup>
-      </EuiFormRow>
-      <EuiFormRow
-        error={endTimeValidationErrorMessages}
-        fullWidth
-        isInvalid={endTimeValidationErrorMessages.length > 0}
-        label={endTimeLabel}
-      >
-        <EuiFlexGroup gutterSize="s">
-          <EuiFormControlLayout
-            clear={endTime && !disabled ? { onClick: () => setEndTime(undefined) } : undefined}
-            isDisabled={disabled}
-          >
-            <FixedDatePicker
-              disabled={disabled}
-              showTimeSelect
-              selected={endTimeValue}
-              onChange={(date) => setEndTime(selectedDateToParam(date))}
-              placeholder={endTimeDefaultDescription}
-              openToDate={now}
-              minDate={startTimeValue}
-              minTime={selectedEndTimeIsToday ? now : moment().hour(0).minutes(0)}
-              maxTime={moment().hour(23).minutes(59)}
-            />
-          </EuiFormControlLayout>
-        </EuiFlexGroup>
-      </EuiFormRow>
-    </EuiDescribedFormGroup>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFormRow
+          error={startTimeValidationErrorMessages}
+          fullWidth
+          isInvalid={startTimeValidationErrorMessages.length > 0}
+          label={startTimeLabel}
+        >
+          <EuiFlexGroup gutterSize="s">
+            <EuiFormControlLayout
+              clear={
+                startTime && !disabled ? { onClick: () => setStartTime(undefined) } : undefined
+              }
+              isDisabled={disabled}
+            >
+              <FixedDatePicker
+                disabled={disabled}
+                showTimeSelect
+                selected={startTimeValue}
+                onChange={(date) => setStartTime(selectedDateToParam(date))}
+                placeholder={startTimeDefaultDescription}
+                maxDate={now}
+              />
+            </EuiFormControlLayout>
+          </EuiFlexGroup>
+        </EuiFormRow>
+        <EuiFormRow
+          error={endTimeValidationErrorMessages}
+          fullWidth
+          isInvalid={endTimeValidationErrorMessages.length > 0}
+          label={endTimeLabel}
+        >
+          <EuiFlexGroup gutterSize="s">
+            <EuiFormControlLayout
+              clear={endTime && !disabled ? { onClick: () => setEndTime(undefined) } : undefined}
+              isDisabled={disabled}
+            >
+              <FixedDatePicker
+                disabled={disabled}
+                showTimeSelect
+                selected={endTimeValue}
+                onChange={(date) => setEndTime(selectedDateToParam(date))}
+                placeholder={endTimeDefaultDescription}
+                openToDate={now}
+                minDate={startTimeValue}
+                minTime={selectedEndTimeIsToday ? now : moment().hour(0).minutes(0)}
+                maxTime={moment().hour(23).minutes(59)}
+              />
+            </EuiFormControlLayout>
+          </EuiFlexGroup>
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_row.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_row.tsx
@@ -63,7 +63,7 @@ export const IndexSetupRow: React.FC<{
   const isSelected = index.validity === 'valid' && index.isSelected;
 
   return (
-    <EuiFlexGroup alignItems="center">
+    <EuiFlexGroup gutterSize="s" direction="column">
       <EuiFlexItem>
         <EuiCheckbox
           key={index.name}
@@ -90,7 +90,7 @@ export const IndexSetupRow: React.FC<{
           disabled={isDisabled || index.validity === 'invalid'}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem>
         {index.validity === 'invalid' ? (
           <EuiIconTip content={formatValidationError(index.errors)} type="alert" color="danger" />
         ) : index.validity === 'valid' ? (

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_row.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/index_setup_row.tsx
@@ -63,7 +63,7 @@ export const IndexSetupRow: React.FC<{
   const isSelected = index.validity === 'valid' && index.isSelected;
 
   return (
-    <EuiFlexGroup gutterSize="s" direction="column">
+    <EuiFlexGroup alignItems="center">
       <EuiFlexItem>
         <EuiCheckbox
           key={index.name}
@@ -90,7 +90,7 @@ export const IndexSetupRow: React.FC<{
           disabled={isDisabled || index.validity === 'invalid'}
         />
       </EuiFlexItem>
-      <EuiFlexItem>
+      <EuiFlexItem grow={false}>
         {index.validity === 'invalid' ? (
           <EuiIconTip content={formatValidationError(index.errors)} type="alert" color="danger" />
         ) : index.validity === 'valid' ? (

--- a/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/initial_configuration_step.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_analysis_setup/initial_configuration_step/initial_configuration_step.tsx
@@ -63,7 +63,6 @@ export const InitialConfigurationStep: React.FunctionComponent<InitialConfigurat
 
   return (
     <>
-      <EuiSpacer size="m" />
       <EuiForm>
         <AnalysisSetupTimerangeForm
           disabled={disabled}
@@ -73,6 +72,7 @@ export const InitialConfigurationStep: React.FunctionComponent<InitialConfigurat
           endTime={endTime}
           validationErrors={timeRangeValidationErrors}
         />
+        <EuiSpacer size="xl" />
         <AnalysisSetupIndicesForm
           disabled={disabled}
           indices={validatedIndices}


### PR DESCRIPTION
## Summary

Closes #66368.

The layout of the ML setup form looked broken in some scenarios where the index name was too long. This PR moves the dataset selector button below the index name.

### Before
<img width="1281" alt="Screenshot 2021-08-09 at 17 20 02" src="https://user-images.githubusercontent.com/57448/128731015-ab0ac753-6995-451d-9428-50f8d9709f85.png">


### After
![Uploading Screenshot 2021-08-10 at 14.56.55.png…]()



----
