### PR TITLE
[App Search] use setSuccessMessage instead of flashSuccessToast for successful crawler domain deletes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.test.ts
@@ -61,7 +61,7 @@ const MOCK_CLIENT_CRAWLER_DATA = crawlerDataServerToClient(MOCK_SERVER_CRAWLER_D
 describe('CrawlerOverviewLogic', () => {
   const { mount, unmount } = new LogicMounter(CrawlerOverviewLogic);
   const { http } = mockHttpValues;
-  const { flashAPIErrors, flashSuccessToast } = mockFlashMessageHelpers;
+  const { flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -192,7 +192,7 @@ describe('CrawlerOverviewLogic', () => {
         expect(CrawlerOverviewLogic.actions.onReceiveCrawlerData).toHaveBeenCalledWith(
           MOCK_CLIENT_CRAWLER_DATA
         );
-        expect(flashSuccessToast).toHaveBeenCalled();
+        expect(setSuccessMessage).toHaveBeenCalled();
       });
 
       it('calls flashApiErrors when there is an error', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview_logic.ts
@@ -7,7 +7,7 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_messages';
+import { flashAPIErrors, setSuccessMessage } from '../../../shared/flash_messages';
 
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
@@ -136,7 +136,7 @@ export const CrawlerOverviewLogic = kea<
         );
         const crawlerData = crawlerDataServerToClient(response);
         actions.onReceiveCrawlerData(crawlerData);
-        flashSuccessToast(getDeleteDomainSuccessMessage(domain.url));
+        setSuccessMessage(getDeleteDomainSuccessMessage(domain.url));
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_single_domain_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_single_domain_logic.test.ts
@@ -26,7 +26,7 @@ const DEFAULT_VALUES: CrawlerSingleDomainValues = {
 describe('CrawlerSingleDomainLogic', () => {
   const { mount } = new LogicMounter(CrawlerSingleDomainLogic);
   const { http } = mockHttpValues;
-  const { flashAPIErrors, flashSuccessToast } = mockFlashMessageHelpers;
+  const { flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -67,7 +67,7 @@ describe('CrawlerSingleDomainLogic', () => {
           '/api/app_search/engines/some-engine/crawler/domains/1234'
         );
 
-        expect(flashSuccessToast).toHaveBeenCalled();
+        expect(setSuccessMessage).toHaveBeenCalled();
         expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/crawler');
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_single_domain_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_single_domain_logic.ts
@@ -7,7 +7,7 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_messages';
+import { flashAPIErrors, setSuccessMessage } from '../../../shared/flash_messages';
 
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
@@ -59,7 +59,7 @@ export const CrawlerSingleDomainLogic = kea<
       try {
         await http.delete(`/api/app_search/engines/${engineName}/crawler/domains/${domain.id}`);
 
-        flashSuccessToast(getDeleteDomainSuccessMessage(domain.url));
+        setSuccessMessage(getDeleteDomainSuccessMessage(domain.url));
         KibanaLogic.values.navigateToUrl(generateEnginePath(ENGINE_CRAWLER_PATH));
       } catch (e) {
         flashAPIErrors(e);


### PR DESCRIPTION
## Summary

Realized this today. 


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
