### PR TITLE
[Enterprise Search] Fix Kibana beta notification nav CSS overrides leaking into other plugins

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/beta.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/beta.scss
@@ -6,15 +6,18 @@
  */
 
 @include euiBreakpoint('m', 'l', 'xl') {
-  .kbnPageTemplateSolutionNav {
-    display: flex;
-    flex-direction: column;
-  }
-  .euiSideNav__content {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+  .betaSidebarNotification {
+    .euiSideNav {
+      display: flex;
+      flex-direction: column;
+
+      .euiSideNav__content {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+    }
   }
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -79,6 +79,7 @@ export const EnterpriseSearchPageTemplate: React.FC<PageTemplateProps> = ({
       }}
       isEmptyState={isEmptyState && !isLoading}
       solutionNav={solutionNav ? { icon: 'logoEnterpriseSearch', ...solutionNav } : undefined}
+      pageSideBarProps={{ className: 'betaSidebarNotification' }}
     >
       {setPageChrome}
       {readOnlyMode && (


### PR DESCRIPTION
## Summary

- We were previously not scoping our sidebar class due to https://github.com/elastic/kibana/pull/103715 and the 7.14 release (now merged in)
- Because of the lack of CSS scope/specificity, loading the Enterprise Search plugin and then another plugin would cause that our Kibana/EUI CSS overrides to leak to other plugins, due to CSS not getting unloaded between plugins (Note: this might get fixed when moving to CSS-in-JS)
- ⚠️ Note for 7.16 when we remove the beta notification: We'll want to delete `beta.scss`, `beta.tsx`, and now line 82 & 66 of `shared/layout/page_template.tsx`.

### Before

<img width="977" alt="" src="https://user-images.githubusercontent.com/549407/128771581-9da23e46-2ea3-45da-beb1-960e93ab438a.png">

### After

<img width="980" alt="" src="https://user-images.githubusercontent.com/549407/128771823-5d565b62-b736-4b5d-acb2-b57ea391daf0.png">

### Checklist

- [x] Enterprise Search's beta notification is still correctly positioned at the bottom of the nav bar
- [x] Navigating to Enterprise Search and then another plugin (e.g. Observability overview) no longer carries over any CSS