### PR TITLE
[Maps] do not show 'EMS Basemap' create layer card when map contains EMS basemap layer

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/layer_wizard_registry.ts
+++ b/x-pack/plugins/maps/public/classes/layers/layer_wizard_registry.ts
@@ -27,9 +27,13 @@ export type RenderWizardArguments = {
   advanceToNextStep: () => void;
 };
 
+export type GetLayerWizardParams = {
+  hasEmsBaseMap: boolean;
+};
+
 export type LayerWizard = {
   categories: LAYER_WIZARD_CATEGORY[];
-  checkVisibility?: () => Promise<boolean>;
+  checkVisibility?: (params: GetLayerWizardParams) => Promise<boolean>;
   description: string;
   disabledReason?: string;
   getIsDisabled?: () => Promise<boolean> | boolean;
@@ -61,11 +65,13 @@ export function registerLayerWizard(layerWizard: LayerWizard) {
   });
 }
 
-export async function getLayerWizards(): Promise<LayerWizardWithMeta[]> {
+export async function getLayerWizards(
+  params: GetLayerWizardParams
+): Promise<LayerWizardWithMeta[]> {
   const promises = registry.map(async (layerWizard: LayerWizard) => {
     return {
       ...layerWizard,
-      isVisible: await layerWizard.checkVisibility!(),
+      isVisible: await layerWizard.checkVisibility!(params),
       isDisabled: await layerWizard.getIsDisabled!(),
     };
   });

--- a/x-pack/plugins/maps/public/classes/sources/ems_tms_source/ems_base_map_layer_wizard.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/ems_tms_source/ems_base_map_layer_wizard.tsx
@@ -7,7 +7,11 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { LayerWizard, RenderWizardArguments } from '../../layers/layer_wizard_registry';
+import {
+  GetLayerWizardParams,
+  LayerWizard,
+  RenderWizardArguments,
+} from '../../layers/layer_wizard_registry';
 // @ts-ignore
 import { EMSTMSSource, getSourceTitle } from './ems_tms_source';
 // @ts-ignore
@@ -30,7 +34,11 @@ function getDescription() {
 
 export const emsBaseMapLayerWizardConfig: LayerWizard = {
   categories: [LAYER_WIZARD_CATEGORY.REFERENCE],
-  checkVisibility: async () => {
+  checkVisibility: async (params: GetLayerWizardParams) => {
+    if (params.hasEmsBaseMap) {
+      return false;
+    }
+
     const emsSettings = getEMSSettings();
     return emsSettings.isIncludeElasticMapsService();
   },

--- a/x-pack/plugins/maps/public/classes/sources/source.ts
+++ b/x-pack/plugins/maps/public/classes/sources/source.ts
@@ -70,6 +70,7 @@ export interface ISource {
   getMaxZoom(): number;
   getLicensedFeatures(): Promise<LICENSED_FEATURES[]>;
   getUpdateDueToTimeslice(prevMeta: DataMeta, timeslice?: Timeslice): boolean;
+  getType(): string;
 }
 
 export class AbstractSource implements ISource {
@@ -82,6 +83,10 @@ export class AbstractSource implements ISource {
   }
 
   destroy(): void {}
+
+  getType(): string {
+    return this._descriptor.type;
+  }
 
   cloneDescriptor(): AbstractSourceDescriptor {
     return copyPersistentState(this._descriptor);

--- a/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/flyout_body.tsx
+++ b/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/flyout_body.tsx
@@ -16,12 +16,15 @@ type Props = RenderWizardArguments & {
   onClear: () => void;
   onWizardSelect: (layerWizard: LayerWizard) => void;
   showBackButton: boolean;
+  hasEmsBaseMap: boolean;
 };
 
 export const FlyoutBody = (props: Props) => {
   function renderContent() {
     if (!props.layerWizard || !props.currentStepId) {
-      return <LayerWizardSelect onSelect={props.onWizardSelect} />;
+      return (
+        <LayerWizardSelect onSelect={props.onWizardSelect} hasEmsBaseMap={props.hasEmsBaseMap} />
+      );
     }
 
     const renderWizardArgs = {

--- a/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/index.ts
+++ b/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/index.ts
@@ -8,11 +8,12 @@
 import { connect } from 'react-redux';
 import { FlyoutBody } from './flyout_body';
 import { MapStoreState } from '../../../reducers/store';
-import { getMapColors } from '../../../selectors/map_selectors';
+import { getHasEmsBaseMap, getMapColors } from '../../../selectors/map_selectors';
 
 function mapStateToProps(state: MapStoreState) {
   return {
     mapColors: getMapColors(state),
+    hasEmsBaseMap: getHasEmsBaseMap(state),
   };
 }
 

--- a/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/layer_wizard_select.test.tsx
+++ b/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/layer_wizard_select.test.tsx
@@ -14,6 +14,7 @@ import { LAYER_WIZARD_CATEGORY } from '../../../../common/constants';
 
 const defaultProps = {
   onSelect: () => {},
+  hasEmsBaseMap: false,
 };
 
 describe('LayerWizardSelect', () => {

--- a/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/layer_wizard_select.tsx
+++ b/x-pack/plugins/maps/public/connected_components/add_layer_panel/flyout_body/layer_wizard_select.tsx
@@ -30,6 +30,7 @@ import './layer_wizard_select.scss';
 
 interface Props {
   onSelect: (layerWizard: LayerWizard) => void;
+  hasEmsBaseMap: boolean;
 }
 
 interface State {
@@ -81,7 +82,7 @@ export class LayerWizardSelect extends Component<Props, State> {
   }
 
   async _loadLayerWizards() {
-    const layerWizards = await getLayerWizards();
+    const layerWizards = await getLayerWizards({ hasEmsBaseMap: this.props.hasEmsBaseMap });
     const activeCategories: LAYER_WIZARD_CATEGORY[] = [];
     layerWizards.forEach((layerWizard: LayerWizard) => {
       layerWizard.categories.forEach((category: LAYER_WIZARD_CATEGORY) => {

--- a/x-pack/plugins/maps/public/selectors/map_selectors.ts
+++ b/x-pack/plugins/maps/public/selectors/map_selectors.ts
@@ -28,6 +28,7 @@ import { getSourceByType } from '../classes/sources/source_registry';
 import { GeoJsonFileSource } from '../classes/sources/geojson_file_source';
 import {
   SOURCE_DATA_REQUEST_ID,
+  SOURCE_TYPES,
   SPATIAL_FILTERS_LAYER_ID,
   STYLE_TYPE,
   VECTOR_STYLES,
@@ -455,3 +456,9 @@ export const areLayersLoaded = createSelector(
     return true;
   }
 );
+
+export const getHasEmsBaseMap = createSelector(getLayerList, (layerList) => {
+  return layerList.some((layer: ILayer) => {
+    return layer.getSource().getType() === SOURCE_TYPES.EMS_TMS;
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/105111

To prevent users from adding multiple EMS basemap layers, hide EMS Basemap layer card when map already contains an EMS base map layer.