### PR TITLE
[build] Clean images from png-js.  Closes #107617

### DIFF
--- a/src/dev/build/tasks/clean_tasks.ts
+++ b/src/dev/build/tasks/clean_tasks.ts
@@ -151,6 +151,9 @@ export const CleanExtraFilesFromModules: Task = {
       '**/.DS_Store',
       '**/Dockerfile',
       '**/docker-compose.yml',
+
+      // https://github.com/elastic/kibana/issues/107617
+      '**/png-js/images/*.png',
     ]);
 
     log.info(


### PR DESCRIPTION
Removes unused images from png-js.  These are used in an examples page, not in the library itself.

Closes #107617