### PR TITLE
[Elastic Agent] add heartbeat to Elastic Agent monitoring datasets

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -74,6 +74,7 @@ const MONITORING_DATASETS = [
   'elastic_agent.packetbeat',
   'elastic_agent.endpoint_security',
   'elastic_agent.auditbeat',
+  'elastic_agent.heartbeat',
 ];
 
 class AgentPolicyService {


### PR DESCRIPTION
Relates to elastic/beats#27238

## Summary

This PR adds heartbeat to the hardcoded list of Elastic Agent monitoring datasets.

Works in conjunction with elastic/integrations#1460 to ensure that heartbeat logs are available from agent.