### PR TITLE
[Expressions] Add support of partial results to the switch expression function

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
@@ -56,25 +56,6 @@ describe('switch', () => {
   });
 
   describe('function', () => {
-    describe('with no cases', () => {
-      it('should return the context if no default is provided', () => {
-        const context = 'foo';
-
-        testScheduler.run(({ expectObservable }) =>
-          expectObservable(fn(context, {})).toBe('(0|)', [context])
-        );
-      });
-
-      it('should return the default if provided', () => {
-        const context = 'foo';
-        const args = { default: () => of('bar') };
-
-        testScheduler.run(({ expectObservable }) =>
-          expectObservable(fn(context, args)).toBe('(0|)', ['bar'])
-        );
-      });
-    });
-
     describe('with no matching cases', () => {
       it('should return the context if no default is provided', () => {
         const context = 'foo';

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
@@ -108,6 +108,55 @@ describe('switch', () => {
           expectObservable(fn(context, args)).toBe('(0|)', [result])
         );
       });
+
+      it('should support partial results', () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          const context = 'foo';
+          const case1 = cold('--ab-c-', {
+            a: {
+              type: 'case',
+              matches: false,
+              result: 1,
+            },
+            b: {
+              type: 'case',
+              matches: true,
+              result: 2,
+            },
+            c: {
+              type: 'case',
+              matches: false,
+              result: 3,
+            },
+          });
+          const case2 = cold('-a--bc-', {
+            a: {
+              type: 'case',
+              matches: true,
+              result: 4,
+            },
+            b: {
+              type: 'case',
+              matches: true,
+              result: 5,
+            },
+            c: {
+              type: 'case',
+              matches: true,
+              result: 6,
+            },
+          });
+          const expected = ' --abc(de)-';
+          const args = { case: [() => case1, () => case2] };
+          expectObservable(fn(context, args)).toBe(expected, {
+            a: 4,
+            b: 2,
+            c: 2,
+            d: 5,
+            e: 6,
+          });
+        });
+      });
     });
   });
 });

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.ts
@@ -12,7 +12,7 @@ import { Case } from '../../../types';
 import { getFunctionHelp } from '../../../i18n';
 
 interface Arguments {
-  case?: Array<() => Observable<Case>>;
+  case: Array<() => Observable<Case>>;
   default?(): Observable<any>;
 }
 
@@ -43,10 +43,7 @@ export function switchFn(): ExpressionFunctionDefinition<
       },
     },
     fn(input, args) {
-      const cases = args.case?.map((item) => defer(() => item())) ?? [];
-      const cases$ = cases.length ? combineLatest(cases) : of([]);
-
-      return cases$.pipe(
+      return combineLatest(args.case.map((item) => defer(() => item()))).pipe(
         concatMap((items) => {
           const item = items.find(({ matches }) => matches);
           const item$ = item && of(item.result);

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { Observable, defer, from, of } from 'rxjs';
-import { concatMap, filter, merge, pluck, take } from 'rxjs/operators';
+import { Observable, combineLatest, defer, of } from 'rxjs';
+import { concatMap } from 'rxjs/operators';
 import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
 import { Case } from '../../../types';
 import { getFunctionHelp } from '../../../i18n';
@@ -43,12 +43,16 @@ export function switchFn(): ExpressionFunctionDefinition<
       },
     },
     fn(input, args) {
-      return from(args.case ?? []).pipe(
-        concatMap((item) => item()),
-        filter(({ matches }) => matches),
-        pluck('result'),
-        merge(defer(() => args.default?.() ?? of(input))),
-        take(1)
+      const cases = args.case?.map((item) => defer(() => item())) ?? [];
+      const cases$ = cases.length ? combineLatest(cases) : of([]);
+
+      return cases$.pipe(
+        concatMap((items) => {
+          const item = items.find(({ matches }) => matches);
+          const item$ = item && of(item.result);
+
+          return item$ ?? args.default?.() ?? of(input);
+        })
       );
     },
   };


### PR DESCRIPTION
## Summary

This PR resolves #107934 by changing the `switch` function's implementation to handle observables on input correctly.

In 7.14, there is a problem with the `switch` function caused by #100409 — the reason for the incorrect behavior is in the way how `concatMap` works. The expressions execution services returns never completing observable, so the `concatMap` stops awaiting first case completion.
There is no such problem in 7.x and the mainstream branch because the behavior was changed by #102403. But even then, the switch function will incorrectly be handling expressions returning partial results.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
