### PR TITLE
[APM] Service inventory: Services table row height is larger than other tables

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -50,6 +50,7 @@ function formatString(value?: string | null) {
 }
 
 const ToolTipWrapper = euiStyled.span`
+  line-height: 0px;
   width: 100%;
   .apmServiceList__serviceNameTooltip {
     width: 100%;


### PR DESCRIPTION
closes #108001

<img width="1164" alt="Screen Shot 2021-08-10 at 15 34 36" src="https://user-images.githubusercontent.com/55978943/128923813-a808c2f4-7113-4779-af2a-796d82a935e3.png">
