### PR TITLE
[Maps] Update EMS landing page url

### DIFF
--- a/src/plugins/maps_ems/common/ems_defaults.ts
+++ b/src/plugins/maps_ems/common/ems_defaults.ts
@@ -9,7 +9,7 @@
 // Default config for the elastic hosted EMS endpoints
 export const DEFAULT_EMS_FILE_API_URL = 'https://vector.maps.elastic.co';
 export const DEFAULT_EMS_TILE_API_URL = 'https://tiles.maps.elastic.co';
-export const DEFAULT_EMS_LANDING_PAGE_URL = 'https://maps.elastic.co/v7.13';
+export const DEFAULT_EMS_LANDING_PAGE_URL = 'https://maps.elastic.co/v7.14';
 export const DEFAULT_EMS_FONT_LIBRARY_URL =
   'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf';
 


### PR DESCRIPTION
## Summary

Updates the link to the EMS landing page from Maps to 7.14. This was missed in 7.14.0.
