### PR TITLE
[7.x] move rules creation out of closing popover (#107957)

### DIFF
--- a/x-pack/plugins/monitoring/public/alerts/alerts_dropdown.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/alerts_dropdown.tsx
@@ -23,7 +23,6 @@ export const AlertsDropdown: React.FC<{}> = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const closePopover = () => {
-    alertsEnableModalProvider.enableAlerts();
     setIsPopoverOpen(false);
   };
 
@@ -32,6 +31,7 @@ export const AlertsDropdown: React.FC<{}> = () => {
   };
 
   const createDefaultRules = () => {
+    alertsEnableModalProvider.enableAlerts();
     closePopover();
   };
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - move rules creation out of closing popover (#107957)