### PR TITLE
[Maps] fix code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -158,6 +158,7 @@
 
 # Maps
 #CC# /x-pack/plugins/maps/ @elastic/kibana-gis
+/x-pack/plugins/maps/ @elastic/kibana-gis
 /x-pack/test/api_integration/apis/maps/ @elastic/kibana-gis
 /x-pack/test/functional/apps/maps/ @elastic/kibana-gis
 /x-pack/test/functional/es_archives/maps/ @elastic/kibana-gis
@@ -165,7 +166,9 @@
 /x-pack/plugins/stack_alerts/server/alert_types/geo_containment @elastic/kibana-gis
 /x-pack/plugins/stack_alerts/public/alert_types/geo_containment @elastic/kibana-gis
 #CC# /src/plugins/maps_legacy/ @elastic/kibana-gis
+/src/plugins/maps_legacy/ @elastic/kibana-gis
 #CC# /x-pack/plugins/file_upload @elastic/kibana-gis
+/x-pack/plugins/file_upload @elastic/kibana-gis
 /src/plugins/tile_map/ @elastic/kibana-gis
 /src/plugins/region_map/ @elastic/kibana-gis
 /packages/kbn-mapbox-gl @elastic/kibana-gis


### PR DESCRIPTION
Maps code owners is not configured properly. Any thing prefixed with `#CC#` needs a duplicate entry to work.

This can be seen in PRs like https://github.com/elastic/kibana/pull/107227 where @elastic/kibana-gis was not pinged