### PR TITLE
[Task Manager] [8.0] Remove `xpack.task_manager.index`

### DIFF
--- a/docs/developer/advanced/running-elasticsearch.asciidoc
+++ b/docs/developer/advanced/running-elasticsearch.asciidoc
@@ -76,7 +76,6 @@ If many other users will be interacting with your remote cluster, you'll want to
 [source,bash]
 ----
 kibana.index: '.{YourGitHubHandle}-kibana'
-xpack.task_manager.index: '.{YourGitHubHandle}-task-manager-kibana'
 ----
 
 ==== Running remote clusters

--- a/docs/settings/task-manager-settings.asciidoc
+++ b/docs/settings/task-manager-settings.asciidoc
@@ -22,9 +22,6 @@ Task Manager runs background tasks by polling for work on an interval.  You can 
 | `xpack.task_manager.request_capacity`
   | How many requests can Task Manager buffer before it rejects new requests.  Defaults to 1000.
 
-| `xpack.task_manager.index`
-  | The name of the index used to store task information.  Defaults to `.kibana_task_manager`.
-
   | `xpack.task_manager.max_workers`
   | The maximum number of tasks that this Kibana instance will run simultaneously.  Defaults to 10.
     Starting in 8.0, it will not be possible to set the value greater than 100.

--- a/docs/user/production-considerations/task-manager-production-considerations.asciidoc
+++ b/docs/user/production-considerations/task-manager-production-considerations.asciidoc
@@ -12,7 +12,7 @@ This has three major benefits:
 
 [IMPORTANT]
 ==============================================
-Task definitions for alerts and actions are stored in the index specified by <<task-manager-settings, `xpack.task_manager.index`>>. The default is `.kibana_task_manager`.
+Task definitions for alerts and actions are stored in the index `.kibana_task_manager`.
  
 You must have at least one replica of this index for production deployments.
 

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -395,7 +395,6 @@ kibana_vars=(
     xpack.spaces.enabled
     xpack.spaces.maxSpaces
     xpack.task_manager.enabled
-    xpack.task_manager.index
     xpack.task_manager.max_attempts
     xpack.task_manager.max_poll_inactivity_cycles
     xpack.task_manager.max_workers

--- a/x-pack/plugins/task_manager/server/config.test.ts
+++ b/x-pack/plugins/task_manager/server/config.test.ts
@@ -17,7 +17,6 @@ describe('config validation', () => {
           "enabled": false,
           "request_capacity": 10,
         },
-        "index": ".kibana_task_manager",
         "max_attempts": 3,
         "max_poll_inactivity_cycles": 10,
         "max_workers": 10,
@@ -42,17 +41,6 @@ describe('config validation', () => {
     `);
   });
 
-  test('the ElastiSearch Tasks index cannot be used for task manager', () => {
-    const config: Record<string, unknown> = {
-      index: '.tasks',
-    };
-    expect(() => {
-      configSchema.validate(config);
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"[index]: \\".tasks\\" is an invalid Kibana Task Manager index, as it is already in use by the ElasticSearch Tasks Manager"`
-    );
-  });
-
   test('the required freshness of the monitored stats config must always be less-than-equal to the poll interval', () => {
     const config: Record<string, unknown> = {
       monitored_stats_required_freshness: 100,
@@ -73,7 +61,6 @@ describe('config validation', () => {
           "enabled": false,
           "request_capacity": 10,
         },
-        "index": ".kibana_task_manager",
         "max_attempts": 3,
         "max_poll_inactivity_cycles": 10,
         "max_workers": 10,
@@ -116,7 +103,6 @@ describe('config validation', () => {
           "enabled": false,
           "request_capacity": 10,
         },
-        "index": ".kibana_task_manager",
         "max_attempts": 3,
         "max_poll_inactivity_cycles": 10,
         "max_workers": 10,

--- a/x-pack/plugins/task_manager/server/config.ts
+++ b/x-pack/plugins/task_manager/server/config.ts
@@ -65,15 +65,6 @@ export const configSchema = schema.object(
       defaultValue: 1000,
       min: 1,
     }),
-    /* The name of the index used to store task information. */
-    index: schema.string({
-      defaultValue: '.kibana_task_manager',
-      validate: (val) => {
-        if (val.toLowerCase() === '.tasks') {
-          return `"${val}" is an invalid Kibana Task Manager index, as it is already in use by the ElasticSearch Tasks Manager`;
-        }
-      },
-    }),
     /* The maximum number of tasks that this Kibana instance will run simultaneously. */
     max_workers: schema.number({
       defaultValue: DEFAULT_MAX_WORKERS,

--- a/x-pack/plugins/task_manager/server/constants.ts
+++ b/x-pack/plugins/task_manager/server/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TASK_MANAGER_INDEX = '.kibana_task_manager';

--- a/x-pack/plugins/task_manager/server/ephemeral_task_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/ephemeral_task_lifecycle.test.ts
@@ -40,7 +40,6 @@ describe('EphemeralTaskLifecycle', () => {
       config: {
         enabled: true,
         max_workers: 10,
-        index: 'foo',
         max_attempts: 9,
         poll_interval: 6000000,
         version_conflict_threshold: 80,

--- a/x-pack/plugins/task_manager/server/index.test.ts
+++ b/x-pack/plugins/task_manager/server/index.test.ts
@@ -31,17 +31,6 @@ const applyTaskManagerDeprecations = (settings: Record<string, unknown> = {}) =>
 };
 
 describe('deprecations', () => {
-  ['.foo', '.kibana_task_manager'].forEach((index) => {
-    it('logs a warning if index is set', () => {
-      const { messages } = applyTaskManagerDeprecations({ index });
-      expect(messages).toMatchInlineSnapshot(`
-        Array [
-          "\\"xpack.task_manager.index\\" is deprecated. Multitenancy by changing \\"kibana.index\\" will not be supported starting in 8.0. See https://ela.st/kbn-remove-legacy-multitenancy for more details",
-        ]
-      `);
-    });
-  });
-
   it('logs a warning if max_workers is over limit', () => {
     const { messages } = applyTaskManagerDeprecations({ max_workers: 1000 });
     expect(messages).toMatchInlineSnapshot(`

--- a/x-pack/plugins/task_manager/server/index.ts
+++ b/x-pack/plugins/task_manager/server/index.ts
@@ -41,18 +41,6 @@ export const config: PluginConfigDescriptor<TaskManagerConfig> = {
   deprecations: () => [
     (settings, fromPath, addDeprecation) => {
       const taskManager = get(settings, fromPath);
-      if (taskManager?.index) {
-        addDeprecation({
-          documentationUrl: 'https://ela.st/kbn-remove-legacy-multitenancy',
-          message: `"${fromPath}.index" is deprecated. Multitenancy by changing "kibana.index" will not be supported starting in 8.0. See https://ela.st/kbn-remove-legacy-multitenancy for more details`,
-          correctiveActions: {
-            manualSteps: [
-              `If you rely on this setting to achieve multitenancy you should use Spaces, cross-cluster replication, or cross-cluster search instead.`,
-              `To migrate to Spaces, we encourage using saved object management to export your saved objects from a tenant into the default tenant in a space.`,
-            ],
-          },
-        });
-      }
       if (taskManager?.max_workers > MAX_WORKERS_LIMIT) {
         addDeprecation({
           message: `setting "${fromPath}.max_workers" (${taskManager?.max_workers}) greater than ${MAX_WORKERS_LIMIT} is deprecated. Values greater than ${MAX_WORKERS_LIMIT} will not be supported starting in 8.0.`,

--- a/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts
@@ -31,7 +31,6 @@ describe('managed configuration', () => {
     const context = coreMock.createPluginInitializerContext<TaskManagerConfig>({
       enabled: true,
       max_workers: 10,
-      index: 'foo',
       max_attempts: 9,
       poll_interval: 3000,
       version_conflict_threshold: 80,

--- a/x-pack/plugins/task_manager/server/monitoring/configuration_statistics.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/configuration_statistics.test.ts
@@ -15,7 +15,6 @@ describe('Configuration Statistics Aggregator', () => {
     const configuration: TaskManagerConfig = {
       enabled: true,
       max_workers: 10,
-      index: 'foo',
       max_attempts: 9,
       poll_interval: 6000000,
       version_conflict_threshold: 80,

--- a/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.test.ts
@@ -19,7 +19,6 @@ describe('createMonitoringStatsStream', () => {
   const configuration: TaskManagerConfig = {
     enabled: true,
     max_workers: 10,
-    index: 'foo',
     max_attempts: 9,
     poll_interval: 6000000,
     version_conflict_threshold: 80,

--- a/x-pack/plugins/task_manager/server/plugin.test.ts
+++ b/x-pack/plugins/task_manager/server/plugin.test.ts
@@ -18,7 +18,6 @@ describe('TaskManagerPlugin', () => {
       const pluginInitializerContext = coreMock.createPluginInitializerContext<TaskManagerConfig>({
         enabled: true,
         max_workers: 10,
-        index: 'foo',
         max_attempts: 9,
         poll_interval: 3000,
         version_conflict_threshold: 80,
@@ -58,7 +57,6 @@ describe('TaskManagerPlugin', () => {
       const pluginInitializerContext = coreMock.createPluginInitializerContext<TaskManagerConfig>({
         enabled: true,
         max_workers: 10,
-        index: 'foo',
         max_attempts: 9,
         poll_interval: 3000,
         version_conflict_threshold: 80,

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -31,6 +31,7 @@ import { createMonitoringStats, MonitoringStats } from './monitoring';
 import { EphemeralTaskLifecycle } from './ephemeral_task_lifecycle';
 import { EphemeralTask } from './task';
 import { registerTaskManagerUsageCollector } from './usage';
+import { TASK_MANAGER_INDEX } from './constants';
 
 export type TaskManagerSetupContract = {
   /**
@@ -114,7 +115,7 @@ export class TaskManagerPlugin
     }
 
     return {
-      index: this.config.index,
+      index: TASK_MANAGER_INDEX,
       addMiddleware: (middleware: Middleware) => {
         this.assertStillInSetup('add Middleware');
         this.middleware = addMiddlewareToChain(this.middleware, middleware);
@@ -134,7 +135,7 @@ export class TaskManagerPlugin
       serializer,
       savedObjectsRepository,
       esClient: elasticsearch.createClient('taskManager').asInternalUser,
-      index: this.config!.index,
+      index: TASK_MANAGER_INDEX,
       definitions: this.definitions,
       taskManagerId: `kibana:${this.taskManagerId!}`,
     });

--- a/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
@@ -38,7 +38,6 @@ describe('TaskPollingLifecycle', () => {
     config: {
       enabled: true,
       max_workers: 10,
-      index: 'foo',
       max_attempts: 9,
       poll_interval: 6000000,
       version_conflict_threshold: 80,

--- a/x-pack/plugins/task_manager/server/saved_objects/index.ts
+++ b/x-pack/plugins/task_manager/server/saved_objects/index.ts
@@ -11,6 +11,7 @@ import mappings from './mappings.json';
 import { migrations } from './migrations';
 import { TaskManagerConfig } from '../config.js';
 import { getOldestIdleActionTask } from '../queries/oldest_idle_action_task';
+import { TASK_MANAGER_INDEX } from '../constants';
 
 export function setupSavedObjects(
   savedObjects: SavedObjectsServiceSetup,
@@ -23,11 +24,11 @@ export function setupSavedObjects(
     convertToAliasScript: `ctx._id = ctx._source.type + ':' + ctx._id; ctx._source.remove("kibana")`,
     mappings: mappings.task as SavedObjectsTypeMappingDefinition,
     migrations,
-    indexPattern: config.index,
+    indexPattern: TASK_MANAGER_INDEX,
     excludeOnUpgrade: async ({ readonlyEsClient }) => {
       const oldestNeededActionParams = await getOldestIdleActionTask(
         readonlyEsClient,
-        config.index
+        TASK_MANAGER_INDEX
       );
 
       // Delete all action tasks that have failed and are no longer needed


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/102076
Related to https://github.com/elastic/kibana/issues/101964

Note: This PR should only live in 8.0 and not in 7.x

This setting is currently deprecated in 7.x and this PR removes it from 8.0.

## Release note

### Details

The `xpack.task_manager.index` setting is no longer supported as a configuration option.

### Impact

Users will need to remove `xpack.task_manager.index` from their Kibana config or Kibana will fail to start.