### PR TITLE
[7.x] [Security Solution][Bug] - Disable alert table RBAC until fields sorted (#108034)

### DIFF
--- a/x-pack/plugins/timelines/server/search_strategy/timeline/index.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/index.ts
@@ -9,7 +9,8 @@ import { ALERT_OWNER, RULE_ID, SPACE_IDS } from '@kbn/rule-data-utils';
 import { map, mergeMap, catchError } from 'rxjs/operators';
 import { from } from 'rxjs';
 import {
-  isValidFeatureId,
+  // TODO: Undo comment in fix here https://github.com/elastic/kibana/pull/107857
+  // isValidFeatureId,
   mapConsumerToIndexName,
   AlertConsumers,
 } from '@kbn/rule-data-utils/target/alerts_as_data_rbac';
@@ -49,7 +50,9 @@ export const timelineSearchStrategyProvider = <T extends TimelineFactoryQueryTyp
     search: (request, options, deps) => {
       const factoryQueryType = request.factoryQueryType;
       const entityType = request.entityType;
-      const alertConsumers = request.alertConsumers;
+      let alertConsumers = request.alertConsumers;
+      // TODO: Remove in fix here https://github.com/elastic/kibana/pull/107857
+      alertConsumers = undefined;
 
       if (factoryQueryType == null) {
         throw new Error('factoryQueryType is required');
@@ -58,7 +61,9 @@ export const timelineSearchStrategyProvider = <T extends TimelineFactoryQueryTyp
       const queryFactory: TimelineFactory<T> = timelineFactory[factoryQueryType];
 
       if (alertConsumers != null && entityType != null && entityType === EntityType.ALERTS) {
-        const allFeatureIdsValid = alertConsumers.every((id) => isValidFeatureId(id));
+        // TODO: Thist won't be hit since alertConsumers = undefined
+        // TODO: remove in fix here https://github.com/elastic/kibana/pull/107857
+        const allFeatureIdsValid = null; // alertConsumers.every((id) => isValidFeatureId(id));
 
         if (!allFeatureIdsValid) {
           throw new Error('An invalid alerts consumer feature id was provided');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution][Bug] - Disable alert table RBAC until fields sorted (#108034)