### PR TITLE
[event log] add consumer/space_id fields to event log docs for RBAC usage

### DIFF
--- a/x-pack/plugins/alerting/common/alert_task_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_task_instance.ts
@@ -17,9 +17,13 @@ export const alertStateSchema = t.partial({
 
 export type AlertTaskState = t.TypeOf<typeof alertStateSchema>;
 
-export const alertParamsSchema = t.type({
-  alertId: t.string,
-  spaceId: t.string,
-  alertConsumer: t.string,
-});
+export const alertParamsSchema = t.intersection([
+  t.type({
+    alertId: t.string,
+  }),
+  t.partial({
+    spaceId: t.string,
+    alertConsumer: t.string,
+  }),
+]);
 export type AlertTaskParams = t.TypeOf<typeof alertParamsSchema>;

--- a/x-pack/plugins/alerting/common/alert_task_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_task_instance.ts
@@ -17,12 +17,9 @@ export const alertStateSchema = t.partial({
 
 export type AlertTaskState = t.TypeOf<typeof alertStateSchema>;
 
-export const alertParamsSchema = t.intersection([
-  t.type({
-    alertId: t.string,
-  }),
-  t.partial({
-    spaceId: t.string,
-  }),
-]);
+export const alertParamsSchema = t.type({
+  alertId: t.string,
+  spaceId: t.string,
+  alertConsumer: t.string,
+});
 export type AlertTaskParams = t.TypeOf<typeof alertParamsSchema>;

--- a/x-pack/plugins/alerting/server/rules_client/rules_client.ts
+++ b/x-pack/plugins/alerting/server/rules_client/rules_client.ts
@@ -357,6 +357,7 @@ export class RulesClient {
         scheduledTask = await this.scheduleAlert(
           createdAlert.id,
           rawAlert.alertTypeId,
+          data.consumer,
           data.schedule
         );
       } catch (e) {
@@ -1129,6 +1130,7 @@ export class RulesClient {
       const scheduledTask = await this.scheduleAlert(
         id,
         attributes.alertTypeId,
+        attributes.consumer,
         attributes.schedule as IntervalSchedule
       );
       await this.unsecuredSavedObjectsClient.update('alert', id, {
@@ -1500,13 +1502,19 @@ export class RulesClient {
     return this.spaceId;
   }
 
-  private async scheduleAlert(id: string, alertTypeId: string, schedule: IntervalSchedule) {
+  private async scheduleAlert(
+    id: string,
+    alertTypeId: string,
+    consumer: string,
+    schedule: IntervalSchedule
+  ) {
     return await this.taskManager.schedule({
       taskType: `alerting:${alertTypeId}`,
       schedule,
       params: {
         alertId: id,
         spaceId: this.spaceId,
+        alertConsumer: consumer,
       },
       state: {
         previousStartedAt: null,

--- a/x-pack/plugins/alerting/server/rules_client/tests/create.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/create.test.ts
@@ -444,6 +444,7 @@ describe('create()', () => {
                                                                         Array [
                                                                           Object {
                                                                             "params": Object {
+                                                                              "alertConsumer": "bar",
                                                                               "alertId": "1",
                                                                               "spaceId": "default",
                                                                             },

--- a/x-pack/plugins/alerting/server/rules_client/tests/enable.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/enable.test.ts
@@ -273,6 +273,7 @@ describe('enable()', () => {
       params: {
         alertId: '1',
         spaceId: 'default',
+        alertConsumer: 'myApp',
       },
       schedule: {
         interval: '10s',

--- a/x-pack/plugins/alerting/server/rules_client/tests/get_alert_state.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/get_alert_state.test.ts
@@ -151,6 +151,8 @@ describe('getAlertState()', () => {
       state: {},
       params: {
         alertId: '1',
+        alertConsumer: 'my-consumer',
+        spaceId: 'my-space',
       },
       ownerId: null,
     });

--- a/x-pack/plugins/alerting/server/task_runner/alert_task_instance.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/alert_task_instance.test.ts
@@ -241,7 +241,7 @@ describe('Alert Task Instance', () => {
     expect(() =>
       taskInstanceToAlertTaskInstance(taskInstance, alert)
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Task \\"215ee69b-1df9-428e-ab1a-ccf274f8fa5b\\" (underlying Alert \\"alert-123\\") has an invalid param at .alertId,.spaceId,.alertConsumer"`
+      `"Task \\"215ee69b-1df9-428e-ab1a-ccf274f8fa5b\\" (underlying Alert \\"alert-123\\") has an invalid param at .0.alertId"`
     );
   });
 });

--- a/x-pack/plugins/alerting/server/task_runner/alert_task_instance.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/alert_task_instance.test.ts
@@ -71,6 +71,8 @@ describe('Alert Task Instance', () => {
       taskType: 'alerting:test',
       params: {
         alertId: '1',
+        alertConsumer: 'my-consumer',
+        spaceId: 'my-space',
       },
       ownerId: null,
     };
@@ -121,6 +123,8 @@ describe('Alert Task Instance', () => {
       taskType: 'alerting:test',
       params: {
         alertId: '1',
+        alertConsumer: 'my-consumer',
+        spaceId: 'my-space',
       },
       ownerId: null,
     };
@@ -152,6 +156,8 @@ describe('Alert Task Instance', () => {
       taskType: 'alerting:test',
       params: {
         alertId: '1',
+        alertConsumer: 'my-consumer',
+        spaceId: 'my-space',
       },
       ownerId: null,
     };
@@ -177,6 +183,8 @@ describe('Alert Task Instance', () => {
       taskType: 'alerting:test',
       params: {
         alertId: '1',
+        alertConsumer: 'my-consumer',
+        spaceId: 'my-space',
       },
       ownerId: null,
     };
@@ -200,6 +208,8 @@ describe('Alert Task Instance', () => {
       taskType: 'alerting:test',
       params: {
         alertId: '1',
+        alertConsumer: 'my-consumer',
+        spaceId: 'my-space',
       },
       ownerId: null,
     };
@@ -231,7 +241,7 @@ describe('Alert Task Instance', () => {
     expect(() =>
       taskInstanceToAlertTaskInstance(taskInstance, alert)
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Task \\"215ee69b-1df9-428e-ab1a-ccf274f8fa5b\\" (underlying Alert \\"alert-123\\") has an invalid param at .0.alertId"`
+      `"Task \\"215ee69b-1df9-428e-ab1a-ccf274f8fa5b\\" (underlying Alert \\"alert-123\\") has an invalid param at .alertId,.spaceId,.alertConsumer"`
     );
   });
 });

--- a/x-pack/plugins/alerting/server/task_runner/alert_task_instance.ts
+++ b/x-pack/plugins/alerting/server/task_runner/alert_task_instance.ts
@@ -30,7 +30,7 @@ export function taskInstanceToAlertTaskInstance<Params extends AlertTypeParams>(
   taskInstance: ConcreteTaskInstance,
   alert?: SanitizedAlert<Params>
 ): AlertTaskInstance {
-  return {
+  const result = {
     ...taskInstance,
     params: pipe(
       alertParamsSchema.decode(taskInstance.params),
@@ -53,4 +53,15 @@ export function taskInstanceToAlertTaskInstance<Params extends AlertTypeParams>(
       }, t.identity)
     ),
   };
+
+  // ensure spaceId and consumer are actually strings
+  if (result.params.spaceId === undefined) {
+    result.params.spaceId = 'undefined';
+  }
+
+  if (result.params.alertConsumer === undefined) {
+    result.params.alertConsumer = 'undefined';
+  }
+
+  return result;
 }

--- a/x-pack/plugins/alerting/server/task_runner/create_execution_handler.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/create_execution_handler.test.ts
@@ -100,6 +100,7 @@ const createExecutionHandlerParams: jest.Mocked<
   },
   supportsEphemeralTasks: false,
   maxEphemeralActionsPerAlert: Promise.resolve(10),
+  alertConsumer: 'my-consumer',
 };
 
 beforeEach(() => {
@@ -176,6 +177,7 @@ test('enqueues execution per selected action', async () => {
             "alerting": Object {
               "action_group_id": "default",
               "action_subgroup": undefined,
+              "consumer": "my-consumer",
               "instance_id": "2",
             },
             "saved_objects": Array [
@@ -192,6 +194,9 @@ test('enqueues execution per selected action', async () => {
                 "type": "action",
                 "type_id": "test",
               },
+            ],
+            "space_ids": Array [
+              "test1",
             ],
           },
           "message": "alert: test:1: 'name-of-alert' instanceId: '2' scheduled actionGroup: 'default' action: test:1",

--- a/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
+++ b/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
@@ -56,6 +56,7 @@ export interface CreateExecutionHandlerOptions<
   alertParams: AlertTypeParams;
   supportsEphemeralTasks: boolean;
   maxEphemeralActionsPerAlert: Promise<number>;
+  alertConsumer: string;
 }
 
 interface ExecutionHandlerOptions<ActionGroupIds extends string> {
@@ -94,6 +95,7 @@ export function createExecutionHandler<
   alertParams,
   supportsEphemeralTasks,
   maxEphemeralActionsPerAlert,
+  alertConsumer,
 }: CreateExecutionHandlerOptions<
   Params,
   ExtractedParams,
@@ -208,10 +210,12 @@ export function createExecutionHandler<
           category: [alertType.producer],
         },
         kibana: {
+          space_ids: [spaceId],
           alerting: {
             instance_id: alertInstanceId,
             action_group_id: actionGroup,
             action_subgroup: actionSubgroup,
+            consumer: alertConsumer,
           },
           saved_objects: [
             {

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
@@ -74,6 +74,8 @@ describe('Task Runner', () => {
       taskType: 'alerting:test',
       params: {
         alertId: '1',
+        alertConsumer: 'bar',
+        spaceId: 'default',
       },
       ownerId: null,
     };
@@ -306,6 +308,9 @@ describe('Task Runner', () => {
           "kind": "alert",
         },
         "kibana": Object {
+          "alerting": Object {
+            "consumer": "bar",
+          },
           "saved_objects": Array [
             Object {
               "id": "1",
@@ -314,6 +319,9 @@ describe('Task Runner', () => {
               "type": "alert",
               "type_id": "test",
             },
+          ],
+          "space_ids": Array [
+            "default",
           ],
           "task": Object {
             "schedule_delay": 0,
@@ -424,7 +432,7 @@ describe('Task Runner', () => {
             },
             "type": "SAVED_OBJECT",
           },
-          "spaceId": undefined,
+          "spaceId": "default",
         },
       ]
     `);
@@ -456,6 +464,10 @@ describe('Task Runner', () => {
             schedule_delay: 0,
             scheduled: '1970-01-01T00:00:00.000Z',
           },
+          space_ids: ['default'],
+          alerting: {
+            consumer: 'bar',
+          },
           saved_objects: [
             {
               id: '1',
@@ -483,10 +495,12 @@ describe('Task Runner', () => {
           start: '1970-01-01T00:00:00.000Z',
         },
         kibana: {
+          space_ids: ['default'],
           alerting: {
             action_group_id: 'default',
             action_subgroup: 'subDefault',
             instance_id: '1',
+            consumer: 'bar',
           },
           saved_objects: [
             {
@@ -504,7 +518,6 @@ describe('Task Runner', () => {
           id: '1',
           license: 'basic',
           name: 'alert-name',
-          namespace: undefined,
           ruleset: 'alerts',
         },
       });
@@ -517,7 +530,13 @@ describe('Task Runner', () => {
           start: '1970-01-01T00:00:00.000Z',
         },
         kibana: {
-          alerting: { action_group_id: 'default', action_subgroup: 'subDefault', instance_id: '1' },
+          alerting: {
+            action_group_id: 'default',
+            action_subgroup: 'subDefault',
+            instance_id: '1',
+            consumer: 'bar',
+          },
+          space_ids: ['default'],
           saved_objects: [
             { id: '1', namespace: undefined, rel: 'primary', type: 'alert', type_id: 'test' },
           ],
@@ -529,7 +548,6 @@ describe('Task Runner', () => {
           id: '1',
           license: 'basic',
           name: 'alert-name',
-          namespace: undefined,
           ruleset: 'alerts',
         },
       });
@@ -544,18 +562,18 @@ describe('Task Runner', () => {
             instance_id: '1',
             action_group_id: 'default',
             action_subgroup: 'subDefault',
+            consumer: 'bar',
           },
+          space_ids: ['default'],
           saved_objects: [
             {
               id: '1',
-              namespace: undefined,
               rel: 'primary',
               type: 'alert',
               type_id: 'test',
             },
             {
               id: '1',
-              namespace: undefined,
               type: 'action',
               type_id: 'action',
             },
@@ -568,7 +586,6 @@ describe('Task Runner', () => {
           id: '1',
           license: 'basic',
           name: 'alert-name',
-          namespace: undefined,
           ruleset: 'alerts',
         },
       });
@@ -577,12 +594,14 @@ describe('Task Runner', () => {
         event: { action: 'execute', category: ['alerts'], kind: 'alert', outcome: 'success' },
         kibana: {
           alerting: {
+            consumer: 'bar',
             status: 'active',
           },
           task: {
             schedule_delay: 0,
             scheduled: '1970-01-01T00:00:00.000Z',
           },
+          space_ids: ['default'],
           saved_objects: [
             {
               id: '1',
@@ -672,6 +691,10 @@ describe('Task Runner', () => {
           schedule_delay: 0,
           scheduled: '1970-01-01T00:00:00.000Z',
         },
+        space_ids: ['default'],
+        alerting: {
+          consumer: 'bar',
+        },
         saved_objects: [
           {
             id: '1',
@@ -699,8 +722,10 @@ describe('Task Runner', () => {
         start: '1970-01-01T00:00:00.000Z',
       },
       kibana: {
+        space_ids: ['default'],
         alerting: {
           action_group_id: 'default',
+          consumer: 'bar',
           instance_id: '1',
         },
         saved_objects: [
@@ -719,7 +744,6 @@ describe('Task Runner', () => {
         id: '1',
         license: 'basic',
         name: 'alert-name',
-        namespace: undefined,
         ruleset: 'alerts',
       },
     });
@@ -732,9 +756,11 @@ describe('Task Runner', () => {
         start: '1970-01-01T00:00:00.000Z',
       },
       kibana: {
+        space_ids: ['default'],
         alerting: {
           instance_id: '1',
           action_group_id: 'default',
+          consumer: 'bar',
         },
         saved_objects: [
           {
@@ -752,7 +778,6 @@ describe('Task Runner', () => {
         id: '1',
         license: 'basic',
         name: 'alert-name',
-        namespace: undefined,
         ruleset: 'alerts',
       },
     });
@@ -765,8 +790,10 @@ describe('Task Runner', () => {
         outcome: 'success',
       },
       kibana: {
+        space_ids: ['default'],
         alerting: {
           status: 'active',
+          consumer: 'bar',
         },
         task: {
           schedule_delay: 0,
@@ -927,6 +954,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -935,6 +965,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -964,6 +997,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -974,6 +1008,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -999,6 +1036,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -1009,6 +1047,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -1241,7 +1282,7 @@ describe('Task Runner', () => {
             },
             "type": "SAVED_OBJECT",
           },
-          "spaceId": undefined,
+          "spaceId": "default",
         },
       ]
     `);
@@ -1262,6 +1303,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -1270,6 +1314,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -1299,6 +1346,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -1309,6 +1357,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' created new instance: '1'",
@@ -1335,6 +1386,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -1345,6 +1397,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -1370,22 +1425,24 @@ describe('Task Runner', () => {
               "alerting": Object {
                 "action_group_id": "default",
                 "action_subgroup": undefined,
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
                 Object {
                   "id": "1",
-                  "namespace": undefined,
                   "rel": "primary",
                   "type": "alert",
                   "type_id": "test",
                 },
                 Object {
                   "id": "1",
-                  "namespace": undefined,
                   "type": "action",
                   "type_id": "action",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "alert: test:1: 'alert-name' instanceId: '1' scheduled actionGroup: 'default' action: action:1",
@@ -1411,6 +1468,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -1421,6 +1479,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -1558,6 +1619,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -1566,6 +1630,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -1595,6 +1662,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -1605,6 +1673,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' instance '2' has recovered",
@@ -1631,6 +1702,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -1641,6 +1713,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -1666,22 +1741,24 @@ describe('Task Runner', () => {
               "alerting": Object {
                 "action_group_id": "recovered",
                 "action_subgroup": undefined,
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
                 Object {
                   "id": "1",
-                  "namespace": undefined,
                   "rel": "primary",
                   "type": "alert",
                   "type_id": "test",
                 },
                 Object {
                   "id": "2",
-                  "namespace": undefined,
                   "type": "action",
                   "type_id": "action",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "alert: test:1: 'alert-name' instanceId: '2' scheduled actionGroup: 'recovered' action: action:2",
@@ -1707,22 +1784,24 @@ describe('Task Runner', () => {
               "alerting": Object {
                 "action_group_id": "default",
                 "action_subgroup": undefined,
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
                 Object {
                   "id": "1",
-                  "namespace": undefined,
                   "rel": "primary",
                   "type": "alert",
                   "type_id": "test",
                 },
                 Object {
                   "id": "1",
-                  "namespace": undefined,
                   "type": "action",
                   "type_id": "action",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "alert: test:1: 'alert-name' instanceId: '1' scheduled actionGroup: 'default' action: action:1",
@@ -1748,6 +1827,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -1758,6 +1838,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -1801,7 +1884,7 @@ describe('Task Runner', () => {
             },
             "type": "SAVED_OBJECT",
           },
-          "spaceId": undefined,
+          "spaceId": "default",
         },
       ]
     `);
@@ -1852,6 +1935,8 @@ describe('Task Runner', () => {
           },
           params: {
             alertId,
+            alertConsumer: 'my-consumer',
+            spaceId: 'default',
           },
         },
         customTaskRunnerFactoryInitializerParams
@@ -2030,7 +2115,7 @@ describe('Task Runner', () => {
             },
             "type": "SAVED_OBJECT",
           },
-          "spaceId": undefined,
+          "spaceId": "default",
         },
       ]
     `);
@@ -2125,6 +2210,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -2133,6 +2221,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2163,6 +2254,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -2173,6 +2265,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' instance '2' has recovered",
@@ -2199,6 +2294,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -2209,6 +2305,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -2234,6 +2333,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -2244,6 +2344,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2461,6 +2564,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -2469,6 +2575,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2501,6 +2610,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "error",
               },
               "saved_objects": Array [
@@ -2511,6 +2621,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2570,6 +2683,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -2578,6 +2694,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2610,6 +2729,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "error",
               },
               "saved_objects": Array [
@@ -2620,6 +2740,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2687,6 +2810,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -2695,6 +2821,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2727,6 +2856,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "error",
               },
               "saved_objects": Array [
@@ -2737,6 +2867,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2804,6 +2937,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -2812,6 +2948,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2844,6 +2983,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "error",
               },
               "saved_objects": Array [
@@ -2854,6 +2994,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2920,6 +3063,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -2928,6 +3074,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -2960,6 +3109,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "error",
               },
               "saved_objects": Array [
@@ -2970,6 +3120,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3210,6 +3363,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -3218,6 +3374,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3247,6 +3406,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -3257,6 +3417,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' created new instance: '1'",
@@ -3283,6 +3446,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -3293,6 +3457,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' created new instance: '2'",
@@ -3319,6 +3486,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -3329,6 +3497,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -3355,6 +3526,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -3365,6 +3537,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '2' in actionGroup: 'default'",
@@ -3390,6 +3565,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -3400,6 +3576,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3496,6 +3675,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -3504,6 +3686,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3533,6 +3718,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -3543,6 +3729,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -3569,6 +3758,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -3579,6 +3769,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '2' in actionGroup: 'default'",
@@ -3604,6 +3797,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -3614,6 +3808,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3702,6 +3899,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -3710,6 +3910,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3737,6 +3940,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -3747,6 +3951,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '1' in actionGroup: 'default'",
@@ -3771,6 +3978,7 @@ describe('Task Runner', () => {
             "kibana": Object {
               "alerting": Object {
                 "action_group_id": "default",
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -3781,6 +3989,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' active instance: '2' in actionGroup: 'default'",
@@ -3806,6 +4017,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "active",
               },
               "saved_objects": Array [
@@ -3816,6 +4028,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3899,6 +4114,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -3907,6 +4125,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -3936,6 +4157,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -3946,6 +4168,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' instance '1' has recovered",
@@ -3972,6 +4197,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -3982,6 +4208,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' instance '2' has recovered",
@@ -4007,6 +4236,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "ok",
               },
               "saved_objects": Array [
@@ -4017,6 +4247,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -4102,6 +4335,9 @@ describe('Task Runner', () => {
               "kind": "alert",
             },
             "kibana": Object {
+              "alerting": Object {
+                "consumer": "bar",
+              },
               "saved_objects": Array [
                 Object {
                   "id": "1",
@@ -4110,6 +4346,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -4136,6 +4375,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "instance_id": "1",
               },
               "saved_objects": Array [
@@ -4146,6 +4386,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' instance '1' has recovered",
@@ -4169,6 +4412,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "instance_id": "2",
               },
               "saved_objects": Array [
@@ -4179,6 +4423,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
             },
             "message": "test:1: 'alert-name' instance '2' has recovered",
@@ -4204,6 +4451,7 @@ describe('Task Runner', () => {
             },
             "kibana": Object {
               "alerting": Object {
+                "consumer": "bar",
                 "status": "ok",
               },
               "saved_objects": Array [
@@ -4214,6 +4462,9 @@ describe('Task Runner', () => {
                   "type": "alert",
                   "type_id": "test",
                 },
+              ],
+              "space_ids": Array [
+                "default",
               ],
               "task": Object {
                 "schedule_delay": 0,
@@ -4350,6 +4601,9 @@ describe('Task Runner', () => {
           "kind": "alert",
         },
         "kibana": Object {
+          "alerting": Object {
+            "consumer": "bar",
+          },
           "saved_objects": Array [
             Object {
               "id": "1",
@@ -4358,6 +4612,9 @@ describe('Task Runner', () => {
               "type": "alert",
               "type_id": "test",
             },
+          ],
+          "space_ids": Array [
+            "default",
           ],
           "task": Object {
             "schedule_delay": 0,

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -28,6 +28,7 @@ import {
   Services,
   RawAlertInstance,
   AlertTaskState,
+  AlertTaskParams,
   Alert,
   SanitizedAlert,
   AlertExecutionStatus,
@@ -65,6 +66,7 @@ interface AlertTaskRunResult {
 }
 
 interface AlertTaskInstance extends ConcreteTaskInstance {
+  params: AlertTaskParams;
   state: AlertTaskState;
 }
 
@@ -450,7 +452,7 @@ export class TaskRunner<
       alertId,
       alert.name,
       alert.tags,
-      spaceId,
+      spaceId || 'default',
       apiKey,
       this.context.kibanaBaseUrl,
       alert.actions,
@@ -462,7 +464,7 @@ export class TaskRunner<
       alert,
       validatedParams,
       executionHandler,
-      spaceId,
+      spaceId || 'default',
       event
     );
   }
@@ -473,11 +475,14 @@ export class TaskRunner<
     } = this.taskInstance;
     let apiKey: string | null;
     try {
-      apiKey = await this.getApiKeyForAlertPermissions(alertId, spaceId);
+      apiKey = await this.getApiKeyForAlertPermissions(alertId, spaceId || 'default');
     } catch (err) {
       throw new ErrorWithReason(AlertExecutionStatusErrorReasons.Decrypt, err);
     }
-    const [services, rulesClient] = this.getServicesWithSpaceLevelPermissions(spaceId, apiKey);
+    const [services, rulesClient] = this.getServicesWithSpaceLevelPermissions(
+      spaceId || 'default',
+      apiKey
+    );
 
     let alert: SanitizedAlert<Params>;
 

--- a/x-pack/plugins/event_log/generated/mappings.json
+++ b/x-pack/plugins/event_log/generated/mappings.json
@@ -237,6 +237,13 @@
                     "type": "keyword",
                     "ignore_above": 1024
                 },
+                "space_ids": {
+                    "type": "keyword",
+                    "ignore_above": 1024,
+                    "meta": {
+                        "isArray": "true"
+                    }
+                },
                 "task": {
                     "properties": {
                         "scheduled": {
@@ -262,6 +269,10 @@
                             "ignore_above": 1024
                         },
                         "status": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        },
+                        "consumer": {
                             "type": "keyword",
                             "ignore_above": 1024
                         }

--- a/x-pack/plugins/event_log/generated/schemas.ts
+++ b/x-pack/plugins/event_log/generated/schemas.ts
@@ -102,6 +102,7 @@ export const EventSchema = schema.maybe(
     kibana: schema.maybe(
       schema.object({
         server_uuid: ecsString(),
+        space_ids: ecsStringMulti(),
         task: schema.maybe(
           schema.object({
             scheduled: ecsDate(),
@@ -114,6 +115,7 @@ export const EventSchema = schema.maybe(
             action_group_id: ecsString(),
             action_subgroup: ecsString(),
             status: ecsString(),
+            consumer: ecsString(),
           })
         ),
         saved_objects: schema.maybe(

--- a/x-pack/plugins/event_log/scripts/mappings.js
+++ b/x-pack/plugins/event_log/scripts/mappings.js
@@ -17,6 +17,10 @@ exports.EcsCustomPropertyMappings = {
         type: 'keyword',
         ignore_above: 1024,
       },
+      space_ids: {
+        type: 'keyword',
+        ignore_above: 1024,
+      },
       // task specific fields
       task: {
         properties: {
@@ -44,6 +48,10 @@ exports.EcsCustomPropertyMappings = {
             ignore_above: 1024,
           },
           status: {
+            type: 'keyword',
+            ignore_above: 1024,
+          },
+          consumer: {
             type: 'keyword',
             ignore_above: 1024,
           },
@@ -105,4 +113,10 @@ exports.EcsPropertiesToGenerate = [
 /**
  * These properties can have multiple values (are arrays in the generated event schema).
  */
-exports.EcsEventLogMultiValuedProperties = ['tags', 'event.category', 'event.type', 'rule.author'];
+exports.EcsEventLogMultiValuedProperties = [
+  'tags',
+  'event.category',
+  'event.type',
+  'rule.author',
+  'kibana.space_ids',
+];

--- a/x-pack/plugins/event_log/server/es/cluster_client_adapter.mock.ts
+++ b/x-pack/plugins/event_log/server/es/cluster_client_adapter.mock.ts
@@ -18,6 +18,7 @@ const createClusterClientMock = () => {
     doesAliasExist: jest.fn(),
     createIndex: jest.fn(),
     queryEventsBySavedObjects: jest.fn(),
+    queryEvents: jest.fn(),
     shutdown: jest.fn(),
   };
   return mock;

--- a/x-pack/plugins/event_log/server/event_log_client.ts
+++ b/x-pack/plugins/event_log/server/event_log_client.ts
@@ -103,4 +103,17 @@ export class EventLogClient implements IEventLogClient {
       legacyIds,
     });
   }
+
+  async findEvents(options?: Partial<FindOptionsType>): Promise<QueryEventsBySavedObjectResult> {
+    const findOptions = findOptionsSchema.validate(options ?? {});
+
+    // Use 'default' if spaces plugin is not enabled
+    const spaceId = this.spacesService ? this.spacesService.getSpaceId(this.request) : 'default';
+
+    return await this.esContext.esAdapter.queryEvents(
+      this.esContext.esNames.indexPattern,
+      spaceId,
+      findOptions
+    );
+  }
 }

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/create.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/create.ts
@@ -136,6 +136,7 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
               expect(JSON.parse(taskRecord.task.params)).to.eql({
                 alertId: response.body.id,
                 spaceId: space.id,
+                alertConsumer: 'alertsFixture',
               });
               // Ensure AAD isn't broken
               await checkAAD({

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/enable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/enable.ts
@@ -128,6 +128,7 @@ export default function createEnableAlertTests({ getService }: FtrProviderContex
               expect(JSON.parse(taskRecord.task.params)).to.eql({
                 alertId: createdAlert.id,
                 spaceId: space.id,
+                alertConsumer: 'alertsFixture',
               });
               // Ensure AAD isn't broken
               await checkAAD({
@@ -358,6 +359,7 @@ export default function createEnableAlertTests({ getService }: FtrProviderContex
               expect(JSON.parse(taskRecord.task.params)).to.eql({
                 alertId: createdAlert.id,
                 spaceId: space.id,
+                alertConsumer: 'alertsFixture',
               });
               // Ensure AAD isn't broken
               await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/create.ts
@@ -445,6 +445,7 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
         expect(JSON.parse(taskRecord.task.params)).to.eql({
           alertId: response.body.id,
           spaceId: Spaces.space1.id,
+          alertConsumer: 'alertsFixture',
         });
         // Ensure AAD isn't broken
         await checkAAD({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/enable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/enable.ts
@@ -58,6 +58,7 @@ export default function createEnableAlertTests({ getService }: FtrProviderContex
       expect(JSON.parse(taskRecord.task.params)).to.eql({
         alertId: createdAlert.id,
         spaceId: Spaces.space1.id,
+        alertConsumer: 'alertsFixture',
       });
 
       // Ensure AAD isn't broken
@@ -109,6 +110,7 @@ export default function createEnableAlertTests({ getService }: FtrProviderContex
         expect(JSON.parse(taskRecord.task.params)).to.eql({
           alertId: createdAlert.id,
           spaceId: Spaces.space1.id,
+          alertConsumer: 'alertsFixture',
         });
 
         // Ensure AAD isn't broken


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
