### PR TITLE
[kbn/es-archiver] fix flaky test

### DIFF
--- a/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.test.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.test.ts
@@ -99,10 +99,8 @@ const testRecords = [
   },
 ];
 
-// FLAKY: https://github.com/elastic/kibana/issues/108043
-it.skip('indexes documents using the bulk client helper', async () => {
+it('indexes documents using the bulk client helper', async () => {
   const client = new MockClient();
-  client.helpers.bulk.mockImplementation(async () => {});
 
   const progress = new Progress();
   const stats = createStats('test', log);
@@ -186,11 +184,11 @@ it.skip('indexes documents using the bulk client helper', async () => {
       "results": Array [
         Object {
           "type": "return",
-          "value": Promise {},
+          "value": undefined,
         },
         Object {
           "type": "return",
-          "value": Promise {},
+          "value": undefined,
         },
       ],
     }


### PR DESCRIPTION
Fixes flaky test https://github.com/elastic/kibana/issues/108043 by not returning a promise and then snapshotting it, which can apparently be flaky.