### PR TITLE
Spike: Remove angular from stack monitoring

### DIFF
--- a/x-pack/plugins/monitoring/public/application.tsx
+++ b/x-pack/plugins/monitoring/public/application.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { History } from 'history';
+import { CoreStart, AppMountParameters } from 'kibana/public';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Route, Router, Switch } from 'react-router-dom';
+import { KibanaContextProvider } from '../../../../src/plugins/kibana_react/public';
+import { MonitoringStartPluginDependencies } from './types';
+import { OverviewPage } from './react/overview_page';
+
+export const renderApp = (
+  core: CoreStart,
+  plugins: MonitoringStartPluginDependencies,
+  { element, history, setHeaderActionMenu }: AppMountParameters
+) => {
+  ReactDOM.render(<MonitoringApp history={history} core={core} plugins={plugins} />, element);
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(element);
+  };
+};
+
+const MonitoringApp: React.FC<{
+  core: CoreStart;
+  history: History<unknown>;
+  plugins: MonitoringStartPluginDependencies;
+}> = ({ core, history, plugins }) => {
+  return (
+    <KibanaContextProvider services={{ ...core, ...plugins }}>
+      <Router history={history}>
+        <Switch>
+          <Route path="/overview" component={OverviewPage} />
+        </Switch>
+      </Router>
+    </KibanaContextProvider>
+  );
+};

--- a/x-pack/plugins/monitoring/public/components/cluster/overview/helpers.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/helpers.js
@@ -18,7 +18,6 @@ import {
 import { i18n } from '@kbn/i18n';
 import { get } from 'lodash';
 import React from 'react';
-import { Legacy } from '../../../legacy_shims';
 import { formatBytesUsage, formatNumber, formatPercentageUsage } from '../../../lib/format_number';
 
 export function HealthLabel(props) {
@@ -50,7 +49,7 @@ export function HealthLabel(props) {
         {i18n.translate('xpack.monitoring.cluster.health.pluginIssues', {
           defaultMessage: 'Some plugins may be experiencing issues. Please check ',
         })}
-        <EuiLink href={`${Legacy.shims.getBasePath()}/status`}>the Kibana status page</EuiLink>.
+        <EuiLink href="/status">the Kibana status page</EuiLink>.
       </EuiText>
     );
   }

--- a/x-pack/plugins/monitoring/public/components/cluster/overview/index.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/index.js
@@ -6,12 +6,13 @@
  */
 
 import React, { Fragment } from 'react';
+// import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { ElasticsearchPanel } from './elasticsearch_panel';
-import { KibanaPanel } from './kibana_panel';
-import { LogstashPanel } from './logstash_panel';
-import { BeatsPanel } from './beats_panel';
+// import { KibanaPanel } from './kibana_panel';
+// import { LogstashPanel } from './logstash_panel';
+// import { BeatsPanel } from './beats_panel';
 import { EuiPage, EuiPageBody, EuiScreenReaderOnly } from '@elastic/eui';
-import { ApmPanel } from './apm_panel';
+// import { ApmPanel } from './apm_panel';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { STANDALONE_CLUSTER_CLUSTER_UUID } from '../../../../common/constants';
 
@@ -40,15 +41,15 @@ export function Overview(props) {
               showLicenseExpiration={props.showLicenseExpiration}
               alerts={props.alerts}
             />
-            <KibanaPanel
+            {/* <KibanaPanel
               {...props.cluster.kibana}
               setupMode={props.setupMode}
               alerts={props.alerts}
-            />
+            /> */}
           </Fragment>
         ) : null}
 
-        <LogstashPanel
+        {/* <LogstashPanel
           {...props.cluster.logstash}
           setupMode={props.setupMode}
           alerts={props.alerts}
@@ -56,7 +57,7 @@ export function Overview(props) {
 
         <BeatsPanel {...props.cluster.beats} setupMode={props.setupMode} alerts={props.alerts} />
 
-        <ApmPanel {...props.cluster.apm} setupMode={props.setupMode} alerts={props.alerts} />
+        <ApmPanel {...props.cluster.apm} setupMode={props.setupMode} alerts={props.alerts} /> */}
       </EuiPageBody>
     </EuiPage>
   );

--- a/x-pack/plugins/monitoring/public/components/logs/reason.js
+++ b/x-pack/plugins/monitoring/public/components/logs/reason.js
@@ -9,13 +9,12 @@ import React from 'react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { Legacy } from '../../legacy_shims';
 import { Monospace } from '../metricbeat_migration/instruction_steps/components/monospace/monospace';
 
 export const Reason = ({ reason }) => {
-  const filebeatUrl = Legacy.shims.docLinks.links.filebeat.installation;
-  const elasticsearchUrl = Legacy.shims.docLinks.links.filebeat.elasticsearchModule;
-  const troubleshootUrl = Legacy.shims.docLinks.links.monitoring.troubleshootKibana;
+  const filebeatUrl = 'http://aUrl.com';
+  const elasticsearchUrl = 'http://aUrl.com';
+  const troubleshootUrl = 'http://aUrl.com';
   let title = i18n.translate('xpack.monitoring.logs.reason.defaultTitle', {
     defaultMessage: 'No log data found',
   });

--- a/x-pack/plugins/monitoring/public/legacy_shims.ts
+++ b/x-pack/plugins/monitoring/public/legacy_shims.ts
@@ -142,9 +142,9 @@ export class Legacy {
   }
 
   public static get shims(): Readonly<IShims> {
-    if (!Legacy._shims) {
-      throw new Error('Legacy needs to be initiated with Legacy.init(...) before use');
-    }
+    // if (!Legacy._shims) {
+    //   console.log('Legacy needs to be initiated with Legacy.init(...) before use');
+    // }
     return Legacy._shims;
   }
 }

--- a/x-pack/plugins/monitoring/public/react/overview_page.tsx
+++ b/x-pack/plugins/monitoring/public/react/overview_page.tsx
@@ -22,7 +22,10 @@ export const OverviewPage = () => {
   useEffect(() => {
     // from services/clusters.js
     const fetchClusters = async () => {
-      const url = '/api/monitoring/v1/clusters/dltQ_pDUTOW04Do08ltpdA';
+      // hardcoding the cluster uuid. For some reason /clusters and /clusters/:cluster_uuid
+      // returns different data for a cluster, so the overview component crashes because
+      // it's missing some expected data
+      const url = '/api/monitoring/v1/clusters/rZvPbJdeQfyVdw2FWUKO-w';
       const max = moment();
       const min = moment().subtract(15, 'm');
 
@@ -40,19 +43,30 @@ export const OverviewPage = () => {
         });
 
         setData(response[0]);
+
+        // Just testing toast notifications
+        kibana.notifications.toasts.warning({
+          toastLifeTimeMs: 3000,
+          title: 'Data has been loaded successfully',
+          body: (
+            <div>
+              <h5>This is the toast content</h5>
+            </div>
+          ),
+        });
       } catch (err) {
         // TODO: handle error
       }
     };
 
     fetchClusters();
-  }, [kibana.services.http]);
+  }, [kibana.services.http, kibana.notifications.toasts]);
 
   return (
     <EuiErrorBoundary>
-      {data && (
+      {data ? (
         <Overview cluster={data} alerts={{}} setupMode={false} showLicenseExpiration={false} />
-      )}
+      ) : null}
     </EuiErrorBoundary>
   );
 };

--- a/x-pack/plugins/monitoring/public/react/overview_page.tsx
+++ b/x-pack/plugins/monitoring/public/react/overview_page.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiErrorBoundary } from '@elastic/eui';
+import React, { useState, useEffect, useCallback } from 'react';
+import moment from 'moment';
+import { useKibana } from '../../../../../src/plugins/kibana_react/public';
+import { Overview } from '../components/cluster/overview';
+
+import { CODE_PATH_ALL } from '../../common/constants';
+
+const CODE_PATHS = [CODE_PATH_ALL];
+
+export const OverviewPage = () => {
+  const [data, setData] = useState(undefined);
+  const kibana = useKibana();
+
+  useEffect(() => {
+    // from services/clusters.js
+    const fetchClusters = async () => {
+      const url = '/api/monitoring/v1/clusters/dltQ_pDUTOW04Do08ltpdA';
+      const max = moment();
+      const min = moment().subtract(15, 'm');
+
+      try {
+        const response = await kibana.services.http.fetch(url, {
+          method: 'POST',
+          body: JSON.stringify({
+            css: undefined,
+            timeRange: {
+              min: min.toISOString(),
+              max: max.toISOString(),
+            },
+            codePaths: CODE_PATHS,
+          }),
+        });
+
+        setData(response[0]);
+      } catch (err) {
+        // TODO: handle error
+      }
+    };
+
+    fetchClusters();
+  }, [kibana.services.http]);
+
+  return (
+    <EuiErrorBoundary>
+      {data && (
+        <Overview cluster={data} alerts={{}} setupMode={false} showLicenseExpiration={false} />
+      )}
+    </EuiErrorBoundary>
+  );
+};

--- a/x-pack/plugins/monitoring/server/config.ts
+++ b/x-pack/plugins/monitoring/server/config.ts
@@ -49,6 +49,7 @@ export const configSchema = schema.object({
     }),
     min_interval_seconds: schema.number({ defaultValue: 10 }),
     show_license_expiration: schema.boolean({ defaultValue: true }),
+    render_react_app: schema.boolean({ defaultValue: false }),
   }),
   kibana: schema.object({
     collection: schema.object({


### PR DESCRIPTION
**This PR is not meant to be merged. Is just a spike to validate the approach that we will take in order to remove angular from stack monitoring.**

It adds a feature toggle that renders a react app with one route: `/overview`. The page renders the elasticsearch panel from the overview page (with a hardcoded clusterId)