### PR TITLE
chore(NA): moving @kbn/crypto to babel transpiler

### DIFF
--- a/packages/kbn-crypto/.babelrc
+++ b/packages/kbn-crypto/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-crypto/BUILD.bazel
+++ b/packages/kbn-crypto/BUILD.bazel
@@ -63,7 +63,6 @@ ts_project(
   declaration = True,
   declaration_map = True,
   emit_declaration_only = True,
-  incremental = False,
   out_dir = "target_types",
   source_map = True,
   root_dir = "src",

--- a/packages/kbn-crypto/BUILD.bazel
+++ b/packages/kbn-crypto/BUILD.bazel
@@ -1,6 +1,7 @@
 
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-crypto"
 PKG_REQUIRE_NAME = "@kbn/crypto"
@@ -26,22 +27,24 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md"
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-dev-utils",
   "@npm//node-forge",
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-dev-utils",
   "@npm//@types/flot",
   "@npm//@types/jest",
   "@npm//@types/node",
   "@npm//@types/node-forge",
-  "@npm//@types/testing-library__jest-dom",
-  "@npm//resize-observer-polyfill",
-  "@npm//@emotion/react",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -53,13 +56,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -68,7 +73,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-crypto/package.json
+++ b/packages/kbn-crypto/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts"
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts"
 }

--- a/packages/kbn-crypto/tsconfig.json
+++ b/packages/kbn-crypto/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "incremental": false,
     "outDir": "./target_types",
     "rootDir": "src",
     "sourceMap": true,

--- a/packages/kbn-crypto/tsconfig.json
+++ b/packages/kbn-crypto/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.bazel.json",
   "compilerOptions": {
-    "outDir": "./target/types",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "./target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-crypto/src",


### PR DESCRIPTION
One step forward on #69706

That PR moves the @kbn/crypto from using tsc compiler to babel transpiler to produce the js outputs.