### PR TITLE
[ML] Adds initial record score to the anomalies table expanded row content

### DIFF
--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.js
@@ -190,7 +190,7 @@ function getDetailsItems(anomaly, filter) {
         position="left"
         content={i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.recordScoreTooltip', {
           defaultMessage:
-            'A normalized score between 0-100, which indicates the relative significance of the anomaly record result.',
+            'A normalized score between 0-100, which indicates the relative significance of the anomaly record result. This value might change as new data is analyzed.',
         })}
       >
         <span>
@@ -212,7 +212,7 @@ function getDetailsItems(anomaly, filter) {
           'xpack.ml.anomaliesTable.anomalyDetails.initialRecordScoreTooltip',
           {
             defaultMessage:
-              'A normalized score between 0-100, which indicates the relative significance of the anomaly record result. This is the initial value that was calculated at the time the bucket was processed.',
+              'A normalized score between 0-100, which indicates the relative significance of the anomaly record when the bucket was initially processed.',
           }
         )}
       >

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.js
@@ -26,6 +26,7 @@ import {
   EuiSpacer,
   EuiTabbedContent,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import { formatHumanReadableDateTimeSeconds } from '../../../../common/util/date_utils';
 
@@ -47,7 +48,7 @@ function getFilterEntity(entityName, entityValue, filter) {
   return <EntityCell entityName={entityName} entityValue={entityValue} filter={filter} />;
 }
 
-function getDetailsItems(anomaly, examples, filter) {
+function getDetailsItems(anomaly, filter) {
   const source = anomaly.source;
 
   // TODO - when multivariate analyses are more common,
@@ -184,10 +185,53 @@ function getDetailsItems(anomaly, examples, filter) {
   }
 
   items.push({
+    title: (
+      <EuiToolTip
+        position="left"
+        content={i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.recordScoreTooltip', {
+          defaultMessage:
+            'A normalized score between 0-100, which indicates the relative significance of the anomaly record result.',
+        })}
+      >
+        <span>
+          {i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.recordScoreTitle', {
+            defaultMessage: 'Record score',
+          })}
+          <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+        </span>
+      </EuiToolTip>
+    ),
+    description: Math.floor(1000 * source.record_score) / 1000,
+  });
+
+  items.push({
+    title: (
+      <EuiToolTip
+        position="left"
+        content={i18n.translate(
+          'xpack.ml.anomaliesTable.anomalyDetails.initialRecordScoreTooltip',
+          {
+            defaultMessage:
+              'A normalized score between 0-100, which indicates the relative significance of the anomaly record result. This is the initial value that was calculated at the time the bucket was processed.',
+          }
+        )}
+      >
+        <span>
+          {i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.initialRecordScoreTitle', {
+            defaultMessage: 'Initial record score',
+          })}
+          <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+        </span>
+      </EuiToolTip>
+    ),
+    description: Math.floor(1000 * source.initial_record_score) / 1000,
+  });
+
+  items.push({
     title: i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.probabilityTitle', {
       defaultMessage: 'Probability',
     }),
-    description: source.probability,
+    description: Number.parseFloat(source.probability).toPrecision(3),
   });
 
   // If there was only one cause, the actual, typical and by_field
@@ -469,7 +513,7 @@ export class AnomalyDetails extends Component {
   }
 
   renderDetails() {
-    const detailItems = getDetailsItems(this.props.anomaly, this.props.examples, this.props.filter);
+    const detailItems = getDetailsItems(this.props.anomaly, this.props.filter);
     const isInterimResult = get(this.props.anomaly, 'source.is_interim', false);
     return (
       <React.Fragment>

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/anomaly_details.js
@@ -231,7 +231,8 @@ function getDetailsItems(anomaly, filter) {
     title: i18n.translate('xpack.ml.anomaliesTable.anomalyDetails.probabilityTitle', {
       defaultMessage: 'Probability',
     }),
-    description: Number.parseFloat(source.probability).toPrecision(3),
+    description:
+      source.probability !== undefined ? Number.parseFloat(source.probability).toPrecision(3) : '',
   });
 
   // If there was only one cause, the actual, typical and by_field


### PR DESCRIPTION
## Summary

Adds initial record score, as well as record score, to the information displayed in the expanded rows of the anomalies table.

Users sometimes question why an anomaly may "feel" like it should have been scored differently (usually higher). Often an anomaly is scored highly while the bucket is open, but later rescored lower and the user only sees that normalized score. To provide a little more insight, the initial record score is now shown in the expanded rows.

![image](https://user-images.githubusercontent.com/7405507/129167211-358e8f40-f965-4128-ba5b-118e5dd03ee5.png)

Also lowers the precision used for the `probability` value to 3 significant figures.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixes #106563
