### PR TITLE
[Fleet] Link to Add Data (Beats tutorials) when there are no integrations found

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
@@ -61,8 +61,8 @@ export const DefaultLayout: React.FunctionComponent<Props> = memo(({ section, ch
           <EuiText>
             <h1>
               <FormattedMessage
-                id="xpack.fleet.integrationsAppTitle"
-                defaultMessage="Integrations"
+                id="xpack.fleet.integrationsHeaderTitle"
+                defaultMessage="Elastic Agent Integrations"
               />
             </h1>
           </EuiText>

--- a/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/layouts/default.tsx
@@ -74,7 +74,7 @@ export const DefaultLayout: React.FunctionComponent<Props> = memo(({ section, ch
               <p>
                 <FormattedMessage
                   id="xpack.fleet.epm.pageSubtitle"
-                  defaultMessage="Collect data from popular apps and services."
+                  defaultMessage="Collect data from popular apps and services using Elastic Agent"
                 />
               </p>
             </EuiText>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
@@ -22,6 +22,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
+import { useStartServices } from '../../../../../hooks';
 import { Loading } from '../../../components';
 import type { PackageList } from '../../../types';
 import { useLocalSearch, searchIdField } from '../../../hooks';
@@ -191,6 +192,9 @@ function MissingIntegrationContent({
   resetQuery,
   setSelectedCategory,
 }: MissingIntegrationContentProps) {
+  const {
+    application: { getUrlForApp },
+  } = useStartServices();
   const handleCustomInputsLinkClick = useCallback(() => {
     resetQuery();
     setSelectedCategory('custom');
@@ -201,7 +205,7 @@ function MissingIntegrationContent({
       <p>
         <FormattedMessage
           id="xpack.fleet.integrations.missing"
-          defaultMessage="Don't see an integration? Collect any logs or metrics using our {customInputsLink}. Request new integrations using our {discussForumLink}."
+          defaultMessage="Don't see an integration? Collect any logs or metrics using our {customInputsLink}, or set up {beatsTutorialLink}. Request new integrations using our {discussForumLink}."
           values={{
             customInputsLink: (
               <EuiLink onClick={handleCustomInputsLinkClick}>
@@ -216,6 +220,14 @@ function MissingIntegrationContent({
                 <FormattedMessage
                   id="xpack.fleet.integrations.discussForumLink"
                   defaultMessage="discuss forum"
+                />
+              </EuiLink>
+            ),
+            beatsTutorialLink: (
+              <EuiLink href={getUrlForApp('home', { path: '#/tutorial_directory' })}>
+                <FormattedMessage
+                  id="xpack.fleet.integrations.customInputsLink"
+                  defaultMessage="individual Beats"
                 />
               </EuiLink>
             ),

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
@@ -205,7 +205,7 @@ function MissingIntegrationContent({
       <p>
         <FormattedMessage
           id="xpack.fleet.integrations.missing"
-          defaultMessage="Don't see an integration? Collect any logs or metrics using our {customInputsLink}, or set up {beatsTutorialLink}. Request new integrations using our {discussForumLink}."
+          defaultMessage="Don't see an integration? Collect any logs or metrics using our {customInputsLink}, or add data using {beatsTutorialLink}. Request new integrations using our {discussForumLink}."
           values={{
             customInputsLink: (
               <EuiLink onClick={handleCustomInputsLinkClick}>
@@ -226,8 +226,8 @@ function MissingIntegrationContent({
             beatsTutorialLink: (
               <EuiLink href={getUrlForApp('home', { path: '#/tutorial_directory' })}>
                 <FormattedMessage
-                  id="xpack.fleet.integrations.customInputsLink"
-                  defaultMessage="individual Beats"
+                  id="xpack.fleet.integrations.beatsModulesLink"
+                  defaultMessage="Beats modules"
                 />
               </EuiLink>
             ),

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -9832,7 +9832,6 @@
     "xpack.fleet.integrations.discussForumLink": "ディスカッションフォーラム",
     "xpack.fleet.integrations.installPackage.installingPackageButtonLabel": "{title} アセットをインストールしています",
     "xpack.fleet.integrations.installPackage.installPackageButtonLabel": "{title}アセットをインストール",
-    "xpack.fleet.integrations.missing": "統合が表示されない場合{customInputsLink}を使用してログまたはメトリックを収集してください。{discussForumLink}を使用して新しい統合を要求してください。",
     "xpack.fleet.integrations.packageInstallErrorDescription": "このパッケージのインストール中に問題が発生しました。しばらくたってから再試行してください。",
     "xpack.fleet.integrations.packageInstallErrorTitle": "{title}パッケージをインストールできませんでした",
     "xpack.fleet.integrations.packageInstallSuccessDescription": "正常に{title}をインストールしました",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10094,7 +10094,6 @@
     "xpack.fleet.integrations.discussForumLink": "讨论论坛",
     "xpack.fleet.integrations.installPackage.installingPackageButtonLabel": "正在安装 {title} 资产",
     "xpack.fleet.integrations.installPackage.installPackageButtonLabel": "安装 {title} 资产",
-    "xpack.fleet.integrations.missing": "未看到集成？使用我们的{customInputsLink}收集任何日志或指标。使用{discussForumLink}请求新的集成。",
     "xpack.fleet.integrations.packageInstallErrorDescription": "尝试安装此软件包时出现问题。请稍后重试。",
     "xpack.fleet.integrations.packageInstallErrorTitle": "无法安装 {title} 软件包",
     "xpack.fleet.integrations.packageInstallSuccessDescription": "已成功安装 {title}",


### PR DESCRIPTION
## Summary

Relates to #107682. This PR adds a link to Add Data tutorials directory when there are no integrations found from the user's query, in addition to the existing link for a custom input:

![image](https://user-images.githubusercontent.com/1965714/129060356-4fed558a-368c-4cab-958c-481899e26cd4.png)