### PR TITLE
[Enterprise Search] Fix search not working on some table columns on Users and Roles page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -219,7 +219,7 @@ export const ROLE_MAPPINGS_HEADING_BUTTON = i18n.translate(
 
 export const ROLE_MAPPINGS_NO_RESULTS_MESSAGE = i18n.translate(
   'xpack.enterpriseSearch.roleMapping.noResults.message',
-  { defaultMessage: 'Create a new role mapping' }
+  { defaultMessage: 'No matching role mappings found' }
 );
 
 export const ROLES_DISABLED_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.test.tsx
@@ -10,8 +10,10 @@ import { wsRoleMapping, asRoleMapping } from './__mocks__/roles';
 import React from 'react';
 
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
-import { EuiInMemoryTable, EuiTableHeaderCell } from '@elastic/eui';
+import { EuiInMemoryTable, EuiTableHeaderCell, EuiTableRow } from '@elastic/eui';
+import type { EuiSearchBarProps } from '@elastic/eui';
 
 import { engines } from '../../app_search/__mocks__/engines.mock';
 
@@ -105,5 +107,28 @@ describe('RoleMappingsTable', () => {
     expect(wrapper.find('[data-test-subj="AccessItems"]').prop('children')).toEqual(
       `${engines[0].name}, ${engines[1].name} + 1`
     );
+  });
+
+  it('handles search', () => {
+    const wrapper = mount(
+      <RoleMappingsTable
+        {...props}
+        roleMappings={[
+          { ...wsRoleMapping, roleType: 'admin' },
+          { ...wsRoleMapping, roleType: 'user' },
+        ]}
+      />
+    );
+    const roleMappingsTable = wrapper.find('[data-test-subj="RoleMappingsTable"]').first();
+    const searchProp = roleMappingsTable.prop('search') as EuiSearchBarProps;
+
+    act(() => {
+      if (searchProp.onChange) {
+        searchProp.onChange({ queryText: 'admin' } as any);
+      }
+    });
+    wrapper.update();
+
+    expect(wrapper.find(EuiTableRow)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -166,13 +166,13 @@ export const RoleMappingsTable: React.FC<Props> = ({
 
   const onQueryChange = ({ queryText }: EuiSearchBarOnChangeArgs) => {
     const filteredItems = standardizedRoleMappings.filter((rm) => {
-      // JSON.stringify allows us to search all the role mapping fields
+      // JSON.stringify allows us to search all the object fields
       // without converting all the nested arrays and objects to strings manually
       // Some false-positives are possible, because the search is also performed on
       // object keys, but the simplicity of JSON.stringify seems to worth the tradeoff.
-      const normalizedRoleMappingString = JSON.stringify(rm).toLowerCase();
+      const normalizedTableItemString = JSON.stringify(rm).toLowerCase();
       const normalizedQuery = queryText.toLowerCase();
-      return normalizedRoleMappingString.indexOf(normalizedQuery) !== -1;
+      return normalizedTableItemString.indexOf(normalizedQuery) !== -1;
     });
 
     setItems(filteredItems);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { EuiIconTip, EuiInMemoryTable, EuiBasicTableColumn, EuiLink } from '@elastic/eui';
+import type { EuiSearchBarOnChangeArgs } from '@elastic/eui';
 
 import { ASRoleMapping } from '../../app_search/types';
 import { WSRoleMapping } from '../../workplace_search/types';
@@ -69,6 +70,8 @@ export const RoleMappingsTable: React.FC<Props> = ({
     _rm.accessItems = rm[accessItemKey];
     return _rm;
   }) as SharedRoleMapping[];
+
+  const [items, setItems] = useState(standardizedRoleMappings);
 
   const attributeNameCol: EuiBasicTableColumn<SharedRoleMapping> = {
     field: 'attribute',
@@ -161,7 +164,22 @@ export const RoleMappingsTable: React.FC<Props> = ({
     pageSize: 10,
   };
 
+  const onQueryChange = ({ queryText }: EuiSearchBarOnChangeArgs) => {
+    const filteredItems = standardizedRoleMappings.filter((rm) => {
+      // JSON.stringify allows us to search all the role mapping fields
+      // without converting all the nested arrays and objects to strings manually
+      // Some false-positives are possible, because the search is also performed on
+      // object keys, but the simplicity of JSON.stringify seems to worth the tradeoff.
+      const normalizedRoleMappingString = JSON.stringify(rm).toLowerCase();
+      const normalizedQuery = queryText.toLowerCase();
+      return normalizedRoleMappingString.indexOf(normalizedQuery) !== -1;
+    });
+
+    setItems(filteredItems);
+  };
+
   const search = {
+    onChange: onQueryChange,
     box: {
       incremental: true,
       fullWidth: false,
@@ -173,7 +191,7 @@ export const RoleMappingsTable: React.FC<Props> = ({
     <EuiInMemoryTable
       data-test-subj="RoleMappingsTable"
       columns={columns}
-      items={standardizedRoleMappings}
+      items={items}
       search={search}
       pagination={pagination}
       message={ROLE_MAPPINGS_NO_RESULTS_MESSAGE}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.test.tsx
@@ -5,13 +5,20 @@
  * 2.0.
  */
 
-import { asSingleUserRoleMapping, wsSingleUserRoleMapping, asRoleMapping } from './__mocks__/roles';
+import {
+  asSingleUserRoleMapping,
+  wsSingleUserRoleMapping,
+  asRoleMapping,
+  wsRoleMapping,
+} from './__mocks__/roles';
 
 import React from 'react';
 
 import { shallow, mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
-import { EuiInMemoryTable, EuiTextColor, EuiBadge } from '@elastic/eui';
+import { EuiInMemoryTable, EuiTextColor, EuiBadge, EuiTableRow } from '@elastic/eui';
+import type { EuiSearchBarProps } from '@elastic/eui';
 
 import { engines } from '../../app_search/__mocks__/engines.mock';
 
@@ -114,5 +121,28 @@ describe('UsersTable', () => {
     const cell = wrapper.find('[data-test-subj="UsernameCell"]');
 
     expect(cell.find(EuiBadge)).toHaveLength(1);
+  });
+
+  it('handles search', () => {
+    const wrapper = mount(
+      <UsersTable
+        {...props}
+        singleUserRoleMappings={[
+          { ...wsSingleUserRoleMapping, roleMapping: { ...wsRoleMapping, roleType: 'admin' } },
+          { ...wsSingleUserRoleMapping, roleMapping: { ...wsRoleMapping, roleType: 'user' } },
+        ]}
+      />
+    );
+    const roleMappingsTable = wrapper.find('[data-test-subj="UsersTable"]').first();
+    const searchProp = roleMappingsTable.prop('search') as EuiSearchBarProps;
+
+    act(() => {
+      if (searchProp.onChange) {
+        searchProp.onChange({ queryText: 'admin' } as any);
+      }
+    });
+    wrapper.update();
+
+    expect(wrapper.find(EuiTableRow)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/workplace-search-team/issues/1853

Not searchable columns had non-string data: arrays, objects.
The default implementation of table search doesn't perform a search on non-string data.

The solution used here is to have a custom search callback that converts the entire
role mapping object to string and then checks if user query exists in this string.

It was copied and adjusted from example in EUI docs:
https://elastic.github.io/eui/#/tabular-content/in-memory-tables#in-memory-table-with-search-callback

The same issue was fixed for Users table.

Also fixed a typo in copy.

Before:

https://user-images.githubusercontent.com/11838280/129062918-53cd5a73-473c-4054-a006-86dc9f9bf7d3.mp4

After:

https://user-images.githubusercontent.com/11838280/129063395-5b1b95cc-a758-4560-8d1c-ec6f19a454db.mp4

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios