### PR TITLE
[Security Solution] update host isolation support

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
@@ -7,6 +7,7 @@
 
 import uuid from 'uuid';
 import seedrandom from 'seedrandom';
+import semverLte from 'semver/functions/lte';
 import { assertNever } from '@kbn/std';
 import {
   AlertEvent,
@@ -261,6 +262,7 @@ interface HostInfo {
     state?: {
       isolation: boolean;
     };
+    capabilities?: string[];
   };
 }
 
@@ -455,10 +457,13 @@ export class EndpointDocGenerator extends BaseDataGenerator {
   private createHostData(): HostInfo {
     const hostName = this.randomHostname();
     const isIsolated = this.randomBoolean(0.3);
+    const agentVersion = this.randomVersion();
+    const minCapabilitiesVersion = '7.15.0';
+    const capabilities = ['isolation'];
 
     return {
       agent: {
-        version: this.randomVersion(),
+        version: agentVersion,
         id: this.seededUUIDv4(),
         type: 'endpoint',
       },
@@ -487,6 +492,7 @@ export class EndpointDocGenerator extends BaseDataGenerator {
         state: {
           isolation: isIsolated,
         },
+        capabilities: semverLte(minCapabilitiesVersion, agentVersion) ? capabilities : [],
       },
     };
   }

--- a/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.test.ts
@@ -9,58 +9,71 @@ import { isVersionSupported, isOsSupported, isIsolationSupported } from './utils
 
 describe('Host Isolation utils isVersionSupported', () => {
   test.each`
-    a                         | b           | expected
-    ${'8.14.0'}               | ${'7.13.0'} | ${true}
-    ${'7.14.0'}               | ${'7.13.0'} | ${true}
-    ${'7.14.1'}               | ${'7.14.0'} | ${true}
-    ${'8.14.0'}               | ${'9.14.0'} | ${false}
-    ${'7.13.0'}               | ${'7.14.0'} | ${false}
-    ${'7.14.0'}               | ${'7.14.1'} | ${false}
-    ${'7.14.0'}               | ${'7.14.0'} | ${true}
-    ${'7.14.0-SNAPSHOT'}      | ${'7.14.0'} | ${true}
-    ${'7.14.0-SNAPSHOT-beta'} | ${'7.14.0'} | ${true}
-    ${'7.14.0-alpha'}         | ${'7.14.0'} | ${true}
-    ${'8.0.0-SNAPSHOT'}       | ${'7.14.0'} | ${true}
-    ${'8.0.0'}                | ${'7.14.0'} | ${true}
-  `('should validate that version $a is compatible($expected) to $b', ({ a, b, expected }) => {
-    expect(
-      isVersionSupported({
-        currentVersion: a,
-        minVersionRequired: b,
-      })
-    ).toEqual(expected);
-  });
+    currentVersion            | minVersionRequired | expected
+    ${'8.14.0'}               | ${'7.13.0'}        | ${true}
+    ${'7.14.0'}               | ${'7.13.0'}        | ${true}
+    ${'7.14.1'}               | ${'7.14.0'}        | ${true}
+    ${'8.14.0'}               | ${'9.14.0'}        | ${false}
+    ${'7.13.0'}               | ${'7.14.0'}        | ${false}
+    ${'7.14.0'}               | ${'7.14.1'}        | ${false}
+    ${'7.14.0'}               | ${'7.14.0'}        | ${true}
+    ${'7.14.0-SNAPSHOT'}      | ${'7.14.0'}        | ${true}
+    ${'7.14.0-SNAPSHOT-beta'} | ${'7.14.0'}        | ${true}
+    ${'7.14.0-alpha'}         | ${'7.14.0'}        | ${true}
+    ${'8.0.0-SNAPSHOT'}       | ${'7.14.0'}        | ${true}
+    ${'8.0.0'}                | ${'7.14.0'}        | ${true}
+  `(
+    'should validate that version $a is compatible($expected) to $b',
+    ({ currentVersion, minVersionRequired, expected }) => {
+      expect(
+        isVersionSupported({
+          currentVersion,
+          minVersionRequired,
+        })
+      ).toEqual(expected);
+    }
+  );
 });
 
 describe('Host Isolation utils isOsSupported', () => {
   test.each`
-    a          | b                       | expected
-    ${'linux'} | ${['macos', 'linux']}   | ${true}
-    ${'linux'} | ${['macos', 'windows']} | ${false}
-  `('should validate that os $a is compatible($expected) to $b', ({ a, b, expected }) => {
-    expect(
-      isOsSupported({
-        currentOs: a,
-        supportedOss: b,
-      })
-    ).toEqual(expected);
-  });
+    currentOs  | supportedOss                      | expected
+    ${'linux'} | ${{ macos: true, linux: true }}   | ${true}
+    ${'linux'} | ${{ macos: true, windows: true }} | ${false}
+  `(
+    'should validate that os $a is compatible($expected) to $b',
+    ({ currentOs, supportedOss, expected }) => {
+      expect(
+        isOsSupported({
+          currentOs,
+          supportedOss,
+        })
+      ).toEqual(expected);
+    }
+  );
 });
 
 describe('Host Isolation utils isIsolationSupported', () => {
   test.each`
-    a            | b           | expected
-    ${'windows'} | ${'7.14.0'} | ${true}
-    ${'linux'}   | ${'7.13.0'} | ${false}
-    ${'linux'}   | ${'7.14.0'} | ${false}
-    ${'macos'}   | ${'7.13.0'} | ${false}
+    osName       | version     | capabilities     | expected
+    ${'windows'} | ${'7.14.0'} | ${[]}            | ${true}
+    ${'linux'}   | ${'7.13.0'} | ${['isolation']} | ${false}
+    ${'linux'}   | ${'7.14.0'} | ${['isolation']} | ${false}
+    ${'macos'}   | ${'7.13.0'} | ${['isolation']} | ${false}
+    ${'linux'}   | ${'7.13.0'} | ${['isolation']} | ${false}
+    ${'windows'} | ${'7.15.0'} | ${[]}            | ${false}
+    ${'macos'}   | ${'7.15.0'} | ${[]}            | ${false}
+    ${'linux'}   | ${'7.15.0'} | ${['isolation']} | ${true}
+    ${'macos'}   | ${'7.15.0'} | ${['isolation']} | ${true}
+    ${'linux'}   | ${'7.16.0'} | ${['isolation']} | ${true}
   `(
-    'should validate that os $a and version $b supports hostIsolation($expected)',
-    ({ a, b, expected }) => {
+    'should validate that os $a, version $b, and capabilities $c supports hostIsolation($expected)',
+    ({ osName, version, capabilities, expected }) => {
       expect(
         isIsolationSupported({
-          osName: a,
-          version: b,
+          osName,
+          version,
+          capabilities,
         })
       ).toEqual(expected);
     }

--- a/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/host_isolation/utils.ts
@@ -4,39 +4,68 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import semverLt from 'semver/functions/lt';
+import semverLte from 'semver/functions/lte';
+import { ImmutableArray } from '../../types';
+
+const minSupportedVersion = '7.14.0';
+const minCapabilitiesVersion = '7.15.0';
+const supportedOssMap = {
+  macos: true,
+  windows: true,
+};
+const isolationCapability = 'isolation';
+
+function parseSemver(semver: string) {
+  return semver.includes('-') ? semver.substring(0, semver.indexOf('-')) : semver;
+}
 
 export const isVersionSupported = ({
   currentVersion,
-  minVersionRequired,
+  minVersionRequired = minSupportedVersion,
 }: {
   currentVersion: string;
-  minVersionRequired: string;
+  minVersionRequired?: string;
 }) => {
-  const parsedCurrentVersion = currentVersion.includes('-')
-    ? currentVersion.substring(0, currentVersion.indexOf('-'))
-    : currentVersion;
-
-  return (
-    parsedCurrentVersion === minVersionRequired ||
-    semverLt(minVersionRequired, parsedCurrentVersion)
-  );
+  const parsedCurrentVersion = parseSemver(currentVersion);
+  return semverLte(minVersionRequired, parsedCurrentVersion);
 };
 
 export const isOsSupported = ({
   currentOs,
-  supportedOss,
+  supportedOss = supportedOssMap,
 }: {
   currentOs: string;
-  supportedOss: string[];
-}) => {
-  return supportedOss.some((os) => currentOs === os);
-};
+  supportedOss?: { [os: string]: boolean };
+}) => !!supportedOss[currentOs];
 
-export const isIsolationSupported = ({ osName, version }: { osName: string; version: string }) => {
+function isCapabilitiesSupported(semver: string): boolean {
+  const parsedVersion = parseSemver(semver);
+  // capabilities is only available from 7.15+
+  return semverLte(minCapabilitiesVersion, parsedVersion);
+}
+
+function isIsolationSupportedCapabilities(capabilities: ImmutableArray<string> = []): boolean {
+  return capabilities.includes(isolationCapability);
+}
+
+// capabilities isn't introduced until 7.15 so check the OS for support
+function isIsolationSupportedOS(osName: string): boolean {
   const normalizedOs = osName.toLowerCase();
-  return (
-    isOsSupported({ currentOs: normalizedOs, supportedOss: ['macos', 'windows'] }) &&
-    isVersionSupported({ currentVersion: version, minVersionRequired: '7.14.0' })
-  );
+  return isOsSupported({ currentOs: normalizedOs });
+}
+
+export const isIsolationSupported = ({
+  osName,
+  version,
+  capabilities,
+}: {
+  osName: string;
+  version: string;
+  capabilities?: ImmutableArray<string>;
+}): boolean => {
+  if (!version || !isVersionSupported({ currentVersion: version })) return false;
+
+  return isCapabilitiesSupported(version)
+    ? isIsolationSupportedCapabilities(capabilities)
+    : isIsolationSupportedOS(osName);
 };

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -507,6 +507,7 @@ export type HostMetadata = Immutable<{
        */
       isolation?: boolean;
     };
+    capabilities?: string[];
   };
   agent: {
     id: string;

--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/helpers.ts
@@ -8,6 +8,19 @@ import { find } from 'lodash/fp';
 
 import type { TimelineEventsDetailsItem } from '../../../../common';
 
+export const getFieldValues = (
+  {
+    category,
+    field,
+  }: {
+    category: string;
+    field: string;
+  },
+  data: TimelineEventsDetailsItem[] | null
+) => {
+  return find({ category, field }, data)?.values;
+};
+
 export const getFieldValue = (
   {
     category,
@@ -18,6 +31,6 @@ export const getFieldValue = (
   },
   data: TimelineEventsDetailsItem[] | null
 ) => {
-  const currentField = find({ category, field }, data)?.values;
+  const currentField = getFieldValues({ category, field }, data);
   return currentField && currentField.length > 0 ? currentField[0] : '';
 };

--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/use_host_isolation_action.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/use_host_isolation_action.tsx
@@ -12,7 +12,7 @@ import { useIsolationPrivileges } from '../../../common/hooks/endpoint/use_isola
 import { endpointAlertCheck } from '../../../common/utils/endpoint_alert_check';
 import { useHostIsolationStatus } from '../../containers/detection_engine/alerts/use_host_isolation_status';
 import { ISOLATE_HOST, UNISOLATE_HOST } from './translations';
-import { getFieldValue } from './helpers';
+import { getFieldValue, getFieldValues } from './helpers';
 
 interface UseHostIsolationActionProps {
   closePopover: () => void;
@@ -46,9 +46,19 @@ export const useHostIsolationAction = ({
     [detailsData]
   );
 
+  const hostCapabilities = useMemo(
+    () =>
+      getFieldValues(
+        { category: 'Endpoint', field: 'Endpoint.capabilities' },
+        detailsData
+      ) as string[],
+    [detailsData]
+  );
+
   const isolationSupported = isIsolationSupported({
     osName: hostOsFamily,
     version: agentVersion,
+    capabilities: hostCapabilities,
   });
 
   const {

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/use_endpoint_action_items.tsx
@@ -41,6 +41,7 @@ export const useEndpointActionItems = (
       const isolationSupported = isIsolationSupported({
         osName: endpointMetadata.host.os.name,
         version: endpointMetadata.agent.version,
+        capabilities: endpointMetadata.Endpoint.capabilities,
       });
       const {
         show,


### PR DESCRIPTION
## Summary

* host isolation support for 7.15+ is now determined by the new capabilities field
* 7.14 will continue to use legacy OS check for support

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
