### PR TITLE
[Workplace Search] Add custom branding controls to Settings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/constants/actions.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/constants/actions.ts
@@ -44,3 +44,8 @@ export const CLOSE_BUTTON_LABEL = i18n.translate(
   'xpack.enterpriseSearch.actions.closeButtonLabel',
   { defaultMessage: 'Close' }
 );
+
+export const RESET_DEFAULT_BUTTON_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.actions.resetDefaultButtonLabel',
+  { defaultMessage: 'Reset to default' }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/index.ts
@@ -8,3 +8,4 @@
 export { toSentenceSerial } from './to_sentence_serial';
 export { getAsLocalDateTimeString } from './get_as_local_datetime_string';
 export { mimeType } from './mime_types';
+export { readUploadedFileAsBase64 } from './read_uploaded_file_as_base64';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/read_uploaded_file_as_base64.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/read_uploaded_file_as_base64.test.ts
@@ -8,10 +8,10 @@
 import { readUploadedFileAsBase64 } from './';
 
 describe('readUploadedFileAsBase64', () => {
-  it('reads a file as data URL', async () => {
+  it('reads a file and returns base64 string', async () => {
     const file = new File(['a mock file'], 'mockFile.png', { type: 'img/png' });
     const text = await readUploadedFileAsBase64(file);
-    expect(text).toEqual('data:image/png;base64,YSBtb2NrIGZpbGU=');
+    expect(text).toEqual('YSBtb2NrIGZpbGU=');
   });
 
   it('throws an error if the file cannot be read', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/read_uploaded_file_as_base64.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/read_uploaded_file_as_base64.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { readUploadedFileAsBase64 } from './';
+
+describe('readUploadedFileAsBase64', () => {
+  it('reads a file as data URL', async () => {
+    const file = new File(['a mock file'], 'mockFile.png', { type: 'img/png' });
+    const text = await readUploadedFileAsBase64(file);
+    expect(text).toEqual('data:image/png;base64,YSBtb2NrIGZpbGU=');
+  });
+
+  it('throws an error if the file cannot be read', async () => {
+    const badFile = ('causes an error' as unknown) as File;
+    await expect(readUploadedFileAsBase64(badFile)).rejects.toThrow();
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/read_uploaded_file_as_base64.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/utils/read_uploaded_file_as_base64.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const readUploadedFileAsBase64 = (fileInput: File): Promise<string> => {
+  const reader = new FileReader();
+
+  return new Promise((resolve, reject) => {
+    reader.onload = () => {
+      // We need to split off the prefix from the DataUrl and only pass the base64 string
+      // before: 'data:image/png;base64,encodedData=='
+      // after: 'encodedData=='
+      const base64 = (reader.result as string).split(',')[1];
+      resolve(base64);
+    };
+    try {
+      reader.readAsDataURL(fileInput);
+    } catch {
+      reader.abort();
+      reject(new Error());
+    }
+  });
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/branding_section.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/branding_section.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow, mount } from 'enzyme';
+
+import { EuiFilePicker, EuiConfirmModal } from '@elastic/eui';
+import { nextTick } from '@kbn/test/jest';
+
+jest.mock('../../../utils', () => ({
+  readUploadedFileAsBase64: jest.fn(({ img }) => img),
+}));
+import { readUploadedFileAsBase64 } from '../../../utils';
+
+import { RESET_IMAGE_TITLE } from '../constants';
+
+import { BrandingSection, defaultLogo } from './branding_section';
+
+describe('BrandingSection', () => {
+  const stageImage = jest.fn();
+  const saveImage = jest.fn();
+  const resetImage = jest.fn();
+
+  const props = {
+    image: 'foo',
+    imageType: 'logo' as 'logo',
+    description: 'logo test',
+    helpText: 'this is a logo',
+    stageImage,
+    saveImage,
+    resetImage,
+  };
+
+  it('renders logo', () => {
+    const wrapper = mount(<BrandingSection {...props} />);
+
+    expect(wrapper.find(EuiFilePicker)).toHaveLength(1);
+  });
+
+  it('renders icon copy', () => {
+    const wrapper = shallow(<BrandingSection {...props} imageType="icon" />);
+    wrapper.find('[data-test-subj="ResetImageButton"]').simulate('click');
+
+    expect(wrapper.find(EuiConfirmModal).prop('title')).toEqual(RESET_IMAGE_TITLE);
+  });
+
+  it('renders default Workplace Search logo', () => {
+    const wrapper = shallow(<BrandingSection {...props} image={null} />);
+
+    expect(wrapper.find('img').prop('src')).toContain(defaultLogo);
+  });
+
+  describe('resetConfirmModal', () => {
+    it('calls method and hides modal when modal confirmed', () => {
+      const wrapper = shallow(<BrandingSection {...props} />);
+      wrapper.find('[data-test-subj="ResetImageButton"]').simulate('click');
+      wrapper.find(EuiConfirmModal).prop('onConfirm')!({} as any);
+
+      expect(wrapper.find(EuiConfirmModal)).toHaveLength(0);
+      expect(resetImage).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('handleUpload', () => {
+    it('handles empty files', () => {
+      const wrapper = shallow(<BrandingSection {...props} />);
+      wrapper.find(EuiFilePicker).prop('onChange')!([] as any);
+
+      expect(stageImage).toHaveBeenCalledWith(null);
+    });
+
+    it('handles image', async () => {
+      const wrapper = shallow(<BrandingSection {...props} />);
+      wrapper.find(EuiFilePicker).prop('onChange')!(['foo'] as any);
+
+      expect(readUploadedFileAsBase64).toHaveBeenCalledWith('foo');
+      await nextTick();
+      expect(stageImage).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/branding_section.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/branding_section.test.tsx
@@ -62,7 +62,7 @@ describe('BrandingSection', () => {
       wrapper.find(EuiConfirmModal).prop('onConfirm')!({} as any);
 
       expect(wrapper.find(EuiConfirmModal)).toHaveLength(0);
-      expect(resetImage).toHaveBeenCalledWith();
+      expect(resetImage).toHaveBeenCalled();
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/branding_section.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/branding_section.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useEffect } from 'react';
+
+import {
+  EuiButton,
+  EuiConfirmModal,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiFilePicker,
+  EuiText,
+  EuiSpacer,
+} from '@elastic/eui';
+
+import {
+  SAVE_BUTTON_LABEL,
+  CANCEL_BUTTON_LABEL,
+  RESET_DEFAULT_BUTTON_LABEL,
+} from '../../../../shared/constants';
+import { readUploadedFileAsBase64 } from '../../../utils';
+
+import {
+  LOGO_TEXT,
+  ICON_TEXT,
+  RESET_IMAGE_TITLE,
+  RESET_LOGO_DESCRIPTION,
+  RESET_ICON_DESCRIPTION,
+  RESET_IMAGE_CONFIRMATION_TEXT,
+  ORGANIZATION_LABEL,
+  BRAND_TEXT,
+} from '../constants';
+
+export const defaultLogo =
+  'iVBORw0KGgoAAAANSUhEUgAAAMMAAAAeCAMAAACmAVppAAABp1BMVEUAAAAmLjf/xRPwTpglLjf/xhIlLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjcwMTslLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjclLjf+xBMlLjclLjclLjclLjclLjf/xxBUOFP+wRclLjf+xxb/0w3wTpgkLkP+xRM6ME3wTphKPEnxU5PwT5f/yhDwTpj/xxD/yBJQLF/wTpjyWY7/zQw5I1z/0Aj3SKT/zg//zg38syyoOYfhTZL/0QT+xRP/Uqr/UqtBMFD+xBV6SllaOVY7J1VXM1v/yhH/1wYlLjf+xRPwTpgzN0HvTpc1OEH+xBMuNj7/UaX/UKEXMzQQMzH4TpvwS5swNkArNj4nNTv/UqflTZPdTJA6OEQiNDr/yQ7zT5q9SIB1P19nPlhMOkz/UqbUTIvSS4oFLTD1hLkfAAAAbXRSTlMADfLy4wwCKflGIPzzaF0k8BEFlMd/G9rNFAjosWJWNC8s1LZ4bey9q6SZclHewJxlQDkLoIqDfE09So4Y6MSniIaFy8G8h04Q/vb29ObitpyQiodmXlZUVDssJSQfHQj+7Ovi4caspKFzbGw11xUNcgAABZRJREFUWMPVmIeT0kAUh180IoQOJyAgvQt4dLD33nvvXX8ed/beu3+0bzcJtjiDjuMM38xluU12932b3U2ytGu+ZM8RGrFl0zzJqgU0GczoPHq0l3QWXH79+vYtyaQ4zJ8x2U+C0xtumcybPIeZw/zv8fO3Jtph2wmim7cn2mF29uIZoqO3J9lh5tnnjZxx4PbkOsw+e/H4wVXO2WTpoCgBIyUz/QnrPGopNhoTZWHaT2MTUAI/OczePTt3//Gd60Rb51k5OOyqKLLS56oS03at+zUEl8tCIuNaOKZBxQmgHKIx6bl6PzrM3pt9eX9ueGfuGNENKwc/0OTEAywjxo4q/YwfsHDwIT2eQgaYqgOxxTQea9H50eHhvfcP5obD4ZPdnLfKaj5kkeNjEKhxkoQ9Sj9iI8V0+GHwqBjvPuSQ8RKFwmjTeCzCItPBGElv798ZMo/vHCLaZ+WwFFk+huGE1/wnN6VmPZxGl63QSoUGSYdBOe6n9opWJxzp2UwHW66urs6RIFkJhyspYhZ3Mmq5QQZxTMvT5aV81ILhWrsp+4Mbqef5R7rsaa5WNSJ3US26pcN0qliL902HN3ffPRhKnm4k2mLlkIY9QF6sXga3aDBP/ghgB8pyELkAj3QYgLunBYTBTEV1B60G+CC9+5Bw6Joqy7tJJ4iplaO2fPJUlcyScaIqnAC8lIUgKxyKEFQNh4czH17pDk92RumklQPFMKAlyHtRInJxZW2++baBj2NXfCg0Qq0oQCFgKYkMV7PVLKCnOyxFRqOQCgf5nVgXjQYBogiCAY4MxiT2OuEMeuRkCKjYbOO2nArlENFIK6BJDqCe0riqWDOQ9CHHDugqoSKmDId7z18+HepsV2jrDiuHZRxdiSuDi7yIURTQiLilDNmcSMo5XUipQoEUOxycJKDqDooMrYQ8ublJplKyebkgs54zdZKyh0tp4nCLeoMeo2Qdbs4sEFNAn4+Nspt68iov7H/gkECJfIjSFAIJVGiAmhzUAJHemYrL7uRrxC/wdSQ0zTldDcZjwBJqs6OOG7VyPLsmgjVk4s2XAHuKowvzqXIYK0Ylpw0xDbCN5nRQz/iDseSHmhK9mENiPRJURUTOOenAccoRBKhe3UGeMx1SqpgcGXhoDf/p5MHKTsTUzfQdoSyH2tVPqWqekqJkJMb2DtT5fOo7B7nKLwTGn9NiABdFL7KICj8l4SPjXpoOdiwPIqw7LBYB6Q4aZdDWAtThSIKyb6nlt3kQp+8IrFtk0+vz0TSCZBDGMi5ZGjks1msmxf/NYey1VYrrsarAau5kn+zSCocSNRwAMfPbYlRhhb7UiKtDZIdNxjNNy1GIciQFZ0CB3c+Znm5KdwDkk38dIqQhJkfbIs0GEFMbOVBEPtk69hXfHMZ+xjFNQCUZNnpyNiPn4N9J8o8cFEqLsdtyOVFJBIHlQsrLUyg+6Ef4jIgh7EmEUReGsSWNtYCDJNNAyZ3PAgniEVfzNCqi1gjKzX5Gzge5GnCCYH89MKD1aP/oMHvv+Zz5rnHwd++tPlT0yY2kSLtgfFUZfNp0IDeQIhQWgVlkvGukVQC1Kbj5FqwGU/fLdYdxLSGDHgR2MecDcTCFPlEyBiBT5JLLESGB2wnAyTWtlatB2nSQo+nF8P7cq2tEC+b9ziGVWClv+3KHuY6s9YhgbI7lLZk4xJBpeNIBOGlhN7eQmEFfYT13x00rEyES57vdhlFfrrNkJY0ILel2+QEhSfbWehS57uU707Lk4mrSuMy9Oa+J1hOi41oczMhh5tmLuS9XLN69/wI/0KL/BzuYEh8/XfpH30ByVP0/2GFkceFffYvKL4n/gPWewPF/syeg/B8F672ZU+duTfD3tLlHtur1xDn8sld5Smz0TdZepcWe8cENk7Vn/BXafhbMBIo0xQAAAABJRU5ErkJggg==';
+const defaultIcon =
+  'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAA/1BMVEUAAADwTpj+xRT+xRTwTpjwTpj+xRTwTpj+wxT+xRT/yBMSHkn8yxL+wxX+xRT+xRT/1QwzN0E6OkH/xxPwTpjwTpjwTpj/xBQsMUPwTpj/UK3/yRMWHkvwTpj/zg7wTpj/0A3wTpjwTpgRIEf/0Qx/P2P/yBMuM0I1OEH+xRQuM0L+xRQuM0LntRr+xRT+xRT+xBQ1JlZjPVdaUDwtMEUbJkYbJEj+xRTwTpg0N0E2N0LuTZX/U6z/Uqf9UaFkPVYRMjD/UqnzTpgKMS0BMCn/UaL3T53gTJGwRn2jRHRdPFUtNj4qNjwmNToALyfKSojISoeJQWhtPlsFKTP/yxKq4k7GAAAAN3RSTlMA29vt7fPy6uPQdjYd/aSVBfHs49nPwq+nlIuEU084MichEAoK/vPXz6iempOSjn9kY1w0LBcVaxnnyQAAASFJREFUOMuVk3lbgkAQh6cIxQq0u6zM7vs+cHchRbE7O7//Z+nng60PDuDj+9/MvMCyM0O0YE4Ac35lkzTTp3M5A+QKCPK1HuY69bjY+3UjDERjNc1GVD9zNeNxIb+FeOfYZYJmEXHFzhBUGYnVdEHde1fILHFB1+uNG5zCYoKuh2L2jqhqJwnqwfsOpRQHyE0mCU3vqyOkEOIESYsLyv9svUoB5BRewYVm8NJCvcsymsGF9uP7m4iY2SYqMMF/aoh/8I1DLjz3hTWi4ogC/4Qz9JCj/6byP7IvCle925Fd4yj5qtGsoB7C2I83i7f7Fiew0wfm55qoZKWOXDu4zBo5UMbz50PGvop85uKUigMCXz0nJrDlja2OQcnrX3H0+v8BzVCfXpvPH1sAAAAASUVORK5CYII=';
+
+interface Props {
+  imageType: 'logo' | 'icon';
+  description: string;
+  helpText: string;
+  image?: string | null;
+  stagedImage?: string | null;
+  stageImage(image: string | null): void;
+  saveImage(): void;
+  resetImage(): void;
+}
+
+export const BrandingSection: React.FC<Props> = ({
+  imageType,
+  description,
+  helpText,
+  image,
+  stagedImage,
+  stageImage,
+  saveImage,
+  resetImage,
+}) => {
+  const [resetConfirmModalVisible, setVisible] = useState(false);
+  const [imageUploadKey, setKey] = useState(1);
+  const showDeleteModal = () => setVisible(true);
+  const closeDeleteModal = () => setVisible(false);
+  const isLogo = imageType === 'logo';
+  const imageText = isLogo ? LOGO_TEXT : ICON_TEXT;
+  const defaultImage = isLogo ? defaultLogo : defaultIcon;
+
+  const handleUpload = async (files: FileList | null) => {
+    if (!files || files.length < 1) {
+      return stageImage(null);
+    }
+    const file = files[0];
+    const img = await readUploadedFileAsBase64(file);
+    stageImage(img);
+  };
+
+  const resetConfirmModal = (
+    <EuiConfirmModal
+      title={isLogo ? RESET_IMAGE_TITLE : RESET_IMAGE_TITLE}
+      onCancel={closeDeleteModal}
+      onConfirm={() => {
+        resetImage();
+        closeDeleteModal();
+      }}
+      cancelButtonText={CANCEL_BUTTON_LABEL}
+      confirmButtonText={RESET_DEFAULT_BUTTON_LABEL}
+      buttonColor="danger"
+      defaultFocusedButton="confirm"
+    >
+      <>
+        <p>{isLogo ? RESET_LOGO_DESCRIPTION : RESET_ICON_DESCRIPTION}</p>
+        <p>{RESET_IMAGE_CONFIRMATION_TEXT}</p>
+      </>
+    </EuiConfirmModal>
+  );
+
+  // EUI currently does not support clearing an upload input programatically, so we can render a new
+  // one each time the image is changed.
+  useEffect(() => {
+    setKey(imageUploadKey + 1);
+  }, [image]);
+
+  return (
+    <>
+      <EuiFormRow
+        label={`${ORGANIZATION_LABEL} ${imageText}`}
+        helpText={helpText}
+        labelAppend={
+          <EuiText color="subdued" size="xs">
+            {description}
+          </EuiText>
+        }
+      >
+        <>
+          <EuiSpacer size="m" />
+          <img
+            src={`data:image/png;base64,${image || defaultImage}`}
+            alt={`${BRAND_TEXT} ${imageType}`}
+          />
+          <EuiSpacer size="m" />
+          <EuiFilePicker
+            key={imageType + imageUploadKey}
+            accept="image/png"
+            onChange={handleUpload}
+          />
+        </>
+      </EuiFormRow>
+      <EuiFormRow>
+        <EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <EuiButton disabled={!stagedImage} color="primary" onClick={saveImage}>
+              {SAVE_BUTTON_LABEL}
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            {image && (
+              <EuiButton color="danger" onClick={showDeleteModal} data-test-subj="ResetImageButton">
+                {RESET_DEFAULT_BUTTON_LABEL}
+              </EuiButton>
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFormRow>
+      {resetConfirmModalVisible && resetConfirmModal}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.test.tsx
@@ -17,6 +17,7 @@ import { EuiFieldText } from '@elastic/eui';
 
 import { ContentSection } from '../../../components/shared/content_section';
 
+import { BrandingSection } from './branding_section';
 import { Customize } from './customize';
 
 describe('Customize', () => {
@@ -32,6 +33,7 @@ describe('Customize', () => {
     const wrapper = shallow(<Customize />);
 
     expect(wrapper.find(ContentSection)).toHaveLength(1);
+    expect(wrapper.find(BrandingSection)).toHaveLength(2);
   });
 
   it('handles input change', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.tsx
@@ -9,7 +9,14 @@ import React, { FormEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
 
 import { WorkplaceSearchPageTemplate } from '../../../components/layout';
 import { ContentSection } from '../../../components/shared/content_section';
@@ -20,11 +27,25 @@ import {
   CUSTOMIZE_NAME_LABEL,
   CUSTOMIZE_NAME_BUTTON,
 } from '../../../constants';
+import { LOGO_DESCRIPTION, LOGO_HELP_TEXT, ICON_DESCRIPTION, ICON_HELP_TEXT } from '../constants';
 import { SettingsLogic } from '../settings_logic';
 
+import { BrandingSection } from './branding_section';
+
 export const Customize: React.FC = () => {
-  const { onOrgNameInputChange, updateOrgName } = useActions(SettingsLogic);
-  const { orgNameInputValue } = useValues(SettingsLogic);
+  const {
+    onOrgNameInputChange,
+    updateOrgName,
+    setStagedIcon,
+    setStagedLogo,
+    updateOrgLogo,
+    updateOrgIcon,
+    resetOrgLogo,
+    resetOrgIcon,
+  } = useActions(SettingsLogic);
+  const { dataLoading, orgNameInputValue, icon, stagedIcon, logo, stagedLogo } = useValues(
+    SettingsLogic
+  );
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -38,6 +59,7 @@ export const Customize: React.FC = () => {
         pageTitle: CUSTOMIZE_HEADER_TITLE,
         description: CUSTOMIZE_HEADER_DESCRIPTION,
       }}
+      isLoading={dataLoading}
     >
       <form onSubmit={handleSubmit}>
         <ContentSection>
@@ -63,6 +85,28 @@ export const Customize: React.FC = () => {
           </EuiFormRow>
         </ContentSection>
       </form>
+      <EuiSpacer size="s" />
+      <BrandingSection
+        imageType="logo"
+        description={LOGO_DESCRIPTION}
+        helpText={LOGO_HELP_TEXT}
+        image={logo}
+        stagedImage={stagedLogo}
+        stageImage={setStagedLogo}
+        saveImage={updateOrgLogo}
+        resetImage={resetOrgLogo}
+      />
+      <EuiSpacer size="xl" />
+      <BrandingSection
+        imageType="icon"
+        description={ICON_DESCRIPTION}
+        helpText={ICON_HELP_TEXT}
+        image={icon}
+        stagedImage={stagedIcon}
+        stageImage={setStagedIcon}
+        saveImage={updateOrgIcon}
+        resetImage={resetOrgIcon}
+      />
     </WorkplaceSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/constants.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const LOGO_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.logoText',
+  {
+    defaultMessage: 'logo',
+  }
+);
+
+export const ICON_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.iconText',
+  {
+    defaultMessage: 'icon',
+  }
+);
+
+export const RESET_IMAGE_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.resetImageTitle',
+  {
+    defaultMessage: 'Reset to default branding',
+  }
+);
+
+export const RESET_LOGO_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.resetLogoDescription',
+  {
+    defaultMessage: "You're about to reset the logo to the default Workplace Search branding.",
+  }
+);
+
+export const RESET_ICON_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.resetIconDescription',
+  {
+    defaultMessage: "You're about to reset the icon to the default Workplace Search branding.",
+  }
+);
+
+export const RESET_IMAGE_CONFIRMATION_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.resetImageConfirmationText',
+  {
+    defaultMessage: 'Are you sure you want to do this?',
+  }
+);
+
+export const ORGANIZATION_LABEL = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.organizationLabel',
+  {
+    defaultMessage: 'Organization',
+  }
+);
+
+export const BRAND_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.brandText',
+  {
+    defaultMessage: 'Brand',
+  }
+);
+
+export const LOGO_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.logoDescription',
+  {
+    defaultMessage: 'Used as the main visual branding element across prebuilt search applications',
+  }
+);
+
+export const LOGO_HELP_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.logoHelpText',
+  {
+    defaultMessage: 'Maximum file size is 2MB. Only PNG files are supported.',
+  }
+);
+
+export const ICON_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.iconDescription',
+  {
+    defaultMessage: 'Used as the branding element for smaller screen sizes and browser icons',
+  }
+);
+
+export const ICON_HELP_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.settings.iconHelpText',
+  {
+    defaultMessage:
+      'Maximum file size is 2MB and recommended aspect ratio is 1:1. Only PNG files are supported.',
+  }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
@@ -192,7 +192,6 @@ describe('SettingsLogic', () => {
       it('calls API and sets values', async () => {
         const ICON = 'icon';
         SettingsLogic.actions.setStagedIcon(ICON);
-        SettingsLogic.actions.onOrgNameInputChange(ICON);
         const setIconSpy = jest.spyOn(SettingsLogic.actions, 'setIcon');
         http.put.mockReturnValue(Promise.resolve({ icon: ICON }));
 
@@ -219,7 +218,6 @@ describe('SettingsLogic', () => {
       it('calls API and sets values', async () => {
         const LOGO = 'logo';
         SettingsLogic.actions.setStagedLogo(LOGO);
-        SettingsLogic.actions.onOrgNameInputChange(LOGO);
         const setLogoSpy = jest.spyOn(SettingsLogic.actions, 'setLogo');
         http.put.mockReturnValue(Promise.resolve({ logo: LOGO }));
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
@@ -25,7 +25,7 @@ describe('SettingsLogic', () => {
   const {
     clearFlashMessages,
     flashAPIErrors,
-    setSuccessMessage,
+    flashSuccessToast,
     setQueuedSuccessMessage,
   } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(SettingsLogic);
@@ -143,7 +143,7 @@ describe('SettingsLogic', () => {
           body: JSON.stringify({ name: NAME }),
         });
         await nextTick();
-        expect(setSuccessMessage).toHaveBeenCalledWith(ORG_UPDATED_MESSAGE);
+        expect(flashSuccessToast).toHaveBeenCalledWith(ORG_UPDATED_MESSAGE);
         expect(setUpdatedNameSpy).toHaveBeenCalledWith({ organizationName: NAME });
       });
 
@@ -179,7 +179,7 @@ describe('SettingsLogic', () => {
         );
         await nextTick();
         expect(setUpdatedOauthApplicationSpy).toHaveBeenCalledWith({ oauthApplication });
-        expect(setSuccessMessage).toHaveBeenCalledWith(OAUTH_APP_UPDATED_MESSAGE);
+        expect(flashSuccessToast).toHaveBeenCalledWith(OAUTH_APP_UPDATED_MESSAGE);
       });
 
       it('handles error', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
@@ -35,8 +35,12 @@ describe('SettingsLogic', () => {
     connectors: [],
     orgNameInputValue: '',
     oauthApplication: null,
+    icon: null,
+    stagedIcon: null,
+    logo: null,
+    stagedLogo: null,
   };
-  const serverProps = { organizationName: ORG_NAME, oauthApplication };
+  const serverProps = { organizationName: ORG_NAME, oauthApplication, logo: null, icon: null };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -77,6 +81,34 @@ describe('SettingsLogic', () => {
       SettingsLogic.actions.setOauthApplication(oauthApplication);
 
       expect(SettingsLogic.values.oauthApplication).toEqual(oauthApplication);
+    });
+
+    it('setIcon', () => {
+      SettingsLogic.actions.setStagedIcon('stagedIcon');
+      SettingsLogic.actions.setIcon('icon');
+
+      expect(SettingsLogic.values.icon).toEqual('icon');
+      expect(SettingsLogic.values.stagedIcon).toEqual(null);
+    });
+
+    it('setStagedIcon', () => {
+      SettingsLogic.actions.setStagedIcon('stagedIcon');
+
+      expect(SettingsLogic.values.stagedIcon).toEqual('stagedIcon');
+    });
+
+    it('setLogo', () => {
+      SettingsLogic.actions.setStagedLogo('stagedLogo');
+      SettingsLogic.actions.setLogo('logo');
+
+      expect(SettingsLogic.values.logo).toEqual('logo');
+      expect(SettingsLogic.values.stagedLogo).toEqual(null);
+    });
+
+    it('setStagedLogo', () => {
+      SettingsLogic.actions.setStagedLogo('stagedLogo');
+
+      expect(SettingsLogic.values.stagedLogo).toEqual('stagedLogo');
     });
 
     it('setUpdatedOauthApplication', () => {
@@ -154,6 +186,82 @@ describe('SettingsLogic', () => {
         await nextTick();
         expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
+    });
+
+    describe('updateOrgIcon', () => {
+      it('calls API and sets values', async () => {
+        const ICON = 'icon';
+        SettingsLogic.actions.setStagedIcon(ICON);
+        SettingsLogic.actions.onOrgNameInputChange(ICON);
+        const setIconSpy = jest.spyOn(SettingsLogic.actions, 'setIcon');
+        http.put.mockReturnValue(Promise.resolve({ icon: ICON }));
+
+        SettingsLogic.actions.updateOrgIcon();
+
+        expect(http.put).toHaveBeenCalledWith('/api/workplace_search/org/settings/upload_images', {
+          body: JSON.stringify({ icon: ICON }),
+        });
+        await nextTick();
+        expect(flashSuccessToast).toHaveBeenCalledWith(ORG_UPDATED_MESSAGE);
+        expect(setIconSpy).toHaveBeenCalledWith(ICON);
+      });
+
+      it('handles error', async () => {
+        http.put.mockReturnValue(Promise.reject('this is an error'));
+        SettingsLogic.actions.updateOrgIcon();
+
+        await nextTick();
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
+      });
+    });
+
+    describe('updateOrgLogo', () => {
+      it('calls API and sets values', async () => {
+        const LOGO = 'logo';
+        SettingsLogic.actions.setStagedLogo(LOGO);
+        SettingsLogic.actions.onOrgNameInputChange(LOGO);
+        const setLogoSpy = jest.spyOn(SettingsLogic.actions, 'setLogo');
+        http.put.mockReturnValue(Promise.resolve({ logo: LOGO }));
+
+        SettingsLogic.actions.updateOrgLogo();
+
+        expect(http.put).toHaveBeenCalledWith('/api/workplace_search/org/settings/upload_images', {
+          body: JSON.stringify({ logo: LOGO }),
+        });
+        await nextTick();
+        expect(flashSuccessToast).toHaveBeenCalledWith(ORG_UPDATED_MESSAGE);
+        expect(setLogoSpy).toHaveBeenCalledWith(LOGO);
+      });
+
+      it('handles error', async () => {
+        http.put.mockReturnValue(Promise.reject('this is an error'));
+        SettingsLogic.actions.updateOrgLogo();
+
+        await nextTick();
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
+      });
+    });
+
+    it('resetOrgLogo', () => {
+      const updateOrgLogoSpy = jest.spyOn(SettingsLogic.actions, 'updateOrgLogo');
+      SettingsLogic.actions.setStagedLogo('stagedLogo');
+      SettingsLogic.actions.setLogo('logo');
+      SettingsLogic.actions.resetOrgLogo();
+
+      expect(SettingsLogic.values.logo).toEqual(null);
+      expect(SettingsLogic.values.stagedLogo).toEqual(null);
+      expect(updateOrgLogoSpy).toHaveBeenCalled();
+    });
+
+    it('resetOrgIcon', () => {
+      const updateOrgIconSpy = jest.spyOn(SettingsLogic.actions, 'updateOrgIcon');
+      SettingsLogic.actions.setStagedIcon('stagedIcon');
+      SettingsLogic.actions.setIcon('icon');
+      SettingsLogic.actions.resetOrgIcon();
+
+      expect(SettingsLogic.values.icon).toEqual(null);
+      expect(SettingsLogic.values.stagedIcon).toEqual(null);
+      expect(updateOrgIconSpy).toHaveBeenCalled();
     });
 
     describe('updateOauthApplication', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -34,6 +34,8 @@ interface IOauthApplication {
 export interface SettingsServerProps {
   organizationName: string;
   oauthApplication: IOauthApplication;
+  logo: string | null;
+  icon: string | null;
 }
 
 interface SettingsActions {
@@ -41,6 +43,10 @@ interface SettingsActions {
   onOrgNameInputChange(orgNameInputValue: string): string;
   setUpdatedName({ organizationName }: { organizationName: string }): string;
   setServerProps(props: SettingsServerProps): SettingsServerProps;
+  setIcon(icon: string | null): string | null;
+  setStagedIcon(stagedIcon: string | null): string | null;
+  setLogo(logo: string | null): string | null;
+  setStagedLogo(stagedLogo: string | null): string | null;
   setOauthApplication(oauthApplication: IOauthApplication): IOauthApplication;
   setUpdatedOauthApplication({
     oauthApplication,
@@ -52,6 +58,10 @@ interface SettingsActions {
   initializeConnectors(): void;
   updateOauthApplication(): void;
   updateOrgName(): void;
+  updateOrgLogo(): void;
+  updateOrgIcon(): void;
+  resetOrgLogo(): void;
+  resetOrgIcon(): void;
   deleteSourceConfig(
     serviceType: string,
     name: string
@@ -66,7 +76,13 @@ interface SettingsValues {
   connectors: Connector[];
   orgNameInputValue: string;
   oauthApplication: IOauthApplication | null;
+  logo: string | null;
+  icon: string | null;
+  stagedLogo: string | null;
+  stagedIcon: string | null;
 }
+
+const imageRoute = '/api/workplace_search/org/settings/upload_images';
 
 export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>({
   actions: {
@@ -74,6 +90,10 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     onOrgNameInputChange: (orgNameInputValue: string) => orgNameInputValue,
     setUpdatedName: ({ organizationName }) => organizationName,
     setServerProps: (props: SettingsServerProps) => props,
+    setIcon: (icon) => icon,
+    setStagedIcon: (stagedIcon) => stagedIcon,
+    setLogo: (logo) => logo,
+    setStagedLogo: (stagedLogo) => stagedLogo,
     setOauthApplication: (oauthApplication: IOauthApplication) => oauthApplication,
     setUpdatedOauthApplication: ({ oauthApplication }: { oauthApplication: IOauthApplication }) =>
       oauthApplication,
@@ -81,6 +101,10 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     initializeSettings: () => true,
     initializeConnectors: () => true,
     updateOrgName: () => true,
+    updateOrgLogo: () => true,
+    updateOrgIcon: () => true,
+    resetOrgLogo: () => true,
+    resetOrgIcon: () => true,
     updateOauthApplication: () => true,
     deleteSourceConfig: (serviceType: string, name: string) => ({
       serviceType,
@@ -113,8 +137,41 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     dataLoading: [
       true,
       {
+        setServerProps: () => false,
         onInitializeConnectors: () => false,
         resetSettingsState: () => true,
+      },
+    ],
+    logo: [
+      null,
+      {
+        setServerProps: (_, { logo }) => logo,
+        setLogo: (_, logo) => logo,
+        resetOrgLogo: () => null,
+      },
+    ],
+    stagedLogo: [
+      null,
+      {
+        setStagedLogo: (_, stagedLogo) => stagedLogo,
+        resetOrgLogo: () => null,
+        setLogo: () => null,
+      },
+    ],
+    icon: [
+      null,
+      {
+        setServerProps: (_, { icon }) => icon,
+        setIcon: (_, icon) => icon,
+        resetOrgIcon: () => null,
+      },
+    ],
+    stagedIcon: [
+      null,
+      {
+        setStagedIcon: (_, stagedIcon) => stagedIcon,
+        resetOrgIcon: () => null,
+        setIcon: () => null,
       },
     ],
   },
@@ -152,6 +209,32 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
         actions.setUpdatedName(response);
         flashSuccessToast(ORG_UPDATED_MESSAGE);
         AppLogic.actions.setOrgName(name);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+    updateOrgLogo: async () => {
+      const { http } = HttpLogic.values;
+      const { stagedLogo: logo } = values;
+      const body = JSON.stringify({ logo });
+
+      try {
+        const response = await http.put(imageRoute, { body });
+        actions.setLogo(response.logo);
+        flashSuccessToast(ORG_UPDATED_MESSAGE);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+    updateOrgIcon: async () => {
+      const { http } = HttpLogic.values;
+      const { stagedIcon: icon } = values;
+      const body = JSON.stringify({ icon });
+
+      try {
+        const response = await http.put(imageRoute, { body });
+        actions.setIcon(response.icon);
+        flashSuccessToast(ORG_UPDATED_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);
       }
@@ -194,6 +277,12 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     },
     resetSettingsState: () => {
       clearFlashMessages();
+    },
+    resetOrgLogo: () => {
+      actions.updateOrgLogo();
+    },
+    resetOrgIcon: () => {
+      actions.updateOrgIcon();
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import {
   clearFlashMessages,
   setQueuedSuccessMessage,
-  setSuccessMessage,
+  flashSuccessToast,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
@@ -150,7 +150,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
       try {
         const response = await http.put(route, { body });
         actions.setUpdatedName(response);
-        setSuccessMessage(ORG_UPDATED_MESSAGE);
+        flashSuccessToast(ORG_UPDATED_MESSAGE);
         AppLogic.actions.setOrgName(name);
       } catch (e) {
         flashAPIErrors(e);
@@ -170,7 +170,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
       try {
         const response = await http.put(route, { body });
         actions.setUpdatedOauthApplication(response);
-        setSuccessMessage(OAUTH_APP_UPDATED_MESSAGE);
+        flashSuccessToast(OAUTH_APP_UPDATED_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.test.ts
@@ -10,6 +10,7 @@ import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks_
 import {
   registerOrgSettingsRoute,
   registerOrgSettingsCustomizeRoute,
+  registerOrgSettingsUploadImagesRoute,
   registerOrgSettingsOauthApplicationRoute,
 } from './settings';
 
@@ -62,6 +63,36 @@ describe('settings routes', () => {
     describe('validates', () => {
       it('correctly', () => {
         const request = { body: { name: 'foo' } };
+        mockRouter.shouldValidate(request);
+      });
+    });
+  });
+
+  describe('PUT /api/workplace_search/org/settings/upload_images', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/org/settings/upload_images',
+      });
+
+      registerOrgSettingsUploadImagesRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/upload_images',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: { logo: 'foo', icon: null } };
         mockRouter.shouldValidate(request);
       });
     });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
@@ -43,6 +43,26 @@ export function registerOrgSettingsCustomizeRoute({
   );
 }
 
+export function registerOrgSettingsUploadImagesRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.put(
+    {
+      path: '/api/workplace_search/org/settings/upload_images',
+      validate: {
+        body: schema.object({
+          logo: schema.nullable(schema.string()),
+          icon: schema.nullable(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/upload_images',
+    })
+  );
+}
+
 export function registerOrgSettingsOauthApplicationRoute({
   router,
   enterpriseSearchRequestHandler,
@@ -69,5 +89,6 @@ export function registerOrgSettingsOauthApplicationRoute({
 export const registerSettingsRoutes = (dependencies: RouteDependencies) => {
   registerOrgSettingsRoute(dependencies);
   registerOrgSettingsCustomizeRoute(dependencies);
+  registerOrgSettingsUploadImagesRoute(dependencies);
   registerOrgSettingsOauthApplicationRoute(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
@@ -52,8 +52,8 @@ export function registerOrgSettingsUploadImagesRoute({
       path: '/api/workplace_search/org/settings/upload_images',
       validate: {
         body: schema.object({
-          logo: schema.nullable(schema.string()),
-          icon: schema.nullable(schema.string()),
+          logo: schema.maybe(schema.nullable(schema.string())),
+          icon: schema.maybe(schema.nullable(schema.string())),
         }),
       },
     },


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1895

## Summary

This PR adds upload form controls to the Workplace Search settings page to allow users to upload branding in the form of a custom logo and a custom icon.

https://user-images.githubusercontent.com/1869731/129068978-a0e97c5f-950a-4471-9385-1c154bca2838.mp4

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
