### PR TITLE
[build-ts-refs] normalize paths before writing them to the FS

### DIFF
--- a/src/dev/typescript/root_refs_config.ts
+++ b/src/dev/typescript/root_refs_config.ts
@@ -11,6 +11,7 @@ import Fs from 'fs/promises';
 
 import dedent from 'dedent';
 import { REPO_ROOT, ToolingLog } from '@kbn/dev-utils';
+import normalize from 'normalize-path';
 
 import { PROJECTS } from './projects';
 
@@ -53,7 +54,7 @@ export async function updateRootRefsConfig(log: ToolingLog) {
   }
 
   const refs = PROJECTS.filter((p) => p.isCompositeProject())
-    .map((p) => `./${Path.relative(REPO_ROOT, p.tsConfigPath)}`)
+    .map((p) => `./${normalize(Path.relative(REPO_ROOT, p.tsConfigPath))}`)
     .sort((a, b) => a.localeCompare(b));
 
   log.debug('updating', ROOT_REFS_CONFIG_PATH);


### PR DESCRIPTION
When writing the `tsconfig.refs.json` file we are currently writing paths using the system path separator. On Windows this causes issues for paths where directory/file names start with `n` as the path separator combines with the `n` to form a new line and breaks the syntax of the file.

To fix this we just need to normalize the paths to refs before we write them to the file.