### PR TITLE
[7.x] [APM] Rename "Error rate" to "Failed transaction rate" (#107895)

### DIFF
--- a/x-pack/plugins/apm/common/alert_types.ts
+++ b/x-pack/plugins/apm/common/alert_types.ts
@@ -71,7 +71,7 @@ export const ALERT_TYPES_CONFIG: Record<
   },
   [AlertType.TransactionErrorRate]: {
     name: i18n.translate('xpack.apm.transactionErrorRateAlert.name', {
-      defaultMessage: 'Transaction error rate threshold',
+      defaultMessage: 'Failed transaction rate threshold',
     }),
     actionGroups: [THRESHOLD_MET_GROUP],
     defaultActionGroupId: THRESHOLD_MET_GROUP_ID,

--- a/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
+++ b/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
@@ -164,7 +164,7 @@ export function registerApmAlerts(
       reason: i18n.translate(
         'xpack.apm.alertTypes.transactionErrorRate.reason',
         {
-          defaultMessage: `Transaction error rate is greater than {threshold} (current value is {measured}) for {serviceName}`,
+          defaultMessage: `Failed transactions rate is greater than {threshold} (current value is {measured}) for {serviceName}`,
           values: {
             threshold: asPercent(fields[ALERT_EVALUATION_THRESHOLD], 100),
             measured: asPercent(fields[ALERT_EVALUATION_VALUE], 100),

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_error_rate_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_error_rate_chart.tsx
@@ -21,7 +21,11 @@ function yLabelFormat(y?: number | null) {
   return asPercent(y || 0, 1);
 }
 
-export function BackendErrorRateChart({ height }: { height: number }) {
+export function BackendFailedTransactionRateChart({
+  height,
+}: {
+  height: number;
+}) {
   const { backendName } = useApmBackendContext();
 
   const theme = useTheme();
@@ -72,7 +76,7 @@ export function BackendErrorRateChart({ height }: { height: number }) {
         type: 'linemark',
         color: theme.eui.euiColorVis7,
         title: i18n.translate('xpack.apm.backendErrorRateChart.chartTitle', {
-          defaultMessage: 'Error rate',
+          defaultMessage: 'Failed transaction rate',
         }),
       });
     }

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/index.tsx
@@ -21,7 +21,7 @@ import { BackendLatencyChart } from './backend_latency_chart';
 import { BackendInventoryTitle } from '../../routing/home';
 import { BackendDetailDependenciesTable } from './backend_detail_dependencies_table';
 import { BackendThroughputChart } from './backend_throughput_chart';
-import { BackendErrorRateChart } from './backend_error_rate_chart';
+import { BackendFailedTransactionRateChart } from './backend_error_rate_chart';
 import { BackendDetailTemplate } from '../../routing/templates/backend_detail_template';
 
 export function BackendDetailOverview() {
@@ -86,12 +86,12 @@ export function BackendDetailOverview() {
                 <EuiTitle size="xs">
                   <h2>
                     {i18n.translate(
-                      'xpack.apm.backendDetailErrorRateChartTitle',
-                      { defaultMessage: 'Error rate' }
+                      'xpack.apm.backendDetailFailedTransactionRateChartTitle',
+                      { defaultMessage: 'Failed transaction rate' }
                     )}
                   </h2>
                 </EuiTitle>
-                <BackendErrorRateChart height={200} />
+                <BackendFailedTransactionRateChart height={200} />
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -54,7 +54,7 @@ import { useApmServiceContext } from '../../../context/apm_service/use_apm_servi
 const errorRateTab = {
   key: 'errorRate',
   label: i18n.translate('xpack.apm.correlations.tabs.errorRateLabel', {
-    defaultMessage: 'Error rate',
+    defaultMessage: 'Failed transaction rate',
   }),
   component: ErrorCorrelations,
 };

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -187,7 +187,7 @@ export function getServiceColumns({
     {
       field: 'transactionErrorRate',
       name: i18n.translate('xpack.apm.servicesTable.transactionErrorRate', {
-        defaultMessage: 'Error rate %',
+        defaultMessage: 'Failed transaction rate',
       }),
       sortable: true,
       dataType: 'number',

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/stats_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/stats_list.tsx
@@ -104,7 +104,7 @@ export function StatsList({ data, isLoading }: StatsListProps) {
     },
     {
       title: i18n.translate('xpack.apm.serviceMap.errorRatePopoverStat', {
-        defaultMessage: 'Trans. error rate (avg.)',
+        defaultMessage: 'Failed transaction rate (avg.)',
       }),
       description: asPercent(avgErrorRate, 1, ''),
     },

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -148,7 +148,7 @@ export function getColumns({
       field: 'errorRate',
       name: i18n.translate(
         'xpack.apm.serviceOverview.instancesTableColumnErrorRate',
-        { defaultMessage: 'Error rate' }
+        { defaultMessage: 'Failed transaction rate' }
       ),
       width: `${unit * 8}px`,
       render: (_, { serviceNodeName, errorRate }) => {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
@@ -129,7 +129,7 @@ export function ServiceOverviewThroughputChart({
               {data.throughputUnit === 'second'
                 ? i18n.translate(
                     'xpack.apm.serviceOverview.throughtputPerSecondChartTitle',
-                    { defaultMessage: '(per second)' }
+                    { defaultMessage: ' (per second)' }
                   )
                 : ''}
             </h2>

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/alerting_popover_flyout.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/alerting_popover_flyout.tsx
@@ -26,7 +26,7 @@ const transactionDurationLabel = i18n.translate(
 );
 const transactionErrorRateLabel = i18n.translate(
   'xpack.apm.home.alertsMenu.transactionErrorRate',
-  { defaultMessage: 'Transaction error rate' }
+  { defaultMessage: 'Failed transaction rate' }
 );
 const errorCountLabel = i18n.translate('xpack.apm.home.alertsMenu.errorCount', {
   defaultMessage: 'Error count',
@@ -146,7 +146,7 @@ export function AlertingPopoverAndFlyout({
       ],
     },
 
-    // transaction error rate panel
+    // Failed transactions panel
     {
       id: CREATE_TRANSACTION_ERROR_RATE_ALERT_PANEL_ID,
       title: transactionErrorRateLabel,

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -114,7 +114,7 @@ export function TransactionErrorRateChart({
       type: 'linemark',
       color: theme.eui.euiColorVis7,
       title: i18n.translate('xpack.apm.errorRate.chart.errorRate', {
-        defaultMessage: 'Error rate (avg.)',
+        defaultMessage: 'Failed transaction rate (avg.)',
       }),
     },
     ...(comparisonEnabled
@@ -137,7 +137,7 @@ export function TransactionErrorRateChart({
       <EuiTitle size="xs">
         <h2>
           {i18n.translate('xpack.apm.errorRate', {
-            defaultMessage: 'Error rate',
+            defaultMessage: 'Failed transaction rate',
           })}
         </h2>
       </EuiTitle>

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -113,7 +113,7 @@ export function DependenciesTable(props: Props) {
     {
       field: 'errorRateValue',
       name: i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
-        defaultMessage: 'Error rate',
+        defaultMessage: 'Failed transaction rate',
       }),
       width: `${unit * 10}px`,
       render: (_, { currentStats, previousStats }) => {

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -122,7 +122,7 @@ export function getColumns({
       sortable: true,
       name: i18n.translate(
         'xpack.apm.serviceOverview.transactionsTableColumnErrorRate',
-        { defaultMessage: 'Error rate' }
+        { defaultMessage: 'Failed transaction rate' }
       ),
       width: `${unit * 8}px`,
       render: (_, { errorRate, name }) => {

--- a/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_error_rate.ts
@@ -17,7 +17,7 @@ import { environmentQuery } from '../../../../common/utils/environment_query';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import {
-  calculateTransactionErrorPercentage,
+  calculateFailedTransactionRate,
   getOutcomeAggregation,
 } from '../../helpers/transaction_error_rate';
 
@@ -75,12 +75,9 @@ export async function getTransactionErrorRateChartPreview({
   }
 
   return resp.aggregations.timeseries.buckets.map((bucket) => {
-    const errorPercentage = calculateTransactionErrorPercentage(
-      bucket.outcomes
-    );
     return {
       x: bucket.key,
-      y: errorPercentage,
+      y: calculateFailedTransactionRate(bucket.outcomes),
     };
   });
 }

--- a/x-pack/plugins/apm/server/lib/correlations/errors/get_correlations_for_failed_transactions.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/errors/get_correlations_for_failed_transactions.ts
@@ -19,7 +19,7 @@ import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import {
   getTimeseriesAggregation,
-  getTransactionErrorRateTimeSeries,
+  getFailedTransactionRateTimeSeries,
 } from '../../helpers/transaction_error_rate';
 import { CorrelationsOptions, getCorrelationsFilters } from '../get_filters';
 
@@ -145,7 +145,7 @@ export async function getErrorRateTimeSeries({
 
       return {
         ...topSig,
-        timeseries: getTransactionErrorRateTimeSeries(agg.timeseries.buckets),
+        timeseries: getFailedTransactionRateTimeSeries(agg.timeseries.buckets),
       };
     }),
   };

--- a/x-pack/plugins/apm/server/lib/correlations/errors/get_overall_error_timeseries.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/errors/get_overall_error_timeseries.ts
@@ -9,7 +9,7 @@ import { ProcessorEvent } from '../../../../common/processor_event';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import {
   getTimeseriesAggregation,
-  getTransactionErrorRateTimeSeries,
+  getFailedTransactionRateTimeSeries,
 } from '../../helpers/transaction_error_rate';
 import { CorrelationsOptions, getCorrelationsFilters } from '../get_filters';
 
@@ -43,7 +43,7 @@ export async function getOverallErrorTimeseries(options: CorrelationsOptions) {
 
   return {
     overall: {
-      timeseries: getTransactionErrorRateTimeSeries(
+      timeseries: getFailedTransactionRateTimeSeries(
         aggregations.timeseries.buckets
       ),
     },

--- a/x-pack/plugins/apm/server/lib/helpers/transaction_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transaction_error_rate.ts
@@ -35,7 +35,7 @@ export const getTimeseriesAggregation = (
   aggs: { outcomes: getOutcomeAggregation() },
 });
 
-export function calculateTransactionErrorPercentage(
+export function calculateFailedTransactionRate(
   outcomeResponse: AggregationResultOf<OutcomeAggregation, {}>
 ) {
   const outcomes = Object.fromEntries(
@@ -48,7 +48,7 @@ export function calculateTransactionErrorPercentage(
   return failedTransactions / (successfulTransactions + failedTransactions);
 }
 
-export function getTransactionErrorRateTimeSeries(
+export function getFailedTransactionRateTimeSeries(
   buckets: AggregationResultOf<
     {
       date_histogram: AggregationOptionsByType['date_histogram'];
@@ -60,7 +60,7 @@ export function getTransactionErrorRateTimeSeries(
   return buckets.map((dateBucket) => {
     return {
       x: dateBucket.key,
-      y: calculateTransactionErrorPercentage(dateBucket.outcomes),
+      y: calculateFailedTransactionRate(dateBucket.outcomes),
     };
   });
 }

--- a/x-pack/plugins/apm/server/lib/services/get_service_transaction_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_transaction_group_detailed_statistics.ts
@@ -29,7 +29,7 @@ import {
   getLatencyValue,
 } from '../helpers/latency_aggregation_type';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
-import { calculateTransactionErrorPercentage } from '../helpers/transaction_error_rate';
+import { calculateFailedTransactionRate } from '../helpers/transaction_error_rate';
 
 export async function getServiceTransactionGroupDetailedStatistics({
   environment,
@@ -164,7 +164,7 @@ export async function getServiceTransactionGroupDetailedStatistics({
     }));
     const errorRate = bucket.timeseries.buckets.map((timeseriesBucket) => ({
       x: timeseriesBucket.key,
-      y: calculateTransactionErrorPercentage(timeseriesBucket[EVENT_OUTCOME]),
+      y: calculateFailedTransactionRate(timeseriesBucket[EVENT_OUTCOME]),
     }));
     const transactionGroupTotalDuration =
       bucket.transaction_group_total_duration.value || 0;

--- a/x-pack/plugins/apm/server/lib/services/get_service_transaction_groups.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_transaction_groups.ts
@@ -26,7 +26,7 @@ import {
   getLatencyValue,
 } from '../helpers/latency_aggregation_type';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
-import { calculateTransactionErrorPercentage } from '../helpers/transaction_error_rate';
+import { calculateFailedTransactionRate } from '../helpers/transaction_error_rate';
 
 export type ServiceOverviewTransactionGroupSortField =
   | 'name'
@@ -115,9 +115,7 @@ export async function getServiceTransactionGroups({
 
   const transactionGroups =
     response.aggregations?.transaction_groups.buckets.map((bucket) => {
-      const errorRate = calculateTransactionErrorPercentage(
-        bucket[EVENT_OUTCOME]
-      );
+      const errorRate = calculateFailedTransactionRate(bucket[EVENT_OUTCOME]);
 
       const transactionGroupTotalDuration =
         bucket.transaction_group_total_duration.value || 0;

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_service_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_service_transaction_stats.ts
@@ -25,7 +25,7 @@ import {
 } from '../../helpers/aggregated_transactions';
 import { calculateThroughput } from '../../helpers/calculate_throughput';
 import {
-  calculateTransactionErrorPercentage,
+  calculateFailedTransactionRate,
   getOutcomeAggregation,
 } from '../../helpers/transaction_error_rate';
 import { ServicesItemsSetup } from './get_services_items';
@@ -137,7 +137,7 @@ export async function getServiceTransactionStats({
           AGENT_NAME
         ] as AgentName,
         latency: topTransactionTypeBucket.avg_duration.value,
-        transactionErrorRate: calculateTransactionErrorPercentage(
+        transactionErrorRate: calculateFailedTransactionRate(
           topTransactionTypeBucket.outcomes
         ),
         throughput: calculateThroughput({

--- a/x-pack/plugins/apm/server/lib/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
@@ -26,7 +26,7 @@ import { calculateThroughput } from '../../helpers/calculate_throughput';
 import { getBucketSizeForAggregatedTransactions } from '../../helpers/get_bucket_size_for_aggregated_transactions';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import {
-  calculateTransactionErrorPercentage,
+  calculateFailedTransactionRate,
   getOutcomeAggregation,
 } from '../../helpers/transaction_error_rate';
 
@@ -148,7 +148,7 @@ export async function getServiceTransactionDetailedStatistics({
         transactionErrorRate: topTransactionTypeBucket.timeseries.buckets.map(
           (dateBucket) => ({
             x: dateBucket.key + offsetInMs,
-            y: calculateTransactionErrorPercentage(dateBucket.outcomes),
+            y: calculateFailedTransactionRate(dateBucket.outcomes),
           })
         ),
         throughput: topTransactionTypeBucket.timeseries.buckets.map(

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
@@ -23,9 +23,9 @@ import {
 import { getBucketSizeForAggregatedTransactions } from '../helpers/get_bucket_size_for_aggregated_transactions';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
 import {
-  calculateTransactionErrorPercentage,
+  calculateFailedTransactionRate,
   getOutcomeAggregation,
-  getTransactionErrorRateTimeSeries,
+  getFailedTransactionRateTimeSeries,
 } from '../helpers/transaction_error_rate';
 
 export async function getErrorRate({
@@ -124,13 +124,11 @@ export async function getErrorRate({
     return { noHits, transactionErrorRate: [], average: null };
   }
 
-  const transactionErrorRate = getTransactionErrorRateTimeSeries(
+  const transactionErrorRate = getFailedTransactionRateTimeSeries(
     resp.aggregations.timeseries.buckets
   );
 
-  const average = calculateTransactionErrorPercentage(
-    resp.aggregations.outcomes
-  );
+  const average = calculateFailedTransactionRate(resp.aggregations.outcomes);
 
   return { noHits, transactionErrorRate, average };
 }

--- a/x-pack/plugins/apm/server/routes/backends.ts
+++ b/x-pack/plugins/apm/server/routes/backends.ts
@@ -237,7 +237,7 @@ const backendThroughputChartsRoute = createApmServerRoute({
   },
 });
 
-const backendErrorRateChartsRoute = createApmServerRoute({
+const backendFailedTransactionRateChartsRoute = createApmServerRoute({
   endpoint: 'GET /api/apm/backends/{backendName}/charts/error_rate',
   params: t.type({
     path: t.type({
@@ -288,4 +288,4 @@ export const backendsRouteRepository = createApmServerRouteRepository()
   .add(backendMetadataRoute)
   .add(backendLatencyChartsRoute)
   .add(backendThroughputChartsRoute)
-  .add(backendErrorRateChartsRoute);
+  .add(backendFailedTransactionRateChartsRoute);

--- a/x-pack/test/apm_api_integration/tests/alerts/rule_registry.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/rule_registry.ts
@@ -215,7 +215,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           actions: [],
           tags: ['apm', 'service.name:opbeans-go'],
           notifyWhen: 'onActionGroupChange',
-          name: 'Transaction error rate threshold | opbeans-go',
+          name: 'Failed transaction rate threshold | opbeans-go',
         };
 
         const { body: response, status } = await supertest
@@ -371,13 +371,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               "apm.transaction_error_rate_opbeans-go_request_ENVIRONMENT_NOT_DEFINED",
             ],
             "kibana.alert.rule.category": Array [
-              "Transaction error rate threshold",
+              "Failed transaction rate threshold",
             ],
             "kibana.alert.rule.consumer": Array [
               "apm",
             ],
             "kibana.alert.rule.name": Array [
-              "Transaction error rate threshold | opbeans-go",
+              "Failed transaction rate threshold | opbeans-go",
             ],
             "kibana.alert.rule.producer": Array [
               "apm",
@@ -447,13 +447,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               "apm.transaction_error_rate_opbeans-go_request_ENVIRONMENT_NOT_DEFINED",
             ],
             "kibana.alert.rule.category": Array [
-              "Transaction error rate threshold",
+              "Failed transaction rate threshold",
             ],
             "kibana.alert.rule.consumer": Array [
               "apm",
             ],
             "kibana.alert.rule.name": Array [
-              "Transaction error rate threshold | opbeans-go",
+              "Failed transaction rate threshold | opbeans-go",
             ],
             "kibana.alert.rule.producer": Array [
               "apm",
@@ -551,13 +551,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               "apm.transaction_error_rate_opbeans-go_request_ENVIRONMENT_NOT_DEFINED",
             ],
             "kibana.alert.rule.category": Array [
-              "Transaction error rate threshold",
+              "Failed transaction rate threshold",
             ],
             "kibana.alert.rule.consumer": Array [
               "apm",
             ],
             "kibana.alert.rule.name": Array [
-              "Transaction error rate threshold | opbeans-go",
+              "Failed transaction rate threshold | opbeans-go",
             ],
             "kibana.alert.rule.producer": Array [
               "apm",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Rename "Error rate" to "Failed transaction rate" (#107895)