### PR TITLE
[APM] Removing loading spinner while fetching comparison data from tables

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/README
+++ b/x-pack/plugins/apm/ftr_e2e/README
@@ -1,0 +1,25 @@
+# APM E2E
+
+APM uses FTR (funcional test runner) and Cypress to run the e2e tests. The tests are located at `kibana/x-pack/plugins/apm/ftr_e2e/cypress/integration`. 
+
+
+## Running tests
+
+**Run all tests**
+```sh
+//kibana directory
+node x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js
+```
+
+**Run specific test**
+
+```sh
+//kibana directory
+node x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js --spec ./cypress/integration/read_only_user/home.spec.ts
+```
+## Opening tests
+
+```sh
+//kibana directory
+node x-pack/plugins/apm/scripts/ftr_e2e/cypress_open.js
+```

--- a/x-pack/plugins/apm/ftr_e2e/README.md
+++ b/x-pack/plugins/apm/ftr_e2e/README.md
@@ -1,6 +1,6 @@
 # APM E2E
 
-APM uses FTR (funcional test runner) and Cypress to run the e2e tests. The tests are located at `kibana/x-pack/plugins/apm/ftr_e2e/cypress/integration`.
+APM uses [FTR](../../../../packages/kbn-test/README.md) (functional test runner) and [Cypress](https://www.cypress.io/) to run the e2e tests. The tests are located at `kibana/x-pack/plugins/apm/ftr_e2e/cypress/integration`.
 
 ## Running tests
 

--- a/x-pack/plugins/apm/ftr_e2e/README.md
+++ b/x-pack/plugins/apm/ftr_e2e/README.md
@@ -1,11 +1,11 @@
 # APM E2E
 
-APM uses FTR (funcional test runner) and Cypress to run the e2e tests. The tests are located at `kibana/x-pack/plugins/apm/ftr_e2e/cypress/integration`. 
-
+APM uses FTR (funcional test runner) and Cypress to run the e2e tests. The tests are located at `kibana/x-pack/plugins/apm/ftr_e2e/cypress/integration`.
 
 ## Running tests
 
 **Run all tests**
+
 ```sh
 //kibana directory
 node x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js
@@ -17,6 +17,7 @@ node x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js
 //kibana directory
 node x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js --spec ./cypress/integration/read_only_user/home.spec.ts
 ```
+
 ## Opening tests
 
 ```sh

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/home.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/home.spec.ts
@@ -7,6 +7,7 @@
 
 import url from 'url';
 import archives_metadata from '../../fixtures/es_archiver/archives_metadata';
+import { esArchiverLoad, esArchiverUnload } from '../../tasks/es_archiver';
 
 const { start, end } = archives_metadata['apm_8.0.0'];
 
@@ -27,6 +28,12 @@ const apisToIntercept = [
 ];
 
 describe('Home page', () => {
+  before(() => {
+    esArchiverLoad('apm_8.0.0');
+  });
+  after(() => {
+    esArchiverUnload('apm_8.0.0');
+  });
   beforeEach(() => {
     cy.loginAsReadOnlyUser();
   });
@@ -39,8 +46,7 @@ describe('Home page', () => {
     );
   });
 
-  // Flaky
-  it.skip('includes services with only metric documents', () => {
+  it('includes services with only metric documents', () => {
     cy.visit(
       `${serviceInventoryHref}&kuery=not%2520(processor.event%2520%253A%2522transaction%2522%2520)`
     );
@@ -50,11 +56,7 @@ describe('Home page', () => {
   });
 
   describe('navigations', () => {
-    /*
-     This test is flaky, there's a problem with EuiBasicTable, that it blocks any action while loading is enabled.
-     So it might fail to click on the service link.
-    */
-    it.skip('navigates to service overview page with transaction type', () => {
+    it('navigates to service overview page with transaction type', () => {
       apisToIntercept.map(({ endpoint, name }) => {
         cy.intercept('GET', endpoint).as(name);
       });
@@ -62,9 +64,6 @@ describe('Home page', () => {
       cy.visit(serviceInventoryHref);
 
       cy.contains('Services');
-
-      cy.wait('@servicesMainStatistics', { responseTimeout: 10000 });
-      cy.wait('@servicesDetailedStatistics', { responseTimeout: 10000 });
 
       cy.get('[data-test-subj="serviceLink_rum-js"]').then((element) => {
         element[0].click();

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
@@ -67,8 +67,7 @@ describe('Instances table', () => {
       cy.contains('opbeans-java');
       cy.contains(serviceNodeName);
     });
-    // For some reason the details panel is not opening after clicking on the button.
-    it.skip('shows instance details', () => {
+    it('shows instance details', () => {
       apisToIntercept.map(({ endpoint, name }) => {
         cy.intercept('GET', endpoint).as(name);
       });
@@ -88,8 +87,7 @@ describe('Instances table', () => {
         cy.contains('Service');
       });
     });
-    // For some reason the tooltip is not opening after clicking on the button.
-    it.skip('shows actions available', () => {
+    it('shows actions available', () => {
       apisToIntercept.map(({ endpoint, name }) => {
         cy.intercept('GET', endpoint).as(name);
       });

--- a/x-pack/plugins/apm/ftr_e2e/cypress_run.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress_run.ts
@@ -4,15 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { argv } from 'yargs';
 import { FtrConfigProviderContext } from '@kbn/test';
 import { cypressRunTests } from './cypress_start';
+
+const spec = argv.grep as string;
 
 async function runE2ETests({ readConfigFile }: FtrConfigProviderContext) {
   const cypressConfig = await readConfigFile(require.resolve('./config.ts'));
   return {
     ...cypressConfig.getAll(),
-    testRunner: cypressRunTests,
+    testRunner: cypressRunTests(spec),
   };
 }
 

--- a/x-pack/plugins/apm/ftr_e2e/cypress_start.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress_start.ts
@@ -11,17 +11,19 @@ import { FtrProviderContext } from './ftr_provider_context';
 import archives_metadata from './cypress/fixtures/es_archiver/archives_metadata';
 import { createKibanaUserRole } from '../scripts/kibana-security/create_kibana_user_role';
 
-export async function cypressRunTests({ getService }: FtrProviderContext) {
-  try {
-    const result = await cypressStart(getService, cypress.run);
+export function cypressRunTests(spec?: string) {
+  return async ({ getService }: FtrProviderContext) => {
+    try {
+      const result = await cypressStart(getService, cypress.run, spec);
 
-    if (result && (result.status === 'failed' || result.totalFailed > 0)) {
+      if (result && (result.status === 'failed' || result.totalFailed > 0)) {
+        process.exit(1);
+      }
+    } catch (error) {
+      console.error('errors: ', error);
       process.exit(1);
     }
-  } catch (error) {
-    console.error('errors: ', error);
-    process.exit(1);
-  }
+  };
 }
 
 export async function cypressOpenTests({ getService }: FtrProviderContext) {
@@ -30,7 +32,8 @@ export async function cypressOpenTests({ getService }: FtrProviderContext) {
 
 async function cypressStart(
   getService: FtrProviderContext['getService'],
-  cypressExecution: typeof cypress.run | typeof cypress.open
+  cypressExecution: typeof cypress.run | typeof cypress.open,
+  spec?: string
 ) {
   const config = getService('config');
 
@@ -56,6 +59,7 @@ async function cypressStart(
   });
 
   return cypressExecution({
+    ...(spec !== 'undefined' ? { spec } : {}),
     config: { baseUrl: kibanaUrl },
     env: {
       START_DATE: start,

--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -80,7 +80,7 @@ function useServicesFetcher() {
 
   const { mainStatisticsData, requestId } = data;
 
-  const { data: comparisonData, status: comparisonStatus } = useFetcher(
+  const { data: comparisonData } = useFetcher(
     (callApmApi) => {
       if (start && end && mainStatisticsData.items.length) {
         return callApmApi({
@@ -147,9 +147,7 @@ function useServicesFetcher() {
     servicesData: mainStatisticsData,
     servicesStatus: mainStatisticsStatus,
     comparisonData,
-    isLoading:
-      mainStatisticsStatus === FETCH_STATUS.LOADING ||
-      comparisonStatus === FETCH_STATUS.LOADING,
+    isLoading: mainStatisticsStatus === FETCH_STATUS.LOADING,
   };
 }
 

--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -144,8 +144,8 @@ function useServicesFetcher() {
   ]);
 
   return {
-    servicesData: mainStatisticsData,
-    servicesStatus: mainStatisticsStatus,
+    mainStatisticsData,
+    mainStatisticsStatus,
     comparisonData,
     isLoading: mainStatisticsStatus === FETCH_STATUS.LOADING,
   };
@@ -154,8 +154,8 @@ function useServicesFetcher() {
 export function ServiceInventory() {
   const { core } = useApmPluginContext();
   const {
-    servicesData,
-    servicesStatus,
+    mainStatisticsData,
+    mainStatisticsStatus,
     comparisonData,
     isLoading,
   } = useServicesFetcher();
@@ -190,13 +190,13 @@ export function ServiceInventory() {
         <EuiFlexItem>
           <ServiceList
             isLoading={isLoading}
-            items={servicesData.items}
+            items={mainStatisticsData.items}
             comparisonData={comparisonData}
             noItemsMessage={
               !isLoading && (
                 <NoServicesMessage
-                  historicalDataFound={servicesData.hasHistoricalData}
-                  status={servicesStatus}
+                  historicalDataFound={mainStatisticsData.hasHistoricalData}
+                  status={mainStatisticsStatus}
                 />
               )
             }

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
@@ -143,7 +143,6 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
 
   const {
     data: errorGroupDetailedStatistics = INITIAL_STATE_DETAILED_STATISTICS,
-    status: errorGroupDetailedStatisticsStatus,
   } = useFetcher(
     (callApmApi) => {
       if (requestId && items.length && start && end && transactionType) {
@@ -220,10 +219,7 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
                 pageSizeOptions: [PAGE_SIZE],
                 hidePerPageOptions: true,
               }}
-              loading={
-                status === FETCH_STATUS.LOADING ||
-                errorGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING
-              }
+              loading={status === FETCH_STATUS.LOADING}
               onChange={(newTableOptions: {
                 page?: {
                   index: number;

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
@@ -166,7 +166,6 @@ export function ServiceOverviewInstancesChartAndTable({
 
   const {
     data: detailedStatsData = INITIAL_STATE_DETAILED_STATISTICS,
-    status: detailedStatsStatus,
   } = useFetcher(
     (callApmApi) => {
       if (
@@ -228,10 +227,7 @@ export function ServiceOverviewInstancesChartAndTable({
             detailedStatsData={detailedStatsData}
             serviceName={serviceName}
             tableOptions={tableOptions}
-            isLoading={
-              mainStatsStatus === FETCH_STATUS.LOADING ||
-              detailedStatsStatus === FETCH_STATUS.LOADING
-            }
+            isLoading={mainStatsStatus === FETCH_STATUS.LOADING}
             onChangeTableOptions={(newTableOptions) => {
               setTableOptions({
                 pageIndex: newTableOptions.page?.index ?? 0,

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -169,10 +169,7 @@ export function TransactionsTable({
     },
   } = data;
 
-  const {
-    data: transactionGroupDetailedStatistics,
-    status: transactionGroupDetailedStatisticsStatus,
-  } = useFetcher(
+  const { data: transactionGroupDetailedStatistics } = useFetcher(
     (callApmApi) => {
       if (
         transactionGroupsTotalItems &&
@@ -217,9 +214,7 @@ export function TransactionsTable({
     comparisonEnabled,
   });
 
-  const isLoading =
-    status === FETCH_STATUS.LOADING ||
-    transactionGroupDetailedStatisticsStatus === FETCH_STATUS.LOADING;
+  const isLoading = status === FETCH_STATUS.LOADING;
 
   const pagination = {
     pageIndex,

--- a/x-pack/plugins/apm/readme.md
+++ b/x-pack/plugins/apm/readme.md
@@ -33,11 +33,7 @@ _Docker Compose is required_
 
 ### Cypress tests
 
-```sh
-node x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js
-```
-
-_Starts Kibana (:5701), APM Server (:8201) and Elasticsearch (:9201). Ingests sample data into Elasticsearch via APM Server and runs the Cypress tests_
+See [ftr_e2e](./ftr_e2e)
 
 ### Jest tests
 
@@ -82,9 +78,10 @@ For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
 
 ### API integration tests
 
-API tests are separated in two suites: 
- - a basic license test suite
- - a trial license test suite (the equivalent of gold+)
+API tests are separated in two suites:
+
+- a basic license test suite
+- a trial license test suite (the equivalent of gold+)
 
 This requires separate test servers and test runners.
 
@@ -112,10 +109,10 @@ node scripts/functional_test_runner --config x-pack/test/apm_api_integration/tri
 
 The API tests for "trial" are located in `x-pack/test/apm_api_integration/trial/tests`.
 
-
 **API Test tips**
- - For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
- - To update snapshots append `--updateSnapshots` to the functional_test_runner command
+
+- For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
+- To update snapshots append `--updateSnapshots` to the functional_test_runner command
 
 ## Linting
 

--- a/x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js
+++ b/x-pack/plugins/apm/scripts/ftr_e2e/cypress_run.js
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+const { argv } = require('yargs');
 const childProcess = require('child_process');
 const path = require('path');
+
+const { spec } = argv;
 
 const e2eDir = path.join(__dirname, '../../ftr_e2e');
 
 childProcess.execSync(
-  `node ../../../../scripts/functional_tests --config ./cypress_run.ts`,
+  `node ../../../../scripts/functional_tests --config ./cypress_run.ts --grep ${spec}`,
   { cwd: e2eDir, stdio: 'inherit' }
 );


### PR DESCRIPTION
closes #103645

The EuiBasicTable locks a table while it is loading, that's the reason why nothing happens when the user clicks on any link or button inside the table. https://github.com/elastic/eui/issues/5014

Tables changed:
- Service inventory table
- Transactions table
- Dependencies table
- Instances table

E2E tests improvements:
- Added a README file
- Added a `--spec` argument to specify a specific test to run.
- Re-enabled some tests that needed to be skipped because it could not click on the links in the table because of the loading stage.

https://user-images.githubusercontent.com/55978943/129087439-69c38d99-d353-4590-8a55-eca974ea78fe.mov
