### PR TITLE
Update console.asciidoc note transform GET with body to POST

### DIFF
--- a/docs/dev-tools/console/console.asciidoc
+++ b/docs/dev-tools/console/console.asciidoc
@@ -49,7 +49,7 @@ click the action icon (image:dev-tools/console/images/wrench.png[]) and select *
 Once copied, the username and password will need to be provided
 for the calls to work from external environments.
 
-Note: If you post a GET request with a body, will be automaically be converted to *Console* syntax as a POST request.
+NOTE: If you post a GET request with a body, it is automatically converted to *Console* syntax as a POST request.
 
 [float]
 [[console-autocomplete]]

--- a/docs/dev-tools/console/console.asciidoc
+++ b/docs/dev-tools/console/console.asciidoc
@@ -49,6 +49,8 @@ click the action icon (image:dev-tools/console/images/wrench.png[]) and select *
 Once copied, the username and password will need to be provided
 for the calls to work from external environments.
 
+Note: If you post a GET request with a body, will be automaically be converted to *Console* syntax as a POST request.
+
 [float]
 [[console-autocomplete]]
 ==== Autocomplete


### PR DESCRIPTION
Per a slack discussion https://elastic.slack.com/archives/C0D1XEXEZ/p1628706191394900

There is a misleading issue with Kibana > Dev Tools, regarding posting a GET request with a body, in particular say a search.  

GET [index]/_search {....} this gets converted to a POST request.  It can be seen if you are looking at the console view in the browser tools.

This can cause different responses (different results) when using Kibana versus other tools ex. POSTMAN when diagnosing something such as a search query with aggs.

See references: 
https://github.com/elastic/kibana/issues/11593
https://github.com/elastic/kibana/issues/11125
https://github.com/elastic/kibana/issues/11948

This doc change is to add it so that is it more obvious that we do this (transform to POST when GET has body).

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
