### PR TITLE
[7.14] [Expressions] Add support of partial results to the switch expression function (#108086)

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/switch.test.js
@@ -55,25 +55,6 @@ describe('switch', () => {
   });
 
   describe('function', () => {
-    describe('with no cases', () => {
-      it('should return the context if no default is provided', () => {
-        const context = 'foo';
-
-        testScheduler.run(({ expectObservable }) =>
-          expectObservable(fn(context, {})).toBe('(0|)', [context])
-        );
-      });
-
-      it('should return the default if provided', () => {
-        const context = 'foo';
-        const args = { default: () => of('bar') };
-
-        testScheduler.run(({ expectObservable }) =>
-          expectObservable(fn(context, args)).toBe('(0|)', ['bar'])
-        );
-      });
-    });
-
     describe('with no matching cases', () => {
       it('should return the context if no default is provided', () => {
         const context = 'foo';
@@ -106,6 +87,55 @@ describe('switch', () => {
         testScheduler.run(({ expectObservable }) =>
           expectObservable(fn(context, args)).toBe('(0|)', [result])
         );
+      });
+
+      it('should support partial results', () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          const context = 'foo';
+          const case1 = cold('--ab-c-', {
+            a: {
+              type: 'case',
+              matches: false,
+              result: 1,
+            },
+            b: {
+              type: 'case',
+              matches: true,
+              result: 2,
+            },
+            c: {
+              type: 'case',
+              matches: false,
+              result: 3,
+            },
+          });
+          const case2 = cold('-a--bc-', {
+            a: {
+              type: 'case',
+              matches: true,
+              result: 4,
+            },
+            b: {
+              type: 'case',
+              matches: true,
+              result: 5,
+            },
+            c: {
+              type: 'case',
+              matches: true,
+              result: 6,
+            },
+          });
+          const expected = ' --abc(de)-';
+          const args = { case: [() => case1, () => case2] };
+          expectObservable(fn(context, args)).toBe(expected, {
+            a: 4,
+            b: 2,
+            c: 2,
+            d: 5,
+            e: 6,
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Expressions] Add support of partial results to the switch expression function (#108086)