### PR TITLE
[7.x] [ML] Data Frame Analytics: add evaluation quality metrics to Classification exploration view (#107862)

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/common/analytics.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/common/analytics.ts
@@ -65,6 +65,12 @@ export interface LoadExploreDataArg {
   searchQuery: SavedSearchQuery;
 }
 
+export interface ClassificationMetricItem {
+  className: string;
+  accuracy?: number;
+  recall?: number;
+}
+
 export const SEARCH_SIZE = 1000;
 
 export const TRAINING_PERCENT_MIN = 1;

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/_classification_exploration.scss
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/_classification_exploration.scss
@@ -41,3 +41,7 @@ $labelColumnWidth: 80px;
     text-transform: none;
   }
 }
+
+.mlDataFrameAnalyticsClassification__evaluationMetrics {
+  width: 60%;
+}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluate_panel.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluate_panel.tsx
@@ -34,6 +34,7 @@ import { ResultsSearchQuery } from '../../../../common/analytics';
 
 import { ExpandableSection, HEADER_ITEMS_LOADING } from '../expandable_section';
 import { EvaluateStat } from './evaluate_stat';
+import { EvaluationQualityMetricsTable } from './evaluation_quality_metrics_table';
 
 import { getRocCurveChartVegaLiteSpec } from './get_roc_curve_chart_vega_lite_spec';
 
@@ -85,6 +86,13 @@ const trainingDatasetHelpText = i18n.translate(
   }
 );
 
+const evaluationQualityMetricsHelpText = i18n.translate(
+  'xpack.ml.dataframe.analytics.classificationExploration.evaluationQualityMetricsHelpText',
+  {
+    defaultMessage: 'Evaluation quality metrics',
+  }
+);
+
 function getHelpText(dataSubsetTitle: string): string {
   let helpText = entireDatasetHelpText;
   if (dataSubsetTitle === SUBSET_TITLE.TESTING) {
@@ -120,6 +128,7 @@ export const EvaluatePanel: FC<EvaluatePanelProps> = ({ jobConfig, jobStatus, se
     error: errorConfusionMatrix,
     isLoading: isLoadingConfusionMatrix,
     overallAccuracy,
+    evaluationMetricsItems,
   } = useConfusionMatrix(jobConfig, searchQuery);
 
   useEffect(() => {
@@ -365,46 +374,61 @@ export const EvaluatePanel: FC<EvaluatePanelProps> = ({ jobConfig, jobStatus, se
             ) : null}
             {/* Accuracy and Recall */}
             <EuiSpacer size="xl" />
-            <EuiFlexGroup gutterSize="l">
+            <EuiTitle size="xxs">
+              <span>{evaluationQualityMetricsHelpText}</span>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup
+              direction="column"
+              justifyContent="center"
+              className="mlDataFrameAnalyticsClassification__evaluationMetrics"
+            >
               <EuiFlexItem grow={false}>
-                <EvaluateStat
-                  dataTestSubj={'mlDFAEvaluateSectionOverallAccuracyStat'}
-                  title={overallAccuracy}
-                  isLoading={isLoadingConfusionMatrix}
-                  description={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyStat',
-                    {
-                      defaultMessage: 'Overall accuracy',
-                    }
-                  )}
-                  tooltipContent={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyTooltip',
-                    {
-                      defaultMessage:
-                        'The ratio of the number of correct class predictions to the total number of predictions.',
-                    }
-                  )}
-                />
+                <EuiFlexGroup gutterSize="l">
+                  <EuiFlexItem grow={false}>
+                    <EvaluateStat
+                      dataTestSubj={'mlDFAEvaluateSectionOverallAccuracyStat'}
+                      title={overallAccuracy}
+                      isLoading={isLoadingConfusionMatrix}
+                      description={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyStat',
+                        {
+                          defaultMessage: 'Overall accuracy',
+                        }
+                      )}
+                      tooltipContent={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionOverallAccuracyTooltip',
+                        {
+                          defaultMessage:
+                            'The ratio of the number of correct class predictions to the total number of predictions.',
+                        }
+                      )}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EvaluateStat
+                      dataTestSubj={'mlDFAEvaluateSectionAvgRecallStat'}
+                      title={avgRecall}
+                      isLoading={isLoadingConfusionMatrix}
+                      description={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionMeanRecallStat',
+                        {
+                          defaultMessage: 'Mean recall',
+                        }
+                      )}
+                      tooltipContent={i18n.translate(
+                        'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionAvgRecallTooltip',
+                        {
+                          defaultMessage:
+                            'Mean recall shows how many of the data points that are actual class members were identified correctly as class members.',
+                        }
+                      )}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EvaluateStat
-                  dataTestSubj={'mlDFAEvaluateSectionAvgRecallStat'}
-                  title={avgRecall}
-                  isLoading={isLoadingConfusionMatrix}
-                  description={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionMeanRecallStat',
-                    {
-                      defaultMessage: 'Mean recall',
-                    }
-                  )}
-                  tooltipContent={i18n.translate(
-                    'xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionAvgRecallTooltip',
-                    {
-                      defaultMessage:
-                        'Mean recall shows how many of the data points that are actual class members were identified correctly as class members.',
-                    }
-                  )}
-                />
+                <EvaluationQualityMetricsTable evaluationMetricsItems={evaluationMetricsItems} />
               </EuiFlexItem>
             </EuiFlexGroup>
             {/* AUC ROC Chart */}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/classification_exploration/evaluation_quality_metrics_table.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
+import { EuiAccordion, EuiInMemoryTable, EuiPanel } from '@elastic/eui';
+
+import { ClassificationMetricItem } from '../../../../common/analytics';
+
+const columns = [
+  {
+    field: 'className',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyClassColumn',
+      {
+        defaultMessage: 'Class',
+      }
+    ),
+    sortable: true,
+    truncateText: true,
+  },
+  {
+    field: 'accuracy',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyAccuracyColumn',
+      {
+        defaultMessage: 'Accuracy',
+      }
+    ),
+    render: (value: number) => Math.round(value * 1000) / 1000,
+  },
+  {
+    field: 'recall',
+    name: i18n.translate(
+      'xpack.ml.dataframe.analytics.classificationExploration.recallAndAccuracyRecallColumn',
+      {
+        defaultMessage: 'Recall',
+      }
+    ),
+    render: (value: number) => Math.round(value * 1000) / 1000,
+  },
+];
+
+export const EvaluationQualityMetricsTable: FC<{
+  evaluationMetricsItems: ClassificationMetricItem[];
+}> = ({ evaluationMetricsItems }) => (
+  <>
+    <EuiAccordion
+      id="recall-and-accuracy"
+      buttonContent={
+        <FormattedMessage
+          id="xpack.ml.dataframe.analytics.classificationExploration.evaluateSectionRecallAndAccuracy"
+          defaultMessage="Per class recall and accuracy"
+        />
+      }
+    >
+      <EuiPanel>
+        <EuiInMemoryTable<ClassificationMetricItem>
+          items={evaluationMetricsItems}
+          columns={columns}
+          pagination
+          sorting
+        />
+      </EuiPanel>
+    </EuiAccordion>
+  </>
+);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Data Frame Analytics: add evaluation quality metrics to Classification exploration view (#107862)