### PR TITLE
Enabling a11y test

### DIFF
--- a/x-pack/test/accessibility/apps/spaces.ts
+++ b/x-pack/test/accessibility/apps/spaces.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-// a11y tests for spaces, space selection and spacce creation and feature controls
+// a11y tests for spaces, space selection and space creation and feature controls
 
 import { FtrProviderContext } from '../ftr_provider_context';
 
@@ -52,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     // EUI issue - https://github.com/elastic/eui/issues/3999
-    it.skip('a11y test for color picker', async () => {
+    it('a11y test for color picker', async () => {
       await PageObjects.spaceSelector.clickColorPicker();
       await a11y.testAppSnapshot();
       await browser.pressKeys(browser.keys.ESCAPE);


### PR DESCRIPTION
Unskipping a test that was fixed in EUI in v35.1.0 (https://github.com/elastic/eui/pull/4886)