### PR TITLE
docs: Add anonymous auth to central config

### DIFF
--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -27,12 +27,11 @@ For this reason, it is still essential to set custom default configurations loca
 ==== APM Server setup
 
 This feature requires {apm-server-ref}/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
+In addition, if an APM agent is using {apm-server-ref}/configuration-anonymous.html[anonymous authentication] to communicate with the APM Server,
+the agent's service name must be included in the `apm-server.auth.anonymous.allow_service` list.
 
 APM Server acts as a proxy between the agents and Kibana.
 Kibana communicates any changed settings to APM Server so that your agents only need to poll APM Server to determine which settings have changed.
-
-In addition, if an APM agent is using {apm-server-ref}/configuration-anonymous.html[anonymous authentication] to communicate with the APM Server,
-the agent's service name must be included in the `apm-server.auth.anonymous.allow_service` list.
 
 [float]
 ==== Supported configurations

--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -31,6 +31,9 @@ This feature requires {apm-server-ref}/setup-kibana-endpoint.html[Kibana endpoin
 APM Server acts as a proxy between the agents and Kibana.
 Kibana communicates any changed settings to APM Server so that your agents only need to poll APM Server to determine which settings have changed.
 
+In addition, if an APM agent is using {apm-server-ref}/configuration-anonymous.html[anonymous authentication] to communicate with the APM Server,
+the agent's service name must be included in the `apm-server.auth.anonymous.allow_service` list.
+
 [float]
 ==== Supported configurations
 


### PR DESCRIPTION
## Summary

This PR adds a note on anonymous auth to the central config docs.

~Blocked by https://github.com/elastic/apm-server/pull/5930~
For https://github.com/elastic/apm-server/issues/5698.