### PR TITLE
[ML] Transforms: replace deprecated EuiCodeEditor

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_pivot_editor/advanced_pivot_editor.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_pivot_editor/advanced_pivot_editor.tsx
@@ -27,9 +27,9 @@ export const AdvancedPivotEditor: FC<StepDefineFormHook['advancedPivotEditor']> 
         label={i18n.translate('xpack.transform.stepDefineForm.advancedEditorLabel', {
           defaultMessage: 'Pivot configuration object',
         })}
+        data-test-subj="transformAdvancedPivotEditor"
       >
         <CodeEditor
-          data-test-subj="transformAdvancedPivotEditor"
           height={250}
           languageId={'json'}
           onChange={(d: string) => {

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_pivot_editor/advanced_pivot_editor.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_pivot_editor/advanced_pivot_editor.tsx
@@ -8,9 +8,11 @@
 import { isEqual } from 'lodash';
 import React, { memo, FC } from 'react';
 
-import { EuiCodeEditor, EuiFormRow } from '@elastic/eui';
+import { EuiFormRow } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
+import { CodeEditor } from '../../../../../../../../../src/plugins/kibana_react/public';
 
 import { StepDefineFormHook } from '../step_define';
 
@@ -26,13 +28,10 @@ export const AdvancedPivotEditor: FC<StepDefineFormHook['advancedPivotEditor']> 
           defaultMessage: 'Pivot configuration object',
         })}
       >
-        <EuiCodeEditor
+        <CodeEditor
           data-test-subj="transformAdvancedPivotEditor"
-          style={{ border: '1px solid #e3e6ef' }}
-          height="250px"
-          width="100%"
-          mode={xJsonMode}
-          value={advancedEditorConfig}
+          height={250}
+          languageId={'json'}
           onChange={(d: string) => {
             setAdvancedEditorConfig(d);
 
@@ -51,13 +50,21 @@ export const AdvancedPivotEditor: FC<StepDefineFormHook['advancedPivotEditor']> 
               setAdvancedPivotEditorApplyButtonEnabled(false);
             }
           }}
-          setOptions={{
-            fontSize: '12px',
+          options={{
+            ariaLabel: i18n.translate('xpack.transform.stepDefineForm.advancedEditorAriaLabel', {
+              defaultMessage: 'Advanced pivot editor',
+            }),
+            automaticLayout: true,
+            fontSize: 12,
+            scrollBeyondLastLine: false,
+            quickSuggestions: true,
+            minimap: {
+              enabled: false,
+            },
+            wordWrap: 'on',
+            wrappingIndent: 'indent',
           }}
-          theme="textmate"
-          aria-label={i18n.translate('xpack.transform.stepDefineForm.advancedEditorAriaLabel', {
-            defaultMessage: 'Advanced pivot editor',
-          })}
+          value={advancedEditorConfig}
         />
       </EuiFormRow>
     );

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_runtime_mappings_editor/advanced_runtime_mappings_editor.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_runtime_mappings_editor/advanced_runtime_mappings_editor.tsx
@@ -26,47 +26,50 @@ export const AdvancedRuntimeMappingsEditor: FC<StepDefineFormHook['runtimeMappin
     state: { advancedEditorRuntimeMappingsLastApplied, advancedRuntimeMappingsConfig, xJsonMode },
   }) => {
     return (
-      <CodeEditor
-        data-test-subj="transformAdvancedRuntimeMappingsEditor"
-        height={250}
-        languageId={'json'}
-        onChange={(d: string) => {
-          setAdvancedRuntimeMappingsConfig(d);
+      <div data-test-subj="transformAdvancedRuntimeMappingsEditor">
+        <CodeEditor
+          height={250}
+          languageId={'json'}
+          onChange={(d: string) => {
+            setAdvancedRuntimeMappingsConfig(d);
 
-          // Disable the "Apply"-Button if the config hasn't changed.
-          if (advancedEditorRuntimeMappingsLastApplied === d) {
-            setRuntimeMappingsEditorApplyButtonEnabled(false);
-            return;
-          }
+            // Disable the "Apply"-Button if the config hasn't changed.
+            if (advancedEditorRuntimeMappingsLastApplied === d) {
+              setRuntimeMappingsEditorApplyButtonEnabled(false);
+              return;
+            }
 
-          // Try to parse the string passed on from the editor.
-          // If parsing fails, the "Apply"-Button will be disabled
-          try {
-            // if the user deletes the json in the editor
-            // they should still be able to apply changes
-            const isEmptyStr = d === '';
-            const parsedJson = isEmptyStr ? {} : JSON.parse(convertToJson(d));
-            setRuntimeMappingsEditorApplyButtonEnabled(isEmptyStr || isRuntimeMappings(parsedJson));
-          } catch (e) {
-            setRuntimeMappingsEditorApplyButtonEnabled(false);
-          }
-        }}
-        options={{
-          ariaLabel: i18n.translate('xpack.transform.stepDefineForm.advancedEditorAriaLabel', {
-            defaultMessage: 'Advanced pivot editor',
-          }),
-          automaticLayout: true,
-          fontSize: 12,
-          scrollBeyondLastLine: false,
-          quickSuggestions: true,
-          minimap: {
-            enabled: false,
-          },
-          wordWrap: 'on',
-          wrappingIndent: 'indent',
-        }}
-        value={advancedRuntimeMappingsConfig}
-      />
+            // Try to parse the string passed on from the editor.
+            // If parsing fails, the "Apply"-Button will be disabled
+            try {
+              // if the user deletes the json in the editor
+              // they should still be able to apply changes
+              const isEmptyStr = d === '';
+              const parsedJson = isEmptyStr ? {} : JSON.parse(convertToJson(d));
+              setRuntimeMappingsEditorApplyButtonEnabled(
+                isEmptyStr || isRuntimeMappings(parsedJson)
+              );
+            } catch (e) {
+              setRuntimeMappingsEditorApplyButtonEnabled(false);
+            }
+          }}
+          options={{
+            ariaLabel: i18n.translate('xpack.transform.stepDefineForm.advancedEditorAriaLabel', {
+              defaultMessage: 'Advanced pivot editor',
+            }),
+            automaticLayout: true,
+            fontSize: 12,
+            scrollBeyondLastLine: false,
+            quickSuggestions: true,
+            minimap: {
+              enabled: false,
+            },
+            wordWrap: 'on',
+            wrappingIndent: 'indent',
+          }}
+          value={advancedRuntimeMappingsConfig}
+        />
+      </div>
     );
   },
   (prevProps, nextProps) => isEqual(pickProps(prevProps), pickProps(nextProps))

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_runtime_mappings_editor/advanced_runtime_mappings_editor.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_runtime_mappings_editor/advanced_runtime_mappings_editor.tsx
@@ -8,9 +8,9 @@
 import { isEqual } from 'lodash';
 import React, { memo, FC } from 'react';
 
-import { EuiCodeEditor } from '@elastic/eui';
-
 import { i18n } from '@kbn/i18n';
+
+import { CodeEditor } from '../../../../../../../../../src/plugins/kibana_react/public';
 
 import { isRuntimeMappings } from '../../../../../../common/shared_imports';
 
@@ -26,13 +26,10 @@ export const AdvancedRuntimeMappingsEditor: FC<StepDefineFormHook['runtimeMappin
     state: { advancedEditorRuntimeMappingsLastApplied, advancedRuntimeMappingsConfig, xJsonMode },
   }) => {
     return (
-      <EuiCodeEditor
+      <CodeEditor
         data-test-subj="transformAdvancedRuntimeMappingsEditor"
-        style={{ border: '1px solid #e3e6ef' }}
-        height="250px"
-        width="100%"
-        mode={xJsonMode}
-        value={advancedRuntimeMappingsConfig}
+        height={250}
+        languageId={'json'}
         onChange={(d: string) => {
           setAdvancedRuntimeMappingsConfig(d);
 
@@ -54,13 +51,21 @@ export const AdvancedRuntimeMappingsEditor: FC<StepDefineFormHook['runtimeMappin
             setRuntimeMappingsEditorApplyButtonEnabled(false);
           }
         }}
-        setOptions={{
-          fontSize: '12px',
+        options={{
+          ariaLabel: i18n.translate('xpack.transform.stepDefineForm.advancedEditorAriaLabel', {
+            defaultMessage: 'Advanced pivot editor',
+          }),
+          automaticLayout: true,
+          fontSize: 12,
+          scrollBeyondLastLine: false,
+          quickSuggestions: true,
+          minimap: {
+            enabled: false,
+          },
+          wordWrap: 'on',
+          wrappingIndent: 'indent',
         }}
-        theme="textmate"
-        aria-label={i18n.translate('xpack.transform.stepDefineForm.advancedEditorAriaLabel', {
-          defaultMessage: 'Advanced pivot editor',
-        })}
+        value={advancedRuntimeMappingsConfig}
       />
     );
   },

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_source_editor/advanced_source_editor.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_source_editor/advanced_source_editor.tsx
@@ -7,9 +7,9 @@
 
 import React, { FC } from 'react';
 
-import { EuiCodeEditor } from '@elastic/eui';
-
 import { i18n } from '@kbn/i18n';
+
+import { CodeEditor } from '../../../../../../../../../src/plugins/kibana_react/public';
 
 import { StepDefineFormHook } from '../step_define';
 
@@ -23,12 +23,10 @@ export const AdvancedSourceEditor: FC<StepDefineFormHook> = ({
   },
 }) => {
   return (
-    <EuiCodeEditor
-      style={{ border: '1px solid #e3e6ef' }}
-      mode="json"
-      height="250px"
-      width="100%"
-      value={advancedEditorSourceConfig}
+    <CodeEditor
+      data-test-subj="transformAdvancedRuntimeMappingsEditor"
+      height={250}
+      languageId={'json'}
       onChange={(d: string) => {
         setSearchString(undefined);
         setAdvancedEditorSourceConfig(d);
@@ -48,13 +46,21 @@ export const AdvancedSourceEditor: FC<StepDefineFormHook> = ({
           setAdvancedSourceEditorApplyButtonEnabled(false);
         }
       }}
-      setOptions={{
-        fontSize: '12px',
+      options={{
+        ariaLabel: i18n.translate('xpack.transform.stepDefineForm.advancedSourceEditorAriaLabel', {
+          defaultMessage: 'Advanced query editor',
+        }),
+        automaticLayout: true,
+        fontSize: 12,
+        scrollBeyondLastLine: false,
+        quickSuggestions: true,
+        minimap: {
+          enabled: false,
+        },
+        wordWrap: 'on',
+        wrappingIndent: 'indent',
       }}
-      theme="textmate"
-      aria-label={i18n.translate('xpack.transform.stepDefineForm.advancedSourceEditorAriaLabel', {
-        defaultMessage: 'Advanced query editor',
-      })}
+      value={advancedEditorSourceConfig}
     />
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_source_editor/advanced_source_editor.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/advanced_source_editor/advanced_source_editor.tsx
@@ -23,44 +23,48 @@ export const AdvancedSourceEditor: FC<StepDefineFormHook> = ({
   },
 }) => {
   return (
-    <CodeEditor
-      data-test-subj="transformAdvancedRuntimeMappingsEditor"
-      height={250}
-      languageId={'json'}
-      onChange={(d: string) => {
-        setSearchString(undefined);
-        setAdvancedEditorSourceConfig(d);
+    <div data-test-subj="transformAdvancedRuntimeMappingsEditor">
+      <CodeEditor
+        height={250}
+        languageId={'json'}
+        onChange={(d: string) => {
+          setSearchString(undefined);
+          setAdvancedEditorSourceConfig(d);
 
-        // Disable the "Apply"-Button if the config hasn't changed.
-        if (advancedEditorSourceConfigLastApplied === d) {
-          setAdvancedSourceEditorApplyButtonEnabled(false);
-          return;
-        }
+          // Disable the "Apply"-Button if the config hasn't changed.
+          if (advancedEditorSourceConfigLastApplied === d) {
+            setAdvancedSourceEditorApplyButtonEnabled(false);
+            return;
+          }
 
-        // Try to parse the string passed on from the editor.
-        // If parsing fails, the "Apply"-Button will be disabled
-        try {
-          JSON.parse(d);
-          setAdvancedSourceEditorApplyButtonEnabled(true);
-        } catch (e) {
-          setAdvancedSourceEditorApplyButtonEnabled(false);
-        }
-      }}
-      options={{
-        ariaLabel: i18n.translate('xpack.transform.stepDefineForm.advancedSourceEditorAriaLabel', {
-          defaultMessage: 'Advanced query editor',
-        }),
-        automaticLayout: true,
-        fontSize: 12,
-        scrollBeyondLastLine: false,
-        quickSuggestions: true,
-        minimap: {
-          enabled: false,
-        },
-        wordWrap: 'on',
-        wrappingIndent: 'indent',
-      }}
-      value={advancedEditorSourceConfig}
-    />
+          // Try to parse the string passed on from the editor.
+          // If parsing fails, the "Apply"-Button will be disabled
+          try {
+            JSON.parse(d);
+            setAdvancedSourceEditorApplyButtonEnabled(true);
+          } catch (e) {
+            setAdvancedSourceEditorApplyButtonEnabled(false);
+          }
+        }}
+        options={{
+          ariaLabel: i18n.translate(
+            'xpack.transform.stepDefineForm.advancedSourceEditorAriaLabel',
+            {
+              defaultMessage: 'Advanced query editor',
+            }
+          ),
+          automaticLayout: true,
+          fontSize: 12,
+          scrollBeyondLastLine: false,
+          quickSuggestions: true,
+          minimap: {
+            enabled: false,
+          },
+          wordWrap: 'on',
+          wrappingIndent: 'indent',
+        }}
+        value={advancedEditorSourceConfig}
+      />
+    </div>
   );
 };

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 
 import {
   EuiButton,
-  EuiCodeEditor,
+  EuiCodeBlock,
   EuiComboBox,
   EuiFieldText,
   EuiForm,
@@ -326,16 +326,17 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
         </EuiFormRow>
       )}
       {isUnsupportedAgg && (
-        <EuiCodeEditor
-          mode="json"
-          theme="textmate"
-          width="100%"
-          height="200px"
-          value={JSON.stringify(getEsAggFromAggConfig(defaultData), null, 2)}
-          setOptions={{ fontSize: '12px', showLineNumbers: false }}
-          isReadOnly
-          aria-label="Read only code editor"
-        />
+        <EuiCodeBlock
+          aria-label={i18n.translate('xpack.transform.agg.popoverForm.codeBlock', {
+            defaultMessage: 'Read only code editor',
+          })}
+          fontSize="s"
+          language="json"
+          paddingSize="s"
+          style={{ width: '100%', height: '200px' }}
+        >
+          {JSON.stringify(getEsAggFromAggConfig(defaultData), null, 2)}
+        </EuiCodeBlock>
       )}
       <EuiFormRow hasEmptyLabelSpace>
         <EuiButton

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/aggregation_list/popover_form.tsx
@@ -328,7 +328,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
       {isUnsupportedAgg && (
         <EuiCodeBlock
           aria-label={i18n.translate('xpack.transform.agg.popoverForm.codeBlock', {
-            defaultMessage: 'Read only code editor',
+            defaultMessage: 'JSON of transform aggregation',
           })}
           fontSize="s"
           language="json"

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/popover_form.tsx
@@ -13,7 +13,7 @@ import {
   htmlIdGenerator,
   EuiButton,
   EuiCheckbox,
-  EuiCodeEditor,
+  EuiCodeBlock,
   EuiFieldText,
   EuiForm,
   EuiFormRow,
@@ -298,16 +298,17 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
       {isUnsupportedAgg && (
         <>
           <EuiSpacer size="m" />
-          <EuiCodeEditor
-            mode="json"
-            theme="textmate"
-            width="100%"
-            height="200px"
-            value={JSON.stringify(getEsAggFromGroupByConfig(defaultData), null, 2)}
-            setOptions={{ fontSize: '12px', showLineNumbers: false }}
-            isReadOnly
-            aria-label="Read only code editor"
-          />
+          <EuiCodeBlock
+            aria-label={i18n.translate('xpack.transform.agg.popoverForm.codeBlock', {
+              defaultMessage: 'Read only code editor',
+            })}
+            fontSize="s"
+            language="json"
+            paddingSize="s"
+            style={{ width: '100%', height: '200px' }}
+          >
+            {JSON.stringify(getEsAggFromGroupByConfig(defaultData), null, 2)}
+          </EuiCodeBlock>
         </>
       )}
       <EuiFormRow hasEmptyLabelSpace>

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/popover_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/group_by_list/popover_form.tsx
@@ -300,7 +300,7 @@ export const PopoverForm: React.FC<Props> = ({ defaultData, otherAggNames, onCha
           <EuiSpacer size="m" />
           <EuiCodeBlock
             aria-label={i18n.translate('xpack.transform.agg.popoverForm.codeBlock', {
-              defaultMessage: 'Read only code editor',
+              defaultMessage: 'JSON of transform aggregation',
             })}
             fontSize="s"
             language="json"

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/components/editor_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/filter_agg/components/editor_form.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { EuiCodeEditor, EuiSpacer } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
+import { CodeEditor } from '../../../../../../../../../../../../src/plugins/kibana_react/public';
 import { FilterAggConfigEditor } from '../types';
 
 export const FilterEditorForm: FilterAggConfigEditor['aggTypeConfig']['FilterAggFormComponent'] = ({
@@ -16,15 +17,24 @@ export const FilterEditorForm: FilterAggConfigEditor['aggTypeConfig']['FilterAgg
   return (
     <>
       <EuiSpacer size="m" />
-      <EuiCodeEditor
-        value={config}
+      <CodeEditor
+        height={300}
+        languageId={'json'}
         onChange={(d) => {
           onChange({ config: d });
         }}
-        mode="json"
-        style={{ width: '100%' }}
-        theme="textmate"
-        height="300px"
+        options={{
+          automaticLayout: true,
+          fontSize: 12,
+          scrollBeyondLastLine: false,
+          quickSuggestions: true,
+          minimap: {
+            enabled: false,
+          },
+          wordWrap: 'on',
+          wrappingIndent: 'indent',
+        }}
+        value={config || ''}
       />
     </>
   );

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/__snapshots__/expanded_row_json_pane.test.tsx.snap
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/__snapshots__/expanded_row_json_pane.test.tsx.snap
@@ -9,50 +9,51 @@ exports[`Transform: Transform List Expanded Row <ExpandedRowJsonPane /> Minimal 
       <EuiSpacer
         size="s"
       />
-      <EuiCodeEditor
-        mode="json"
-        readOnly={true}
-        setOptions={Object {}}
+      <EuiCodeBlock
+        fontSize="s"
+        language="json"
+        paddingSize="s"
         style={
           Object {
             "width": "100%",
           }
         }
-        theme="textmate"
-        value="{
-  \\"id\\": \\"fq_date_histogram_1m_1441\\",
-  \\"source\\": {
-    \\"index\\": [
-      \\"farequote-2019\\"
+      >
+        value=
+        {
+  "id": "fq_date_histogram_1m_1441",
+  "source": {
+    "index": [
+      "farequote-2019"
     ],
-    \\"query\\": {
-      \\"match_all\\": {}
+    "query": {
+      "match_all": {}
     }
   },
-  \\"dest\\": {
-    \\"index\\": \\"fq_date_histogram_1m_1441\\"
+  "dest": {
+    "index": "fq_date_histogram_1m_1441"
   },
-  \\"pivot\\": {
-    \\"group_by\\": {
-      \\"@timestamp\\": {
-        \\"date_histogram\\": {
-          \\"field\\": \\"@timestamp\\",
-          \\"calendar_interval\\": \\"1m\\"
+  "pivot": {
+    "group_by": {
+      "@timestamp": {
+        "date_histogram": {
+          "field": "@timestamp",
+          "calendar_interval": "1m"
         }
       }
     },
-    \\"aggregations\\": {
-      \\"responsetime.avg\\": {
-        \\"avg\\": {
-          \\"field\\": \\"responsetime\\"
+    "aggregations": {
+      "responsetime.avg": {
+        "avg": {
+          "field": "responsetime"
         }
       }
     }
   },
-  \\"version\\": \\"8.0.0\\",
-  \\"create_time\\": 1564388146667
-}"
-      />
+  "version": "8.0.0",
+  "create_time": 1564388146667
+}
+      </EuiCodeBlock>
     </EuiFlexItem>
     <EuiFlexItem
       grow={false}

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/__snapshots__/expanded_row_json_pane.test.tsx.snap
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/__snapshots__/expanded_row_json_pane.test.tsx.snap
@@ -10,7 +10,9 @@ exports[`Transform: Transform List Expanded Row <ExpandedRowJsonPane /> Minimal 
         size="s"
       />
       <EuiCodeBlock
+        aria-label="JSON of transform configuration"
         fontSize="s"
+        isCopyable={true}
         language="json"
         paddingSize="s"
         style={

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_json_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_json_pane.tsx
@@ -9,6 +9,8 @@ import React, { FC } from 'react';
 
 import { EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
+
 interface Props {
   json: object;
 }
@@ -19,7 +21,19 @@ export const ExpandedRowJsonPane: FC<Props> = ({ json }) => {
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiSpacer size="s" />
-          <EuiCodeBlock fontSize="s" language="json" paddingSize="s" style={{ width: '100%' }}>
+          <EuiCodeBlock
+            aria-label={i18n.translate(
+              'xpack.transform.transformList.transformDetails.expandedRowJsonPane',
+              {
+                defaultMessage: 'JSON of transform configuration',
+              }
+            )}
+            fontSize="s"
+            language="json"
+            paddingSize="s"
+            style={{ width: '100%' }}
+            isCopyable
+          >
             value={JSON.stringify(json, null, 2)}
           </EuiCodeBlock>
         </EuiFlexItem>

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_json_pane.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row_json_pane.tsx
@@ -7,13 +7,7 @@
 
 import React, { FC } from 'react';
 
-import {
-  // @ts-ignore
-  EuiCodeEditor,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 interface Props {
   json: object;
@@ -25,13 +19,9 @@ export const ExpandedRowJsonPane: FC<Props> = ({ json }) => {
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiSpacer size="s" />
-          <EuiCodeEditor
+          <EuiCodeBlock fontSize="s" language="json" paddingSize="s" style={{ width: '100%' }}>
             value={JSON.stringify(json, null, 2)}
-            readOnly={true}
-            mode="json"
-            style={{ width: '100%' }}
-            theme="textmate"
-          />
+          </EuiCodeBlock>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>&nbsp;</EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/test/functional/services/transform/wizard.ts
+++ b/x-pack/test/functional/services/transform/wizard.ts
@@ -385,9 +385,9 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
     async assertRuntimeMappingsEditorContent(expectedContent: string[]) {
       await this.assertRuntimeMappingsEditorExists();
 
-      const runtimeMappingsEditorString = await aceEditor.getValue(
-        'transformAdvancedRuntimeMappingsEditor'
-      );
+      const wrapper = await testSubjects.find('transformAdvancedRuntimeMappingsEditor');
+      const editor = await wrapper.findByCssSelector('.monaco-editor .view-lines');
+      const runtimeMappingsEditorString = await editor.getVisibleText();
       // Not all lines may be visible in the editor and thus aceEditor may not return all lines.
       // This means we might not get back valid JSON so we only test against the first few lines
       // and see if the string matches.
@@ -624,7 +624,9 @@ export function TransformWizardProvider({ getService, getPageObjects }: FtrProvi
     },
 
     async assertAdvancedPivotEditorContent(expectedValue: string[]) {
-      const advancedEditorString = await aceEditor.getValue('transformAdvancedPivotEditor');
+      const wrapper = await testSubjects.find('transformAdvancedPivotEditor');
+      const editor = await wrapper.findByCssSelector('.monaco-editor .view-lines');
+      const advancedEditorString = await editor.getVisibleText();
       // Not all lines may be visible in the editor and thus aceEditor may not return all lines.
       // This means we might not get back valid JSON so we only test against the first few lines
       // and see if the string matches.


### PR DESCRIPTION
## Summary

Related meta issue: https://github.com/elastic/kibana/issues/107082

Replaces deprecated EuiCodeEditor in Transforms:

- public/app/sections/create_components/advanced_pivot_editor/advanced_pivot_editor.tsx
-  public/app/sections/create_components/advanced_runtime_mappings_editor/advanced_runtime_mappings_editor.tsx
-  public/app/sections/create_components/advanced_source_editor/advanced_source_editor.tsx
-  public/app/sections/create_components/aggregation_list/popover_form.tsx
-  public/app/sections/create_components/group_by_list/popover_form.tsx
-  public/app/sections/create_components/step_define/common/filter_agg/components/editor_form.tsx
-  public/app/sections/transform_management/components/transform_list/expanded_row_json_pane.tsx



### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))


Fixes #41832