### PR TITLE
[Discover][Context] Fix limit of 50 documents using classic table

### DIFF
--- a/src/plugins/discover/public/application/angular/doc_table/create_doc_table_react.tsx
+++ b/src/plugins/discover/public/application/angular/doc_table/create_doc_table_react.tsx
@@ -23,13 +23,13 @@ export interface DocTableLegacyProps {
   onFilter: (field: IndexPatternField | string, value: string, type: '+' | '-') => void;
   rows: estypes.SearchHit[];
   indexPattern: IIndexPattern;
-  minimumVisibleRows?: number;
+  minimumVisibleRows: number;
   onAddColumn?: (column: string) => void;
-  onBackToTop: () => void;
+  onBackToTop?: () => void;
   onSort?: (sort: string[][]) => void;
   onMoveColumn?: (columns: string, newIdx: number) => void;
   onRemoveColumn?: (column: string) => void;
-  sampleSize: number;
+  sampleSize?: number;
   sort?: string[][];
   useNewFieldsApi?: boolean;
 }
@@ -102,7 +102,7 @@ export function DocTableLegacy(renderProps: DocTableLegacyProps) {
   const ref = useRef<HTMLDivElement>(null);
   const scope = useRef<AngularScope | undefined>();
   const [rows, setRows] = useState(renderProps.rows);
-  const [minimumVisibleRows, setMinimumVisibleRows] = useState(50);
+  const [minimumVisibleRows, setMinimumVisibleRows] = useState(renderProps.minimumVisibleRows);
   const onSkipBottomButtonClick = useCallback(async () => {
     // delay scrolling to after the rows have been rendered
     const bottomMarker = document.getElementById('discoverBottomMarker');
@@ -119,9 +119,9 @@ export function DocTableLegacy(renderProps: DocTableLegacyProps) {
   }, [setMinimumVisibleRows, renderProps.rows]);
 
   useEffect(() => {
-    setMinimumVisibleRows(50);
+    setMinimumVisibleRows(renderProps.minimumVisibleRows);
     setRows(renderProps.rows);
-  }, [renderProps.rows, setMinimumVisibleRows]);
+  }, [renderProps.rows, setMinimumVisibleRows, renderProps.minimumVisibleRows]);
 
   useEffect(() => {
     if (ref && ref.current && !scope.current) {
@@ -146,7 +146,7 @@ export function DocTableLegacy(renderProps: DocTableLegacyProps) {
     <div>
       <SkipBottomButton onClick={onSkipBottomButtonClick} />
       <div ref={ref} />
-      {renderProps.rows.length === renderProps.sampleSize ? (
+      {renderProps.onBackToTop && renderProps.rows.length === renderProps.sampleSize ? (
         <div
           className="dscTable__footer"
           data-test-subj="discoverDocTableFooter"

--- a/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/layout/discover_layout.tsx
@@ -341,6 +341,7 @@ export function DiscoverLayout({
                           <DocTableLegacyMemoized
                             columns={columns}
                             indexPattern={indexPattern}
+                            minimumVisibleRows={50}
                             rows={rows}
                             sort={state.sort || []}
                             searchDescription={savedSearch.description}

--- a/src/plugins/discover/public/application/components/context_app/context_app_content.tsx
+++ b/src/plugins/discover/public/application/components/context_app/context_app_content.tsx
@@ -125,7 +125,6 @@ export function ContextAppContent({
   };
 
   const legacyDocTableProps = () => {
-    // @ts-expect-error doesn't implement full DocTableLegacyProps interface
     return {
       columns,
       indexPattern,

--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }) {
   const kibanaServer = getService('kibanaServer');
   const retry = getService('retry');
   const docTable = getService('docTable');
-  const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
   const PageObjects = getPageObjects(['context']);
   let expectedRowLength = 2 * TEST_DEFAULT_CONTEXT_SIZE + 1;
 
@@ -74,11 +74,14 @@ export default function ({ getService, getPageObjects }) {
 
     it('should show 101 records when 50 newer and 50 older records are requests', async function () {
       const predecessorCountPicker = await PageObjects.context.getPredecessorCountPicker();
-      testSubjects.setValue('predecessorsCountPicker', 50);
-      await PageObjects.common.pressEnterKey();
+      await predecessorCountPicker.clearValueWithKeyboard();
+      await predecessorCountPicker.pressKeys('50');
+      await predecessorCountPicker.pressKeys(browser.keys.ENTER);
+
       const successorCountPicker = await PageObjects.context.getSuccessorCountPicker();
-      testSubjects.setValue('successorsCountPicker', 50);
-      await PageObjects.common.pressEnterKey();
+      await successorCountPicker.clearValueWithKeyboard();
+      await successorCountPicker.pressKeys('50');
+      await successorCountPicker.pressKeys(browser.keys.ENTER);
 
       await retry.waitFor(
         `number of rows displayed after clicking load more successors is ${expectedRowLength}`,

--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -70,5 +70,22 @@ export default function ({ getService, getPageObjects }) {
         }
       );
     });
+
+    it('should show 101 records when 50 newer and 50 older records are requests', async function () {
+      const predecessorCountPicker = await PageObjects.context.getPredecessorCountPicker();
+      await predecessorCountPicker.setAttribute('value', 50);
+      await PageObjects.common.pressEnterKey();
+      const successorCountPicker = await PageObjects.context.getSuccessorCountPicker();
+      await successorCountPicker.setAttribute('value', 50);
+      await PageObjects.common.pressEnterKey();
+
+      await retry.waitFor(
+        `number of rows displayed after clicking load more successors is ${expectedRowLength}`,
+        async function () {
+          const rows = await docTable.getRowsText();
+          return rows.length === 101;
+        }
+      );
+    });
   });
 }

--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -15,6 +15,7 @@ export default function ({ getService, getPageObjects }) {
   const kibanaServer = getService('kibanaServer');
   const retry = getService('retry');
   const docTable = getService('docTable');
+  const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects(['context']);
   let expectedRowLength = 2 * TEST_DEFAULT_CONTEXT_SIZE + 1;
 
@@ -73,10 +74,10 @@ export default function ({ getService, getPageObjects }) {
 
     it('should show 101 records when 50 newer and 50 older records are requests', async function () {
       const predecessorCountPicker = await PageObjects.context.getPredecessorCountPicker();
-      await predecessorCountPicker.setAttribute('value', 50);
+      testSubjects.setValue('predecessorsCountPicker', 50);
       await PageObjects.common.pressEnterKey();
       const successorCountPicker = await PageObjects.context.getSuccessorCountPicker();
-      await successorCountPicker.setAttribute('value', 50);
+      testSubjects.setValue('successorsCountPicker', 50);
       await PageObjects.common.pressEnterKey();
 
       await retry.waitFor(


### PR DESCRIPTION
In 7.13 the maximum number of the list displayed in the context view was unintentionally set to 50 using classic table. 

With this PR this limit was removed. Note that it was also fixed with deangularizing classic table in 7.15 (#103444), so this PR is just for 7.14.

Fixes #107732