### PR TITLE
[APM] Make environment & kuery required

### DIFF
--- a/x-pack/plugins/apm/server/lib/services/get_services/get_services_items.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_services_items.ts
@@ -6,13 +6,12 @@
  */
 
 import { Logger } from '@kbn/logging';
-import { asMutableArray } from '../../../../common/utils/as_mutable_array';
-import { joinByKey } from '../../../../common/utils/join_by_key';
 import { withApmSpan } from '../../../utils/with_apm_span';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import { getHealthStatuses } from './get_health_statuses';
 import { getServicesFromMetricDocuments } from './get_services_from_metric_documents';
 import { getServiceTransactionStats } from './get_service_transaction_stats';
+import { mergeServiceStats } from './merge_service_stats';
 
 export type ServicesItemsSetup = Setup & SetupTimeRange;
 
@@ -53,31 +52,10 @@ export async function getServicesItems({
       }),
     ]);
 
-    const foundServiceNames = transactionStats.map(
-      ({ serviceName }) => serviceName
-    );
-
-    const servicesWithOnlyMetricDocuments = servicesFromMetricDocuments.filter(
-      ({ serviceName }) => !foundServiceNames.includes(serviceName)
-    );
-
-    const allServiceNames = foundServiceNames.concat(
-      servicesWithOnlyMetricDocuments.map(({ serviceName }) => serviceName)
-    );
-
-    // make sure to exclude health statuses from services
-    // that are not found in APM data
-    const matchedHealthStatuses = healthStatuses.filter(({ serviceName }) =>
-      allServiceNames.includes(serviceName)
-    );
-
-    return joinByKey(
-      asMutableArray([
-        ...transactionStats,
-        ...servicesWithOnlyMetricDocuments,
-        ...matchedHealthStatuses,
-      ] as const),
-      'serviceName'
-    );
+    return mergeServiceStats({
+      transactionStats,
+      servicesFromMetricDocuments,
+      healthStatuses,
+    });
   });
 }

--- a/x-pack/plugins/apm/server/lib/services/get_services/merge_service_stats.test.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/merge_service_stats.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { ServiceHealthStatus } from '../../../../common/service_health_status';
+import { PromiseReturnType } from '../../../../../observability/typings/common';
+import { getServiceTransactionStats } from './get_service_transaction_stats';
+import { mergeServiceStats } from './merge_service_stats';
+
+type ServiceTransactionStat = PromiseReturnType<
+  typeof getServiceTransactionStats
+>[number];
+
+function stat(values: Partial<ServiceTransactionStat>): ServiceTransactionStat {
+  return {
+    serviceName: 'opbeans-java',
+    environments: ['production'],
+    latency: 1,
+    throughput: 2,
+    transactionErrorRate: 3,
+    transactionType: 'request',
+    agentName: 'java',
+    ...values,
+  };
+}
+
+describe('mergeServiceStats', () => {
+  it('joins stats by service name', () => {
+    expect(
+      mergeServiceStats({
+        transactionStats: [
+          stat({
+            serviceName: 'opbeans-java',
+            environments: ['production'],
+          }),
+          stat({
+            serviceName: 'opbeans-java-2',
+            environments: ['staging'],
+            throughput: 4,
+          }),
+        ],
+        servicesFromMetricDocuments: [
+          {
+            environments: ['production'],
+            serviceName: 'opbeans-java',
+            agentName: 'java',
+          },
+        ],
+        healthStatuses: [
+          {
+            healthStatus: ServiceHealthStatus.healthy,
+            serviceName: 'opbeans-java',
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        agentName: 'java',
+        environments: ['staging'],
+        serviceName: 'opbeans-java-2',
+        latency: 1,
+        throughput: 4,
+        transactionErrorRate: 3,
+        transactionType: 'request',
+      },
+      {
+        agentName: 'java',
+        environments: ['production'],
+        healthStatus: ServiceHealthStatus.healthy,
+        serviceName: 'opbeans-java',
+        latency: 1,
+        throughput: 2,
+        transactionErrorRate: 3,
+        transactionType: 'request',
+      },
+    ]);
+  });
+
+  it('shows services that only have metric documents', () => {
+    expect(
+      mergeServiceStats({
+        transactionStats: [
+          stat({
+            serviceName: 'opbeans-java-2',
+            environments: ['staging'],
+          }),
+        ],
+        servicesFromMetricDocuments: [
+          {
+            environments: ['production'],
+            serviceName: 'opbeans-java',
+            agentName: 'java',
+          },
+        ],
+        healthStatuses: [
+          {
+            healthStatus: ServiceHealthStatus.healthy,
+            serviceName: 'opbeans-java',
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        agentName: 'java',
+        environments: ['staging'],
+        serviceName: 'opbeans-java-2',
+        latency: 1,
+        throughput: 2,
+        transactionErrorRate: 3,
+        transactionType: 'request',
+      },
+      {
+        agentName: 'java',
+        environments: ['production'],
+        healthStatus: ServiceHealthStatus.healthy,
+        serviceName: 'opbeans-java',
+      },
+    ]);
+  });
+
+  it('does not show services that only have ML data', () => {
+    expect(
+      mergeServiceStats({
+        transactionStats: [
+          stat({
+            serviceName: 'opbeans-java-2',
+            environments: ['staging'],
+          }),
+        ],
+        servicesFromMetricDocuments: [],
+        healthStatuses: [
+          {
+            healthStatus: ServiceHealthStatus.healthy,
+            serviceName: 'opbeans-java',
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        agentName: 'java',
+        environments: ['staging'],
+        serviceName: 'opbeans-java-2',
+        latency: 1,
+        throughput: 2,
+        transactionErrorRate: 3,
+        transactionType: 'request',
+      },
+    ]);
+  });
+
+  it('concatenates environments from metric/transaction data', () => {
+    expect(
+      mergeServiceStats({
+        transactionStats: [
+          stat({
+            serviceName: 'opbeans-java',
+            environments: ['staging'],
+          }),
+        ],
+        servicesFromMetricDocuments: [
+          {
+            environments: ['production'],
+            serviceName: 'opbeans-java',
+            agentName: 'java',
+          },
+        ],
+        healthStatuses: [],
+      })
+    ).toEqual([
+      {
+        agentName: 'java',
+        environments: ['staging', 'production'],
+        serviceName: 'opbeans-java',
+        latency: 1,
+        throughput: 2,
+        transactionErrorRate: 3,
+        transactionType: 'request',
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/apm/server/lib/services/get_services/merge_service_stats.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/merge_service_stats.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { uniq } from 'lodash';
+import { asMutableArray } from '../../../../common/utils/as_mutable_array';
+import { joinByKey } from '../../../../common/utils/join_by_key';
+import { PromiseReturnType } from '../../../../../observability/typings/common';
+import { getHealthStatuses } from './get_health_statuses';
+import { getServicesFromMetricDocuments } from './get_services_from_metric_documents';
+import { getServiceTransactionStats } from './get_service_transaction_stats';
+
+export function mergeServiceStats({
+  transactionStats,
+  servicesFromMetricDocuments,
+  healthStatuses,
+}: {
+  transactionStats: PromiseReturnType<typeof getServiceTransactionStats>;
+  servicesFromMetricDocuments: PromiseReturnType<
+    typeof getServicesFromMetricDocuments
+  >;
+  healthStatuses: PromiseReturnType<typeof getHealthStatuses>;
+}) {
+  const foundServiceNames = transactionStats.map(
+    ({ serviceName }) => serviceName
+  );
+
+  const servicesWithOnlyMetricDocuments = servicesFromMetricDocuments.filter(
+    ({ serviceName }) => !foundServiceNames.includes(serviceName)
+  );
+
+  const allServiceNames = foundServiceNames.concat(
+    servicesWithOnlyMetricDocuments.map(({ serviceName }) => serviceName)
+  );
+
+  // make sure to exclude health statuses from services
+  // that are not found in APM data
+  const matchedHealthStatuses = healthStatuses.filter(({ serviceName }) =>
+    allServiceNames.includes(serviceName)
+  );
+
+  return joinByKey(
+    asMutableArray([
+      ...transactionStats,
+      ...servicesFromMetricDocuments,
+      ...matchedHealthStatuses,
+    ] as const),
+    'serviceName',
+    function merge(a, b) {
+      const aEnvs = 'environments' in a ? a.environments : [];
+      const bEnvs = 'environments' in b ? b.environments : [];
+
+      return {
+        ...a,
+        ...b,
+        environments: uniq(aEnvs.concat(bEnvs)),
+      };
+    }
+  );
+}


### PR DESCRIPTION
Closes #102692.

## Summary

Require `kuery` and `environment` client-side and server-side, where possible.