### PR TITLE
[RAC] [Security Solution] Update Alert page header style

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -31,7 +31,6 @@ import { SiemSearchBar } from '../../../common/components/search_bar';
 import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
 import { inputsSelectors } from '../../../common/store/inputs';
 import { setAbsoluteRangeDatePicker } from '../../../common/store/inputs/actions';
-import { useAlertInfo } from '../../components/alerts_info';
 import { AlertsTable } from '../../components/alerts_table';
 import { NoApiIntegrationKeyCallOut } from '../../components/callouts/no_api_integration_callout';
 import { AlertsHistogramPanel } from '../../components/alerts_kpis/alerts_histogram_panel';
@@ -42,7 +41,7 @@ import { DetectionEngineHeaderPage } from '../../components/detection_engine_hea
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
 import { DetectionEngineUserUnauthenticated } from './detection_engine_user_unauthenticated';
 import * as i18n from './translations';
-import { LinkButton } from '../../../common/components/links';
+import { LinkAnchor } from '../../../common/components/links';
 import { useFormatUrl } from '../../../common/components/link_to';
 import { useGlobalFullScreen } from '../../../common/containers/use_full_screen';
 import { Display } from '../../../hosts/pages/display';
@@ -122,7 +121,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
     loading: listsConfigLoading,
     needsConfiguration: needsListsConfiguration,
   } = useListsConfig();
-  const [lastAlerts] = useAlertInfo({});
   const { formatUrl } = useFormatUrl(SecurityPageName.rules);
   const [showBuildingBlockAlerts, setShowBuildingBlockAlerts] = useState(false);
   const [showOnlyThreatIndicatorAlerts, setShowOnlyThreatIndicatorAlerts] = useState(false);
@@ -281,27 +279,14 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
             data-test-subj="detectionsAlertsPage"
           >
             <Display show={!globalFullScreen}>
-              <DetectionEngineHeaderPage
-                subtitle={
-                  lastAlerts != null && (
-                    <>
-                      {i18n.LAST_ALERT}
-                      {': '}
-                      {lastAlerts}
-                    </>
-                  )
-                }
-                title={i18n.PAGE_TITLE}
-              >
-                <LinkButton
-                  fill
+              <DetectionEngineHeaderPage title={i18n.PAGE_TITLE}>
+                <LinkAnchor
                   onClick={goToRules}
                   href={formatUrl(getRulesUrl())}
-                  iconType="gear"
                   data-test-subj="manage-alert-detection-rules"
                 >
                   {i18n.BUTTON_MANAGE_RULES}
-                </LinkButton>
+                </LinkAnchor>
               </DetectionEngineHeaderPage>
               <EuiHorizontalRule margin="m" />
               <AlertsTableFilterGroup onFilterGroupChanged={onFilterGroupChangedCallback} />

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/translations.ts
@@ -43,7 +43,7 @@ export const ALERT = i18n.translate('xpack.securitySolution.detectionEngine.aler
 export const BUTTON_MANAGE_RULES = i18n.translate(
   'xpack.securitySolution.detectionEngine.buttonManageRules',
   {
-    defaultMessage: 'Manage detection rules',
+    defaultMessage: 'Manage rules',
   }
 );
 


### PR DESCRIPTION
## Summary

Update the Alert Header to meet the below style requirements:

issue: https://github.com/elastic/kibana/issues/107909
For reference: https://github.com/elastic/kibana/issues/106585


**Current:**
![image](https://user-images.githubusercontent.com/3756330/126677131-c4bec126-0924-4a5a-aac1-3d63b6df223a.png)

**Update:**
<img width="600" alt="Screenshot 2021-08-12 at 14 01 06" src="https://user-images.githubusercontent.com/1490444/129193248-797ccd56-f151-431c-b415-e2a42671c058.png">

- [x] Remove gear icon from Rules button
- [x] Change text of Rules button to 'Manage rules'
- [x] Change to empty button
- [x] Remove 'Last alert...' timestamp 


