### PR TITLE
[APM] Backends UI: Show "NEW" badge in the Observability solution nav for the new Backends view

### DIFF
--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -81,6 +81,24 @@ export interface ApmPluginStartDeps {
   fleet?: FleetStart;
 }
 
+const servicesTitle = i18n.translate('xpack.apm.navigation.servicesTitle', {
+  defaultMessage: 'Services',
+});
+const tracesTitle = i18n.translate('xpack.apm.navigation.tracesTitle', {
+  defaultMessage: 'Traces',
+});
+const serviceMapTitle = i18n.translate('xpack.apm.navigation.serviceMapTitle', {
+  defaultMessage: 'Service Map',
+});
+
+const backendsTitle = i18n.translate('xpack.apm.navigation.backendsTitle', {
+  defaultMessage: 'Backends',
+});
+
+const newBadgeLabel = i18n.translate('xpack.apm.navigation.newBadge', {
+  defaultMessage: 'NEW',
+});
+
 export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
   constructor(
     private readonly initializerContext: PluginInitializerContext<ConfigSchema>
@@ -95,21 +113,6 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       pluginSetupDeps.home.environment.update({ apmUi: true });
       pluginSetupDeps.home.featureCatalogue.register(featureCatalogueEntry);
     }
-
-    const servicesTitle = i18n.translate('xpack.apm.navigation.servicesTitle', {
-      defaultMessage: 'Services',
-    });
-    const tracesTitle = i18n.translate('xpack.apm.navigation.tracesTitle', {
-      defaultMessage: 'Traces',
-    });
-    const serviceMapTitle = i18n.translate(
-      'xpack.apm.navigation.serviceMapTitle',
-      { defaultMessage: 'Service Map' }
-    );
-
-    const backendsTitle = i18n.translate('xpack.apm.navigation.backendsTitle', {
-      defaultMessage: 'Backends',
-    });
 
     // register observability nav if user has access to plugin
     plugins.observability.navigation.registerSections(
@@ -129,6 +132,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
                     label: backendsTitle,
                     app: 'apm',
                     path: '/backends',
+                    sideBadgeLabel: newBadgeLabel,
                     onClick: () => {
                       const { usageCollection } = pluginsStart as {
                         usageCollection?: UsageCollectionStart;

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -127,7 +127,6 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
                 entries: [
                   { label: servicesTitle, app: 'apm', path: '/services' },
                   { label: tracesTitle, app: 'apm', path: '/traces' },
-                  { label: serviceMapTitle, app: 'apm', path: '/service-map' },
                   {
                     label: backendsTitle,
                     app: 'apm',
@@ -147,6 +146,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
                       }
                     },
                   },
+                  { label: serviceMapTitle, app: 'apm', path: '/service-map' },
                 ],
               },
 

--- a/x-pack/plugins/observability/public/components/shared/page_template/nav_name_with_badge.tsx
+++ b/x-pack/plugins/observability/public/components/shared/page_template/nav_name_with_badge.tsx
@@ -14,6 +14,15 @@ interface Props {
   localstorageId: string;
 }
 
+const LabelContainer = styled.span`
+  max-width: 72%;
+  float: left;
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+`;
+
 const StyledBadge = styled(EuiBadge)`
   margin-left: 8px;
 `;
@@ -44,7 +53,9 @@ export function NavNameWithBadge({ label, badgeLabel, localstorageId }: Props) {
   const isBadgeVisible = getBadgeVisibility(localstorageId);
   return (
     <>
-      <span>{label}</span>
+      <LabelContainer className="eui-textTruncate">
+        <span>{label}</span>
+      </LabelContainer>
       {isBadgeVisible && <StyledBadge color="accent">{badgeLabel}</StyledBadge>}
     </>
   );

--- a/x-pack/plugins/observability/public/components/shared/page_template/nav_name_with_badge.tsx
+++ b/x-pack/plugins/observability/public/components/shared/page_template/nav_name_with_badge.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiBadge } from '@elastic/eui';
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  label: string;
+  badgeLabel: string;
+  localstorageId: string;
+}
+
+const StyledBadge = styled(EuiBadge)`
+  margin-left: 8px;
+`;
+
+/**
+ * Gets current state from local storage to show or hide the badge.
+ * Default value: true
+ * @param localstorageId
+ */
+function getBadgeVisibility(localstorageId: string) {
+  const storedItem = window.localStorage.getItem(localstorageId);
+  if (storedItem) {
+    return JSON.parse(storedItem) as boolean;
+  }
+
+  return true;
+}
+
+/**
+ * Saves on local storage that this item should no longer be visible
+ * @param localstorageId
+ */
+export function hideBadge(localstorageId: string) {
+  window.localStorage.setItem(localstorageId, JSON.stringify(false));
+}
+
+export function NavNameWithBadge({ label, badgeLabel, localstorageId }: Props) {
+  const isBadgeVisible = getBadgeVisibility(localstorageId);
+  return (
+    <>
+      <span>{label}</span>
+      {isBadgeVisible && <StyledBadge color="accent">{badgeLabel}</StyledBadge>}
+    </>
+  );
+}

--- a/x-pack/plugins/observability/public/components/shared/page_template/page_template.tsx
+++ b/x-pack/plugins/observability/public/components/shared/page_template/page_template.tsx
@@ -17,6 +17,7 @@ import {
   KibanaPageTemplateProps,
 } from '../../../../../../../src/plugins/kibana_react/public';
 import type { NavigationSection } from '../../../services/navigation_registry';
+import { NavNameWithBadge, hideBadge } from './nav_name_with_badge';
 
 export type WrappedPageTemplateProps = Pick<
   KibanaPageTemplateProps,
@@ -71,15 +72,28 @@ export function ObservabilityPageTemplate({
               exact: !!entry.matchFullPath,
               strict: !entry.ignoreTrailingSlash,
             }) != null;
-
+          const badgeLocalStorageId = `nav_item_badge_visible_${entry.app}${entry.path}`;
           return {
             id: `${sectionIndex}.${entryIndex}`,
-            name: entry.label,
+            name: entry.sideBadgeLabel ? (
+              <NavNameWithBadge
+                label={entry.label}
+                badgeLabel={entry.sideBadgeLabel}
+                localstorageId={badgeLocalStorageId}
+              />
+            ) : (
+              entry.label
+            ),
             href,
             isSelected,
             onClick: (event) => {
               if (entry.onClick) {
                 entry.onClick(event);
+              }
+
+              // When side badge is defined hides it when the item is clicked
+              if (entry.sideBadgeLabel) {
+                hideBadge(badgeLocalStorageId);
               }
 
               if (

--- a/x-pack/plugins/observability/public/components/shared/page_template/page_template.tsx
+++ b/x-pack/plugins/observability/public/components/shared/page_template/page_template.tsx
@@ -72,7 +72,7 @@ export function ObservabilityPageTemplate({
               exact: !!entry.matchFullPath,
               strict: !entry.ignoreTrailingSlash,
             }) != null;
-          const badgeLocalStorageId = `nav_item_badge_visible_${entry.app}${entry.path}`;
+          const badgeLocalStorageId = `observability.nav_item_badge_visible_${entry.app}${entry.path}`;
           return {
             id: `${sectionIndex}.${entryIndex}`,
             name: entry.sideBadgeLabel ? (

--- a/x-pack/plugins/observability/public/services/navigation_registry.ts
+++ b/x-pack/plugins/observability/public/services/navigation_registry.ts
@@ -30,6 +30,8 @@ export interface NavigationEntry {
   ignoreTrailingSlash?: boolean;
   // handler to be called when the item is clicked
   onClick?: (event: React.MouseEvent<HTMLElement | HTMLButtonElement, MouseEvent>) => void;
+  // the label of the badge that is shown besides the navigation label
+  sideBadgeLabel?: string;
 }
 
 export interface NavigationRegistry {


### PR DESCRIPTION
closes #107718

- Adds new property to navigation definition named `sideBadgeLabel`
- Shows it besides the nav label
<img width="177" alt="Screen Shot 2021-08-12 at 12 12 04" src="https://user-images.githubusercontent.com/55978943/129231040-f72550b2-9983-4e6a-9bb6-49233f83b825.png">
- When the nav item is clicked saves on local storage that the badge must be hidden.


https://user-images.githubusercontent.com/55978943/129231144-c631af0c-1b57-4d4f-8018-2099bb18d0f5.mov

Repositioning the backends link on top of service map link.
<img width="238" alt="Screen Shot 2021-08-12 at 14 53 57" src="https://user-images.githubusercontent.com/55978943/129252691-6e45e583-ba71-4dd9-9123-92fe81f8510e.png">

When label is too big, truncates it:
<img width="236" alt="Screen Shot 2021-08-12 at 16 02 36" src="https://user-images.githubusercontent.com/55978943/129263058-01e3aaff-6661-4808-8345-1c3255b07df4.png">

