### PR TITLE
[CTI] Fixes AlienVaultOTX counts on the Overview page

### DIFF
--- a/x-pack/plugins/security_solution/common/cti/constants.ts
+++ b/x-pack/plugins/security_solution/common/cti/constants.ts
@@ -60,7 +60,7 @@ export const EVENT_ENRICHMENT_INDICATOR_FIELD_MAP = {
 export const DEFAULT_EVENT_ENRICHMENT_FROM = 'now-30d';
 export const DEFAULT_EVENT_ENRICHMENT_TO = 'now';
 
-export const CTI_DEFAULT_SOURCES: { [key: string]: string } = {
+export const CTI_DATASET_KEY_MAP: { [key: string]: string } = {
   'Abuse URL': 'threatintel.abuseurl',
   'Abuse Malware': 'threatintel.abusemalware',
   'AlienVault OTX': 'threatintel.otx',

--- a/x-pack/plugins/security_solution/common/cti/constants.ts
+++ b/x-pack/plugins/security_solution/common/cti/constants.ts
@@ -60,14 +60,14 @@ export const EVENT_ENRICHMENT_INDICATOR_FIELD_MAP = {
 export const DEFAULT_EVENT_ENRICHMENT_FROM = 'now-30d';
 export const DEFAULT_EVENT_ENRICHMENT_TO = 'now';
 
-export const CTI_DEFAULT_SOURCES = [
-  'Abuse URL',
-  'Abuse Malware',
-  'AlienVault OTX',
-  'Anomali',
-  'Malware Bazaar',
-  'MISP',
-  'Recorded Future',
-];
+export const CTI_DEFAULT_SOURCES: { [key: string]: string } = {
+  'Abuse URL': 'threatintel.abuseurl',
+  'Abuse Malware': 'threatintel.abusemalware',
+  'AlienVault OTX': 'threatintel.otx',
+  Anomali: 'threatintel.anomali',
+  'Malware Bazaar': 'threatintel.malwarebazaar',
+  MISP: 'threatintel.misp',
+  'Recorded Future': 'threatintel.recordedfuture',
+};
 
 export const DEFAULT_CTI_SOURCE_INDEX = ['filebeat-*'];

--- a/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/helpers.ts
+++ b/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/helpers.ts
@@ -14,8 +14,8 @@ export interface CtiListItem {
   count: number;
 }
 
-export const EMPTY_LIST_ITEMS: CtiListItem[] = CTI_DEFAULT_SOURCES.map((item) => ({
-  title: item,
+export const EMPTY_LIST_ITEMS: CtiListItem[] = Object.keys(CTI_DEFAULT_SOURCES).map((title) => ({
+  title,
   count: 0,
   path: '',
 }));
@@ -37,7 +37,7 @@ export const OVERVIEW_DASHBOARD_LINK_TITLE = 'Overview';
 export const getListItemsWithoutLinks = (eventCounts: EventCounts): CtiListItem[] => {
   return EMPTY_LIST_ITEMS.map((item) => ({
     ...item,
-    count: eventCounts[item.title.replace(' ', '').toLowerCase()] ?? 0,
+    count: eventCounts[CTI_DEFAULT_SOURCES[item.title]] ?? 0,
   }));
 };
 
@@ -58,15 +58,12 @@ export const createLinkFromDashboardSO = (
       : undefined;
   return {
     title,
-    count:
-      typeof title === 'string'
-        ? eventCountsByDataset[title.replace(' ', '').toLowerCase()]
-        : undefined,
+    count: typeof title === 'string' ? eventCountsByDataset[CTI_DEFAULT_SOURCES[title]] : undefined,
     path,
   };
 };
 
-export const emptyEventCountsByDataset = CTI_DEFAULT_SOURCES.reduce((acc, item) => {
-  acc[item.toLowerCase().replace(' ', '')] = 0;
+export const emptyEventCountsByDataset = Object.values(CTI_DEFAULT_SOURCES).reduce((acc, id) => {
+  acc[id] = 0;
   return acc;
 }, {} as { [key: string]: number });

--- a/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/helpers.ts
+++ b/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/helpers.ts
@@ -6,15 +6,18 @@
  */
 
 import { SavedObjectAttributes } from '@kbn/securitysolution-io-ts-alerting-types';
-import { CTI_DEFAULT_SOURCES } from '../../../../common/cti/constants';
+import { CTI_DATASET_KEY_MAP } from '../../../../common/cti/constants';
 
 export interface CtiListItem {
   path: string;
-  title: string;
+  title: CtiDatasetTitle;
   count: number;
 }
 
-export const EMPTY_LIST_ITEMS: CtiListItem[] = Object.keys(CTI_DEFAULT_SOURCES).map((title) => ({
+export type CtiDatasetTitle = keyof typeof CTI_DATASET_KEY_MAP;
+export const ctiTitles = Object.keys(CTI_DATASET_KEY_MAP) as CtiDatasetTitle[];
+
+export const EMPTY_LIST_ITEMS: CtiListItem[] = ctiTitles.map((title) => ({
   title,
   count: 0,
   path: '',
@@ -37,7 +40,7 @@ export const OVERVIEW_DASHBOARD_LINK_TITLE = 'Overview';
 export const getListItemsWithoutLinks = (eventCounts: EventCounts): CtiListItem[] => {
   return EMPTY_LIST_ITEMS.map((item) => ({
     ...item,
-    count: eventCounts[CTI_DEFAULT_SOURCES[item.title]] ?? 0,
+    count: eventCounts[CTI_DATASET_KEY_MAP[item.title]] ?? 0,
   }));
 };
 
@@ -58,12 +61,12 @@ export const createLinkFromDashboardSO = (
       : undefined;
   return {
     title,
-    count: typeof title === 'string' ? eventCountsByDataset[CTI_DEFAULT_SOURCES[title]] : undefined,
+    count: typeof title === 'string' ? eventCountsByDataset[CTI_DATASET_KEY_MAP[title]] : undefined,
     path,
   };
 };
 
-export const emptyEventCountsByDataset = Object.values(CTI_DEFAULT_SOURCES).reduce((acc, id) => {
+export const emptyEventCountsByDataset = Object.values(CTI_DATASET_KEY_MAP).reduce((acc, id) => {
   acc[id] = 0;
   return acc;
 }, {} as { [key: string]: number });

--- a/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/use_cti_event_counts.ts
+++ b/x-pack/plugins/security_solution/public/overview/containers/overview_cti_links/use_cti_event_counts.ts
@@ -11,7 +11,6 @@ import { emptyEventCountsByDataset } from './helpers';
 import { CtiEnabledModuleProps } from '../../components/overview_cti_links/cti_enabled_module';
 
 export const ID = 'ctiEventCountQuery';
-const PREFIX = 'threatintel.';
 
 export const useCtiEventCounts = ({ deleteQuery, from, setQuery, to }: CtiEnabledModuleProps) => {
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -23,7 +22,7 @@ export const useCtiEventCounts = ({ deleteQuery, from, setQuery, to }: CtiEnable
       data.reduce(
         (acc, item) => {
           if (item.y && item.g) {
-            const id = item.g.replace(PREFIX, '');
+            const id = item.g;
             acc[id] += item.y;
           }
           return acc;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

<img width="604" alt="Screen Shot 2021-08-12 at 3 22 34 PM" src="https://user-images.githubusercontent.com/18617331/129256431-b28bf0bc-2847-489e-959f-297e69f8d324.png">

to test:
POST `"event": { "dataset": "threatintel.otx"}` to your `filebeat` index to confirm that the indicator count is updated on the Overview page for AlienVault OTX. 


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
