### PR TITLE
[7.x] [file_upload] include caused_by field for import failures (#107907)

### DIFF
--- a/x-pack/plugins/file_upload/common/types.ts
+++ b/x-pack/plugins/file_upload/common/types.ts
@@ -111,6 +111,10 @@ export interface ImportResponse {
 export interface ImportFailure {
   item: number;
   reason: string;
+  caused_by?: {
+    type: string;
+    reason: string;
+  };
   doc: ImportDoc;
 }
 

--- a/x-pack/plugins/file_upload/server/import_data.ts
+++ b/x-pack/plugins/file_upload/server/import_data.ts
@@ -164,6 +164,7 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
         failures.push({
           item: i,
           reason: item.index.error.reason,
+          caused_by: item.index.error.caused_by,
           doc: data[i],
         });
       }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [file_upload] include caused_by field for import failures (#107907)