### PR TITLE
[7.x] Deprecate ability to disable alerting, actions, task manager, stack alerts, and event log plugins (#108281)

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -41,7 +41,7 @@ You can configure the following settings in the `kibana.yml` file.
 [cols="2*<"]
 |===
 | `xpack.actions.enabled`
-  | Feature toggle that enables Actions in {kib}.
+  | Deprecated. This will be removed in 8.0. Feature toggle that enables Actions in {kib}.
   If `false`, all features dependent on Actions are disabled, including the *Observability* and *Security* apps.  Default: `true`.
 
 | `xpack.actions.allowedHosts` {ess-icon}

--- a/x-pack/plugins/actions/server/index.test.ts
+++ b/x-pack/plugins/actions/server/index.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { config } from './index';
+import { applyDeprecations, configDeprecationFactory } from '@kbn/config';
+
+const CONFIG_PATH = 'xpack.actions';
+const applyStackAlertDeprecations = (settings: Record<string, unknown> = {}) => {
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const deprecationMessages: string[] = [];
+  const _config = {
+    [CONFIG_PATH]: settings,
+  };
+  const { config: migrated } = applyDeprecations(
+    _config,
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: CONFIG_PATH,
+    })),
+    () => ({ message }) => deprecationMessages.push(message)
+  );
+  return {
+    messages: deprecationMessages,
+    migrated,
+  };
+};
+
+describe('index', () => {
+  describe('deprecations', () => {
+    it('should deprecate .enabled flag', () => {
+      const { messages } = applyStackAlertDeprecations({ enabled: false });
+      expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"xpack.actions.enabled\\" is deprecated. The ability to disable this plugin will be removed in 8.0.0.",
+        ]
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/actions/server/index.ts
+++ b/x-pack/plugins/actions/server/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { get } from 'lodash';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { PluginInitializerContext, PluginConfigDescriptor } from '../../../../src/core/server';
 import { ActionsPlugin } from './plugin';
@@ -59,7 +59,8 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
   deprecations: ({ renameFromRoot, unused }) => [
     renameFromRoot('xpack.actions.whitelistedHosts', 'xpack.actions.allowedHosts'),
     (settings, fromPath, addDeprecation) => {
-      const customHostSettings = settings?.xpack?.actions?.customHostSettings ?? [];
+      const actions = get(settings, fromPath);
+      const customHostSettings = actions?.customHostSettings ?? [];
       if (
         customHostSettings.find(
           (customHostSchema: CustomHostSettings) =>
@@ -84,7 +85,8 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
       }
     },
     (settings, fromPath, addDeprecation) => {
-      if (!!settings?.xpack?.actions?.rejectUnauthorized) {
+      const actions = get(settings, fromPath);
+      if (!!actions?.rejectUnauthorized) {
         addDeprecation({
           message:
             `"xpack.actions.rejectUnauthorized" is deprecated. Use "xpack.actions.verificationMode" instead, ` +
@@ -102,7 +104,8 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
       }
     },
     (settings, fromPath, addDeprecation) => {
-      if (!!settings?.xpack?.actions?.proxyRejectUnauthorizedCertificates) {
+      const actions = get(settings, fromPath);
+      if (!!actions?.proxyRejectUnauthorizedCertificates) {
         addDeprecation({
           message:
             `"xpack.actions.proxyRejectUnauthorizedCertificates" is deprecated. Use "xpack.actions.proxyVerificationMode" instead, ` +
@@ -115,6 +118,17 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
                 `with the setting "proxyVerificationMode:full" eql to "rejectUnauthorized:true",` +
                 `and "proxyVerificationMode:none" eql to "rejectUnauthorized:false".`,
             ],
+          },
+        });
+      }
+    },
+    (settings, fromPath, addDeprecation) => {
+      const actions = get(settings, fromPath);
+      if (actions?.enabled === false || actions?.enabled === true) {
+        addDeprecation({
+          message: `"xpack.actions.enabled" is deprecated. The ability to disable this plugin will be removed in 8.0.0.`,
+          correctiveActions: {
+            manualSteps: [`Remove "xpack.actions.enabled" from your kibana configs.`],
           },
         });
       }

--- a/x-pack/plugins/alerting/server/index.test.ts
+++ b/x-pack/plugins/alerting/server/index.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { config } from './index';
+import { applyDeprecations, configDeprecationFactory } from '@kbn/config';
+
+const CONFIG_PATH = 'xpack.alerting';
+const applyStackAlertDeprecations = (settings: Record<string, unknown> = {}) => {
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const deprecationMessages: string[] = [];
+  const _config = {
+    [CONFIG_PATH]: settings,
+  };
+  const { config: migrated } = applyDeprecations(
+    _config,
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: CONFIG_PATH,
+    })),
+    () => ({ message }) => deprecationMessages.push(message)
+  );
+  return {
+    messages: deprecationMessages,
+    migrated,
+  };
+};
+
+describe('index', () => {
+  describe('deprecations', () => {
+    it('should deprecate .enabled flag', () => {
+      const { messages } = applyStackAlertDeprecations({ enabled: false });
+      expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"xpack.alerting.enabled\\" is deprecated. The ability to disable this plugin will be removed in 8.0.0.",
+        ]
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/alerting/server/index.ts
+++ b/x-pack/plugins/alerting/server/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { get } from 'lodash';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { RulesClient as RulesClientClass } from './rules_client';
 import { PluginConfigDescriptor, PluginInitializerContext } from '../../../../src/core/server';
@@ -58,5 +58,16 @@ export const config: PluginConfigDescriptor<AlertsConfigType> = {
       'xpack.alerts.invalidateApiKeysTask.removalDelay',
       'xpack.alerting.invalidateApiKeysTask.removalDelay'
     ),
+    (settings, fromPath, addDeprecation) => {
+      const alerting = get(settings, fromPath);
+      if (alerting?.enabled === false || alerting?.enabled === true) {
+        addDeprecation({
+          message: `"xpack.alerting.enabled" is deprecated. The ability to disable this plugin will be removed in 8.0.0.`,
+          correctiveActions: {
+            manualSteps: [`Remove "xpack.alerting.enabled" from your kibana configs.`],
+          },
+        });
+      }
+    },
   ],
 };

--- a/x-pack/plugins/event_log/server/index.ts
+++ b/x-pack/plugins/event_log/server/index.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { PluginInitializerContext } from 'src/core/server';
-import { ConfigSchema } from './types';
+import { PluginInitializerContext, PluginConfigDescriptor } from 'src/core/server';
+import { ConfigSchema, IEventLogConfig } from './types';
 import { Plugin } from './plugin';
 
 export {
@@ -24,5 +24,22 @@ export { ClusterClientAdapter } from './es/cluster_client_adapter';
 
 export { createReadySignal } from './lib/ready_signal';
 
-export const config = { schema: ConfigSchema };
+export const config: PluginConfigDescriptor<IEventLogConfig> = {
+  schema: ConfigSchema,
+  deprecations: () => [
+    (settings, fromPath, addDeprecation) => {
+      if (
+        settings?.xpack?.eventLog?.enabled === false ||
+        settings?.xpack?.eventLog?.enabled === true
+      ) {
+        addDeprecation({
+          message: `"xpack.eventLog.enabled" is deprecated. The ability to disable this plugin will be removed in 8.0.0.`,
+          correctiveActions: {
+            manualSteps: [`Remove "xpack.eventLog.enabled" from your kibana configs.`],
+          },
+        });
+      }
+    },
+  ],
+};
 export const plugin = (context: PluginInitializerContext) => new Plugin(context);

--- a/x-pack/plugins/stack_alerts/server/index.test.ts
+++ b/x-pack/plugins/stack_alerts/server/index.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { config } from './index';
+import { applyDeprecations, configDeprecationFactory } from '@kbn/config';
+
+const CONFIG_PATH = 'xpack.stack_alerts';
+const applyStackAlertDeprecations = (settings: Record<string, unknown> = {}) => {
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const deprecationMessages: string[] = [];
+  const _config = {
+    [CONFIG_PATH]: settings,
+  };
+  const { config: migrated } = applyDeprecations(
+    _config,
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: CONFIG_PATH,
+    })),
+    () => ({ message }) => deprecationMessages.push(message)
+  );
+  return {
+    messages: deprecationMessages,
+    migrated,
+  };
+};
+
+describe('index', () => {
+  describe('deprecations', () => {
+    it('should deprecate .enabled flag', () => {
+      const { messages } = applyStackAlertDeprecations({ enabled: false });
+      expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"xpack.stack_alerts.enabled\\" is deprecated. The ability to disable this plugin will be removed in 8.0.0.",
+        ]
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/stack_alerts/server/index.ts
+++ b/x-pack/plugins/stack_alerts/server/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { get } from 'lodash';
 import { PluginConfigDescriptor, PluginInitializerContext } from 'src/core/server';
 import { AlertingBuiltinsPlugin } from './plugin';
 import { configSchema, Config } from '../common/config';
@@ -13,6 +13,19 @@ export { ID as INDEX_THRESHOLD_ID } from './alert_types/index_threshold/alert_ty
 export const config: PluginConfigDescriptor<Config> = {
   exposeToBrowser: {},
   schema: configSchema,
+  deprecations: () => [
+    (settings, fromPath, addDeprecation) => {
+      const stackAlerts = get(settings, fromPath);
+      if (stackAlerts?.enabled === false || stackAlerts?.enabled === true) {
+        addDeprecation({
+          message: `"xpack.stack_alerts.enabled" is deprecated. The ability to disable this plugin will be removed in 8.0.0.`,
+          correctiveActions: {
+            manualSteps: [`Remove "xpack.stack_alerts.enabled" from your kibana configs.`],
+          },
+        });
+      }
+    },
+  ],
 };
 
 export const plugin = (ctx: PluginInitializerContext) => new AlertingBuiltinsPlugin(ctx);

--- a/x-pack/plugins/task_manager/server/index.test.ts
+++ b/x-pack/plugins/task_manager/server/index.test.ts
@@ -50,4 +50,13 @@ describe('deprecations', () => {
       ]
     `);
   });
+
+  it('logs a deprecation warning for the enabled config', () => {
+    const { messages } = applyTaskManagerDeprecations({ enabled: true });
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "\\"xpack.task_manager.enabled\\" is deprecated. The ability to disable this plugin will be removed in 8.0.0.",
+      ]
+    `);
+  });
 });

--- a/x-pack/plugins/task_manager/server/index.ts
+++ b/x-pack/plugins/task_manager/server/index.ts
@@ -65,5 +65,16 @@ export const config: PluginConfigDescriptor<TaskManagerConfig> = {
         });
       }
     },
+    (settings, fromPath, addDeprecation) => {
+      const taskManager = get(settings, fromPath);
+      if (taskManager?.enabled === false || taskManager?.enabled === true) {
+        addDeprecation({
+          message: `"xpack.task_manager.enabled" is deprecated. The ability to disable this plugin will be removed in 8.0.0.`,
+          correctiveActions: {
+            manualSteps: [`Remove "xpack.task_manager.enabled" from your kibana configs.`],
+          },
+        });
+      }
+    },
   ],
 };

--- a/x-pack/plugins/triggers_actions_ui/server/index.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/index.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { config } from './index';
+import { applyDeprecations, configDeprecationFactory } from '@kbn/config';
+
+const CONFIG_PATH = 'xpack.trigger_actions_ui';
+const applyStackAlertDeprecations = (settings: Record<string, unknown> = {}) => {
+  const deprecations = config.deprecations!(configDeprecationFactory);
+  const deprecationMessages: string[] = [];
+  const _config = {
+    [CONFIG_PATH]: settings,
+  };
+  const { config: migrated } = applyDeprecations(
+    _config,
+    deprecations.map((deprecation) => ({
+      deprecation,
+      path: CONFIG_PATH,
+    })),
+    () => ({ message }) => deprecationMessages.push(message)
+  );
+  return {
+    messages: deprecationMessages,
+    migrated,
+  };
+};
+
+describe('index', () => {
+  describe('deprecations', () => {
+    it('should deprecate .enabled flag', () => {
+      const { messages } = applyStackAlertDeprecations({ enabled: false });
+      expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "\\"xpack.trigger_actions_ui.enabled\\" is deprecated. The ability to disable this plugin will be removed in 8.0.0.",
+        ]
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/triggers_actions_ui/server/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { get } from 'lodash';
 import { PluginConfigDescriptor, PluginInitializerContext } from 'kibana/server';
 import { configSchema, ConfigSchema } from '../config';
 import { TriggersActionsPlugin } from './plugin';
@@ -26,6 +26,19 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     enableGeoTrackingThresholdAlert: true,
   },
   schema: configSchema,
+  deprecations: () => [
+    (settings, fromPath, addDeprecation) => {
+      const triggersActionsUi = get(settings, fromPath);
+      if (triggersActionsUi?.enabled === false || triggersActionsUi?.enabled === true) {
+        addDeprecation({
+          message: `"xpack.trigger_actions_ui.enabled" is deprecated. The ability to disable this plugin will be removed in 8.0.0.`,
+          correctiveActions: {
+            manualSteps: [`Remove "xpack.trigger_actions_ui.enabled" from your kibana configs.`],
+          },
+        });
+      }
+    },
+  ],
 };
 
 export const plugin = (ctx: PluginInitializerContext) => new TriggersActionsPlugin(ctx);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Deprecate ability to disable alerting, actions, task manager, stack alerts, and event log plugins (#108281)