### PR TITLE
[canvas] Fix setup server expressions cache; move to mount

### DIFF
--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -95,8 +95,6 @@ export class CanvasPlugin
       }));
     }
 
-    setupExpressions({ coreSetup, setupPlugins });
-
     coreSetup.application.register({
       category: DEFAULT_APP_CATEGORIES.kibana,
       id: 'canvas',
@@ -108,6 +106,7 @@ export class CanvasPlugin
         const { CanvasSrcPlugin } = await import('../canvas_plugin_src/plugin');
         const srcPlugin = new CanvasSrcPlugin();
         srcPlugin.setup(coreSetup, { canvas: canvasApi });
+        setupExpressions({ coreSetup, setupPlugins });
 
         // Get start services
         const [coreStart, startPlugins] = await coreSetup.getStartServices();

--- a/x-pack/plugins/canvas/public/setup_expressions.ts
+++ b/x-pack/plugins/canvas/public/setup_expressions.ts
@@ -11,6 +11,8 @@ import { API_ROUTE_FUNCTIONS } from '../common/lib/constants';
 
 import { CanvasSetupDeps } from './plugin';
 
+let cached: Promise<void> | null = null;
+
 // TODO: clintandrewhall - This is getting refactored shortly.  https://github.com/elastic/kibana/issues/105675
 export const setupExpressions = async ({
   coreSetup,
@@ -20,8 +22,6 @@ export const setupExpressions = async ({
   setupPlugins: CanvasSetupDeps;
 }) => {
   const { expressions, bfetch } = setupPlugins;
-
-  let cached: Promise<void> | null = null;
 
   const loadServerFunctionWrappers = async () => {
     if (!cached) {


### PR DESCRIPTION
> Fixes #107756 

## Summary

#107350 moved the server function wrappers logic to its own module to simplify refactoring when we address #105675.  It had a side-effect where the setup portion of the lifecycle was being run and making an API call to Canvas on every page load.

This PR:

- returns the cache to a module-level variable, and
- runs the registration on mount, (so you don't see a call to Canvas on the first page load that might not be Canvas).

This is a simple fix for a setup file that will be removed when we fix #105675.