### PR TITLE
[RAC] [Security Solution] Reposition the alert detail take action popover on scroll

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -266,6 +266,7 @@ export const TakeActionDropdown = React.memo(
           closePopover={closePopoverHandler}
           panelPaddingSize="none"
           anchorPosition="downLeft"
+          repositionOnScroll
         >
           <EuiContextMenu size="s" initialPanelId={0} panels={panels} />
         </EuiPopover>


### PR DESCRIPTION
## Summary
This pr is a small fix to reposition the take action popover menu on scroll, in the case where the page beneath the flyout scrolls.


![take_action_repo_on_scroll](https://user-images.githubusercontent.com/56408403/129300346-12992b92-6bf0-455e-8500-18660d575195.gif)
