### PR TITLE
[APM] Change table SparkPlot content properties

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_column.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_column.tsx
@@ -62,6 +62,7 @@ export function getColumns({
         return <TimestampTooltip time={lastSeen} timeUnit="minutes" />;
       },
       width: `${unit * 9}px`,
+      align: 'right',
     },
     {
       field: 'occurrences',

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -73,7 +73,7 @@ export function SparkPlot({
 
   const chartSize = {
     height: theme.eui.euiSizeL,
-    width: compact ? unit * 3 : unit * 4,
+    width: compact ? unit * 4 : unit * 5,
   };
 
   const Sparkline = hasComparisonSeries ? LineSeries : AreaSeries;

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -79,7 +79,12 @@ export function SparkPlot({
   const Sparkline = hasComparisonSeries ? LineSeries : AreaSeries;
 
   return (
-    <EuiFlexGroup gutterSize="m" responsive={false}>
+    <EuiFlexGroup
+      justifyContent="spaceBetween"
+      gutterSize="m"
+      responsive={false}
+      alignItems="flexEnd"
+    >
       <EuiFlexItem grow={false}>
         {hasValidTimeseries(series) ? (
           <Chart size={chartSize}>

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -82,6 +82,7 @@ export function DependenciesTable(props: Props) {
       render: (_, { currentStats, previousStats }) => {
         return (
           <SparkPlot
+            compact
             color="euiColorVis1"
             series={currentStats.latency.timeseries}
             comparisonSeries={previousStats?.latency.timeseries}


### PR DESCRIPTION
## Summary

**Before**

<img width="1679" alt="CleanShot 2021-08-13 at 13 49 08@2x" src="https://user-images.githubusercontent.com/4104278/129355809-a6c5aee6-a6d1-41a4-ac7a-b7e4738ed536.png">

**After**

<img width="1672" alt="CleanShot 2021-08-13 at 13 56 31@2x" src="https://user-images.githubusercontent.com/4104278/129355839-359fe8cd-02ab-439b-955b-5194fe618950.png">

**Before**

<img width="1147" alt="CleanShot 2021-08-13 at 14 18 31@2x" src="https://user-images.githubusercontent.com/4104278/129356000-2a4780ea-df28-44d9-a7f7-10fd0a634140.png">

**After**

<img width="1151" alt="CleanShot 2021-08-13 at 14 09 47@2x" src="https://user-images.githubusercontent.com/4104278/129355865-2cdbd649-2727-4ba1-a99a-ef080ac63b3c.png">

**Before**

<img width="1147" alt="CleanShot 2021-08-13 at 14 18 35@2x" src="https://user-images.githubusercontent.com/4104278/129356007-4789f665-46a1-4a2e-a13d-932602df90d5.png">

**After**

<img width="1148" alt="CleanShot 2021-08-13 at 14 09 53@2x" src="https://user-images.githubusercontent.com/4104278/129355880-14cd1d8d-6253-493b-8d66-e4c832c92d30.png">


- [x] Changed alignment of the sparkplot and value labels so the values are right-aligned, more appropriate for numbers.
- [x] Changed sparkplot sizes for compact and default to fill out the space between, adds a wider plot.
- [x] Changed sparklot size in the Dependencies overview table
- [x] Changed the content text alignment of the timestamp column in the Errors overview table

