### PR TITLE
[7.x] Reposition the take action popover on scroll (#108475)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -266,6 +266,7 @@ export const TakeActionDropdown = React.memo(
           closePopover={closePopoverHandler}
           panelPaddingSize="none"
           anchorPosition="downLeft"
+          repositionOnScroll
         >
           <EuiContextMenu size="s" initialPanelId={0} panels={panels} />
         </EuiPopover>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Reposition the take action popover on scroll (#108475)