### PR TITLE
Adding host_risk_score_latest to the list of patterns to track for telemetry

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
@@ -120,6 +120,9 @@ export const DATA_DATASETS_INDEX_PATTERNS = [
 
   // meow attacks
   { pattern: '*meow*', patternName: 'meow' },
+
+  // experimental ml
+  { pattern: '*host_risk_score_latest', patternName: 'host_risk_score' },
 ] as const;
 
 // Get the unique list of index patterns (some are duplicated for documentation purposes)

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
@@ -73,7 +73,7 @@ describe('get_data_telemetry', () => {
           { name: '.app-search-1234', docCount: 0 },
           { name: 'logs-endpoint.1234', docCount: 0 }, // Matching pattern with a dot in the name
           { name: 'ml_host_risk_score_latest', docCount: 0 },
-          { name: 'ml_host_risk_score', docCount: 0 }, // This should not match  
+          { name: 'ml_host_risk_score', docCount: 0 }, // This should not match
           // New Indexing strategy: everything can be inferred from the constant_keyword values
           {
             name: '.ds-logs-nginx.access-default-000001',

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
@@ -72,6 +72,8 @@ describe('get_data_telemetry', () => {
           { name: 'metricbeat-1234', docCount: 100, sizeInBytes: 10, isECS: false },
           { name: '.app-search-1234', docCount: 0 },
           { name: 'logs-endpoint.1234', docCount: 0 }, // Matching pattern with a dot in the name
+          { name: 'ml_host_risk_score_latest', docCount: 0 },
+          { name: 'ml_host_risk_score', docCount: 0 }, // This should not match  
           // New Indexing strategy: everything can be inferred from the constant_keyword values
           {
             name: '.ds-logs-nginx.access-default-000001',
@@ -162,6 +164,11 @@ describe('get_data_telemetry', () => {
         {
           pattern_name: 'logs-endpoint',
           shipper: 'endpoint',
+          index_count: 1,
+          doc_count: 0,
+        },
+        {
+          pattern_name: 'host_risk_score',
           index_count: 1,
           doc_count: 0,
         },


### PR DESCRIPTION
## Summary
The Security Data Science team would like to gauge the adoption of an experimental [prototype](https://github.com/elastic/dreml/tree/main/releases/HostRiskScore) for Host Risk Scoring, which is to hit the Security App soon. The easiest way to track adoption is to get telemetry from indices matching the pattern "*host_risk_score_latest". This PR adds this pattern to the list of patterns to track for telemetry.
