### PR TITLE
[Security Solution] bump isolation timeout to 5 minutes

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -23,6 +23,9 @@ export interface EndpointAction {
   input_type: 'endpoint';
   agents: string[];
   user_id: string;
+  // the number of seconds Elastic Agent (on the host) should
+  // wait to send back an action result before it will timeout
+  timeout?: number;
   data: EndpointActionData;
 }
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.test.ts
@@ -274,6 +274,14 @@ describe('Host Isolation', () => {
         actionID
       );
     });
+    it('records the timeout in the action payload', async () => {
+      const ctx = await callRoute(ISOLATE_HOST_ROUTE, {
+        body: { endpoint_ids: ['XYZ'] },
+      });
+      const actionDoc: EndpointAction = (ctx.core.elasticsearch.client.asCurrentUser
+        .index as jest.Mock).mock.calls[0][0].body;
+      expect(actionDoc.timeout).toEqual(300);
+    });
 
     it('succeeds when just an endpoint ID is provided', async () => {
       await callRoute(ISOLATE_HOST_ROUTE, { body: { endpoint_ids: ['XYZ'] } });

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/isolation.ts
@@ -120,6 +120,7 @@ export const isolationRequestHandler = function (
           input_type: 'endpoint',
           agents: endpointData.map((endpt: HostMetadata) => endpt.elastic.agent.id),
           user_id: user!.username,
+          timeout: 300, // 5 minutes
           data: {
             command: isolate ? 'isolate' : 'unisolate',
             comment: req.body.comment ?? undefined,


### PR DESCRIPTION
## Summary

* bump isolation action timeout to 5 minutes

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
