### PR TITLE
[7.14] chore(NA): moving @kbn/es-archiver to babel transpiler (#108370)

### DIFF
--- a/packages/kbn-es-archiver/.babelrc
+++ b/packages/kbn-es-archiver/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-es-archiver/BUILD.bazel
+++ b/packages/kbn-es-archiver/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-es-archiver"
 PKG_REQUIRE_NAME = "@kbn/es-archiver"
@@ -27,7 +28,7 @@ NPM_MODULE_EXTRA_FILES = [
   "package.json",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-dev-utils",
   "//packages/kbn-test",
   "//packages/kbn-utils",
@@ -43,6 +44,13 @@ SRC_DEPS = [
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-dev-utils",
+  "//packages/kbn-test",
+  "//packages/kbn-utils",
+  "@npm//@elastic/elasticsearch",
+  "@npm//aggregate-error",
+  "@npm//globby",
+  "@npm//zlib",
   "@npm//@types/bluebird",
   "@npm//@types/chance",
   "@npm//@types/jest",
@@ -52,7 +60,11 @@ TYPES_DEPS = [
   "@npm//@types/sinon",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -63,14 +75,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -79,7 +92,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-es-archiver/package.json
+++ b/packages/kbn-es-archiver/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": "true",
-  "main": "target/index.js",
-  "types": "target/index.d.ts",
+  "main": "target_node/index.js",
+  "types": "target_types/index.d.ts",
   "kibana": {
     "devOnly": true
   }

--- a/packages/kbn-es-archiver/tsconfig.json
+++ b/packages/kbn-es-archiver/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "./target",
-    "target": "ES2019",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "./target_types",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-es-archiver/src",
     "types": [


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/es-archiver to babel transpiler (#108370)