### PR TITLE
[7.x] docs: Add anonymous auth to central config (#108285)

### DIFF
--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -26,7 +26,9 @@ For this reason, it is still essential to set custom default configurations loca
 [float]
 ==== APM Server setup
 
-This feature requires https://www.elastic.co/guide/en/apm/server/master/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
+This feature requires {apm-server-ref}/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
+In addition, if an APM agent is using {apm-server-ref}/configuration-anonymous.html[anonymous authentication] to communicate with the APM Server,
+the agent's service name must be included in the `apm-server.auth.anonymous.allow_service` list.
 
 APM Server acts as a proxy between the agents and Kibana.
 Kibana communicates any changed settings to APM Server so that your agents only need to poll APM Server to determine which settings have changed.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: Add anonymous auth to central config (#108285)