### PR TITLE
[Security Solution] Add signal.original_event.reason to signal_extra_fields

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/signal_extra_fields.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/signal_extra_fields.json
@@ -43,6 +43,14 @@
           }
         }
       },
+      "original_event": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "keyword"
+          }
+        }
+      },
       "reason": {
         "type": "keyword"
       },


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/pull/107532 added signal.reason, signal.original_event.reason, and aliases from those fields to their `kibana.alert` counterparts. However, signal.original_event.reason was missed in signal_extra_fields, the field mappings that we add to old indices in addition to the aliases to ensure that the fields being aliased always exist in the mapping as well. Without this addition, the PUT mapping call fails because old indices don't have `signal.original_event.reason` and thus we can't add an alias for that field.

How to test applying aliases to old signals indices (as old as 7.6):
- TO MAKE .siem-signals index IN 7.6:
  - start ES on 7.6 with `yarn es snapshot --license trial -E xpack.security.authc.api_key.enabled=true -E path.data=<PATH TO WHERE YOU WANT DATA FOLDER>`
  - Start Kibana on 7.6
  - load a document from auditbeat/default into auditbeat index using dev tools, but delete event.module from the document first (es archiver doesn't seem to work...)
  - visit DETECTIONS page in siem app, not just overview page - this makes the .siem-signals index
- Stop ES
- Restart ES using the same command as above but on this branch
- Start kibana on this branch
- Visit Detections page to trigger .siem-signals index update


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
