### PR TITLE
[Actions][Docs] Updated ServiceNow docs with information about the user permissions for making CRUD operations.

### DIFF
--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -18,6 +18,8 @@ URL::       ServiceNow instance URL.
 Username::  Username for HTTP Basic authentication.
 Password::  Password for HTTP Basic authentication.
 
+The ServiceNow user requires at minimum read/create/update access to the Incident table and read access to the sys_choice. If access is not provided to sys_choice, then the choices will not render.
+
 [float]
 [[servicenow-connector-networking-configuration]]
 ==== Connector networking configuration

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -18,7 +18,7 @@ URL::       ServiceNow instance URL.
 Username::  Username for HTTP Basic authentication.
 Password::  Password for HTTP Basic authentication.
 
-The ServiceNow user requires at minimum read/create/update access to the Incident table and read access to the sys_choice. If access is not provided to sys_choice, then the choices will not render.
+The ServiceNow user requires at minimum read, create, and update access to the Incident table and read access to the sys_choice. If you don't provide access to sys_choice, then the choices will not render.
 
 [float]
 [[servicenow-connector-networking-configuration]]

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -18,7 +18,7 @@ URL::       ServiceNow instance URL.
 Username::  Username for HTTP Basic authentication.
 Password::  Password for HTTP Basic authentication.
 
-The ServiceNow user requires at minimum read, create, and update access to the Incident table and read access to the sys_choice. If you don't provide access to sys_choice, then the choices will not render.
+The ServiceNow user requires at minimum read, create, and update access to the Incident table and read access to the https://docs.servicenow.com/bundle/paris-platform-administration/page/administer/localization/reference/r_ChoicesTable.html[sys_choice]. If you don't provide access to sys_choice, then the choices will not render.
 
 [float]
 [[servicenow-connector-networking-configuration]]


### PR DESCRIPTION
Changes only in the ServiceNow.asciidocs related to adding information about the minimum required permissions for the connector user to be able to use and display all connector information.

This PR opened in favor of closing the existing one #106423
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
