### PR TITLE
[7.x] [APM] Add telemetry to links into backend (#107872)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/backend_inventory/backend_inventory_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_inventory/backend_inventory_dependencies_table/index.tsx
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import { METRIC_TYPE } from '@kbn/analytics';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
 import { getNodeName, NodeType } from '../../../../../common/connections';
 import { useApmParams } from '../../../../hooks/use_apm_params';
@@ -16,6 +17,7 @@ import { getTimeRangeComparison } from '../../../shared/time_comparison/get_time
 import { DependenciesTable } from '../../../shared/dependencies_table';
 import { BackendLink } from '../../../shared/backend_link';
 import { DependenciesTableServiceMapLink } from '../../../shared/dependencies_table/dependencies_table_service_map_link';
+import { useUiTracker } from '../../../../../../observability/public';
 
 export function BackendInventoryDependenciesTable() {
   const {
@@ -27,6 +29,9 @@ export function BackendInventoryDependenciesTable() {
   } = useApmParams('/backends');
 
   const router = useApmRouter();
+
+  const trackEvent = useUiTracker();
+
   const serviceMapLink = router.link('/service-map', {
     query: {
       rangeFrom,
@@ -79,6 +84,13 @@ export function BackendInventoryDependenciesTable() {
             kuery,
             rangeFrom,
             rangeTo,
+          }}
+          onClick={() => {
+            trackEvent({
+              app: 'apm',
+              metricType: METRIC_TYPE.CLICK,
+              metric: 'backend_inventory_to_backend_detail',
+            });
           }}
         />
       );

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/backend_contents.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/backend_contents.tsx
@@ -8,7 +8,9 @@
 import { EuiButton, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { TypeOf } from '@kbn/typed-react-router-config';
+import { METRIC_TYPE } from '@kbn/analytics';
 import React from 'react';
+import { useUiTracker } from '../../../../../../observability/public';
 import { ContentsProps } from '.';
 import { NodeStats } from '../../../../../common/service_map';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
@@ -58,13 +60,26 @@ export function BackendContents({ nodeData, environment }: ContentsProps) {
     >['query'],
   });
 
+  const trackEvent = useUiTracker();
+
   return (
     <>
       <EuiFlexItem>
         <StatsList data={data} isLoading={isLoading} />
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiButton href={detailsUrl} fill={true}>
+        {/* eslint-disable-next-line @elastic/eui/href-or-on-click*/}
+        <EuiButton
+          href={detailsUrl}
+          fill={true}
+          onClick={() => {
+            trackEvent({
+              app: 'apm',
+              metricType: METRIC_TYPE.CLICK,
+              metric: 'service_map_to_backend_detail',
+            });
+          }}
+        >
           {i18n.translate('xpack.apm.serviceMap.backendDetailsButtonText', {
             defaultMessage: 'Backend Details',
           })}

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
@@ -8,6 +8,8 @@
 import { EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import { METRIC_TYPE } from '@kbn/analytics';
+import { useUiTracker } from '../../../../../../observability/public';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
 import { getNodeName, NodeType } from '../../../../../common/connections';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
@@ -53,6 +55,8 @@ export function ServiceOverviewDependenciesTable() {
     query,
   });
 
+  const trackEvent = useUiTracker();
+
   const { data, status } = useFetcher(
     (callApmApi) => {
       if (!start || !end) {
@@ -87,6 +91,13 @@ export function ServiceOverviewDependenciesTable() {
               kuery,
               rangeFrom,
               rangeTo,
+            }}
+            onClick={() => {
+              trackEvent({
+                app: 'apm',
+                metricType: METRIC_TYPE.CLICK,
+                metric: 'service_dependencies_to_backend_detail',
+              });
             }}
           />
         ) : (

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/span_flyout/sticky_span_properties.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/span_flyout/sticky_span_properties.tsx
@@ -8,6 +8,10 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import {
+  METRIC_TYPE,
+  useUiTracker,
+} from '../../../../../../../../../observability/public';
+import {
   SERVICE_NAME,
   SPAN_DESTINATION_SERVICE_RESOURCE,
   SPAN_NAME,
@@ -31,6 +35,8 @@ interface Props {
 export function StickySpanProperties({ span, transaction }: Props) {
   const { query } = useApmParams('/services/:serviceName/transactions/view');
   const { environment, latencyAggregationType } = query;
+
+  const trackEvent = useUiTracker();
 
   const nextEnvironment = getNextEnvironmentUrlParam({
     requestedEnvironment: transaction?.service.environment,
@@ -101,6 +107,13 @@ export function StickySpanProperties({ span, transaction }: Props) {
               query={query}
               subtype={span.span.subtype}
               type={span.span.type}
+              onClick={() => {
+                trackEvent({
+                  app: 'apm',
+                  metricType: METRIC_TYPE.CLICK,
+                  metric: 'span_flyout_to_backend_detail',
+                });
+              }}
             />
           ),
           width: '25%',

--- a/x-pack/plugins/apm/public/components/shared/backend_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/backend_link.tsx
@@ -21,6 +21,7 @@ interface BackendLinkProps {
   query: TypeOf<ApmRoutes, '/backends/:backendName/overview'>['query'];
   subtype?: string;
   type?: string;
+  onClick?: React.ComponentProps<typeof EuiLink>['onClick'];
 }
 
 export function BackendLink({
@@ -28,6 +29,7 @@ export function BackendLink({
   query,
   subtype,
   type,
+  onClick,
 }: BackendLinkProps) {
   const { link } = useApmRouter();
 
@@ -37,6 +39,7 @@ export function BackendLink({
         path: { backendName },
         query,
       })}
+      onClick={onClick}
     >
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/observability/public/components/shared/page_template/page_template.tsx
+++ b/x-pack/plugins/observability/public/components/shared/page_template/page_template.tsx
@@ -78,6 +78,10 @@ export function ObservabilityPageTemplate({
             href,
             isSelected,
             onClick: (event) => {
+              if (entry.onClick) {
+                entry.onClick(event);
+              }
+
               if (
                 event.button !== 0 ||
                 event.defaultPrevented ||

--- a/x-pack/plugins/observability/public/services/navigation_registry.ts
+++ b/x-pack/plugins/observability/public/services/navigation_registry.ts
@@ -28,6 +28,8 @@ export interface NavigationEntry {
   matchFullPath?: boolean;
   // whether to ignore trailing slashes, defaults to `true`
   ignoreTrailingSlash?: boolean;
+  // handler to be called when the item is clicked
+  onClick?: (event: React.MouseEvent<HTMLElement | HTMLButtonElement, MouseEvent>) => void;
 }
 
 export interface NavigationRegistry {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Add telemetry to links into backend views (#107872)