### PR TITLE
[7.14] migrationsv2: handle 413 errors and log the request details for unexpected ES failures (#108213)

### DIFF
--- a/src/core/server/elasticsearch/client/index.ts
+++ b/src/core/server/elasticsearch/client/index.ts
@@ -20,5 +20,5 @@ export type { IScopedClusterClient } from './scoped_cluster_client';
 export type { ElasticsearchClientConfig } from './client_config';
 export { ClusterClient } from './cluster_client';
 export type { IClusterClient, ICustomClusterClient } from './cluster_client';
-export { configureClient } from './configure_client';
+export { configureClient, getRequestDebugMeta, getErrorMessage } from './configure_client';
 export { retryCallCluster, migrationRetryCallCluster } from './retry_call_cluster';

--- a/src/core/server/elasticsearch/index.ts
+++ b/src/core/server/elasticsearch/index.ts
@@ -34,3 +34,4 @@ export type {
   GetResponse,
   DeleteDocumentResponse,
 } from './client';
+export { getRequestDebugMeta, getErrorMessage } from './client';

--- a/src/core/server/saved_objects/migrationsv2/actions/index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/index.ts
@@ -120,6 +120,10 @@ export interface TargetIndexHadWriteBlock {
   type: 'target_index_had_write_block';
 }
 
+export interface RequestEntityTooLargeException {
+  type: 'request_entity_too_large_exception';
+}
+
 /** @internal */
 export interface AcknowledgeResponse {
   acknowledged: boolean;
@@ -136,6 +140,7 @@ export interface ActionErrorTypeMap {
   alias_not_found_exception: AliasNotFound;
   remove_index_not_a_concrete_index: RemoveIndexNotAConcreteIndex;
   documents_transform_failed: DocumentsTransformFailed;
+  request_entity_too_large_exception: RequestEntityTooLargeException;
 }
 
 /**

--- a/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
@@ -46,6 +46,12 @@ import { TaskEither } from 'fp-ts/lib/TaskEither';
 
 const { startES } = kbnTestServer.createTestServers({
   adjustTimeout: (t: number) => jest.setTimeout(t),
+  settings: {
+    es: {
+      license: 'basic',
+      esArgs: ['http.max_content_length=10Kb'],
+    },
+  },
 });
 let esServer: kbnTestServer.TestElasticsearchUtils;
 
@@ -1471,11 +1477,11 @@ describe('migration actions', () => {
       });
 
       await expect(task()).resolves.toMatchInlineSnapshot(`
-                Object {
-                  "_tag": "Right",
-                  "right": "bulk_index_succeeded",
-                }
-              `);
+        Object {
+          "_tag": "Right",
+          "right": "bulk_index_succeeded",
+        }
+      `);
     });
     it('resolves right even if there were some version_conflict_engine_exception', async () => {
       const existingDocs = ((await searchForOutdatedDocuments(client, {
@@ -1500,7 +1506,7 @@ describe('migration actions', () => {
                 }
               `);
     });
-    it('resolves left if there are write_block errors', async () => {
+    it('resolves left target_index_had_write_block if there are write_block errors', async () => {
       const newDocs = ([
         { _source: { title: 'doc 5' } },
         { _source: { title: 'doc 6' } },
@@ -1514,13 +1520,34 @@ describe('migration actions', () => {
           refresh: 'wait_for',
         })()
       ).resolves.toMatchInlineSnapshot(`
-              Object {
-                "_tag": "Left",
-                "left": Object {
-                  "type": "target_index_had_write_block",
-                },
-              }
-            `);
+        Object {
+          "_tag": "Left",
+          "left": Object {
+            "type": "target_index_had_write_block",
+          },
+        }
+      `);
+    });
+    it('resolves left request_entity_too_large_exception when the payload is too large', async () => {
+      const newDocs = new Array(10000).fill({
+        _source: {
+          title:
+            'how do I create a document thats large enoug to exceed the limits without typing long sentences',
+        },
+      }) as SavedObjectsRawDoc[];
+      const task = bulkOverwriteTransformedDocuments({
+        client,
+        index: 'existing_index_with_docs',
+        transformedDocs: newDocs,
+      });
+      await expect(task()).resolves.toMatchInlineSnapshot(`
+        Object {
+          "_tag": "Left",
+          "left": Object {
+            "type": "request_entity_too_large_exception",
+          },
+        }
+      `);
     });
   });
 });

--- a/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/migrations_state_action_machine.test.ts
@@ -353,6 +353,9 @@ describe('migrationsStateActionMachine', () => {
         next: () => {
           throw new ResponseError(
             elasticsearchClientMock.createApiResponse({
+              meta: {
+                request: { options: {}, id: '', params: { method: 'POST', path: '/mock' } },
+              } as any,
               body: {
                 error: {
                   type: 'snapshot_in_progress_exception',
@@ -365,14 +368,14 @@ describe('migrationsStateActionMachine', () => {
         client: esClient,
       })
     ).rejects.toMatchInlineSnapshot(
-      `[Error: Unable to complete saved object migrations for the [.my-so-index] index. Please check the health of your Elasticsearch cluster and try again. Error: [snapshot_in_progress_exception]: Cannot delete indices that are being snapshotted]`
+      `[Error: Unable to complete saved object migrations for the [.my-so-index] index. Please check the health of your Elasticsearch cluster and try again. Unexpected Elasticsearch ResponseError: statusCode: 200, method: POST, url: /mock error: [snapshot_in_progress_exception]: Cannot delete indices that are being snapshotted,]`
     );
     expect(loggingSystemMock.collect(mockLogger)).toMatchInlineSnapshot(`
       Object {
         "debug": Array [],
         "error": Array [
           Array [
-            "[.my-so-index] [snapshot_in_progress_exception]: Cannot delete indices that are being snapshotted",
+            "[.my-so-index] Unexpected Elasticsearch ResponseError: statusCode: 200, method: POST, url: /mock error: [snapshot_in_progress_exception]: Cannot delete indices that are being snapshotted,",
           ],
           Array [
             "[.my-so-index] migration failed, dumping execution log:",

--- a/src/core/server/saved_objects/migrationsv2/model/model.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/model.test.ts
@@ -1154,6 +1154,16 @@ describe('migrations v2 model', () => {
         expect(newState.retryCount).toEqual(0);
         expect(newState.retryDelay).toEqual(0);
       });
+      test('REINDEX_SOURCE_TO_TEMP_INDEX_BULK -> FATAL if action returns left request_entity_too_large_exception', () => {
+        const res: ResponseType<'REINDEX_SOURCE_TO_TEMP_INDEX_BULK'> = Either.left({
+          type: 'request_entity_too_large_exception',
+        });
+        const newState = model(reindexSourceToTempIndexBulkState, res) as FatalState;
+        expect(newState.controlState).toEqual('FATAL');
+        expect(newState.reason).toMatchInlineSnapshot(
+          `"While indexing a batch of saved objects, Elasticsearch returned a 413 Request Entity Too Large exception. Try to use smaller batches by changing the Kibana 'migrations.batchSize' configuration option and restarting Kibana."`
+        );
+      });
       test('REINDEX_SOURCE_TO_TEMP_INDEX_BULK should throw a throwBadResponse error if action failed', () => {
         const res: ResponseType<'REINDEX_SOURCE_TO_TEMP_INDEX_BULK'> = Either.left({
           type: 'retryable_es_client_error',
@@ -1531,6 +1541,17 @@ describe('migrations v2 model', () => {
         expect(newState.controlState).toEqual('TRANSFORMED_DOCUMENTS_BULK_INDEX');
         expect(newState.retryCount).toEqual(1);
         expect(newState.retryDelay).toEqual(2000);
+      });
+
+      test('TRANSFORMED_DOCUMENTS_BULK_INDEX -> FATAL if action returns left request_entity_too_large_exception', () => {
+        const res: ResponseType<'TRANSFORMED_DOCUMENTS_BULK_INDEX'> = Either.left({
+          type: 'request_entity_too_large_exception',
+        });
+        const newState = model(transformedDocumentsBulkIndexState, res) as FatalState;
+        expect(newState.controlState).toEqual('FATAL');
+        expect(newState.reason).toMatchInlineSnapshot(
+          `"While indexing a batch of saved objects, Elasticsearch returned a 413 Request Entity Too Large exception. Try to use smaller batches by changing the Kibana 'migrations.batchSize' configuration option and restarting Kibana."`
+        );
       });
     });
 

--- a/src/core/server/saved_objects/migrationsv2/model/model.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/model.ts
@@ -540,6 +540,12 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
           ...stateP,
           controlState: 'REINDEX_SOURCE_TO_TEMP_CLOSE_PIT',
         };
+      } else if (isLeftTypeof(res.left, 'request_entity_too_large_exception')) {
+        return {
+          ...stateP,
+          controlState: 'FATAL',
+          reason: `While indexing a batch of saved objects, Elasticsearch returned a 413 Request Entity Too Large exception. Try to use smaller batches by changing the Kibana 'migrations.batchSize' configuration option and restarting Kibana.`,
+        };
       }
       throwBadResponse(stateP, res.left);
     }
@@ -709,7 +715,19 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
         hasTransformedDocs: true,
       };
     } else {
-      throwBadResponse(stateP, res as never);
+      if (isLeftTypeof(res.left, 'request_entity_too_large_exception')) {
+        return {
+          ...stateP,
+          controlState: 'FATAL',
+          reason: `While indexing a batch of saved objects, Elasticsearch returned a 413 Request Entity Too Large exception. Try to use smaller batches by changing the Kibana 'migrations.batchSize' configuration option and restarting Kibana.`,
+        };
+      } else if (isLeftTypeof(res.left, 'target_index_had_write_block')) {
+        // we fail on this error since the target index will only have a write
+        // block if a newer version of Kibana started an upgrade
+        throwBadResponse(stateP, res.left as never);
+      } else {
+        throwBadResponse(stateP, res.left);
+      }
     }
   } else if (stateP.controlState === 'UPDATE_TARGET_MAPPINGS') {
     const res = resW as ExcludeRetryableEsError<ResponseType<typeof stateP.controlState>>;


### PR DESCRIPTION
Backports the following commits to 7.14:
 - migrationsv2: handle 413 errors and log the request details for unexpected ES failures (#108213)