### PR TITLE
[Metrics UI] Fix refresh button for node details page

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/metric_detail/components/node_details_page.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metric_detail/components/node_details_page.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import dateMath from '@elastic/datemath';
+import moment from 'moment';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { InfraTimerangeInput } from '../../../../../common/http_api/snapshot_api';
 import { InventoryMetric, InventoryItemType } from '../../../../../common/inventory_models/types';
 import { useNodeDetails } from '../hooks/use_node_details';
 import { MetricsSideNav } from './side_nav';
@@ -28,7 +29,6 @@ interface Props {
   nodeType: InventoryItemType;
   sourceId: string;
   timeRange: MetricsTimeInput;
-  parsedTimeRange: InfraTimerangeInput;
   metadataLoading: boolean;
   isAutoReloading: boolean;
   refreshInterval: number;
@@ -40,24 +40,39 @@ interface Props {
   triggerRefresh(): void;
   setTimeRange(timeRange: MetricsTimeInput): void;
 }
+
+const parseRange = (range: MetricsTimeInput) => {
+  const parsedFrom = dateMath.parse(range.from.toString());
+  const parsedTo = dateMath.parse(range.to.toString(), { roundUp: true });
+  return {
+    ...range,
+    from: (parsedFrom && parsedFrom.valueOf()) || moment().subtract(1, 'hour').valueOf(),
+    to: (parsedTo && parsedTo.valueOf()) || moment().valueOf(),
+  };
+};
+
 export const NodeDetailsPage = (props: Props) => {
-  const { parsedTimeRange } = props;
+  const [parsedTimeRange, setParsedTimeRange] = useState(parseRange(props.timeRange));
   const { metrics, loading, makeRequest, error } = useNodeDetails(
     props.requiredMetrics,
     props.nodeId,
     props.nodeType,
     props.sourceId,
-    props.parsedTimeRange,
+    parsedTimeRange,
     props.cloudId
   );
 
-  const refetch = useCallback(() => {
-    makeRequest();
-  }, [makeRequest]);
+  const refetch = () => {
+    setParsedTimeRange(parseRange(props.timeRange));
+  };
+
+  useEffect(() => {
+    setParsedTimeRange(parseRange(props.timeRange));
+  }, [props.timeRange]);
 
   useEffect(() => {
     makeRequest();
-  }, [makeRequest, parsedTimeRange]);
+  }, [makeRequest, setParsedTimeRange]);
 
   if (error) {
     return <PageError error={error} name={props.name} />;

--- a/x-pack/plugins/infra/public/pages/metrics/metric_detail/components/node_details_page.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metric_detail/components/node_details_page.tsx
@@ -62,9 +62,9 @@ export const NodeDetailsPage = (props: Props) => {
     props.cloudId
   );
 
-  const refetch = () => {
+  const refetch = useCallback(() => {
     setParsedTimeRange(parseRange(props.timeRange));
-  };
+  }, [props.timeRange]);
 
   useEffect(() => {
     setParsedTimeRange(parseRange(props.timeRange));
@@ -72,7 +72,7 @@ export const NodeDetailsPage = (props: Props) => {
 
   useEffect(() => {
     makeRequest();
-  }, [makeRequest, setParsedTimeRange]);
+  }, [makeRequest, parsedTimeRange]);
 
   if (error) {
     return <PageError error={error} name={props.name} />;

--- a/x-pack/plugins/infra/public/pages/metrics/metric_detail/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metric_detail/index.tsx
@@ -114,7 +114,6 @@ export const MetricDetail = withMetricPageProviders(
             requiredMetrics={filteredRequiredMetrics}
             sourceId={sourceId}
             timeRange={timeRange}
-            parsedTimeRange={parsedTimeRange}
             nodeType={nodeType}
             nodeId={nodeId}
             cloudId={cloudId}


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/104898

### Technical details
The issue was with the time range sent in the request that fetches the data. We were using a `parsedTimeRange` that comes from the [useMetricsTime](https://github.com/elastic/kibana/blob/master/x-pack/plugins/infra/public/pages/metrics/metric_detail/hooks/use_metrics_time.ts) hook. When the user selects a relative time range, the parsedTimeRange was not updated when the user clicked on the Refresh button.
I changed it to keep the parsed time range in the component and updating it just before making the request.