### PR TITLE
[ML] Functional tests - stabilize delete annotation test

### DIFF
--- a/x-pack/test/functional/services/ml/job_annotations_table.ts
+++ b/x-pack/test/functional/services/ml/job_annotations_table.ts
@@ -136,13 +136,13 @@ export function MachineLearningJobAnnotationsProvider({ getService }: FtrProvide
     }
 
     public async assertAnnotationsRowExists(annotationId: string) {
-      await retry.tryForTime(1000, async () => {
+      await retry.tryForTime(5 * 1000, async () => {
         await testSubjects.existOrFail(this.rowSelector(annotationId));
       });
     }
 
     public async assertAnnotationsRowMissing(annotationId: string) {
-      await retry.tryForTime(1000, async () => {
+      await retry.tryForTime(5 * 1000, async () => {
         await testSubjects.missingOrFail(this.rowSelector(annotationId));
       });
     }


### PR DESCRIPTION
## Summary

This PR stabilizes the delete annotation UI test by increasing the timeout while waiting for annotation table changes.

Closes #108521