### PR TITLE
[7.x] Adjusts panel styling in metrics and logs settings (#108412)

### DIFF
--- a/x-pack/plugins/infra/public/pages/logs/settings/source_configuration_settings.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/settings/source_configuration_settings.tsx
@@ -100,7 +100,7 @@ export const LogsSettingsPage = () => {
         <Prompt
           prompt={sourceConfigurationFormElement.isDirty ? unsavedFormPromptMessage : undefined}
         />
-        <EuiPanel paddingSize="l">
+        <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
           <NameConfigurationPanel
             isLoading={isLoading}
             isReadOnly={!isWriteable}
@@ -108,7 +108,7 @@ export const LogsSettingsPage = () => {
           />
         </EuiPanel>
         <EuiSpacer />
-        <EuiPanel paddingSize="l">
+        <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
           <IndicesConfigurationPanel
             isLoading={isLoading}
             isReadOnly={!isWriteable}
@@ -118,7 +118,7 @@ export const LogsSettingsPage = () => {
           />
         </EuiPanel>
         <EuiSpacer />
-        <EuiPanel paddingSize="l">
+        <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
           <LogColumnsConfigurationPanel
             availableFields={availableFields}
             isLoading={isLoading}

--- a/x-pack/plugins/infra/public/pages/metrics/settings/source_configuration_settings.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/settings/source_configuration_settings.tsx
@@ -107,7 +107,7 @@ export const SourceConfigurationSettings = ({
             : undefined
         }
       />
-      <EuiPanel paddingSize="l">
+      <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
         <NameConfigurationPanel
           isLoading={isLoading}
           nameFieldProps={indicesConfigurationProps.name}
@@ -115,7 +115,7 @@ export const SourceConfigurationSettings = ({
         />
       </EuiPanel>
       <EuiSpacer />
-      <EuiPanel paddingSize="l">
+      <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
         <IndicesConfigurationPanel
           isLoading={isLoading}
           metricAliasFieldProps={indicesConfigurationProps.metricAlias}
@@ -123,7 +123,7 @@ export const SourceConfigurationSettings = ({
         />
       </EuiPanel>
       <EuiSpacer />
-      <EuiPanel paddingSize="l">
+      <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
         <FieldsConfigurationPanel
           containerFieldProps={indicesConfigurationProps.containerField}
           hostFieldProps={indicesConfigurationProps.hostField}
@@ -136,7 +136,7 @@ export const SourceConfigurationSettings = ({
       <EuiSpacer />
       {hasInfraMLCapabilities && (
         <>
-          <EuiPanel paddingSize="l">
+          <EuiPanel paddingSize="l" hasShadow={false} hasBorder={true}>
             <MLConfigurationPanel
               isLoading={isLoading}
               readOnly={!isWriteable}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adjusts panel styling in metrics and logs settings (#108412)