### PR TITLE
[RAC][Observability][Security Solution] Prevent observability table actions from ever wrapping

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -232,7 +232,7 @@ function ObservabilityActions({
           />
         </Suspense>
       )}
-      <EuiFlexGroup gutterSize="none">
+      <EuiFlexGroup gutterSize="none" responsive={false}>
         <EuiFlexItem>
           <EuiButtonIcon
             size="s"


### PR DESCRIPTION
## Summary

Fixes #108676 by preventing the action items cell flex group from ever wrapping at any resolution.
![image](https://user-images.githubusercontent.com/56408403/129577576-93634d01-393c-4c08-89b5-3477a2f7783c.png)


### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))



