### PR TITLE
[7.14] chore(NA): moving @kbn/docs-utils to babel transpiler (#108190)

### DIFF
--- a/packages/kbn-docs-utils/.babelrc
+++ b/packages/kbn-docs-utils/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-docs-utils/BUILD.bazel
+++ b/packages/kbn-docs-utils/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-docs-utils"
 PKG_REQUIRE_NAME = "@kbn/docs-utils"
@@ -26,7 +27,7 @@ NPM_MODULE_EXTRA_FILES = [
   "package.json",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-config",
   "//packages/kbn-dev-utils",
   "//packages/kbn-utils",
@@ -35,12 +36,20 @@ SRC_DEPS = [
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-config",
+  "//packages/kbn-dev-utils",
+  "//packages/kbn-utils",
+  "@npm//ts-morph",
   "@npm//@types/dedent",
   "@npm//@types/jest",
   "@npm//@types/node",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -51,14 +60,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -67,7 +77,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-docs-utils/package.json
+++ b/packages/kbn-docs-utils/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": "true",
-  "main": "target/index.js",
-  "types": "target/index.d.ts",
+  "main": "target_node/index.js",
+  "types": "target_types/index.d.ts",
   "kibana": {
     "devOnly": true
   }

--- a/packages/kbn-docs-utils/tsconfig.json
+++ b/packages/kbn-docs-utils/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "./target",
-    "target": "ES2019",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-docs-utils/src",
+    "target": "ES2019",
     "types": [
       "jest",
       "node"


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/docs-utils to babel transpiler (#108190)