### PR TITLE
[ML] Adding failed job import telemetry

### DIFF
--- a/x-pack/plugins/ml/common/constants/usage_collection.ts
+++ b/x-pack/plugins/ml/common/constants/usage_collection.ts
@@ -7,7 +7,9 @@
 
 export const ML_USAGE_EVENT = {
   IMPORTED_ANOMALY_DETECTOR_JOBS: 'imported_anomaly_detector_jobs',
+  IMPORT_FAILED_ANOMALY_DETECTOR_JOBS: 'import_failed_anomaly_detector_jobs',
   IMPORTED_DATA_FRAME_ANALYTICS_JOBS: 'imported_data_frame_analytics_jobs',
+  IMPORT_FAILED_DATA_FRAME_ANALYTICS_JOBS: 'import_failed_data_frame_analytics_jobs',
   EXPORTED_ANOMALY_DETECTOR_JOBS: 'exported_anomaly_detector_jobs',
   EXPORTED_DATA_FRAME_ANALYTICS_JOBS: 'exported_data_frame_analytics_jobs',
 } as const;

--- a/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/import_jobs_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/components/import_export_jobs/import_jobs_flyout/import_jobs_flyout.tsx
@@ -197,8 +197,10 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
     const results = await bulkCreateJobs(jobs);
     let successCount = 0;
     const errors: ErrorType[] = [];
+    const failedJobIds = new Set();
     Object.entries(results).forEach(([jobId, { job, datafeed }]) => {
       if (job.error || datafeed.error) {
+        failedJobIds.add(jobId);
         if (job.error) {
           errors.push(job.error);
         }
@@ -214,7 +216,8 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
       displayImportSuccessToast(successCount);
     }
     if (errors.length > 0) {
-      displayImportErrorToast(errors);
+      displayImportErrorToast(errors, failedJobIds.size);
+      mlUsageCollection.count('import_failed_anomaly_detector_jobs', failedJobIds.size);
     }
   }, []);
 
@@ -234,7 +237,8 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
       displayImportSuccessToast(successCount);
     }
     if (errors.length > 0) {
-      displayImportErrorToast(errors);
+      displayImportErrorToast(errors, errors.length);
+      mlUsageCollection.count('import_failed_data_frame_analytics_jobs', errors.length);
     }
   }, []);
 
@@ -246,10 +250,10 @@ export const ImportJobsFlyout: FC<Props> = ({ isDisabled }) => {
     displaySuccessToast(title);
   }, []);
 
-  const displayImportErrorToast = useCallback((errors: ErrorType[]) => {
+  const displayImportErrorToast = useCallback((errors: ErrorType[], failureCount: number) => {
     const title = i18n.translate('xpack.ml.importExport.importFlyout.importJobErrorToast', {
       defaultMessage: '{count, plural, one {# job} other {# jobs}} failed to import correctly',
-      values: { count: errors.length },
+      values: { count: failureCount },
     });
 
     const errorList = errors.map(extractErrorProperties);


### PR DESCRIPTION
Adding telemetry counts `import_failed_anomaly_detector_jobs` and `import_failed_data_frame_analytics_jobs` to track when importing a job fails.

Also fixes a bug in the failure count where an anomaly detection job import failure would be counted twice as the datafeed failure would also be counted.

