### PR TITLE
[ML] Add support for model_prune_window in job wizard

### DIFF
--- a/x-pack/plugins/ml/server/routes/schemas/anomaly_detectors_schema.ts
+++ b/x-pack/plugins/ml/server/routes/schemas/anomaly_detectors_schema.ts
@@ -101,6 +101,7 @@ export const analysisConfigSchema = schema.object({
       stop_on_warn: schema.maybe(schema.boolean()),
     })
   ),
+  model_prune_window: schema.maybe(schema.string()),
 });
 
 export const anomalyDetectionJobSchema = {


### PR DESCRIPTION
`model_prune_window` can now be added when editing the JSON in the Advanced Job wizard.
![image](https://user-images.githubusercontent.com/22172091/129600202-8a938531-f437-48b0-8db1-fd950eb25fe1.png)


This value is saved to the job as expected and is visible in the job's expanded row on the Job Management page.

![image](https://user-images.githubusercontent.com/22172091/129600127-7aff3fc4-2084-4562-983c-4cf785121a0e.png)

`model_prune_window` is also correctly copied over when cloning or importing a job.

Closes https://github.com/elastic/kibana/issues/107273

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
