### PR TITLE
Improves not found response handling in the saved objects repository

### DIFF
--- a/docs/development/core/server/kibana-plugin-core-server.savedobjectserrorhelpers.creategenericnotfoundesunavailableerror.md
+++ b/docs/development/core/server/kibana-plugin-core-server.savedobjectserrorhelpers.creategenericnotfoundesunavailableerror.md
@@ -7,15 +7,15 @@
 <b>Signature:</b>
 
 ```typescript
-static createGenericNotFoundEsUnavailableError(type: string, id: string): DecoratedError;
+static createGenericNotFoundEsUnavailableError(type?: string | null, id?: string | null): DecoratedError;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  type | <code>string</code> |  |
-|  id | <code>string</code> |  |
+|  type | <code>string &#124; null</code> |  |
+|  id | <code>string &#124; null</code> |  |
 
 <b>Returns:</b>
 

--- a/src/core/server/elasticsearch/client/mocks.ts
+++ b/src/core/server/elasticsearch/client/mocks.ts
@@ -142,7 +142,7 @@ export type MockedTransportRequestPromise<T> = TransportRequestPromise<T> & {
 const createSuccessTransportRequestPromise = <T>(
   body: T,
   { statusCode = 200 }: { statusCode?: number } = {},
-  headers?: Record<string, string | string[]>
+  headers: Record<string, string | string[]> = { 'x-elastic-product': 'Elasticsearch' }
 ): MockedTransportRequestPromise<ApiResponse<T>> => {
   const response = createApiResponse({ body, statusCode, headers });
   const promise = Promise.resolve(response);
@@ -163,7 +163,7 @@ function createApiResponse<TResponse = Record<string, any>>(
   return {
     body: {} as any,
     statusCode: 200,
-    headers: {},
+    headers: { 'x-elastic-product': 'Elasticsearch' },
     warnings: [],
     meta: {} as any,
     ...opts,

--- a/src/core/server/elasticsearch/client/mocks.ts
+++ b/src/core/server/elasticsearch/client/mocks.ts
@@ -11,6 +11,7 @@ import { TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport';
 import type { DeeplyMockedKeys } from '@kbn/utility-types/jest';
 import { ElasticsearchClient } from './types';
 import { ICustomClusterClient } from './cluster_client';
+import { PRODUCT_RESPONSE_HEADER } from '../supported_server_response_check';
 
 const createInternalClientMock = (
   res?: MockedTransportRequestPromise<unknown>
@@ -142,7 +143,7 @@ export type MockedTransportRequestPromise<T> = TransportRequestPromise<T> & {
 const createSuccessTransportRequestPromise = <T>(
   body: T,
   { statusCode = 200 }: { statusCode?: number } = {},
-  headers: Record<string, string | string[]> = { 'x-elastic-product': 'Elasticsearch' }
+  headers: Record<string, string | string[]> = { [PRODUCT_RESPONSE_HEADER]: 'Elasticsearch' }
 ): MockedTransportRequestPromise<ApiResponse<T>> => {
   const response = createApiResponse({ body, statusCode, headers });
   const promise = Promise.resolve(response);
@@ -163,7 +164,7 @@ function createApiResponse<TResponse = Record<string, any>>(
   return {
     body: {} as any,
     statusCode: 200,
-    headers: { 'x-elastic-product': 'Elasticsearch' },
+    headers: { [PRODUCT_RESPONSE_HEADER]: 'Elasticsearch' },
     warnings: [],
     meta: {} as any,
     ...opts,

--- a/src/core/server/elasticsearch/client/mocks.ts
+++ b/src/core/server/elasticsearch/client/mocks.ts
@@ -11,6 +11,7 @@ import { TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport';
 import type { DeeplyMockedKeys } from '@kbn/utility-types/jest';
 import { ElasticsearchClient } from './types';
 import { ICustomClusterClient } from './cluster_client';
+import { PRODUCT_RESPONSE_HEADER } from '../supported_server_response_check';
 
 const createInternalClientMock = (
   res?: MockedTransportRequestPromise<unknown>
@@ -142,7 +143,7 @@ export type MockedTransportRequestPromise<T> = TransportRequestPromise<T> & {
 const createSuccessTransportRequestPromise = <T>(
   body: T,
   { statusCode = 200 }: { statusCode?: number } = {},
-  headers: Record<string, string | string[]> = { 'x-elastic-product': 'Elasticsearch' }
+  headers: Record<string, string | string[]> = { PRODUCT_RESPONSE_HEADER: 'Elasticsearch' }
 ): MockedTransportRequestPromise<ApiResponse<T>> => {
   const response = createApiResponse({ body, statusCode, headers });
   const promise = Promise.resolve(response);
@@ -163,7 +164,7 @@ function createApiResponse<TResponse = Record<string, any>>(
   return {
     body: {} as any,
     statusCode: 200,
-    headers: { 'x-elastic-product': 'Elasticsearch' },
+    headers: { PRODUCT_RESPONSE_HEADER: 'Elasticsearch' },
     warnings: [],
     meta: {} as any,
     ...opts,

--- a/src/core/server/elasticsearch/client/mocks.ts
+++ b/src/core/server/elasticsearch/client/mocks.ts
@@ -11,7 +11,6 @@ import { TransportRequestPromise } from '@elastic/elasticsearch/lib/Transport';
 import type { DeeplyMockedKeys } from '@kbn/utility-types/jest';
 import { ElasticsearchClient } from './types';
 import { ICustomClusterClient } from './cluster_client';
-import { PRODUCT_RESPONSE_HEADER } from '../supported_server_response_check';
 
 const createInternalClientMock = (
   res?: MockedTransportRequestPromise<unknown>
@@ -143,7 +142,7 @@ export type MockedTransportRequestPromise<T> = TransportRequestPromise<T> & {
 const createSuccessTransportRequestPromise = <T>(
   body: T,
   { statusCode = 200 }: { statusCode?: number } = {},
-  headers: Record<string, string | string[]> = { PRODUCT_RESPONSE_HEADER: 'Elasticsearch' }
+  headers: Record<string, string | string[]> = { 'x-elastic-product': 'Elasticsearch' }
 ): MockedTransportRequestPromise<ApiResponse<T>> => {
   const response = createApiResponse({ body, statusCode, headers });
   const promise = Promise.resolve(response);
@@ -164,7 +163,7 @@ function createApiResponse<TResponse = Record<string, any>>(
   return {
     body: {} as any,
     statusCode: 200,
-    headers: { PRODUCT_RESPONSE_HEADER: 'Elasticsearch' },
+    headers: { 'x-elastic-product': 'Elasticsearch' },
     warnings: [],
     meta: {} as any,
     ...opts,

--- a/src/core/server/elasticsearch/index.ts
+++ b/src/core/server/elasticsearch/index.ts
@@ -41,4 +41,5 @@ export { getRequestDebugMeta, getErrorMessage } from './client';
 export {
   isSupportedEsServer,
   isNotFoundFromUnsupportedServer,
+  PRODUCT_RESPONSE_HEADER,
 } from './supported_server_response_check';

--- a/src/core/server/elasticsearch/index.ts
+++ b/src/core/server/elasticsearch/index.ts
@@ -38,4 +38,7 @@ export type {
   DeleteDocumentResponse,
 } from './client';
 export { getRequestDebugMeta, getErrorMessage } from './client';
-export { isSupportedEsServer } from './supported_server_response_check';
+export {
+  isSupportedEsServer,
+  isNotFoundFromUnsupportedServer,
+} from './supported_server_response_check';

--- a/src/core/server/elasticsearch/supported_server_response_check.test.ts
+++ b/src/core/server/elasticsearch/supported_server_response_check.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isNotFoundFromUnsupportedServer } from './supported_server_response_check';
+
+describe('#isNotFoundFromUnsupportedServer', () => {
+  it('returns true with not found response from unsupported server', () => {
+    const rawResponse = {
+      statusCode: 404,
+      headers: {},
+    };
+
+    const result = isNotFoundFromUnsupportedServer(rawResponse);
+    expect(result).toBe(true);
+  });
+
+  it('returns false with not found response from supported server', async () => {
+    const rawResponse = {
+      statusCode: 404,
+      headers: { 'x-elastic-product': 'Elasticsearch' },
+    };
+
+    const result = isNotFoundFromUnsupportedServer(rawResponse);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when not a 404', async () => {
+    const rawResponse = {
+      statusCode: 200,
+      headers: { 'x-elastic-product': 'Elasticsearch' },
+    };
+
+    const result = isNotFoundFromUnsupportedServer(rawResponse);
+    expect(result).toBe(false);
+  });
+});

--- a/src/core/server/elasticsearch/supported_server_response_check.ts
+++ b/src/core/server/elasticsearch/supported_server_response_check.ts
@@ -12,6 +12,6 @@ export const PRODUCT_RESPONSE_HEADER = 'x-elastic-product';
  * @returns boolean
  */
 // This check belongs to the elasticsearch service as a dedicated helper method.
-export const isSupportedEsServer = (headers: Record<string, string> | null) => {
+export const isSupportedEsServer = (headers: Record<string, string | string[]> | null) => {
   return !!headers && headers[PRODUCT_RESPONSE_HEADER] === 'Elasticsearch';
 };

--- a/src/core/server/elasticsearch/supported_server_response_check.ts
+++ b/src/core/server/elasticsearch/supported_server_response_check.ts
@@ -15,3 +15,19 @@ export const PRODUCT_RESPONSE_HEADER = 'x-elastic-product';
 export const isSupportedEsServer = (headers: Record<string, string | string[]> | null) => {
   return !!headers && headers[PRODUCT_RESPONSE_HEADER] === 'Elasticsearch';
 };
+
+/**
+ * Check to ensure that a 404 response does not come from Elasticsearch
+ *
+ * WARNING: This is a hack to work around for 404 responses returned from a proxy.
+ * We're aiming to minimise the risk of data loss when consumers act on Not Found errors
+ *
+ * @param response response from elasticsearch client call
+ * @returns boolean 'true' if the status code is 404 and the Elasticsearch product header is missing/unexpected value
+ */
+export const isNotFoundFromUnsupportedServer = (args: {
+  statusCode: number | null;
+  headers: Record<string, string | string[]> | null;
+}): boolean => {
+  return args.statusCode === 404 && !isSupportedEsServer(args.headers);
+};

--- a/src/core/server/saved_objects/service/lib/collect_multi_namespace_references.test.ts
+++ b/src/core/server/saved_objects/service/lib/collect_multi_namespace_references.test.ts
@@ -25,6 +25,7 @@ import { savedObjectsPointInTimeFinderMock } from './point_in_time_finder.mock';
 import { savedObjectsRepositoryMock } from './repository.mock';
 import { PointInTimeFinder } from './point_in_time_finder';
 import { ISavedObjectsRepository } from './repository';
+import { SavedObjectsErrorHelpers } from './errors';
 
 const SPACES = ['default', 'another-space'];
 const VERSION_PROPS = { _seq_no: 1, _primary_term: 1 };
@@ -317,6 +318,23 @@ describe('collectMultiNamespaceReferences', () => {
       { ...obj2, spaces: [], inboundReferences: [] },
       // obj3 is excluded from the results
     ]);
+  });
+  it(`handles 404 responses that don't come from Elasticsearch`, async () => {
+    const createEsUnavailableNotFoundError = () => {
+      return SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
+    };
+    const obj1 = { type: MULTI_NAMESPACE_OBJ_TYPE_1, id: 'id-1' };
+    const params = setup([obj1]);
+    client.mget.mockReturnValueOnce(
+      elasticsearchClientMock.createSuccessTransportRequestPromise(
+        { docs: [] },
+        { statusCode: 404 },
+        {}
+      )
+    );
+    await expect(() => collectMultiNamespaceReferences(params)).rejects.toThrowError(
+      createEsUnavailableNotFoundError()
+    );
   });
 
   describe('legacy URL aliases', () => {

--- a/src/core/server/saved_objects/service/lib/collect_multi_namespace_references.ts
+++ b/src/core/server/saved_objects/service/lib/collect_multi_namespace_references.ts
@@ -7,17 +7,14 @@
  */
 
 import * as esKuery from '@kbn/es-query';
+import { isNotFoundFromUnsupportedServer } from '../../../elasticsearch';
 import { LegacyUrlAlias, LEGACY_URL_ALIAS_TYPE } from '../../object_types';
 import type { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import type { SavedObjectsSerializer } from '../../serialization';
 import type { SavedObject, SavedObjectsBaseOptions } from '../../types';
 import { SavedObjectsErrorHelpers } from './errors';
 import { getRootFields } from './included_fields';
-import {
-  getSavedObjectFromSource,
-  rawDocExistsInNamespace,
-  isNotFoundFromUnsupportedServer,
-} from './internal_utils';
+import { getSavedObjectFromSource, rawDocExistsInNamespace } from './internal_utils';
 import type {
   ISavedObjectsPointInTimeFinder,
   SavedObjectsCreatePointInTimeFinderOptions,

--- a/src/core/server/saved_objects/service/lib/collect_multi_namespace_references.ts
+++ b/src/core/server/saved_objects/service/lib/collect_multi_namespace_references.ts
@@ -7,11 +7,12 @@
  */
 
 import * as esKuery from '@kbn/es-query';
-
+import { isSupportedEsServer } from '../../../elasticsearch';
 import { LegacyUrlAlias, LEGACY_URL_ALIAS_TYPE } from '../../object_types';
 import type { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import type { SavedObjectsSerializer } from '../../serialization';
 import type { SavedObject, SavedObjectsBaseOptions } from '../../types';
+import { SavedObjectsErrorHelpers } from './errors';
 import { getRootFields } from './included_fields';
 import { getSavedObjectFromSource, rawDocExistsInNamespace } from './internal_utils';
 import type {
@@ -198,6 +199,10 @@ async function getObjectsAndReferences({
       { body: { docs: makeBulkGetDocs(bulkGetObjects) } },
       { ignore: [404] }
     );
+    // exit early if we can't verify a 404 response is from Elasticsearch
+    if (bulkGetResponse.statusCode === 404 && !isSupportedEsServer(bulkGetResponse.headers)) {
+      throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
+    }
     const newObjectsToGet = new Set<string>();
     for (let i = 0; i < bulkGetObjects.length; i++) {
       // For every element in bulkGetObjects, there should be a matching element in bulkGetResponse.body.docs

--- a/src/core/server/saved_objects/service/lib/errors.ts
+++ b/src/core/server/saved_objects/service/lib/errors.ts
@@ -203,7 +203,11 @@ export class SavedObjectsErrorHelpers {
     return isSavedObjectsClientError(error) && error[code] === CODE_GENERAL_ERROR;
   }
 
-  public static createGenericNotFoundEsUnavailableError(type: string, id: string) {
+  public static createGenericNotFoundEsUnavailableError(
+    // type and id not availablefor all operations (e.g. mget)
+    type: string | null = null,
+    id: string | null = null
+  ) {
     const notFoundError = this.createGenericNotFoundError(type, id);
     return this.decorateEsUnavailableError(
       new Error(`${notFoundError.message}`),

--- a/src/core/server/saved_objects/service/lib/errors.ts
+++ b/src/core/server/saved_objects/service/lib/errors.ts
@@ -204,7 +204,7 @@ export class SavedObjectsErrorHelpers {
   }
 
   public static createGenericNotFoundEsUnavailableError(
-    // type and id not availablefor all operations (e.g. mget)
+    // type and id not available in all operations (e.g. mget)
     type: string | null = null,
     id: string | null = null
   ) {

--- a/src/core/server/saved_objects/service/lib/internal_utils.test.ts
+++ b/src/core/server/saved_objects/service/lib/internal_utils.test.ts
@@ -13,7 +13,6 @@ import {
   getBulkOperationError,
   getSavedObjectFromSource,
   rawDocExistsInNamespace,
-  isNotFoundFromUnsupportedServer,
 } from './internal_utils';
 import { ALL_NAMESPACES_STRING } from './utils';
 
@@ -240,37 +239,5 @@ describe('#rawDocExistsInNamespace', () => {
       expect(rawDocExistsInNamespace(registry, doc2, 'some-space')).toBe(true);
       expect(rawDocExistsInNamespace(registry, doc2, 'other-space')).toBe(true);
     });
-  });
-});
-
-describe('#isNotFoundFromUnsupportedServer', () => {
-  it('returns true with not found response from unsupported server', () => {
-    const rawResponse = {
-      statusCode: 404,
-      headers: {},
-    };
-
-    const result = isNotFoundFromUnsupportedServer(rawResponse);
-    expect(result).toBeTruthy();
-  });
-
-  it('returns false with not found response from supported server', async () => {
-    const rawResponse = {
-      statusCode: 404,
-      headers: { 'x-elastic-product': 'Elasticsearch' },
-    };
-
-    const result = isNotFoundFromUnsupportedServer(rawResponse);
-    expect(result).toBeFalsy();
-  });
-
-  it('returns false when not a 404', async () => {
-    const rawResponse = {
-      statusCode: 200,
-      headers: { 'x-elastic-product': 'Elasticsearch' },
-    };
-
-    const result = isNotFoundFromUnsupportedServer(rawResponse);
-    expect(result).toBeFalsy();
   });
 });

--- a/src/core/server/saved_objects/service/lib/internal_utils.test.ts
+++ b/src/core/server/saved_objects/service/lib/internal_utils.test.ts
@@ -273,9 +273,4 @@ describe('#isNotFoundFromUnsupportedServer', () => {
     const result = isNotFoundFromUnsupportedServer(rawResponse);
     expect(result).toBeFalsy();
   });
-
-  it('returns false when there is no response', async () => {
-    const result = isNotFoundFromUnsupportedServer();
-    expect(result).toBeFalsy();
-  });
 });

--- a/src/core/server/saved_objects/service/lib/internal_utils.test.ts
+++ b/src/core/server/saved_objects/service/lib/internal_utils.test.ts
@@ -13,6 +13,7 @@ import {
   getBulkOperationError,
   getSavedObjectFromSource,
   rawDocExistsInNamespace,
+  isNotFoundFromUnsupportedServer,
 } from './internal_utils';
 import { ALL_NAMESPACES_STRING } from './utils';
 
@@ -239,5 +240,42 @@ describe('#rawDocExistsInNamespace', () => {
       expect(rawDocExistsInNamespace(registry, doc2, 'some-space')).toBe(true);
       expect(rawDocExistsInNamespace(registry, doc2, 'other-space')).toBe(true);
     });
+  });
+});
+
+describe('#isNotFoundFromUnsupportedServer', () => {
+  it('returns true with not found response from unsupported server', () => {
+    const rawResponse = {
+      statusCode: 404,
+      headers: {},
+    };
+
+    const result = isNotFoundFromUnsupportedServer(rawResponse);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns false with not found response from supported server', async () => {
+    const rawResponse = {
+      statusCode: 404,
+      headers: { 'x-elastic-product': 'Elasticsearch' },
+    };
+
+    const result = isNotFoundFromUnsupportedServer(rawResponse);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when not a 404', async () => {
+    const rawResponse = {
+      statusCode: 200,
+      headers: { 'x-elastic-product': 'Elasticsearch' },
+    };
+
+    const result = isNotFoundFromUnsupportedServer(rawResponse);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when there is no response', async () => {
+    const result = isNotFoundFromUnsupportedServer();
+    expect(result).toBeFalsy();
   });
 });

--- a/src/core/server/saved_objects/service/lib/internal_utils.ts
+++ b/src/core/server/saved_objects/service/lib/internal_utils.ts
@@ -144,7 +144,6 @@ export function rawDocExistsInNamespace(
   return existsInNamespace ?? false;
 }
 
-type NotFoundServerCheckResponse = Partial<Pick<ApiResponse, 'statusCode' | 'headers' | 'body'>>;
 /**
  * Check to ensure that a 404 response does not come from Elasticsearch
  *
@@ -154,8 +153,9 @@ type NotFoundServerCheckResponse = Partial<Pick<ApiResponse, 'statusCode' | 'hea
  * @param response response from elasticsearch client call
  * @returns boolean 'true' if the status code is 404 and the Elasticsearch product header is missing/unexpected value
  */
-export const isNotFoundFromUnsupportedServer = (
-  response?: NotFoundServerCheckResponse | undefined
-) => {
-  return response && response.statusCode === 404 && !isSupportedEsServer(response.headers!);
+export const isNotFoundFromUnsupportedServer = (args: {
+  statusCode: number | null;
+  headers: Record<string, string | string[]> | null;
+}): boolean => {
+  return args.statusCode === 404 && !isSupportedEsServer(args.headers);
 };

--- a/src/core/server/saved_objects/service/lib/internal_utils.ts
+++ b/src/core/server/saved_objects/service/lib/internal_utils.ts
@@ -7,7 +7,6 @@
  */
 
 import type { Payload } from '@hapi/boom';
-import { ApiResponse } from '@elastic/elasticsearch';
 import type { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import type { SavedObjectsRawDoc, SavedObjectsRawDocSource } from '../../serialization';
 import type { SavedObject } from '../../types';

--- a/src/core/server/saved_objects/service/lib/internal_utils.ts
+++ b/src/core/server/saved_objects/service/lib/internal_utils.ts
@@ -13,7 +13,6 @@ import type { SavedObject } from '../../types';
 import { decodeRequestVersion, encodeHitVersion } from '../../version';
 import { SavedObjectsErrorHelpers } from './errors';
 import { ALL_NAMESPACES_STRING, SavedObjectsUtils } from './utils';
-import { isSupportedEsServer } from '../../../elasticsearch';
 
 /**
  * Checks the raw response of a bulk operation and returns an error if necessary.
@@ -142,19 +141,3 @@ export function rawDocExistsInNamespace(
     namespaces?.includes(ALL_NAMESPACES_STRING);
   return existsInNamespace ?? false;
 }
-
-/**
- * Check to ensure that a 404 response does not come from Elasticsearch
- *
- * WARNING: This is a hack to work around for 404 responses returned from a proxy.
- * We're aiming to minimise the risk of data loss when consumers act on Not Found errors
- *
- * @param response response from elasticsearch client call
- * @returns boolean 'true' if the status code is 404 and the Elasticsearch product header is missing/unexpected value
- */
-export const isNotFoundFromUnsupportedServer = (args: {
-  statusCode: number | null;
-  headers: Record<string, string | string[]> | null;
-}): boolean => {
-  return args.statusCode === 404 && !isSupportedEsServer(args.headers);
-};

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -652,6 +652,29 @@ describe('SavedObjectsRepository', () => {
         });
       };
 
+      const bulkCreateMgetError = async (objects, options) => {
+        const multiNamespaceObjects = objects.filter(
+          ({ type, id }) => registry.isMultiNamespace(type) && id
+        );
+        if (multiNamespaceObjects?.length) {
+          const response = getMockMgetResponse(multiNamespaceObjects, options?.namespace);
+          client.mget.mockResolvedValue(
+            elasticsearchClientMock.createSuccessTransportRequestPromise(
+              { ...response },
+              { statusCode: 404 },
+              {}
+            )
+          );
+        }
+        const response = getMockBulkCreateResponse(objects, options?.namespace);
+        client.bulk.mockResolvedValue(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(response)
+        );
+        await expect(savedObjectsRepository.bulkCreate(objects, options)).rejects.toThrowError(
+          createGenericNotFoundEsUnavailableError()
+        );
+      };
+
       it(`throws when options.namespace is '*'`, async () => {
         await expect(
           savedObjectsRepository.bulkCreate([obj3], { namespace: ALL_NAMESPACES_STRING })
@@ -758,6 +781,13 @@ describe('SavedObjectsRepository', () => {
       it(`returns bulk error`, async () => {
         const expectedErrorResult = { type: obj3.type, id: obj3.id, error: 'Oh no, a bulk error!' };
         await bulkCreateError(obj3, true, expectedErrorResult);
+      });
+
+      it(`throws when ES mget action returns 404 with missing Elasticsearch header`, async () => {
+        const objects = [obj1, { ...obj2, type: MULTI_NAMESPACE_ISOLATED_TYPE }];
+        await bulkCreateMgetError(objects);
+        expect(client.mget).toHaveBeenCalledTimes(1);
+        expect(client.bulk).toHaveBeenCalledTimes(0);
       });
     });
 
@@ -1011,6 +1041,21 @@ describe('SavedObjectsRepository', () => {
         });
       };
 
+      const bulkGetMgetError = async (objects, options) => {
+        const response = getMockMgetResponse(objects, options?.namespace);
+        client.mget.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { ...response },
+            { statusCode: 404 },
+            {}
+          )
+        );
+        await expect(bulkGet(objects, options)).rejects.toThrowError(
+          createGenericNotFoundEsUnavailableError()
+        );
+        expect(client.mget).toHaveBeenCalledTimes(1);
+      };
+
       it(`throws when options.namespace is '*'`, async () => {
         const obj = { type: 'dashboard', id: 'three' };
         await expect(
@@ -1045,6 +1090,12 @@ describe('SavedObjectsRepository', () => {
         const response = getMockMgetResponse([obj1, obj, obj2]);
         response.docs[1].namespaces = ['bar-namespace'];
         await bulkGetErrorNotFound([obj1, obj, obj2], { namespace }, response);
+      });
+
+      it(`throws when ES mget action responds with a 404 and a missing Elasticsearch product header`, async () => {
+        const getId = (type, id) => `${type}:${id}`;
+        await bulkGetMgetError([obj1, obj2]); // returns 404 without required product header
+        _expectClientCallArgs([obj1, obj2], { getId });
       });
     });
 
@@ -1450,6 +1501,34 @@ describe('SavedObjectsRepository', () => {
           saved_objects: [expectSuccess(obj1), expectErrorNotFound(_obj), expectSuccess(obj2)],
         });
       };
+      const bulkUpdateMgetError = async (objects, options, includeOriginId) => {
+        const multiNamespaceObjects = objects.filter(({ type }) => registry.isMultiNamespace(type));
+        if (multiNamespaceObjects?.length) {
+          const response = getMockMgetResponse(multiNamespaceObjects, options?.namespace);
+          client.mget.mockResolvedValueOnce(
+            elasticsearchClientMock.createSuccessTransportRequestPromise(
+              { ...response },
+              { statusCode: 404 },
+              {}
+            )
+          );
+        }
+        const response = getMockBulkUpdateResponse(objects, options?.namespace, includeOriginId);
+        client.bulk.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(response)
+        );
+
+        await expect(savedObjectsRepository.bulkUpdate(objects, options)).rejects.toThrowError(
+          createGenericNotFoundEsUnavailableError()
+        );
+        expect(client.mget).toHaveBeenCalledTimes(multiNamespaceObjects?.length ? 1 : 0);
+      };
+
+      it(`throws when ES mget action responds with a 404 and a missing Elasticsearch product header`, async () => {
+        const objects = [obj1, { ...obj2, type: MULTI_NAMESPACE_ISOLATED_TYPE }];
+        await bulkUpdateMgetError(objects);
+        expect(client.mget).toHaveBeenCalledTimes(1);
+      });
 
       it(`throws when options.namespace is '*'`, async () => {
         await expect(
@@ -1650,6 +1729,24 @@ describe('SavedObjectsRepository', () => {
         await expect(
           savedObjectsRepository.checkConflicts([obj1], { namespace: ALL_NAMESPACES_STRING })
         ).rejects.toThrowError(createBadRequestError('"options.namespace" cannot be "*"'));
+      });
+
+      it(`throws when not found responses aren't from Elasticsearch`, async () => {
+        const checkConflictsMgetError = async (objects, options) => {
+          const response = getMockMgetResponse(objects, options?.namespace);
+          client.mget.mockResolvedValue(
+            elasticsearchClientMock.createSuccessTransportRequestPromise(
+              { ...response },
+              { statusCode: 404 },
+              {}
+            )
+          );
+          await expect(checkConflicts(objects, options)).rejects.toThrowError(
+            createGenericNotFoundEsUnavailableError()
+          );
+          expect(client.mget).toHaveBeenCalledTimes(1);
+        };
+        await checkConflictsMgetError([obj1, obj2], { namespace: 'default' });
       });
     });
 
@@ -2228,11 +2325,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            { found: false },
-            undefined,
-            { 'x-elastic-product': 'Elasticsearch' }
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({ found: false }, undefined)
         );
         await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -2240,11 +2333,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the index during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            {},
-            { statusCode: 404 },
-            { 'x-elastic-product': 'Elasticsearch' }
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
         );
         await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -2252,14 +2341,18 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during get with missing Elasticsearch header`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({ found: false })
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { found: false },
+            { statusCode: 404 },
+            {}
+          )
         );
         await expectNotFoundEsUnavailableError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
       });
 
       it(`throws when ES is unable to find the index during get with missing Elasticsearch header`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
+          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 }, {})
         );
         await expectNotFoundEsUnavailableError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
       });
@@ -2305,7 +2398,11 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during delete`, async () => {
         client.delete.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({ result: 'not_found' })
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { result: 'not_found' },
+            {},
+            {}
+          )
         );
         await expectNotFoundEsUnavailableError(type, id);
         expect(client.delete).toHaveBeenCalledTimes(1);
@@ -2313,9 +2410,13 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the index during delete`, async () => {
         client.delete.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({
-            error: { type: 'index_not_found_exception' },
-          })
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            {
+              error: { type: 'index_not_found_exception' },
+            },
+            {},
+            {}
+          )
         );
         await expectNotFoundEsUnavailableError(type, id);
         expect(client.delete).toHaveBeenCalledTimes(1);
@@ -2572,6 +2673,22 @@ describe('SavedObjectsRepository', () => {
           savedObjectsRepository.removeReferencesTo(type, id, defaultOptions)
         ).rejects.toThrowError(createConflictError(type, id));
       });
+
+      it(`throws on 404 with missing Elasticsearch header`, async () => {
+        client.updateByQuery.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            {
+              updated: updatedCount,
+            },
+            { statusCode: 404 },
+            {}
+          )
+        );
+        await expect(
+          savedObjectsRepository.removeReferencesTo(type, id, defaultOptions)
+        ).rejects.toThrowError(createGenericNotFoundEsUnavailableError(type, id));
+        expect(client.updateByQuery).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -2748,6 +2865,21 @@ describe('SavedObjectsRepository', () => {
     });
 
     describe('errors', () => {
+      const findNotSupportedServerError = async (options, namespace) => {
+        const expectedSearchResults = generateSearchResults(namespace);
+        client.search.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { ...expectedSearchResults },
+            { statusCode: 404 },
+            {}
+          )
+        );
+        await expect(savedObjectsRepository.find(options)).rejects.toThrowError(
+          createGenericNotFoundEsUnavailableError()
+        );
+        expect(getSearchDslNS.getSearchDsl).toHaveBeenCalledTimes(1);
+        expect(client.search).toHaveBeenCalledTimes(1);
+      };
       it(`throws when type is not defined`, async () => {
         await expect(savedObjectsRepository.find({})).rejects.toThrowError(
           'options.type must be a string or an array of strings'
@@ -2827,6 +2959,11 @@ describe('SavedObjectsRepository', () => {
                       `);
         expect(getSearchDslNS.getSearchDsl).not.toHaveBeenCalled();
         expect(client.search).not.toHaveBeenCalled();
+      });
+
+      it(`throws when ES is unable to find with missing Elasticsearch`, async () => {
+        await findNotSupportedServerError({ type });
+        expect(client.search).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -3204,6 +3341,7 @@ describe('SavedObjectsRepository', () => {
           createGenericNotFoundEsUnavailableError(type, id)
         );
       };
+
       it(`throws when options.namespace is '*'`, async () => {
         await expect(
           savedObjectsRepository.get(type, id, { namespace: ALL_NAMESPACES_STRING })
@@ -3222,11 +3360,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            { found: false },
-            undefined,
-            { 'x-elastic-product': 'Elasticsearch' }
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({ found: false }, undefined)
         );
         await expectNotFoundError(type, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -3234,11 +3368,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the index during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            {},
-            { statusCode: 404 },
-            { 'x-elastic-product': 'Elasticsearch' }
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
         );
         await expectNotFoundError(type, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -3257,7 +3387,11 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES does not return the correct header when finding the document during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({ found: false })
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { found: false },
+            undefined,
+            {}
+          )
         );
         await expectNotFoundEsUnavailableError(type, id);
 
@@ -3367,8 +3501,7 @@ describe('SavedObjectsRepository', () => {
           client.get.mockResolvedValueOnce(
             elasticsearchClientMock.createSuccessTransportRequestPromise(
               { found: false },
-              undefined,
-              { 'x-elastic-product': 'Elasticsearch' }
+              undefined
             ) // for actual target
           );
 
@@ -3421,10 +3554,16 @@ describe('SavedObjectsRepository', () => {
         describe('because alias is not used', () => {
           const expectExactMatchResult = async (aliasResult) => {
             const options = { namespace };
-            client.update.mockResolvedValueOnce(aliasResult); // for alias object
+            if (!aliasResult.body) {
+              client.update.mockResolvedValueOnce(
+                elasticsearchClientMock.createSuccessTransportRequestPromise({}, { ...aliasResult })
+              );
+            } else {
+              client.update.mockResolvedValueOnce(aliasResult); // for alias object
+            }
             const response = getMockGetResponse({ type, id }, options.namespace);
             client.get.mockResolvedValueOnce(
-              elasticsearchClientMock.createSuccessTransportRequestPromise(response) // for actual target
+              elasticsearchClientMock.createSuccessTransportRequestPromise({ ...response }) // for actual target
             );
 
             const result = await savedObjectsRepository.resolve(type, id, options);
@@ -3909,8 +4048,7 @@ describe('SavedObjectsRepository', () => {
         client.get.mockResolvedValueOnce(
           elasticsearchClientMock.createSuccessTransportRequestPromise(
             { ...mockGetResponse },
-            { statusCode: 200 },
-            { 'x-elastic-product': 'Elasticsearch' }
+            { statusCode: 200 }
           )
         );
       }
@@ -3932,8 +4070,7 @@ describe('SavedObjectsRepository', () => {
               },
             },
           },
-          { statusCode: 200 },
-          { 'x-elastic-product': 'Elasticsearch' }
+          { statusCode: 200 }
         )
       );
       const result = await savedObjectsRepository.update(type, id, attributes, options);
@@ -4144,11 +4281,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            { found: false },
-            undefined,
-            { 'x-elastic-product': 'Elasticsearch' }
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({ found: false }, undefined)
         );
         await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -4156,11 +4289,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the index during get`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            {},
-            { statusCode: 404 },
-            { 'x-elastic-product': 'Elasticsearch' }
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
         );
         await expectNotFoundError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -4168,15 +4297,19 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during get with missing Elasticsearch header`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({ found: false })
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { found: false },
+            { statusCode: 404 },
+            {}
+          )
         );
         await expectNotFoundEsUnavailableError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
         expect(client.get).toHaveBeenCalledTimes(1);
       });
 
-      it(`throws when ES is unable to find the index during get with missing Elasticsearch`, async () => {
+      it(`throws when ES is unable to find the index during get with missing Elasticsearch header`, async () => {
         client.get.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
+          elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 }, {})
         );
         await expectNotFoundEsUnavailableError(MULTI_NAMESPACE_ISOLATED_TYPE, id);
         expect(client.get).toHaveBeenCalledTimes(1);
@@ -4303,6 +4436,21 @@ describe('SavedObjectsRepository', () => {
         );
       };
 
+      const expectNotFoundUnsupportedProductError = async (type, options) => {
+        const results = generateResults();
+        client.openPointInTime.mockResolvedValueOnce(
+          elasticsearchClientMock.createSuccessTransportRequestPromise(
+            { ...results },
+            { statusCode: 404 },
+            {}
+          )
+        );
+        await expect(
+          savedObjectsRepository.openPointInTimeForType(type, options)
+        ).rejects.toThrowError(createGenericNotFoundEsUnavailableError());
+        expect(client.openPointInTime).toHaveBeenCalledTimes(1);
+      };
+
       it(`throws when ES is unable to find the index`, async () => {
         client.openPointInTime.mockResolvedValueOnce(
           elasticsearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
@@ -4320,6 +4468,11 @@ describe('SavedObjectsRepository', () => {
         await test('unknownType');
         await test(HIDDEN_TYPE);
         await test(['unknownType', HIDDEN_TYPE]);
+      });
+
+      it(`throws on 404 with missing Elasticsearch product header`, async () => {
+        await expectNotFoundUnsupportedProductError(type);
+        expect(client.openPointInTime).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -652,7 +652,7 @@ describe('SavedObjectsRepository', () => {
         });
       };
 
-      const bulkCreateMgetError = async (objects, options) => {
+      const unsupportedProductBulkCreateMgetError = async (objects, options) => {
         const multiNamespaceObjects = objects.filter(
           ({ type, id }) => registry.isMultiNamespace(type) && id
         );
@@ -785,7 +785,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES mget action returns 404 with missing Elasticsearch header`, async () => {
         const objects = [obj1, { ...obj2, type: MULTI_NAMESPACE_ISOLATED_TYPE }];
-        await bulkCreateMgetError(objects);
+        await unsupportedProductBulkCreateMgetError(objects);
         expect(client.mget).toHaveBeenCalledTimes(1);
         expect(client.bulk).toHaveBeenCalledTimes(0);
       });
@@ -1041,7 +1041,7 @@ describe('SavedObjectsRepository', () => {
         });
       };
 
-      const bulkGetMgetError = async (objects, options) => {
+      const unsupportedProductBulkGetMgetError = async (objects, options) => {
         const response = getMockMgetResponse(objects, options?.namespace);
         client.mget.mockResolvedValueOnce(
           elasticsearchClientMock.createSuccessTransportRequestPromise(
@@ -1094,7 +1094,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES mget action responds with a 404 and a missing Elasticsearch product header`, async () => {
         const getId = (type, id) => `${type}:${id}`;
-        await bulkGetMgetError([obj1, obj2]); // returns 404 without required product header
+        await unsupportedProductBulkGetMgetError([obj1, obj2]); // returns 404 without required product header
         _expectClientCallArgs([obj1, obj2], { getId });
       });
     });
@@ -1501,7 +1501,7 @@ describe('SavedObjectsRepository', () => {
           saved_objects: [expectSuccess(obj1), expectErrorNotFound(_obj), expectSuccess(obj2)],
         });
       };
-      const bulkUpdateMgetError = async (objects, options, includeOriginId) => {
+      const unsupportedProductBulkUpdateMgetError = async (objects, options, includeOriginId) => {
         const multiNamespaceObjects = objects.filter(({ type }) => registry.isMultiNamespace(type));
         if (multiNamespaceObjects?.length) {
           const response = getMockMgetResponse(multiNamespaceObjects, options?.namespace);
@@ -1526,7 +1526,7 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES mget action responds with a 404 and a missing Elasticsearch product header`, async () => {
         const objects = [obj1, { ...obj2, type: MULTI_NAMESPACE_ISOLATED_TYPE }];
-        await bulkUpdateMgetError(objects);
+        await unsupportedProductBulkUpdateMgetError(objects);
         expect(client.mget).toHaveBeenCalledTimes(1);
       });
 
@@ -4436,7 +4436,7 @@ describe('SavedObjectsRepository', () => {
         );
       };
 
-      const expectNotFoundUnsupportedProductError = async (type, options) => {
+      const unsupportedProductExpectNotFoundError = async (type, options) => {
         const results = generateResults();
         client.openPointInTime.mockResolvedValueOnce(
           elasticsearchClientMock.createSuccessTransportRequestPromise(
@@ -4471,7 +4471,7 @@ describe('SavedObjectsRepository', () => {
       });
 
       it(`throws on 404 with missing Elasticsearch product header`, async () => {
-        await expectNotFoundUnsupportedProductError(type);
+        await unsupportedProductExpectNotFoundError(type);
         expect(client.openPointInTime).toHaveBeenCalledTimes(1);
       });
     });

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -14,7 +14,7 @@ import {
   REPOSITORY_RESOLVE_OUTCOME_STATS,
 } from '../../../core_usage_data';
 import type { ElasticsearchClient } from '../../../elasticsearch/';
-import { isSupportedEsServer } from '../../../elasticsearch';
+import { isSupportedEsServer, isNotFoundFromUnsupportedServer } from '../../../elasticsearch';
 import type { Logger } from '../../../logging';
 import { getRootPropertiesObjects, IndexMapping } from '../../mappings';
 import {
@@ -74,7 +74,6 @@ import {
   getExpectedVersionProperties,
   getSavedObjectFromSource,
   rawDocExistsInNamespace,
-  isNotFoundFromUnsupportedServer,
 } from './internal_utils';
 import {
   ALL_NAMESPACES_STRING,

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -428,7 +428,7 @@ export class SavedObjectsRepository {
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: { ...bulkGetResponse.headers },
+        headers: bulkGetResponse.headers,
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
@@ -606,7 +606,7 @@ export class SavedObjectsRepository {
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: { ...bulkGetResponse.headers },
+        headers: bulkGetResponse.headers,
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
@@ -1011,7 +1011,7 @@ export class SavedObjectsRepository {
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: { ...bulkGetResponse.headers },
+        headers: bulkGetResponse.headers,
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
@@ -1142,7 +1142,7 @@ export class SavedObjectsRepository {
     if (
       isNotFoundFromUnsupportedServer({
         statusCode: aliasResponse.statusCode,
-        headers: { ...aliasResponse.headers },
+        headers: aliasResponse.headers,
       })
     ) {
       // throw if we cannot verify the response is from Elasticsearch
@@ -1185,7 +1185,7 @@ export class SavedObjectsRepository {
     if (
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: { ...bulkGetResponse.headers },
+        headers: bulkGetResponse.headers,
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(type, id);
@@ -1503,7 +1503,7 @@ export class SavedObjectsRepository {
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: { ...bulkGetResponse.headers },
+        headers: bulkGetResponse.headers,
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -341,7 +341,7 @@ export class SavedObjectsRepository {
         ? await this.client.index(requestParams)
         : await this.client.create(requestParams);
 
-    // fail fast if we can't be sure a 404 response is from Elasticsearch
+    // throw if we can't verify a 404 response is from Elasticsearch
     if (isNotFoundFromUnsupportedServer({ statusCode, headers })) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(id, type);
     }
@@ -424,12 +424,12 @@ export class SavedObjectsRepository {
           { ignore: [404] }
         )
       : undefined;
-    // fail fast if we can't be sure a 404 response is from Elasticsearch
+    // throw if we can't verify a 404 response is from Elasticsearch
     if (
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: bulkGetResponse.headers,
+        headers: { ...bulkGetResponse.headers },
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
@@ -602,12 +602,12 @@ export class SavedObjectsRepository {
           { ignore: [404] }
         )
       : undefined;
-    // fail fast if we can't be sure a 404 response is from Elasticsearch
+    // throw if we can't verify a 404 response is from Elasticsearch
     if (
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: bulkGetResponse.headers,
+        headers: { ...bulkGetResponse.headers },
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
@@ -754,7 +754,7 @@ export class SavedObjectsRepository {
       },
       { ignore: [404] }
     );
-    // fail fast if we can't be sure a 404 response is from Elasticsearch
+    // throw if we can't verify a 404 response is from Elasticsearch
     if (isNotFoundFromUnsupportedServer({ statusCode, headers })) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
     }
@@ -1013,7 +1013,7 @@ export class SavedObjectsRepository {
       bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: bulkGetResponse.headers,
+        headers: { ...bulkGetResponse.headers },
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
@@ -1144,7 +1144,7 @@ export class SavedObjectsRepository {
     if (
       isNotFoundFromUnsupportedServer({
         statusCode: aliasResponse.statusCode,
-        headers: aliasResponse.headers,
+        headers: { ...aliasResponse.headers },
       })
     ) {
       // throw if we cannot verify the response is from Elasticsearch
@@ -1187,7 +1187,7 @@ export class SavedObjectsRepository {
     if (
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: bulkGetResponse.headers,
+        headers: { ...bulkGetResponse.headers },
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(type, id);
@@ -1502,10 +1502,10 @@ export class SavedObjectsRepository {
       : undefined;
     // fail fast if we can't verify a 404 response is from Elasticsearch
     if (
-      bulkGetResponse !== undefined &&
+      bulkGetResponse &&
       isNotFoundFromUnsupportedServer({
         statusCode: bulkGetResponse.statusCode,
-        headers: bulkGetResponse.headers,
+        headers: { ...bulkGetResponse.headers },
       })
     ) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -909,7 +909,6 @@ export class SavedObjectsRepository {
       }
     );
     if (statusCode === 404) {
-      // first need to ensure the 404 is a valid Elasticsearch response
       if (!isSupportedEsServer(headers)) {
         throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
       }

--- a/src/core/server/saved_objects/service/lib/update_objects_spaces.test.ts
+++ b/src/core/server/saved_objects/service/lib/update_objects_spaces.test.ts
@@ -23,6 +23,7 @@ import type {
   UpdateObjectsSpacesParams,
 } from './update_objects_spaces';
 import { updateObjectsSpaces } from './update_objects_spaces';
+import { SavedObjectsErrorHelpers } from './errors';
 
 type SetupParams = Partial<
   Pick<UpdateObjectsSpacesParams, 'objects' | 'spacesToAdd' | 'spacesToRemove' | 'options'>
@@ -103,6 +104,32 @@ describe('#updateObjectsSpaces', () => {
               }
         ),
       })
+    );
+  }
+  /** Mocks the saved objects client so as to test unsupported server responding with 404 */
+  function mockMgetResultsNotFound(...results: Array<{ found: boolean }>) {
+    client.mget.mockReturnValueOnce(
+      elasticsearchClientMock.createSuccessTransportRequestPromise(
+        {
+          docs: results.map((x) =>
+            x.found
+              ? {
+                  _id: 'doesnt-matter',
+                  _index: 'doesnt-matter',
+                  _source: { namespaces: [EXISTING_SPACE] },
+                  ...VERSION_PROPS,
+                  found: true,
+                }
+              : {
+                  _id: 'doesnt-matter',
+                  _index: 'doesnt-matter',
+                  found: false,
+                }
+          ),
+        },
+        { statusCode: 404 },
+        {}
+      )
     );
   }
 
@@ -239,6 +266,17 @@ describe('#updateObjectsSpaces', () => {
         { ...obj6, spaces: [], error: BULK_ERROR },
         { ...obj7, spaces: [EXISTING_SPACE, 'foo-space'] },
       ]);
+    });
+
+    it('throws when mget not found response is missing the Elasticsearch header', async () => {
+      const objects = [{ type: SHAREABLE_OBJ_TYPE, id: 'id-1' }];
+      const spacesToAdd = ['foo-space'];
+      const params = setup({ objects, spacesToAdd });
+      mockMgetResultsNotFound({ found: true });
+
+      await expect(() => updateObjectsSpaces(params)).rejects.toThrowError(
+        SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError()
+      );
     });
   });
 

--- a/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
+++ b/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
@@ -196,7 +196,7 @@ export async function updateObjectsSpaces({
     bulkGetResponse &&
     isNotFoundFromUnsupportedServer({
       statusCode: bulkGetResponse.statusCode,
-      headers: { ...bulkGetResponse.headers },
+      headers: bulkGetResponse.headers,
     })
   ) {
     throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();

--- a/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
+++ b/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
@@ -8,7 +8,6 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import intersection from 'lodash/intersection';
-import { isSupportedEsServer } from 'src/core/server/elasticsearch';
 
 import type { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import type { SavedObjectsRawDocSource, SavedObjectsSerializer } from '../../serialization';

--- a/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
+++ b/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
@@ -8,6 +8,7 @@
 
 import type { estypes } from '@elastic/elasticsearch';
 import intersection from 'lodash/intersection';
+import { isSupportedEsServer } from 'src/core/server/elasticsearch';
 
 import type { ISavedObjectTypeRegistry } from '../../saved_objects_type_registry';
 import type { SavedObjectsRawDocSource, SavedObjectsSerializer } from '../../serialization';
@@ -22,6 +23,7 @@ import {
   getBulkOperationError,
   getExpectedVersionProperties,
   rawDocExistsInNamespace,
+  isNotFoundFromUnsupportedServer,
 } from './internal_utils';
 import { DEFAULT_REFRESH_SETTING } from './repository';
 import type { RepositoryEsClient } from './repository_es_client';
@@ -190,6 +192,16 @@ export async function updateObjectsSpaces({
       )
     : undefined;
 
+  // fail fast if we can't verify a 404 response is from Elasticsearch
+  if (
+    bulkGetResponse &&
+    isNotFoundFromUnsupportedServer({
+      statusCode: bulkGetResponse.statusCode,
+      headers: { ...bulkGetResponse.headers },
+    })
+  ) {
+    throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError();
+  }
   const time = new Date().toISOString();
   let bulkOperationRequestIndexCounter = 0;
   const bulkOperationParams: estypes.BulkOperationContainer[] = [];

--- a/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
+++ b/src/core/server/saved_objects/service/lib/update_objects_spaces.ts
@@ -22,10 +22,10 @@ import {
   getBulkOperationError,
   getExpectedVersionProperties,
   rawDocExistsInNamespace,
-  isNotFoundFromUnsupportedServer,
 } from './internal_utils';
 import { DEFAULT_REFRESH_SETTING } from './repository';
 import type { RepositoryEsClient } from './repository_es_client';
+import { isNotFoundFromUnsupportedServer } from '../../../elasticsearch';
 
 /**
  * An object that should have its spaces updated.

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -2528,7 +2528,7 @@ export class SavedObjectsErrorHelpers {
     // (undocumented)
     static createGenericNotFoundError(type?: string | null, id?: string | null): DecoratedError;
     // (undocumented)
-    static createGenericNotFoundEsUnavailableError(type: string, id: string): DecoratedError;
+    static createGenericNotFoundEsUnavailableError(type?: string | null, id?: string | null): DecoratedError;
     // (undocumented)
     static createIndexAliasNotFoundError(alias: string): DecoratedError;
     // (undocumented)


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/107343

This PR is to address the follow up on #107301, and verifies that 404 responses are from ES in the remaining saved object repository APIs where we explicitly `ignore` `404` and handle the error ourselves. 
If the check fails, we throw a decorated `EsUnavailableError` instead of `Not Found`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| False positives&mdash; An intermediate proxy doesn't forward `x-elastic-product` header . | Low | Low | As of 7.15.0 Kibana won't start unless the required headers are present. For 7.14 patches, the type of error returned could be a 404 or a 503 but we will still get an error|

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

