### PR TITLE
updating waffle icon and toggle style

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/view_switcher.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/view_switcher.tsx
@@ -21,7 +21,7 @@ export const ViewSwitcher = ({ view, onChange }: Props) => {
       label: i18n.translate('xpack.infra.viewSwitcher.mapViewLabel', {
         defaultMessage: 'Map view',
       }),
-      iconType: 'apps',
+      iconType: 'grid',
     },
     {
       id: 'table',
@@ -37,7 +37,7 @@ export const ViewSwitcher = ({ view, onChange }: Props) => {
         defaultMessage: 'Switch between table and map view',
       })}
       options={buttons}
-      color="text"
+      color="primary"
       buttonSize="m"
       idSelected={view}
       onChange={onChange}


### PR DESCRIPTION
Updating waffle icon to use `grid` and updating waffle / table toggle to use the primary button styles

![Kapture 2021-08-16 at 12 13 42](https://user-images.githubusercontent.com/455281/129610902-4a666f8a-aaca-4012-8556-6fe4a665859b.gif)

Fixes https://github.com/elastic/observability-design/issues/85