### PR TITLE
[App Search] Don't wrap tables for Crawler Single Domain view with panels

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_single_domain.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_single_domain.tsx
@@ -57,22 +57,16 @@ export const CrawlerSingleDomain: React.FC = () => {
       <EuiSpacer size="l" />
       {domain && (
         <>
-          <EuiPanel paddingSize="l" hasBorder>
-            <EntryPointsTable domain={domain} engineName={engineName} items={domain.entryPoints} />
-          </EuiPanel>
+          <EntryPointsTable domain={domain} engineName={engineName} items={domain.entryPoints} />
           <EuiSpacer size="xl" />
-          <EuiPanel paddingSize="l" hasBorder>
-            <SitemapsTable domain={domain} engineName={engineName} items={domain.sitemaps} />
-          </EuiPanel>
+          <SitemapsTable domain={domain} engineName={engineName} items={domain.sitemaps} />
           <EuiSpacer size="xl" />
-          <EuiPanel paddingSize="l" hasBorder>
-            <CrawlRulesTable
-              domainId={domainId}
-              engineName={engineName}
-              crawlRules={domain.crawlRules}
-              defaultCrawlRule={domain.defaultCrawlRule}
-            />
-          </EuiPanel>
+          <CrawlRulesTable
+            domainId={domainId}
+            engineName={engineName}
+            crawlRules={domain.crawlRules}
+            defaultCrawlRule={domain.defaultCrawlRule}
+          />
           <EuiSpacer size="xxl" />
         </>
       )}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/inline_editable_table/inline_editable_table.tsx
@@ -123,7 +123,7 @@ export const InlineEditableTableContents = <Item extends ItemWithAnID>({
     <>
       <EuiFlexGroup alignItems="center">
         <EuiFlexItem>
-          <EuiTitle size="xs">
+          <EuiTitle size="s">
             <h3>{title}</h3>
           </EuiTitle>
           {!!description && (


### PR DESCRIPTION
## Summary

I took a stab at removing the panels around the tables, which seems in line with other views in Kibana as far as I can tell. 

## Screenshots

### Before

![Screen Shot 2021-08-16 at 4 35 01 PM](https://user-images.githubusercontent.com/2479295/129626242-a40f5316-796d-46c6-9403-45692971d806.png)

### After

![Screen Shot 2021-08-16 at 4 31 54 PM](https://user-images.githubusercontent.com/2479295/129626252-785f8c0b-f715-422e-b4ff-27617b951fb3.png)

## Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
