### PR TITLE
[Workplace Search] Clear flash messages when saving Settings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -199,6 +199,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
       }
     },
     updateOrgName: async () => {
+      clearFlashMessages();
       const { http } = HttpLogic.values;
       const route = '/api/workplace_search/org/settings/customize';
       const { orgNameInputValue: name } = values;
@@ -214,6 +215,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
       }
     },
     updateOrgLogo: async () => {
+      clearFlashMessages();
       const { http } = HttpLogic.values;
       const { stagedLogo: logo } = values;
       const body = JSON.stringify({ logo });
@@ -227,6 +229,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
       }
     },
     updateOrgIcon: async () => {
+      clearFlashMessages();
       const { http } = HttpLogic.values;
       const { stagedIcon: icon } = values;
       const body = JSON.stringify({ icon });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -281,6 +281,12 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
     resetSettingsState: () => {
       clearFlashMessages();
     },
+    setStagedLogo: () => {
+      clearFlashMessages();
+    },
+    setStagedIcon: () => {
+      clearFlashMessages();
+    },
     resetOrgLogo: () => {
       actions.updateOrgLogo();
     },


### PR DESCRIPTION
fixes https://github.com/elastic/workplace-search-team/issues/1972
related to https://github.com/elastic/workplace-search-team/issues/1964

## Summary

Previously when making changes to the UI in Settings, the error messages would persist. This PR removes the flash messages when any API requests are made.

![2021-08-16_15-43-33 (1)](https://user-images.githubusercontent.com/1869731/129627232-5bc63abb-31fd-437b-b40a-0d995c2807e3.gif)
