### PR TITLE
[build] Exclude integration tests

### DIFF
--- a/src/dev/build/tasks/copy_source_task.ts
+++ b/src/dev/build/tasks/copy_source_task.ts
@@ -20,7 +20,7 @@ export const CopySource: Task = {
         'src/**',
         '!src/**/*.{test,test.mocks,mock}.{js,ts,tsx}',
         '!src/**/mocks.ts', // special file who imports .mock files
-        '!src/**/{target,__tests__,__snapshots__,__mocks__}/**',
+        '!src/**/{target,__tests__,__snapshots__,__mocks__,integration_tests}/**',
         '!src/core/server/core_app/assets/favicons/favicon.distribution.png',
         '!src/core/server/core_app/assets/favicons/favicon.distribution.svg',
         '!src/test_utils/**',


### PR DESCRIPTION
`src/core/server/saved_objects/migrationsv2/integration_tests` comes in
at 36mb.  This adds it to the exclude list.

