### PR TITLE
[Workplace Search] Set `maxBytes` to image fix upload bug

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
@@ -9,6 +9,8 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDependencies } from '../../plugin';
 
+const MAX_IMAGE_BYTES = 2000000;
+
 export function registerOrgSettingsRoute({
   router,
   enterpriseSearchRequestHandler,
@@ -55,6 +57,11 @@ export function registerOrgSettingsUploadImagesRoute({
           logo: schema.maybe(schema.nullable(schema.string())),
           icon: schema.maybe(schema.nullable(schema.string())),
         }),
+      },
+      options: {
+        body: {
+          maxBytes: MAX_IMAGE_BYTES,
+        },
       },
     },
     enterpriseSearchRequestHandler.createRequest({


### PR DESCRIPTION
## Summary

There was an issue where the Kibana server was incorrectly limiting files over 1MB. This PR fixes that issue as pointed out [here](https://github.com/elastic/workplace-search-team/issues/1964#issuecomment-899804460). 

**Before**
![2021-08-16_15-17-47 (1)](https://user-images.githubusercontent.com/1869731/129624539-ecc7e8a4-0fcb-44f2-bfff-91d279e8f759.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/129634006-b5714862-10d0-4f55-9b4a-aca895f416a4.gif)
