### PR TITLE
[Stack Integration] Fix APM failing test due to HTML change

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/apm/apm_smoke_test.js
+++ b/x-pack/test/stack_functional_integration/apps/apm/apm_smoke_test.js
@@ -23,7 +23,7 @@ export default function ({ getService, getPageObjects }) {
       await testSubjects.existOrFail('apmMainContainer', {
         timeout: 10000,
       });
-      await find.clickByLinkText('apm-a-rum-test-e2e-general-usecase');
+      await find.clickByDisplayedLinkText('apm-a-rum-test-e2e-general-usecase');
       log.debug('### apm smoke test passed');
       await find.clickByLinkText('general-usecase-initial-p-load');
       log.debug('### general use case smoke test passed');


### PR DESCRIPTION
## Summary
This PR changes the method used to click on the APM object in the stack functional integration tests.
It only applies to 7.x, it works fine on master.
