### PR TITLE
[7.x] changes investigate icon to eye icon (#108436)

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -232,11 +232,10 @@ function ObservabilityActions({
         <EuiFlexItem>
           <EuiButtonIcon
             size="s"
-            target="_blank"
-            rel="nofollow noreferrer"
             href={prepend(alert.link ?? '')}
-            iconType="inspect"
+            iconType="eye"
             color="text"
+            aria-label="View alert in app"
           />
         </EuiFlexItem>
         <EuiFlexItem>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - changes investigate icon to eye icon (#108436)