### PR TITLE
[7.x] [Lens] Fixes flakiness in editing pre-existing runtime field (#108653)

### DIFF
--- a/test/functional/services/field_editor.ts
+++ b/test/functional/services/field_editor.ts
@@ -12,8 +12,11 @@ export class FieldEditorService extends FtrService {
   private readonly browser = this.ctx.getService('browser');
   private readonly testSubjects = this.ctx.getService('testSubjects');
 
-  public async setName(name: string) {
-    await this.testSubjects.setValue('nameField > input', name);
+  public async setName(name: string, clearFirst = false, typeCharByChar = false) {
+    await this.testSubjects.setValue('nameField > input', name, {
+      clearWithKeyboard: clearFirst,
+      typeCharByChar,
+    });
   }
   public async enableCustomLabel() {
     await this.testSubjects.setEuiSwitch('customLabelRow > toggle', 'check');

--- a/x-pack/test/functional/apps/lens/runtime_fields.ts
+++ b/x-pack/test/functional/apps/lens/runtime_fields.ts
@@ -14,8 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const fieldEditor = getService('fieldEditor');
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/95614
-  describe.skip('lens runtime fields', () => {
+  describe('lens runtime fields', () => {
     it('should be able to add runtime field and use it', async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');
@@ -49,7 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('should able to edit field', async () => {
       await PageObjects.lens.clickField('runtimefield');
       await PageObjects.lens.editField();
-      await fieldEditor.setName('runtimefield2');
+      await fieldEditor.setName('runtimefield2', true, true);
       await fieldEditor.save();
       await fieldEditor.confirmSave();
       await PageObjects.lens.searchField('runtime');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Lens] Fixes flakiness in editing pre-existing runtime field (#108653)