### PR TITLE
Import EuiCodeEditor from kibana

### DIFF
--- a/src/plugins/advanced_settings/kibana.json
+++ b/src/plugins/advanced_settings/kibana.json
@@ -5,7 +5,7 @@
   "ui": true,
   "requiredPlugins": ["management"],
   "optionalPlugins": ["home", "usageCollection"],
-  "requiredBundles": ["kibanaReact", "kibanaUtils", "home"],
+  "requiredBundles": ["kibanaReact", "kibanaUtils", "home", "esUiShared"],
   "owner": {
     "name": "Kibana App",
     "githubTeam": "kibana-app"

--- a/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/field/field.tsx
@@ -8,7 +8,6 @@
 
 import React, { PureComponent, Fragment } from 'react';
 import classNames from 'classnames';
-
 import 'brace/theme/textmate';
 import 'brace/mode/markdown';
 import 'brace/mode/json';
@@ -19,7 +18,6 @@ import {
   EuiCodeBlock,
   EuiColorPicker,
   EuiScreenReaderOnly,
-  EuiCodeEditor,
   EuiDescribedFormGroup,
   EuiFieldNumber,
   EuiFieldText,
@@ -40,6 +38,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { FieldSetting, FieldState } from '../../types';
 import { isDefaultValue } from '../../lib';
 import { UiSettingsType, DocLinksStart, ToastsStart } from '../../../../../../core/public';
+import { EuiCodeEditor } from '../../../../../es_ui_shared/public';
 
 interface FieldProps {
   setting: FieldSetting;

--- a/src/plugins/advanced_settings/tsconfig.json
+++ b/src/plugins/advanced_settings/tsconfig.json
@@ -16,5 +16,6 @@
     { "path": "../home/tsconfig.json" },
     { "path": "../usage_collection/tsconfig.json" },
     { "path": "../kibana_react/tsconfig.json" },
+    { "path": "../es_ui_shared/tsconfig.json" },
   ]
 }

--- a/src/plugins/vis_type_vega/kibana.json
+++ b/src/plugins/vis_type_vega/kibana.json
@@ -5,7 +5,7 @@
   "ui": true,
   "requiredPlugins": ["data", "visualizations", "mapsEms", "expressions", "inspector"],
   "optionalPlugins": ["home","usageCollection"],
-  "requiredBundles": ["kibanaUtils", "kibanaReact", "visDefaultEditor"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact", "visDefaultEditor", "esUiShared"],
   "owner": {
     "name": "Kibana App",
     "githubTeam": "kibana-app"

--- a/src/plugins/vis_type_vega/public/components/vega_vis_editor.tsx
+++ b/src/plugins/vis_type_vega/public/components/vega_vis_editor.tsx
@@ -7,13 +7,13 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiCodeEditor } from '@elastic/eui';
 import compactStringify from 'json-stringify-pretty-compact';
 import hjson from 'hjson';
 import 'brace/mode/hjson';
 import { i18n } from '@kbn/i18n';
 
 import { VisEditorOptionsProps } from 'src/plugins/visualizations/public';
+import { EuiCodeEditor } from '../../../es_ui_shared/public';
 import { getNotifications } from '../services';
 import { VisParams } from '../vega_fn';
 import { VegaHelpMenu } from './vega_help_menu';

--- a/src/plugins/vis_type_vega/tsconfig.json
+++ b/src/plugins/vis_type_vega/tsconfig.json
@@ -26,5 +26,6 @@
     { "path": "../kibana_utils/tsconfig.json" },
     { "path": "../kibana_react/tsconfig.json" },
     { "path": "../vis_default_editor/tsconfig.json" },
+    { "path": "../es_ui_shared/tsconfig.json" },
   ]
 }


### PR DESCRIPTION
## Summary

This PR actually imports the EUICodeEditor, used in vega and advanced settings, with the component that was moved to kibana https://github.com/elastic/kibana/pull/108318.

EUI wants to remove this component from their codebase https://github.com/elastic/kibana/issues/106931

In the future, we want to replace it with monaco editor. 