### PR TITLE
[7.x] [ILM] Added index templates flyout to the edit policy form (#108362)

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/app/app.helpers.tsx
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/app/app.helpers.tsx
@@ -29,7 +29,6 @@ const getTestBedConfig = (initialEntries: string[]): TestBedConfig => ({
   },
   defaultProps: {
     getUrlForApp: () => {},
-    navigateToApp: () => {},
   },
 });
 

--- a/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/edit_policy/features/edit_warning.test.ts
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/client_integration/edit_policy/features/edit_warning.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act } from 'react-dom/test-utils';
+import { TestBed } from '@kbn/test/jest';
+import { setupEnvironment } from '../../helpers';
+import { initTestBed } from '../init_test_bed';
+import { getDefaultHotPhasePolicy, POLICY_NAME } from '../constants';
+
+describe('<EditPolicy /> edit warning', () => {
+  let testBed: TestBed;
+  const { server, httpRequestsMockHelpers } = setupEnvironment();
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+    server.restore();
+  });
+
+  beforeEach(async () => {
+    httpRequestsMockHelpers.setDefaultResponses();
+
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+
+    const { component } = testBed;
+    component.update();
+  });
+
+  test('no edit warning for a new policy', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { exists, component } = testBed;
+    component.update();
+    expect(exists('editWarning')).toBe(false);
+  });
+
+  test('an edit warning is shown for an existing policy', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([getDefaultHotPhasePolicy(POLICY_NAME)]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { exists, component } = testBed;
+    component.update();
+    expect(exists('editWarning')).toBe(true);
+  });
+
+  test('no indices link if no indices', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([
+      { ...getDefaultHotPhasePolicy(POLICY_NAME), indices: [] },
+    ]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { exists, component } = testBed;
+    component.update();
+    expect(exists('linkedIndicesLink')).toBe(false);
+  });
+
+  test('no index templates link if no index templates', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([
+      { ...getDefaultHotPhasePolicy(POLICY_NAME), indexTemplates: [] },
+    ]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { exists, component } = testBed;
+    component.update();
+    expect(exists('linkedIndexTemplatesLink')).toBe(false);
+  });
+
+  test('index templates link has number of indices', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([
+      {
+        ...getDefaultHotPhasePolicy(POLICY_NAME),
+        indices: ['index1', 'index2', 'index3'],
+      },
+    ]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { component, find } = testBed;
+    component.update();
+    expect(find('linkedIndicesLink').text()).toBe('3 linked indices');
+  });
+
+  test('index templates link has number of index templates', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([
+      {
+        ...getDefaultHotPhasePolicy(POLICY_NAME),
+        indexTemplates: ['template1', 'template2', 'template3'],
+      },
+    ]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { component, find } = testBed;
+    component.update();
+    expect(find('linkedIndexTemplatesLink').text()).toBe('3 linked index templates');
+  });
+
+  test('index templates link opens the flyout', async () => {
+    httpRequestsMockHelpers.setLoadPolicies([
+      {
+        ...getDefaultHotPhasePolicy(POLICY_NAME),
+        indexTemplates: ['template1'],
+      },
+    ]);
+    await act(async () => {
+      testBed = await initTestBed();
+    });
+    const { component, find, exists } = testBed;
+    component.update();
+    expect(exists('indexTemplatesFlyoutHeader')).toBe(false);
+    find('linkedIndexTemplatesLink').simulate('click');
+    expect(exists('indexTemplatesFlyoutHeader')).toBe(true);
+  });
+});

--- a/x-pack/plugins/index_lifecycle_management/public/application/components/index_templates_flyout.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/components/index_templates_flyout.tsx
@@ -18,15 +18,19 @@ import {
   EuiLink,
   EuiTitle,
 } from '@elastic/eui';
-import { PolicyFromES } from '../../../common/types';
 import { useKibana } from '../../shared_imports';
 import { getTemplateDetailsLink } from '../../../../index_management/public/';
 
 interface Props {
-  policy: PolicyFromES;
+  policyName: string;
+  indexTemplates: string[];
   close: () => void;
 }
-export const IndexTemplatesFlyout: FunctionComponent<Props> = ({ policy, close }) => {
+export const IndexTemplatesFlyout: FunctionComponent<Props> = ({
+  policyName,
+  indexTemplates,
+  close,
+}) => {
   const {
     services: { getUrlForApp },
   } = useKibana();
@@ -43,7 +47,7 @@ export const IndexTemplatesFlyout: FunctionComponent<Props> = ({ policy, close }
             <FormattedMessage
               id="xpack.indexLifecycleMgmt.policyTable.indexTemplatesFlyout.headerText"
               defaultMessage="Index templates that apply {policyName}"
-              values={{ policyName: policy.name }}
+              values={{ policyName }}
             />
           </h2>
         </EuiTitle>
@@ -51,7 +55,7 @@ export const IndexTemplatesFlyout: FunctionComponent<Props> = ({ policy, close }
       <EuiFlyoutBody>
         <EuiInMemoryTable
           pagination={true}
-          items={policy.indexTemplates ?? []}
+          items={indexTemplates ?? []}
           columns={[
             {
               name: i18n.translate(

--- a/x-pack/plugins/index_lifecycle_management/public/application/index.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/index.tsx
@@ -28,13 +28,11 @@ export const renderApp = (
   license: ILicense,
   cloud?: CloudSetup
 ): UnmountCallback => {
-  const { navigateToApp, getUrlForApp } = application;
+  const { getUrlForApp } = application;
   render(
     <RedirectAppLinks application={application}>
       <I18nContext>
-        <KibanaContextProvider
-          services={{ cloud, breadcrumbService, license, navigateToApp, getUrlForApp }}
-        >
+        <KibanaContextProvider services={{ cloud, breadcrumbService, license, getUrlForApp }}>
           <App history={history} />
         </KibanaContextProvider>
       </I18nContext>

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/edit_warning.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/edit_warning.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FunctionComponent, useState } from 'react';
+import { EuiLink, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { useEditPolicyContext } from '../edit_policy_context';
+import { getIndicesListPath } from '../../../services/navigation';
+import { useKibana } from '../../../../shared_imports';
+import { IndexTemplatesFlyout } from '../../../components/index_templates_flyout';
+
+export const EditWarning: FunctionComponent = () => {
+  const { isNewPolicy, indices, indexTemplates, policyName } = useEditPolicyContext();
+  const {
+    services: { getUrlForApp },
+  } = useKibana();
+
+  const [isIndexTemplatesFlyoutShown, setIsIndexTemplatesShown] = useState<boolean>(false);
+
+  if (isNewPolicy) {
+    return null;
+  }
+  const indicesLink =
+    indices.length > 0 ? (
+      <EuiLink
+        data-test-subj="linkedIndicesLink"
+        external={true}
+        href={getIndicesListPath(policyName ?? '', getUrlForApp)}
+        target="_blank"
+      >
+        <FormattedMessage
+          id="xpack.indexLifecycleMgmt.editPolicy.linkedIndices"
+          defaultMessage="{indicesCount, plural, one {# linked index} other {# linked indices}}"
+          values={{ indicesCount: indices.length }}
+        />
+      </EuiLink>
+    ) : null;
+
+  const indexTemplatesLink =
+    indexTemplates.length > 0 ? (
+      <EuiLink
+        data-test-subj="linkedIndexTemplatesLink"
+        onClick={() => setIsIndexTemplatesShown(!isIndexTemplatesFlyoutShown)}
+      >
+        <FormattedMessage
+          id="xpack.indexLifecycleMgmt.editPolicy.linkedIndexTemplates"
+          defaultMessage="{indexTemplatesCount, plural, one {# linked index template} other {# linked index templates}}"
+          values={{ indexTemplatesCount: indexTemplates.length }}
+        />
+      </EuiLink>
+    ) : null;
+  const dependenciesLinks = indicesLink ? (
+    <>
+      {indicesLink}
+      {indexTemplatesLink ? (
+        <FormattedMessage
+          id="xpack.indexLifecycleMgmt.editPolicy.andDependenciesLink"
+          defaultMessage=" and {indexTemplatesLink}"
+          values={{ indexTemplatesLink }}
+        />
+      ) : null}
+    </>
+  ) : (
+    indexTemplatesLink
+  );
+  return (
+    <>
+      {isIndexTemplatesFlyoutShown && (
+        <IndexTemplatesFlyout
+          policyName={policyName ?? ''}
+          indexTemplates={indexTemplates}
+          close={() => setIsIndexTemplatesShown(false)}
+        />
+      )}
+      <EuiText data-test-subj="editWarning">
+        <p>
+          <strong>
+            <FormattedMessage
+              id="xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyMessage"
+              defaultMessage="You are editing an existing policy."
+            />
+          </strong>
+          {dependenciesLinks ? (
+            <FormattedMessage
+              id="xpack.indexLifecycleMgmt.editPolicy.dependenciesMessage"
+              defaultMessage=" Any changes you make will affect {dependenciesLinks} that {count, plural, one {is} other {are}} attached to this policy."
+              values={{
+                dependenciesLinks,
+                count: indices.length + indexTemplates.length,
+              }}
+            />
+          ) : null}
+          <FormattedMessage
+            id="xpack.indexLifecycleMgmt.editPolicy.saveAsNewMessage"
+            defaultMessage=" Alternatively, you can save these changes in a new policy."
+          />
+        </p>
+      </EuiText>
+    </>
+  );
+};

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/index.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/index.ts
@@ -14,4 +14,5 @@ export { Timeline } from './timeline';
 export { FormErrorsCallout } from './form_errors_callout';
 export { PhaseFooter } from './phase_footer';
 export { InfinityIcon } from './infinity_icon';
+export { EditWarning } from './edit_warning';
 export * from './phases';

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy.container.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy.container.tsx
@@ -96,6 +96,9 @@ export const EditPolicy: React.FunctionComponent<RouteComponentProps<RouterProps
         license: {
           canUseSearchableSnapshot: () => license.hasAtLeast(MIN_SEARCHABLE_SNAPSHOT_LICENSE),
         },
+        indices: existingPolicy && existingPolicy.indices ? existingPolicy.indices : [],
+        indexTemplates:
+          existingPolicy && existingPolicy.indexTemplates ? existingPolicy.indexTemplates : [],
       }}
     >
       <PresentationComponent />

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy.tsx
@@ -21,7 +21,6 @@ import {
   EuiHorizontalRule,
   EuiSpacer,
   EuiSwitch,
-  EuiText,
   EuiPageHeader,
 } from '@elastic/eui';
 
@@ -39,6 +38,7 @@ import {
   WarmPhase,
   Timeline,
   FormErrorsCallout,
+  EditWarning,
 } from './components';
 import {
   createPolicyNameValidations,
@@ -179,23 +179,7 @@ export const EditPolicy: React.FunctionComponent = () => {
       <Form form={form}>
         {isNewPolicy ? null : (
           <Fragment>
-            <EuiText>
-              <p>
-                <strong>
-                  <FormattedMessage
-                    id="xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyMessage"
-                    defaultMessage="You are editing an existing policy"
-                  />
-                </strong>
-                .{' '}
-                <FormattedMessage
-                  id="xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyExplanationMessage"
-                  defaultMessage="Any changes you make will affect the indices that are
-                              attached to this policy. Alternatively, you can save these changes in
-                              a new policy."
-                />
-              </p>
-            </EuiText>
+            <EditWarning />
             <EuiSpacer />
 
             <EuiFormRow>

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy_context.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/edit_policy_context.tsx
@@ -17,6 +17,8 @@ export interface EditPolicyContextValue {
     canUseSearchableSnapshot: () => boolean;
   };
   policyName?: string;
+  indices: string[];
+  indexTemplates: string[];
 }
 
 const EditPolicyContext = createContext<EditPolicyContextValue>(null as any);

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_list/components/list_action_handler.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_list/components/list_action_handler.tsx
@@ -19,7 +19,8 @@ export const ListActionHandler: React.FunctionComponent<Props> = ({ updatePolici
   if (listAction?.actionType === 'viewIndexTemplates') {
     return (
       <IndexTemplatesFlyout
-        policy={listAction.selectedPolicy}
+        policyName={listAction.selectedPolicy.name}
+        indexTemplates={listAction.selectedPolicy.indexTemplates ?? []}
         close={() => {
           setListAction(null);
         }}

--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_list/components/policy_table.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/policy_list/components/policy_table.tsx
@@ -15,10 +15,9 @@ import { METRIC_TYPE } from '@kbn/analytics';
 import { useHistory } from 'react-router-dom';
 import { EuiBasicTableColumn } from '@elastic/eui/src/components/basic_table/basic_table';
 import { reactRouterNavigate } from '../../../../../../../../src/plugins/kibana_react/public';
-import { getIndexListUri } from '../../../../../../index_management/public';
 import { PolicyFromES } from '../../../../../common/types';
 import { useKibana } from '../../../../shared_imports';
-import { getPolicyEditPath } from '../../../services/navigation';
+import { getIndicesListPath, getPolicyEditPath } from '../../../services/navigation';
 import { trackUiMetric } from '../../../services/ui_metric';
 
 import { UIM_EDIT_CLICK } from '../../../constants';
@@ -53,7 +52,7 @@ interface Props {
 export const PolicyTable: React.FunctionComponent<Props> = ({ policies }) => {
   const history = useHistory();
   const {
-    services: { navigateToApp },
+    services: { getUrlForApp },
   } = useKibana();
 
   const { setListAction } = usePolicyListContext();
@@ -115,19 +114,7 @@ export const PolicyTable: React.FunctionComponent<Props> = ({ policies }) => {
       render: (value: string[], policy: PolicyFromES) => {
         return value && value.length > 0 ? (
           <EuiToolTip content={actionTooltips.viewIndices} position="left">
-            <EuiButtonEmpty
-              flush="both"
-              onClick={() =>
-                navigateToApp('management', {
-                  path: `/data/index_management${getIndexListUri(
-                    `ilm.policy:"${policy.name}"`,
-                    true
-                  )}`,
-                })
-              }
-            >
-              {value.length}
-            </EuiButtonEmpty>
+            <EuiLink href={getIndicesListPath(policy.name, getUrlForApp)}>{value.length}</EuiLink>
           </EuiToolTip>
         ) : (
           '0'

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/navigation.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/navigation.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import { ApplicationStart } from 'kibana/public';
+import { getIndexListUri } from '../../../../index_management/public';
+
 export const ROUTES = {
   list: '/policies',
   edit: '/policies/edit/:policyName?',
@@ -22,3 +25,11 @@ export const getPolicyCreatePath = () => {
 export const getPoliciesListPath = () => {
   return ROUTES.list;
 };
+
+export const getIndicesListPath = (
+  policyName: string,
+  getUrlForApp: ApplicationStart['getUrlForApp']
+) =>
+  getUrlForApp('management', {
+    path: `/data/index_management${getIndexListUri(`ilm.policy="${policyName}"`, true)}`,
+  });

--- a/x-pack/plugins/index_lifecycle_management/public/types.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/types.ts
@@ -39,6 +39,5 @@ export interface AppServicesContext {
   breadcrumbService: BreadcrumbService;
   license: ILicense;
   cloud?: CloudSetup;
-  navigateToApp: ApplicationStart['navigateToApp'];
   getUrlForApp: ApplicationStart['getUrlForApp'];
 }

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -11483,7 +11483,6 @@
     "xpack.indexLifecycleMgmt.editPolicy.deletePhase.waitForSnapshotTitle": "スナップショットポリシーを待機",
     "xpack.indexLifecycleMgmt.editPolicy.differentPolicyNameRequiredError": "ポリシー名は異なるものである必要があります。",
     "xpack.indexLifecycleMgmt.editPolicy.documentationLinkText": "ドキュメント",
-    "xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyExplanationMessage": "すべての変更はこのポリシーに関連付けられているインデックスに影響を及ぼします。代わりに、これらの変更を新規ポリシーに保存することもできます。",
     "xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyMessage": "既存のポリシーを編集しています",
     "xpack.indexLifecycleMgmt.editPolicy.editPolicyMessage": "ポリシー{originalPolicyName}の編集",
     "xpack.indexLifecycleMgmt.editPolicy.errors.integerRequiredError": "整数のみを使用できます。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11621,7 +11621,6 @@
     "xpack.indexLifecycleMgmt.editPolicy.deletePhase.waitForSnapshotTitle": "等候快照策略",
     "xpack.indexLifecycleMgmt.editPolicy.differentPolicyNameRequiredError": "策略名称必须不同。",
     "xpack.indexLifecycleMgmt.editPolicy.documentationLinkText": "文档",
-    "xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyExplanationMessage": "所做的任何更改将影响附加到此策略的索引。或者，您可以在新策略中保存这些更改。",
     "xpack.indexLifecycleMgmt.editPolicy.editingExistingPolicyMessage": "您正在编辑现有策略",
     "xpack.indexLifecycleMgmt.editPolicy.editPolicyMessage": "编辑策略 {originalPolicyName}",
     "xpack.indexLifecycleMgmt.editPolicy.errors.integerRequiredError": "仅允许使用整数。",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ILM] Added index templates flyout to the edit policy form (#108362)