### PR TITLE
[7.x] Update dependency @elastic/elasticsearch to ^7.15.0-canary.3 (#107536)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@elastic/apm-rum-react": "^1.2.11",
     "@elastic/charts": "33.2.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.17",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.15.0-canary.3",
     "@elastic/ems-client": "7.15.0",
     "@elastic/eui": "37.1.1",
     "@elastic/filesaver": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@elastic/apm-rum-react": "^1.2.11",
     "@elastic/charts": "33.2.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.14",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.17",
     "@elastic/ems-client": "7.15.0",
     "@elastic/eui": "37.1.1",
     "@elastic/filesaver": "1.1.2",

--- a/packages/kbn-es-query/src/kuery/functions/geo_bounding_box.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/geo_bounding_box.test.ts
@@ -108,6 +108,7 @@ describe('kuery functions', () => {
         const node = nodeTypes.function.buildNode('geoBoundingBox', 'geo', params);
         const result = geoBoundingBox.toElasticsearchQuery(node, indexPattern);
 
+        // @ts-expect-error @elastic/elasticsearch doesn't support ignore_unmapped in QueryDslGeoBoundingBoxQuery
         expect(result.geo_bounding_box!.ignore_unmapped).toBe(true);
       });
 

--- a/packages/kbn-es-query/src/kuery/functions/geo_bounding_box.ts
+++ b/packages/kbn-es-query/src/kuery/functions/geo_bounding_box.ts
@@ -53,6 +53,7 @@ export function toElasticsearchQuery(
   }
 
   return {
+    // @ts-expect-error @elastic/elasticsearch doesn't support ignore_unmapped in QueryDslGeoBoundingBoxQuery
     geo_bounding_box: {
       [fieldName]: queryParams,
       ignore_unmapped: true,

--- a/packages/kbn-es-query/src/kuery/functions/geo_polygon.ts
+++ b/packages/kbn-es-query/src/kuery/functions/geo_polygon.ts
@@ -49,6 +49,7 @@ export function toElasticsearchQuery(
   }
 
   return {
+    // @ts-expect-error @elastic/elasticsearch doesn't support ignore_unmapped in QueryDslGeoPolygonQuery
     geo_polygon: {
       [fieldName]: queryParams,
       ignore_unmapped: true,

--- a/src/core/server/elasticsearch/client/configure_client.test.ts
+++ b/src/core/server/elasticsearch/client/configure_client.test.ts
@@ -58,6 +58,7 @@ const createApiResponse = <T>({
     headers,
     warnings,
     meta: {
+      body,
       request: {
         params: params!,
         options: requestOptions,
@@ -367,7 +368,7 @@ describe('configureClient', () => {
       it('logs default error info when the error response body is empty', () => {
         const client = configureClient(createFakeConfig(), { logger, type: 'test', scoped: false });
 
-        let response = createApiResponse({
+        let response: RequestEvent<any, any> = createApiResponse({
           statusCode: 400,
           headers: {},
           params: {
@@ -384,7 +385,7 @@ describe('configureClient', () => {
           Array [
             Array [
               "400
-          GET /_path [undefined]: Response Error",
+          GET /_path [undefined]: {\\"error\\":{}}",
               undefined,
             ],
           ]
@@ -399,7 +400,7 @@ describe('configureClient', () => {
             method: 'GET',
             path: '/_path',
           },
-          body: {} as any,
+          body: undefined,
         });
         client.emit('response', new errors.ResponseError(response), response);
 

--- a/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
@@ -421,17 +421,13 @@ describe('migration actions', () => {
         timeout: '0s',
       })();
 
-      await cloneIndexPromise.then((res) => {
-        expect(res).toMatchInlineSnapshot(`
-          Object {
-            "_tag": "Left",
-            "left": Object {
-              "error": [ResponseError: Response Error],
-              "message": "Response Error",
-              "type": "retryable_es_client_error",
-            },
-          }
-        `);
+      await expect(cloneIndexPromise).resolves.toMatchObject({
+        _tag: 'Left',
+        left: {
+          error: expect.any(ResponseError),
+          message: expect.stringMatching(/\"timed_out\":true/),
+          type: 'retryable_es_client_error',
+        },
       });
     });
   });

--- a/src/core/server/saved_objects/migrationsv2/actions/integration_tests/es_errors.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/integration_tests/es_errors.test.ts
@@ -64,6 +64,7 @@ describe('Elasticsearch Errors', () => {
         { ignore: [403] }
       );
 
+      // @ts-expect-error @elastic/elasticsearch doesn't declare error on IndexResponse
       expect(isWriteBlockException(res.body.error!)).toEqual(true);
     });
 
@@ -79,6 +80,7 @@ describe('Elasticsearch Errors', () => {
         { ignore: [403] }
       );
 
+      // @ts-expect-error @elastic/elasticsearch doesn't declare error on IndexResponse
       expect(isWriteBlockException(res.body.error!)).toEqual(true);
     });
 

--- a/src/core/server/saved_objects/service/lib/decorate_es_error.test.ts
+++ b/src/core/server/saved_objects/service/lib/decorate_es_error.test.ts
@@ -124,7 +124,7 @@ describe('savedObjectsClient/decorateEsError', () => {
     expect(SavedObjectsErrorHelpers.isGeneralError(error)).toBe(false);
     const genericError = decorateEsError(error);
     expect(genericError.message).toEqual(
-      `Saved object index alias [.kibana_8.0.0] not found: Response Error`
+      `Saved object index alias [.kibana_8.0.0] not found: {\"error\":{\"reason\":\"no such index [.kibana_8.0.0] and [require_alias] request flag is [true] and [.kibana_8.0.0] is not an alias\"}}`
     );
     expect(genericError.output.statusCode).toBe(500);
     expect(SavedObjectsErrorHelpers.isGeneralError(error)).toBe(true);

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -665,6 +665,7 @@ export class SavedObjectsRepository {
     }
 
     const deleteDocNotFound = body.result === 'not_found';
+    // @ts-expect-error @elastic/elasticsearch doesn't declare error on DeleteResponse
     const deleteIndexNotFound = body.error && body.error.type === 'index_not_found_exception';
     const esServerSupported = isSupportedEsServer(headers);
     if (deleteDocNotFound || deleteIndexNotFound) {

--- a/src/plugins/es_ui_shared/__packages_do_not_import__/errors/handle_es_error.test.ts
+++ b/src/plugins/es_ui_shared/__packages_do_not_import__/errors/handle_es_error.test.ts
@@ -59,7 +59,7 @@ describe('handleEsError', () => {
 
     expect(payload).toEqual({
       attributes: { causes: undefined, error: undefined },
-      message: 'Response Error',
+      message: '{}',
     });
 
     expect(status).toBe(400);

--- a/x-pack/plugins/event_log/server/es/cluster_client_adapter.ts
+++ b/x-pack/plugins/event_log/server/es/cluster_client_adapter.ts
@@ -265,6 +265,7 @@ export class ClusterClientAdapter<TDoc extends { body: AliasAny; index: string }
                     'kibana.saved_objects.id': ids,
                   },
                 },
+                // @ts-expect-error undefined is not assignable as QueryDslTermQuery value
                 namespaceQuery,
               ],
             },

--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { estypes } from '@elastic/elasticsearch';
+import type { estypes } from '@elastic/elasticsearch';
 import { i18n } from '@kbn/i18n';
 import {
   ALERT_EVALUATION_THRESHOLD,
@@ -650,13 +650,8 @@ export const getUngroupedESQuery = (
   };
 };
 
-type SupportedESQueryTypes = 'term' | 'match' | 'match_phrase' | 'range';
-type Filter = {
-  [key in SupportedESQueryTypes]?: object;
-};
-
 const buildFiltersForCriteria = (criteria: CountCriteria) => {
-  let filters: Filter[] = [];
+  let filters: estypes.QueryDslQueryContainer[] = [];
 
   criteria.forEach((criterion) => {
     const criterionQuery = buildCriterionQuery(criterion);
@@ -667,7 +662,7 @@ const buildFiltersForCriteria = (criteria: CountCriteria) => {
   return filters;
 };
 
-const buildCriterionQuery = (criterion: Criterion): Filter | undefined => {
+const buildCriterionQuery = (criterion: Criterion): estypes.QueryDslQueryContainer | undefined => {
   const { field, value, comparator } = criterion;
 
   const queryType = getQueryMappingForComparator(comparator);
@@ -691,7 +686,7 @@ const buildCriterionQuery = (criterion: Criterion): Filter | undefined => {
     case 'match_phrase': {
       return {
         match_phrase: {
-          [field]: value,
+          [field]: String(value),
         },
       };
     }

--- a/x-pack/plugins/infra/server/lib/log_analysis/queries/log_entry_category_examples.ts
+++ b/x-pack/plugins/infra/server/lib/log_analysis/queries/log_entry_category_examples.ts
@@ -37,7 +37,7 @@ export const createLogEntryCategoryExamplesQuery = (
             match: {
               message: {
                 query: categoryQuery,
-                operator: 'AND',
+                operator: 'and',
               },
             },
           },

--- a/x-pack/plugins/infra/server/lib/log_analysis/queries/log_entry_examples.ts
+++ b/x-pack/plugins/infra/server/lib/log_analysis/queries/log_entry_examples.ts
@@ -62,7 +62,7 @@ export const createLogEntryExamplesQuery = (
                   match: {
                     message: {
                       query: categoryQuery,
-                      operator: 'AND' as const,
+                      operator: 'and' as const,
                     },
                   },
                 },

--- a/x-pack/plugins/lists/server/services/utils/get_query_filter_from_type_value.ts
+++ b/x-pack/plugins/lists/server/services/utils/get_query_filter_from_type_value.ts
@@ -4,14 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import type { estypes } from '@elastic/elasticsearch';
 import { isEmpty, isObject } from 'lodash/fp';
 import type { Type } from '@kbn/securitysolution-io-ts-list-types';
 
-export type QueryFilterType = [
-  { term: Record<string, unknown> },
-  { terms: Record<string, unknown[]> } | { bool: {} }
-];
+export type QueryFilterType = estypes.QueryDslQueryContainer[];
 
 /**
  * Given a type, value, and listId, this will return a valid query. If the type is
@@ -166,6 +163,7 @@ export const getShouldQuery = ({
     {
       bool: {
         minimum_should_match: 1,
+        // @ts-expect-error unknown is not assignable to estypes.QueryDslQueryContainer
         should,
       },
     },

--- a/x-pack/plugins/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/common/job_creator/job_creator.ts
@@ -287,6 +287,7 @@ export class JobCreator {
     if (enable) {
       this._job_config.results_index_name = this._job_config.job_id;
     } else {
+      // @ts-expect-error The operand of a 'delete' operator must be optional
       delete this._job_config.results_index_name;
     }
   }

--- a/x-pack/plugins/ml/public/ui_actions/open_in_anomaly_explorer_action.tsx
+++ b/x-pack/plugins/ml/public/ui_actions/open_in_anomaly_explorer_action.tsx
@@ -83,7 +83,7 @@ export function createOpenInExplorerAction(getStartServices: MlCoreSetup['getSta
                 should: [
                   {
                     match_phrase: {
-                      [fieldName]: fieldValue,
+                      [fieldName]: String(fieldValue),
                     },
                   },
                 ],
@@ -104,6 +104,7 @@ export function createOpenInExplorerAction(getStartServices: MlCoreSetup['getSta
           pageState: {
             jobIds,
             timeRange,
+            // @ts-ignore QueryDslQueryContainer is not compatible with SerializableRecord
             ...(mlExplorerFilter ? ({ mlExplorerFilter } as SerializableRecord) : {}),
             query: {},
           },

--- a/x-pack/plugins/monitoring/server/alerts/base_rule.ts
+++ b/x-pack/plugins/monitoring/server/alerts/base_rule.ts
@@ -251,7 +251,7 @@ export class BaseRule {
       ? {
           timestamp: {
             format: 'epoch_millis',
-            gte: +new Date() - limit - this.ruleOptions.fetchClustersRange,
+            gte: String(+new Date() - limit - this.ruleOptions.fetchClustersRange),
           },
         }
       : undefined;

--- a/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
+++ b/x-pack/plugins/monitoring/server/lib/alerts/fetch_clusters.ts
@@ -12,7 +12,7 @@ import { AlertCluster } from '../../../common/types/alerts';
 interface RangeFilter {
   [field: string]: {
     format?: string;
-    gte: string | number;
+    gte: string;
   };
 }
 

--- a/x-pack/plugins/remote_clusters/server/routes/api/get_route.test.ts
+++ b/x-pack/plugins/remote_clusters/server/routes/api/get_route.test.ts
@@ -175,7 +175,7 @@ describe('GET remote clusters', () => {
           causes: undefined,
           error: undefined,
         },
-        message: 'Response Error',
+        message: '{"message":"test error"}',
       });
 
       expect(getSettingsMockFn).toHaveBeenCalled();

--- a/x-pack/plugins/security_solution/server/endpoint/routes/resolver/entity.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/resolver/entity.ts
@@ -99,7 +99,6 @@ export function handleEntities(): RequestHandler<unknown, TypeOf<typeof validate
               {
                 // only return documents with the matching _id
                 ids: {
-                  // @ts-expect-error expected string[]
                   values: _id,
                 },
               },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/migrations/get_signals_indices_in_range.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/migrations/get_signals_indices_in_range.ts
@@ -60,7 +60,6 @@ export const getSignalsIndicesInRange = async ({
                 '@timestamp': {
                   gte: from,
                   lte: 'now',
-                  // @ts-expect-error format doesn't exist in RangeQuery
                   format: 'strict_date_optional_time',
                 },
               },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_events_query.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_events_query.ts
@@ -61,7 +61,6 @@ export const buildEventsSearchQuery = ({
                     '@timestamp': {
                       lte: to,
                       gte: from,
-                      // @ts-expect-error
                       format: 'strict_date_optional_time',
                     },
                   },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/helpers.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/helpers.ts
@@ -27,6 +27,7 @@ export const buildIndicatorShouldClauses = (
 
     if (!isEmpty(eventFieldValue)) {
       shoulds.push({
+        // @ts-expect-error unknown is not assignable to query
         match: {
           [EVENT_ENRICHMENT_INDICATOR_FIELD_MAP[eventField]]: {
             query: eventFieldValue,

--- a/x-pack/test/api_integration/apis/management/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/test/api_integration/apis/management/ingest_pipelines/ingest_pipelines.ts
@@ -204,7 +204,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(body).to.eql({
           statusCode: 404,
           error: 'Not Found',
-          message: 'Response Error',
+          message: '{}',
           attributes: {},
         });
       });
@@ -494,7 +494,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(body).to.eql({
           error: 'Not Found',
-          message: 'Response Error',
+          message: '{"_index":"test_index","_id":"2","found":false}',
           statusCode: 404,
           attributes: {},
         });

--- a/x-pack/test/api_integration/apis/management/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/test/api_integration/apis/management/ingest_pipelines/ingest_pipelines.ts
@@ -492,12 +492,8 @@ export default function ({ getService }: FtrProviderContext) {
 
         const { body } = await supertest.get(uri).set('kbn-xsrf', 'xxx').expect(404);
 
-        expect(body).to.eql({
-          error: 'Not Found',
-          message: '{"_index":"test_index","_id":"2","found":false}',
-          statusCode: 404,
-          attributes: {},
-        });
+        expect(body.error).to.be('Not Found');
+        expect(body.statusCode).to.be(404);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,10 +1433,10 @@
   dependencies:
     "@elastic/ecs-helpers" "^1.1.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@^8.0.0-canary.17":
-  version "8.0.0-canary.17"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.0.0-canary.17.tgz#0625a04cc585e3f311bc6471e04cd4fb0e927e9a"
-  integrity sha512-rsbEdzxYlEU+jS+qf5Gr3+2U6/1Z/S/Yt2dM7lp1A64mCjuOqqHoR2FTHN27BWvBCjtJrtyhlCJht4fsTLNuYA==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@^7.15.0-canary.3":
+  version "7.15.0-canary.3"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-7.15.0-canary.3.tgz#0f0f21641d4eab0eaa98e6f9f5c18f28a968c4ad"
+  integrity sha512-9T3/RNW0b6R1D7ZrdMZ7aujEjs4IoiKvhkTqrH6fDNzTaMmTCTf6BLnIbWWwGdFLYOyIjnpDg+pSfYF+JYjKFA==
   dependencies:
     debug "^4.3.1"
     hpagent "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,10 +1433,10 @@
   dependencies:
     "@elastic/ecs-helpers" "^1.1.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@^8.0.0-canary.14":
-  version "8.0.0-canary.14"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.0.0-canary.14.tgz#36f0dedc5e02c43a2fd1ceb86e273e29c603f1fb"
-  integrity sha512-ZwyjT16581grvJLgsbkT9tzy49g5E2qYQ05mS41Db98Kqe0sYZsm25eHGuV7U9DqJo5LuV0TTTs3rhsaqL5Mhw==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@^8.0.0-canary.17":
+  version "8.0.0-canary.17"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.0.0-canary.17.tgz#0625a04cc585e3f311bc6471e04cd4fb0e927e9a"
+  integrity sha512-rsbEdzxYlEU+jS+qf5Gr3+2U6/1Z/S/Yt2dM7lp1A64mCjuOqqHoR2FTHN27BWvBCjtJrtyhlCJht4fsTLNuYA==
   dependencies:
     debug "^4.3.1"
     hpagent "^0.1.1"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update dependency @elastic/elasticsearch to ^8.0.0-canary.17 (#107536)