### PR TITLE
[Workplace Search] Replaces success Flash Messages with Toasts

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -11,7 +11,7 @@ import { useActions, useValues } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
-import { setSuccessMessage } from '../../../../../shared/flash_messages';
+import { flashSuccessToast } from '../../../../../shared/flash_messages';
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { AppLogic } from '../../../../app_logic';
 import {
@@ -90,7 +90,7 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
 
   const goToFormSourceCreated = () => {
     KibanaLogic.values.navigateToUrl(`${getSourcesPath(SOURCES_PATH, isOrganization)}`);
-    setSuccessMessage(FORM_SOURCE_ADDED_SUCCESS_MESSAGE);
+    flashSuccessToast(FORM_SOURCE_ADDED_SUCCESS_MESSAGE);
   };
 
   const header = <AddSourceHeader name={name} serviceType={serviceType} categories={categories} />;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -14,7 +14,7 @@ import { HttpFetchQuery } from 'src/core/public';
 
 import {
   flashAPIErrors,
-  setSuccessMessage,
+  flashSuccessToast,
   clearFlashMessages,
   setErrorMessage,
 } from '../../../../../shared/flash_messages';
@@ -491,7 +491,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         });
         if (successCallback) successCallback();
         if (isUpdating) {
-          setSuccessMessage(
+          flashSuccessToast(
             i18n.translate(
               'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceConfigUpdated',
               {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.test.ts
@@ -31,7 +31,7 @@ import { DisplaySettingsLogic, defaultSearchResultConfig } from './display_setti
 describe('DisplaySettingsLogic', () => {
   const { http } = mockHttpValues;
   const { navigateToUrl } = mockKibanaValues;
-  const { clearFlashMessages, flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
+  const { clearFlashMessages, flashAPIErrors, flashSuccessToast } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(DisplaySettingsLogic);
 
   const { searchResultConfig, exampleDocuments } = exampleResult;
@@ -110,7 +110,7 @@ describe('DisplaySettingsLogic', () => {
         serverProps.searchResultConfig
       );
 
-      expect(setSuccessMessage).toHaveBeenCalled();
+      expect(flashSuccessToast).toHaveBeenCalled();
     });
 
     it('handles empty color', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
@@ -11,7 +11,7 @@ import { cloneDeep, isEqual, differenceBy } from 'lodash';
 import { DropResult } from '@elastic/eui';
 
 import {
-  setSuccessMessage,
+  flashSuccessToast,
   clearFlashMessages,
   flashAPIErrors,
 } from '../../../../../shared/flash_messages';
@@ -405,7 +405,7 @@ export const DisplaySettingsLogic = kea<
       }
     },
     setServerResponseData: () => {
-      setSuccessMessage(SUCCESS_MESSAGE);
+      flashSuccessToast(SUCCESS_MESSAGE);
     },
     toggleFieldEditorModal: () => {
       clearFlashMessages();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -43,7 +43,7 @@ describe('SchemaLogic', () => {
   const {
     clearFlashMessages,
     flashAPIErrors,
-    setSuccessMessage,
+    flashSuccessToast,
     setErrorMessage,
   } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(SchemaLogic);
@@ -371,7 +371,7 @@ describe('SchemaLogic', () => {
             }
           );
           await nextTick();
-          expect(setSuccessMessage).toHaveBeenCalledWith(SCHEMA_FIELD_ADDED_MESSAGE);
+          expect(flashSuccessToast).toHaveBeenCalledWith(SCHEMA_FIELD_ADDED_MESSAGE);
           expect(onSchemaSetSuccessSpy).toHaveBeenCalledWith(serverResponse);
         });
 
@@ -430,7 +430,7 @@ describe('SchemaLogic', () => {
             }
           );
           await nextTick();
-          expect(setSuccessMessage).toHaveBeenCalledWith(SCHEMA_UPDATED_MESSAGE);
+          expect(flashSuccessToast).toHaveBeenCalledWith(SCHEMA_UPDATED_MESSAGE);
           expect(onSchemaSetSuccessSpy).toHaveBeenCalledWith(serverResponse);
         });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -13,7 +13,7 @@ import { i18n } from '@kbn/i18n';
 import { ADD, UPDATE } from '../../../../../shared/constants/operations';
 import {
   flashAPIErrors,
-  setSuccessMessage,
+  flashSuccessToast,
   setErrorMessage,
   clearFlashMessages,
 } from '../../../../../shared/flash_messages';
@@ -346,7 +346,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
           body: JSON.stringify({ ...updatedSchema }),
         });
         actions.onSchemaSetSuccess(response);
-        setSuccessMessage(successMessage);
+        flashSuccessToast(successMessage);
       } catch (e) {
         window.scrollTo(0, 0);
         if (isAdding) {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
@@ -30,7 +30,6 @@ describe('SourceLogic', () => {
     clearFlashMessages,
     flashAPIErrors,
     flashSuccessToast,
-    setQueuedSuccessMessage,
     setErrorMessage,
   } = mockFlashMessageHelpers;
   const { navigateToUrl } = mockKibanaValues;
@@ -391,7 +390,7 @@ describe('SourceLogic', () => {
         expect(clearFlashMessages).toHaveBeenCalled();
         expect(http.delete).toHaveBeenCalledWith('/api/workplace_search/org/sources/123');
         await promise;
-        expect(setQueuedSuccessMessage).toHaveBeenCalled();
+        expect(flashSuccessToast).toHaveBeenCalled();
         expect(setButtonNotLoadingSpy).toHaveBeenCalled();
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
@@ -29,7 +29,7 @@ describe('SourceLogic', () => {
   const {
     clearFlashMessages,
     flashAPIErrors,
-    setSuccessMessage,
+    flashSuccessToast,
     setQueuedSuccessMessage,
     setErrorMessage,
   } = mockFlashMessageHelpers;
@@ -79,7 +79,7 @@ describe('SourceLogic', () => {
         ...contentSource,
         name: NAME,
       });
-      expect(setSuccessMessage).toHaveBeenCalled();
+      expect(flashSuccessToast).toHaveBeenCalled();
     });
 
     it('setSearchResults', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import { DEFAULT_META } from '../../../shared/constants';
 import {
   flashAPIErrors,
-  setSuccessMessage,
+  flashSuccessToast,
   setErrorMessage,
   setQueuedSuccessMessage,
   clearFlashMessages,
@@ -256,7 +256,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
       }
     },
     onUpdateSourceName: (name: string) => {
-      setSuccessMessage(
+      flashSuccessToast(
         i18n.translate(
           'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceNameChanged',
           {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -14,7 +14,6 @@ import {
   flashAPIErrors,
   flashSuccessToast,
   setErrorMessage,
-  setQueuedSuccessMessage,
   clearFlashMessages,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
@@ -239,7 +238,8 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
 
       try {
         const response = await HttpLogic.values.http.delete(route);
-        setQueuedSuccessMessage(
+        KibanaLogic.values.navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
+        flashSuccessToast(
           i18n.translate(
             'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceRemoved',
             {
@@ -248,7 +248,6 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
             }
           )
         );
-        KibanaLogic.values.navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
       } catch (e) {
         flashAPIErrors(e);
       } finally {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.test.ts
@@ -23,7 +23,7 @@ import { SourcesLogic, fetchSourceStatuses, POLLING_INTERVAL } from './sources_l
 
 describe('SourcesLogic', () => {
   const { http } = mockHttpValues;
-  const { flashAPIErrors, setQueuedSuccessMessage } = mockFlashMessageHelpers;
+  const { flashAPIErrors, flashSuccessToast } = mockFlashMessageHelpers;
   const { mount, unmount } = new LogicMounter(SourcesLogic);
 
   const contentSource = contentSources[0];
@@ -126,7 +126,7 @@ describe('SourcesLogic', () => {
           additionalConfiguration: false,
           serviceType: 'custom',
         });
-        expect(setQueuedSuccessMessage).toHaveBeenCalledWith('Successfully connected source. ');
+        expect(flashSuccessToast).toHaveBeenCalledWith('Successfully connected source. ');
       });
 
       it('unconfigured', () => {
@@ -138,7 +138,7 @@ describe('SourcesLogic', () => {
           additionalConfiguration: true,
           serviceType: 'custom',
         });
-        expect(setQueuedSuccessMessage).toHaveBeenCalledWith(
+        expect(flashSuccessToast).toHaveBeenCalledWith(
           'Successfully connected source. This source requires additional configuration.'
         );
       });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.ts
@@ -10,7 +10,7 @@ import { cloneDeep, findIndex } from 'lodash';
 
 import { i18n } from '@kbn/i18n';
 
-import { flashAPIErrors, setQueuedSuccessMessage } from '../../../shared/flash_messages';
+import { flashAPIErrors, flashSuccessToast } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { AppLogic } from '../../app_logic';
 import { Connector, ContentSourceDetails, ContentSourceStatus, SourceDataItem } from '../../types';
@@ -222,7 +222,7 @@ export const SourcesLogic = kea<MakeLogicType<ISourcesValues, ISourcesActions>>(
         }
       );
 
-      setQueuedSuccessMessage(
+      flashSuccessToast(
         [
           successfullyConnectedMessage,
           additionalConfiguration ? additionalConfigurationMessage : '',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -27,7 +27,7 @@ describe('GroupLogic', () => {
   const {
     clearFlashMessages,
     flashAPIErrors,
-    setSuccessMessage,
+    flashSuccessToast,
     setQueuedSuccessMessage,
     setQueuedErrorMessage,
   } = mockFlashMessageHelpers;
@@ -255,7 +255,7 @@ describe('GroupLogic', () => {
 
         await nextTick();
         expect(onGroupNameChangedSpy).toHaveBeenCalledWith(group);
-        expect(setSuccessMessage).toHaveBeenCalledWith(
+        expect(flashSuccessToast).toHaveBeenCalledWith(
           'Successfully renamed this group to "group".'
         );
       });
@@ -286,7 +286,7 @@ describe('GroupLogic', () => {
 
         await nextTick();
         expect(onGroupSourcesSavedSpy).toHaveBeenCalledWith(group);
-        expect(setSuccessMessage).toHaveBeenCalledWith(
+        expect(flashSuccessToast).toHaveBeenCalledWith(
           'Successfully updated shared content sources.'
         );
       });
@@ -323,7 +323,7 @@ describe('GroupLogic', () => {
         });
 
         await nextTick();
-        expect(setSuccessMessage).toHaveBeenCalledWith(
+        expect(flashSuccessToast).toHaveBeenCalledWith(
           'Successfully updated shared source prioritization.'
         );
         expect(onGroupPrioritiesChangedSpy).toHaveBeenCalledWith(group);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -28,7 +28,6 @@ describe('GroupLogic', () => {
     clearFlashMessages,
     flashAPIErrors,
     flashSuccessToast,
-    setQueuedSuccessMessage,
     setQueuedErrorMessage,
   } = mockFlashMessageHelpers;
 
@@ -224,9 +223,7 @@ describe('GroupLogic', () => {
 
         await nextTick();
         expect(navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
-        expect(setQueuedSuccessMessage).toHaveBeenCalledWith(
-          'Group "group" was successfully deleted.'
-        );
+        expect(flashSuccessToast).toHaveBeenCalledWith('Group "group" was successfully deleted.');
       });
 
       it('handles error', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
@@ -13,7 +13,7 @@ import { i18n } from '@kbn/i18n';
 import {
   clearFlashMessages,
   flashAPIErrors,
-  setSuccessMessage,
+  flashSuccessToast,
   setQueuedSuccessMessage,
   setQueuedErrorMessage,
 } from '../../../shared/flash_messages';
@@ -231,7 +231,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
             values: { groupName: response.name },
           }
         );
-        setSuccessMessage(GROUP_RENAMED_MESSAGE);
+        flashSuccessToast(GROUP_RENAMED_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);
       }
@@ -256,7 +256,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
             defaultMessage: 'Successfully updated shared content sources.',
           }
         );
-        setSuccessMessage(GROUP_SOURCES_UPDATED_MESSAGE);
+        flashSuccessToast(GROUP_SOURCES_UPDATED_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);
       }
@@ -289,7 +289,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
           }
         );
 
-        setSuccessMessage(GROUP_PRIORITIZATION_UPDATED_MESSAGE);
+        flashSuccessToast(GROUP_PRIORITIZATION_UPDATED_MESSAGE);
         actions.onGroupPrioritiesChanged(response);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
@@ -14,7 +14,6 @@ import {
   clearFlashMessages,
   flashAPIErrors,
   flashSuccessToast,
-  setQueuedSuccessMessage,
   setQueuedErrorMessage,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
@@ -206,7 +205,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
           }
         );
 
-        setQueuedSuccessMessage(GROUP_DELETED_MESSAGE);
+        flashSuccessToast(GROUP_DELETED_MESSAGE);
         KibanaLogic.values.navigateToUrl(GROUPS_PATH);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
@@ -15,7 +15,7 @@ import { DEFAULT_META } from '../../../shared/constants';
 import {
   clearFlashMessages,
   flashAPIErrors,
-  setSuccessMessage,
+  flashSuccessToast,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { ContentSource, Group, User } from '../../types';
@@ -328,7 +328,7 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
           }
         );
 
-        setSuccessMessage(SUCCESS_MESSAGE);
+        flashSuccessToast(SUCCESS_MESSAGE);
         actions.setNewGroup(response);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -10,7 +10,7 @@ import { kea, MakeLogicType } from 'kea';
 import {
   clearFlashMessages,
   flashAPIErrors,
-  setSuccessMessage,
+  flashSuccessToast,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import {
@@ -397,7 +397,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       try {
         await http.delete(route);
         actions.initializeRoleMappings();
-        setSuccessMessage(ROLE_MAPPING_DELETED_MESSAGE);
+        flashSuccessToast(ROLE_MAPPING_DELETED_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);
       }
@@ -435,7 +435,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       try {
         await request;
         actions.initializeRoleMappings();
-        setSuccessMessage(SUCCESS_MESSAGE);
+        flashSuccessToast(SUCCESS_MESSAGE);
       } catch (e) {
         actions.setRoleMappingErrors(e?.body?.attributes?.errors);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -11,7 +11,7 @@ import { isEqual } from 'lodash';
 
 import {
   clearFlashMessages,
-  setSuccessMessage,
+  flashSuccessToast,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
@@ -153,7 +153,7 @@ export const SecurityLogic = kea<MakeLogicType<SecurityValues, SecurityActions>>
       try {
         const response = await http.patch(route, { body });
         actions.setSourceRestrictionsUpdated(response);
-        setSuccessMessage(SOURCE_RESTRICTIONS_SUCCESS_MESSAGE);
+        flashSuccessToast(SOURCE_RESTRICTIONS_SUCCESS_MESSAGE);
         AppLogic.actions.setSourceRestriction(isEnabled);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
@@ -22,12 +22,7 @@ import { SettingsLogic } from './settings_logic';
 describe('SettingsLogic', () => {
   const { http } = mockHttpValues;
   const { navigateToUrl } = mockKibanaValues;
-  const {
-    clearFlashMessages,
-    flashAPIErrors,
-    flashSuccessToast,
-    setQueuedSuccessMessage,
-  } = mockFlashMessageHelpers;
+  const { clearFlashMessages, flashAPIErrors, flashSuccessToast } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(SettingsLogic);
   const ORG_NAME = 'myOrg';
   const defaultValues = {
@@ -309,7 +304,7 @@ describe('SettingsLogic', () => {
 
         await nextTick();
         expect(navigateToUrl).toHaveBeenCalledWith('/settings/connectors');
-        expect(setQueuedSuccessMessage).toHaveBeenCalled();
+        expect(flashSuccessToast).toHaveBeenCalled();
       });
 
       it('handles error', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -11,7 +11,6 @@ import { i18n } from '@kbn/i18n';
 
 import {
   clearFlashMessages,
-  setQueuedSuccessMessage,
   flashSuccessToast,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
@@ -290,7 +289,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
       try {
         await http.delete(route);
         KibanaLogic.values.navigateToUrl(ORG_SETTINGS_CONNECTORS_PATH);
-        setQueuedSuccessMessage(
+        flashSuccessToast(
           i18n.translate('xpack.enterpriseSearch.workplaceSearch.settings.configRemoved.message', {
             defaultMessage: 'Successfully removed configuration for {name}.',
             values: { name },


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1971

## Summary

This PR replaces all usages of success flash messages, and queued success flash messages with Toasts, to align with Kibana guidelines and App Search.

![2021-08-17_10-44-53 (1)](https://user-images.githubusercontent.com/1869731/129758142-ab9bb2ff-240b-4594-94d5-62003570f0b5.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
