### PR TITLE
Add debounce to the status observers to reduce unnecessary CPU loops

### DIFF
--- a/src/core/server/status/plugins_status.ts
+++ b/src/core/server/status/plugins_status.ts
@@ -76,7 +76,7 @@ export class PluginsStatusService {
 
   public getDerivedStatus$(plugin: PluginName): Observable<ServiceStatus> {
     return this.update$.pipe(
-      debounceTime(25),
+      debounceTime(25), // Avoid calling the plugin's custom status logic for every plugin that depends on it.
       switchMap(() => {
         // Only go up the dependency tree if any of this plugin's dependencies have a custom status
         // Helps eliminate memory overhead of creating thousands of Observables unnecessarily.
@@ -104,7 +104,6 @@ export class PluginsStatusService {
     }
 
     return this.update$.pipe(
-      debounceTime(25),
       switchMap(() => {
         const pluginStatuses = plugins
           .map((depName) => {

--- a/src/core/server/status/plugins_status.ts
+++ b/src/core/server/status/plugins_status.ts
@@ -76,6 +76,7 @@ export class PluginsStatusService {
 
   public getDerivedStatus$(plugin: PluginName): Observable<ServiceStatus> {
     return this.update$.pipe(
+      debounceTime(25),
       switchMap(() => {
         // Only go up the dependency tree if any of this plugin's dependencies have a custom status
         // Helps eliminate memory overhead of creating thousands of Observables unnecessarily.
@@ -103,6 +104,7 @@ export class PluginsStatusService {
     }
 
     return this.update$.pipe(
+      debounceTime(25),
       switchMap(() => {
         const pluginStatuses = plugins
           .map((depName) => {


### PR DESCRIPTION
## Summary

Resolves #108950

During plugin registration, plugins can specify their own custom logic to declare the status. The status service was triggering an update of its observers for each registration, using unnecessary extra CPU loops.

This PR adds `debounceTime` to swallow any requests happening too close in time. 

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
