### PR TITLE
[7.14] [Actions][Docs] Updated ServiceNow docs with information about the user permissions for making CRUD operations. (#108642)

### DIFF
--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -18,6 +18,8 @@ URL::       ServiceNow instance URL.
 Username::  Username for HTTP Basic authentication.
 Password::  Password for HTTP Basic authentication.
 
+The ServiceNow user requires at minimum read, create, and update access to the Incident table and read access to the https://docs.servicenow.com/bundle/paris-platform-administration/page/administer/localization/reference/r_ChoicesTable.html[sys_choice]. If you don't provide access to sys_choice, then the choices will not render.
+
 [float]
 [[servicenow-connector-networking-configuration]]
 ==== Connector networking configuration


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Actions][Docs] Updated ServiceNow docs with information about the user permissions for making CRUD operations. (#108642)