### PR TITLE
[Security Solution] investigate in timeline button is unresponsive

### DIFF
--- a/x-pack/plugins/security_solution/public/common/mock/mock_timelines_plugin.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/mock_timelines_plugin.tsx
@@ -19,6 +19,12 @@ export const mockTimelines = {
     .fn()
     .mockReturnValue(<div data-test-subj="add-to-case-action">{'Add to case'}</div>),
   getAddToCaseAction: jest.fn(),
-  getAddToExistingCaseButton: jest.fn(),
-  getAddToNewCaseButton: jest.fn(),
+  getAddToExistingCaseButton: jest
+    .fn()
+    .mockReturnValue(
+      <div data-test-subj="add-to-existing-case-action">{'Add to existing case'}</div>
+    ),
+  getAddToNewCaseButton: jest
+    .fn()
+    .mockReturnValue(<div data-test-subj="add-to-new-case-action">{'Add to new case'}</div>),
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_utility_bar/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_utility_bar/translations.ts
@@ -56,13 +56,6 @@ export const CLEAR_SELECTION = i18n.translate(
   }
 );
 
-export const TAKE_ACTION = i18n.translate(
-  'xpack.securitySolution.detectionEngine.alerts.utilityBar.takeActionTitle',
-  {
-    defaultMessage: 'Take action',
-  }
-);
-
 export const BATCH_ACTIONS = i18n.translate(
   'xpack.securitySolution.detectionEngine.alerts.utilityBar.batchActionsTitle',
   {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_utility_bar/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_utility_bar/translations.ts
@@ -56,6 +56,13 @@ export const CLEAR_SELECTION = i18n.translate(
   }
 );
 
+export const TAKE_ACTION = i18n.translate(
+  'xpack.securitySolution.detectionEngine.alerts.utilityBar.takeActionTitle',
+  {
+    defaultMessage: 'Take action',
+  }
+);
+
 export const BATCH_ACTIONS = i18n.translate(
   'xpack.securitySolution.detectionEngine.alerts.utilityBar.batchActionsTitle',
   {

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.test.tsx
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { ReactElement } from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+import { TakeActionDropdown, TakeActionDropdownProps } from '.';
+import { mockAlertDetailsData } from '../../../common/components/event_details/__mocks__';
+import { mockEcsDataWithAlert } from '../../../common/mock/mock_detection_alerts';
+import { TimelineEventsDetailsItem } from '../../../../common';
+import { TestProviders } from '../../../common/mock';
+import { mockTimelines } from '../../../common/mock/mock_timelines_plugin';
+import { createStartServicesMock } from '../../../common/lib/kibana/kibana_react.mock';
+import { useKibana } from '../../../common/lib/kibana';
+import { EuiContextMenuPanelDescriptor, EuiContextMenuPanelItemDescriptor } from '@elastic/eui';
+
+jest.mock('../../../common/hooks/endpoint/use_isolate_privileges', () => ({
+  useIsolationPrivileges: jest.fn().mockReturnValue({ isAllowed: true }),
+}));
+jest.mock('../../../common/lib/kibana', () => ({
+  useKibana: jest.fn(),
+  useGetUserCasesPermissions: jest.fn().mockReturnValue({}),
+}));
+jest.mock('../../../cases/components/use_insert_timeline');
+
+jest.mock('../../../common/hooks/use_experimental_features', () => ({
+  useIsExperimentalFeatureEnabled: jest.fn().mockReturnValue(true),
+}));
+jest.mock('@kbn/alerts', () => {
+  return { useGetUserAlertsPermissions: jest.fn().mockReturnValue({ crud: true }) };
+});
+
+jest.mock('../../../common/utils/endpoint_alert_check', () => {
+  return { endpointAlertCheck: jest.fn().mockReturnValue(true) };
+});
+
+jest.mock('../../../../common/endpoint/service/host_isolation/utils', () => {
+  return {
+    isIsolationSupported: jest.fn().mockReturnValue(true),
+  };
+});
+
+interface Panel extends EuiContextMenuPanelDescriptor {
+  content: ReactElement<Panel>;
+  items: EuiContextMenuPanelItemDescriptor[];
+}
+
+interface CaseActionPanel extends EuiContextMenuPanelDescriptor {
+  content: Array<ReactElement<CaseActionPanel>>;
+  children: ReactElement;
+}
+
+describe('take action dropdown', () => {
+  const defaultProps: TakeActionDropdownProps = {
+    detailsData: mockAlertDetailsData as TimelineEventsDetailsItem[],
+    ecsData: mockEcsDataWithAlert,
+    handleOnEventClosed: jest.fn(),
+    indexName: 'index',
+    isHostIsolationPanelOpen: false,
+    loadingEventDetails: false,
+    onAddEventFilterClick: jest.fn(),
+    onAddExceptionTypeClick: jest.fn(),
+    onAddIsolationStatusClick: jest.fn(),
+    refetch: jest.fn(),
+    timelineId: 'timelineId',
+  };
+
+  beforeAll(() => {
+    (useKibana as jest.Mock).mockImplementation(() => {
+      const mockStartServicesMock = createStartServicesMock();
+
+      return {
+        services: {
+          ...mockStartServicesMock,
+          timelines: { ...mockTimelines },
+          application: {
+            capabilities: { siem: { crud_alerts: true, read_alerts: true } },
+          },
+        },
+      };
+    });
+  });
+
+  test('should render takeActionButton', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <TakeActionDropdown {...defaultProps} />
+      </TestProviders>
+    );
+    expect(wrapper.find('[data-test-subj="take-action-dropdown-btn"]').exists()).toBeTruthy();
+  });
+
+  test('should render takeActionButton with correct text', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <TakeActionDropdown {...defaultProps} />
+      </TestProviders>
+    );
+    expect(wrapper.find('[data-test-subj="take-action-dropdown-btn"]').first().text()).toEqual(
+      'Take action'
+    );
+  });
+
+  describe('should render take action items', () => {
+    const testProps = {
+      ...defaultProps,
+    };
+    let wrapper: ReactWrapper;
+    beforeAll(() => {
+      wrapper = mount(
+        <TestProviders>
+          <TakeActionDropdown {...testProps} />
+        </TestProviders>
+      );
+      wrapper.find('button[data-test-subj="take-action-dropdown-btn"]').simulate('click');
+    });
+
+    test('should render "Change alert status"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[0].items[0].name
+      ).toEqual('Change alert status');
+    });
+
+    test('should render "Add Endpoint exception"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[0].items[1].name
+      ).toEqual('Add Endpoint exception');
+    });
+    test('should render "Add rule exception"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[0].items[2].name
+      ).toEqual('Add rule exception');
+    });
+    test('should render "Isolate host"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[0].items[3].name
+      ).toEqual('Isolate host');
+    });
+    test('should render "Investigate in timeline"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[0].items[4].name
+      ).toEqual('Investigate in timeline');
+    });
+  });
+
+  describe('should render nested menu items', () => {
+    const testProps = {
+      ...defaultProps,
+    };
+    let wrapper: ReactWrapper;
+    beforeAll(() => {
+      wrapper = mount(
+        <TestProviders>
+          <TakeActionDropdown {...testProps} />
+        </TestProviders>
+      );
+      wrapper.find('button[data-test-subj="take-action-dropdown-btn"]').simulate('click');
+    });
+
+    test('should render "Change alert status" title', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[1].title
+      ).toEqual('Change alert status');
+    });
+
+    test('should render "mark as acknowledge"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[1].content?.props.items[0].key
+      ).toEqual('acknowledge');
+    });
+
+    test('should render "mark as close"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[1].content?.props.items[1].key
+      ).toEqual('close');
+    });
+
+    test('should render "Add to case" title', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<Panel[]>('panels')[2].title
+      ).toEqual('Add to case');
+    });
+
+    test('should render "Add to existing case"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<CaseActionPanel[]>('panels')[2].content[0].props?.children.props['data-test-subj']
+      ).toEqual('add-to-existing-case-action');
+    });
+
+    test('should render "Add to new case"', () => {
+      expect(
+        wrapper
+          .find('EuiContextMenu[data-test-subj="takeActionPanelMenu"]')
+          .prop<CaseActionPanel[]>('panels')[2].content[1].props?.children.props['data-test-subj']
+      ).toEqual('add-to-new-case-action');
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -9,6 +9,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { EuiContextMenu, EuiContextMenuPanel, EuiButton, EuiPopover } from '@elastic/eui';
 import type { ExceptionListType } from '@kbn/securitysolution-io-ts-list-types';
 
+import { isEmpty } from 'lodash/fp';
 import { TAKE_ACTION } from '../alerts_table/alerts_utility_bar/translations';
 
 import { TimelineEventsDetailsItem, TimelineNonEcsData } from '../../../../common';
@@ -90,7 +91,9 @@ export const TakeActionDropdown = React.memo(
       [detailsData]
     );
 
-    const alertIds = useMemo(() => [actionsData.eventId], [actionsData.eventId]);
+    const alertIds = useMemo(() => (isEmpty(actionsData.eventId) ? null : [actionsData.eventId]), [
+      actionsData.eventId,
+    ]);
     const isEvent = actionsData.eventKind === 'event';
 
     const isEndpointAlert = useMemo((): boolean => {

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -8,8 +8,8 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { EuiContextMenu, EuiContextMenuPanel, EuiButton, EuiPopover } from '@elastic/eui';
 import type { ExceptionListType } from '@kbn/securitysolution-io-ts-list-types';
-
 import { isEmpty } from 'lodash/fp';
+import { TAKE_ACTION } from '../alerts_table/alerts_utility_bar/translations';
 import { TimelineEventsDetailsItem } from '../../../../common';
 import { useExceptionActions } from '../alerts_table/timeline_actions/use_add_exception_actions';
 import { useAlertsActions } from '../alerts_table/timeline_actions/use_alerts_actions';
@@ -20,7 +20,7 @@ import { useInsertTimeline } from '../../../cases/components/use_insert_timeline
 import { addToCaseActionItem } from './helpers';
 import { useEventFilterAction } from '../alerts_table/timeline_actions/use_event_filter_action';
 import { useHostIsolationAction } from '../host_isolation/use_host_isolation_action';
-import { CHANGE_ALERT_STATUS, TAKE_ACTION } from './translations';
+import { CHANGE_ALERT_STATUS } from './translations';
 import { getFieldValue } from '../host_isolation/helpers';
 import type { Ecs } from '../../../../common/ecs';
 import { Status } from '../../../../common/detection_engine/schemas/common/schemas';

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/translations.ts
@@ -13,10 +13,3 @@ export const CHANGE_ALERT_STATUS = i18n.translate(
     defaultMessage: 'Change alert status',
   }
 );
-
-export const TAKE_ACTION = i18n.translate(
-  'xpack.securitySolution.endpoint.takeAction.takeActionTitle',
-  {
-    defaultMessage: 'Take action',
-  }
-);

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/translations.ts
@@ -13,3 +13,10 @@ export const CHANGE_ALERT_STATUS = i18n.translate(
     defaultMessage: 'Change alert status',
   }
 );
+
+export const TAKE_ACTION = i18n.translate(
+  'xpack.securitySolution.endpoint.takeAction.takeActionTitle',
+  {
+    defaultMessage: 'Take action',
+  }
+);

--- a/x-pack/plugins/timelines/public/mock/plugin_mock.tsx
+++ b/x-pack/plugins/timelines/public/mock/plugin_mock.tsx
@@ -28,4 +28,8 @@ export const createTGridMocks = () => ({
   getUseAddToTimeline: () => useAddToTimeline,
   getUseAddToTimelineSensor: () => useAddToTimelineSensor,
   getUseDraggableKeyboardWrapper: () => useDraggableKeyboardWrapper,
+  // eslint-disable-next-line react/display-name
+  getAddToExistingCaseButton: () => <div data-test-subj="add-to-existing-case" />,
+  // eslint-disable-next-line react/display-name
+  getAddToNewCaseButton: () => <div data-test-subj="add-to-new-case" />,
 });


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/108901

Steps to verify:
1. Go to alerts page, in alerts table, click on any `view details` button in the row.
2. Find `take action` button in the flyout, and click on it
3. Click on `Investigate button`, and find that the timeline should be expanded with the correct event id.

![Kapture 2021-08-19 at 18 49 28](https://user-images.githubusercontent.com/6295984/130119070-ad326e78-6c01-4ac8-a078-87f6b18371f2.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


