### PR TITLE
[CTI] add hover to threat summary items on alert summary flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -149,6 +149,7 @@ const columns: Array<EuiBasicTableColumn<ThreatSummaryItem>> = [
     name: '',
   },
   {
+    className: 'flyoutOverviewDescription',
     field: 'description',
     truncateText: false,
     render: EnrichmentDescription,


### PR DESCRIPTION
## Summary

Adds feature in which hovering on threat summary item now shows the action menu (on the side). Previously only hovering on the empty space where the action menu was hidden displayed the action menu.

<img width="562" alt="Screen Shot 2021-08-17 at 4 32 57 PM" src="https://user-images.githubusercontent.com/18617331/129796896-f1e3d198-97fb-408f-9148-702d23e6b809.png">
