### PR TITLE
Putting the deduplication controls inside a datapanel.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/deduplication_panel/deduplication_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/deduplication_panel/deduplication_panel.test.tsx
@@ -26,6 +26,8 @@ import {
 
 import { mountWithIntl, rerender } from '../../../../../test_helpers';
 
+import { DataPanel } from '../../../data_panel';
+
 import { DeduplicationPanel } from './deduplication_panel';
 
 const MOCK_ACTIONS = {
@@ -60,7 +62,7 @@ describe('DeduplicationPanel', () => {
   it('contains a button to reset to defaults', () => {
     const wrapper = shallow(<DeduplicationPanel />);
 
-    wrapper.find(EuiButton).simulate('click');
+    wrapper.find(DataPanel).dive().find(EuiButton).simulate('click');
 
     expect(MOCK_ACTIONS.submitDeduplicationUpdate).toHaveBeenCalledWith(MOCK_VALUES.domain, {
       fields: [],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/deduplication_panel/deduplication_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/deduplication_panel/deduplication_panel.tsx
@@ -21,8 +21,6 @@ import {
   EuiSelectable,
   EuiSpacer,
   EuiSwitch,
-  EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 
 import { EuiSelectableLIOption } from '@elastic/eui/src/components/selectable/selectable_option';
@@ -30,6 +28,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 import { DOCS_PREFIX } from '../../../../routes';
+import { DataPanel } from '../../../data_panel';
 import { CrawlerSingleDomainLogic } from '../../crawler_single_domain_logic';
 
 import { getCheckedOptionLabels, getSelectableOptions } from './utils';
@@ -52,62 +51,56 @@ export const DeduplicationPanel: React.FC = () => {
   const selectableOptions = getSelectableOptions(domain, showAllFields);
 
   return (
-    <div className="deduplicationPanel">
-      <EuiFlexGroup direction="row" alignItems="stretch">
-        <EuiFlexItem>
-          <EuiTitle size="s">
-            <h2>
-              {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.title', {
-                defaultMessage: 'Duplicate document handling',
-              })}
-            </h2>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            color="warning"
-            iconType="refresh"
-            size="s"
-            onClick={() => submitDeduplicationUpdate(domain, { fields: [] })}
-            disabled={deduplicationFields.length === 0}
-          >
-            {i18n.translate(
-              'xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.resetToDefaultsButtonLabel',
-              {
-                defaultMessage: 'Reset to defaults',
-              }
-            )}
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <EuiText size="s" color="subdued">
-        <p>
-          <FormattedMessage
-            id="xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.description"
-            defaultMessage="The web crawler only indexes unique pages. Choose which fields the crawler should use when
-            considering which pages are duplicates. Deselect all schema fields to allow duplicate
-            documents on this domain. {documentationLink}."
-            values={{
-              documentationLink: (
-                <EuiLink
-                  href={`${DOCS_PREFIX}/web-crawler-reference.html#web-crawler-reference-content-deduplication`}
-                  target="_blank"
-                  external
-                >
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.learnMoreMessage',
-                    {
-                      defaultMessage: 'Learn more about content hashing',
-                    }
-                  )}
-                </EuiLink>
-              ),
-            }}
-          />
-        </p>
-      </EuiText>
-      <EuiSpacer size="l" />
+    <DataPanel
+      hasBorder
+      title={
+        <h2>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.title', {
+            defaultMessage: 'Duplicate document handling',
+          })}
+        </h2>
+      }
+      action={
+        <EuiButton
+          color="warning"
+          iconType="refresh"
+          size="s"
+          onClick={() => submitDeduplicationUpdate(domain, { fields: [] })}
+          disabled={deduplicationFields.length === 0}
+        >
+          {i18n.translate(
+            'xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.resetToDefaultsButtonLabel',
+            {
+              defaultMessage: 'Reset to defaults',
+            }
+          )}
+        </EuiButton>
+      }
+      subtitle={
+        <FormattedMessage
+          id="xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.description"
+          defaultMessage="The web crawler only indexes unique pages. Choose which fields the crawler should use when
+          considering which pages are duplicates. Deselect all schema fields to allow duplicate
+          documents on this domain. {documentationLink}."
+          values={{
+            documentationLink: (
+              <EuiLink
+                href={`${DOCS_PREFIX}/web-crawler-reference.html#web-crawler-reference-content-deduplication`}
+                target="_blank"
+                external
+              >
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.crawler.deduplicationPanel.learnMoreMessage',
+                  {
+                    defaultMessage: 'Learn more about content hashing',
+                  }
+                )}
+              </EuiLink>
+            ),
+          }}
+        />
+      }
+    >
       <EuiSwitch
         label="Prevent duplicate documents"
         checked={deduplicationEnabled}
@@ -117,6 +110,7 @@ export const DeduplicationPanel: React.FC = () => {
             : submitDeduplicationUpdate(domain, { enabled: true })
         }
       />
+      <EuiSpacer />
       <EuiFlexGroup>
         <EuiFlexItem>
           <div className="selectableWrapper">
@@ -209,6 +203,6 @@ export const DeduplicationPanel: React.FC = () => {
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>
-    </div>
+    </DataPanel>
   );
 };


### PR DESCRIPTION
## Summary

Puts the deduplication settings inside of a data panel so that it matches the standalone app as well as the modules above.

<img width="948" alt="image" src="https://user-images.githubusercontent.com/739960/129803202-db48fbbf-8d81-47b9-be04-5443d6098f8d.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
