### PR TITLE
[7.14] chore(NA): moving @kbn/legacy-logging to babel transpiler (#108703)

### DIFF
--- a/packages/kbn-legacy-logging/.babelrc
+++ b/packages/kbn-legacy-logging/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-legacy-logging/BUILD.bazel
+++ b/packages/kbn-legacy-logging/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-legacy-logging"
 PKG_REQUIRE_NAME = "@kbn/legacy-logging"
@@ -23,7 +24,7 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md"
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-config-schema",
   "//packages/kbn-utils",
   "@npm//@elastic/numeral",
@@ -37,6 +38,13 @@ SRC_DEPS = [
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-config-schema",
+  "//packages/kbn-utils",
+  "@npm//@elastic/numeral",
+  "@npm//chokidar",
+  "@npm//query-string",
+  "@npm//rxjs",
+  "@npm//tslib",
   "@npm//@types/hapi__hapi",
   "@npm//@types/hapi__podium",
   "@npm//@types/jest",
@@ -45,7 +53,11 @@ TYPES_DEPS = [
   "@npm//@types/node",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -56,14 +68,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -72,7 +85,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-legacy-logging/package.json
+++ b/packages/kbn-legacy-logging/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts"
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts"
 }

--- a/packages/kbn-legacy-logging/tsconfig.json
+++ b/packages/kbn-legacy-logging/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "target",
-    "stripInternal": false,
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-legacy-logging/src",
+    "stripInternal": false,
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/legacy-logging to babel transpiler (#108703)