### PR TITLE
[Security Solution]  TopN chart styling issue

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.test.tsx
@@ -69,7 +69,7 @@ describe('show topN button', () => {
   });
 
   describe('tooltip', () => {
-    test('should tooltip by default', () => {
+    test('should show tooltip by default', () => {
       const wrapper = mount(
         <TestProviders>
           <ShowTopNButton {...defaultProps} />

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.test.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiButtonEmpty, EuiContextMenuItem } from '@elastic/eui';
+import { mount } from 'enzyme';
+import React from 'react';
+import { TestProviders } from '../../../mock';
+import { ShowTopNButton } from './show_top_n';
+
+describe('show topN button', () => {
+  const defaultProps = {
+    field: 'signal.rule.name',
+    onClick: jest.fn(),
+    ownFocus: false,
+    showTopN: false,
+    timelineId: 'timeline-1',
+    value: ['rule_name'],
+  };
+
+  describe('button', () => {
+    test('should show EuiButtonIcon by default', () => {
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...defaultProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('EuiButtonIcon').exists()).toBeTruthy();
+      expect(wrapper.find('[data-test-subj="show-top-field"]').first().prop('iconType')).toEqual(
+        'visBarVertical'
+      );
+    });
+
+    test('should support EuiButtonEmpty', () => {
+      const testProps = {
+        ...defaultProps,
+        Component: EuiButtonEmpty,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('EuiButtonIcon').exists()).toBeFalsy();
+      expect(wrapper.find('EuiButtonEmpty').exists()).toBeTruthy();
+      expect(wrapper.find('[data-test-subj="show-top-field"]').first().prop('iconType')).toEqual(
+        'visBarVertical'
+      );
+    });
+
+    test('should support EuiContextMenuItem', () => {
+      const testProps = {
+        ...defaultProps,
+        Component: EuiContextMenuItem,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('EuiButtonIcon').exists()).toBeFalsy();
+      expect(wrapper.find('EuiContextMenuItem').exists()).toBeTruthy();
+      expect(wrapper.find('[data-test-subj="show-top-field"]').first().prop('icon')).toEqual(
+        'visBarVertical'
+      );
+    });
+  });
+
+  describe('tooltip', () => {
+    test('should tooltip by default', () => {
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...defaultProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('EuiToolTip').exists()).toBeTruthy();
+    });
+
+    test('should hide tooltip when topN is showed', () => {
+      const testProps = {
+        ...defaultProps,
+        showTopN: true,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('EuiToolTip').exists()).toBeFalsy();
+    });
+
+    test('should hide tooltip by setting showTooltip to false', () => {
+      const testProps = {
+        ...defaultProps,
+        showTooltip: false,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('EuiToolTip').exists()).toBeFalsy();
+    });
+  });
+
+  describe('popover', () => {
+    test('should be able to show topN without a popover', () => {
+      const testProps = {
+        ...defaultProps,
+        enablePopOver: false,
+        showTopN: true,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('[data-test-subj="top-n"]').exists()).toBeTruthy();
+      expect(wrapper.find('[data-test-subj="showTopNContainer"]').exists()).toBeFalsy();
+    });
+    test('should be able to show topN within a popover', () => {
+      const testProps = {
+        ...defaultProps,
+        enablePopOver: true,
+        showTopN: true,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('[data-test-subj="top-n"]').exists()).toBeTruthy();
+      expect(wrapper.find('[data-test-subj="showTopNContainer"]').exists()).toBeTruthy();
+    });
+  });
+
+  describe('topN', () => {
+    test('should render with correct props', () => {
+      const onFilterAdded = jest.fn();
+      const testProps = {
+        ...defaultProps,
+        enablePopOver: true,
+        showTopN: true,
+        onFilterAdded,
+      };
+      const wrapper = mount(
+        <TestProviders>
+          <ShowTopNButton {...testProps} />
+        </TestProviders>
+      );
+      expect(wrapper.find('[data-test-subj="top-n"]').prop('field')).toEqual(testProps.field);
+      expect(wrapper.find('[data-test-subj="top-n"]').prop('value')).toEqual(testProps.value);
+      expect(wrapper.find('[data-test-subj="top-n"]').prop('toggleTopN')).toEqual(
+        testProps.onClick
+      );
+      expect(wrapper.find('[data-test-subj="top-n"]').prop('timelineId')).toEqual(
+        testProps.timelineId
+      );
+      expect(wrapper.find('[data-test-subj="top-n"]').prop('onFilterAdded')).toEqual(
+        testProps.onFilterAdded
+      );
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
@@ -29,6 +29,9 @@ const SHOW_TOP = (fieldName: string) =>
   });
 
 interface Props {
+  /** When `Component` is used with `EuiDataGrid`; the grid keeps a reference to `Component` for show / hide functionality.
+   * When `Component` is used with `EuiContextMenu`, we pass EuiContextMenuItem to render the right style.
+   */
   Component?: typeof EuiButtonEmpty | typeof EuiButtonIcon | typeof EuiContextMenuItem;
   enablePopOver?: boolean;
   field: string;

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
@@ -6,7 +6,13 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiButtonEmpty, EuiButtonIcon, EuiContextMenuItem, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiPopover,
+  EuiButtonIcon,
+  EuiContextMenuItem,
+  EuiToolTip,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { StatefulTopN } from '../../top_n';
 import { TimelineId } from '../../../../../common/types/timeline';
@@ -25,6 +31,7 @@ const SHOW_TOP = (fieldName: string) =>
 interface Props {
   /** `Component` is only used with `EuiDataGrid`; the grid keeps a reference to `Component` for show / hide functionality */
   Component?: typeof EuiButtonEmpty | typeof EuiButtonIcon | typeof EuiContextMenuItem;
+  enablePopOver?: boolean;
   field: string;
   onClick: () => void;
   onFilterAdded?: () => void;
@@ -38,6 +45,7 @@ interface Props {
 export const ShowTopNButton: React.FC<Props> = React.memo(
   ({
     Component,
+    enablePopOver,
     field,
     onClick,
     onFilterAdded,
@@ -84,16 +92,35 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
       [Component, field, onClick]
     );
 
+    const topNPannel = useMemo(
+      () => (
+        <StatefulTopN
+          browserFields={browserFields}
+          field={field}
+          indexPattern={indexPattern}
+          onFilterAdded={onFilterAdded}
+          timelineId={timelineId ?? undefined}
+          toggleTopN={onClick}
+          value={value}
+        />
+      ),
+      [browserFields, field, indexPattern, onClick, onFilterAdded, timelineId, value]
+    );
+
     return showTopN ? (
-      <StatefulTopN
-        browserFields={browserFields}
-        field={field}
-        indexPattern={indexPattern}
-        onFilterAdded={onFilterAdded}
-        timelineId={timelineId ?? undefined}
-        toggleTopN={onClick}
-        value={value}
-      />
+      enablePopOver ? (
+        <EuiPopover
+          button={button}
+          isOpen={showTopN}
+          closePopover={onClick}
+          panelClassName="withHoverActions__popover"
+          data-test-subj="showTopNContainer"
+        >
+          {topNPannel}
+        </EuiPopover>
+      ) : (
+        topNPannel
+      )
     ) : showTooltip ? (
       <EuiToolTip
         content={

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/actions/show_top_n.tsx
@@ -29,7 +29,6 @@ const SHOW_TOP = (fieldName: string) =>
   });
 
 interface Props {
-  /** `Component` is only used with `EuiDataGrid`; the grid keeps a reference to `Component` for show / hide functionality */
   Component?: typeof EuiButtonEmpty | typeof EuiButtonIcon | typeof EuiContextMenuItem;
   enablePopOver?: boolean;
   field: string;
@@ -66,7 +65,7 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
         : SourcererScopeName.default;
     const { browserFields, indexPattern } = useSourcererScope(activeScope);
 
-    const button = useMemo(
+    const basicButton = useMemo(
       () =>
         Component ? (
           <Component
@@ -92,6 +91,30 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
       [Component, field, onClick]
     );
 
+    const button = useMemo(
+      () =>
+        showTooltip && !showTopN ? (
+          <EuiToolTip
+            content={
+              <TooltipWithKeyboardShortcut
+                additionalScreenReaderOnlyContext={getAdditionalScreenReaderOnlyContext({
+                  field,
+                  value,
+                })}
+                content={SHOW_TOP(field)}
+                shortcut={SHOW_TOP_N_KEYBOARD_SHORTCUT}
+                showShortcut={ownFocus}
+              />
+            }
+          >
+            {basicButton}
+          </EuiToolTip>
+        ) : (
+          basicButton
+        ),
+      [basicButton, field, ownFocus, showTooltip, showTopN, value]
+    );
+
     const topNPannel = useMemo(
       () => (
         <StatefulTopN
@@ -110,7 +133,7 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
     return showTopN ? (
       enablePopOver ? (
         <EuiPopover
-          button={button}
+          button={basicButton}
           isOpen={showTopN}
           closePopover={onClick}
           panelClassName="withHoverActions__popover"
@@ -121,22 +144,6 @@ export const ShowTopNButton: React.FC<Props> = React.memo(
       ) : (
         topNPannel
       )
-    ) : showTooltip ? (
-      <EuiToolTip
-        content={
-          <TooltipWithKeyboardShortcut
-            additionalScreenReaderOnlyContext={getAdditionalScreenReaderOnlyContext({
-              field,
-              value,
-            })}
-            content={SHOW_TOP(field)}
-            shortcut={SHOW_TOP_N_KEYBOARD_SHORTCUT}
-            showShortcut={ownFocus}
-          />
-        }
-      >
-        {button}
-      </EuiToolTip>
     ) : (
       button
     );

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useRef } from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useHoverActionItems, UseHoverActionItemsProps } from './use_hover_action_items';
+import { useDeepEqualSelector } from '../../hooks/use_selector';
+import { DataProvider } from '../../../../common/types/timeline';
+
+jest.mock('../../lib/kibana');
+jest.mock('../../hooks/use_selector');
+jest.mock('../../containers/sourcerer', () => ({
+  useSourcererScope: jest.fn().mockReturnValue({ browserFields: {} }),
+}));
+
+describe('useHoverActionItems', () => {
+  const defaultProps: UseHoverActionItemsProps = ({
+    dataProvider: [{} as DataProvider],
+    defaultFocusedButtonRef: null,
+    field: 'signal.rule.name',
+    handleHoverActionClicked: jest.fn(),
+    isObjectArray: true,
+    ownFocus: false,
+    showTopN: false,
+    stKeyboardEvent: undefined,
+    toggleColumn: jest.fn(),
+    toggleTopN: jest.fn(),
+    values: ['rule name'],
+  } as unknown) as UseHoverActionItemsProps;
+
+  beforeEach(() => {
+    (useDeepEqualSelector as jest.Mock).mockImplementation((cb) => {
+      return cb();
+    });
+  });
+  afterEach(() => {
+    (useDeepEqualSelector as jest.Mock).mockClear();
+  });
+
+  test('should return allActionItems', async () => {
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook(() => {
+        const defaultFocusedButtonRef = useRef(null);
+        const testProps = {
+          ...defaultProps,
+          defaultFocusedButtonRef,
+        };
+        return useHoverActionItems(testProps);
+      });
+      await waitForNextUpdate();
+
+      expect(result.current.allActionItems).toHaveLength(6);
+      expect(result.current.allActionItems[0].props['data-test-subj']).toEqual(
+        'hover-actions-filter-for'
+      );
+      expect(result.current.allActionItems[1].props['data-test-subj']).toEqual(
+        'hover-actions-filter-out'
+      );
+      expect(result.current.allActionItems[2].props['data-test-subj']).toEqual(
+        'hover-actions-toggle-column'
+      );
+      expect(result.current.allActionItems[3].props['data-test-subj']).toEqual(
+        'hover-actions-add-timeline'
+      );
+      expect(result.current.allActionItems[4].props['data-test-subj']).toEqual(
+        'hover-actions-show-top-n'
+      );
+      expect(result.current.allActionItems[5].props['data-test-subj']).toEqual(
+        'hover-actions-copy-button'
+      );
+    });
+  });
+
+  test('should return overflowActionItems', async () => {
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook(() => {
+        const defaultFocusedButtonRef = useRef(null);
+        const testProps = {
+          ...defaultProps,
+          defaultFocusedButtonRef,
+          enableOverflowButton: true,
+        };
+        return useHoverActionItems(testProps);
+      });
+      await waitForNextUpdate();
+
+      expect(result.current.overflowActionItems).toHaveLength(3);
+      expect(result.current.overflowActionItems[0].props['data-test-subj']).toEqual(
+        'hover-actions-filter-for'
+      );
+      expect(result.current.overflowActionItems[1].props['data-test-subj']).toEqual(
+        'hover-actions-filter-out'
+      );
+      expect(result.current.overflowActionItems[2].props['data-test-subj']).toEqual(
+        'more-actions-signal.rule.name'
+      );
+      expect(result.current.overflowActionItems[2].props.items[0].props['data-test-subj']).toEqual(
+        'hover-actions-toggle-column'
+      );
+
+      expect(result.current.overflowActionItems[2].props.items[1].props['data-test-subj']).toEqual(
+        'hover-actions-add-timeline'
+      );
+      expect(result.current.overflowActionItems[2].props.items[2].props['data-test-subj']).toEqual(
+        'hover-actions-show-top-n'
+      );
+      expect(result.current.overflowActionItems[2].props.items[3].props['data-test-subj']).toEqual(
+        'hover-actions-copy-button'
+      );
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
@@ -243,7 +243,7 @@ export const useHoverActionItems = ({
     ]
   ) as JSX.Element[];
 
-  const overflowBtn = useMemo(
+  const showTopNBtn = useMemo(
     () => (
       <ShowTopNButton
         Component={enableOverflowButton ? EuiContextMenuItem : undefined}
@@ -276,7 +276,7 @@ export const useHoverActionItems = ({
                 onClick: onOverflowButtonClick,
                 showTooltip: enableOverflowButton ? false : true,
                 value: values,
-                items: showTopN ? [overflowBtn] : allItems.slice(itemsToShow),
+                items: showTopN ? [showTopNBtn] : allItems.slice(itemsToShow),
                 isOverflowPopoverOpen: !!isOverflowPopoverOpen,
               }),
             ]
@@ -293,7 +293,7 @@ export const useHoverActionItems = ({
       isOverflowPopoverOpen,
       itemsToShow,
       onOverflowButtonClick,
-      overflowBtn,
+      showTopNBtn,
       ownFocus,
       showTopN,
       stKeyboardEvent,
@@ -301,9 +301,9 @@ export const useHoverActionItems = ({
     ]
   );
 
-  const allActionItems = useMemo(() => (showTopN ? [overflowBtn] : allItems), [
+  const allActionItems = useMemo(() => (showTopN ? [showTopNBtn] : allItems), [
     allItems,
-    overflowBtn,
+    showTopNBtn,
     showTopN,
   ]);
 

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
@@ -21,7 +21,7 @@ import { useSourcererScope } from '../../containers/sourcerer';
 import { timelineSelectors } from '../../../timelines/store/timeline';
 import { ShowTopNButton } from './actions/show_top_n';
 
-interface UseHoverActionItemsProps {
+export interface UseHoverActionItemsProps {
   dataProvider?: DataProvider | DataProvider[];
   dataType?: string;
   defaultFocusedButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
@@ -43,7 +43,7 @@ interface UseHoverActionItemsProps {
   values?: string[] | string | null;
 }
 
-interface UseHoverActionItems {
+export interface UseHoverActionItems {
   overflowActionItems: JSX.Element[];
   allActionItems: JSX.Element[];
 }
@@ -116,7 +116,6 @@ export const useHoverActionItems = ({
    */
   const showFilters =
     values != null && (enableOverflowButton || (!showTopN && !enableOverflowButton));
-
   const allItems = useMemo(
     () =>
       [

--- a/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx
@@ -140,6 +140,7 @@ export const defaultCellActions: TGridCellAction[] = [
         }) && (
           <ShowTopNButton
             Component={Component}
+            enablePopOver={true}
             data-test-subj="hover-actions-show-top-n"
             field={columnId}
             onClick={onClick}

--- a/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx
@@ -140,7 +140,7 @@ export const defaultCellActions: TGridCellAction[] = [
         }) && (
           <ShowTopNButton
             Component={Component}
-            enablePopOver={true}
+            enablePopOver
             data-test-subj="hover-actions-show-top-n"
             field={columnId}
             onClick={onClick}

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/overflow.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/overflow.tsx
@@ -16,6 +16,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 
+import styled from 'styled-components';
 import { stopPropagationAndPreventDefault } from '../../../../common';
 import { TooltipWithKeyboardShortcut } from '../../tooltip_with_keyboard_shortcut';
 import { getAdditionalScreenReaderOnlyContext } from '../utils';
@@ -33,6 +34,10 @@ export interface OverflowButtonProps extends HoverActionComponentProps {
   items: JSX.Element[];
   isOverflowPopoverOpen: boolean;
 }
+
+const StyledEuiContextMenuPanel = styled(EuiContextMenuPanel)`
+  visibility: inherit;
+`;
 
 const OverflowButton: React.FC<OverflowButtonProps> = React.memo(
   ({
@@ -91,9 +96,10 @@ const OverflowButton: React.FC<OverflowButtonProps> = React.memo(
           isOpen={isOverflowPopoverOpen}
           closePopover={closePopOver}
           panelPaddingSize="none"
+          panelClassName="withHoverActions__popover"
           anchorPosition="downLeft"
         >
-          <EuiContextMenuPanel items={items} />
+          <StyledEuiContextMenuPanel items={items} />
         </EuiPopover>
       ),
       [


### PR DESCRIPTION
## Summary

issue https://github.com/elastic/kibana/issues/108942

Steps to verify:
1. Go to alerts page (and make sure you have some alerts in the table)
2. Hover on a value with show topN action, click on it.
3. The topN chart should be displayed properly.
4. Click on expand event button at the leftest of the row.
5. Click on the overflow button of a value, and click show topN button again.
6. The topN chart should be displayed properly.

![Kapture 2021-08-17 at 23 05 25](https://user-images.githubusercontent.com/6295984/129807111-84ea0b6b-0689-4cd3-bd6f-309425f98a49.gif)


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


