### PR TITLE
[Enterprise Search] Fix a bug where role mappings not populated

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { EuiIconTip, EuiInMemoryTable, EuiBasicTableColumn, EuiLink } from '@elastic/eui';
 import type { EuiSearchBarOnChangeArgs } from '@elastic/eui';
@@ -71,7 +71,11 @@ export const RoleMappingsTable: React.FC<Props> = ({
     return _rm;
   }) as SharedRoleMapping[];
 
-  const [items, setItems] = useState(standardizedRoleMappings);
+  const [items, setItems] = useState([] as SharedRoleMapping[]);
+
+  useEffect(() => {
+    setItems(standardizedRoleMappings);
+  }, [roleMappings]);
 
   const attributeNameCol: EuiBasicTableColumn<SharedRoleMapping> = {
     field: 'attribute',


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1983

## Summary

This fixes a bug where adding or deleting a role mapping resulted in the table not being updated. The issue stems from the fact that a copy of the mappings called “items” is created with loca state in the component for filtering before passing to EuiBasicTable. The issue is that this works fine on initial load, but the copy of items is never updated on subsequent renders. The solution is to update the items each time roleMappings is updated.

**Before**
![before](https://user-images.githubusercontent.com/1869731/129807346-c97de663-df45-425c-9ec0-47a2e861babb.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/129807352-868930ef-c3cf-43f3-91aa-6dd7653d5747.gif)

