### PR TITLE
[APM] Use doc link service instead of ElasticDocsLink

### DIFF
--- a/docs/development/core/public/kibana-plugin-core-public.doclinksstart.links.md
+++ b/docs/development/core/public/kibana-plugin-core-public.doclinksstart.links.md
@@ -9,6 +9,10 @@
 ```typescript
 readonly links: {
         readonly settings: string;
+        readonly apm: {
+            readonly kibanaSettings: string;
+            readonly supportedServiceMaps: string;
+        };
         readonly canvas: {
             readonly guide: string;
         };

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -30,6 +30,10 @@ export class DocLinksService {
       ELASTIC_WEBSITE_URL,
       links: {
         settings: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/settings.html`,
+        apm: {
+          kibanaSettings: `${KIBANA_DOCS}apm-settings-in-kibana.html`,
+          supportedServiceMaps: `${KIBANA_DOCS}service-maps.html#service-maps-supported`,
+        },
         canvas: {
           guide: `${KIBANA_DOCS}canvas.html`,
         },
@@ -451,6 +455,10 @@ export interface DocLinksStart {
   readonly ELASTIC_WEBSITE_URL: string;
   readonly links: {
     readonly settings: string;
+    readonly apm: {
+      readonly kibanaSettings: string;
+      readonly supportedServiceMaps: string;
+    };
     readonly canvas: {
       readonly guide: string;
     };

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -473,6 +473,10 @@ export interface DocLinksStart {
     // (undocumented)
     readonly links: {
         readonly settings: string;
+        readonly apm: {
+            readonly kibanaSettings: string;
+            readonly supportedServiceMaps: string;
+        };
         readonly canvas: {
             readonly guide: string;
         };

--- a/x-pack/plugins/apm/public/components/app/service_map/EmptyBanner.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/EmptyBanner.tsx
@@ -6,12 +6,12 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import { EuiCallOut } from '@elastic/eui';
+import { EuiCallOut, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
-import { ElasticDocsLink } from '../../shared/Links/ElasticDocsLink';
 import { CytoscapeContext } from './Cytoscape';
 import { useTheme } from '../../../hooks/use_theme';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 
 const EmptyBannerContainer = euiStyled.div`
   margin: ${({ theme }) => theme.eui.gutterTypes.gutterSmall};
@@ -28,6 +28,7 @@ export function EmptyBanner() {
   const theme = useTheme();
   const cy = useContext(CytoscapeContext);
   const [nodeCount, setNodeCount] = useState(0);
+  const { docLinks } = useApmPluginContext().core;
 
   useEffect(() => {
     const handler: cytoscape.EventHandler = (event) =>
@@ -67,14 +68,11 @@ export function EmptyBanner() {
           defaultMessage:
             "We will map out connected services and external requests if we can detect them. Please make sure you're running the latest version of the APM agent.",
         })}{' '}
-        <ElasticDocsLink
-          section="/kibana"
-          path="/service-maps.html#service-maps-supported"
-        >
+        <EuiLink href={docLinks.links.apm.supportedServiceMaps}>
           {i18n.translate('xpack.apm.serviceMap.emptyBanner.docsLink', {
             defaultMessage: 'Learn more in the docs',
           })}
-        </ElasticDocsLink>
+        </EuiLink>
       </EuiCallOut>
     </EmptyBannerContainer>
   );

--- a/x-pack/plugins/apm/public/components/app/service_map/timeout_prompt.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/timeout_prompt.tsx
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { EuiEmptyPrompt } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { ElasticDocsLink } from '../../shared/Links/ElasticDocsLink';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 
 export function TimeoutPrompt({
   isGlobalServiceMap,
@@ -44,11 +44,12 @@ export function TimeoutPrompt({
 }
 
 function ApmSettingsDocLink() {
+  const { docLinks } = useApmPluginContext().core;
   return (
-    <ElasticDocsLink section="/kibana" path="/apm-settings-in-kibana.html">
+    <EuiLink href={docLinks.links.apm.kibanaSettings}>
       {i18n.translate('xpack.apm.serviceMap.timeoutPrompt.docsLink', {
         defaultMessage: 'Learn more about APM settings in the docs',
       })}
-    </ElasticDocsLink>
+    </EuiLink>
   );
 }

--- a/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -10,6 +10,7 @@ import { Observable, of } from 'rxjs';
 import { RouterProvider } from '@kbn/typed-react-router-config';
 import { useHistory } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
+import { docLinksServiceMock } from 'src/core/public/mocks';
 import { UrlService } from '../../../../../../src/plugins/share/common/url_service';
 import { createObservabilityRuleTypeRegistryMock } from '../../../../observability/public';
 import { ApmPluginContext, ApmPluginContextValue } from './apm_plugin_context';
@@ -58,10 +59,7 @@ const mockCore = {
     setHelpExtension: () => {},
     setBadge: () => {},
   },
-  docLinks: {
-    DOC_LINK_VERSION: '0',
-    ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
-  },
+  docLinks: docLinksServiceMock.createStartContract(),
   http: {
     basePath: {
       prepend: (path: string) => `/basepath${path}`,

--- a/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -10,7 +10,6 @@ import { Observable, of } from 'rxjs';
 import { RouterProvider } from '@kbn/typed-react-router-config';
 import { useHistory } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
-import { docLinksServiceMock } from 'src/core/public/mocks';
 import { UrlService } from '../../../../../../src/plugins/share/common/url_service';
 import { createObservabilityRuleTypeRegistryMock } from '../../../../observability/public';
 import { ApmPluginContext, ApmPluginContextValue } from './apm_plugin_context';
@@ -59,7 +58,13 @@ const mockCore = {
     setHelpExtension: () => {},
     setBadge: () => {},
   },
-  docLinks: docLinksServiceMock.createStartContract(),
+  docLinks: {
+    DOC_LINK_VERSION: '0',
+    ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
+    links: {
+      apm: {},
+    },
+  },
   http: {
     basePath: {
       prepend: (path: string) => `/basepath${path}`,


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/88107
This PR replaces the need for https://github.com/elastic/kibana/blob/master/x-pack/plugins/apm/public/components/shared/Links/ElasticDocsLink.tsx in the service map component the APM app. Instead, it uses the https://github.com/elastic/kibana/blob/master/src/core/public/doc_links/doc_links_service.ts, which is checked as part of the documentation builds.


