### PR TITLE
Realign cypress/ccs_integration with cypress/integration

### DIFF
--- a/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
@@ -58,7 +58,7 @@ describe('Alert details with unmapped fields', () => {
 
   it('Displays the unmapped field on the table', () => {
     const expectedUnmmappedField = {
-      row: 88,
+      row: 90,
       field: 'unmapped',
       text: 'This is the unmapped field',
     };


### PR DESCRIPTION
cypress/ccs_integration is a subset/fork of cypress/integration and already tends to be left behind.

Situation is expected to improve once proper signaling of failing tests is reported to #security-solution-slack-testing.

For the moment, let's keep aligning manually.