### PR TITLE
[7.x] Realign cypress/ccs_integration with cypress/integration (#109048)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
@@ -58,7 +58,7 @@ describe('Alert details with unmapped fields', () => {
 
   it('Displays the unmapped field on the table', () => {
     const expectedUnmmappedField = {
-      row: 89,
+      row: 91,
       field: 'unmapped',
       text: 'This is the unmapped field',
     };


### PR DESCRIPTION
Backports the following commits to 7.x:

* Realign cypress/ccs_integration with cypress/integration (https://github.com/elastic/kibana/pull/109048)