### PR TITLE
[Reporting][Revert] Deprecate v1 report types

### DIFF
--- a/x-pack/plugins/reporting/server/export_types/png/create_job/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/png/create_job/index.ts
@@ -22,11 +22,10 @@ export const createJobFnFactory: CreateJobFnFactory<
     validateUrls([jobParams.relativeUrl]);
 
     return {
-      isDeprecated: true,
+      ...jobParams,
       headers: serializedEncryptedHeaders,
       spaceId: reporting.getSpaceId(req, logger),
       forceNow: new Date().toISOString(),
-      ...jobParams,
     };
   };
 };

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf/create_job/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf/create_job/index.ts
@@ -34,7 +34,6 @@ export const createJobFnFactory: CreateJobFnFactory<
     // return the payload
     return {
       ...jobParams,
-      isDeprecated: true,
       headers: serializedEncryptedHeaders,
       spaceId: reporting.getSpaceId(req, logger),
       forceNow: new Date().toISOString(),


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/108499 was pre-maturely merged because the v1 PDF/PNG report types will still be the only report types users are able to have for 7.15.