### PR TITLE
Fix black scroll bar on alert count table

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/alerts_count.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/alerts_count.tsx
@@ -24,8 +24,7 @@ interface AlertsCountProps {
 }
 
 const Wrapper = styled.div`
-  overflow: scroll;
-  margin-top: -8px;
+  margin-top: -${({ theme }) => theme.eui.euiSizeS};
 `;
 
 const getAlertsCountTableColumns = (
@@ -70,7 +69,7 @@ export const AlertsCount = memo<AlertsCountProps>(({ loading, selectedStackByOpt
     <>
       {loading && <EuiProgress size="xs" position="absolute" color="accent" />}
 
-      <Wrapper data-test-subj="alertsCountTable">
+      <Wrapper data-test-subj="alertsCountTable" className="eui-yScroll">
         <EuiInMemoryTable
           isSelectable={false}
           columns={tableColumns}


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/108283

## Summary

Fix black scroll bar on alert count table

<img width="400" src="https://user-images.githubusercontent.com/1490444/129899083-05280b5d-3882-4cb5-9d63-e97dd099ef99.png">

OBS: I can't reproduce it on my machine. 



