### PR TITLE
Hide "Manage Searches" if user has insufficient permissions

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render 1`] = `
+exports[`OpenSearchPanel render 1`] = `
 <EuiFlyout
   data-test-subj="loadSearchForm"
   onClose={[MockFunction]}
@@ -52,6 +52,7 @@ exports[`render 1`] = `
         grow={false}
       >
         <EuiButton
+          data-test-subj="manageSearchesBtn"
           fill={true}
           href="/app/management/kibana/objects?_a=(tab:search)"
           onClick={[MockFunction]}

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.test.tsx
@@ -9,18 +9,38 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+const mockCapabilities = jest.fn().mockReturnValue({
+  savedObjectsManagement: {
+    edit: true,
+  },
+});
+
 jest.mock('../../../../../kibana_services', () => {
   return {
     getServices: () => ({
       core: { uiSettings: {}, savedObjects: {} },
       addBasePath: (path: string) => path,
+      capabilities: mockCapabilities(),
     }),
   };
 });
 
 import { OpenSearchPanel } from './open_search_panel';
 
-test('render', () => {
-  const component = shallow(<OpenSearchPanel onClose={jest.fn()} makeUrl={jest.fn()} />);
-  expect(component).toMatchSnapshot();
+describe('OpenSearchPanel', () => {
+  test('render', () => {
+    const component = shallow(<OpenSearchPanel onClose={jest.fn()} makeUrl={jest.fn()} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('should not render manage searches button without permissions', () => {
+    mockCapabilities.mockReturnValue({
+      savedObjectsManagement: {
+        edit: false,
+        delete: false,
+      },
+    });
+    const component = shallow(<OpenSearchPanel onClose={jest.fn()} makeUrl={jest.fn()} />);
+    expect(component.find('[data-test-subj="manageSearches"]').exists()).toBe(false);
+  });
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.tsx
@@ -34,7 +34,11 @@ export function OpenSearchPanel(props: OpenSearchPanelProps) {
   const {
     core: { uiSettings, savedObjects },
     addBasePath,
+    capabilities,
   } = getServices();
+
+  const hasSavedObjectPermission =
+    capabilities.savedObjectsManagement?.edit || capabilities.savedObjectsManagement?.delete;
 
   return (
     <EuiFlyout ownFocus onClose={props.onClose} data-test-subj="loadSearchForm">
@@ -73,25 +77,28 @@ export function OpenSearchPanel(props: OpenSearchPanelProps) {
           savedObjects={savedObjects}
         />
       </EuiFlyoutBody>
-      <EuiFlyoutFooter>
-        <EuiFlexGroup justifyContent="flexEnd">
-          <EuiFlexItem grow={false}>
-            {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
-            <EuiButton
-              fill
-              onClick={props.onClose}
-              href={addBasePath(
-                `/app/management/kibana/objects?_a=${rison.encode({ tab: SEARCH_OBJECT_TYPE })}`
-              )}
-            >
-              <FormattedMessage
-                id="discover.topNav.openSearchPanel.manageSearchesButtonLabel"
-                defaultMessage="Manage searches"
-              />
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlyoutFooter>
+      {hasSavedObjectPermission && (
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
+              <EuiButton
+                fill
+                onClick={props.onClose}
+                data-test-subj="manageSearchesBtn"
+                href={addBasePath(
+                  `/app/management/kibana/objects?_a=${rison.encode({ tab: SEARCH_OBJECT_TYPE })}`
+                )}
+              >
+                <FormattedMessage
+                  id="discover.topNav.openSearchPanel.manageSearchesButtonLabel"
+                  defaultMessage="Manage searches"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      )}
     </EuiFlyout>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #106580

We're now checking whether the user has savedObjectsManagement write permissions (either edit or delete) and don't show the Manage Searches button if she doesn't.


### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~
