### PR TITLE
[APM] Rum service details doesn't show any data

### DIFF
--- a/x-pack/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
@@ -64,8 +64,8 @@ Object {
   },
   "body": Object {
     "_source": Array [
-      "service.runtime.name",
       "agent.name",
+      "service.runtime.name",
     ],
     "query": Object {
       "bool": Object {
@@ -86,15 +86,15 @@ Object {
           },
           Object {
             "exists": Object {
-              "field": "service.runtime.name",
-            },
-          },
-          Object {
-            "exists": Object {
               "field": "agent.name",
             },
           },
         ],
+        "should": Object {
+          "exists": Object {
+            "field": "service.runtime.name",
+          },
+        },
       },
     },
     "size": 1,

--- a/x-pack/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
@@ -64,9 +64,16 @@ Object {
   },
   "body": Object {
     "_source": Array [
-      "service.runtime.name",
       "agent.name",
     ],
+    "aggs": Object {
+      "runtimeName": Object {
+        "terms": Object {
+          "field": "service.runtime.name",
+          "size": 1,
+        },
+      },
+    },
     "query": Object {
       "bool": Object {
         "filter": Array [
@@ -82,11 +89,6 @@ Object {
                 "gte": 1528113600000,
                 "lte": 1528977600000,
               },
-            },
-          },
-          Object {
-            "exists": Object {
-              "field": "service.runtime.name",
             },
           },
           Object {

--- a/x-pack/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
@@ -67,14 +67,6 @@ Object {
       "agent.name",
       "service.runtime.name",
     ],
-    "aggs": Object {
-      "runtimeName": Object {
-        "terms": Object {
-          "field": "service.runtime.name",
-          "size": 1,
-        },
-      },
-    },
     "query": Object {
       "bool": Object {
         "filter": Array [

--- a/x-pack/plugins/apm/server/lib/services/get_service_agent.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_agent.ts
@@ -19,6 +19,11 @@ interface ServiceAgent {
   agent?: {
     name: string;
   };
+  service?: {
+    runtime?: {
+      name?: string;
+    };
+  };
 }
 
 export async function getServiceAgent({
@@ -45,7 +50,7 @@ export async function getServiceAgent({
     },
     body: {
       size: 1,
-      _source: [AGENT_NAME],
+      _source: [AGENT_NAME, SERVICE_RUNTIME_NAME],
       query: {
         bool: {
           filter: [
@@ -57,13 +62,10 @@ export async function getServiceAgent({
               },
             },
           ],
-        },
-      },
-      aggs: {
-        runtimeName: {
-          terms: {
-            field: SERVICE_RUNTIME_NAME,
-            size: 1,
+          should: {
+            exists: {
+              field: SERVICE_RUNTIME_NAME,
+            },
           },
         },
       },
@@ -78,9 +80,6 @@ export async function getServiceAgent({
     return {};
   }
 
-  const { agent } = response.hits.hits[0]._source as ServiceAgent;
-  const runtimeName = response.aggregations?.runtimeName.buckets[0]?.key as
-    | string
-    | undefined;
-  return { agentName: agent?.name, runtimeName };
+  const { agent, service } = response.hits.hits[0]._source as ServiceAgent;
+  return { agentName: agent?.name, runtimeName: service?.runtime?.name };
 }


### PR DESCRIPTION
closes #109102

I removed the `exists` filter on the `service.runtime.name` field, but I need to add a terms aggregation because that could be that the sampled document returned from the query doesn't have this field.

<img width="890" alt="Screen Shot 2021-08-18 at 11 17 33" src="https://user-images.githubusercontent.com/55978943/129925275-d172c591-fd92-431b-a5a1-7feca4abb577.png">
<img width="1468" alt="Screen Shot 2021-08-18 at 11 19 44" src="https://user-images.githubusercontent.com/55978943/129925278-e57e563f-fd80-404f-bc34-72c3c94a06f1.png">
