### PR TITLE
[7.15] Hide "Manage Searches" if insufficient permissions (#109099)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/__snapshots__/open_search_panel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render 1`] = `
+exports[`OpenSearchPanel render 1`] = `
 <EuiFlyout
   data-test-subj="loadSearchForm"
   onClose={[MockFunction]}
@@ -52,6 +52,7 @@ exports[`render 1`] = `
         grow={false}
       >
         <EuiButton
+          data-test-subj="manageSearchesBtn"
           fill={true}
           href="/app/management/kibana/objects?_a=(tab:search)"
           onClick={[MockFunction]}

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.test.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.test.tsx
@@ -9,18 +9,38 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+const mockCapabilities = jest.fn().mockReturnValue({
+  savedObjectsManagement: {
+    edit: true,
+  },
+});
+
 jest.mock('../../../../../kibana_services', () => {
   return {
     getServices: () => ({
       core: { uiSettings: {}, savedObjects: {} },
       addBasePath: (path: string) => path,
+      capabilities: mockCapabilities(),
     }),
   };
 });
 
 import { OpenSearchPanel } from './open_search_panel';
 
-test('render', () => {
-  const component = shallow(<OpenSearchPanel onClose={jest.fn()} makeUrl={jest.fn()} />);
-  expect(component).toMatchSnapshot();
+describe('OpenSearchPanel', () => {
+  test('render', () => {
+    const component = shallow(<OpenSearchPanel onClose={jest.fn()} makeUrl={jest.fn()} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('should not render manage searches button without permissions', () => {
+    mockCapabilities.mockReturnValue({
+      savedObjectsManagement: {
+        edit: false,
+        delete: false,
+      },
+    });
+    const component = shallow(<OpenSearchPanel onClose={jest.fn()} makeUrl={jest.fn()} />);
+    expect(component.find('[data-test-subj="manageSearches"]').exists()).toBe(false);
+  });
 });

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/open_search_panel.tsx
@@ -34,7 +34,11 @@ export function OpenSearchPanel(props: OpenSearchPanelProps) {
   const {
     core: { uiSettings, savedObjects },
     addBasePath,
+    capabilities,
   } = getServices();
+
+  const hasSavedObjectPermission =
+    capabilities.savedObjectsManagement?.edit || capabilities.savedObjectsManagement?.delete;
 
   return (
     <EuiFlyout ownFocus onClose={props.onClose} data-test-subj="loadSearchForm">
@@ -73,25 +77,28 @@ export function OpenSearchPanel(props: OpenSearchPanelProps) {
           savedObjects={savedObjects}
         />
       </EuiFlyoutBody>
-      <EuiFlyoutFooter>
-        <EuiFlexGroup justifyContent="flexEnd">
-          <EuiFlexItem grow={false}>
-            {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
-            <EuiButton
-              fill
-              onClick={props.onClose}
-              href={addBasePath(
-                `/app/management/kibana/objects?_a=${rison.encode({ tab: SEARCH_OBJECT_TYPE })}`
-              )}
-            >
-              <FormattedMessage
-                id="discover.topNav.openSearchPanel.manageSearchesButtonLabel"
-                defaultMessage="Manage searches"
-              />
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlyoutFooter>
+      {hasSavedObjectPermission && (
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
+              <EuiButton
+                fill
+                onClick={props.onClose}
+                data-test-subj="manageSearchesBtn"
+                href={addBasePath(
+                  `/app/management/kibana/objects?_a=${rison.encode({ tab: SEARCH_OBJECT_TYPE })}`
+                )}
+              >
+                <FormattedMessage
+                  id="discover.topNav.openSearchPanel.manageSearchesButtonLabel"
+                  defaultMessage="Manage searches"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      )}
     </EuiFlyout>
   );
 }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Hide "Manage Searches" if insufficient permissions (#109099)