### PR TITLE
[7.15] chore(NA): adds 7.16 into  backportrc (#109128)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,6 +3,7 @@
   "targetBranchChoices": [
     { "name": "master", "checked": true },
     { "name": "7.x", "checked": true },
+    "7.15",
     "7.14",
     "7.13",
     "7.12",
@@ -32,7 +33,7 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v8.0.0$": "master",
-    "^v7.15.0$": "7.x",
+    "^v7.16.0$": "7.x",
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   }
 }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - chore(NA): adds 7.16 into  backportrc (#109128)