### PR TITLE
[7.15] Abort full screen in dashboard and maps when user clicks back button (#108747)

### DIFF
--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -183,27 +183,8 @@ export class DashboardPlugin
     const getStartServices = async () => {
       const [coreStart, deps] = await core.getStartServices();
 
-      const useHideChrome = ({ toggleChrome } = { toggleChrome: true }) => {
-        React.useEffect(() => {
-          if (toggleChrome) {
-            coreStart.chrome.setIsVisible(false);
-          }
-
-          return () => {
-            if (toggleChrome) {
-              coreStart.chrome.setIsVisible(true);
-            }
-          };
-        }, [toggleChrome]);
-      };
-
-      const ExitFullScreenButton: React.FC<
-        ExitFullScreenButtonProps & {
-          toggleChrome: boolean;
-        }
-      > = ({ toggleChrome, ...props }) => {
-        useHideChrome({ toggleChrome });
-        return <ExitFullScreenButtonUi {...props} />;
+      const ExitFullScreenButton: React.FC<ExitFullScreenButtonProps> = (props) => {
+        return <ExitFullScreenButtonUi {...props} chrome={coreStart.chrome} />;
       };
       return {
         SavedObjectFinder: getSavedObjectFinder(coreStart.savedObjects, coreStart.uiSettings),

--- a/src/plugins/kibana_react/public/exit_full_screen_button/__snapshots__/exit_full_screen_button.test.tsx.snap
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/__snapshots__/exit_full_screen_button.test.tsx.snap
@@ -2,6 +2,11 @@
 
 exports[`is rendered 1`] = `
 <ExitFullScreenButtonUi
+  chrome={
+    Object {
+      "setIsVisible": [Function],
+    }
+  }
   onExitFullScreenMode={[Function]}
 >
   <div>

--- a/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.test.tsx
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.test.tsx
@@ -11,9 +11,16 @@ import sinon from 'sinon';
 import { ExitFullScreenButton } from './exit_full_screen_button';
 import { keys } from '@elastic/eui';
 import { mount } from 'enzyme';
+import type { ChromeStart } from '../../../../core/public';
+
+const MockChrome = ({
+  setIsVisible: () => {},
+} as unknown) as ChromeStart;
 
 test('is rendered', () => {
-  const component = mount(<ExitFullScreenButton onExitFullScreenMode={() => {}} />);
+  const component = mount(
+    <ExitFullScreenButton onExitFullScreenMode={() => {}} chrome={MockChrome} />
+  );
 
   expect(component).toMatchSnapshot();
 });
@@ -22,7 +29,9 @@ describe('onExitFullScreenMode', () => {
   test('is called when the button is pressed', () => {
     const onExitHandler = sinon.stub();
 
-    const component = mount(<ExitFullScreenButton onExitFullScreenMode={onExitHandler} />);
+    const component = mount(
+      <ExitFullScreenButton onExitFullScreenMode={onExitHandler} chrome={MockChrome} />
+    );
 
     component.find('button').simulate('click');
 
@@ -32,7 +41,7 @@ describe('onExitFullScreenMode', () => {
   test('is called when the ESC key is pressed', () => {
     const onExitHandler = sinon.stub();
 
-    mount(<ExitFullScreenButton onExitFullScreenMode={onExitHandler} />);
+    mount(<ExitFullScreenButton onExitFullScreenMode={onExitHandler} chrome={MockChrome} />);
 
     const escapeKeyEvent = new KeyboardEvent('keydown', { key: keys.ESCAPE } as any);
     document.dispatchEvent(escapeKeyEvent);

--- a/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
@@ -10,9 +10,11 @@ import { i18n } from '@kbn/i18n';
 import React, { PureComponent } from 'react';
 import { EuiScreenReaderOnly, keys } from '@elastic/eui';
 import { EuiIcon, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import type { ChromeStart } from '../../../../core/public';
 
 export interface ExitFullScreenButtonProps {
   onExitFullScreenMode: () => void;
+  chrome: ChromeStart;
 }
 
 import './index.scss';
@@ -24,11 +26,13 @@ class ExitFullScreenButtonUi extends PureComponent<ExitFullScreenButtonProps> {
     }
   };
 
-  public UNSAFE_componentWillMount() {
+  public componentDidMount() {
+    this.props.chrome.setIsVisible(false);
     document.addEventListener('keydown', this.onKeyDown, false);
   }
 
   public componentWillUnmount() {
+    this.props.chrome.setIsVisible(true);
     document.removeEventListener('keydown', this.onKeyDown, false);
   }
 

--- a/x-pack/plugins/maps/public/connected_components/map_container/index.ts
+++ b/x-pack/plugins/maps/public/connected_components/map_container/index.ts
@@ -19,7 +19,6 @@ import {
   getQueryableUniqueIndexPatternIds,
 } from '../../selectors/map_selectors';
 import { MapStoreState } from '../../reducers/store';
-import { getCoreChrome } from '../../kibana_services';
 
 function mapStateToProps(state: MapStoreState) {
   return {
@@ -35,10 +34,7 @@ function mapStateToProps(state: MapStoreState) {
 
 function mapDispatchToProps(dispatch: ThunkDispatch<MapStoreState, void, AnyAction>) {
   return {
-    exitFullScreen: () => {
-      dispatch(exitFullScreen());
-      getCoreChrome().setIsVisible(true);
-    },
+    exitFullScreen: () => dispatch(exitFullScreen()),
     cancelAllInFlightRequests: () => dispatch(cancelAllInFlightRequests()),
   };
 }

--- a/x-pack/plugins/maps/public/connected_components/map_container/map_container.tsx
+++ b/x-pack/plugins/maps/public/connected_components/map_container/map_container.tsx
@@ -21,6 +21,7 @@ import { ToolbarOverlay } from '../toolbar_overlay';
 import { EditLayerPanel } from '../edit_layer_panel';
 import { AddLayerPanel } from '../add_layer_panel';
 import { ExitFullScreenButton } from '../../../../../../src/plugins/kibana_react/public';
+import { getCoreChrome } from '../../kibana_services';
 import { RawValue } from '../../../common/constants';
 import { FLYOUT_STATE } from '../../reducers/ui';
 import { MapSettings } from '../../reducers/map';
@@ -190,7 +191,9 @@ export class MapContainer extends Component<Props, State> {
 
     let exitFullScreenButton;
     if (isFullScreen) {
-      exitFullScreenButton = <ExitFullScreenButton onExitFullScreenMode={exitFullScreen} />;
+      exitFullScreenButton = (
+        <ExitFullScreenButton onExitFullScreenMode={exitFullScreen} chrome={getCoreChrome()} />
+      );
     }
     return (
       <EuiFlexGroup

--- a/x-pack/plugins/maps/public/routes/map_page/top_nav_config.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/top_nav_config.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { Adapters } from 'src/plugins/inspector/public';
 import {
-  getCoreChrome,
   getMapsCapabilities,
   getIsAllowByValueEmbeddables,
   getInspector,
@@ -92,7 +91,6 @@ export function getTopNavConfig({
       }),
       testId: 'mapsFullScreenMode',
       run() {
-        getCoreChrome().setIsVisible(false);
         enableFullScreen();
       },
     }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Abort full screen in dashboard and maps when user clicks back button (#108747)