### PR TITLE
[Fleet] Missing migration backport in 7.14.0

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -322,6 +322,7 @@ const getSavedObjectTypes = (
     },
     migrations: {
       '7.14.0': migrateInstallationToV7140,
+      '7.14.1': migrateInstallationToV7140,
     },
   },
   [ASSETS_SAVED_OBJECT_TYPE]: {


### PR DESCRIPTION
## Summary

Resolve #108888 

I previously pushed a migration to fix a missing migration from 7.9 to next version of Fleet https://github.com/elastic/kibana/pull/107214 but I had a conflict in the auto backport and somehow missed the last release candidate and the backport is not present in 7.14.0.

That PR ensure the migration is here for 7.14.1


## How to test

* Install Kibana 7.9 and install a package other than system, endpoint like nginx for example
* Upgrade to 7.14.0 you should not be able to fo the integration details page, and have a not found message
* Upgrade to this PR you should be able to go to the integration details page and update your package.




