### PR TITLE
exclude tsx test and mock files from test coverage

### DIFF
--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -104,10 +104,10 @@ module.exports = {
   collectCoverageFrom: [
     '**/*.{js,mjs,jsx,ts,tsx}',
     '!**/{__test__,__snapshots__,__examples__,*mock*,tests,test_helpers,integration_tests,types}/**/*',
-    '!**/*mock*.ts',
-    '!**/*.test.ts',
+    '!**/*mock*.{ts,tsx}',
+    '!**/*.test.{ts,tsx}',
     '!**/*.d.ts',
-    '!**/index.{js,ts}',
+    '!**/index.{js,ts,tsx}',
   ],
 
   // A custom resolver to preserve symlinks by default


### PR DESCRIPTION
## Summary

jest collects test coverage for test files with `tsx` extension, which seriously skews our coverage metrics.
![2021-08-19_09-59-00](https://user-images.githubusercontent.com/3198181/130028491-127d23e5-333a-4ad7-b0bc-9c5884741188.png)

This PR excludes `*test.tsx` files from test coverage.