### PR TITLE
[Flaky-tests] Fix SOM edit-saved-objects test

### DIFF
--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -53,6 +53,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await button.focus();
     await delay(10);
     await button.click();
+    // Allow some time for the transition/animations to occur before assuming the click is done
+    await delay(10);
   };
 
   describe('saved objects edition page', () => {

--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -57,7 +57,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await delay(10);
   };
 
-  describe('saved objects edition page', () => {
+  describe.only('saved objects edition page', () => {
     beforeEach(async () => {
       await esArchiver.load(
         'test/functional/fixtures/es_archiver/saved_objects_management/edit_saved_object'

--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -57,7 +57,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await delay(10);
   };
 
-  describe.only('saved objects edition page', () => {
+  describe('saved objects edition page', () => {
     beforeEach(async () => {
       await esArchiver.load(
         'test/functional/fixtures/es_archiver/saved_objects_management/edit_saved_object'


### PR DESCRIPTION
## Summary

Resolves #105313

This PR adds a small wait after clicking the Save Edit button to allow the re-render to occur. There were some moments when the checks after the click event happened before the render occurred so, for example, the table was not in "loading" state yet, and the logic assumed it had already refreshed because of that.

In my tests, the small delay is enough: [flaky-test-runner](https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1830/) succeded after 42 executions.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
