### PR TITLE
[Upgrade Assistant] Overview page should reference nextMajor

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/overview.helpers.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/overview.helpers.ts
@@ -76,4 +76,6 @@ export type OverviewTestSubjects =
   | 'upgradeSetupDocsLink'
   | 'upgradeSetupCloudLink'
   | 'deprecationWarningCallout'
+  | 'whatsNewLink'
+  | 'documentationLink'
   | 'upgradeStatusError';

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// import { act } from 'react-dom/test-utils';
+
+import { mockKibanaSemverVersion } from '../../../common/constants';
+import { OverviewTestBed, setupOverviewPage, setupEnvironment } from '../helpers';
+
+describe('Overview Page', () => {
+  let testBed: OverviewTestBed;
+  const { server } = setupEnvironment();
+
+  beforeEach(async () => {
+    testBed = await setupOverviewPage();
+    testBed.component.update();
+  });
+
+  afterAll(() => {
+    server.restore();
+  });
+
+  describe('Documentation links', () => {
+    test('Has a whatsNew link and it references nextMajor version', () => {
+      const { exists, find } = testBed;
+      const nextMajor = mockKibanaSemverVersion.major + 1;
+
+      expect(exists('whatsNewLink')).toBe(true);
+      expect(find('whatsNewLink').text()).toContain(`${nextMajor}.0`);
+    });
+
+    test('Has a documentation link', () => {
+      const { exists } = testBed;
+
+      expect(exists('documentationLink')).toBe(true);
+    });
+  });
+});

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/overview.test.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-// import { act } from 'react-dom/test-utils';
-
 import { mockKibanaSemverVersion } from '../../../common/constants';
 import { OverviewTestBed, setupOverviewPage, setupEnvironment } from '../helpers';
 
@@ -32,7 +30,7 @@ describe('Overview Page', () => {
       expect(find('whatsNewLink').text()).toContain(`${nextMajor}.0`);
     });
 
-    test('Has a documentation link', () => {
+    test('Has a link for upgrade assistant in page header', () => {
       const { exists } = testBed;
 
       expect(exists('documentationLink')).toBe(true);

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
@@ -27,7 +27,7 @@ import { getUpgradeStep } from './upgrade_step';
 
 export const Overview: FunctionComponent = () => {
   const { kibanaVersionInfo, breadcrumbs, docLinks, api } = useAppContext();
-  const { currentMajor } = kibanaVersionInfo;
+  const { nextMajor } = kibanaVersionInfo;
 
   useEffect(() => {
     async function sendTelemetryData() {
@@ -68,12 +68,12 @@ export const Overview: FunctionComponent = () => {
             </EuiButtonEmpty>,
           ]}
         >
-          <EuiText>
+          <EuiText data-test-subj="whatsNewLink">
             <EuiLink href={docLinks.links.elasticsearch.releaseHighlights} target="_blank">
               <FormattedMessage
                 id="xpack.upgradeAssistant.overview.whatsNewLink"
-                defaultMessage="What's new in version {currentMajor}.0?"
-                values={{ currentMajor }}
+                defaultMessage="What's new in version {nextMajor}.0?"
+                values={{ nextMajor }}
               />
             </EuiLink>
           </EuiText>
@@ -83,9 +83,9 @@ export const Overview: FunctionComponent = () => {
 
         <EuiSteps
           steps={[
-            getReviewLogsStep({ currentMajor }),
+            getReviewLogsStep({ nextMajor }),
             getFixDeprecationLogsStep(),
-            getUpgradeStep({ docLinks, currentMajor }),
+            getUpgradeStep({ docLinks, nextMajor }),
           ]}
         />
       </EuiPageContent>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/review_logs_step/review_logs_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/review_logs_step/review_logs_step.tsx
@@ -20,7 +20,7 @@ const i18nTexts = {
   }),
 };
 
-export const getReviewLogsStep = ({ currentMajor }: { currentMajor: number }): EuiStepProps => {
+export const getReviewLogsStep = ({ nextMajor }: { nextMajor: number }): EuiStepProps => {
   return {
     title: i18nTexts.reviewStepTitle,
     status: 'incomplete',
@@ -30,8 +30,8 @@ export const getReviewLogsStep = ({ currentMajor }: { currentMajor: number }): E
           <p>
             <FormattedMessage
               id="xpack.upgradeAssistant.overview.resolveStepDescription"
-              defaultMessage="Update your Elasticsearch and Kibana deployments to be compatible with {currentMajor}.0. Critical issues must be resolved before you upgrade."
-              values={{ currentMajor }}
+              defaultMessage="Update your Elasticsearch and Kibana deployments to be compatible with {nextMajor}.0. Critical issues must be resolved before you upgrade."
+              values={{ nextMajor }}
             />
           </p>
         </EuiText>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
@@ -21,10 +21,10 @@ import type { DocLinksStart } from 'src/core/public';
 import { useKibana } from '../../../../shared_imports';
 
 const i18nTexts = {
-  upgradeStepTitle: (currentMajor: number) =>
+  upgradeStepTitle: (nextMajor: number) =>
     i18n.translate('xpack.upgradeAssistant.overview.upgradeStepTitle', {
-      defaultMessage: 'Install {currentMajor}.0',
-      values: { currentMajor },
+      defaultMessage: 'Install {nextMajor}.0',
+      values: { nextMajor },
     }),
   upgradeStepDescription: i18n.translate('xpack.upgradeAssistant.overview.upgradeStepDescription', {
     defaultMessage:
@@ -117,12 +117,12 @@ const UpgradeStep = ({ docLinks }: { docLinks: DocLinksStart }) => {
 
 interface Props {
   docLinks: DocLinksStart;
-  currentMajor: number;
+  nextMajor: number;
 }
 
-export const getUpgradeStep = ({ docLinks, currentMajor }: Props): EuiStepProps => {
+export const getUpgradeStep = ({ docLinks, nextMajor }: Props): EuiStepProps => {
   return {
-    title: i18nTexts.upgradeStepTitle(currentMajor),
+    title: i18nTexts.upgradeStepTitle(nextMajor),
     status: 'incomplete',
     children: <UpgradeStep docLinks={docLinks} />,
   };


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/109168

## Summary
Overview page should reference nextMajor instead of currentMajor.

