### PR TITLE
[7.14] chore(NA): moving @kbn/mapbox-gl to babel transpiler (#109082)

### DIFF
--- a/packages/kbn-mapbox-gl/.babelrc
+++ b/packages/kbn-mapbox-gl/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-mapbox-gl/BUILD.bazel
+++ b/packages/kbn-mapbox-gl/BUILD.bazel
@@ -1,6 +1,7 @@
 
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-mapbox-gl"
 PKG_REQUIRE_NAME = "@kbn/mapbox-gl"
@@ -26,17 +27,23 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md"
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "@npm//@mapbox/mapbox-gl-rtl-text",
   "@npm//file-loader",
   "@npm//mapbox-gl",
 ]
 
 TYPES_DEPS = [
+  "@npm//@mapbox/mapbox-gl-rtl-text",
+  "@npm//file-loader",
   "@npm//@types/mapbox-gl",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -47,14 +54,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -63,7 +71,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-mapbox-gl/package.json
+++ b/packages/kbn-mapbox-gl/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts"
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts"
 }

--- a/packages/kbn-mapbox-gl/src/index.ts
+++ b/packages/kbn-mapbox-gl/src/index.ts
@@ -35,8 +35,9 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 mapboxgl.workerUrl = mbWorkerUrl;
 mapboxgl.setRTLTextPlugin(mbRtlPlugin);
 
-export {
-  mapboxgl,
+export { mapboxgl };
+
+export type {
   Map,
   GeoJSONSource,
   VectorSource,

--- a/packages/kbn-mapbox-gl/tsconfig.json
+++ b/packages/kbn-mapbox-gl/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "./target",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-mapbox-gl/src",


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/mapbox-gl to babel transpiler (#109082)