### PR TITLE
[7.15] [Dashboard] Minor copy tweak for copy to dashboard action (#108361)

### DIFF
--- a/src/plugins/dashboard/public/dashboard_strings.ts
+++ b/src/plugins/dashboard/public/dashboard_strings.ts
@@ -92,7 +92,7 @@ export const dashboardCopyToDashboardAction = {
     }),
   getDescription: () =>
     i18n.translate('dashboard.panel.copyToDashboard.description', {
-      defaultMessage: "Select where to copy the panel. You're navigated to destination dashboard.",
+      defaultMessage: 'Choose the destination dashboard.',
     }),
 };
 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Dashboard] Minor copy tweak for copy to dashboard action (#108361)