### PR TITLE
Use https in package.json links

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://www.elastic.co/products/kibana",
   "bugs": {
-    "url": "http://github.com/elastic/kibana/issues"
+    "url": "https://github.com/elastic/kibana/issues"
   },
   "kibana": {
     "clean": {


### PR DESCRIPTION
## Summary

Super small change. My IDE showed a security warning because we have a link to github issues using the `http` protocol. This PR changes that to `https`.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
