### PR TITLE
[7.x] remove layout.selectors from job parameters (#109010)

### DIFF
--- a/x-pack/plugins/reporting/common/index.ts
+++ b/x-pack/plugins/reporting/common/index.ts
@@ -5,15 +5,6 @@
  * 2.0.
  */
 
-import { LayoutSelectorDictionary } from './types';
-
 export * as constants from './constants';
 export { CancellationToken } from './cancellation_token';
 export { Poller } from './poller';
-
-export const getDefaultLayoutSelectors = (): LayoutSelectorDictionary => ({
-  screenshot: '[data-shared-items-container]',
-  renderComplete: '[data-shared-item]',
-  itemsCountAttribute: 'data-shared-items-count',
-  timefilterDurationAttribute: 'data-shared-timefilter-duration',
-});

--- a/x-pack/plugins/reporting/common/types.ts
+++ b/x-pack/plugins/reporting/common/types.ts
@@ -16,13 +16,6 @@ export interface PageSizeParams {
   subheadingHeight: number;
 }
 
-export interface LayoutSelectorDictionary {
-  screenshot: string;
-  renderComplete: string;
-  itemsCountAttribute: string;
-  timefilterDurationAttribute: string;
-}
-
 export interface PdfImageSize {
   width: number;
   height?: number;
@@ -36,7 +29,6 @@ export interface Size {
 export interface LayoutParams {
   id: string;
   dimensions?: Size;
-  selectors?: LayoutSelectorDictionary;
 }
 
 export interface ReportDocumentHead {

--- a/x-pack/plugins/reporting/public/index.ts
+++ b/x-pack/plugins/reporting/public/index.ts
@@ -6,20 +6,18 @@
  */
 
 import { PluginInitializerContext } from 'src/core/public';
-import { getDefaultLayoutSelectors } from '../common';
 import { ReportingAPIClient } from './lib/reporting_api_client';
 import { ReportingPublicPlugin } from './plugin';
 import { getSharedComponents } from './shared';
 
 export interface ReportingSetup {
-  getDefaultLayoutSelectors: typeof getDefaultLayoutSelectors;
   usesUiCapabilities: () => boolean;
   components: ReturnType<typeof getSharedComponents>;
 }
 
 export type ReportingStart = ReportingSetup;
 
-export { constants, getDefaultLayoutSelectors } from '../common';
+export { constants } from '../common';
 export { ReportingAPIClient, ReportingPublicPlugin as Plugin };
 
 export function plugin(initializerContext: PluginInitializerContext) {

--- a/x-pack/plugins/reporting/public/mocks.ts
+++ b/x-pack/plugins/reporting/public/mocks.ts
@@ -8,7 +8,6 @@
 import { coreMock } from 'src/core/public/mocks';
 import { ReportingAPIClient } from './lib/reporting_api_client';
 import { ReportingSetup } from '.';
-import { getDefaultLayoutSelectors } from '../common';
 import { getSharedComponents } from './shared';
 
 type Setup = jest.Mocked<ReportingSetup>;
@@ -17,7 +16,6 @@ const createSetupContract = (): Setup => {
   const coreSetup = coreMock.createSetup();
   const apiClient = new ReportingAPIClient(coreSetup.http, coreSetup.uiSettings, '7.15.0');
   return {
-    getDefaultLayoutSelectors: jest.fn().mockImplementation(getDefaultLayoutSelectors),
     usesUiCapabilities: jest.fn().mockImplementation(() => true),
     components: getSharedComponents(coreSetup, apiClient),
   };

--- a/x-pack/plugins/reporting/public/plugin.ts
+++ b/x-pack/plugins/reporting/public/plugin.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../../src/plugins/home/public';
 import { ManagementSetup, ManagementStart } from '../../../../src/plugins/management/public';
 import { LicensingPluginSetup, LicensingPluginStart } from '../../licensing/public';
-import { constants, getDefaultLayoutSelectors } from '../common';
+import { constants } from '../common';
 import { durationToNumber } from '../common/schema_utils';
 import { JobId, JobSummarySet } from '../common/types';
 import { ReportingSetup, ReportingStart } from './';
@@ -121,7 +121,6 @@ export class ReportingPublicPlugin
   private getContract(core?: CoreSetup) {
     if (core) {
       this.contract = {
-        getDefaultLayoutSelectors,
         usesUiCapabilities: () => this.config.roles?.enabled === false,
         components: getSharedComponents(core, this.getApiClient(core.http, core.uiSettings)),
       };

--- a/x-pack/plugins/reporting/public/share_context_menu/__snapshots__/screen_capture_panel_content.test.tsx.snap
+++ b/x-pack/plugins/reporting/public/share_context_menu/__snapshots__/screen_capture_panel_content.test.tsx.snap
@@ -349,7 +349,7 @@ exports[`ScreenCapturePanelContent properly renders a view with "canvas" layout 
                 <EuiCopy
                   afterMessage="Copied"
                   anchorClassName="eui-displayBlock"
-                  textToCopy="http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%2Cselectors%3A%28itemsCountAttribute%3Adata-shared-items-count%2CrenderComplete%3A%5Bdata-shared-item%5D%2Cscreenshot%3A%5Bdata-shared-items-container%5D%2CtimefilterDurationAttribute%3Adata-shared-timefilter-duration%29%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"
+                  textToCopy="http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"
                 >
                   <EuiToolTip
                     anchorClassName="eui-displayBlock"
@@ -787,7 +787,7 @@ exports[`ScreenCapturePanelContent properly renders a view with "print" layout o
                 <EuiCopy
                   afterMessage="Copied"
                   anchorClassName="eui-displayBlock"
-                  textToCopy="http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%2Cselectors%3A%28itemsCountAttribute%3Adata-shared-items-count%2CrenderComplete%3A%5Bdata-shared-item%5D%2Cscreenshot%3A%5Bdata-shared-items-container%5D%2CtimefilterDurationAttribute%3Adata-shared-timefilter-duration%29%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"
+                  textToCopy="http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"
                 >
                   <EuiToolTip
                     anchorClassName="eui-displayBlock"
@@ -1097,7 +1097,7 @@ exports[`ScreenCapturePanelContent renders the default view properly 1`] = `
                 <EuiCopy
                   afterMessage="Copied"
                   anchorClassName="eui-displayBlock"
-                  textToCopy="http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%2Cselectors%3A%28itemsCountAttribute%3Adata-shared-items-count%2CrenderComplete%3A%5Bdata-shared-item%5D%2Cscreenshot%3A%5Bdata-shared-items-container%5D%2CtimefilterDurationAttribute%3Adata-shared-timefilter-duration%29%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"
+                  textToCopy="http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"
                 >
                   <EuiToolTip
                     anchorClassName="eui-displayBlock"

--- a/x-pack/plugins/reporting/public/share_context_menu/screen_capture_panel_content.test.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/screen_capture_panel_content.test.tsx
@@ -96,6 +96,6 @@ test('ScreenCapturePanelContent decorated job params are visible in the POST URL
   );
 
   expect(component.find('EuiCopy').prop('textToCopy')).toMatchInlineSnapshot(
-    `"http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%2Cselectors%3A%28itemsCountAttribute%3Adata-shared-items-count%2CrenderComplete%3A%5Bdata-shared-item%5D%2Cscreenshot%3A%5Bdata-shared-items-container%5D%2CtimefilterDurationAttribute%3Adata-shared-timefilter-duration%29%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"`
+    `"http://localhost/api/reporting/generate/Analytical%20App?jobParams=%28browserTimezone%3AAmerica%2FNew_York%2Clayout%3A%28dimensions%3A%28height%3A768%2Cwidth%3A1024%29%2Cid%3Apreserve_layout%29%2CobjectType%3Atest-object-type%2Ctitle%3A%27Test%20Report%20Title%27%2Cversion%3A%277.15.0%27%29"`
   );
 });

--- a/x-pack/plugins/reporting/public/share_context_menu/screen_capture_panel_content.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/screen_capture_panel_content.tsx
@@ -8,7 +8,6 @@
 import { EuiFormRow, EuiSwitch, EuiSwitchEvent } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React, { Component } from 'react';
-import { getDefaultLayoutSelectors } from '../../common';
 import { LayoutParams } from '../../common/types';
 import { ReportingPanelContent, ReportingPanelProps } from './reporting_panel_content';
 
@@ -114,20 +113,15 @@ export class ScreenCapturePanelContent extends Component<Props, State> {
       dimensions = { height, width };
     }
 
-    let selectors = outerLayout?.selectors;
-    if (!selectors) {
-      selectors = getDefaultLayoutSelectors();
-    }
-
     if (this.state.usePrintLayout) {
-      return { id: 'print', dimensions, selectors };
+      return { id: 'print', dimensions };
     }
 
     if (this.state.useCanvasLayout) {
-      return { id: 'canvas', dimensions, selectors };
+      return { id: 'canvas', dimensions };
     }
 
-    return { id: 'preserve_layout', dimensions, selectors };
+    return { id: 'preserve_layout', dimensions };
   };
 
   private getJobParams = () => {

--- a/x-pack/plugins/reporting/server/export_types/common/generate_png.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/generate_png.ts
@@ -32,7 +32,7 @@ export async function generatePngObservableFactory(reporting: ReportingCore) {
     if (!layoutParams || !layoutParams.dimensions) {
       throw new Error(`LayoutParams.Dimensions is undefined.`);
     }
-    const layout = new PreserveLayout(layoutParams.dimensions, layoutParams.selectors);
+    const layout = new PreserveLayout(layoutParams.dimensions);
     if (apmLayout) apmLayout.end();
 
     const apmScreenshots = apmTrans?.startSpan('screenshots_pipeline', 'setup');

--- a/x-pack/plugins/reporting/server/lib/layouts/index.ts
+++ b/x-pack/plugins/reporting/server/lib/layouts/index.ts
@@ -6,21 +6,22 @@
  */
 
 import { LevelLogger } from '../';
-import { LayoutSelectorDictionary, Size } from '../../../common/types';
+import { Size } from '../../../common/types';
 import { HeadlessChromiumDriver } from '../../browsers';
 import type { Layout } from './layout';
 
-export {
-  LayoutParams,
-  LayoutSelectorDictionary,
-  PageSizeParams,
-  PdfImageSize,
-  Size,
-} from '../../../common/types';
+export interface LayoutSelectorDictionary {
+  screenshot: string;
+  renderComplete: string;
+  itemsCountAttribute: string;
+  timefilterDurationAttribute: string;
+}
+
+export { LayoutParams, PageSizeParams, PdfImageSize, Size } from '../../../common/types';
+export { CanvasLayout } from './canvas_layout';
 export { createLayout } from './create_layout';
 export type { Layout } from './layout';
 export { PreserveLayout } from './preserve_layout';
-export { CanvasLayout } from './canvas_layout';
 export { PrintLayout } from './print_layout';
 
 export const LayoutTypes = {

--- a/x-pack/plugins/reporting/server/lib/layouts/preserve_layout.ts
+++ b/x-pack/plugins/reporting/server/lib/layouts/preserve_layout.ts
@@ -7,33 +7,28 @@
 
 import path from 'path';
 import { CustomPageSize } from 'pdfmake/interfaces';
-import { getDefaultLayoutSelectors } from '../../../common';
 import { LAYOUT_TYPES } from '../../../common/constants';
-import { LayoutSelectorDictionary, PageSizeParams, Size } from '../../../common/types';
-import type { LayoutInstance } from './';
+import { PageSizeParams, Size } from '../../../common/types';
+import { getDefaultLayoutSelectors, LayoutInstance } from './';
 import { Layout } from './layout';
 
 // We use a zoom of two to bump up the resolution of the screenshot a bit.
 const ZOOM: number = 2;
 
 export class PreserveLayout extends Layout implements LayoutInstance {
-  public readonly selectors: LayoutSelectorDictionary = getDefaultLayoutSelectors();
+  public readonly selectors = getDefaultLayoutSelectors();
   public readonly groupCount = 1;
   public readonly height: number;
   public readonly width: number;
   private readonly scaledHeight: number;
   private readonly scaledWidth: number;
 
-  constructor(size: Size, layoutSelectors?: LayoutSelectorDictionary) {
+  constructor(size: Size) {
     super(LAYOUT_TYPES.PRESERVE_LAYOUT);
     this.height = size.height;
     this.width = size.width;
     this.scaledHeight = size.height * ZOOM;
     this.scaledWidth = size.width * ZOOM;
-
-    if (layoutSelectors) {
-      this.selectors = layoutSelectors;
-    }
   }
 
   public getCssOverridesPath() {

--- a/x-pack/plugins/reporting/server/lib/layouts/print_layout.ts
+++ b/x-pack/plugins/reporting/server/lib/layouts/print_layout.ts
@@ -9,18 +9,17 @@ import path from 'path';
 import { PageOrientation, PredefinedPageSize } from 'pdfmake/interfaces';
 import { EvaluateFn, SerializableOrJSHandle } from 'puppeteer';
 import { LevelLogger } from '../';
-import { getDefaultLayoutSelectors } from '../../../common';
 import { LAYOUT_TYPES } from '../../../common/constants';
-import { LayoutSelectorDictionary, Size } from '../../../common/types';
+import { Size } from '../../../common/types';
 import { HeadlessChromiumDriver } from '../../browsers';
 import { CaptureConfig } from '../../types';
-import type { LayoutInstance } from './';
+import { getDefaultLayoutSelectors, LayoutInstance, LayoutSelectorDictionary } from './';
 import { Layout } from './layout';
 
 export class PrintLayout extends Layout implements LayoutInstance {
   public readonly selectors: LayoutSelectorDictionary = {
     ...getDefaultLayoutSelectors(),
-    screenshot: '[data-shared-item]',
+    screenshot: '[data-shared-item]', // override '[data-shared-items-container]'
   };
   public readonly groupCount = 2;
   private captureConfig: CaptureConfig;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - remove layout.selectors from job parameters (#109010)