### PR TITLE
[Monitoring] document monitoring.ui.ccs.enabled

### DIFF
--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -38,7 +38,7 @@ For more information, see
   cluster.
 
 | `monitoring.ui.ccs.enabled`
-  | Set to `true` (default) to enable {ref}/monitor-elasticsearch-cluster.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html[`remote_cluster_client`] role must exist on each node.
+  | Set to `true` (default) to enable {ref}/modules-cross-cluster-search.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html#remote-cluster-settings[`remote_cluster_client`] role must exist on each node.
 
 
 | `monitoring.ui.elasticsearch.hosts`

--- a/docs/settings/monitoring-settings.asciidoc
+++ b/docs/settings/monitoring-settings.asciidoc
@@ -37,6 +37,10 @@ For more information, see
   monitoring back-end does not run and {kib} stats are not sent to the monitoring
   cluster.
 
+| `monitoring.ui.ccs.enabled`
+  | Set to `true` (default) to enable {ref}/monitor-elasticsearch-cluster.html[cross-cluster search] of your monitoring data. The {ref}/modules-remote-clusters.html[`remote_cluster_client`] role must exist on each node.
+
+
 | `monitoring.ui.elasticsearch.hosts`
   | Specifies the location of the {es} cluster where your monitoring data is stored.
   By default, this is the same as <<elasticsearch-hosts, `elasticsearch.hosts`>>. This setting enables


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/109272

Document monitoring.ui.ccs.enabled

<img width="777" alt="Screen Shot 2021-08-19 at 3 17 35 PM" src="https://user-images.githubusercontent.com/1676003/130131172-8d3a05f9-dfb0-4caa-943f-4841263c3e67.png">

The first link goes to https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-cross-cluster-search.html
The second link goes to https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-remote-clusters.html#remote-cluster-settings

Relates to: https://github.com/elastic/kibana/issues/93432