### PR TITLE
[Exploratory View] Remove references to deprecated IIndexPattern

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/utils.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/utils.ts
@@ -7,7 +7,7 @@
 import rison, { RisonValue } from 'rison-node';
 import type { SeriesUrl, UrlFilter } from '../types';
 import type { AllSeries, AllShortSeries } from '../hooks/use_series_storage';
-import { IIndexPattern } from '../../../../../../../../src/plugins/data/common/index_patterns';
+import { IndexPattern } from '../../../../../../../../src/plugins/data/common/index_patterns';
 import { esFilters, ExistsFilter } from '../../../../../../../../src/plugins/data/public';
 import { URL_KEYS } from './constants/url_constants';
 import { PersistableFilter } from '../../../../../../lens/common';
@@ -53,7 +53,7 @@ export function createExploratoryViewUrl(allSeries: AllSeries, baseHref = '') {
   );
 }
 
-export function buildPhraseFilter(field: string, value: string, indexPattern: IIndexPattern) {
+export function buildPhraseFilter(field: string, value: string, indexPattern: IndexPattern) {
   const fieldMeta = indexPattern?.fields.find((fieldT) => fieldT.name === field);
   if (fieldMeta) {
     return [esFilters.buildPhraseFilter(fieldMeta, value, indexPattern)];
@@ -61,7 +61,7 @@ export function buildPhraseFilter(field: string, value: string, indexPattern: II
   return [];
 }
 
-export function buildPhrasesFilter(field: string, value: string[], indexPattern: IIndexPattern) {
+export function buildPhrasesFilter(field: string, value: string[], indexPattern: IndexPattern) {
   const fieldMeta = indexPattern?.fields.find((fieldT) => fieldT.name === field);
   if (fieldMeta) {
     return [esFilters.buildPhrasesFilter(fieldMeta, value, indexPattern)];
@@ -69,7 +69,7 @@ export function buildPhrasesFilter(field: string, value: string[], indexPattern:
   return [];
 }
 
-export function buildExistsFilter(field: string, indexPattern: IIndexPattern) {
+export function buildExistsFilter(field: string, indexPattern: IndexPattern) {
   const fieldMeta = indexPattern?.fields.find((fieldT) => fieldT.name === field);
   if (fieldMeta) {
     return [esFilters.buildExistsFilter(fieldMeta, indexPattern)];
@@ -86,7 +86,7 @@ export function urlFilterToPersistedFilter({
 }: {
   urlFilters: UrlFilter[];
   initFilters: FiltersType;
-  indexPattern: IIndexPattern;
+  indexPattern: IndexPattern;
 }) {
   const parsedFilters: FiltersType = initFilters ? [...initFilters] : [];
 

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_app_index_pattern.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_app_index_pattern.tsx
@@ -13,14 +13,14 @@ import { ObservabilityPublicPluginsStart } from '../../../../plugin';
 import { ObservabilityIndexPatterns } from '../utils/observability_index_patterns';
 import { getDataHandler } from '../../../../data_handler';
 
-export interface IIndexPatternContext {
+export interface IndexPatternContext {
   loading: boolean;
   indexPatterns: IndexPatternState;
   hasAppData: HasAppDataState;
   loadIndexPattern: (params: { dataType: AppDataType }) => void;
 }
 
-export const IndexPatternContext = createContext<Partial<IIndexPatternContext>>({});
+export const IndexPatternContext = createContext<Partial<IndexPatternContext>>({});
 
 interface ProviderProps {
   children: JSX.Element;
@@ -46,7 +46,7 @@ export function IndexPatternContextProvider({ children }: ProviderProps) {
     services: { data },
   } = useKibana<ObservabilityPublicPluginsStart>();
 
-  const loadIndexPattern: IIndexPatternContext['loadIndexPattern'] = useCallback(
+  const loadIndexPattern: IndexPatternContext['loadIndexPattern'] = useCallback(
     async ({ dataType }) => {
       if (hasAppData[dataType] === null && !loading[dataType]) {
         setLoading((prevState) => ({ ...prevState, [dataType]: true }));
@@ -101,7 +101,7 @@ export function IndexPatternContextProvider({ children }: ProviderProps) {
 
 export const useAppIndexPatternContext = (dataType?: AppDataType) => {
   const { loading, hasAppData, loadIndexPattern, indexPatterns } = useContext(
-    (IndexPatternContext as unknown) as Context<IIndexPatternContext>
+    (IndexPatternContext as unknown) as Context<IndexPatternContext>
   );
 
   if (dataType && !indexPatterns?.[dataType] && !loading) {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/types.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/types.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../../lens/public';
 
 import { PersistableFilter } from '../../../../../lens/common';
-import { IIndexPattern } from '../../../../../../../src/plugins/data/public';
+import { IndexPattern } from '../../../../../../../src/plugins/data/public';
 
 export const ReportViewTypes = {
   dist: 'data-distribution',
@@ -91,7 +91,7 @@ export interface UrlFilter {
 }
 
 export interface ConfigProps {
-  indexPattern: IIndexPattern;
+  indexPattern: IndexPattern;
   series?: SeriesUrl;
 }
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/uptime/issues/350.

Removes the references to the deprecated IIndexPattern interface.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
