### PR TITLE
[Flaky test] Better logging for the Application Usage integration tests

### DIFF
--- a/x-pack/test/usage_collection/test_suites/application_usage/index.ts
+++ b/x-pack/test/usage_collection/test_suites/application_usage/index.ts
@@ -18,6 +18,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('keys in the schema match the registered application IDs', async () => {
       await common.navigateToApp('home'); // Navigate to Home to make sure all the appIds are loaded
       const appIds = await browser.execute(() => window.__applicationIds__);
+      if (!appIds || !Array.isArray(appIds)) {
+        throw new Error(
+          'Failed to retrieve all the existing applications in Kibana. Did it fail to boot or to navigate to home?'
+        );
+      }
       try {
         expect(Object.keys(applicationUsageSchema).sort()).to.eql(appIds.sort());
       } catch (err) {


### PR DESCRIPTION
## Summary

#90536 shows that the test failed, but the reason behind it is that Kibana failed to log in due to a licensing error. This PR adds a different error message to indicate that in the future.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
