### PR TITLE
[7.14] chore(NA): moving @kbn/interpreter to babel transpiler (#108512)

### DIFF
--- a/packages/kbn-interpreter/.babelrc
+++ b/packages/kbn-interpreter/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-interpreter/BUILD.bazel
+++ b/packages/kbn-interpreter/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@npm//peggy:index.bzl", "peggy")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-interpreter"
 PKG_REQUIRE_NAME = "@kbn/interpreter"
@@ -25,7 +26,7 @@ NPM_MODULE_EXTRA_FILES = [
   "package.json",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "@npm//lodash",
 ]
 
@@ -35,7 +36,11 @@ TYPES_DEPS = [
   "@npm//@types/node",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 peggy(
   name = "grammar",
@@ -61,15 +66,16 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   allow_js = True,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -78,7 +84,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES + [":grammar"],
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-interpreter/common/package.json
+++ b/packages/kbn-interpreter/common/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "main": "../target/common/index.js",
-  "types": "../target/common/index.d.ts"
+  "main": "../target_node/common/index.js",
+  "types": "../target_types/common/index.d.ts"
 }

--- a/packages/kbn-interpreter/src/common/lib/ast.from_expression.test.js
+++ b/packages/kbn-interpreter/src/common/lib/ast.from_expression.test.js
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { fromExpression } from '@kbn/interpreter/target/common/lib/ast';
+import { fromExpression } from '@kbn/interpreter/common';
 import { getType } from './get_type';
 
 describe('ast fromExpression', () => {

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -2,10 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "incremental": true,
-    "outDir": "./target",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "./target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-interpreter/src",

--- a/x-pack/plugins/lens/public/embeddable/embeddable_factory.ts
+++ b/x-pack/plugins/lens/public/embeddable/embeddable_factory.ts
@@ -8,7 +8,7 @@
 import { Capabilities, HttpSetup, SavedObjectReference } from 'kibana/public';
 import { i18n } from '@kbn/i18n';
 import { RecursiveReadonly } from '@kbn/utility-types';
-import { Ast } from '@kbn/interpreter/target/common';
+import { Ast } from '@kbn/interpreter/common';
 import { EmbeddableStateWithType } from 'src/plugins/embeddable/common';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
 import { IndexPatternsContract, TimefilterContract } from '../../../../../src/plugins/data/public';

--- a/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { Ast } from '@kbn/interpreter/target/common';
+import { Ast } from '@kbn/interpreter/common';
 import { getSuggestions } from './metric_suggestions';
 import { LensIconChartMetric } from '../assets/chart_metric';
 import { Visualization, OperationMetadata, DatasourcePublicAPI } from '../types';

--- a/x-pack/plugins/lens/public/xy_visualization/to_expression.test.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/to_expression.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Ast } from '@kbn/interpreter/target/common';
+import { Ast } from '@kbn/interpreter/common';
 import { Position } from '@elastic/charts';
 import { chartPluginMock } from '../../../../../src/plugins/charts/public/mocks';
 import { getXyVisualization } from './xy_visualization';


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/interpreter to babel transpiler (#108512)