### PR TITLE
[7.14] chore(NA): moving @kbn/logging to babel transpiler (#108702)

### DIFF
--- a/packages/kbn-config/src/config_service.test.ts
+++ b/packages/kbn-config/src/config_service.test.ts
@@ -13,7 +13,7 @@ import { mockApplyDeprecations, mockedChangedPaths } from './config_service.test
 import { rawConfigServiceMock } from './raw/raw_config_service.mock';
 
 import { schema } from '@kbn/config-schema';
-import { MockedLogger, loggerMock } from '@kbn/logging/target/mocks';
+import { MockedLogger, loggerMock } from '@kbn/logging/mocks';
 
 import { ConfigService, Env, RawPackageInfo } from '.';
 

--- a/packages/kbn-logging/.babelrc
+++ b/packages/kbn-logging/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"]
+}

--- a/packages/kbn-logging/BUILD.bazel
+++ b/packages/kbn-logging/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-logging"
 PKG_REQUIRE_NAME = "@kbn/logging"
@@ -21,20 +22,26 @@ filegroup(
 )
 
 NPM_MODULE_EXTRA_FILES = [
+  "mocks/package.json",
   "package.json",
   "README.md"
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-std"
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-std",
   "@npm//@types/jest",
   "@npm//@types/node",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -45,14 +52,15 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   source_map = True,
   root_dir = "src",
   tsconfig = ":tsconfig",
@@ -61,7 +69,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-logging/mocks/package.json
+++ b/packages/kbn-logging/mocks/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "main": "../target_node/mocks/index.js",
+  "types": "../target_types/mocks/index.d.ts"
+}

--- a/packages/kbn-logging/package.json
+++ b/packages/kbn-logging/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts"
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts"
 }

--- a/packages/kbn-logging/tsconfig.json
+++ b/packages/kbn-logging/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "incremental": true,
-    "outDir": "target",
-    "stripInternal": false,
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-logging/src",
+    "stripInternal": false,
     "types": [
       "jest",
       "node"

--- a/src/core/server/http/integration_tests/router.test.ts
+++ b/src/core/server/http/integration_tests/router.test.ts
@@ -16,7 +16,7 @@ import { loggingSystemMock } from '../../logging/logging_system.mock';
 import { createHttpServer } from '../test_utils';
 import { HttpService } from '../http_service';
 import { Router } from '../router';
-import { loggerMock } from '@kbn/logging/target/mocks';
+import { loggerMock } from '@kbn/logging/mocks';
 
 let server: HttpService;
 let logger: ReturnType<typeof loggingSystemMock.create>;

--- a/src/core/server/logging/logger.mock.ts
+++ b/src/core/server/logging/logger.mock.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export { loggerMock } from '@kbn/logging/target/mocks';
-export type { MockedLogger } from '@kbn/logging/target/mocks';
+export { loggerMock } from '@kbn/logging/mocks';
+export type { MockedLogger } from '@kbn/logging/mocks';

--- a/src/core/server/metrics/collectors/cgroup.test.ts
+++ b/src/core/server/metrics/collectors/cgroup.test.ts
@@ -7,7 +7,7 @@
  */
 
 import mockFs from 'mock-fs';
-import { loggerMock } from '@kbn/logging/target/mocks';
+import { loggerMock } from '@kbn/logging/mocks';
 import { OsCgroupMetricsCollector } from './cgroup';
 
 describe('OsCgroupMetricsCollector', () => {

--- a/src/core/server/metrics/collectors/os.test.ts
+++ b/src/core/server/metrics/collectors/os.test.ts
@@ -8,7 +8,7 @@
 
 jest.mock('getos', () => (cb: Function) => cb(null, { dist: 'distrib', release: 'release' }));
 
-import { loggerMock } from '@kbn/logging/target/mocks';
+import { loggerMock } from '@kbn/logging/mocks';
 import os from 'os';
 import { cgroupCollectorMock } from './os.test.mocks';
 import { OsMetricsCollector } from './os';

--- a/src/core/server/metrics/ops_metrics_collector.test.ts
+++ b/src/core/server/metrics/ops_metrics_collector.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { loggerMock } from '@kbn/logging/target/mocks';
+import { loggerMock } from '@kbn/logging/mocks';
 import {
   mockOsCollector,
   mockProcessCollector,

--- a/x-pack/plugins/alerting/server/saved_objects/is_rule_exportable.test.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/is_rule_exportable.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { MockedLogger, loggerMock } from '@kbn/logging/target/mocks';
+import { MockedLogger, loggerMock } from '@kbn/logging/mocks';
 import { TaskRunnerFactory } from '../task_runner';
 import { AlertTypeRegistry, ConstructorOptions } from '../alert_type_registry';
 import { taskManagerMock } from '../../../task_manager/server/mocks';

--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_rule_type.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { loggerMock } from '@kbn/logging/target/mocks';
+import { loggerMock } from '@kbn/logging/mocks';
 import { castArray, omit, mapValues } from 'lodash';
 import { RuleDataClient } from '../rule_data_client';
 import { createRuleDataClientMock } from '../rule_data_client/create_rule_data_client_mock';


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/logging to babel transpiler (#108702)