### PR TITLE
[Fleet] Fix Fleet settings and HostInput error handling

### DIFF
--- a/x-pack/plugins/fleet/public/components/settings_flyout/hosts_input.tsx
+++ b/x-pack/plugins/fleet/public/components/settings_flyout/hosts_input.tsx
@@ -162,7 +162,7 @@ export const HostsInput: FunctionComponent<Props> = ({
     if (!errors) {
       return [];
     }
-    return errors.reduce((acc, err) => {
+    return errors.reduce<string[][]>((acc, err) => {
       if (err.index === undefined) {
         return acc;
       }
@@ -174,7 +174,7 @@ export const HostsInput: FunctionComponent<Props> = ({
       acc[err.index].push(err.message);
 
       return acc;
-    }, [] as string[][]);
+    }, []);
   }, [errors]);
 
   const onDelete = useCallback(

--- a/x-pack/plugins/fleet/public/components/settings_flyout/hosts_input.tsx
+++ b/x-pack/plugins/fleet/public/components/settings_flyout/hosts_input.tsx
@@ -158,33 +158,6 @@ export const HostsInput: FunctionComponent<Props> = ({
     [value, onChange]
   );
 
-  const onDelete = useCallback(
-    (idx: number) => {
-      onChange([...value.slice(0, idx), ...value.slice(idx + 1)]);
-    },
-    [value, onChange]
-  );
-
-  const addRowHandler = useCallback(() => {
-    setAutoFocus(true);
-    onChange([...value, '']);
-  }, [value, onChange]);
-
-  const onDragEndHandler = useCallback(
-    ({ source, destination }) => {
-      if (source && destination) {
-        const items = euiDragDropReorder(value, source.index, destination.index);
-
-        onChange(items);
-      }
-    },
-    [value, onChange]
-  );
-
-  const globalErrors = useMemo(() => {
-    return errors && errors.filter((err) => err.index === undefined).map(({ message }) => message);
-  }, [errors]);
-
   const indexedErrors = useMemo(() => {
     if (!errors) {
       return [];
@@ -202,6 +175,37 @@ export const HostsInput: FunctionComponent<Props> = ({
 
       return acc;
     }, [] as string[][]);
+  }, [errors]);
+
+  const onDelete = useCallback(
+    (idx: number) => {
+      indexedErrors.splice(idx, 1);
+      onChange([...value.slice(0, idx), ...value.slice(idx + 1)]);
+    },
+    [value, onChange, indexedErrors]
+  );
+
+  const addRowHandler = useCallback(() => {
+    setAutoFocus(true);
+    onChange([...value, '']);
+  }, [value, onChange]);
+
+  const onDragEndHandler = useCallback(
+    ({ source, destination }) => {
+      if (source && destination) {
+        const items = euiDragDropReorder(value, source.index, destination.index);
+
+        const destinationErrors = indexedErrors[destination.index];
+        indexedErrors[destination.index] = indexedErrors[source.index];
+        indexedErrors[source.index] = destinationErrors;
+        onChange(items);
+      }
+    },
+    [value, onChange, indexedErrors]
+  );
+
+  const globalErrors = useMemo(() => {
+    return errors && errors.filter((err) => err.index === undefined).map(({ message }) => message);
   }, [errors]);
 
   const isSortable = rows.length > 1;

--- a/x-pack/plugins/fleet/public/components/settings_flyout/hosts_input.tsx
+++ b/x-pack/plugins/fleet/public/components/settings_flyout/hosts_input.tsx
@@ -194,10 +194,9 @@ export const HostsInput: FunctionComponent<Props> = ({
     ({ source, destination }) => {
       if (source && destination) {
         const items = euiDragDropReorder(value, source.index, destination.index);
-
-        const destinationErrors = indexedErrors[destination.index];
-        indexedErrors[destination.index] = indexedErrors[source.index];
-        indexedErrors[source.index] = destinationErrors;
+        const sourceErrors = indexedErrors[source.index];
+        indexedErrors.splice(source.index, 1);
+        indexedErrors.splice(destination.index, 0, sourceErrors);
         onChange(items);
       }
     },

--- a/x-pack/plugins/fleet/public/components/settings_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/settings_flyout/index.tsx
@@ -58,9 +58,11 @@ const CodeEditorPlaceholder = styled(EuiTextColor).attrs((props) => ({
 }))`
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
   // Matches monaco editor
   font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 21px;
   pointer-events: none;
 `;
 

--- a/x-pack/plugins/fleet/public/components/settings_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/settings_flyout/index.tsx
@@ -102,6 +102,7 @@ function useSettingsForm(outputId: string | undefined, onSuccess: () => void) {
     }
 
     const res: Array<{ message: string; index: number }> = [];
+    const hostIndexes: { [key: string]: number[] } = {};
     value.forEach((val, idx) => {
       if (!val.match(URL_REGEX)) {
         res.push({
@@ -111,7 +112,23 @@ function useSettingsForm(outputId: string | undefined, onSuccess: () => void) {
           index: idx,
         });
       }
+      const curIndexes = hostIndexes[val] || [];
+      hostIndexes[val] = [...curIndexes, idx];
     });
+
+    Object.values(hostIndexes)
+      .filter(({ length }) => length > 1)
+      .forEach((indexes) => {
+        indexes.forEach((index) =>
+          res.push({
+            message: i18n.translate('xpack.fleet.settings.fleetServerHostsDuplicateError', {
+              defaultMessage: 'Duplicate URL',
+            }),
+            index,
+          })
+        );
+      });
+
     if (res.length) {
       return res;
     }
@@ -132,6 +149,7 @@ function useSettingsForm(outputId: string | undefined, onSuccess: () => void) {
 
   const elasticsearchUrlInput = useComboInput('esHostsComboxBox', [], (value) => {
     const res: Array<{ message: string; index: number }> = [];
+    const urlIndexes: { [key: string]: number[] } = {};
     value.forEach((val, idx) => {
       if (!val.match(URL_REGEX)) {
         res.push({
@@ -141,7 +159,23 @@ function useSettingsForm(outputId: string | undefined, onSuccess: () => void) {
           index: idx,
         });
       }
+      const curIndexes = urlIndexes[val] || [];
+      urlIndexes[val] = [...curIndexes, idx];
     });
+
+    Object.values(urlIndexes)
+      .filter(({ length }) => length > 1)
+      .forEach((indexes) => {
+        indexes.forEach((index) =>
+          res.push({
+            message: i18n.translate('xpack.fleet.settings.elasticHostDuplicateError', {
+              defaultMessage: 'Duplicate URL',
+            }),
+            index,
+          })
+        );
+      });
+
     if (res.length) {
       return res;
     }

--- a/x-pack/plugins/fleet/public/components/settings_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/components/settings_flyout/index.tsx
@@ -196,11 +196,11 @@ function useSettingsForm(outputId: string | undefined, onSuccess: () => void) {
   });
 
   const validate = useCallback(() => {
-    if (
-      !fleetServerHostsInput.validate() ||
-      !elasticsearchUrlInput.validate() ||
-      !additionalYamlConfigInput.validate()
-    ) {
+    const fleetServerHostsValid = fleetServerHostsInput.validate();
+    const elasticsearchUrlsValid = elasticsearchUrlInput.validate();
+    const additionalYamlConfigValid = additionalYamlConfigInput.validate();
+
+    if (!fleetServerHostsValid || !elasticsearchUrlsValid || !additionalYamlConfigValid) {
       return false;
     }
 


### PR DESCRIPTION
## Summary

Three changes to the error handling in the fleet settings flyout:

- Duplicate URLs are now detected and flagged (fixes #105942)
- All sections are validated on save (previously we exited early once the first error was found)
- Validation errors are now rearranged when a host is swapped or deleted

<img width="995" alt="Screenshot 2021-08-20 at 11 59 57" src="https://user-images.githubusercontent.com/3315046/130224615-ad4b42ce-631e-4aed-9900-2094a26ed396.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
