### PR TITLE
[Security Solution] Update Missing Privileges callout

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -55,7 +55,7 @@ export const DEFAULT_RULE_REFRESH_INTERVAL_ON = true;
 export const DEFAULT_RULE_REFRESH_INTERVAL_VALUE = 60000; // ms
 export const DEFAULT_RULE_REFRESH_IDLE_VALUE = 2700000; // ms
 export const DEFAULT_RULE_NOTIFICATION_QUERY_SIZE = 100;
-export const SAVED_OBJECTS_MANAGEMENT_FEATURE_ID = 'Saved Objects Management';
+export const SECURITY_FEATURE_ID = 'Security';
 export const DEFAULT_SPACE_ID = 'default';
 
 // Document path where threat indicator fields are expected. Fields are used

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/translations.tsx
@@ -17,7 +17,7 @@ import {
   DEFAULT_ITEMS_INDEX,
   DEFAULT_LISTS_INDEX,
   DEFAULT_SIGNALS_INDEX,
-  SAVED_OBJECTS_MANAGEMENT_FEATURE_ID,
+  SECURITY_FEATURE_ID,
 } from '../../../../../common/constants';
 import { CommaSeparatedValues } from './comma_separated_values';
 import { MissingPrivileges } from './use_missing_privileges';
@@ -56,7 +56,7 @@ export const missingPrivilegesCallOutBody = ({
 }: MissingPrivileges) => (
   <FormattedMessage
     id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail"
-    defaultMessage="{essence} Missing privileges: {privileges} Related documentation: {docs}"
+    defaultMessage="{essence} {indexPrivileges} {featurePrivileges} Related documentation: {docs}"
     values={{
       essence: (
         <p>
@@ -66,16 +66,34 @@ export const missingPrivilegesCallOutBody = ({
           />
         </p>
       ),
-      privileges: (
-        <ul>
-          {indexPrivileges.map(([index, missingPrivileges]) => (
-            <li key={index}>{missingIndexPrivileges(index, missingPrivileges)}</li>
-          ))}
-          {featurePrivileges.map(([feature, missingPrivileges]) => (
-            <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
-          ))}
-        </ul>
-      ),
+      indexPrivileges:
+        indexPrivileges.length > 0 ? (
+          <>
+            <FormattedMessage
+              id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.indexPrivilegesTitle"
+              defaultMessage="Missing Elasticsearch index privileges:"
+            />
+            <ul>
+              {indexPrivileges.map(([index, missingPrivileges]) => (
+                <li key={index}>{missingIndexPrivileges(index, missingPrivileges)}</li>
+              ))}
+            </ul>
+          </>
+        ) : null,
+      featurePrivileges:
+        featurePrivileges.length > 0 ? (
+          <>
+            <FormattedMessage
+              id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.featurePrivilegesTitle"
+              defaultMessage="Missing Kibana feature privileges:"
+            />
+            <ul>
+              {featurePrivileges.map(([feature, missingPrivileges]) => (
+                <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
+              ))}
+            </ul>
+          </>
+        ) : null,
       docs: (
         <ul>
           <li>
@@ -97,7 +115,7 @@ interface PrivilegeExplanations {
 }
 
 const PRIVILEGE_EXPLANATIONS: PrivilegeExplanations = {
-  [SAVED_OBJECTS_MANAGEMENT_FEATURE_ID]: {
+  [SECURITY_FEATURE_ID]: {
     all: CANNOT_EDIT_RULES,
   },
   [DEFAULT_SIGNALS_INDEX]: {

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/use_missing_privileges.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/use_missing_privileges.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { SAVED_OBJECTS_MANAGEMENT_FEATURE_ID } from '../../../../../common/constants';
+import { SECURITY_FEATURE_ID } from '../../../../../common/constants';
 import { Privilege } from '../../../containers/detection_engine/alerts/types';
 import { useUserData } from '../../user_info';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
@@ -40,18 +40,14 @@ export interface MissingPrivileges {
 }
 
 export const useMissingPrivileges = (): MissingPrivileges => {
-  const { detectionEnginePrivileges, listPrivileges } = useUserPrivileges();
+  const { listPrivileges } = useUserPrivileges();
   const [{ canUserCRUD }] = useUserData();
 
   return useMemo<MissingPrivileges>(() => {
     const featurePrivileges: MissingFeaturePrivileges[] = [];
     const indexPrivileges: MissingIndexPrivileges[] = [];
 
-    if (
-      canUserCRUD == null ||
-      listPrivileges.result == null ||
-      detectionEnginePrivileges.result == null
-    ) {
+    if (canUserCRUD == null || listPrivileges.result == null) {
       /**
        * Do not check privileges till we get all the data. That helps to reduce
        * subsequent layout shift while loading and skip unneeded re-renders.
@@ -63,7 +59,7 @@ export const useMissingPrivileges = (): MissingPrivileges => {
     }
 
     if (canUserCRUD === false) {
-      featurePrivileges.push([SAVED_OBJECTS_MANAGEMENT_FEATURE_ID, ['all']]);
+      featurePrivileges.push([SECURITY_FEATURE_ID, ['all']]);
     }
 
     const missingItemsPrivileges = getMissingIndexPrivileges(listPrivileges.result.listItems.index);
@@ -76,16 +72,9 @@ export const useMissingPrivileges = (): MissingPrivileges => {
       indexPrivileges.push(missingListsPrivileges);
     }
 
-    const missingDetectionPrivileges = getMissingIndexPrivileges(
-      detectionEnginePrivileges.result.index
-    );
-    if (missingDetectionPrivileges) {
-      indexPrivileges.push(missingDetectionPrivileges);
-    }
-
     return {
       featurePrivileges,
       indexPrivileges,
     };
-  }, [canUserCRUD, listPrivileges, detectionEnginePrivileges]);
+  }, [canUserCRUD, listPrivileges]);
 };

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -20307,7 +20307,6 @@
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.cannotEditLists": "これらの権限がない場合は、値リストを作成したり編集したりできません。",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.cannotEditRules": "その権限がない場合、検出エンジンルールを作製したり編集したりできません。",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.essenceDescription": "この機能のすべてにアクセスするには、次の権限が必要です。サポートについては、管理者にお問い合わせください。",
-    "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail": "{essence}不足している権限：{privileges}関連するドキュメント：{docs}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingFeaturePrivileges": "{index}機能の{privileges}権限が不足しています。{explanation}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingIndexPrivileges": "{index}インデックスの{privileges}権限が不足しています。{explanation}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageTitle": "権限が不十分です",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -20773,7 +20773,6 @@
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.cannotEditLists": "没有这些权限，将无法创建或编辑值列表。",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.cannotEditRules": "没有该权限，将无法创建或编辑检测引擎规则。",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.essenceDescription": "您需要以下权限，才能完全使用此功能。有关进一步帮助，请联系您的管理员。",
-    "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail": "{essence} 缺失权限：{privileges} 相关文档：{docs}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingFeaturePrivileges": "缺失 {privileges} 权限，无法使用 {index} 功能。{explanation}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingIndexPrivileges": "缺失 {privileges} 权限，无法使用 {index} 索引。{explanation}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageTitle": "权限不足",


### PR DESCRIPTION
## Summary

- Removed reference to `.siem-signal` from the missing privileges callout as it is no longer needed after [this PR](https://github.com/elastic/kibana/pull/108961).
- Renamed _"Missing all privileges for the **Saved Objects Management** feature"_ to _"Missing all privileges for the **Security** feature"_ to match Kibana feature privileges UI.


**Before**
![Screenshot 2021-08-20 at 13 36 02](https://user-images.githubusercontent.com/1938181/130257865-ab2e4bbb-9872-41e0-b587-5cb5cafce26d.png)

**After**
![Screenshot 2021-08-20 at 13 28 33](https://user-images.githubusercontent.com/1938181/130257827-6b3881c6-6052-41ec-85f5-be01d760e4ae.png)


