### PR TITLE
[Reporting] Fix check for security and added jest test

### DIFF
--- a/x-pack/plugins/reporting/server/routes/deprecations.test.ts
+++ b/x-pack/plugins/reporting/server/routes/deprecations.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { of } from 'rxjs';
+import { UnwrapPromise } from '@kbn/utility-types';
+import { setupServer } from 'src/core/server/test_utils';
+import { API_GET_ILM_POLICY_STATUS } from '../../common/constants';
+import { securityMock } from '../../../security/server/mocks';
+
+import supertest from 'supertest';
+
+import {
+  createMockConfigSchema,
+  createMockPluginSetup,
+  createMockReportingCore,
+  createMockLevelLogger,
+} from '../test_helpers';
+
+import { registerDeprecationsRoutes } from './deprecations';
+
+type SetupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
+
+describe(`GET ${API_GET_ILM_POLICY_STATUS}`, () => {
+  const reportingSymbol = Symbol('reporting');
+  let server: SetupServerReturn['server'];
+  let httpSetup: SetupServerReturn['httpSetup'];
+
+  const createReportingCore = ({
+    security,
+  }: {
+    security?: ReturnType<typeof securityMock.createSetup>;
+  }) =>
+    createMockReportingCore(
+      createMockConfigSchema({
+        queue: {
+          indexInterval: 'year',
+          timeout: 10000,
+          pollEnabled: true,
+        },
+        index: '.reporting',
+      }),
+      createMockPluginSetup({
+        security,
+        router: httpSetup.createRouter(''),
+        licensing: { license$: of({ isActive: true, isAvailable: true, type: 'gold' }) },
+      })
+    );
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    ({ server, httpSetup } = await setupServer(reportingSymbol));
+  });
+
+  it('correctly handles authz when security is unavailable', async () => {
+    const core = await createReportingCore({});
+
+    registerDeprecationsRoutes(core, createMockLevelLogger());
+    await server.start();
+
+    await supertest(httpSetup.server.listener)
+      .get(API_GET_ILM_POLICY_STATUS)
+      .expect(200)
+      .then(/* Ignore result */);
+  });
+
+  it('correctly handles authz when security is disabled', async () => {
+    const security = securityMock.createSetup();
+    security.license.isEnabled.mockReturnValue(false);
+    const core = await createReportingCore({ security });
+
+    registerDeprecationsRoutes(core, createMockLevelLogger());
+    await server.start();
+
+    await supertest(httpSetup.server.listener)
+      .get(API_GET_ILM_POLICY_STATUS)
+      .expect(200)
+      .then(/* Ignore result */);
+  });
+});

--- a/x-pack/plugins/reporting/server/routes/deprecations.ts
+++ b/x-pack/plugins/reporting/server/routes/deprecations.ts
@@ -22,7 +22,7 @@ export const registerDeprecationsRoutes = (reporting: ReportingCore, logger: Log
   const authzWrapper = <P, Q, B>(handler: RequestHandler<P, Q, B>): RequestHandler<P, Q, B> => {
     return async (ctx, req, res) => {
       const { security } = reporting.getPluginSetupDeps();
-      if (!security || !security.license.isEnabled()) {
+      if (!security?.license.isEnabled()) {
         return handler(ctx, req, res);
       }
 

--- a/x-pack/plugins/reporting/server/routes/deprecations.ts
+++ b/x-pack/plugins/reporting/server/routes/deprecations.ts
@@ -22,7 +22,7 @@ export const registerDeprecationsRoutes = (reporting: ReportingCore, logger: Log
   const authzWrapper = <P, Q, B>(handler: RequestHandler<P, Q, B>): RequestHandler<P, Q, B> => {
     return async (ctx, req, res) => {
       const { security } = reporting.getPluginSetupDeps();
-      if (!security) {
+      if (!security || !security.license.isEnabled()) {
         return handler(ctx, req, res);
       }
 


### PR DESCRIPTION
## Summary

Per the issue reported here: https://github.com/elastic/kibana/issues/108774. This contribution fixes a check for whether security is available and adds a test to confirm the expected behaviour. This brings the check in line with other places in Kibana like: https://github.com/elastic/kibana/blob/ca6bb4b6d153761afecd178d2e0cbd7acf218cb2/x-pack/plugins/ingest_pipelines/server/plugin.ts#L40

## How to test

This is a little bit tricky to test, since the code for throwing the ES error is only on 7.x branches and relates to a very specific state of licensing (trial without security enabled).

On the reported issue (https://github.com/elastic/kibana/issues/108774), this can be tested by downloading the linked snapshots and editing the javascript directly (adding the `security.license.isEnabled()` to the if statement).

1. Start Kibana & ES
2. Ensure that trial license is active
3. Navigate to the Reporting Management UI
4. Check the Kibana terminal for `Internal Server Error` (should be clear with the fix applied)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
