### PR TITLE
[7.14] [Maps] fix edit layer settings action showing when readonly (#109321)

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
@@ -535,17 +535,6 @@ exports[`TOCEntryActionsPopover should not show edit actions in read only mode 1
               "onClick": [Function],
               "toolTipContent": null,
             },
-            Object {
-              "data-test-subj": "layerSettingsButton",
-              "disabled": false,
-              "icon": <EuiIcon
-                size="m"
-                type="pencil"
-              />,
-              "name": "Edit layer settings",
-              "onClick": [Function],
-              "toolTipContent": null,
-            },
           ],
           "title": "Layer actions",
         },

--- a/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
+++ b/x-pack/plugins/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
@@ -158,19 +158,19 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
         },
       },
     ];
-    actionItems.push({
-      disabled: this.props.isEditButtonDisabled,
-      name: EDIT_LAYER_SETTINGS_LABEL,
-      icon: <EuiIcon type="pencil" size="m" />,
-      'data-test-subj': 'layerSettingsButton',
-      toolTipContent: null,
-      onClick: () => {
-        this._closePopover();
-        this.props.openLayerSettings();
-      },
-    });
 
     if (!this.props.isReadOnly) {
+      actionItems.push({
+        disabled: this.props.isEditButtonDisabled,
+        name: EDIT_LAYER_SETTINGS_LABEL,
+        icon: <EuiIcon type="pencil" size="m" />,
+        'data-test-subj': 'layerSettingsButton',
+        toolTipContent: null,
+        onClick: () => {
+          this._closePopover();
+          this.props.openLayerSettings();
+        },
+      });
       if (this.state.supportsFeatureEditing) {
         actionItems.push({
           name: EDIT_FEATURES_LABEL,


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Maps] fix edit layer settings action showing when readonly (#109321)