### PR TITLE
[Security Solution][Endpoint] Remove min and max date restrictions

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
@@ -94,7 +94,6 @@ export const DateRangePicker = memo(() => {
                   aria-label="Start date"
                   endDate={endDate ? moment(endDate) : undefined}
                   isInvalid={isInvalidDateRange}
-                  maxDate={moment(endDate) || moment()}
                   onChange={onChangeStartDate}
                   onClear={() => onClear({ clearStart: true })}
                   placeholderText={i18.ACTIVITY_LOG.datePicker.startDate}
@@ -108,8 +107,6 @@ export const DateRangePicker = memo(() => {
                   aria-label="End date"
                   endDate={endDate ? moment(endDate) : undefined}
                   isInvalid={isInvalidDateRange}
-                  maxDate={moment()}
-                  minDate={startDate ? moment(startDate) : undefined}
                   onChange={onChangeEndDate}
                   onClear={() => onClear({ clearEnd: true })}
                   placeholderText={i18.ACTIVITY_LOG.datePicker.endDate}


### PR DESCRIPTION
fixes elastic/kibana/issues/108866

ref elastic/eui/issues/5058

## Summary

Restricting the date range picker to disallow invalid date range selection - one where start-date is greater than end-date - results in a broken year selection UI as the number of years shown are not in multiples of 3. This PR removes the UX restriction and allows for showing all possible year values.

**before:**
![date-picker-bug](https://user-images.githubusercontent.com/1849116/130243965-9286afce-304f-4210-88c9-5fb98175ef35.gif)

**after:**
![date-picker-bug-fix](https://user-images.githubusercontent.com/1849116/130244003-e258d5c7-f2d6-4459-99b6-008d7f192267.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)