### PR TITLE
[ML] Functional tests - re-enable modules API test suite

### DIFF
--- a/x-pack/test/api_integration/apis/ml/modules/index.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/index.ts
@@ -14,8 +14,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
   const fleetPackages = ['apache', 'nginx'];
 
-  // FLAKY: https://github.com/elastic/kibana/issues/102282
-  describe.skip('modules', function () {
+  describe('modules', function () {
     before(async () => {
       // use empty_kibana to make sure the fleet setup is removed correctly after the tests
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');


### PR DESCRIPTION
## Summary

This PR re-enables the temporarily skipped API integration test suite for modules.

### Details

There have been issues with the Fleet setup on CI, but they should be resolved now.

Closes #102282
Closes #102283
