### PR TITLE
[7.14] [DOCS] Reformats the Graph settings tables into definition lists (#108065)

### DIFF
--- a/docs/settings/graph-settings.asciidoc
+++ b/docs/settings/graph-settings.asciidoc
@@ -7,13 +7,5 @@
 
 You do not need to configure any settings to use the {graph-features}.
 
-[float]
-[[general-graph-settings]]
-==== General graph settings
-
-[cols="2*<"]
-|===
-| `xpack.graph.enabled` {ess-icon}
-  | Set to `false` to disable the {graph-features}.
-
-|===
+`xpack.graph.enabled` {ess-icon}::
+Set to `false` to disable the {graph-features}.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Reformats the Graph settings tables into definition lists (#108065)