### PR TITLE
Fix link to Cloud deployment URL in upgrade step.

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/upgrade_step/upgrade_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/upgrade_step/upgrade_step.test.tsx
@@ -36,8 +36,8 @@ describe('Overview - Upgrade Step', () => {
           servicesOverrides: {
             cloud: {
               isCloudEnabled: true,
-              baseUrl: 'https://test.com',
-              cloudId: '1234',
+              deploymentUrl:
+                'https://cloud.elastic.co./deployments/bfdad4ef99a24212a06d387593686d63',
             },
           },
         });
@@ -49,7 +49,9 @@ describe('Overview - Upgrade Step', () => {
       expect(exists('upgradeSetupCloudLink')).toBe(true);
       expect(exists('upgradeSetupDocsLink')).toBe(true);
 
-      expect(find('upgradeSetupCloudLink').props().href).toBe('https://test.com/deployments/1234');
+      expect(find('upgradeSetupCloudLink').props().href).toBe(
+        'https://cloud.elastic.co./deployments/bfdad4ef99a24212a06d387593686d63'
+      );
     });
   });
 });

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
@@ -50,10 +50,7 @@ const i18nTexts = {
 
 const UpgradeStep = ({ docLinks }: { docLinks: DocLinksStart }) => {
   const { cloud } = useKibana().services;
-
   const isCloudEnabled: boolean = Boolean(cloud?.isCloudEnabled);
-  const cloudDeploymentUrl: string = `${cloud?.baseUrl ?? ''}/deployments/${cloud?.cloudId ?? ''}`;
-
   let callToAction;
 
   if (isCloudEnabled) {
@@ -61,7 +58,7 @@ const UpgradeStep = ({ docLinks }: { docLinks: DocLinksStart }) => {
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiButton
-            href={cloudDeploymentUrl}
+            href={cloud?.deploymentUrl}
             target="_blank"
             data-test-subj="upgradeSetupCloudLink"
             iconSide="right"

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/upgrade_step/upgrade_step.tsx
@@ -58,7 +58,7 @@ const UpgradeStep = ({ docLinks }: { docLinks: DocLinksStart }) => {
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiButton
-            href={cloud?.deploymentUrl}
+            href={cloud!.deploymentUrl}
             target="_blank"
             data-test-subj="upgradeSetupCloudLink"
             iconSide="right"


### PR DESCRIPTION
I noticed that we're concatenating values to build this URL, and it looks like it resolves to a 404 when I tested the latest 7.16 snapshot on Cloud. After digging into the Cloud plugin README and https://github.com/elastic/kibana/pull/95569 a bit, I think this will resolve to the right URL.

I added some more details to the Cloud README in https://github.com/elastic/kibana/pull/109529 which should also provide more context for this change.