### PR TITLE
[7.x] [Metrics UI] Re-enabled saved view tests (#108725)

### DIFF
--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -87,8 +87,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/106660
-    describe.skip('Saved Views', () => {
+    describe('Saved Views', () => {
       before(() => esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       after(() => esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       it('should have save and load controls', async () => {

--- a/x-pack/test/functional/apps/infra/metrics_explorer.ts
+++ b/x-pack/test/functional/apps/infra/metrics_explorer.ts
@@ -87,8 +87,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/106651
-    describe.skip('Saved Views', () => {
+    describe('Saved Views', () => {
       before(() => esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       after(() => esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs'));
       describe('save functionality', () => {

--- a/x-pack/test/functional/page_objects/infra_saved_views.ts
+++ b/x-pack/test/functional/page_objects/infra_saved_views.ts
@@ -79,9 +79,8 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
     },
 
     async ensureViewIsLoadable(name: string) {
-      const subjects = await testSubjects.getVisibleTextAll('savedViews-loadList');
-      const includesName = subjects.some((s) => s.includes(name));
-      expect(includesName).to.be(true);
+      const subject = await testSubjects.find('savedViews-loadList');
+      await subject.findByCssSelector(`li[title="${name}"]`);
     },
 
     async closeSavedViewsLoadModal() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Re-enabled saved view tests (#108725)