### PR TITLE
[fix] passing async functions to the Promise constructor

### DIFF
--- a/src/core/public/application/integration_tests/utils.tsx
+++ b/src/core/public/application/integration_tests/utils.tsx
@@ -20,15 +20,16 @@ type Renderer = () => Dom | Promise<Dom>;
 export const createRenderer = (element: ReactElement | null): Renderer => {
   const dom: Dom = element && mount(<I18nProvider>{element}</I18nProvider>);
 
-  return () =>
-    new Promise(async (resolve) => {
-      if (dom) {
-        await act(async () => {
-          dom.update();
-        });
-      }
-      setImmediate(() => resolve(dom)); // flushes any pending promises
-    });
+  return async () => {
+    if (dom) {
+      act(() => {
+        dom.update();
+      });
+    }
+    // flushes any pending promises
+    await new Promise((resolve) => setImmediate(resolve));
+    return dom;
+  };
 };
 
 export const createAppMounter = ({

--- a/src/core/public/chrome/ui/header/header_action_menu.test.tsx
+++ b/src/core/public/chrome/ui/header/header_action_menu.test.tsx
@@ -25,15 +25,14 @@ describe('HeaderActionMenu', () => {
     unmounts = {};
   });
 
-  const refresh = () => {
-    new Promise(async (resolve) => {
-      if (component) {
-        act(() => {
-          component.update();
-        });
-      }
-      setImmediate(() => resolve(component)); // flushes any pending promises
-    });
+  const refresh = async () => {
+    if (component) {
+      act(() => {
+        component.update();
+      });
+    }
+    await new Promise((resolve) => setImmediate(resolve)); // flushes any pending promises
+    return component;
   };
 
   const createMountPoint = (id: string, content: string = id): MountPoint => (

--- a/src/plugins/bfetch/server/streaming/create_compressed_stream.ts
+++ b/src/plugins/bfetch/server/streaming/create_compressed_stream.ts
@@ -17,18 +17,11 @@ const delimiter = '\n';
 const pDeflate = promisify(deflate);
 
 async function zipMessageToStream(output: PassThrough, message: string) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const gzipped = await pDeflate(message, {
-        flush: constants.Z_SYNC_FLUSH,
-      });
-      output.write(gzipped.toString('base64'));
-      output.write(delimiter);
-      resolve(undefined);
-    } catch (err) {
-      reject(err);
-    }
+  const gzipped = await pDeflate(message, {
+    flush: constants.Z_SYNC_FLUSH,
   });
+  output.write(gzipped.toString('base64'));
+  output.write(delimiter);
 }
 
 export const createCompressedStream = <Response>(

--- a/src/plugins/kibana_react/public/util/mount_point_portal.test.tsx
+++ b/src/plugins/kibana_react/public/util/mount_point_portal.test.tsx
@@ -18,15 +18,14 @@ describe('MountPointPortal', () => {
   let setMountPoint: jest.Mock<(mountPoint: MountPoint<HTMLElement>) => void>;
   let dom: ReactWrapper;
 
-  const refresh = () => {
-    new Promise(async (resolve) => {
-      if (dom) {
-        act(() => {
-          dom.update();
-        });
-      }
-      setImmediate(() => resolve(dom)); // flushes any pending promises
-    });
+  const refresh = async () => {
+    if (dom) {
+      act(() => {
+        dom.update();
+      });
+    }
+    await new Promise((resolve) => setImmediate(resolve)); // flushes any pending promises
+    return dom;
   };
 
   beforeEach(() => {

--- a/src/plugins/maps_ems/public/lazy_load_bundle/get_service_settings.ts
+++ b/src/plugins/maps_ems/public/lazy_load_bundle/get_service_settings.ts
@@ -13,13 +13,14 @@ let loadPromise: Promise<IServiceSettings>;
 
 export async function getServiceSettings(): Promise<IServiceSettings> {
   if (typeof loadPromise !== 'undefined') {
-    return loadPromise;
+    return await loadPromise;
   }
 
-  loadPromise = new Promise(async (resolve) => {
+  loadPromise = (async () => {
     const { ServiceSettings } = await import('./lazy');
     const config = getMapsEmsConfig();
-    resolve(new ServiceSettings(config, config.tilemap));
-  });
-  return loadPromise;
+    return new ServiceSettings(config, config.tilemap);
+  })();
+
+  return await loadPromise;
 }

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.test.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.test.tsx
@@ -109,14 +109,13 @@ describe('TopNavMenu', () => {
     let dom: ReactWrapper;
 
     const refresh = () => {
-      new Promise(async (resolve) => {
-        if (dom) {
-          act(() => {
-            dom.update();
-          });
-        }
-        setImmediate(() => resolve(dom)); // flushes any pending promises
-      });
+      if (dom) {
+        act(() => {
+          dom.update();
+        });
+      }
+      new Promise((resolve) => setImmediate(resolve)); // flushes any pending promises
+      return dom;
     };
 
     beforeEach(() => {

--- a/src/plugins/vis_types/vislib/public/vislib/components/legend/legend.tsx
+++ b/src/plugins/vis_types/vislib/public/vislib/components/legend/legend.tsx
@@ -123,18 +123,24 @@ export class VisLegend extends PureComponent<VisLegendProps, VisLegendState> {
     }));
   };
 
-  setFilterableLabels = (items: LegendItem[]): Promise<void> =>
-    new Promise(async (resolve) => {
-      const filterableLabels = new Set<string>();
-      items.forEach(async (item) => {
-        const canFilter = await this.canFilter(item);
-        if (canFilter) {
-          filterableLabels.add(item.label);
-        }
-      });
+  setFilterableLabels = async (items: LegendItem[]): Promise<void> => {
+    const filterableLabels = new Set<string>();
 
-      this.setState({ filterableLabels }, resolve);
+    for (const item of items) {
+      const canFilter = await this.canFilter(item);
+      if (canFilter) {
+        filterableLabels.add(item.label);
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.setState({ filterableLabels }, resolve);
+      } catch (error) {
+        reject(error);
+      }
     });
+  };
 
   setLabels = (data: any, type: string) => {
     let labels = [];

--- a/x-pack/plugins/data_visualizer/public/lazy_load_bundle/index.ts
+++ b/x-pack/plugins/data_visualizer/public/lazy_load_bundle/index.ts
@@ -19,16 +19,17 @@ interface LazyLoadedModules {
 
 export async function lazyLoadModules(): Promise<LazyLoadedModules> {
   if (typeof loadModulesPromise !== 'undefined') {
-    return loadModulesPromise;
+    return await loadModulesPromise;
   }
 
-  loadModulesPromise = new Promise(async (resolve) => {
+  loadModulesPromise = (async () => {
     const lazyImports = await import('./lazy');
 
-    resolve({
+    return {
       ...lazyImports,
       getHttp: () => getCoreStart().http,
-    });
-  });
-  return loadModulesPromise;
+    };
+  })();
+
+  return await loadModulesPromise;
 }

--- a/x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts
+++ b/x-pack/plugins/file_upload/public/lazy_load_bundle/index.ts
@@ -41,18 +41,19 @@ export interface LazyLoadedFileUploadModules {
 
 export async function lazyLoadModules(): Promise<LazyLoadedFileUploadModules> {
   if (typeof loadModulesPromise !== 'undefined') {
-    return loadModulesPromise;
+    return await loadModulesPromise;
   }
 
-  loadModulesPromise = new Promise(async (resolve) => {
+  loadModulesPromise = (async () => {
     const { JsonUploadAndParse, importerFactory, IndexNameForm } = await import('./lazy');
 
-    resolve({
+    return {
       JsonUploadAndParse,
       importerFactory,
       getHttp,
       IndexNameForm,
-    });
-  });
-  return loadModulesPromise;
+    };
+  })();
+
+  return await loadModulesPromise;
 }

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/use_state_listener.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/use_state_listener.tsx
@@ -94,18 +94,18 @@ export const useMappingsStateListener = ({ onChange, value }: Args) => {
       validate: async () => {
         const configurationFormValidator =
           state.configuration.submitForm !== undefined
-            ? new Promise(async (resolve) => {
+            ? (async () => {
                 const { isValid } = await state.configuration.submitForm!();
-                resolve(isValid);
-              })
+                return isValid;
+              })()
             : Promise.resolve(true);
 
         const templatesFormValidator =
           state.templates.submitForm !== undefined
-            ? new Promise(async (resolve) => {
+            ? (async () => {
                 const { isValid } = await state.templates.submitForm!();
-                resolve(isValid);
-              })
+                return isValid;
+              })()
             : Promise.resolve(true);
 
         const promisesToValidate = [configurationFormValidator, templatesFormValidator];

--- a/x-pack/plugins/maps/public/lazy_load_bundle/index.ts
+++ b/x-pack/plugins/maps/public/lazy_load_bundle/index.ts
@@ -70,7 +70,7 @@ export async function lazyLoadMapModules(): Promise<LazyLoadedMapModules> {
     return loadModulesPromise;
   }
 
-  loadModulesPromise = new Promise(async (resolve) => {
+  loadModulesPromise = (async () => {
     const {
       MapEmbeddable,
       getIndexPatternService,
@@ -86,7 +86,7 @@ export async function lazyLoadMapModules(): Promise<LazyLoadedMapModules> {
       suggestEMSTermJoinConfig,
     } = await import('./lazy');
 
-    resolve({
+    return {
       MapEmbeddable,
       getIndexPatternService,
       getMapsCapabilities,
@@ -99,7 +99,7 @@ export async function lazyLoadMapModules(): Promise<LazyLoadedMapModules> {
       createBasemapLayerDescriptor,
       createESSearchSourceLayerDescriptor,
       suggestEMSTermJoinConfig,
-    });
-  });
+    };
+  })();
   return loadModulesPromise;
 }

--- a/x-pack/plugins/ml/public/application/settings/calendars/edit/utils.js
+++ b/x-pack/plugins/ml/public/application/settings/calendars/edit/utils.js
@@ -71,25 +71,23 @@ function getCalendars() {
   });
 }
 
-export function getCalendarSettingsData() {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const [jobIds, groupIds, calendars] = await Promise.all([
-        getJobIds(),
-        getGroupIds(),
-        getCalendars(),
-      ]);
+export async function getCalendarSettingsData() {
+  try {
+    const [jobIds, groupIds, calendars] = await Promise.all([
+      getJobIds(),
+      getGroupIds(),
+      getCalendars(),
+    ]);
 
-      resolve({
-        jobIds,
-        groupIds,
-        calendars,
-      });
-    } catch (error) {
-      console.log(error);
-      reject(error);
-    }
-  });
+    return {
+      jobIds,
+      groupIds,
+      calendars,
+    };
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
 }
 
 export function validateCalendarId(calendarId) {

--- a/x-pack/plugins/monitoring/server/lib/logstash/get_paginated_pipelines.js
+++ b/x-pack/plugins/monitoring/server/lib/logstash/get_paginated_pipelines.js
@@ -97,29 +97,28 @@ function processPipelinesAPIResponse(response, throughputMetricKey, nodesCountMe
 async function getPaginatedThroughputData(pipelines, req, lsIndexPattern, throughputMetric) {
   const metricSeriesData = Object.values(
     await Promise.all(
-      pipelines.map((pipeline) => {
-        return new Promise(async (resolve) => {
-          const data = await getMetrics(
-            req,
-            lsIndexPattern,
-            [throughputMetric],
-            [
-              {
-                bool: {
-                  should: [
-                    { term: { type: 'logstash_stats' } },
-                    { term: { 'metricset.name': 'stats' } },
-                  ],
-                },
-              },
-            ],
+      pipelines.map(async (pipeline) => {
+        const data = await getMetrics(
+          req,
+          lsIndexPattern,
+          [throughputMetric],
+          [
             {
-              pipeline,
+              bool: {
+                should: [
+                  { term: { type: 'logstash_stats' } },
+                  { term: { 'metricset.name': 'stats' } },
+                ],
+              },
             },
-            2
-          );
-          resolve(reduceData(pipeline, data));
-        });
+          ],
+          {
+            pipeline,
+          },
+          2
+        );
+
+        return reduceData(pipeline, data);
       })
     )
   );
@@ -183,29 +182,27 @@ async function getPipelines(req, lsIndexPattern, pipelines, throughputMetric, no
 
 async function getThroughputPipelines(req, lsIndexPattern, pipelines, throughputMetric) {
   const metricsResponse = await Promise.all(
-    pipelines.map((pipeline) => {
-      return new Promise(async (resolve) => {
-        const data = await getMetrics(
-          req,
-          lsIndexPattern,
-          [throughputMetric],
-          [
-            {
-              bool: {
-                should: [
-                  { term: { type: 'logstash_stats' } },
-                  { term: { 'metricset.name': 'stats' } },
-                ],
-              },
-            },
-          ],
+    pipelines.map(async (pipeline) => {
+      const data = await getMetrics(
+        req,
+        lsIndexPattern,
+        [throughputMetric],
+        [
           {
-            pipeline,
-          }
-        );
+            bool: {
+              should: [
+                { term: { type: 'logstash_stats' } },
+                { term: { 'metricset.name': 'stats' } },
+              ],
+            },
+          },
+        ],
+        {
+          pipeline,
+        }
+      );
 
-        resolve(reduceData(pipeline, data));
-      });
+      return reduceData(pipeline, data);
     })
   );
 

--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -1183,7 +1183,7 @@ export const createContainerWithEndpointEntries = async (
 
   // Add the endpoint exception list container to the backend
   await Promise.all(
-    endpointEntries.map((endpointEntry) => {
+    endpointEntries.map(async (endpointEntry) => {
       const exceptionListItem: CreateExceptionListItemSchema = {
         description: 'endpoint description',
         entries: endpointEntry.entries,
@@ -1192,7 +1192,7 @@ export const createContainerWithEndpointEntries = async (
         os_types: endpointEntry.osTypes,
         type: 'simple',
       };
-      return createExceptionListItem(supertest, exceptionListItem);
+      await createExceptionListItem(supertest, exceptionListItem);
     })
   );
 
@@ -1239,7 +1239,7 @@ export const createContainerWithEntries = async (
 
   // Add the rule exception list container to the backend
   await Promise.all(
-    entries.map((entry) => {
+    entries.map(async (entry) => {
       const exceptionListItem: CreateExceptionListItemSchema = {
         description: 'some description',
         list_id: 'some-list-id',
@@ -1247,7 +1247,7 @@ export const createContainerWithEntries = async (
         type: 'simple',
         entries: entry,
       };
-      return createExceptionListItem(supertest, exceptionListItem);
+      await createExceptionListItem(supertest, exceptionListItem);
     })
   );
 
@@ -1343,12 +1343,12 @@ export const deleteMigrations = async ({
   kbnClient: KbnClient;
 }): Promise<void> => {
   await Promise.all(
-    ids.map((id) =>
-      kbnClient.savedObjects.delete({
+    ids.map(async (id) => {
+      await kbnClient.savedObjects.delete({
         id,
         type: signalsMigrationType,
-      })
-    )
+      });
+    })
   );
 };
 


### PR DESCRIPTION
After fixing https://github.com/elastic/kibana/pull/109560 I did a little searching and found many cases where we are passing async functions to the `Promise` constructor without handling the potential of a rejected promise being created by said async function.

The following examples show the types of scenarios which are fixed by this PR:

---
Bad:
```ts
return () => 
  new Promise(async (resolve) => {
    await someAyncOperation();
    setImmediate(resolve); // or some other callback-based function
  })
```

In this example if `someAsyncOperation()` fails then the error will propagate from its call site to the promise created when the `Promise()` constructor called the async function. Unfortunately that promise is not accessible by user code so it will always result in an unhandled rejection. There are two ways to fix this, either ensure the hidden promise never rejects by wrapping the whole body of the function in a `try/catch`, or limit the code which is wrapped in the `Promise` constructor. I think the second approach is more ideal as it keeps the need for a `resolve()` callback as close to the source of that need as possible:

Fixed: 
```ts
return async () => {
  await someAyncOperation();
  await new Promise((resolve) => setImmediate(resolve)); // or some other callback-based function
}
```
---
Bad:
```ts
const propValue = new Promise(async (resolve) => {
  const { prop } = await getObject();
  resolve(prop)
})
```

The goal of this function is to mutate the data coming back from the resolved promise in some way before returning/resolving to the outside caller. This should instead be done one of two ways:

Fix:
```ts
const propValue = (async () => {
  const { prop } = await getObject();
  return prop
})();
```

Using an async-IIFE is stylistically similar to the problematic code and properly routes errors in the case that `getObject()` rejects and handles possible synchronous errors, like `getObject()` not being a function, not returning a promise, or throwing synchronously for some reason.

---

Bad:
```ts
await new Promise(async (resolve, reject) => {
  const data = await loadSomeData();

  renderSomethingAndWaitForUserInteraction({
    data,
    onConfirm(selection) {
      resolve(selection);
    },
    onCancel() {
      reject()
    }
  })
})
```

Just like the previous example, if `loadSomeData()` rejects it's promise the hidden promise created by the Promise constructor will be rejected as the error propagates, but there is no way for us to handle that rejection. In this scenario I modeled the user interaction using an RxJS `ReplaySubject(1)`, which is an `Observable` whose events can be programmatically customized from the outside and will remember the last value emitted and re-emit with new subscriptions. This might look unnecessarily complicated in my example but in the code where this pattern is used there are many things happening in the same place and the callbacks passed to `renderSomethingAndWaitForUserInteraction()` are not always constant, so this was a flexible way to model this scenario which has added benefits like being able to process each event produced on the `Subject`.

Fixed:
```ts
const selection$ = new Rx.ReplaySubject<SelectionType>(1);
const data = await loadSomeData();

renderSomethingAndWaitForUserInteraction({
  data,
  onConfirm(selection) {
    selection$.next(selection)
  },
  onCancel() {
    selection$.error(new Error('user canceled'))
  }
});

const selection = await firstValueFrom(selection$);
```