### PR TITLE
[APM] Use useTimeRange where possible

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/alerting_flyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/alerting_flyout/index.tsx
@@ -16,8 +16,8 @@ import { ApmPluginStartDeps } from '../../../plugin';
 import { useServiceName } from '../../../hooks/use_service_name';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { AlertMetadata } from '../helper';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 interface Props {
   addFlyoutVisible: boolean;
@@ -30,9 +30,12 @@ export function AlertingFlyout(props: Props) {
 
   const serviceName = useServiceName();
   const { query } = useApmParams('/*');
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+
+  const rangeFrom = 'rangeFrom' in query ? query.rangeFrom : undefined;
+  const rangeTo = 'rangeTo' in query ? query.rangeTo : undefined;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo }, true);
+
   const environment =
     'environment' in query ? query.environment : ENVIRONMENT_ALL.value;
   const transactionType =

--- a/x-pack/plugins/apm/public/components/alerting/alerting_flyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/alerting_flyout/index.tsx
@@ -34,7 +34,7 @@ export function AlertingFlyout(props: Props) {
   const rangeFrom = 'rangeFrom' in query ? query.rangeFrom : undefined;
   const rangeTo = 'rangeTo' in query ? query.rangeTo : undefined;
 
-  const { start, end } = useTimeRange({ rangeFrom, rangeTo }, true);
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo, optional: true });
 
   const environment =
     'environment' in query ? query.environment : ENVIRONMENT_ALL.value;

--- a/x-pack/plugins/apm/public/components/app/TraceLink/trace_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceLink/trace_link.test.tsx
@@ -16,7 +16,6 @@ import {
   MockApmPluginContextWrapper,
 } from '../../../context/apm_plugin/mock_apm_plugin_context';
 import * as hooks from '../../../hooks/use_fetcher';
-import * as urlParamsHooks from '../../../context/url_params_context/use_url_params';
 import * as useApmParamsHooks from '../../../hooks/use_apm_params';
 
 function Wrapper({ children }: { children?: ReactNode }) {
@@ -69,15 +68,6 @@ describe('TraceLink', () => {
 
   describe('when no transaction is found', () => {
     it('renders a trace page', () => {
-      jest.spyOn(urlParamsHooks, 'useUrlParams').mockReturnValue({
-        rangeId: 0,
-        refreshTimeRange: jest.fn(),
-        uxUiFilters: {},
-        urlParams: {
-          rangeFrom: 'now-24h',
-          rangeTo: 'now',
-        },
-      });
       jest.spyOn(hooks, 'useFetcher').mockReturnValue({
         data: { transaction: undefined },
         status: hooks.FETCH_STATUS.SUCCESS,
@@ -103,15 +93,6 @@ describe('TraceLink', () => {
   });
 
   describe('transaction page', () => {
-    beforeAll(() => {
-      jest.spyOn(urlParamsHooks, 'useUrlParams').mockReturnValue({
-        rangeId: 0,
-        refreshTimeRange: jest.fn(),
-        uxUiFilters: {},
-        urlParams: {},
-      });
-    });
-
     it('renders with date range params', () => {
       const transaction = {
         service: { name: 'foo' },

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_detail_dependencies_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_detail_dependencies_table.tsx
@@ -15,15 +15,18 @@ import { getTimeRangeComparison } from '../../shared/time_comparison/get_time_ra
 import { DependenciesTable } from '../../shared/dependencies_table';
 import { useApmBackendContext } from '../../../context/apm_backend/use_apm_backend_context';
 import { ServiceLink } from '../../shared/service_link';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 export function BackendDetailDependenciesTable() {
   const {
-    urlParams: { start, end, comparisonEnabled, comparisonType },
+    urlParams: { comparisonEnabled, comparisonType },
   } = useUrlParams();
 
   const {
     query: { rangeFrom, rangeTo, kuery, environment },
   } = useApmParams('/backends/:backendName/overview');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { offset } = getTimeRangeComparison({
     start,

--- a/x-pack/plugins/apm/public/components/app/backend_inventory/backend_inventory_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_inventory/backend_inventory_dependencies_table/index.tsx
@@ -13,18 +13,21 @@ import { getNodeName, NodeType } from '../../../../../common/connections';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { useFetcher } from '../../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 import { BackendLink } from '../../../shared/backend_link';
 import { DependenciesTable } from '../../../shared/dependencies_table';
 import { getTimeRangeComparison } from '../../../shared/time_comparison/get_time_range_comparison';
 
 export function BackendInventoryDependenciesTable() {
   const {
-    urlParams: { start, end, comparisonEnabled, comparisonType },
+    urlParams: { comparisonEnabled, comparisonType },
   } = useUrlParams();
 
   const {
     query: { rangeFrom, rangeTo, environment, kuery },
   } = useApmParams('/backends');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const trackEvent = useUiTracker();
 

--- a/x-pack/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
@@ -45,6 +45,7 @@ import type { SearchServiceParams } from '../../../../common/search_strategies/c
 import type { FailedTransactionsCorrelationValue } from '../../../../common/search_strategies/failure_correlations/types';
 import { Summary } from '../../shared/Summary';
 import { asPercent } from '../../../../common/utils/formatters';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 export function FailedTransactionsCorrelations({
   onFilter,
@@ -59,11 +60,13 @@ export function FailedTransactionsCorrelations({
   const { serviceName, transactionType } = useApmServiceContext();
 
   const {
-    query: { kuery, environment },
+    query: { kuery, environment, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName');
 
   const { urlParams } = useUrlParams();
-  const { transactionName, start, end } = urlParams;
+  const { transactionName } = urlParams;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const inspectEnabled = uiSettings.get<boolean>(enableInspectEsQueries);
 

--- a/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
@@ -40,6 +40,7 @@ import { CorrelationsLog } from './correlations_log';
 import { CorrelationsEmptyStatePrompt } from './empty_state_prompt';
 import { CrossClusterSearchCompatibilityWarning } from './cross_cluster_search_warning';
 import { CorrelationsProgressControls } from './progress_controls';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 const DEFAULT_PERCENTILE_THRESHOLD = 95;
 
@@ -59,12 +60,14 @@ export function LatencyCorrelations({ onFilter }: { onFilter: () => void }) {
   const { serviceName, transactionType } = useApmServiceContext();
 
   const {
-    query: { kuery, environment },
+    query: { kuery, environment, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName');
 
   const { urlParams } = useUrlParams();
 
-  const { transactionName, start, end } = urlParams;
+  const { transactionName } = urlParams;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const displayLog = uiSettings.get<boolean>(enableInspectEsQueries);
 

--- a/x-pack/plugins/apm/public/components/app/error_group_details/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/index.tsx
@@ -25,6 +25,7 @@ import { useApmParams } from '../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../hooks/use_apm_router';
 import { useErrorGroupDistributionFetcher } from '../../../hooks/use_error_group_distribution_fetcher';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { DetailView } from './detail_view';
 import { ErrorDistribution } from './Distribution';
 
@@ -94,7 +95,7 @@ function ErrorGroupHeader({
 
 export function ErrorGroupDetails() {
   const { urlParams } = useUrlParams();
-  const { start, end } = urlParams;
+
   const { serviceName } = useApmServiceContext();
 
   const apmRouter = useApmRouter();
@@ -103,6 +104,8 @@ export function ErrorGroupDetails() {
     path: { groupId },
     query: { rangeFrom, rangeTo, environment, kuery },
   } = useApmParams('/services/:serviceName/errors/:groupId');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   useBreadcrumb({
     title: groupId,

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -15,10 +15,10 @@ import {
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useErrorGroupDistributionFetcher } from '../../../hooks/use_error_group_distribution_fetcher';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { ErrorDistribution } from '../error_group_details/Distribution';
 import { ErrorGroupList } from './List';
 
@@ -26,12 +26,10 @@ export function ErrorGroupOverview() {
   const { serviceName } = useApmServiceContext();
 
   const {
-    query: { environment, kuery, sortField, sortDirection },
+    query: { environment, kuery, sortField, sortDirection, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/errors');
 
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { errorDistributionData } = useErrorGroupDistributionFetcher({
     serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -16,6 +16,7 @@ import { useUrlParams } from '../../../context/url_params_context/use_url_params
 import { useLocalStorage } from '../../../hooks/useLocalStorage';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { useUpgradeAssistantHref } from '../../shared/Links/kibana';
 import { SearchBar } from '../../shared/search_bar';
 import { getTimeRangeComparison } from '../../shared/time_comparison/get_time_range_comparison';
@@ -34,16 +35,17 @@ const initialData = {
 
 let hasDisplayedToast = false;
 
-function useServicesFetcher({
-  environment,
-  kuery,
-}: {
-  environment: string;
-  kuery: string;
-}) {
+function useServicesFetcher() {
   const {
-    urlParams: { start, end, comparisonEnabled, comparisonType },
+    urlParams: { comparisonEnabled, comparisonType },
   } = useUrlParams();
+
+  const {
+    query: { rangeFrom, rangeTo, environment, kuery },
+  } = useApmParams('/services/:serviceName', '/services');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { core } = useApmPluginContext();
   const upgradeAssistantHref = useUpgradeAssistantHref();
 
@@ -154,14 +156,10 @@ export function ServiceInventory() {
   const { core } = useApmPluginContext();
 
   const {
-    query: { environment, kuery },
-  } = useApmParams('/services');
-
-  const {
     mainStatisticsData,
     mainStatisticsStatus,
     comparisonData,
-  } = useServicesFetcher({ environment, kuery });
+  } = useServicesFetcher();
 
   const {
     anomalyDetectionJobsData,

--- a/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
@@ -10,7 +10,6 @@ import { EuiLoadingSpinner, EuiEmptyPrompt } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { LogStream } from '../../../../../infra/public';
@@ -22,17 +21,16 @@ import {
   POD_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
 import { useApmParams } from '../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 export function ServiceLogs() {
   const { serviceName } = useApmServiceContext();
 
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/logs');
 
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { data, status } = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/Popover.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/Popover.stories.tsx
@@ -98,7 +98,14 @@ const stories: Meta<Args> = {
 export default stories;
 
 export const Backend: Story<Args> = () => {
-  return <Popover environment={ENVIRONMENT_ALL.value} kuery="" />;
+  return (
+    <Popover
+      environment={ENVIRONMENT_ALL.value}
+      kuery=""
+      start="2021-08-20T10:00:00.000Z"
+      end="2021-08-20T10:15:00.000Z"
+    />
+  );
 };
 Backend.args = {
   nodeData: {
@@ -111,7 +118,14 @@ Backend.args = {
 };
 
 export const BackendWithLongTitle: Story<Args> = () => {
-  return <Popover environment={ENVIRONMENT_ALL.value} kuery="" />;
+  return (
+    <Popover
+      environment={ENVIRONMENT_ALL.value}
+      kuery=""
+      start="2021-08-20T10:00:00.000Z"
+      end="2021-08-20T10:15:00.000Z"
+    />
+  );
 };
 BackendWithLongTitle.args = {
   nodeData: {
@@ -125,14 +139,28 @@ BackendWithLongTitle.args = {
 };
 
 export const ExternalsList: Story<Args> = () => {
-  return <Popover environment={ENVIRONMENT_ALL.value} kuery="" />;
+  return (
+    <Popover
+      environment={ENVIRONMENT_ALL.value}
+      kuery=""
+      start="2021-08-20T10:00:00.000Z"
+      end="2021-08-20T10:15:00.000Z"
+    />
+  );
 };
 ExternalsList.args = {
   nodeData: exampleGroupedConnectionsData,
 };
 
 export const Resource: Story<Args> = () => {
-  return <Popover environment={ENVIRONMENT_ALL.value} kuery="" />;
+  return (
+    <Popover
+      environment={ENVIRONMENT_ALL.value}
+      kuery=""
+      start="2021-08-20T10:00:00.000Z"
+      end="2021-08-20T10:15:00.000Z"
+    />
+  );
 };
 Resource.args = {
   nodeData: {
@@ -145,7 +173,14 @@ Resource.args = {
 };
 
 export const Service: Story<Args> = () => {
-  return <Popover environment={ENVIRONMENT_ALL.value} kuery="" />;
+  return (
+    <Popover
+      environment={ENVIRONMENT_ALL.value}
+      kuery=""
+      start="2021-08-20T10:00:00.000Z"
+      end="2021-08-20T10:15:00.000Z"
+    />
+  );
 };
 Service.args = {
   nodeData: {

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/backend_contents.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/backend_contents.tsx
@@ -13,29 +13,30 @@ import React from 'react';
 import { useUiTracker } from '../../../../../../observability/public';
 import { ContentsProps } from '.';
 import { NodeStats } from '../../../../../common/service_map';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
 import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
 import { ApmRoutes } from '../../../routing/apm_route_config';
 import { StatsList } from './stats_list';
 
-export function BackendContents({ nodeData, environment }: ContentsProps) {
+export function BackendContents({
+  nodeData,
+  environment,
+  start,
+  end,
+}: ContentsProps) {
   const { query } = useApmParams(
     '/service-map',
     '/services/:serviceName/service-map'
   );
 
   const apmRouter = useApmRouter();
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
 
   const backendName = nodeData.label;
 
   const { data = { transactionStats: {} } as NodeStats, status } = useFetcher(
     (callApmApi) => {
-      if (backendName && start && end) {
+      if (backendName) {
         return callApmApi({
           endpoint: 'GET /api/apm/service-map/backend/{backendName}',
           params: {

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/index.tsx
@@ -56,6 +56,8 @@ export interface ContentsProps {
   nodeData: cytoscape.NodeDataDefinition;
   environment: Environment;
   kuery: string;
+  start: string;
+  end: string;
   onFocusClick: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
 
@@ -63,12 +65,16 @@ interface PopoverProps {
   focusedServiceName?: string;
   environment: Environment;
   kuery: string;
+  start: string;
+  end: string;
 }
 
 export function Popover({
   focusedServiceName,
   environment,
   kuery,
+  start,
+  end,
 }: PopoverProps) {
   const theme = useTheme();
   const cy = useContext(CytoscapeContext);
@@ -182,6 +188,8 @@ export function Popover({
           nodeData={selectedNodeData}
           environment={environment}
           kuery={kuery}
+          start={start}
+          end={end}
         />
       </EuiFlexGroup>
     </EuiPopover>

--- a/x-pack/plugins/apm/public/components/app/service_map/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/index.test.tsx
@@ -71,7 +71,12 @@ describe('ServiceMap', () => {
     it('renders null', async () => {
       expect(
         await render(
-          <ServiceMap environment={ENVIRONMENT_ALL.value} kuery="" />,
+          <ServiceMap
+            environment={ENVIRONMENT_ALL.value}
+            kuery=""
+            start="2021-08-20T10:00:00.000Z"
+            end="2021-08-20T10:15:00.000Z"
+          />,
           {
             wrapper: createWrapper(null),
           }
@@ -84,7 +89,12 @@ describe('ServiceMap', () => {
     it('renders the license banner', async () => {
       expect(
         await render(
-          <ServiceMap environment={ENVIRONMENT_ALL.value} kuery="" />,
+          <ServiceMap
+            environment={ENVIRONMENT_ALL.value}
+            kuery=""
+            start="2021-08-20T10:00:00.000Z"
+            end="2021-08-20T10:15:00.000Z"
+          />,
           {
             wrapper: createWrapper(expiredLicense),
           }
@@ -104,7 +114,12 @@ describe('ServiceMap', () => {
 
         expect(
           await render(
-            <ServiceMap environment={ENVIRONMENT_ALL.value} kuery="" />,
+            <ServiceMap
+              environment={ENVIRONMENT_ALL.value}
+              kuery=""
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />,
             {
               wrapper: createWrapper(activeLicense),
             }

--- a/x-pack/plugins/apm/public/components/app/service_map/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/index.tsx
@@ -20,7 +20,6 @@ import {
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { useLicenseContext } from '../../../context/license/use_license_context';
 import { useTheme } from '../../../hooks/use_theme';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { LicensePrompt } from '../../shared/license_prompt';
 import { Controls } from './Controls';
 import { Cytoscape } from './Cytoscape';
@@ -34,6 +33,7 @@ import { SearchBar } from '../../shared/search_bar';
 import { useServiceName } from '../../../hooks/use_service_name';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { Environment } from '../../../../common/environment_rt';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 function PromptContainer({ children }: { children: ReactNode }) {
   return (
@@ -67,29 +67,47 @@ function LoadingSpinner() {
 
 export function ServiceMapHome() {
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/service-map');
-  return <ServiceMap environment={environment} kuery={kuery} />;
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+  return (
+    <ServiceMap
+      environment={environment}
+      kuery={kuery}
+      start={start}
+      end={end}
+    />
+  );
 }
 
 export function ServiceMapServiceDetail() {
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/service-map');
-  return <ServiceMap environment={environment} kuery={kuery} />;
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+  return (
+    <ServiceMap
+      environment={environment}
+      kuery={kuery}
+      start={start}
+      end={end}
+    />
+  );
 }
 
 export function ServiceMap({
   environment,
   kuery,
+  start,
+  end,
 }: {
   environment: Environment;
   kuery: string;
+  start: string;
+  end: string;
 }) {
   const theme = useTheme();
   const license = useLicenseContext();
-
-  const { urlParams } = useUrlParams();
 
   const serviceName = useServiceName();
 
@@ -100,23 +118,20 @@ export function ServiceMap({
         return;
       }
 
-      const { start, end } = urlParams;
-      if (start && end) {
-        return callApmApi({
-          isCachable: false,
-          endpoint: 'GET /api/apm/service-map',
-          params: {
-            query: {
-              start,
-              end,
-              environment,
-              serviceName,
-            },
+      return callApmApi({
+        isCachable: false,
+        endpoint: 'GET /api/apm/service-map',
+        params: {
+          query: {
+            start,
+            end,
+            environment,
+            serviceName,
           },
-        });
-      }
+        },
+      });
     },
-    [license, serviceName, environment, urlParams]
+    [license, serviceName, environment, start, end]
   );
 
   const { ref, height } = useRefDimensions();
@@ -181,6 +196,8 @@ export function ServiceMap({
               focusedServiceName={serviceName}
               environment={environment}
               kuery={kuery}
+              start={start}
+              end={end}
             />
           </Cytoscape>
         </div>

--- a/x-pack/plugins/apm/public/components/app/service_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_metrics/index.tsx
@@ -8,15 +8,14 @@
 import { EuiFlexGrid, EuiFlexItem, EuiPanel, EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useServiceMetricChartsFetcher } from '../../../hooks/use_service_metric_charts_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { MetricsChart } from '../../shared/charts/metrics_chart';
 
 export function ServiceMetrics() {
-  const { urlParams } = useUrlParams();
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/metrics');
 
   const { data, status } = useServiceMetricChartsFetcher({
@@ -24,7 +23,10 @@ export function ServiceMetrics() {
     environment,
     kuery,
   });
-  const { start, end } = urlParams;
+  const { start, end } = useTimeRange({
+    rangeFrom,
+    rangeTo,
+  });
 
   return (
     <ChartPointerEventContextProvider>

--- a/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
@@ -26,11 +26,11 @@ import {
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { useBreadcrumb } from '../../../context/breadcrumbs/use_breadcrumb';
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../hooks/use_apm_router';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { useServiceMetricChartsFetcher } from '../../../hooks/use_service_metric_charts_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { truncate, unit } from '../../../utils/style';
 import { MetricsChart } from '../../shared/charts/metrics_chart';
 import { ElasticDocsLink } from '../../shared/Links/ElasticDocsLink';
@@ -46,9 +46,6 @@ const Truncate = euiStyled.span`
 `;
 
 export function ServiceNodeMetrics() {
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
   const { agentName, serviceName } = useApmServiceContext();
 
   const apmRouter = useApmRouter();
@@ -58,7 +55,9 @@ export function ServiceNodeMetrics() {
     query,
   } = useApmParams('/services/:serviceName/nodes/:serviceNodeName/metrics');
 
-  const { environment, kuery } = query;
+  const { environment, kuery, rangeFrom, rangeTo } = query;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   useBreadcrumb({
     title: getServiceNodeName(serviceNodeName),

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -18,9 +18,9 @@ import {
   asPercent,
 } from '../../../../common/utils/formatters';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { truncate, unit } from '../../../utils/style';
 import { ServiceNodeMetricOverviewLink } from '../../shared/Links/apm/ServiceNodeMetricOverviewLink';
 import { ITableColumn, ManagedTable } from '../../shared/managed_table';
@@ -35,12 +35,10 @@ const ServiceNodeName = euiStyled.div`
 
 function ServiceNodeOverview() {
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/nodes');
 
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { serviceName } = useApmServiceContext();
 

--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -25,6 +25,7 @@ import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFallbackToTransactionsFetcher } from '../../../hooks/use_fallback_to_transactions_fetcher';
 import { AggregatedTransactionsBadge } from '../../shared/aggregated_transactions_badge';
 import { useApmRouter } from '../../../hooks/use_apm_router';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 /**
  * The height a chart should be if it's next to a table with 5 rows and a title.
@@ -36,11 +37,13 @@ export function ServiceOverview() {
   const { agentName, serviceName } = useApmServiceContext();
   const {
     query,
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/overview');
   const { fallbackToTransactions } = useFallbackToTransactionsFetcher({
     kuery,
   });
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   // The default EuiFlexGroup breaks at 768, but we want to break at 992, so we
   // observe the window width and set the flex directions of rows accordingly
@@ -61,6 +64,8 @@ export function ServiceOverview() {
     <AnnotationsContextProvider
       serviceName={serviceName}
       environment={environment}
+      start={start}
+      end={end}
     >
       <ChartPointerEventContextProvider>
         <EuiFlexGroup direction="column" gutterSize="s">
@@ -97,6 +102,8 @@ export function ServiceOverview() {
                     kuery={kuery}
                     environment={environment}
                     fixedHeight={true}
+                    start={start}
+                    end={end}
                   />
                 </EuiPanel>
               </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
@@ -14,6 +14,7 @@ import { useApmServiceContext } from '../../../../context/apm_service/use_apm_se
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { useFetcher } from '../../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 import { BackendLink } from '../../../shared/backend_link';
 import { DependenciesTable } from '../../../shared/dependencies_table';
 import { ServiceLink } from '../../../shared/service_link';
@@ -29,18 +30,14 @@ export function ServiceOverviewDependenciesTable({
   link,
 }: ServiceOverviewDependenciesTableProps) {
   const {
-    urlParams: {
-      start,
-      end,
-      comparisonEnabled,
-      comparisonType,
-      latencyAggregationType,
-    },
+    urlParams: { comparisonEnabled, comparisonType, latencyAggregationType },
   } = useUrlParams();
 
   const {
     query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/*');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { offset } = getTimeRangeComparison({
     start,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
@@ -25,6 +25,7 @@ import { getTimeRangeComparison } from '../../../shared/time_comparison/get_time
 import { OverviewTableContainer } from '../../../shared/overview_table_container';
 import { getColumns } from './get_column';
 import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 
 interface Props {
   serviceName: string;
@@ -58,7 +59,7 @@ const INITIAL_STATE_DETAILED_STATISTICS: ErrorGroupDetailedStatistics = {
 
 export function ServiceOverviewErrorsTable({ serviceName }: Props) {
   const {
-    urlParams: { start, end, comparisonType, comparisonEnabled },
+    urlParams: { comparisonType, comparisonEnabled },
   } = useUrlParams();
   const { transactionType } = useApmServiceContext();
   const [tableOptions, setTableOptions] = useState<{
@@ -72,6 +73,12 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
     sort: DEFAULT_SORT,
   });
 
+  const {
+    query: { environment, kuery, rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName/overview');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { comparisonStart, comparisonEnd } = getTimeRangeComparison({
     start,
     end,
@@ -81,10 +88,6 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
 
   const { pageIndex, sort } = tableOptions;
   const { direction, field } = sort;
-
-  const {
-    query: { environment, kuery },
-  } = useApmParams('/services/:serviceName/overview');
 
   const { data = INITIAL_STATE_MAIN_STATISTICS, status } = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
@@ -13,6 +13,7 @@ import { useApmServiceContext } from '../../../context/apm_service/use_apm_servi
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
 import { InstancesLatencyDistributionChart } from '../../shared/charts/instances_latency_distribution_chart';
 import { getTimeRangeComparison } from '../../shared/time_comparison/get_time_range_comparison';
@@ -70,18 +71,14 @@ export function ServiceOverviewInstancesChartAndTable({
   const { direction, field } = sort;
 
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/overview');
 
   const {
-    urlParams: {
-      latencyAggregationType,
-      start,
-      end,
-      comparisonType,
-      comparisonEnabled,
-    },
+    urlParams: { latencyAggregationType, comparisonType, comparisonEnabled },
   } = useUrlParams();
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { comparisonStart, comparisonEnd } = getTimeRangeComparison({
     start,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/use_instance_details_fetcher.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/use_instance_details_fetcher.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 import { useFetcher } from '../../../../hooks/use_fetcher';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 
 export function useInstanceDetailsFetcher({
   serviceName,
@@ -15,8 +16,10 @@ export function useInstanceDetailsFetcher({
   serviceNodeName: string;
 }) {
   const {
-    urlParams: { start, end },
-  } = useUrlParams();
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName/overview');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { data, status } = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
@@ -17,8 +17,10 @@ import React from 'react';
 import { asExactTransactionRate } from '../../../../common/utils/formatters';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFetcher } from '../../../hooks/use_fetcher';
 import { useTheme } from '../../../hooks/use_theme';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { TimeseriesChart } from '../../shared/charts/timeseries_chart';
 import {
   getComparisonChartTheme,
@@ -43,8 +45,14 @@ export function ServiceOverviewThroughputChart({
   const theme = useTheme();
 
   const {
-    urlParams: { start, end, comparisonEnabled, comparisonType },
+    urlParams: { comparisonEnabled, comparisonType },
   } = useUrlParams();
+
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { transactionType, serviceName } = useApmServiceContext();
   const comparisonChartTheme = getComparisonChartTheme(theme);

--- a/x-pack/plugins/apm/public/components/app/service_profiling/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_profiling/index.tsx
@@ -11,9 +11,9 @@ import {
   ProfilingValueType,
 } from '../../../../common/profiling';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
 import { ServiceProfilingFlamegraph } from './service_profiling_flamegraph';
 import { ServiceProfilingTimeline } from './service_profiling_timeline';
@@ -25,12 +25,10 @@ export function ServiceProfiling() {
   const { serviceName } = useApmServiceContext();
 
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/profiling');
 
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { data = DEFAULT_DATA } = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/components/app/trace_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/trace_overview/index.tsx
@@ -7,7 +7,6 @@
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
@@ -15,6 +14,7 @@ import { SearchBar } from '../../shared/search_bar';
 import { TraceList } from './trace_list';
 import { useFallbackToTransactionsFetcher } from '../../../hooks/use_fallback_to_transactions_fetcher';
 import { AggregatedTransactionsBadge } from '../../shared/aggregated_transactions_badge';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 type TracesAPIResponse = APIReturnType<'GET /api/apm/traces'>;
 const DEFAULT_RESPONSE: TracesAPIResponse = {
@@ -23,15 +23,14 @@ const DEFAULT_RESPONSE: TracesAPIResponse = {
 
 export function TraceOverview() {
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/traces');
   const { fallbackToTransactions } = useFallbackToTransactionsFetcher({
     kuery,
   });
 
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { status, data = DEFAULT_RESPONSE } = useFetcher(
     (callApmApi) => {
       if (start && end) {

--- a/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.tsx
@@ -26,6 +26,7 @@ import { useUiTracker } from '../../../../../../observability/public';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { isErrorMessage } from '../../correlations/utils/is_error_message';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 
 const DEFAULT_PERCENTILE_THRESHOLD = 95;
 // Enforce min height so it's consistent across all tabs on the same level
@@ -66,12 +67,14 @@ export function TransactionDistribution({
   const { serviceName, transactionType } = useApmServiceContext();
 
   const {
-    query: { kuery, environment },
+    query: { kuery, environment, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { urlParams } = useUrlParams();
 
-  const { transactionName, start, end } = urlParams;
+  const { transactionName } = urlParams;
 
   const emptySelectionText = i18n.translate(
     'xpack.apm.transactionDetails.emptySelectionText',

--- a/x-pack/plugins/apm/public/components/app/transaction_details/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/index.tsx
@@ -11,6 +11,7 @@ import { useBreadcrumb } from '../../../context/breadcrumbs/use_breadcrumb';
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../hooks/use_apm_router';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { TransactionCharts } from '../../shared/charts/transaction_charts';
 
 import { TransactionDetailsTabs } from './transaction_details_tabs';
@@ -19,7 +20,9 @@ export function TransactionDetails() {
   const { path, query } = useApmParams(
     '/services/:serviceName/transactions/view'
   );
-  const { transactionName } = query;
+  const { transactionName, rangeFrom, rangeTo } = query;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const apmRouter = useApmRouter();
 
@@ -45,6 +48,8 @@ export function TransactionDetails() {
         <TransactionCharts
           kuery={query.kuery}
           environment={query.environment}
+          start={start}
+          end={end}
         />
       </ChartPointerEventContextProvider>
 

--- a/x-pack/plugins/apm/public/components/app/transaction_details/use_waterfall_fetcher.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/use_waterfall_fetcher.ts
@@ -7,7 +7,9 @@
 
 import { useMemo } from 'react';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { getWaterfall } from './waterfall_with_summary/waterfall_container/Waterfall/waterfall_helpers/waterfall_helpers';
 
 const INITIAL_DATA = {
@@ -18,7 +20,14 @@ const INITIAL_DATA = {
 
 export function useWaterfallFetcher() {
   const { urlParams } = useUrlParams();
-  const { traceId, start, end, transactionId } = urlParams;
+  const { traceId, transactionId } = urlParams;
+
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName/transactions/view');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { data = INITIAL_DATA, status, error } = useFetcher(
     (callApmApi) => {
       if (traceId && start && end) {

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
@@ -14,6 +14,7 @@ import { IUrlParams } from '../../../context/url_params_context/types';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFallbackToTransactionsFetcher } from '../../../hooks/use_fallback_to_transactions_fetcher';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import { AggregatedTransactionsBadge } from '../../shared/aggregated_transactions_badge';
 import { TransactionCharts } from '../../shared/charts/transaction_charts';
 import { fromQuery, toQuery } from '../../shared/Links/url_helpers';
@@ -45,8 +46,10 @@ function getRedirectLocation({
 
 export function TransactionOverview() {
   const {
-    query: { environment, kuery },
+    query: { environment, kuery, rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/transactions');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { fallbackToTransactions } = useFallbackToTransactionsFetcher({
     kuery,
@@ -76,7 +79,12 @@ export function TransactionOverview() {
           <EuiSpacer size="s" />
         </>
       )}
-      <TransactionCharts kuery={kuery} environment={environment} />
+      <TransactionCharts
+        kuery={kuery}
+        environment={environment}
+        start={start}
+        end={end}
+      />
       <EuiSpacer size="s" />
       <EuiPanel hasBorder={true}>
         <TransactionsTable
@@ -85,6 +93,8 @@ export function TransactionOverview() {
           showAggregationAccurateCallout
           environment={environment}
           kuery={kuery}
+          start={start}
+          end={end}
         />
       </EuiPanel>
     </>

--- a/x-pack/plugins/apm/public/components/routing/app_root.tsx
+++ b/x-pack/plugins/apm/public/components/routing/app_root.tsx
@@ -27,6 +27,7 @@ import {
 import { useApmPluginContext } from '../../context/apm_plugin/use_apm_plugin_context';
 import { BreadcrumbsContextProvider } from '../../context/breadcrumbs/context';
 import { LicenseProvider } from '../../context/license/license_context';
+import { TimeRangeIdContextProvider } from '../../context/time_range_id/time_range_id_context';
 import { UrlParamsProvider } from '../../context/url_params_context/url_params_context';
 import { ApmPluginStartDeps } from '../../plugin';
 import { ApmHeaderActionMenu } from '../shared/apm_header_action_menu';
@@ -54,24 +55,26 @@ export function ApmAppRoot({
       <ApmPluginContext.Provider value={apmPluginContextValue}>
         <KibanaContextProvider services={{ ...core, ...pluginsStart }}>
           <i18nCore.Context>
-            <RouterProvider history={history} router={apmRouter as any}>
-              <TrackPageview>
-                <BreadcrumbsContextProvider>
-                  <UrlParamsProvider>
-                    <LicenseProvider>
-                      <AnomalyDetectionJobsContextProvider>
-                        <ApmThemeProvider>
-                          <MountApmHeaderActionMenu />
+            <TimeRangeIdContextProvider>
+              <RouterProvider history={history} router={apmRouter as any}>
+                <TrackPageview>
+                  <BreadcrumbsContextProvider>
+                    <UrlParamsProvider>
+                      <LicenseProvider>
+                        <AnomalyDetectionJobsContextProvider>
+                          <ApmThemeProvider>
+                            <MountApmHeaderActionMenu />
 
-                          <Route component={ScrollToTopOnPathChange} />
-                          <RouteRenderer />
-                        </ApmThemeProvider>
-                      </AnomalyDetectionJobsContextProvider>
-                    </LicenseProvider>
-                  </UrlParamsProvider>
-                </BreadcrumbsContextProvider>
-              </TrackPageview>
-            </RouterProvider>
+                            <Route component={ScrollToTopOnPathChange} />
+                            <RouteRenderer />
+                          </ApmThemeProvider>
+                        </AnomalyDetectionJobsContextProvider>
+                      </LicenseProvider>
+                    </UrlParamsProvider>
+                  </BreadcrumbsContextProvider>
+                </TrackPageview>
+              </RouterProvider>
+            </TimeRangeIdContextProvider>
           </i18nCore.Context>
         </KibanaContextProvider>
       </ApmPluginContext.Provider>

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -34,7 +34,6 @@ export function ApmMainTemplate({
 
   const ObservabilityPageTemplate =
     services.observability.navigation.PageTemplate;
-
   return (
     <ObservabilityPageTemplate
       pageHeader={{

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.stories.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.stories.tsx
@@ -7,10 +7,12 @@
 
 import type { Story, StoryContext } from '@storybook/react';
 import React, { ComponentType } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { CoreStart } from '../../../../../../../../src/core/public';
 import { createKibanaReactContext } from '../../../../../../../../src/plugins/kibana_react/public';
+import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
+import { MockApmPluginContextWrapper } from '../../../../context/apm_plugin/mock_apm_plugin_context';
 import { APMServiceContext } from '../../../../context/apm_service/apm_service_context';
-import { MockUrlParamsContextProvider } from '../../../../context/url_params_context/mock_url_params_context_provider';
 import { AnalyzeDataButton } from './analyze_data_button';
 
 interface Args {
@@ -35,17 +37,28 @@ export default {
       } as unknown) as Partial<CoreStart>);
 
       return (
-        <MockUrlParamsContextProvider
-          params={{ environment, rangeFrom: 'now-15m', rangeTo: 'now' }}
+        <MemoryRouter
+          initialEntries={[
+            `/services/${serviceName}/overview?rangeFrom=now-15m&rangeTo=now&environment=${
+              environment ?? ENVIRONMENT_ALL.value
+            }&kuery=`,
+          ]}
         >
-          <APMServiceContext.Provider
-            value={{ agentName, alerts: [], transactionTypes: [], serviceName }}
-          >
-            <KibanaContext.Provider>
-              <StoryComponent />
-            </KibanaContext.Provider>
-          </APMServiceContext.Provider>
-        </MockUrlParamsContextProvider>
+          <MockApmPluginContextWrapper>
+            <APMServiceContext.Provider
+              value={{
+                agentName,
+                alerts: [],
+                transactionTypes: [],
+                serviceName,
+              }}
+            >
+              <KibanaContext.Provider>
+                <StoryComponent />
+              </KibanaContext.Provider>
+            </APMServiceContext.Provider>
+          </MockApmPluginContextWrapper>
+        </MemoryRouter>
       );
     },
   ],

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.test.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.test.tsx
@@ -53,16 +53,6 @@ describe('AnalyzeDataButton', () => {
     });
   });
 
-  describe('with no environment', () => {
-    it('does not include the environment', () => {
-      render(<Example environment={undefined} />);
-
-      expect((screen.getByRole('link') as HTMLAnchorElement).href).toEqual(
-        'http://localhost/app/observability/exploratory-view#?sr=(apm-series:(dt:mobile,isNew:!t,op:average,rdf:(service.name:!(testServiceName)),rt:kpi-over-time,time:(from:now-15m,to:now)))'
-      );
-    });
-  });
-
   describe('with environment not defined', () => {
     it('does not include the environment', () => {
       render(<Example environment={ENVIRONMENT_NOT_DEFINED.value} />);

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/analyze_data_button.tsx
@@ -27,7 +27,7 @@ import {
   ENVIRONMENT_NOT_DEFINED,
 } from '../../../../../common/environment_filter_values';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../../hooks/use_apm_params';
 
 function getEnvironmentDefinition(environment?: string) {
   switch (environment) {
@@ -44,8 +44,11 @@ function getEnvironmentDefinition(environment?: string) {
 export function AnalyzeDataButton() {
   const { agentName, serviceName } = useApmServiceContext();
   const { services } = useKibana();
-  const { urlParams } = useUrlParams();
-  const { rangeTo, rangeFrom, environment } = urlParams;
+
+  const {
+    query: { rangeFrom, rangeTo, environment },
+  } = useApmParams('/services/:serviceName');
+
   const basepath = services.http?.basePath.get();
   const canShowDashboard = services.application?.capabilities.dashboard.show;
 

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -27,6 +27,7 @@ import { useApmServiceContext } from '../../../../context/apm_service/use_apm_se
 import { useBreadcrumb } from '../../../../context/breadcrumbs/use_breadcrumb';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 import { SearchBar } from '../../../shared/search_bar';
 import { ServiceIcons } from '../../../shared/service_icons';
 import { ApmMainTemplate } from '../apm_main_template';
@@ -70,7 +71,10 @@ function TemplateWithContext({
   const {
     path: { serviceName },
     query,
+    query: { rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName/*');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const router = useApmRouter();
 
@@ -100,7 +104,11 @@ function TemplateWithContext({
                   </EuiTitle>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <ServiceIcons serviceName={serviceName} />
+                  <ServiceIcons
+                    serviceName={serviceName}
+                    start={start}
+                    end={end}
+                  />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -18,6 +18,7 @@ import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher'
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { fromQuery, toQuery } from '../Links/url_helpers';
 import { useApmParams } from '../../../hooks/use_apm_params';
+import { getDateRange } from '../../../context/url_params_context/helpers';
 
 function updateEnvironmentUrl(
   history: History,
@@ -66,7 +67,17 @@ export function EnvironmentFilter() {
   const apmParams = useApmParams('/*', true);
   const { urlParams } = useUrlParams();
 
-  const { environment, start, end } = urlParams;
+  const { start, end } =
+    apmParams?.query &&
+    'rangeFrom' in apmParams.query &&
+    'rangeTo' in apmParams.query
+      ? getDateRange({
+          rangeFrom: apmParams.query.rangeFrom,
+          rangeTo: apmParams.query.rangeTo,
+        })
+      : { start: undefined, end: undefined };
+
+  const { environment } = urlParams;
   const { environments, status = 'loading' } = useEnvironmentsFetcher({
     serviceName:
       apmParams && 'serviceName' in apmParams.path

--- a/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -18,7 +18,7 @@ import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher'
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { fromQuery, toQuery } from '../Links/url_helpers';
 import { useApmParams } from '../../../hooks/use_apm_params';
-import { getDateRange } from '../../../context/url_params_context/helpers';
+import { useTimeRange } from '../../../hooks/use_time_range';
 
 function updateEnvironmentUrl(
   history: History,
@@ -67,15 +67,17 @@ export function EnvironmentFilter() {
   const apmParams = useApmParams('/*', true);
   const { urlParams } = useUrlParams();
 
-  const { start, end } =
-    apmParams?.query &&
-    'rangeFrom' in apmParams.query &&
-    'rangeTo' in apmParams.query
-      ? getDateRange({
-          rangeFrom: apmParams.query.rangeFrom,
-          rangeTo: apmParams.query.rangeTo,
-        })
-      : { start: undefined, end: undefined };
+  const rangeFrom =
+    apmParams?.query && 'rangeFrom' in apmParams.query
+      ? apmParams.query.rangeFrom
+      : undefined;
+
+  const rangeTo =
+    apmParams?.query && 'rangeTo' in apmParams.query
+      ? apmParams.query.rangeTo
+      : undefined;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo, optional: true });
 
   const { environment } = urlParams;
   const { environments, status = 'loading' } = useEnvironmentsFetcher({

--- a/x-pack/plugins/apm/public/components/shared/charts/breakdown_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/breakdown_chart/index.tsx
@@ -32,12 +32,13 @@ import {
 } from '../../../../../common/utils/formatters';
 import { Coordinate, TimeSeries } from '../../../../../typings/timeseries';
 import { useChartPointerEventContext } from '../../../../context/chart_pointer_event/use_chart_pointer_event_context';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
 import { useTheme } from '../../../../hooks/use_theme';
 import { unit } from '../../../../utils/style';
 import { ChartContainer } from '../../charts/chart_container';
 import { isTimeseriesEmpty, onBrushEnd } from '../../charts/helper/helper';
+import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 
 interface Props {
   fetchStatus: FETCH_STATUS;
@@ -63,9 +64,14 @@ export function BreakdownChart({
   const chartTheme = useChartTheme();
 
   const { chartRef, setPointerEvent } = useChartPointerEventContext();
-  const { urlParams } = useUrlParams();
+
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
   const theme = useTheme();
-  const { start, end } = urlParams;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const min = moment.utc(start).valueOf();
   const max = moment.utc(end).valueOf();

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/use_transaction_breakdown.ts
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/use_transaction_breakdown.ts
@@ -8,6 +8,8 @@
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 
 export function useTransactionBreakdown({
   kuery,
@@ -17,8 +19,15 @@ export function useTransactionBreakdown({
   environment: string;
 }) {
   const {
-    urlParams: { start, end, transactionName },
+    urlParams: { transactionName },
   } = useUrlParams();
+
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { transactionType, serviceName } = useApmServiceContext();
 
   const { data = { timeseries: undefined }, error, status } = useFetcher(

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/index.tsx
@@ -17,13 +17,21 @@ import { TransactionErrorRateChart } from '../transaction_error_rate_chart/';
 export function TransactionCharts({
   kuery,
   environment,
+  start,
+  end,
 }: {
   kuery: string;
   environment: string;
+  start: string;
+  end: string;
 }) {
   return (
     <>
-      <AnnotationsContextProvider environment={environment}>
+      <AnnotationsContextProvider
+        environment={environment}
+        start={start}
+        end={end}
+      >
         <ChartPointerEventContextProvider>
           <EuiFlexGrid columns={2} gutterSize="s">
             <EuiFlexItem data-cy={`transaction-duration-charts`}>

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -21,6 +21,8 @@ import {
   getComparisonChartTheme,
   getTimeRangeComparison,
 } from '../../time_comparison/get_time_range_comparison';
+import { useApmParams } from '../../../../hooks/use_apm_params';
+import { useTimeRange } from '../../../../hooks/use_time_range';
 
 function yLabelFormat(y?: number | null) {
   return asPercent(y || 0, 1);
@@ -56,14 +58,15 @@ export function TransactionErrorRateChart({
 }: Props) {
   const theme = useTheme();
   const {
-    urlParams: {
-      start,
-      end,
-      transactionName,
-      comparisonEnabled,
-      comparisonType,
-    },
+    urlParams: { transactionName, comparisonEnabled, comparisonType },
   } = useUrlParams();
+
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { serviceName, transactionType, alerts } = useApmServiceContext();
   const comparisonChartThem = getComparisonChartTheme(theme);
   const { comparisonStart, comparisonEnd } = getTimeRangeComparison({

--- a/x-pack/plugins/apm/public/components/shared/service_icons/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/index.test.tsx
@@ -62,7 +62,11 @@ describe('ServiceIcons', () => {
       const { getByTestId, queryAllByTestId } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );
@@ -81,7 +85,11 @@ describe('ServiceIcons', () => {
       const { queryAllByTestId } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );
@@ -102,7 +110,11 @@ describe('ServiceIcons', () => {
       const { queryAllByTestId, getByTestId } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );
@@ -124,7 +136,11 @@ describe('ServiceIcons', () => {
       const { queryAllByTestId, getByTestId } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );
@@ -147,7 +163,11 @@ describe('ServiceIcons', () => {
       const { queryAllByTestId, getByTestId } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );
@@ -192,7 +212,11 @@ describe('ServiceIcons', () => {
       const { queryAllByTestId, getByTestId } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );
@@ -230,7 +254,11 @@ describe('ServiceIcons', () => {
       const { queryAllByTestId, getByTestId, getByText } = render(
         <Wrapper>
           <EuiThemeProvider>
-            <ServiceIcons serviceName="foo" />
+            <ServiceIcons
+              serviceName="foo"
+              start="2021-08-20T10:00:00.000Z"
+              end="2021-08-20T10:15:00.000Z"
+            />
           </EuiThemeProvider>
         </Wrapper>
       );

--- a/x-pack/plugins/apm/public/components/shared/service_icons/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/index.tsx
@@ -10,7 +10,6 @@ import { i18n } from '@kbn/i18n';
 import React, { ReactChild, useState } from 'react';
 import { useTheme } from '../../../hooks/use_theme';
 import { ContainerType } from '../../../../common/service_metadata';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
 import { getAgentIcon } from '../agent_icon/get_agent_icon';
 import { CloudDetails } from './cloud_details';
@@ -20,6 +19,8 @@ import { ServiceDetails } from './service_details';
 
 interface Props {
   serviceName: string;
+  start: string;
+  end: string;
 }
 
 const cloudIcons: Record<string, string> = {
@@ -60,10 +61,7 @@ interface PopoverItem {
   component: ReactChild;
 }
 
-export function ServiceIcons({ serviceName }: Props) {
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+export function ServiceIcons({ start, end, serviceName }: Props) {
   const [
     selectedIconPopover,
     setSelectedIconPopover,

--- a/x-pack/plugins/apm/public/components/shared/time_comparison/get_comparison_types.ts
+++ b/x-pack/plugins/apm/public/components/shared/time_comparison/get_comparison_types.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { getDateDifference } from '../../../../common/utils/formatters';
+import { TimeRangeComparisonType } from './get_time_range_comparison';
+
+export function getComparisonTypes({
+  start,
+  end,
+}: {
+  start?: string;
+  end?: string;
+}) {
+  const momentStart = moment(start);
+  const momentEnd = moment(end);
+
+  const dateDiff = getDateDifference({
+    start: momentStart,
+    end: momentEnd,
+    unitOfTime: 'days',
+    precise: true,
+  });
+
+  // Less than or equals to one day
+  if (dateDiff <= 1) {
+    return [
+      TimeRangeComparisonType.DayBefore,
+      TimeRangeComparisonType.WeekBefore,
+    ];
+  }
+
+  // Less than or equals to one week
+  if (dateDiff <= 7) {
+    return [TimeRangeComparisonType.WeekBefore];
+  }
+  // }
+
+  // above one week or when rangeTo is not "now"
+  return [TimeRangeComparisonType.PeriodBefore];
+}

--- a/x-pack/plugins/apm/public/components/shared/time_comparison/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/time_comparison/index.test.tsx
@@ -9,23 +9,45 @@ import { render } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { EuiThemeProvider } from '../../../../../../../src/plugins/kibana_react/common';
-import { MockUrlParamsContextProvider } from '../../../context/url_params_context/mock_url_params_context_provider';
-import { IUrlParams } from '../../../context/url_params_context/types';
 import {
   expectTextsInDocument,
   expectTextsNotInDocument,
 } from '../../../utils/testHelpers';
-import { getComparisonTypes, getSelectOptions, TimeComparison } from './';
+import { getSelectOptions, TimeComparison } from './';
 import * as urlHelpers from '../../shared/Links/url_helpers';
 import moment from 'moment';
 import { TimeRangeComparisonType } from './get_time_range_comparison';
+import { getComparisonTypes } from './get_comparison_types';
+import { MockApmPluginContextWrapper } from '../../../context/apm_plugin/mock_apm_plugin_context';
+import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import { MockUrlParamsContextProvider } from '../../../context/url_params_context/mock_url_params_context_provider';
 
-function getWrapper(params?: IUrlParams) {
+function getWrapper({
+  exactStart,
+  exactEnd,
+  comparisonType,
+  comparisonEnabled,
+  environment = ENVIRONMENT_ALL.value,
+}: {
+  exactStart: string;
+  exactEnd: string;
+  comparisonType?: TimeRangeComparisonType;
+  comparisonEnabled?: boolean;
+  environment?: string;
+}) {
   return ({ children }: { children?: ReactNode }) => {
     return (
-      <MemoryRouter>
-        <MockUrlParamsContextProvider params={params}>
-          <EuiThemeProvider>{children}</EuiThemeProvider>
+      <MemoryRouter
+        initialEntries={[
+          `/services?rangeFrom=${exactStart}&rangeTo=${exactEnd}&environment=${environment}`,
+        ]}
+      >
+        <MockUrlParamsContextProvider
+          params={{ comparisonType, comparisonEnabled }}
+        >
+          <MockApmPluginContextWrapper>
+            <EuiThemeProvider>{children}</EuiThemeProvider>
+          </MockApmPluginContextWrapper>
         </MockUrlParamsContextProvider>
       </MemoryRouter>
     );

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -62,6 +62,8 @@ interface Props {
   environment: string;
   fixedHeight?: boolean;
   kuery: string;
+  start: string;
+  end: string;
 }
 
 export function TransactionsTable({
@@ -71,6 +73,8 @@ export function TransactionsTable({
   showAggregationAccurateCallout = false,
   environment,
   kuery,
+  start,
+  end,
 }: Props) {
   const [tableOptions, setTableOptions] = useState<{
     pageIndex: number;
@@ -88,13 +92,7 @@ export function TransactionsTable({
 
   const { transactionType, serviceName } = useApmServiceContext();
   const {
-    urlParams: {
-      start,
-      end,
-      latencyAggregationType,
-      comparisonType,
-      comparisonEnabled,
-    },
+    urlParams: { latencyAggregationType, comparisonType, comparisonEnabled },
   } = useUrlParams();
 
   const { comparisonStart, comparisonEnd } = getTimeRangeComparison({

--- a/x-pack/plugins/apm/public/context/annotations/annotations_context.tsx
+++ b/x-pack/plugins/apm/public/context/annotations/annotations_context.tsx
@@ -8,7 +8,6 @@
 import React, { createContext } from 'react';
 import { Annotation } from '../../../common/annotations';
 import { useFetcher } from '../../hooks/use_fetcher';
-import { useUrlParams } from '../url_params_context/use_url_params';
 
 export const AnnotationsContext = createContext({ annotations: [] } as {
   annotations: Annotation[];
@@ -19,16 +18,16 @@ const INITIAL_STATE = { annotations: [] };
 export function AnnotationsContextProvider({
   children,
   environment,
+  start,
+  end,
   serviceName,
 }: {
   children: React.ReactNode;
   environment: string;
+  start: string;
+  end: string;
   serviceName?: string;
 }) {
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
-
   const { data = INITIAL_STATE } = useFetcher(
     (callApmApi) => {
       if (start && end && serviceName) {

--- a/x-pack/plugins/apm/public/context/apm_backend/apm_backend_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_backend/apm_backend_context.tsx
@@ -9,7 +9,7 @@ import React, { createContext, useMemo } from 'react';
 import { FETCH_STATUS, useFetcher } from '../../hooks/use_fetcher';
 import { useApmParams } from '../../hooks/use_apm_params';
 import { APIReturnType } from '../../services/rest/createCallApmApi';
-import { useUrlParams } from '../url_params_context/use_url_params';
+import { useTimeRange } from '../../hooks/use_time_range';
 
 export const ApmBackendContext = createContext<
   | {
@@ -29,11 +29,10 @@ export function ApmBackendContextProvider({
 }) {
   const {
     path: { backendName },
+    query: { rangeFrom, rangeTo },
   } = useApmParams('/backends/:backendName/overview');
 
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const backendMetadataFetch = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/context/apm_service/apm_service_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/apm_service_context.tsx
@@ -17,6 +17,7 @@ import { useServiceAgentFetcher } from './use_service_agent_fetcher';
 import { APIReturnType } from '../../services/rest/createCallApmApi';
 import { useServiceAlertsFetcher } from './use_service_alerts_fetcher';
 import { useApmParams } from '../../hooks/use_apm_params';
+import { useTimeRange } from '../../hooks/use_time_range';
 
 export type APMServiceAlert = ValuesType<
   APIReturnType<'GET /api/apm/services/{serviceName}/alerts'>['alerts']
@@ -39,9 +40,16 @@ export function ApmServiceContextProvider({
   const {
     path: { serviceName },
     query,
+    query: { rangeFrom, rangeTo },
   } = useApmParams('/services/:serviceName');
 
-  const { agentName, runtimeName } = useServiceAgentFetcher(serviceName);
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
+  const { agentName, runtimeName } = useServiceAgentFetcher({
+    serviceName,
+    start,
+    end,
+  });
 
   const transactionTypes = useServiceTransactionTypesFetcher(serviceName);
 
@@ -55,7 +63,8 @@ export function ApmServiceContextProvider({
     serviceName,
     transactionType,
     environment: query.environment,
-    kuery: query.kuery,
+    start,
+    end,
   });
 
   return (

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_agent_fetcher.ts
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_agent_fetcher.ts
@@ -6,19 +6,24 @@
  */
 
 import { useFetcher } from '../../hooks/use_fetcher';
-import { useUrlParams } from '../url_params_context/use_url_params';
 
 const INITIAL_STATE = {
   agentName: undefined,
   runtimeName: undefined,
 };
 
-export function useServiceAgentFetcher(serviceName?: string) {
-  const { urlParams } = useUrlParams();
-  const { start, end } = urlParams;
+export function useServiceAgentFetcher({
+  serviceName,
+  start,
+  end,
+}: {
+  serviceName?: string;
+  start: string;
+  end: string;
+}) {
   const { data = INITIAL_STATE, error, status } = useFetcher(
     (callApmApi) => {
-      if (serviceName && start && end) {
+      if (serviceName) {
         return callApmApi({
           endpoint: 'GET /api/apm/services/{serviceName}/agent',
           params: {

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_alerts_fetcher.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_alerts_fetcher.tsx
@@ -6,7 +6,6 @@
  */
 
 import { useApmPluginContext } from '../apm_plugin/use_apm_plugin_context';
-import { useUrlParams } from '../url_params_context/use_url_params';
 import { useFetcher } from '../../hooks/use_fetcher';
 import type { APMServiceAlert } from './apm_service_context';
 
@@ -14,20 +13,18 @@ export function useServiceAlertsFetcher({
   serviceName,
   transactionType,
   environment,
-  kuery,
+  start,
+  end,
 }: {
   serviceName?: string;
   transactionType?: string;
   environment: string;
-  kuery: string;
+  start: string;
+  end: string;
 }) {
   const {
     plugins: { observability },
   } = useApmPluginContext();
-
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
 
   const experimentalAlertsEnabled = observability.isAlertingExperienceEnabled();
 

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_transaction_types_fetcher.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_transaction_types_fetcher.tsx
@@ -5,14 +5,19 @@
  * 2.0.
  */
 
+import { useApmParams } from '../../hooks/use_apm_params';
 import { useFetcher } from '../../hooks/use_fetcher';
-import { useUrlParams } from '../url_params_context/use_url_params';
+import { useTimeRange } from '../../hooks/use_time_range';
 
 const INITIAL_DATA = { transactionTypes: [] };
 
 export function useServiceTransactionTypesFetcher(serviceName?: string) {
-  const { urlParams } = useUrlParams();
-  const { start, end } = urlParams;
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { data = INITIAL_DATA } = useFetcher(
     (callApmApi) => {
       if (serviceName && start && end) {

--- a/x-pack/plugins/apm/public/context/time_range_id/time_range_id_context.tsx
+++ b/x-pack/plugins/apm/public/context/time_range_id/time_range_id_context.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { createContext, useState, useMemo } from 'react';
+
+export const TimeRangeIdContext = createContext<{
+  incrementTimeRangeId: () => void;
+  timeRangeId: number;
+}>({
+  incrementTimeRangeId: () => {},
+  timeRangeId: 0,
+});
+
+export function TimeRangeIdContextProvider({
+  children,
+}: {
+  children: React.ReactChild;
+}) {
+  const [timeRangeId, setTimeRangeId] = useState(0);
+
+  const api = useMemo(() => {
+    return {
+      incrementTimeRangeId: () => setTimeRangeId((id) => id + 1),
+      timeRangeId,
+    };
+  }, [timeRangeId, setTimeRangeId]);
+
+  return (
+    <TimeRangeIdContext.Provider value={api}>
+      {children}
+    </TimeRangeIdContext.Provider>
+  );
+}

--- a/x-pack/plugins/apm/public/context/time_range_id/use_time_range_id.ts
+++ b/x-pack/plugins/apm/public/context/time_range_id/use_time_range_id.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useContext } from 'react';
+import { TimeRangeIdContext } from './time_range_id_context';
+
+export function useTimeRangeId() {
+  return useContext(TimeRangeIdContext);
+}

--- a/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
@@ -30,11 +30,11 @@ export function getExactDate(rawDate: string) {
 }
 
 export function getDateRange({
-  state,
+  state = {},
   rangeFrom,
   rangeTo,
 }: {
-  state: IUrlParams;
+  state?: IUrlParams;
   rangeFrom?: string;
   rangeTo?: string;
 }) {

--- a/x-pack/plugins/apm/public/hooks/use_error_group_distribution_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_error_group_distribution_fetcher.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { useUrlParams } from '../context/url_params_context/use_url_params';
+import { useApmParams } from './use_apm_params';
 import { useFetcher } from './use_fetcher';
+import { useTimeRange } from './use_time_range';
 
 export function useErrorGroupDistributionFetcher({
   serviceName,
@@ -20,8 +21,11 @@ export function useErrorGroupDistributionFetcher({
   environment: string;
 }) {
   const {
-    urlParams: { start, end },
-  } = useUrlParams();
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
   const { data } = useFetcher(
     (callApmApi) => {
       if (start && end) {

--- a/x-pack/plugins/apm/public/hooks/use_fallback_to_transactions_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_fallback_to_transactions_fetcher.tsx
@@ -4,14 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { useUrlParams } from '../context/url_params_context/use_url_params';
+import { useApmParams } from './use_apm_params';
 import { useFetcher } from './use_fetcher';
+import { useTimeRange } from './use_time_range';
 
 export function useFallbackToTransactionsFetcher({ kuery }: { kuery: string }) {
-  const {
-    urlParams: { start, end },
-  } = useUrlParams();
+  const { query } = useApmParams('/*');
+
+  const rangeFrom = 'rangeFrom' in query ? query.rangeFrom : undefined;
+  const rangeTo = 'rangeTo' in query ? query.rangeTo : undefined;
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo }, true);
+
   const { data = { fallbackToTransactions: false } } = useFetcher(
     (callApmApi) => {
       return callApmApi({

--- a/x-pack/plugins/apm/public/hooks/use_fallback_to_transactions_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_fallback_to_transactions_fetcher.tsx
@@ -14,7 +14,7 @@ export function useFallbackToTransactionsFetcher({ kuery }: { kuery: string }) {
   const rangeFrom = 'rangeFrom' in query ? query.rangeFrom : undefined;
   const rangeTo = 'rangeTo' in query ? query.rangeTo : undefined;
 
-  const { start, end } = useTimeRange({ rangeFrom, rangeTo }, true);
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo, optional: true });
 
   const { data = { fallbackToTransactions: false } } = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/hooks/use_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_fetcher.tsx
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import React, { useEffect, useMemo, useState } from 'react';
 import { IHttpFetchError } from 'src/core/public';
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
-import { useUrlParams } from '../context/url_params_context/use_url_params';
+import { useTimeRangeId } from '../context/time_range_id/use_time_range_id';
 import {
   AutoAbortedAPMClient,
   callApmApi,
@@ -76,7 +76,7 @@ export function useFetcher<TReturn>(
     status: FETCH_STATUS.NOT_INITIATED,
   });
   const [counter, setCounter] = useState(0);
-  const { rangeId } = useUrlParams();
+  const { timeRangeId } = useTimeRangeId();
 
   useEffect(() => {
     let controller: AbortController = new AbortController();
@@ -159,7 +159,7 @@ export function useFetcher<TReturn>(
   }, [
     counter,
     preservePreviousData,
-    rangeId,
+    timeRangeId,
     showToastOnError,
     ...fnDeps,
     /* eslint-enable react-hooks/exhaustive-deps */

--- a/x-pack/plugins/apm/public/hooks/use_service_metric_charts_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_service_metric_charts_fetcher.ts
@@ -7,9 +7,10 @@
 
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { MetricsChartsByAgentAPIResponse } from '../../server/lib/metrics/get_metrics_chart_data_by_agent';
-import { useUrlParams } from '../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../context/apm_service/use_apm_service_context';
 import { useFetcher } from './use_fetcher';
+import { useTimeRange } from './use_time_range';
+import { useApmParams } from './use_apm_params';
 
 const INITIAL_DATA: MetricsChartsByAgentAPIResponse = {
   charts: [],
@@ -25,8 +26,10 @@ export function useServiceMetricChartsFetcher({
   environment: string;
 }) {
   const {
-    urlParams: { start, end },
-  } = useUrlParams();
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
   const { agentName, serviceName } = useApmServiceContext();
 
   const { data = INITIAL_DATA, error, status } = useFetcher(

--- a/x-pack/plugins/apm/public/hooks/use_time_range.ts
+++ b/x-pack/plugins/apm/public/hooks/use_time_range.ts
@@ -5,18 +5,47 @@
  * 2.0.
  */
 
-import { isEqual } from 'lodash';
 import { useRef } from 'react';
+import { useTimeRangeId } from '../context/time_range_id/use_time_range_id';
 import { getDateRange } from '../context/url_params_context/helpers';
 
-export function useTimeRange({
-  rangeFrom,
-  rangeTo,
-}: {
+interface TimeRange {
+  start: string;
+  end: string;
+  exactStart: string;
+  exactEnd: string;
+  refreshTimeRange: () => void;
+  timeRangeId: number;
+}
+
+type PartialTimeRange = Pick<TimeRange, 'refreshTimeRange' | 'timeRangeId'> &
+  Pick<Partial<TimeRange>, 'start' | 'end' | 'exactStart' | 'exactEnd'>;
+
+export function useTimeRange(
+  range: { rangeFrom?: string; rangeTo?: string },
+  optional: true
+): PartialTimeRange;
+
+export function useTimeRange(range: {
   rangeFrom: string;
   rangeTo: string;
-}) {
+}): TimeRange;
+
+export function useTimeRange(
+  {
+    rangeFrom,
+    rangeTo,
+  }: {
+    rangeFrom?: string;
+    rangeTo?: string;
+  },
+  optional: boolean = false
+): TimeRange | PartialTimeRange {
   const rangeRef = useRef({ rangeFrom, rangeTo });
+
+  const { timeRangeId, incrementTimeRangeId } = useTimeRangeId();
+
+  const timeRangeIdRef = useRef(timeRangeId);
 
   const stateRef = useRef(getDateRange({ state: {}, rangeFrom, rangeTo }));
 
@@ -24,20 +53,28 @@ export function useTimeRange({
     stateRef.current = getDateRange({ state: {}, rangeFrom, rangeTo });
   };
 
-  if (!isEqual(rangeRef.current, { rangeFrom, rangeTo })) {
+  if (
+    timeRangeIdRef.current !== timeRangeId ||
+    rangeRef.current.rangeFrom !== rangeFrom ||
+    rangeRef.current.rangeTo !== rangeTo
+  ) {
     updateParsedTime();
   }
 
   rangeRef.current = { rangeFrom, rangeTo };
 
-  const { start, end } = stateRef.current;
+  const { start, end, exactStart, exactEnd } = stateRef.current;
 
-  if (!start || !end) {
+  if ((!start || !end || !exactStart || !exactEnd) && !optional) {
     throw new Error('start and/or end were unexpectedly not set');
   }
 
   return {
     start,
     end,
+    exactStart,
+    exactEnd,
+    refreshTimeRange: incrementTimeRangeId,
+    timeRangeId,
   };
 }

--- a/x-pack/plugins/apm/public/hooks/use_time_range.ts
+++ b/x-pack/plugins/apm/public/hooks/use_time_range.ts
@@ -21,26 +21,26 @@ interface TimeRange {
 type PartialTimeRange = Pick<TimeRange, 'refreshTimeRange' | 'timeRangeId'> &
   Pick<Partial<TimeRange>, 'start' | 'end' | 'exactStart' | 'exactEnd'>;
 
-export function useTimeRange(
-  range: { rangeFrom?: string; rangeTo?: string },
-  optional: true
-): PartialTimeRange;
+export function useTimeRange(range: {
+  rangeFrom?: string;
+  rangeTo?: string;
+  optional: true;
+}): PartialTimeRange;
 
 export function useTimeRange(range: {
   rangeFrom: string;
   rangeTo: string;
 }): TimeRange;
 
-export function useTimeRange(
-  {
-    rangeFrom,
-    rangeTo,
-  }: {
-    rangeFrom?: string;
-    rangeTo?: string;
-  },
-  optional: boolean = false
-): TimeRange | PartialTimeRange {
+export function useTimeRange({
+  rangeFrom,
+  rangeTo,
+  optional,
+}: {
+  rangeFrom?: string;
+  rangeTo?: string;
+  optional?: boolean;
+}): TimeRange | PartialTimeRange {
   const rangeRef = useRef({ rangeFrom, rangeTo });
 
   const { timeRangeId, incrementTimeRangeId } = useTimeRangeId();

--- a/x-pack/plugins/apm/public/hooks/use_transaction_latency_chart_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_latency_chart_fetcher.ts
@@ -12,6 +12,8 @@ import { useApmServiceContext } from '../context/apm_service/use_apm_service_con
 import { getLatencyChartSelector } from '../selectors/latency_chart_selectors';
 import { useTheme } from './use_theme';
 import { getTimeRangeComparison } from '../components/shared/time_comparison/get_time_range_comparison';
+import { useTimeRange } from './use_time_range';
+import { useApmParams } from './use_apm_params';
 
 export function useTransactionLatencyChartsFetcher({
   kuery,
@@ -24,14 +26,18 @@ export function useTransactionLatencyChartsFetcher({
   const theme = useTheme();
   const {
     urlParams: {
-      start,
-      end,
       transactionName,
       latencyAggregationType,
       comparisonType,
       comparisonEnabled,
     },
   } = useUrlParams();
+
+  const {
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const { comparisonStart, comparisonEnd } = getTimeRangeComparison({
     start,

--- a/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
@@ -8,6 +8,8 @@
 import { useFetcher } from './use_fetcher';
 import { useUrlParams } from '../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../context/apm_service/use_apm_service_context';
+import { useApmParams } from './use_apm_params';
+import { useTimeRange } from './use_time_range';
 
 export interface TraceSample {
   traceId: string;
@@ -31,14 +33,13 @@ export function useTransactionTraceSamplesFetcher({
   const { serviceName, transactionType } = useApmServiceContext();
 
   const {
-    urlParams: {
-      start,
-      end,
-      transactionId,
-      traceId,
-      sampleRangeFrom,
-      sampleRangeTo,
-    },
+    query: { rangeFrom, rangeTo },
+  } = useApmParams('/services/:serviceName');
+
+  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
+
+  const {
+    urlParams: { transactionId, traceId, sampleRangeFrom, sampleRangeTo },
   } = useUrlParams();
 
   const { data = INITIAL_DATA, status, error } = useFetcher(


### PR DESCRIPTION
## Summary

Instead of using `urlParams.{start,end}`, use `useTimeRange({ rangeFrom, rangeTo})` where possible.