### PR TITLE
[APM] Separate useUrlParams hooks for APM/Uptime

### DIFF
--- a/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/index.tsx
@@ -25,7 +25,6 @@ import {
 import { useBreakPoints } from '../../../../hooks/use_break_points';
 import { FieldValueSuggestions } from '../../../../../../observability/public';
 import { URLFilter } from '../URLFilter';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { SelectedFilters } from './SelectedFilters';
 import {
   SERVICE_NAME,
@@ -35,6 +34,7 @@ import { TRANSACTION_PAGE_LOAD } from '../../../../../common/transaction_types';
 import { useIndexPattern } from './use_index_pattern';
 import { environmentQuery } from './queries';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
+import { useUxUrlParams } from '../../../../context/url_params_context/use_ux_url_params';
 
 const filterNames: UxLocalUIFilterName[] = [
   'location',
@@ -67,7 +67,7 @@ function LocalUIFilters() {
 
   const {
     urlParams: { start, end, serviceName, environment },
-  } = useUrlParams();
+  } = useUxUrlParams();
 
   const getFilters = useMemo(() => {
     const dataFilters: ESFilter[] = [

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/RumHome.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/RumHome.tsx
@@ -13,7 +13,7 @@ import { CsmSharedContextProvider } from './CsmSharedContext';
 import { WebApplicationSelect } from './Panels/WebApplicationSelect';
 import { DatePicker } from '../../shared/DatePicker';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
-import { EnvironmentFilter } from '../../shared/EnvironmentFilter';
+import { UxEnvironmentFilter } from '../../shared/EnvironmentFilter';
 import { UserPercentile } from './UserPercentile';
 import { useBreakPoints } from '../../../hooks/use_break_points';
 
@@ -41,7 +41,7 @@ export function RumHome() {
                 rightSideItems: [
                   <DatePicker />,
                   <div style={envStyle}>
-                    <EnvironmentFilter />
+                    <UxEnvironmentFilter />
                   </div>,
                   <UserPercentile />,
                   <WebApplicationSelect />,
@@ -82,7 +82,7 @@ function PageHeader() {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <div style={envStyle}>
-            <EnvironmentFilter />
+            <UxEnvironmentFilter />
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/__snapshots__/index.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`DetailView should render Discover button 1`] = `
       },
     }
   }
+  kuery=""
 >
   <EuiButtonEmpty
     iconType="discoverApp"

--- a/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.test.tsx
@@ -18,7 +18,7 @@ describe('DetailView', () => {
 
   it('should render empty state', () => {
     const wrapper = shallow(
-      <DetailView errorGroup={{} as any} urlParams={{}} />
+      <DetailView errorGroup={{} as any} urlParams={{}} kuery="" />
     );
     expect(wrapper.isEmptyRender()).toBe(true);
   });
@@ -41,7 +41,7 @@ describe('DetailView', () => {
     };
 
     const wrapper = shallow(
-      <DetailView errorGroup={errorGroup} urlParams={{}} />
+      <DetailView errorGroup={errorGroup} urlParams={{}} kuery="" />
     ).find('DiscoverErrorLink');
 
     expect(wrapper.exists()).toBe(true);
@@ -60,7 +60,7 @@ describe('DetailView', () => {
       transaction: undefined,
     };
     const wrapper = shallow(
-      <DetailView errorGroup={errorGroup} urlParams={{}} />
+      <DetailView errorGroup={errorGroup} urlParams={{}} kuery="" />
     ).find('Summary');
 
     expect(wrapper.exists()).toBe(true);
@@ -80,7 +80,7 @@ describe('DetailView', () => {
       } as any,
     };
     const wrapper = shallow(
-      <DetailView errorGroup={errorGroup} urlParams={{}} />
+      <DetailView errorGroup={errorGroup} urlParams={{}} kuery="" />
     ).find('EuiTabs');
 
     expect(wrapper.exists()).toBe(true);
@@ -100,7 +100,7 @@ describe('DetailView', () => {
       } as any,
     };
     const wrapper = shallow(
-      <DetailView errorGroup={errorGroup} urlParams={{}} />
+      <DetailView errorGroup={errorGroup} urlParams={{}} kuery="" />
     ).find('TabContent');
 
     expect(wrapper.exists()).toBe(true);
@@ -124,7 +124,7 @@ describe('DetailView', () => {
       } as any,
     };
     expect(() =>
-      shallow(<DetailView errorGroup={errorGroup} urlParams={{}} />)
+      shallow(<DetailView errorGroup={errorGroup} urlParams={{}} kuery="" />)
     ).not.toThrowError();
   });
 });

--- a/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
@@ -20,9 +20,9 @@ import { first } from 'lodash';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { euiStyled } from '../../../../../../../../src/plugins/kibana_react/common';
-import { APIReturnType } from '../../../../services/rest/createCallApmApi';
-import { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
-import type { IUrlParams } from '../../../../context/url_params_context/types';
+import type { APIReturnType } from '../../../../services/rest/createCallApmApi';
+import type { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
+import type { ApmUrlParams } from '../../../../context/url_params_context/types';
 import { TransactionDetailLink } from '../../../shared/Links/apm/transaction_detail_link';
 import { DiscoverErrorLink } from '../../../shared/Links/DiscoverLinks/DiscoverErrorLink';
 import { fromQuery, toQuery } from '../../../shared/Links/url_helpers';
@@ -55,7 +55,8 @@ const TransactionLinkName = euiStyled.div`
 
 interface Props {
   errorGroup: APIReturnType<'GET /api/apm/services/{serviceName}/errors/{groupId}'>;
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
+  kuery: string;
 }
 
 // TODO: Move query-string-based tabs into a re-usable component?
@@ -67,7 +68,7 @@ function getCurrentTab(
   return selectedTab ? selectedTab : first(tabs) || {};
 }
 
-export function DetailView({ errorGroup, urlParams }: Props) {
+export function DetailView({ errorGroup, urlParams, kuery }: Props) {
   const history = useHistory();
   const { transaction, error, occurrencesCount } = errorGroup;
 
@@ -96,7 +97,7 @@ export function DetailView({ errorGroup, urlParams }: Props) {
             )}
           </h3>
         </EuiTitle>
-        <DiscoverErrorLink error={error} kuery={urlParams.kuery}>
+        <DiscoverErrorLink error={error} kuery={kuery}>
           <EuiButtonEmpty iconType="discoverApp">
             {i18n.translate(
               'xpack.apm.errorGroupDetails.viewOccurrencesInDiscoverButtonLabel',

--- a/x-pack/plugins/apm/public/components/app/error_group_details/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/index.tsx
@@ -220,7 +220,11 @@ export function ErrorGroupDetails() {
       </EuiPanel>
       <EuiSpacer size="s" />
       {showDetails && (
-        <DetailView errorGroup={errorGroupData} urlParams={urlParams} />
+        <DetailView
+          errorGroup={errorGroupData}
+          urlParams={urlParams}
+          kuery={kuery}
+        />
       )}
     </>
   );

--- a/x-pack/plugins/apm/public/components/app/service_map/Controls.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Controls.test.tsx
@@ -9,6 +9,7 @@ import lightTheme from '@elastic/eui/dist/eui_theme_light.json';
 import { render } from '@testing-library/react';
 import cytoscape from 'cytoscape';
 import React, { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { ThemeContext } from 'styled-components';
 import { MockApmPluginContextWrapper } from '../../../context/apm_plugin/mock_apm_plugin_context';
 import { Controls } from './Controls';
@@ -21,11 +22,18 @@ const cy = cytoscape({
 function Wrapper({ children }: { children?: ReactNode }) {
   return (
     <CytoscapeContext.Provider value={cy}>
-      <MockApmPluginContextWrapper>
-        <ThemeContext.Provider value={{ eui: lightTheme }}>
-          {children}
-        </ThemeContext.Provider>
-      </MockApmPluginContextWrapper>
+      <MemoryRouter
+        initialEntries={[
+          '/service-map?rangeFrom=now-15m&rangeTo=now&environment=ENVIRONMENT_ALL&kuery=',
+        ]}
+      >
+        <MockApmPluginContextWrapper>
+          <ThemeContext.Provider value={{ eui: lightTheme }}>
+            {children}
+          </ThemeContext.Provider>
+        </MockApmPluginContextWrapper>
+      </MemoryRouter>
+      s
     </CytoscapeContext.Provider>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/service_map/Controls.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Controls.tsx
@@ -16,6 +16,7 @@ import { getAPMHref } from '../../shared/Links/apm/APMLink';
 import { APMQueryParams } from '../../shared/Links/url_helpers';
 import { CytoscapeContext } from './Cytoscape';
 import { getAnimationOptions, getNodeHeight } from './cytoscape_options';
+import { useApmParams } from '../../../hooks/use_apm_params';
 
 const ControlsContainer = euiStyled('div')`
   left: ${({ theme }) => theme.eui.gutterTypes.gutterMedium};
@@ -103,14 +104,18 @@ export function Controls() {
   const theme = useTheme();
   const cy = useContext(CytoscapeContext);
   const { urlParams } = useUrlParams();
-  const currentSearch = urlParams.kuery ?? '';
+
+  const {
+    query: { kuery },
+  } = useApmParams('/service-map', '/services/:serviceName/service-map');
+
   const [zoom, setZoom] = useState((cy && cy.zoom()) || 1);
   const duration = parseInt(theme.eui.euiAnimSpeedFast, 10);
   const downloadUrl = useDebugDownloadUrl(cy);
   const viewFullMapUrl = getAPMHref({
     basePath,
     path: '/service-map',
-    search: currentSearch,
+    search: `kuery=${encodeURIComponent(kuery)}`,
     query: urlParams as APMQueryParams,
   });
 

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -39,6 +39,7 @@ type ServiceInstanceDetailedStatistics = APIReturnType<'GET /api/apm/services/{s
 
 export function getColumns({
   serviceName,
+  kuery,
   agentName,
   latencyAggregationType,
   detailedStatsData,
@@ -49,6 +50,7 @@ export function getColumns({
   itemIdToOpenActionMenuRowMap,
 }: {
   serviceName: string;
+  kuery: string;
   agentName?: string;
   latencyAggregationType?: LatencyAggregationType;
   detailedStatsData?: ServiceInstanceDetailedStatistics;
@@ -247,6 +249,7 @@ export function getColumns({
             <InstanceActionsMenu
               serviceName={serviceName}
               serviceNodeName={instanceItem.serviceNodeName}
+              kuery={kuery}
               onClose={() => toggleRowActionMenu(instanceItem.serviceNodeName)}
             />
           </ActionMenu>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
@@ -26,6 +26,7 @@ import {
 import { OverviewTableContainer } from '../../../shared/overview_table_container';
 import { getColumns } from './get_columns';
 import { InstanceDetails } from './intance_details';
+import { useApmParams } from '../../../../hooks/use_apm_params';
 
 type ServiceInstanceMainStatistics = APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type MainStatsServiceInstanceItem = ServiceInstanceMainStatistics['currentPeriod'][0];
@@ -63,6 +64,11 @@ export function ServiceOverviewInstancesTable({
   isLoading,
 }: Props) {
   const { agentName } = useApmServiceContext();
+
+  const {
+    query: { kuery },
+  } = useApmParams('/services/:serviceName');
+
   const {
     urlParams: { latencyAggregationType, comparisonEnabled },
   } = useUrlParams();
@@ -103,6 +109,7 @@ export function ServiceOverviewInstancesTable({
         <InstanceDetails
           serviceNodeName={selectedServiceNodeName}
           serviceName={serviceName}
+          kuery={kuery}
         />
       );
     }
@@ -112,6 +119,7 @@ export function ServiceOverviewInstancesTable({
   const columns = getColumns({
     agentName,
     serviceName,
+    kuery,
     latencyAggregationType,
     detailedStatsData,
     comparisonEnabled,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_actions_menu/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_actions_menu/index.tsx
@@ -18,7 +18,6 @@ import {
 import { isJavaAgentName } from '../../../../../../common/agent_name';
 import { SERVICE_NODE_NAME } from '../../../../../../common/elasticsearch_fieldnames';
 import { useApmPluginContext } from '../../../../../context/apm_plugin/use_apm_plugin_context';
-import { useUrlParams } from '../../../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS } from '../../../../../hooks/use_fetcher';
 import { pushNewItemToKueryBar } from '../../../../shared/kuery_bar/utils';
 import { useMetricOverviewHref } from '../../../../shared/Links/apm/MetricOverviewLink';
@@ -29,6 +28,7 @@ import { getMenuSections } from './menu_sections';
 interface Props {
   serviceName: string;
   serviceNodeName: string;
+  kuery: string;
   onClose: () => void;
 }
 
@@ -37,6 +37,7 @@ const POPOVER_WIDTH = '305px';
 export function InstanceActionsMenu({
   serviceName,
   serviceNodeName,
+  kuery,
   onClose,
 }: Props) {
   const { core } = useApmPluginContext();
@@ -50,9 +51,6 @@ export function InstanceActionsMenu({
   });
   const metricOverviewHref = useMetricOverviewHref(serviceName);
   const history = useHistory();
-  const {
-    urlParams: { kuery },
-  } = useUrlParams();
 
   if (
     status === FETCH_STATUS.LOADING ||

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_details.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_details.test.tsx
@@ -23,7 +23,7 @@ describe('InstanceDetails', () => {
       .spyOn(useInstanceDetailsFetcher, 'useInstanceDetailsFetcher')
       .mockReturnValue({ data: undefined, status: FETCH_STATUS.LOADING });
     const { getByTestId } = renderWithTheme(
-      <InstanceDetails serviceName="foo" serviceNodeName="bar" />
+      <InstanceDetails serviceName="foo" serviceNodeName="bar" kuery="" />
     );
     expect(getByTestId('loadingSpinner')).toBeInTheDocument();
   });
@@ -40,7 +40,7 @@ describe('InstanceDetails', () => {
         status: FETCH_STATUS.SUCCESS,
       });
     const component = renderWithTheme(
-      <InstanceDetails serviceName="foo" serviceNodeName="bar" />
+      <InstanceDetails serviceName="foo" serviceNodeName="bar" kuery="" />
     );
     expectTextsInDocument(component, ['Service', 'Container', 'Cloud']);
   });
@@ -56,7 +56,7 @@ describe('InstanceDetails', () => {
         status: FETCH_STATUS.SUCCESS,
       });
     const component = renderWithTheme(
-      <InstanceDetails serviceName="foo" serviceNodeName="bar" />
+      <InstanceDetails serviceName="foo" serviceNodeName="bar" kuery="" />
     );
     expectTextsInDocument(component, ['Container', 'Cloud']);
     expectTextsNotInDocument(component, ['Service']);
@@ -73,7 +73,7 @@ describe('InstanceDetails', () => {
         status: FETCH_STATUS.SUCCESS,
       });
     const component = renderWithTheme(
-      <InstanceDetails serviceName="foo" serviceNodeName="bar" />
+      <InstanceDetails serviceName="foo" serviceNodeName="bar" kuery="" />
     );
     expectTextsInDocument(component, ['Service', 'Cloud']);
     expectTextsNotInDocument(component, ['Container']);
@@ -90,7 +90,7 @@ describe('InstanceDetails', () => {
         status: FETCH_STATUS.SUCCESS,
       });
     const component = renderWithTheme(
-      <InstanceDetails serviceName="foo" serviceNodeName="bar" />
+      <InstanceDetails serviceName="foo" serviceNodeName="bar" kuery="" />
     );
     expectTextsInDocument(component, ['Service', 'Container']);
     expectTextsNotInDocument(component, ['Cloud']);

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/intance_details.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/intance_details.tsx
@@ -24,7 +24,6 @@ import {
   SERVICE_RUNTIME_VERSION,
   SERVICE_VERSION,
 } from '../../../../../common/elasticsearch_fieldnames';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
 import { useTheme } from '../../../../hooks/use_theme';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
@@ -39,6 +38,7 @@ type ServiceInstanceDetails = APIReturnType<'GET /api/apm/services/{serviceName}
 interface Props {
   serviceName: string;
   serviceNodeName: string;
+  kuery: string;
 }
 
 function toKeyValuePairs(keys: string[], data: ServiceInstanceDetails) {
@@ -60,12 +60,13 @@ const cloudDetailsKeys = [
   CLOUD_PROVIDER,
 ];
 
-export function InstanceDetails({ serviceName, serviceNodeName }: Props) {
+export function InstanceDetails({
+  serviceName,
+  serviceNodeName,
+  kuery,
+}: Props) {
   const theme = useTheme();
   const history = useHistory();
-  const {
-    urlParams: { kuery },
-  } = useUrlParams();
 
   const { data, status } = useInstanceDetailsFetcher({
     serviceName,

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/TransactionTabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/TransactionTabs.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { LogStream } from '../../../../../../infra/public';
 import { Transaction } from '../../../../../typings/es_schemas/ui/transaction';
-import type { IUrlParams } from '../../../../context/url_params_context/types';
+import type { ApmUrlParams } from '../../../../context/url_params_context/types';
 import { fromQuery, toQuery } from '../../../shared/Links/url_helpers';
 import { TransactionMetadata } from '../../../shared/MetadataTable/TransactionMetadata';
 import { WaterfallContainer } from './waterfall_container';
@@ -19,7 +19,7 @@ import { IWaterfall } from './waterfall_container/Waterfall/waterfall_helpers/wa
 
 interface Props {
   transaction: Transaction;
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
   waterfall: IWaterfall;
   exceedsMax: boolean;
 }
@@ -101,7 +101,7 @@ function TimelineTabContent({
   waterfall,
   exceedsMax,
 }: {
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
   waterfall: IWaterfall;
   exceedsMax: boolean;
 }) {

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/index.tsx
@@ -16,7 +16,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import type { IUrlParams } from '../../../../context/url_params_context/types';
+import type { ApmUrlParams } from '../../../../context/url_params_context/types';
 import { fromQuery, toQuery } from '../../../shared/Links/url_helpers';
 import { LoadingStatePrompt } from '../../../shared/LoadingStatePrompt';
 import { TransactionSummary } from '../../../shared/Summary/TransactionSummary';
@@ -28,7 +28,7 @@ import { IWaterfall } from './waterfall_container/Waterfall/waterfall_helpers/wa
 import { useApmParams } from '../../../../hooks/use_apm_params';
 
 interface Props {
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
   waterfall: IWaterfall;
   exceedsMax: boolean;
   isLoading: boolean;

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/index.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { keyBy } from 'lodash';
-import { IUrlParams } from '../../../../../context/url_params_context/types';
+import type { ApmUrlParams } from '../../../../../context/url_params_context/types';
 import {
   IWaterfall,
   WaterfallLegendType,
@@ -17,7 +17,7 @@ import { WaterfallLegends } from './WaterfallLegends';
 import { useApmServiceContext } from '../../../../../context/apm_service/use_apm_service_context';
 
 interface Props {
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
   waterfall: IWaterfall;
   exceedsMax: boolean;
 }

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfallContainer.stories.data.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfallContainer.stories.data.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { Location } from 'history';
-import { IUrlParams } from '../../../../../context/url_params_context/types';
+import type { Location } from 'history';
+import type { ApmUrlParams } from '../../../../../context/url_params_context/types';
 
 export const location = {
   pathname: '/services/opbeans-go/transactions/view',
@@ -25,12 +25,11 @@ export const urlParams = {
   page: 0,
   transactionId: '975c8d5bfd1dd20b',
   traceId: '513d33fafe99bbe6134749310c9b5322',
-  kuery: 'service.name: "opbeans-java" or service.name : "opbeans-go"',
   transactionName: 'GET /api/orders',
   transactionType: 'request',
   processorEvent: 'transaction',
   serviceName: 'opbeans-go',
-} as IUrlParams;
+} as ApmUrlParams;
 
 export const simpleTrace = {
   trace: {

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
@@ -10,7 +10,7 @@ import { Location } from 'history';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
-import { IUrlParams } from '../../../context/url_params_context/types';
+import type { ApmUrlParams } from '../../../context/url_params_context/types';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useFallbackToTransactionsFetcher } from '../../../hooks/use_fallback_to_transactions_fetcher';
@@ -29,7 +29,7 @@ function getRedirectLocation({
 }: {
   location: Location;
   transactionType?: string;
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
 }): Location | undefined {
   const transactionTypeFromUrlParams = urlParams.transactionType;
 

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/transaction_overview.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/transaction_overview.test.tsx
@@ -13,7 +13,7 @@ import { createKibanaReactContext } from 'src/plugins/kibana_react/public';
 import { MockApmPluginContextWrapper } from '../../../context/apm_plugin/mock_apm_plugin_context';
 import { ApmServiceContextProvider } from '../../../context/apm_service/apm_service_context';
 import { UrlParamsProvider } from '../../../context/url_params_context/url_params_context';
-import { IUrlParams } from '../../../context/url_params_context/types';
+import type { ApmUrlParams } from '../../../context/url_params_context/types';
 import * as useFetcherHook from '../../../hooks/use_fetcher';
 import * as useServiceTransactionTypesHook from '../../../context/apm_service/use_service_transaction_types_fetcher';
 import * as useServiceAgentNameHook from '../../../context/apm_service/use_service_agent_fetcher';
@@ -37,7 +37,7 @@ function setup({
   urlParams,
   serviceTransactionTypes,
 }: {
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
   serviceTransactionTypes: string[];
 }) {
   history.replace({

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -9,7 +9,7 @@ import { EuiPageHeaderProps, EuiPageTemplateProps } from '@elastic/eui';
 import React from 'react';
 import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { ApmPluginStartDeps } from '../../../plugin';
-import { EnvironmentFilter } from '../../shared/EnvironmentFilter';
+import { ApmEnvironmentFilter } from '../../shared/EnvironmentFilter';
 
 /*
  * This template contains:
@@ -34,11 +34,12 @@ export function ApmMainTemplate({
 
   const ObservabilityPageTemplate =
     services.observability.navigation.PageTemplate;
+
   return (
     <ObservabilityPageTemplate
       pageHeader={{
         pageTitle,
-        rightSideItems: [<EnvironmentFilter />],
+        rightSideItems: [<ApmEnvironmentFilter />],
         ...pageHeader,
       }}
       {...pageTemplateProps}

--- a/x-pack/plugins/apm/public/components/shared/DatePicker/date_picker.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/DatePicker/date_picker.test.tsx
@@ -13,7 +13,7 @@ import React, { ReactNode } from 'react';
 import { Router } from 'react-router-dom';
 import { MockApmPluginContextWrapper } from '../../../context/apm_plugin/mock_apm_plugin_context';
 import { UrlParamsContext } from '../../../context/url_params_context/url_params_context';
-import { IUrlParams } from '../../../context/url_params_context/types';
+import { ApmUrlParams } from '../../../context/url_params_context/types';
 import { DatePicker } from './';
 
 const history = createMemoryHistory();
@@ -24,7 +24,7 @@ function MockUrlParamsProvider({
   children,
 }: {
   children: ReactNode;
-  urlParams?: IUrlParams;
+  urlParams?: ApmUrlParams;
 }) {
   return (
     <UrlParamsContext.Provider
@@ -39,7 +39,7 @@ function MockUrlParamsProvider({
   );
 }
 
-function mountDatePicker(urlParams?: IUrlParams) {
+function mountDatePicker(urlParams?: ApmUrlParams) {
   const setTimeSpy = jest.fn();
   const getTimeSpy = jest.fn().mockReturnValue({});
   const wrapper = mount(

--- a/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -15,10 +15,10 @@ import {
   ENVIRONMENT_NOT_DEFINED,
 } from '../../../../common/environment_filter_values';
 import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { fromQuery, toQuery } from '../Links/url_helpers';
-import { useApmParams } from '../../../hooks/use_apm_params';
 import { useTimeRange } from '../../../hooks/use_time_range';
+import { useApmParams } from '../../../hooks/use_apm_params';
+import { useUxUrlParams } from '../../../context/url_params_context/use_ux_url_params';
 
 function updateEnvironmentUrl(
   history: History,
@@ -61,30 +61,58 @@ function getOptions(environments: string[]) {
   ];
 }
 
-export function EnvironmentFilter() {
-  const history = useHistory();
-  const location = useLocation();
-  const apmParams = useApmParams('/*', true);
-  const { urlParams } = useUrlParams();
+export function ApmEnvironmentFilter() {
+  const { path, query } = useApmParams('/*');
 
-  const rangeFrom =
-    apmParams?.query && 'rangeFrom' in apmParams.query
-      ? apmParams.query.rangeFrom
-      : undefined;
+  const serviceName = 'serviceName' in path ? path.serviceName : undefined;
+  const environment =
+    ('environment' in query && query.environment) || ENVIRONMENT_ALL.value;
 
-  const rangeTo =
-    apmParams?.query && 'rangeTo' in apmParams.query
-      ? apmParams.query.rangeTo
-      : undefined;
+  const rangeFrom = 'rangeFrom' in query ? query.rangeFrom : undefined;
+  const rangeTo = 'rangeTo' in query ? query.rangeTo : undefined;
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo, optional: true });
 
-  const { environment } = urlParams;
+  return (
+    <EnvironmentFilter
+      start={start}
+      end={end}
+      serviceName={serviceName}
+      environment={environment}
+    />
+  );
+}
+
+export function UxEnvironmentFilter() {
+  const {
+    urlParams: { start, end, environment, serviceName },
+  } = useUxUrlParams();
+
+  return (
+    <EnvironmentFilter
+      start={start}
+      end={end}
+      environment={environment}
+      serviceName={serviceName}
+    />
+  );
+}
+
+export function EnvironmentFilter({
+  start,
+  end,
+  environment,
+  serviceName,
+}: {
+  start?: string;
+  end?: string;
+  environment?: string;
+  serviceName?: string;
+}) {
+  const history = useHistory();
+  const location = useLocation();
   const { environments, status = 'loading' } = useEnvironmentsFetcher({
-    serviceName:
-      apmParams && 'serviceName' in apmParams.path
-        ? apmParams.path.serviceName
-        : undefined,
+    serviceName,
     start,
     end,
   });
@@ -102,7 +130,7 @@ export function EnvironmentFilter() {
         defaultMessage: 'Environment',
       })}
       options={options}
-      value={environment || ENVIRONMENT_ALL.value}
+      value={environment}
       onChange={(event) => {
         updateEnvironmentUrl(history, location, event.target.value);
       }}

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/anomaly_detection_setup_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/anomaly_detection_setup_link.tsx
@@ -20,7 +20,7 @@ import {
 import { useAnomalyDetectionJobsContext } from '../../../context/anomaly_detection_jobs/use_anomaly_detection_jobs_context';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import { useLicenseContext } from '../../../context/license/use_license_context';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../hooks/use_apm_params';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { useTheme } from '../../../hooks/use_theme';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
@@ -31,9 +31,11 @@ export type AnomalyDetectionApiResponse = APIReturnType<'GET /api/apm/settings/a
 const DEFAULT_DATA = { jobs: [], hasLegacyJobs: false };
 
 export function AnomalyDetectionSetupLink() {
-  const {
-    urlParams: { environment },
-  } = useUrlParams();
+  const { query } = useApmParams('/*');
+
+  const environment =
+    ('environment' in query && query.environment) || ENVIRONMENT_ALL.value;
+
   const { core } = useApmPluginContext();
   const canGetJobs = !!core.application.capabilities.ml?.canGetJobs;
   const license = useLicenseContext();

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
@@ -11,7 +11,7 @@ import { isEmpty } from 'lodash';
 import React from 'react';
 import { euiStyled } from '../../../../../../../../src/plugins/kibana_react/common';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
-import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { useApmParams } from '../../../../hooks/use_apm_params';
 import { MLSingleMetricLink } from '../../Links/MachineLearningLinks/MLSingleMetricLink';
 
 interface Props {
@@ -32,14 +32,15 @@ const ShiftedEuiText = euiStyled(EuiText)`
 `;
 
 export function MLHeader({ hasValidMlLicense, mlJobId }: Props) {
-  const { urlParams } = useUrlParams();
   const { transactionType, serviceName } = useApmServiceContext();
+
+  const {
+    query: { kuery },
+  } = useApmParams('/services/:serviceName');
 
   if (!hasValidMlLicense || !mlJobId) {
     return null;
   }
-
-  const { kuery } = urlParams;
 
   const hasKuery = !isEmpty(kuery);
   const icon = hasKuery ? (

--- a/x-pack/plugins/apm/public/components/shared/kuery_bar/get_bool_filter.ts
+++ b/x-pack/plugins/apm/public/components/shared/kuery_bar/get_bool_filter.ts
@@ -16,7 +16,7 @@ import {
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import { UIProcessorEvent } from '../../../../common/processor_event';
 import { environmentQuery } from '../../../../common/utils/environment_query';
-import { IUrlParams } from '../../../context/url_params_context/types';
+import { ApmUrlParams } from '../../../context/url_params_context/types';
 
 export function getBoolFilter({
   groupId,
@@ -29,7 +29,7 @@ export function getBoolFilter({
   processorEvent?: UIProcessorEvent;
   serviceName?: string;
   environment?: string;
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
 }) {
   const boolFilter: ESFilter[] = [];
 

--- a/x-pack/plugins/apm/public/components/shared/search_bar.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/search_bar.test.tsx
@@ -13,7 +13,7 @@ import { createKibanaReactContext } from 'src/plugins/kibana_react/public';
 import { MockApmPluginContextWrapper } from '../../context/apm_plugin/mock_apm_plugin_context';
 import { ApmServiceContextProvider } from '../../context/apm_service/apm_service_context';
 import { UrlParamsProvider } from '../../context/url_params_context/url_params_context';
-import { IUrlParams } from '../../context/url_params_context/types';
+import type { ApmUrlParams } from '../../context/url_params_context/types';
 import * as useFetcherHook from '../../hooks/use_fetcher';
 import * as useServiceTransactionTypesHook from '../../context/apm_service/use_service_transaction_types_fetcher';
 import { renderWithTheme } from '../../utils/testHelpers';
@@ -26,7 +26,7 @@ function setup({
   serviceTransactionTypes,
   history,
 }: {
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
   serviceTransactionTypes: string[];
   history: MemoryHistory;
 }) {

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/sections.ts
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/sections.ts
@@ -11,8 +11,8 @@ import { IBasePath } from 'kibana/public';
 import { isEmpty, pickBy } from 'lodash';
 import moment from 'moment';
 import url from 'url';
-import { Transaction } from '../../../../typings/es_schemas/ui/transaction';
-import { IUrlParams } from '../../../context/url_params_context/types';
+import type { Transaction } from '../../../../typings/es_schemas/ui/transaction';
+import type { ApmUrlParams } from '../../../context/url_params_context/types';
 import { getDiscoverHref } from '../Links/DiscoverLinks/DiscoverLink';
 import { getDiscoverQuery } from '../Links/DiscoverLinks/DiscoverTransactionLink';
 import { getInfraHref } from '../Links/InfraLink';
@@ -38,7 +38,7 @@ export const getSections = ({
   transaction: Transaction;
   basePath: IBasePath;
   location: Location;
-  urlParams: IUrlParams;
+  urlParams: ApmUrlParams;
 }) => {
   const hostName = transaction.host?.hostname;
   const podId = transaction.kubernetes?.pod?.uid;

--- a/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -143,7 +143,6 @@ export function MockApmPluginContextWrapper({
   const usedHistory = useMemo(() => {
     return history || contextHistory || createMemoryHistory();
   }, [history, contextHistory]);
-
   return (
     <RouterProvider router={apmRouter as any} history={usedHistory}>
       <ApmPluginContext.Provider

--- a/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
@@ -8,7 +8,7 @@
 import datemath from '@elastic/datemath';
 import { compact, pickBy } from 'lodash';
 import moment from 'moment';
-import { IUrlParams } from './types';
+import { UrlParams } from './types';
 
 function getParsedDate(rawDate?: string, options = {}) {
   if (rawDate) {
@@ -34,7 +34,10 @@ export function getDateRange({
   rangeFrom,
   rangeTo,
 }: {
-  state?: IUrlParams;
+  state?: Pick<
+    UrlParams,
+    'rangeFrom' | 'rangeTo' | 'start' | 'end' | 'exactStart' | 'exactEnd'
+  >;
   rangeFrom?: string;
   rangeTo?: string;
 }) {

--- a/x-pack/plugins/apm/public/context/url_params_context/mock_url_params_context_provider.tsx
+++ b/x-pack/plugins/apm/public/context/url_params_context/mock_url_params_context_provider.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { IUrlParams } from './types';
+import { UrlParams } from './types';
 import { UrlParamsContext } from './url_params_context';
 
 const defaultUrlParams = {
@@ -18,7 +18,7 @@ const defaultUrlParams = {
 };
 
 interface Props {
-  params?: IUrlParams;
+  params?: UrlParams;
   children: React.ReactNode;
   refreshTimeRange?: (time: any) => void;
 }

--- a/x-pack/plugins/apm/public/context/url_params_context/resolve_url_params.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/resolve_url_params.ts
@@ -19,10 +19,10 @@ import {
   toNumber,
   toString,
 } from './helpers';
-import { IUrlParams } from './types';
+import { UrlParams } from './types';
 
 type TimeUrlParams = Pick<
-  IUrlParams,
+  UrlParams,
   'start' | 'end' | 'rangeFrom' | 'rangeTo' | 'exactStart' | 'exactEnd'
 >;
 

--- a/x-pack/plugins/apm/public/context/url_params_context/types.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/types.ts
@@ -9,7 +9,7 @@ import { LatencyAggregationType } from '../../../common/latency_aggregation_type
 import { UxLocalUIFilterName } from '../../../common/ux_ui_filter';
 import { TimeRangeComparisonType } from '../../components/shared/time_comparison/get_time_range_comparison';
 
-export type IUrlParams = {
+export type UrlParams = {
   detailTab?: string;
   end?: string;
   flyoutDetailTab?: string;
@@ -39,3 +39,6 @@ export type IUrlParams = {
   comparisonEnabled?: boolean;
   comparisonType?: TimeRangeComparisonType;
 } & Partial<Record<UxLocalUIFilterName, string>>;
+
+export type UxUrlParams = UrlParams;
+export type ApmUrlParams = Omit<UrlParams, 'environment' | 'kuery'>;

--- a/x-pack/plugins/apm/public/context/url_params_context/url_params_context.test.tsx
+++ b/x-pack/plugins/apm/public/context/url_params_context/url_params_context.test.tsx
@@ -11,7 +11,7 @@ import { History, Location } from 'history';
 import moment from 'moment-timezone';
 import * as React from 'react';
 import { MemoryRouter, Router } from 'react-router-dom';
-import { IUrlParams } from './types';
+import type { UrlParams } from './types';
 import { UrlParamsContext, UrlParamsProvider } from './url_params_context';
 
 function mountParams(location: Location) {
@@ -19,7 +19,7 @@ function mountParams(location: Location) {
     <MemoryRouter initialEntries={[location]}>
       <UrlParamsProvider>
         <UrlParamsContext.Consumer>
-          {({ urlParams }: { urlParams: IUrlParams }) => (
+          {({ urlParams }: { urlParams: UrlParams }) => (
             <span id="data">{JSON.stringify(urlParams, null, 2)}</span>
           )}
         </UrlParamsContext.Consumer>

--- a/x-pack/plugins/apm/public/context/url_params_context/url_params_context.tsx
+++ b/x-pack/plugins/apm/public/context/url_params_context/url_params_context.tsx
@@ -23,14 +23,14 @@ import { UxUIFilters } from '../../../typings/ui_filters';
 import { useDeepObjectIdentity } from '../../hooks/useDeepObjectIdentity';
 import { getDateRange } from './helpers';
 import { resolveUrlParams } from './resolve_url_params';
-import { IUrlParams } from './types';
+import { UrlParams } from './types';
 
 export interface TimeRange {
   rangeFrom: string;
   rangeTo: string;
 }
 
-function useUxUiFilters(params: IUrlParams): UxUIFilters {
+function useUxUiFilters(params: UrlParams): UxUIFilters {
   const localUiFilters = mapValues(
     pickKeys(params, ...uxLocalUIFilterNames),
     (val) => (val ? val.split(',') : [])
@@ -48,7 +48,7 @@ const UrlParamsContext = createContext({
   rangeId: 0,
   refreshTimeRange: defaultRefresh,
   uxUiFilters: {} as UxUIFilters,
-  urlParams: {} as IUrlParams,
+  urlParams: {} as UrlParams,
 });
 
 const UrlParamsProvider: React.ComponentClass<{}> = withRouter(

--- a/x-pack/plugins/apm/public/context/url_params_context/use_ux_url_params.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/use_ux_url_params.ts
@@ -5,20 +5,13 @@
  * 2.0.
  */
 import type { Assign } from '@kbn/utility-types';
-import { omit } from 'lodash';
-import { useMemo, useContext } from 'react';
-import type { ApmUrlParams } from './types';
+import { useContext } from 'react';
+import type { UxUrlParams } from './types';
 import { UrlParamsContext } from './url_params_context';
 
-export function useUrlParams(): Assign<
+export function useUxUrlParams(): Assign<
   React.ContextType<typeof UrlParamsContext>,
-  { urlParams: ApmUrlParams }
+  { urlParams: UxUrlParams }
 > {
-  const context = useContext(UrlParamsContext);
-  return useMemo(() => {
-    return {
-      ...context,
-      urlParams: omit(context.urlParams, ['environment', 'kuery']),
-    };
-  }, [context]);
+  return useContext(UrlParamsContext);
 }


### PR DESCRIPTION
## Summary

Adds a separate `useUxUrlParams` hook, that allows us to remove properties from `useUrlParams` without affecting the UX app.