### PR TITLE
[7.15] [Discover] Unskip discover tab field data functional tests (#107305)

### DIFF
--- a/test/functional/apps/discover/_data_grid.ts
+++ b/test/functional/apps/discover/_data_grid.ts
@@ -47,10 +47,10 @@ export default function ({
       await PageObjects.discover.clickFieldListItemAdd('agent');
       expect(await getTitles()).to.be('Time (@timestamp) bytes agent');
 
-      await PageObjects.discover.clickFieldListItemAdd('bytes');
+      await PageObjects.discover.clickFieldListItemRemove('bytes');
       expect(await getTitles()).to.be('Time (@timestamp) agent');
 
-      await PageObjects.discover.clickFieldListItemAdd('agent');
+      await PageObjects.discover.clickFieldListItemRemove('agent');
       expect(await getTitles()).to.be('Time (@timestamp) Document');
     });
   });

--- a/test/functional/apps/discover/_data_grid_doc_table.ts
+++ b/test/functional/apps/discover/_data_grid_doc_table.ts
@@ -162,7 +162,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await PageObjects.header.waitUntilLoadingHasFinished();
         }
         // remove the second column
-        await PageObjects.discover.clickFieldListItemAdd(extraColumns[1]);
+        await PageObjects.discover.clickFieldListItemRemove(extraColumns[1]);
         await PageObjects.header.waitUntilLoadingHasFinished();
         // test that the second column is no longer there
         const header = await dataGrid.getHeaderFields();

--- a/test/functional/apps/discover/_discover.ts
+++ b/test/functional/apps/discover/_discover.ts
@@ -336,7 +336,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.clickFieldSort('_score', 'Sort Low-High');
         const currentUrlWithScore = await browser.getCurrentUrl();
         expect(currentUrlWithScore).to.contain('_score');
-        await PageObjects.discover.clickFieldListItemAdd('_score');
+        await PageObjects.discover.clickFieldListItemRemove('_score');
         const currentUrlWithoutScore = await browser.getCurrentUrl();
         expect(currentUrlWithoutScore).not.to.contain('_score');
       });

--- a/test/functional/apps/discover/_doc_table.ts
+++ b/test/functional/apps/discover/_doc_table.ts
@@ -218,7 +218,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             await PageObjects.header.waitUntilLoadingHasFinished();
           }
           // remove the second column
-          await PageObjects.discover.clickFieldListItemAdd(extraColumns[1]);
+          await PageObjects.discover.clickFieldListItemRemove(extraColumns[1]);
           await PageObjects.header.waitUntilLoadingHasFinished();
           // test that the second column is no longer there
           const docHeader = await find.byCssSelector('thead > tr:nth-child(1)');

--- a/test/functional/apps/discover/_field_data.ts
+++ b/test/functional/apps/discover/_field_data.ts
@@ -34,8 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await PageObjects.common.navigateToApp('discover');
     });
-    // FLAKY: https://github.com/elastic/kibana/issues/100437
-    describe.skip('field data', function () {
+    describe('field data', function () {
       it('search php should show the correct hit count', async function () {
         const expectedHitCount = '445';
         await retry.try(async function () {

--- a/test/functional/apps/discover/_field_data_with_fields_api.ts
+++ b/test/functional/apps/discover/_field_data_with_fields_api.ts
@@ -34,8 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await PageObjects.common.navigateToApp('discover');
     });
-    // FLAKY: https://github.com/elastic/kibana/issues/103389
-    describe.skip('field data', function () {
+    describe('field data', function () {
       it('search php should show the correct hit count', async function () {
         const expectedHitCount = '445';
         await retry.try(async function () {

--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -360,17 +360,39 @@ export class DiscoverPageObject extends FtrService {
   public async clickFieldListItemAdd(field: string) {
     // a filter check may make sense here, but it should be properly handled to make
     // it work with the _score and _source fields as well
+    if (await this.isFieldSelected(field)) {
+      return;
+    }
     await this.clickFieldListItemToggle(field);
+    const isLegacyDefault = await this.useLegacyTable();
+    if (isLegacyDefault) {
+      await this.retry.waitFor(`field ${field} to be added to classic table`, async () => {
+        return await this.testSubjects.exists(`docTableHeader-${field}`);
+      });
+    } else {
+      await this.retry.waitFor(`field ${field} to be added to new table`, async () => {
+        return await this.testSubjects.exists(`dataGridHeaderCell-${field}`);
+      });
+    }
+  }
+
+  public async isFieldSelected(field: string) {
+    if (!(await this.testSubjects.exists('fieldList-selected'))) {
+      return false;
+    }
+    const selectedList = await this.testSubjects.find('fieldList-selected');
+    return await this.testSubjects.descendantExists(`field-${field}`, selectedList);
   }
 
   public async clickFieldListItemRemove(field: string) {
-    if (!(await this.testSubjects.exists('fieldList-selected'))) {
+    if (
+      !(await this.testSubjects.exists('fieldList-selected')) ||
+      !(await this.isFieldSelected(field))
+    ) {
       return;
     }
-    const selectedList = await this.testSubjects.find('fieldList-selected');
-    if (await this.testSubjects.descendantExists(`field-${field}`, selectedList)) {
-      await this.clickFieldListItemToggle(field);
-    }
+
+    await this.clickFieldListItemToggle(field);
   }
 
   public async clickFieldListItemVisualize(fieldName: string) {


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Discover] Unskip discover tab field data functional tests (#107305)