### PR TITLE
[7.x] remove min and max date restrictions (#109452)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
@@ -94,7 +94,6 @@ export const DateRangePicker = memo(() => {
                   aria-label="Start date"
                   endDate={endDate ? moment(endDate) : undefined}
                   isInvalid={isInvalidDateRange}
-                  maxDate={moment(endDate) || moment()}
                   onChange={onChangeStartDate}
                   onClear={() => onClear({ clearStart: true })}
                   placeholderText={i18.ACTIVITY_LOG.datePicker.startDate}
@@ -108,8 +107,6 @@ export const DateRangePicker = memo(() => {
                   aria-label="End date"
                   endDate={endDate ? moment(endDate) : undefined}
                   isInvalid={isInvalidDateRange}
-                  maxDate={moment()}
-                  minDate={startDate ? moment(startDate) : undefined}
                   onChange={onChangeEndDate}
                   onClear={() => onClear({ clearEnd: true })}
                   placeholderText={i18.ACTIVITY_LOG.datePicker.endDate}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - remove min and max date restrictions (#109452)