### PR TITLE
[7.15] [Saved Search Embeddable] Do not set source field when reading fields from source (#109069)

### DIFF
--- a/src/plugins/discover/public/application/embeddable/helpers/update_search_source.test.ts
+++ b/src/plugins/discover/public/application/embeddable/helpers/update_search_source.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { createSearchSourceMock } from '../../../../../data/common/search/search_source/mocks';
+import { updateSearchSource } from './update_search_source';
+import { indexPatternMock } from '../../../__mocks__/index_pattern';
+import { SortOrder } from '../../../saved_searches/types';
+
+describe('updateSearchSource', () => {
+  const defaults = {
+    sampleSize: 50,
+    defaultSort: 'asc',
+  };
+
+  it('updates a given search source', async () => {
+    const searchSource = createSearchSourceMock({});
+    updateSearchSource(searchSource, indexPatternMock, [] as SortOrder[], false, defaults);
+    expect(searchSource.getField('fields')).toBe(undefined);
+    // does not explicitly request fieldsFromSource when not using fields API
+    expect(searchSource.getField('fieldsFromSource')).toBe(undefined);
+  });
+
+  it('updates a given search source with the usage of the new fields api', async () => {
+    const searchSource = createSearchSourceMock({});
+    updateSearchSource(searchSource, indexPatternMock, [] as SortOrder[], true, defaults);
+    expect(searchSource.getField('fields')).toEqual([{ field: '*', include_unmapped: 'true' }]);
+    expect(searchSource.getField('fieldsFromSource')).toBe(undefined);
+  });
+});

--- a/src/plugins/discover/public/application/embeddable/helpers/update_search_source.ts
+++ b/src/plugins/discover/public/application/embeddable/helpers/update_search_source.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { IndexPattern, ISearchSource } from '../../../../../data/common';
+import { getSortForSearchSource } from '../../apps/main/components/doc_table';
+import { SortPairArr } from '../../apps/main/components/doc_table/lib/get_sort';
+
+export const updateSearchSource = (
+  searchSource: ISearchSource,
+  indexPattern: IndexPattern | undefined,
+  sort: (SortPairArr[] & string[][]) | undefined,
+  useNewFieldsApi: boolean,
+  defaults: {
+    sampleSize: number;
+    defaultSort: string;
+  }
+) => {
+  const { sampleSize, defaultSort } = defaults;
+  searchSource.setField('size', sampleSize);
+  searchSource.setField('sort', getSortForSearchSource(sort, indexPattern, defaultSort));
+  if (useNewFieldsApi) {
+    searchSource.removeField('fieldsFromSource');
+    const fields: Record<string, string> = { field: '*', include_unmapped: 'true' };
+    searchSource.setField('fields', [fields]);
+  } else {
+    searchSource.removeField('fields');
+  }
+};


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Saved Search Embeddable] Do not set source field when reading fields from source (#109069)