### PR TITLE
[7.14] [Saved Search Embeddable] Do not set source field when reading fields from source (#109069)

### DIFF
--- a/src/plugins/discover/public/application/embeddable/helpers/update_search_source.test.ts
+++ b/src/plugins/discover/public/application/embeddable/helpers/update_search_source.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { createSearchSourceMock } from '../../../../../data/common/search/search_source/mocks';
+import { updateSearchSource } from './update_search_source';
+import { indexPatternMock } from '../../../__mocks__/index_pattern';
+import { SortOrder } from '../../../saved_searches/types';
+
+describe('updateSearchSource', () => {
+  const defaults = {
+    sampleSize: 50,
+    defaultSort: 'asc',
+  };
+
+  it('updates a given search source', async () => {
+    const searchSource = createSearchSourceMock({});
+    updateSearchSource(searchSource, indexPatternMock, [] as SortOrder[], false, defaults);
+    expect(searchSource.getField('fields')).toBe(undefined);
+    // does not explicitly request fieldsFromSource when not using fields API
+    expect(searchSource.getField('fieldsFromSource')).toBe(undefined);
+  });
+
+  it('updates a given search source with the usage of the new fields api', async () => {
+    const searchSource = createSearchSourceMock({});
+    updateSearchSource(searchSource, indexPatternMock, [] as SortOrder[], true, defaults);
+    expect(searchSource.getField('fields')).toEqual([{ field: '*', include_unmapped: 'true' }]);
+    expect(searchSource.getField('fieldsFromSource')).toBe(undefined);
+  });
+});

--- a/src/plugins/discover/public/application/embeddable/helpers/update_search_source.ts
+++ b/src/plugins/discover/public/application/embeddable/helpers/update_search_source.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { IndexPattern, ISearchSource } from '../../../../../data/common';
+import { getSortForSearchSource } from '../../apps/main/components/doc_table';
+import { SortPairArr } from '../../apps/main/components/doc_table/lib/get_sort';
+
+export const updateSearchSource = (
+  searchSource: ISearchSource,
+  indexPattern: IndexPattern | undefined,
+  sort: (SortPairArr[] & string[][]) | undefined,
+  useNewFieldsApi: boolean,
+  defaults: {
+    sampleSize: number;
+    defaultSort: string;
+  }
+) => {
+  const { sampleSize, defaultSort } = defaults;
+  searchSource.setField('size', sampleSize);
+  searchSource.setField('sort', getSortForSearchSource(sort, indexPattern, defaultSort));
+  if (useNewFieldsApi) {
+    searchSource.removeField('fieldsFromSource');
+    const fields: Record<string, string> = { field: '*', include_unmapped: 'true' };
+    searchSource.setField('fields', [fields]);
+  } else {
+    searchSource.removeField('fields');
+  }
+};

--- a/src/plugins/discover/public/application/embeddable/helpers/update_search_source.ts
+++ b/src/plugins/discover/public/application/embeddable/helpers/update_search_source.ts
@@ -7,8 +7,8 @@
  */
 
 import { IndexPattern, ISearchSource } from '../../../../../data/common';
-import { getSortForSearchSource } from '../../apps/main/components/doc_table';
-import { SortPairArr } from '../../apps/main/components/doc_table/lib/get_sort';
+import { getSortForSearchSource } from '../../angular/doc_table';
+import { SortPairArr } from '../../angular/doc_table/lib/get_sort';
 
 export const updateSearchSource = (
   searchSource: ISearchSource,

--- a/src/plugins/discover/public/application/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/application/embeddable/saved_search_embeddable.tsx
@@ -43,6 +43,7 @@ import { getSortForSearchSource, getDefaultSort } from '../angular/doc_table';
 import { handleSourceColumnState } from '../angular/helpers';
 import { DiscoverGridProps } from '../components/discover_grid/discover_grid';
 import { DiscoverGridSettings } from '../components/discover_grid/types';
+import { updateSearchSource } from './helpers/update_search_source';
 
 export interface SearchProps extends Partial<DiscoverGridProps> {
   settings?: DiscoverGridSettings;
@@ -141,26 +142,16 @@ export class SavedSearchEmbeddable
     if (this.abortController) this.abortController.abort();
     this.abortController = new AbortController();
 
-    searchSource.setField('size', this.services.uiSettings.get(SAMPLE_SIZE_SETTING));
-    searchSource.setField(
-      'sort',
-      getSortForSearchSource(
-        this.searchProps!.sort,
-        this.searchProps!.indexPattern,
-        this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING)
-      )
-    );
-    if (useNewFieldsApi) {
-      searchSource.removeField('fieldsFromSource');
-      const fields: Record<string, string> = { field: '*', include_unmapped: 'true' };
-      searchSource.setField('fields', [fields]);
-    } else {
-      searchSource.removeField('fields');
-      if (this.searchProps.indexPattern) {
-        const fieldNames = this.searchProps.indexPattern.fields.map((field) => field.name);
-        searchSource.setField('fieldsFromSource', fieldNames);
+    updateSearchSource(
+      searchSource,
+      this.searchProps!.indexPattern,
+      this.searchProps!.sort,
+      useNewFieldsApi,
+      {
+        sampleSize: this.services.uiSettings.get(SAMPLE_SIZE_SETTING),
+        defaultSort: this.services.uiSettings.get(SORT_DEFAULT_ORDER_SETTING),
       }
-    }
+    );
 
     // Log request to inspector
     this.inspectorAdapters.requests!.reset();

--- a/src/plugins/discover/public/application/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/application/embeddable/saved_search_embeddable.tsx
@@ -39,7 +39,7 @@ import {
   SORT_DEFAULT_ORDER_SETTING,
 } from '../../../common';
 import * as columnActions from '../angular/doc_table/actions/columns';
-import { getSortForSearchSource, getDefaultSort } from '../angular/doc_table';
+import { getDefaultSort } from '../angular/doc_table';
 import { handleSourceColumnState } from '../angular/helpers';
 import { DiscoverGridProps } from '../components/discover_grid/discover_grid';
 import { DiscoverGridSettings } from '../components/discover_grid/types';


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Saved Search Embeddable] Do not set source field when reading fields from source (#109069)