### PR TITLE
[Security Solution] Fixes the `Alerts timeline` failing test on master

### DIFF
--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -41,7 +41,7 @@ export const ACKNOWLEDGED_ALERTS_FILTER_BTN = '[data-test-subj="acknowledgedAler
 
 export const LOADING_ALERTS_PANEL = '[data-test-subj="loading-alerts-panel"]';
 
-export const LOADING_SPINNER = '.SpinnerFlexItem-zdczxa-0';
+export const LOADING_SPINNER = '[data-test-subj="LoadingPanelTimeline"]';
 
 export const MANAGE_ALERT_DETECTION_RULES_BTN = '[data-test-subj="manage-alert-detection-rules"]';
 

--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -41,6 +41,8 @@ export const ACKNOWLEDGED_ALERTS_FILTER_BTN = '[data-test-subj="acknowledgedAler
 
 export const LOADING_ALERTS_PANEL = '[data-test-subj="loading-alerts-panel"]';
 
+export const LOADING_SPINNER = '.SpinnerFlexItem-zdczxa-0';
+
 export const MANAGE_ALERT_DETECTION_RULES_BTN = '[data-test-subj="manage-alert-detection-rules"]';
 
 export const MARK_ALERT_ACKNOWLEDGED_BTN = '[data-test-subj="acknowledged-alert-status"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -14,6 +14,7 @@ import {
   ThreatIndicatorRule,
   ThresholdRule,
 } from '../objects/rule';
+import { LOADING_SPINNER } from '../screens/alerts';
 import {
   ABOUT_CONTINUE_BTN,
   ABOUT_EDIT_TAB,
@@ -531,6 +532,7 @@ export const waitForAlertsToPopulate = async (alertCountThreshold = 1) => {
   cy.waitUntil(
     () => {
       refreshPage();
+      cy.get(LOADING_SPINNER).should('not.exist');
       return cy
         .get(SERVER_SIDE_EVENT_COUNT)
         .invoke('text')

--- a/x-pack/plugins/timelines/public/components/t_grid/footer/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/footer/index.tsx
@@ -287,7 +287,7 @@ export const FooterComponent = ({
     return (
       <LoadingPanelContainer>
         <LoadingPanel
-          data-test-subj="LoadingPanelTimeline"
+          dataTestSubj="LoadingPanelTimeline"
           height="35px"
           showBorder={false}
           text={loadingText}


### PR DESCRIPTION
## Summary

With the new tgrid,  a loading spinner is displayed meanwhile the alerts are loaded, when this happens, the text displayed on the `server-side-event-count` element is displaying `0 alerts`.

Taking into account the screenshot displayed on the failure test + the slowness of the Jenkins machine and the way the code is written for the `waitForAlertsToPopulate` method, looks like what is happening is that we are getting the text of the `server-side-event-count` before the alerts are properly loaded. This is why instead of getting the text we are waiting for the spinner to dissapear.