### PR TITLE
[APM] Show hostname in JVM view

### DIFF
--- a/x-pack/plugins/apm/common/service_nodes.ts
+++ b/x-pack/plugins/apm/common/service_nodes.ts
@@ -16,8 +16,27 @@ const UNIDENTIFIED_SERVICE_NODES_LABEL = i18n.translate(
   }
 );
 
+// const UNIDENTIFIED_HOST_NAME_LABEL = i18n.translate(
+//   'xpack.apm.serviceNodeHostNameMissing',
+//   {
+//     defaultMessage: '(Empty)',
+//   }
+// );
+
 export function getServiceNodeName(serviceNodeName?: string) {
   return serviceNodeName === SERVICE_NODE_NAME_MISSING || !serviceNodeName
     ? UNIDENTIFIED_SERVICE_NODES_LABEL
     : serviceNodeName;
+}
+
+export function getServiceNodeHostName(hostName: string | number | null, serviceNodeName?: string ) {
+  if(hostName === null || !hostName) {
+    return ''
+  }
+
+  // if(serviceNodeName && serviceNodeName === hostName) {
+  //   return 'mimi'
+  // }
+
+  return hostName
 }

--- a/x-pack/plugins/apm/common/service_nodes.ts
+++ b/x-pack/plugins/apm/common/service_nodes.ts
@@ -24,8 +24,8 @@ export function getServiceNodeName(serviceNodeName?: string) {
 
 export function getServiceNodeHostName(hostName: string | number | null) {
   if(hostName === null || !hostName) {
-    return ''
+    return '';
   }
 
-  return hostName
+  return hostName;
 }

--- a/x-pack/plugins/apm/common/service_nodes.ts
+++ b/x-pack/plugins/apm/common/service_nodes.ts
@@ -23,7 +23,7 @@ export function getServiceNodeName(serviceNodeName?: string) {
 }
 
 export function getServiceNodeHostName(hostName: string | number | null) {
-  if(hostName === null || !hostName) {
+  if (hostName === null || !hostName) {
     return '';
   }
 

--- a/x-pack/plugins/apm/common/service_nodes.ts
+++ b/x-pack/plugins/apm/common/service_nodes.ts
@@ -16,27 +16,16 @@ const UNIDENTIFIED_SERVICE_NODES_LABEL = i18n.translate(
   }
 );
 
-// const UNIDENTIFIED_HOST_NAME_LABEL = i18n.translate(
-//   'xpack.apm.serviceNodeHostNameMissing',
-//   {
-//     defaultMessage: '(Empty)',
-//   }
-// );
-
 export function getServiceNodeName(serviceNodeName?: string) {
   return serviceNodeName === SERVICE_NODE_NAME_MISSING || !serviceNodeName
     ? UNIDENTIFIED_SERVICE_NODES_LABEL
     : serviceNodeName;
 }
 
-export function getServiceNodeHostName(hostName: string | number | null, serviceNodeName?: string ) {
+export function getServiceNodeHostName(hostName: string | number | null) {
   if(hostName === null || !hostName) {
     return ''
   }
-
-  // if(serviceNodeName && serviceNodeName === hostName) {
-  //   return 'mimi'
-  // }
 
   return hostName
 }

--- a/x-pack/plugins/apm/common/service_nodes.ts
+++ b/x-pack/plugins/apm/common/service_nodes.ts
@@ -21,11 +21,3 @@ export function getServiceNodeName(serviceNodeName?: string) {
     ? UNIDENTIFIED_SERVICE_NODES_LABEL
     : serviceNodeName;
 }
-
-export function getServiceNodeHostName(hostName: string | number | null) {
-  if (hostName === null || !hostName) {
-    return '';
-  }
-
-  return hostName;
-}

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -80,11 +80,11 @@ function ServiceNodeOverview() {
               defaultMessage: 'Name',
             })}
             <EuiIcon
-            size="s"
-            color="subdued"
-            type="questionInCircle"
-            className="eui-alignTop"
-          />
+             size="s"
+             color="subdued"
+             type="questionInCircle"
+             className="eui-alignTop"
+            />
           </>
         </EuiToolTip>
       ),

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiToolTip } from '@elastic/eui';
+import { EuiToolTip, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
@@ -79,6 +79,12 @@ function ServiceNodeOverview() {
             {i18n.translate('xpack.apm.jvmsTable.nameColumnLabel', {
               defaultMessage: 'Name',
             })}
+            <EuiIcon
+            size="s"
+            color="subdued"
+            type="questionInCircle"
+            className="eui-alignTop"
+          />
           </>
         </EuiToolTip>
       ),
@@ -113,17 +119,18 @@ function ServiceNodeOverview() {
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.hostName', {
-        defaultMessage: 'Host Name',
+        defaultMessage: 'Host name',
       }),
       field: 'hostName',
       sortable: true,
-      render: (_, { hostName, name }) => getServiceNodeHostName(hostName, name),
+      render: (_, { hostName }) => getServiceNodeHostName(hostName),
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.cpuColumnLabel', {
         defaultMessage: 'CPU avg',
       }),
       field: 'cpu',
+      dataType: 'number',
       sortable: true,
       render: (_, { cpu }) => asPercent(cpu, 1),
     },
@@ -132,6 +139,7 @@ function ServiceNodeOverview() {
         defaultMessage: 'Heap memory avg',
       }),
       field: 'heapMemory',
+      dataType: 'number',
       sortable: true,
       render: asDynamicBytes,
     },
@@ -140,6 +148,7 @@ function ServiceNodeOverview() {
         defaultMessage: 'Non-heap memory avg',
       }),
       field: 'nonHeapMemory',
+      dataType: 'number',
       sortable: true,
       render: asDynamicBytes,
     },
@@ -148,6 +157,7 @@ function ServiceNodeOverview() {
         defaultMessage: 'Thread count max',
       }),
       field: 'threadCount',
+      dataType: 'number',
       sortable: true,
       render: asInteger,
     },

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -80,10 +80,10 @@ function ServiceNodeOverview() {
               defaultMessage: 'Name',
             })}
             <EuiIcon
-             size="s"
-             color="subdued"
-             type="questionInCircle"
-             className="eui-alignTop"
+              size="s"
+              color="subdued"
+              type="questionInCircle"
+              className="eui-alignTop"
             />
           </>
         </EuiToolTip>
@@ -123,7 +123,7 @@ function ServiceNodeOverview() {
       }),
       field: 'hostName',
       sortable: true,
-      render: (_, { hostName }) => getServiceNodeHostName(hostName),
+      render: (_, { hostName }) => hostName ?? '',
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.cpuColumnLabel', {

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -9,7 +9,6 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
 import {
-  getServiceNodeHostName,
   getServiceNodeName,
   SERVICE_NODE_NAME_MISSING,
 } from '../../../../common/service_nodes';

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
 import {
+  getServiceNodeHostName,
   getServiceNodeName,
   SERVICE_NODE_NAME_MISSING,
 } from '../../../../common/service_nodes';
@@ -109,6 +110,14 @@ function ServiceNodeOverview() {
           </EuiToolTip>
         );
       },
+    },
+    {
+      name: i18n.translate('xpack.apm.jvmsTable.hostName', {
+        defaultMessage: 'Host Name',
+      }),
+      field: 'hostName',
+      sortable: true,
+      render: (_, { hostName, name }) => getServiceNodeHostName(hostName, name),
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.cpuColumnLabel', {

--- a/x-pack/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
@@ -141,6 +141,18 @@ Object {
               "field": "jvm.memory.heap.used",
             },
           },
+          "latest": Object {
+            "top_metrics": Object {
+              "metrics": Array [
+                Object {
+                  "field": "host.hostname",
+                },
+              ],
+              "sort": Object {
+                "@timestamp": "desc",
+              },
+            },
+          },
           "nonHeapMemory": Object {
             "avg": Object {
               "field": "jvm.memory.non_heap.used",

--- a/x-pack/plugins/apm/server/lib/service_nodes/index.ts
+++ b/x-pack/plugins/apm/server/lib/service_nodes/index.ts
@@ -93,7 +93,12 @@ const getServiceNodes = async ({
       name: bucket.key as string,
       cpu: bucket.cpu.value,
       heapMemory: bucket.heapMemory.value,
-      hostName: bucket.latest.top[0].metrics['host.hostname'],
+      hostName:
+        bucket.latest.top[0] &&
+        (bucket.latest.top[0].metrics['host.hostname'] as
+          | string
+          | null
+          | undefined),
       nonHeapMemory: bucket.nonHeapMemory.value,
       threadCount: bucket.threadCount.value,
     }))

--- a/x-pack/plugins/apm/server/lib/service_nodes/index.ts
+++ b/x-pack/plugins/apm/server/lib/service_nodes/index.ts
@@ -56,12 +56,6 @@ const getServiceNodes = async ({
                 },
               },
             },
-            host: {
-              terms: {
-                field: HOST_NAME,
-                size: 1,
-              },
-            },
             cpu: {
               avg: {
                 field: METRIC_PROCESS_CPU_PERCENT,
@@ -100,7 +94,6 @@ const getServiceNodes = async ({
       cpu: bucket.cpu.value,
       heapMemory: bucket.heapMemory.value,
       hostName: bucket.latest.top[0].metrics['host.hostname'],
-      host: bucket.host,
       nonHeapMemory: bucket.nonHeapMemory.value,
       threadCount: bucket.threadCount.value,
     }))

--- a/x-pack/plugins/apm/server/lib/service_nodes/index.ts
+++ b/x-pack/plugins/apm/server/lib/service_nodes/index.ts
@@ -10,8 +10,10 @@ import {
   METRIC_JAVA_NON_HEAP_MEMORY_USED,
   METRIC_JAVA_THREAD_COUNT,
   METRIC_PROCESS_CPU_PERCENT,
+  HOST_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 import { SERVICE_NODE_NAME_MISSING } from '../../../common/service_nodes';
+import { asMutableArray } from '../../../common/utils/as_mutable_array';
 import { getServiceNodesProjection } from '../../projections/service_nodes';
 import { mergeProjection } from '../../projections/util/merge_projection';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
@@ -46,6 +48,20 @@ const getServiceNodes = async ({
             missing: SERVICE_NODE_NAME_MISSING,
           },
           aggs: {
+            latest: {
+              top_metrics: {
+                metrics: asMutableArray([{ field: HOST_NAME }] as const),
+                sort: {
+                  '@timestamp': 'desc',
+                },
+              },
+            },
+            host: {
+              terms: {
+                field: HOST_NAME,
+                size: 1,
+              },
+            },
             cpu: {
               avg: {
                 field: METRIC_PROCESS_CPU_PERCENT,
@@ -83,6 +99,8 @@ const getServiceNodes = async ({
       name: bucket.key as string,
       cpu: bucket.cpu.value,
       heapMemory: bucket.heapMemory.value,
+      hostName: bucket.latest.top[0].metrics['host.hostname'],
+      host: bucket.host,
       nonHeapMemory: bucket.nonHeapMemory.value,
       threadCount: bucket.threadCount.value,
     }))

--- a/x-pack/plugins/apm/server/lib/service_nodes/index.ts
+++ b/x-pack/plugins/apm/server/lib/service_nodes/index.ts
@@ -93,12 +93,10 @@ const getServiceNodes = async ({
       name: bucket.key as string,
       cpu: bucket.cpu.value,
       heapMemory: bucket.heapMemory.value,
-      hostName:
-        bucket.latest.top[0] &&
-        (bucket.latest.top[0].metrics['host.hostname'] as
-          | string
-          | null
-          | undefined),
+      hostName: bucket.latest.top?.[0]?.metrics?.['host.hostname'] as
+        | string
+        | null
+        | undefined,
       nonHeapMemory: bucket.nonHeapMemory.value,
       threadCount: bucket.threadCount.value,
     }))


### PR DESCRIPTION
## Summary

This PR addresses the issues from [#98539](https://github.com/elastic/kibana/issues/98539)

## What was done

- Add column for host name in JVM table
- Add icon to service node name indicating that there's more info in tooltip
- Align numeric values on the table to the right

## Cases

- When service node name and host name is the same, we show the same

![image](https://user-images.githubusercontent.com/31922082/130455968-a2b4e5e9-d6b3-4b4c-8e62-405484e56c47.png)


- When host name is null, we leave it blank

![image](https://user-images.githubusercontent.com/31922082/130455932-6b08b0aa-56f6-4c96-a316-5b1c143cbbe6.png)

