### PR TITLE
[7.14] chore(NA): moving @kbn/securitysolution-hook-utils to babel transpiler (#109432)

### DIFF
--- a/packages/kbn-securitysolution-hook-utils/.babelrc
+++ b/packages/kbn-securitysolution-hook-utils/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]  
+}

--- a/packages/kbn-securitysolution-hook-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-hook-utils/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-securitysolution-hook-utils"
 
@@ -27,19 +28,27 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
+  "@npm//@testing-library/react-hooks",
   "@npm//react",
   "@npm//rxjs",
   "@npm//tslib",
 ]
 
 TYPES_DEPS = [
+  "@npm//@testing-library/react-hooks",
+  "@npm//rxjs",
+  "@npm//tslib",
   "@npm//@types/jest",
   "@npm//@types/node",
   "@npm//@types/react",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -50,25 +59,26 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
-  srcs = SRCS,
+  name = "tsc_types",
   args = ["--pretty"],
+  srcs = SRCS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   root_dir = "src",
   source_map = True,
   tsconfig = ":tsconfig",
-  deps = DEPS,
 )
 
 js_library(
   name = PKG_BASE_NAME,
-  package_name = PKG_REQUIRE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
-  deps = DEPS + [":tsc"],
 )
 
 pkg_npm(

--- a/packages/kbn-securitysolution-hook-utils/package.json
+++ b/packages/kbn-securitysolution-hook-utils/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Security Solution utilities for React hooks",
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "private": true
 }

--- a/packages/kbn-securitysolution-hook-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-hook-utils/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "incremental": true,
-    "outDir": "target",
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-securitysolution-hook-utils/src",


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/securitysolution-hook-utils to babel transpiler (#109432)