### PR TITLE
[ML] Removes hardcoded datafeed indices for security auth and network modules

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events.json
@@ -1,10 +1,7 @@
 {
-  "job_id": "auth_high_count_logon_events",
+  "job_id": "JOB_ID",
   "indices": [
-    "auditbeat-*",
-    "logs-*",
-    "filebeat-*",
-    "winlogbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_for_a_source_ip.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_for_a_source_ip.json
@@ -1,10 +1,7 @@
 {
-  "job_id": "auth_high_count_logon_events_for_a_source_ip",
+  "job_id": "JOB_ID",
   "indices": [
-    "auditbeat-*",
-    "logs-*",
-    "filebeat-*",
-    "winlogbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_fails.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_fails.json
@@ -1,10 +1,7 @@
 {
-  "job_id": "auth_high_count_logon_fails",
+  "job_id": "JOB_ID",
   "indices": [
-    "auditbeat-*",
-    "logs-*",
-    "filebeat-*",
-    "winlogbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_hour_for_a_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_hour_for_a_user.json
@@ -1,10 +1,7 @@
 {
-  "job_id": "auth_rare_hour_for_a_user",
+  "job_id": "JOB_ID",
   "indices": [
-    "auditbeat-*",
-    "logs-*",
-    "filebeat-*",
-    "winlogbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_source_ip_for_a_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_source_ip_for_a_user.json
@@ -1,10 +1,7 @@
 {
-  "job_id": "auth_rare_source_ip_for_a_user",
+  "job_id": "JOB_ID",
   "indices": [
-    "auditbeat-*",
-    "logs-*",
-    "filebeat-*",
-    "winlogbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_user.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_user.json
@@ -1,10 +1,7 @@
 {
-  "job_id": "auth_rare_user",
+  "job_id": "JOB_ID",
   "indices": [
-    "auditbeat-*",
-    "logs-*",
-    "filebeat-*",
-    "winlogbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_by_destination_country.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_by_destination_country.json
@@ -1,9 +1,7 @@
 {
-  "job_id": "high_count_by_destination_country",
+  "job_id": "JOB_ID",
   "indices": [
-    "logs-*",
-    "filebeat-*",
-    "packetbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_network_denies.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_network_denies.json
@@ -1,9 +1,7 @@
 {
-  "job_id": "high_count_network_denies",
+  "job_id": "JOB_ID",
   "indices": [
-    "logs-*",
-    "filebeat-*",
-    "packetbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_network_events.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_high_count_network_events.json
@@ -1,9 +1,7 @@
 {
-  "job_id": "high_count_network_events",
+  "job_id": "JOB_ID",
   "indices": [
-    "logs-*",
-    "filebeat-*",
-    "packetbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {

--- a/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_rare_destination_country.json
+++ b/x-pack/plugins/ml/server/models/data_recognizer/modules/security_network/ml/datafeed_rare_destination_country.json
@@ -1,9 +1,7 @@
 {
-  "job_id": "rare_destination_country",
+  "job_id": "JOB_ID",
   "indices": [
-    "logs-*",
-    "filebeat-*",
-    "packetbeat-*"
+    "INDEX_PATTERN_NAME"
   ],
   "max_empty_searches": 10,
   "query": {


### PR DESCRIPTION
## Summary

Removes the hard-coded `indices` and `job_id` values  from the datafeed config files for the `security_auth` and `security_network` anomaly detection modules. This ensures the index pattern selected when the job was created is used in the datafeed configuration, rather than the previous hard-coded list of indices.

Note that the hard-coded `job_id` was not actually used in the config previously, but has been replaced with the placeholder `JOB_ID` as is standard in other modules.

Part of #108997
