### PR TITLE
Fix field formatters test on cloud

### DIFF
--- a/test/functional/apps/management/_field_formatter.ts
+++ b/test/functional/apps/management/_field_formatter.ts
@@ -17,6 +17,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const PageObjects = getPageObjects(['settings', 'common']);
   const testSubjects = getService('testSubjects');
+  const security = getService('security');
   const es = getService('es');
   const indexPatterns = getService('indexPatterns');
   const toasts = getService('toasts');
@@ -26,9 +27,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     before(async function () {
       await browser.setWindowSize(1200, 800);
+      await security.testUser.setRoles([
+        'kibana_admin',
+        'test_field_formatters',
+        'test_logstash_reader',
+      ]);
       await esArchiver.load('test/functional/fixtures/es_archiver/discover');
       await kibanaServer.uiSettings.replace({});
-      await kibanaServer.uiSettings.update({});
     });
 
     after(async function afterAll() {

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -178,6 +178,20 @@ export default async function ({ readConfigFile }) {
           },
           kibana: [],
         },
+        test_field_formatters: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['field_formats_management_functional_tests*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
         //for sample data - can remove but not add sample data.( not ml)- for ml use built in role.
         kibana_sample_admin: {
           elasticsearch: {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/109454.  On cloud this runs with test_user and does not have privileges, this PR adds it. 