### PR TITLE
Fix buggy validation when editing an existing space

### DIFF
--- a/x-pack/plugins/spaces/public/management/edit_space/manage_space_page.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/manage_space_page.tsx
@@ -328,9 +328,11 @@ export class ManageSpacePage extends Component<Props, State> {
             ...space,
             avatarType: space.imageUrl ? 'image' : 'initials',
             initials: space.initials || getSpaceInitials(space),
+            color: space.color || getSpaceColor(space),
             customIdentifier: false,
-            customAvatarInitials: getSpaceInitials({ name: space.name }) !== space.initials,
-            customAvatarColor: getSpaceColor({ name: space.name }) !== space.color,
+            customAvatarInitials:
+              !!space.initials && getSpaceInitials({ name: space.name }) !== space.initials,
+            customAvatarColor: !!space.color && getSpaceColor({ name: space.name }) !== space.color,
           },
           features,
           originalSpace: space,


### PR DESCRIPTION
Resolves #109686.

Using `release_note:skip` since this fixes an unreleased regression.

Test:

1. Add a "legacy" space using Kibana Dev Tools
```
POST .kibana/_doc/space:foo
{
"space": {
"name": "Foo",
"description": "bar",
"disabledFeatures": []
},
"type": "space",
"references": [],
"migrationVersion": {
"space": "6.6.0"
},
"coreMigrationVersion": "7.14.0",
"updated_at": "2021-08-23T15:11:23.025Z"
}
```
2. Edit the space and click the "Update space" button (you don't need to change any fields); verify that works
3. Check that the space now has calculated fields using Kibana Dev Tools

```
GET .kibana/_doc/space:foo
```
should return an output like:
```
{
  "_index" : ".kibana_8.0.0_001",
  "_id" : "space:foo",
  "_version" : 10,
  "_seq_no" : 96,
  "_primary_term" : 1,
  "found" : true,
  "_source" : {
    "space" : {
      "name" : "Foo",
      "description" : "bar",
      "disabledFeatures" : [ ],
      "color" : "#54B399",
      "initials" : "F",
      "imageUrl" : ""
    },
    "type" : "space",
    "references" : [ ],
    "migrationVersion" : {
      "space" : "6.6.0"
    },
    "coreMigrationVersion" : "7.14.0",
    "updated_at" : "2021-08-23T18:03:56.720Z"
  }
}
