### PR TITLE
[RAC] [APM] removes hardcoded alerts as data index from apm integration test

### DIFF
--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -17,7 +17,7 @@ import { registry } from './registry';
 interface Config {
   name: APMFtrConfigName;
   license: 'basic' | 'trial';
-  kibanaConfig?: Record<string, string>;
+  kibanaConfig?: Record<string, string | string[]>;
 }
 
 const supertestAsApmUser = (kibanaServer: UrlObject, apmUser: ApmUser) => async (
@@ -81,7 +81,9 @@ export function createTestConfig(config: Config) {
         serverArgs: [
           ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
           ...(kibanaConfig
-            ? Object.entries(kibanaConfig).map(([key, value]) => `--${key}=${value}`)
+            ? Object.entries(kibanaConfig).map(([key, value]) =>
+                Array.isArray(value) ? `--${key}=${JSON.stringify(value)}` : `--${key}=${value}`
+              )
             : []),
         ],
       },

--- a/x-pack/test/apm_api_integration/tests/alerts/rule_registry.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/rule_registry.ts
@@ -287,7 +287,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const { body: targetIndices } = await getAlertsTargetIndices();
 
         try {
-          const beforeDataResponse = await es.search({
+          await es.search({
             index: targetIndices[0],
             body: {
               query: {
@@ -301,10 +301,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               },
             },
           });
-
-          expect(beforeDataResponse.body.hits.hits.length).to.be(0);
-          // eslint-disable-next-line no-empty
-        } catch (exc) {}
+        } catch (exc) {
+          expect(exc.message).contain('index_not_found_exception');
+        }
 
         await es.index({
           index: APM_METRIC_INDEX_NAME,
@@ -319,7 +318,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         alert = await waitUntilNextExecution(alert);
 
         try {
-          const afterInitialDataResponse = await es.search({
+          await es.search({
             index: targetIndices[0],
             body: {
               query: {
@@ -333,10 +332,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               },
             },
           });
-
-          expect(afterInitialDataResponse.body.hits.hits.length).to.be(0);
-          // eslint-disable-next-line no-empty
-        } catch (exc) {}
+        } catch (exc) {
+          expect(exc.message).contain('index_not_found_exception');
+        }
 
         await es.index({
           index: APM_METRIC_INDEX_NAME,

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts_index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts_index.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+
+import { superUser, obsOnlySpacesAll, secOnlyRead } from '../../../common/lib/authentication/users';
+import type { User } from '../../../common/lib/authentication/types';
+import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
+
+// eslint-disable-next-line import/no-default-export
+export default ({ getService }: FtrProviderContext) => {
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const esArchiver = getService('esArchiver');
+
+  const TEST_URL = '/internal/rac/alerts';
+  const ALERTS_INDEX_URL = `${TEST_URL}/index`;
+  const SPACE1 = 'space1';
+  const APM_ALERT_INDEX = '.alerts-observability-apm';
+  const SECURITY_SOLUTION_ALERT_INDEX = '.alerts-security.alerts';
+
+  const getAPMIndexName = async (user: User, space: string, expected: number = 200) => {
+    const {
+      body: indexNames,
+    }: { body: { index_name: string[] | undefined } } = await supertestWithoutAuth
+      .get(`${getSpaceUrlPrefix(space)}${ALERTS_INDEX_URL}?features=apm`)
+      .auth(user.username, user.password)
+      .set('kbn-xsrf', 'true')
+      .expect(expected);
+    return indexNames;
+  };
+
+  const getSecuritySolutionIndexName = async (
+    user: User,
+    space: string,
+    expectedStatusCode: number = 200
+  ) => {
+    const {
+      body: indexNames,
+    }: { body: { index_name: string[] | undefined } } = await supertestWithoutAuth
+      .get(`${getSpaceUrlPrefix(space)}${ALERTS_INDEX_URL}?features=siem`)
+      .auth(user.username, user.password)
+      .set('kbn-xsrf', 'true')
+      .expect(expectedStatusCode);
+    return indexNames;
+  };
+
+  describe('Alert - Get Index - RBAC - spaces', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_registry/alerts');
+    });
+    describe('Users:', () => {
+      it(`${obsOnlySpacesAll.username} should be able to access the APM alert in ${SPACE1}`, async () => {
+        const indexNames = await getAPMIndexName(obsOnlySpacesAll, SPACE1);
+        const observabilityIndex = indexNames?.index_name?.find(
+          (indexName) => indexName === APM_ALERT_INDEX
+        );
+        expect(observabilityIndex).to.eql(APM_ALERT_INDEX); // assert this here so we can use constants in the dynamically-defined test cases below
+      });
+
+      it(`${superUser.username} should be able to access the APM alert in ${SPACE1}`, async () => {
+        const indexNames = await getAPMIndexName(superUser, SPACE1);
+        const observabilityIndex = indexNames?.index_name?.find(
+          (indexName) => indexName === APM_ALERT_INDEX
+        );
+        expect(observabilityIndex).to.eql(APM_ALERT_INDEX); // assert this here so we can use constants in the dynamically-defined test cases below
+      });
+
+      it(`${secOnlyRead.username} should NOT be able to access the APM alert in ${SPACE1}`, async () => {
+        const indexNames = await getAPMIndexName(secOnlyRead, SPACE1);
+        expect(indexNames?.index_name?.length).to.eql(0);
+      });
+
+      it(`${secOnlyRead.username} should be able to access the security solution alert in ${SPACE1}`, async () => {
+        const indexNames = await getSecuritySolutionIndexName(secOnlyRead, SPACE1);
+        const securitySolution = indexNames?.index_name?.find((indexName) =>
+          indexName.startsWith(SECURITY_SOLUTION_ALERT_INDEX)
+        );
+        expect(securitySolution).to.eql(`${SECURITY_SOLUTION_ALERT_INDEX}-${SPACE1}`); // assert this here so we can use constants in the dynamically-defined test cases below
+      });
+    });
+  });
+};

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts
@@ -27,5 +27,6 @@ export default ({ loadTestFile, getService }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./update_alert'));
     loadTestFile(require.resolve('./bulk_update_alerts'));
     loadTestFile(require.resolve('./find_alerts'));
+    loadTestFile(require.resolve('./get_alerts_index'));
   });
 };


### PR DESCRIPTION
## Summary

removes hardcoded alerts as data index from apm integration test and adds integration tests for getting alerts index from rule registry route.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
