### PR TITLE
[7.15] [Security Solution] Fixes the `Alerts timeline` failing test on master (#109644)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -45,6 +45,8 @@ export const ACKNOWLEDGED_ALERTS_FILTER_BTN = '[data-test-subj="acknowledgedAler
 
 export const LOADING_ALERTS_PANEL = '[data-test-subj="loading-alerts-panel"]';
 
+export const LOADING_SPINNER = '[data-test-subj="LoadingPanelTimeline"]';
+
 export const MANAGE_ALERT_DETECTION_RULES_BTN = '[data-test-subj="manage-alert-detection-rules"]';
 
 export const MARK_ALERT_ACKNOWLEDGED_BTN = '[data-test-subj="acknowledged-alert-status"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -14,6 +14,7 @@ import {
   ThreatIndicatorRule,
   ThresholdRule,
 } from '../objects/rule';
+import { LOADING_SPINNER } from '../screens/alerts';
 import {
   ABOUT_CONTINUE_BTN,
   ABOUT_EDIT_TAB,
@@ -531,6 +532,7 @@ export const waitForAlertsToPopulate = async (alertCountThreshold = 1) => {
   cy.waitUntil(
     () => {
       refreshPage();
+      cy.get(LOADING_SPINNER).should('not.exist');
       return cy
         .get(SERVER_SIDE_EVENT_COUNT)
         .invoke('text')

--- a/x-pack/plugins/timelines/public/components/t_grid/footer/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/footer/index.tsx
@@ -287,7 +287,7 @@ export const FooterComponent = ({
     return (
       <LoadingPanelContainer>
         <LoadingPanel
-          data-test-subj="LoadingPanelTimeline"
+          dataTestSubj="LoadingPanelTimeline"
           height="35px"
           showBorder={false}
           text={loadingText}


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Security Solution] Fixes the `Alerts timeline` failing test on master (#109644)