### PR TITLE
[Security Solution] fix disabled dropdown in alerts table

### DIFF
--- a/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/cell_actions/default_cell_actions.tsx
@@ -12,7 +12,6 @@ import type {
   TimelineNonEcsData,
 } from '../../../../../timelines/common/search_strategy';
 import { DataProvider, TGridCellAction } from '../../../../../timelines/common/types';
-import { TimelineId } from '../../../../common';
 import { getMappedNonEcsValue } from '../../../timelines/components/timeline/body/data_driven_columns';
 import { IS_OPERATOR } from '../../../timelines/components/timeline/data_providers/data_provider';
 import { allowTopN, escapeDataProviderId } from '../../components/drag_and_drop/helpers';
@@ -119,11 +118,15 @@ export const defaultCellActions: TGridCellAction[] = [
       </>
     );
   },
-  ({ browserFields, data }: { browserFields: BrowserFields; data: TimelineNonEcsData[][] }) => ({
-    rowIndex,
-    columnId,
-    Component,
-  }) => {
+  ({
+    browserFields,
+    data,
+    timelineId,
+  }: {
+    browserFields: BrowserFields;
+    data: TimelineNonEcsData[][];
+    timelineId: string;
+  }) => ({ rowIndex, columnId, Component }) => {
     const [showTopN, setShowTopN] = useState(false);
     const onClick = useCallback(() => setShowTopN(!showTopN), [showTopN]);
 
@@ -148,7 +151,7 @@ export const defaultCellActions: TGridCellAction[] = [
             ownFocus={false}
             showTopN={showTopN}
             showTooltip={false}
-            timelineId={TimelineId.active}
+            timelineId={timelineId}
             value={value}
           />
         )}

--- a/x-pack/plugins/timelines/common/types/timeline/columns/index.tsx
+++ b/x-pack/plugins/timelines/common/types/timeline/columns/index.tsx
@@ -45,10 +45,12 @@ export type ColumnId = string;
 export type TGridCellAction = ({
   browserFields,
   data,
+  timelineId,
 }: {
   browserFields: BrowserFields;
   /** each row of data is represented as one TimelineNonEcsData[] */
   data: TimelineNonEcsData[][];
+  timelineId: string;
 }) => (props: EuiDataGridColumnCellActionProps) => ReactNode;
 
 /** The specification of a column header */

--- a/x-pack/plugins/timelines/public/components/t_grid/body/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/index.tsx
@@ -575,6 +575,7 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
             tGridCellAction({
               data: data.map((row) => row.data),
               browserFields,
+              timelineId: id,
             });
 
           return {
@@ -583,7 +584,7 @@ export const BodyComponent = React.memo<StatefulBodyProps>(
               header.tGridCellActions?.map(buildAction) ?? defaultCellActions?.map(buildAction),
           };
         }),
-      [browserFields, columnHeaders, data, defaultCellActions]
+      [browserFields, columnHeaders, data, defaultCellActions, id]
     );
 
     const renderTGridCellValue = useMemo(() => {


### PR DESCRIPTION
## Summary

The dropdown for topN chart triggered from alerts table was disabled, with incorrect options, and not set to the right default option.

Before:
<img width="2209" alt="Screenshot 2021-08-23 at 16 07 39" src="https://user-images.githubusercontent.com/6295984/130501030-d549a28d-1783-4714-aaf8-fc046ed0fcb2.png">


It should default to `Detection Alerts`:
After:
![topN](https://user-images.githubusercontent.com/6295984/130501009-faa4f53b-83bb-4896-8a2c-f7625cb5c3ee.gif)
