### PR TITLE
[Fleet] Fix Add Integration page title + Add Integration button icon

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -48,7 +48,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
     'data-test-subj': dataTestSubj,
     tabs = [],
   }) => {
-    const isAdd = useMemo(() => ['package'].includes(from), [from]);
+    const isAdd = useMemo(() => ['policy', 'package'].includes(from), [from]);
     const isEdit = useMemo(() => ['edit', 'package-edit'].includes(from), [from]);
     const isUpgrade = useMemo(
       () =>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -267,7 +267,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
               <EuiButton
                 key="addPackagePolicyButton"
                 isDisabled={!hasWriteCapabilities}
-                iconType="refresh"
+                iconType="plusInCircle"
                 onClick={() => {
                   application.navigateToApp(INTEGRATIONS_PLUGIN_ID, {
                     path: pagePathGetters.integrations_all()[1],


### PR DESCRIPTION
## Summary

- Fix page title for "Add Integration" screen. Fixes https://github.com/elastic/kibana/issues/106573
- Revert "Add Integration" button icon to `plusInCircle`. Fixes https://github.com/elastic/kibana/issues/107458

## Screenshots

![Screen Shot 2021-08-23 at 3 15 37 PM](https://user-images.githubusercontent.com/6766512/130505119-d1092f5d-b12b-4816-92e3-1aaffbcc5c3d.png)

![Screen Shot 2021-08-23 at 3 16 26 PM](https://user-images.githubusercontent.com/6766512/130505121-fc5155bf-bf86-4495-8e6d-925902005ce3.png)
