### PR TITLE
[7.x] [Security Solution][RAC] Remove toggle column when not usable (#109534)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.test.tsx
@@ -23,7 +23,7 @@ describe('useHoverActionItems', () => {
     field: 'signal.rule.name',
     handleHoverActionClicked: jest.fn(),
     hideTopN: false,
-    isObjectArray: true,
+    isObjectArray: false,
     ownFocus: false,
     showTopN: false,
     stKeyboardEvent: undefined,
@@ -127,6 +127,34 @@ describe('useHoverActionItems', () => {
 
       result.current.allActionItems.forEach((item) => {
         expect(item.props['data-test-subj']).not.toEqual('hover-actions-show-top-n');
+      });
+    });
+  });
+
+  test('should not have toggle column', async () => {
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook(() => {
+        const defaultFocusedButtonRef = useRef(null);
+        const testProps = {
+          ...defaultProps,
+          isObjectArray: true,
+          defaultFocusedButtonRef,
+          enableOverflowButton: true,
+        };
+        return useHoverActionItems(testProps);
+      });
+      await waitForNextUpdate();
+
+      expect(result.current.overflowActionItems).toHaveLength(3);
+      expect(result.current.overflowActionItems[0].props['data-test-subj']).toEqual(
+        'hover-actions-filter-for'
+      );
+      expect(result.current.overflowActionItems[1].props['data-test-subj']).toEqual(
+        'hover-actions-filter-out'
+      );
+
+      result.current.overflowActionItems[2].props.items.forEach((item: JSX.Element) => {
+        expect(item.props['data-test-subj']).not.toEqual('hover-actions-toggle-column');
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+/* eslint-disable complexity */
+
 import { EuiContextMenuItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { DraggableId } from 'react-beautiful-dnd';
@@ -118,6 +120,9 @@ export const useHoverActionItems = ({
    */
   const showFilters =
     values != null && (enableOverflowButton || (!showTopN && !enableOverflowButton));
+
+  const shouldDisableColumnToggle = isObjectArray && field !== 'geo_point';
+
   const allItems = useMemo(
     () =>
       [
@@ -150,7 +155,7 @@ export const useHoverActionItems = ({
             })}
           </div>
         ) : null,
-        toggleColumn ? (
+        toggleColumn && !shouldDisableColumnToggle ? (
           <div data-test-subj="hover-actions-toggle-column" key="hover-actions-toggle-column">
             {getColumnToggleButton({
               Component: enableOverflowButton ? EuiContextMenuItem : undefined,
@@ -236,6 +241,7 @@ export const useHoverActionItems = ({
       isObjectArray,
       onFilterAdded,
       ownFocus,
+      shouldDisableColumnToggle,
       showFilters,
       showTopN,
       stKeyboardEvent,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution][RAC] Remove toggle column when not usable (#109534)