### PR TITLE
[canvas] Fix numeric variable casting

### DIFF
--- a/x-pack/plugins/canvas/public/components/var_config/var_value_field.tsx
+++ b/x-pack/plugins/canvas/public/components/var_config/var_value_field.tsx
@@ -53,10 +53,12 @@ export const VarValueField: FC<Props> = ({ type, value, onChange }) => {
         compressed
         name="value"
         value={value as number}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
       />
     );
-  } else if (type === 'boolean') {
+  }
+
+  if (type === 'boolean') {
     return (
       <EuiButtonGroup
         name="value"


### PR DESCRIPTION
## Summary

> Fixes #90833

There was an issue with the casting of the variable to a number in the `onChange` handler when `type` is `number`.

<img width="1228" alt="Screen Shot 2021-08-23 at 4 12 12 PM" src="https://user-images.githubusercontent.com/297604/130520326-919dc5c3-36e6-4b0b-9802-c377c7a63cd9.png">

> Props to @dokmic for the assist!