### PR TITLE
[Reporting] Add reporting domain to code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -423,6 +423,17 @@
 #CC# /x-pack/plugins/logstash/ @elastic/logstash
 
 # Reporting
+/x-pack/examples/reporting_example/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/plugins/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/apps/dashboard/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/apps/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/apps/reporting_management/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/es_archives/lens/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/es_archives/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/functional/fixtures/kbn_archiver/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/reporting_api_integration/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/reporting_functional/ @elastic/kibana-reporting-services @elastic/kibana-app-services
+/x-pack/test/stack_functional_integration/apps/reporting/ @elastic/kibana-reporting-services @elastic/kibana-app-services
 #CC# /x-pack/plugins/reporting/ @elastic/kibana-reporting-services
 
 


### PR DESCRIPTION
## Summary
Adds listing of reporting domain to the code owners for PR reviews. The owners are @elastic/kibana-reporting-services
 and @elastic/kibana-app-services