### PR TITLE
[canvas] Prevent scroll 'jumping' with always-there scrollbars

### DIFF
--- a/x-pack/plugins/canvas/public/components/workpad_app/workpad_app.scss
+++ b/x-pack/plugins/canvas/public/components/workpad_app/workpad_app.scss
@@ -56,7 +56,7 @@ $canvasLayoutFontSize: $euiFontSizeS;
   left: 0;
   right: 0;
   bottom: 0;
-  overflow: auto;
+  overflow: scroll;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## Summary

> Fixes #33622

See title.  By making the scrollbars "aways there", the frame doesn't jump.  I was going to use `overflow: overlay;` for this, but the property is deprecated.

![Aug-23-2021 23-03-07](https://user-images.githubusercontent.com/297604/130554242-b49ddefd-6b03-44cb-85d1-f72678168359.gif)
