### PR TITLE
[canvas] Fix element stats

### DIFF
--- a/x-pack/plugins/canvas/public/state/middleware/element_stats.ts
+++ b/x-pack/plugins/canvas/public/state/middleware/element_stats.ts
@@ -5,10 +5,16 @@
  * 2.0.
  */
 
+import { Middleware } from 'redux';
+import { State } from '../../../types';
+
+// @ts-expect-error untyped local
 import { setElementStats } from '../actions/transient';
 import { getAllElements, getElementCounts, getElementStats } from '../selectors/workpad';
 
-export const elementStats = ({ dispatch, getState }) => (next) => (action) => {
+export const elementStats: Middleware<{}, State> = ({ dispatch, getState }) => (next) => (
+  action
+) => {
   // execute the action
   next(action);
 
@@ -24,7 +30,7 @@ export const elementStats = ({ dispatch, getState }) => (next) => (action) => {
   const pending = total - ready - error;
 
   if (
-    total > 0 &&
+    (total > 0 || stats.total > 0) &&
     (ready !== stats.ready ||
       pending !== stats.pending ||
       error !== stats.error ||


### PR DESCRIPTION
## Summary

> Fixes #34190

Element stats was making sure not to fire an update if the total number of elements was zero... but it wasn't taking into account the _difference_.

This PR fixes Element Stats by making sure the numbers get updated if one of the totals is greater than zero.  It also converts the middleware to Typescript.
