### PR TITLE
[Data] Fix CIDR mask to avoid using big integers

### DIFF
--- a/src/plugins/data/common/search/aggs/utils/ip_address.test.ts
+++ b/src/plugins/data/common/search/aggs/utils/ip_address.test.ts
@@ -37,21 +37,6 @@ describe('IpAddress', () => {
     });
   });
 
-  describe('valueOf', () => {
-    it.each`
-      address            | expected
-      ${'0.0.0.0'}       | ${'0'}
-      ${'0.0.0.1'}       | ${'1'}
-      ${'126.45.211.34'} | ${'2116932386'}
-      ${'ffff::'}        | ${'340277174624079928635746076935438991360'}
-    `(
-      'should return $expected as a decimal representation of $address',
-      ({ address, expected }) => {
-        expect(new IpAddress(address).valueOf().toString()).toBe(expected);
-      }
-    );
-  });
-
   describe('toString()', () => {
     it.each`
       address                 | expected

--- a/src/plugins/data/common/search/aggs/utils/ip_address.ts
+++ b/src/plugins/data/common/search/aggs/utils/ip_address.ts
@@ -32,16 +32,4 @@ export class IpAddress {
 
     return this.value.toString();
   }
-
-  valueOf(): number | bigint {
-    const value = this.value
-      .toByteArray()
-      .reduce((result, octet) => result * 256n + BigInt(octet), 0n);
-
-    if (value > Number.MAX_SAFE_INTEGER) {
-      return value;
-    }
-
-    return Number(value);
-  }
 }


### PR DESCRIPTION
## Summary

This Pull-Request resolves #109548. The updated implementation is no longer relying on `BigInt` and using numbers array to store netmask. Apart from that, the `valueOf` method in the `IpAddress` utility class has been removed since it's no longer used.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
