### PR TITLE
Remove UI actions `any` types

### DIFF
--- a/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
+++ b/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
@@ -24,7 +24,7 @@ const createTestAction = ({
 }) =>
   createAction({
     id: type as string,
-    type: type,
+    type,
     getDisplayName: () => dispayName,
     order,
     execute: async () => {},
@@ -67,7 +67,7 @@ test('sorts items in DESC order by "order" field first, then by display name', a
   ].sort(() => 0.5 - Math.random());
 
   const result = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: {id: ''} })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: '' } })),
   });
 
   expect(result.map(resultMapper)).toMatchInlineSnapshot(`
@@ -127,7 +127,7 @@ test('can build menu with one action', async () => {
         context: {},
         trigger: {
           id: 'TETS_TRIGGER',
-        }
+        },
       },
     ],
     closeMenu: () => {},
@@ -158,7 +158,7 @@ test('orders items according to "order" field', async () => {
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
   });
 
   expect(menu[0].items![0].name).toBe('Bar');
@@ -175,7 +175,7 @@ test('orders items according to "order" field', async () => {
     }),
   ];
   const menu2 = await buildContextMenuForActions({
-    actions: actions2.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
+    actions: actions2.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
   });
 
   expect(menu2[0].items![0].name).toBe('Bar');
@@ -201,7 +201,7 @@ test('hides items behind in "More" submenu if there are more than 4 actions', as
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`
@@ -258,7 +258,7 @@ test('separates grouped items from main items with a separator', async () => {
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`
@@ -324,7 +324,7 @@ test('separates multiple groups each with its own separator', async () => {
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`
@@ -394,7 +394,7 @@ test('does not add separator for first grouping if there are no main items', asy
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: { id: 'TEST' } })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`

--- a/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
+++ b/src/plugins/ui_actions/public/context_menu/build_eui_context_menu_panels.test.ts
@@ -23,8 +23,8 @@ const createTestAction = ({
   grouping?: PresentableGrouping;
 }) =>
   createAction({
-    id: type as any, // mapping doesn't matter for this test
-    type: type as any, // mapping doesn't matter for this test
+    id: type as string,
+    type: type,
     getDisplayName: () => dispayName,
     order,
     execute: async () => {},
@@ -67,7 +67,7 @@ test('sorts items in DESC order by "order" field first, then by display name', a
   ].sort(() => 0.5 - Math.random());
 
   const result = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: '' as any })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: {id: ''} })),
   });
 
   expect(result.map(resultMapper)).toMatchInlineSnapshot(`
@@ -125,7 +125,9 @@ test('can build menu with one action', async () => {
           dispayName: 'Foo',
         }),
         context: {},
-        trigger: 'TETS_TRIGGER' as any,
+        trigger: {
+          id: 'TETS_TRIGGER',
+        }
       },
     ],
     closeMenu: () => {},
@@ -156,7 +158,7 @@ test('orders items according to "order" field', async () => {
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: 'TEST' as any })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
   });
 
   expect(menu[0].items![0].name).toBe('Bar');
@@ -173,7 +175,7 @@ test('orders items according to "order" field', async () => {
     }),
   ];
   const menu2 = await buildContextMenuForActions({
-    actions: actions2.map((action) => ({ action, context: {}, trigger: 'TEST' as any })),
+    actions: actions2.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
   });
 
   expect(menu2[0].items![0].name).toBe('Bar');
@@ -199,7 +201,7 @@ test('hides items behind in "More" submenu if there are more than 4 actions', as
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: 'TEST' as any })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`
@@ -256,7 +258,7 @@ test('separates grouped items from main items with a separator', async () => {
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: 'TEST' as any })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`
@@ -322,7 +324,7 @@ test('separates multiple groups each with its own separator', async () => {
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: 'TEST' as any })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`
@@ -392,7 +394,7 @@ test('does not add separator for first grouping if there are no main items', asy
     }),
   ];
   const menu = await buildContextMenuForActions({
-    actions: actions.map((action) => ({ action, context: {}, trigger: 'TEST' as any })),
+    actions: actions.map((action) => ({ action, context: {}, trigger: {id: 'TEST'} })),
   });
 
   expect(menu.map(resultMapper)).toMatchInlineSnapshot(`

--- a/src/plugins/ui_actions/public/context_menu/open_context_menu.tsx
+++ b/src/plugins/ui_actions/public/context_menu/open_context_menu.tsx
@@ -124,7 +124,7 @@ function getOrCreateContainerElement() {
 class ContextMenuSession extends EventEmitter {
   /**
    * Closes the opened flyout as long as it's still the open one.
-   * If this is not the active session anymore, this method won't do anything.
+   * If this is not the active session, this method will do nothing.
    * If this session was still active and a flyout was closed, the 'closed'
    * event will be emitted on this FlyoutSession instance.
    */

--- a/src/plugins/ui_actions/public/service/ui_actions_execution_service.ts
+++ b/src/plugins/ui_actions/public/service/ui_actions_execution_service.ts
@@ -120,7 +120,7 @@ export class UiActionsExecutionService {
         context,
         trigger,
       })),
-      title: '', // intentionally don't have any title
+      title: '', // Empty title is set intentionally.
       closeMenu: () => {
         tasks.forEach((t) => t.defer.resolve());
         session.close();

--- a/src/plugins/ui_actions/public/service/ui_actions_service.test.ts
+++ b/src/plugins/ui_actions/public/service/ui_actions_service.test.ts
@@ -153,8 +153,8 @@ describe('UiActionsService', () => {
       const list2 = service.getTriggerActions(FOO_TRIGGER);
 
       expect(list2).toHaveLength(2);
-      expect(!!list2.find(({ id }: {id: string}) => id === 'action1')).toBe(true);
-      expect(!!list2.find(({ id }: {id: string}) => id === 'action2')).toBe(true);
+      expect(!!list2.find(({ id }: { id: string }) => id === 'action1')).toBe(true);
+      expect(!!list2.find(({ id }: { id: string }) => id === 'action2')).toBe(true);
     });
   });
 
@@ -162,7 +162,7 @@ describe('UiActionsService', () => {
     test('can register and get actions', async () => {
       const actions: ActionRegistry = new Map();
       const service = new UiActionsService({ actions });
-      const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
+      const helloWorldAction = createHelloWorldAction(({} as unknown) as OverlayStart);
       const length = actions.size;
 
       service.registerAction(helloWorldAction);
@@ -173,7 +173,7 @@ describe('UiActionsService', () => {
 
     test('getTriggerCompatibleActions returns attached actions', async () => {
       const service = new UiActionsService();
-      const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
+      const helloWorldAction = createHelloWorldAction(({} as unknown) as OverlayStart);
 
       service.registerAction(helloWorldAction);
 
@@ -373,10 +373,10 @@ describe('UiActionsService', () => {
       const actions: ActionRegistry = new Map();
       const service = new UiActionsService({ actions });
 
-      service.registerAction({
+      service.registerAction(({
         id: ACTION_HELLO_WORLD,
         order: 13,
-      } as unknown as ActionDefinition);
+      } as unknown) as ActionDefinition);
 
       expect(actions.get(ACTION_HELLO_WORLD)).toMatchObject({
         id: ACTION_HELLO_WORLD,
@@ -390,10 +390,10 @@ describe('UiActionsService', () => {
       const trigger: Trigger = {
         id: MY_TRIGGER,
       };
-      const action = {
+      const action = ({
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as unknown as ActionDefinition;
+      } as unknown) as ActionDefinition;
 
       service.registerTrigger(trigger);
       service.addTriggerAction(MY_TRIGGER, action);
@@ -410,10 +410,10 @@ describe('UiActionsService', () => {
       const trigger: Trigger = {
         id: MY_TRIGGER,
       };
-      const action = {
+      const action = ({
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as unknown as ActionDefinition;
+      } as unknown) as ActionDefinition;
 
       service.registerTrigger(trigger);
       service.registerAction(action);
@@ -427,10 +427,10 @@ describe('UiActionsService', () => {
     test('detaching an invalid action from a trigger throws an error', async () => {
       const service = new UiActionsService();
 
-      const action = {
+      const action = ({
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as unknown as ActionDefinition;
+      } as unknown) as ActionDefinition;
 
       service.registerAction(action);
       expect(() => service.detachAction('i do not exist', ACTION_HELLO_WORLD)).toThrowError(
@@ -441,10 +441,10 @@ describe('UiActionsService', () => {
     test('attaching an invalid action to a trigger throws an error', async () => {
       const service = new UiActionsService();
 
-      const action = {
+      const action = ({
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as unknown as ActionDefinition;
+      } as unknown) as ActionDefinition;
 
       service.registerAction(action);
       expect(() => service.addTriggerAction('i do not exist', action)).toThrowError(
@@ -455,10 +455,10 @@ describe('UiActionsService', () => {
     test('cannot register another action with the same ID', async () => {
       const service = new UiActionsService();
 
-      const action = {
+      const action = ({
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as unknown as ActionDefinition;
+      } as unknown) as ActionDefinition;
 
       service.registerAction(action);
       expect(() => service.registerAction(action)).toThrowError(
@@ -469,7 +469,7 @@ describe('UiActionsService', () => {
     test('cannot register another trigger with the same ID', async () => {
       const service = new UiActionsService();
 
-      const trigger = { id: 'MY-TRIGGER' } as unknown as Trigger;
+      const trigger = ({ id: 'MY-TRIGGER' } as unknown) as Trigger;
 
       service.registerTrigger(trigger);
       expect(() => service.registerTrigger(trigger)).toThrowError(

--- a/src/plugins/ui_actions/public/service/ui_actions_service.test.ts
+++ b/src/plugins/ui_actions/public/service/ui_actions_service.test.ts
@@ -7,10 +7,11 @@
  */
 
 import { UiActionsService } from './ui_actions_service';
-import { Action, ActionInternal, createAction } from '../actions';
+import { Action, ActionDefinition, ActionInternal, createAction } from '../actions';
 import { createHelloWorldAction } from '../tests/test_samples';
 import { TriggerRegistry, ActionRegistry } from '../types';
 import { Trigger } from '../triggers';
+import { OverlayStart } from 'kibana/public';
 
 const FOO_TRIGGER = 'FOO_TRIGGER';
 const BAR_TRIGGER = 'BAR_TRIGGER';
@@ -152,8 +153,8 @@ describe('UiActionsService', () => {
       const list2 = service.getTriggerActions(FOO_TRIGGER);
 
       expect(list2).toHaveLength(2);
-      expect(!!list2.find(({ id }: any) => id === 'action1')).toBe(true);
-      expect(!!list2.find(({ id }: any) => id === 'action2')).toBe(true);
+      expect(!!list2.find(({ id }: {id: string}) => id === 'action1')).toBe(true);
+      expect(!!list2.find(({ id }: {id: string}) => id === 'action2')).toBe(true);
     });
   });
 
@@ -161,7 +162,7 @@ describe('UiActionsService', () => {
     test('can register and get actions', async () => {
       const actions: ActionRegistry = new Map();
       const service = new UiActionsService({ actions });
-      const helloWorldAction = createHelloWorldAction({} as any);
+      const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
       const length = actions.size;
 
       service.registerAction(helloWorldAction);
@@ -172,7 +173,7 @@ describe('UiActionsService', () => {
 
     test('getTriggerCompatibleActions returns attached actions', async () => {
       const service = new UiActionsService();
-      const helloWorldAction = createHelloWorldAction({} as any);
+      const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
 
       service.registerAction(helloWorldAction);
 
@@ -231,7 +232,7 @@ describe('UiActionsService', () => {
       );
     });
 
-    test('returns empty list if trigger not attached to any action', async () => {
+    test('returns empty list if trigger not attached to an action', async () => {
       const service = new UiActionsService();
       const testTrigger: Trigger = {
         id: '123',
@@ -375,7 +376,7 @@ describe('UiActionsService', () => {
       service.registerAction({
         id: ACTION_HELLO_WORLD,
         order: 13,
-      } as any);
+      } as unknown as ActionDefinition);
 
       expect(actions.get(ACTION_HELLO_WORLD)).toMatchObject({
         id: ACTION_HELLO_WORLD,
@@ -392,7 +393,7 @@ describe('UiActionsService', () => {
       const action = {
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as any;
+      } as unknown as ActionDefinition;
 
       service.registerTrigger(trigger);
       service.addTriggerAction(MY_TRIGGER, action);
@@ -412,7 +413,7 @@ describe('UiActionsService', () => {
       const action = {
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as any;
+      } as unknown as ActionDefinition;
 
       service.registerTrigger(trigger);
       service.registerAction(action);
@@ -429,7 +430,7 @@ describe('UiActionsService', () => {
       const action = {
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as any;
+      } as unknown as ActionDefinition;
 
       service.registerAction(action);
       expect(() => service.detachAction('i do not exist', ACTION_HELLO_WORLD)).toThrowError(
@@ -443,7 +444,7 @@ describe('UiActionsService', () => {
       const action = {
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as any;
+      } as unknown as ActionDefinition;
 
       service.registerAction(action);
       expect(() => service.addTriggerAction('i do not exist', action)).toThrowError(
@@ -457,7 +458,7 @@ describe('UiActionsService', () => {
       const action = {
         id: ACTION_HELLO_WORLD,
         order: 25,
-      } as any;
+      } as unknown as ActionDefinition;
 
       service.registerAction(action);
       expect(() => service.registerAction(action)).toThrowError(
@@ -468,7 +469,7 @@ describe('UiActionsService', () => {
     test('cannot register another trigger with the same ID', async () => {
       const service = new UiActionsService();
 
-      const trigger = { id: 'MY-TRIGGER' } as any;
+      const trigger = { id: 'MY-TRIGGER' } as unknown as Trigger;
 
       service.registerTrigger(trigger);
       expect(() => service.registerTrigger(trigger)).toThrowError(

--- a/src/plugins/ui_actions/public/tests/execute_trigger_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/execute_trigger_actions.test.ts
@@ -15,7 +15,7 @@ import { waitFor } from '@testing-library/dom';
 jest.mock('../context_menu');
 
 const executeFn = jest.fn();
-const openContextMenuSpy = (openContextMenu as any) as jest.SpyInstance;
+const openContextMenuSpy = (openContextMenu as unknown) as jest.SpyInstance;
 
 const CONTACT_USER_TRIGGER = 'CONTACT_USER_TRIGGER';
 

--- a/src/plugins/ui_actions/public/tests/get_trigger_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/get_trigger_actions.test.ts
@@ -13,12 +13,12 @@ const action1: Action = {
   id: 'action1',
   order: 1,
   type: 'type1',
-} as any;
+} as unknown as Action;
 const action2: Action = {
   id: 'action2',
   order: 2,
   type: 'type2',
-} as any;
+} as unknown as Action;
 
 test('returns actions set on trigger', () => {
   const { setup, doStart } = uiActionsPluginMock.createPlugin();
@@ -46,6 +46,6 @@ test('returns actions set on trigger', () => {
   const list2 = start.getTriggerActions('trigger');
 
   expect(list2).toHaveLength(2);
-  expect(!!list2.find(({ id }: any) => id === 'action1')).toBe(true);
-  expect(!!list2.find(({ id }: any) => id === 'action2')).toBe(true);
+  expect(!!list2.find(({ id }: {id: string}) => id === 'action1')).toBe(true);
+  expect(!!list2.find(({ id }: {id: string}) => id === 'action2')).toBe(true);
 });

--- a/src/plugins/ui_actions/public/tests/get_trigger_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/get_trigger_actions.test.ts
@@ -9,16 +9,16 @@
 import { ActionInternal, Action } from '../actions';
 import { uiActionsPluginMock } from '../mocks';
 
-const action1: Action = {
+const action1: Action = ({
   id: 'action1',
   order: 1,
   type: 'type1',
-} as unknown as Action;
-const action2: Action = {
+} as unknown) as Action;
+const action2: Action = ({
   id: 'action2',
   order: 2,
   type: 'type2',
-} as unknown as Action;
+} as unknown) as Action;
 
 test('returns actions set on trigger', () => {
   const { setup, doStart } = uiActionsPluginMock.createPlugin();
@@ -46,6 +46,6 @@ test('returns actions set on trigger', () => {
   const list2 = start.getTriggerActions('trigger');
 
   expect(list2).toHaveLength(2);
-  expect(!!list2.find(({ id }: {id: string}) => id === 'action1')).toBe(true);
-  expect(!!list2.find(({ id }: {id: string}) => id === 'action2')).toBe(true);
+  expect(!!list2.find(({ id }: { id: string }) => id === 'action1')).toBe(true);
+  expect(!!list2.find(({ id }: { id: string }) => id === 'action2')).toBe(true);
 });

--- a/src/plugins/ui_actions/public/tests/get_trigger_compatible_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/get_trigger_compatible_actions.test.ts
@@ -10,6 +10,7 @@ import { uiActionsPluginMock } from '../mocks';
 import { createHelloWorldAction } from '../tests/test_samples';
 import { Action, createAction } from '../actions';
 import { Trigger } from '../triggers';
+import { OverlayStart } from 'kibana/public';
 
 let action: Action<{ name: string }>;
 let uiActions: ReturnType<typeof uiActionsPluginMock.createPlugin>;
@@ -31,14 +32,14 @@ beforeEach(() => {
 
 test('can register action', async () => {
   const { setup } = uiActions;
-  const helloWorldAction = createHelloWorldAction({} as any);
+  const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
 
   setup.registerAction(helloWorldAction);
 });
 
 test('getTriggerCompatibleActions returns attached actions', async () => {
   const { setup, doStart } = uiActions;
-  const helloWorldAction = createHelloWorldAction({} as any);
+  const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
 
   setup.registerAction(helloWorldAction);
 

--- a/src/plugins/ui_actions/public/tests/get_trigger_compatible_actions.test.ts
+++ b/src/plugins/ui_actions/public/tests/get_trigger_compatible_actions.test.ts
@@ -32,14 +32,14 @@ beforeEach(() => {
 
 test('can register action', async () => {
   const { setup } = uiActions;
-  const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
+  const helloWorldAction = createHelloWorldAction(({} as unknown) as OverlayStart);
 
   setup.registerAction(helloWorldAction);
 });
 
 test('getTriggerCompatibleActions returns attached actions', async () => {
   const { setup, doStart } = uiActions;
-  const helloWorldAction = createHelloWorldAction({} as unknown as OverlayStart);
+  const helloWorldAction = createHelloWorldAction(({} as unknown) as OverlayStart);
 
   setup.registerAction(helloWorldAction);
 

--- a/src/plugins/ui_actions/public/types.ts
+++ b/src/plugins/ui_actions/public/types.ts
@@ -9,7 +9,7 @@
 import { ActionInternal } from './actions/action_internal';
 import { TriggerInternal } from './triggers/trigger_internal';
 
-export type TriggerRegistry = Map<string, TriggerInternal<any>>;
+export type TriggerRegistry = Map<string, TriggerInternal<object>>;
 export type ActionRegistry = Map<string, ActionInternal>;
 export type TriggerToActionsRegistry = Map<string, string[]>;
 


### PR DESCRIPTION
## Summary

Improves typings in UI Actions plugin.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
