### PR TITLE
[Workplace search] Fix several router issues

### DIFF
--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -56,8 +56,6 @@ export const DEFAULT_INITIAL_APP_DATA = {
       groups: ['Default', 'Cats'],
       isAdmin: true,
       canCreatePersonalSources: true,
-      canCreateInvitations: true,
-      isCurated: false,
       viewedOnboardingPage: true,
     },
   },

--- a/x-pack/plugins/enterprise_search/common/types/workplace_search.ts
+++ b/x-pack/plugins/enterprise_search/common/types/workplace_search.ts
@@ -9,9 +9,7 @@ export interface Account {
   id: string;
   groups: string[];
   isAdmin: boolean;
-  isCurated: boolean;
   canCreatePersonalSources: boolean;
-  canCreateInvitations?: boolean;
   viewedOnboardingPage: boolean;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -27,12 +27,10 @@ describe('AppLogic', () => {
 
   const expectedLogicValues = {
     account: {
-      canCreateInvitations: true,
       canCreatePersonalSources: true,
       groups: ['Default', 'Cats'],
       id: 'some-id-string',
       isAdmin: true,
-      isCurated: false,
       viewedOnboardingPage: true,
     },
     hasInitialized: true,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -94,6 +94,7 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
       </Route>
       <Route path={PERSONAL_PATH}>
         <Switch>
+          <Redirect exact from={PERSONAL_PATH} to={PERSONAL_SOURCES_PATH} />
           <Route path={PERSONAL_SOURCES_PATH}>
             <SourcesRouter />
           </Route>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.test.tsx
@@ -58,4 +58,11 @@ describe('SourcesRouter', () => {
     );
     expect(wrapper.find(Redirect).last().prop('to')).toEqual(PERSONAL_SOURCES_PATH);
   });
+
+  it('does not render the router until canCreatePersonalSources is fetched', () => {
+    setMockValues({ ...mockValues, account: {} }); // canCreatePersonalSources is undefined
+    const wrapper = shallow(<SourcesRouter />);
+
+    expect(wrapper.html()).toEqual(null);
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
@@ -47,6 +47,17 @@ export const SourcesRouter: React.FC = () => {
     resetSourcesState();
   }, [pathname]);
 
+  /**
+   * When opening `workplace_search/p/sources/add` as a bookmark or reloading this page,
+   * Sources router first get rendered *before* it receives the canCreatePersonalSources value.
+   * This results in canCreatePersonalSources always being undefined on the first render,
+   * and user always getting redirected to `workplace_search/p/sources`.
+   * Here we check for this value being present before we render any routes.
+   */
+  if (canCreatePersonalSources === undefined) {
+    return null;
+  }
+
   return (
     <Switch>
       <Route exact path={PERSONAL_SOURCES_PATH}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
@@ -13,7 +13,6 @@ const { workplaceSearch: mockAppValues } = DEFAULT_INITIAL_APP_DATA;
 export const mockOverviewValues = {
   accountsCount: 0,
   activityFeed: [],
-  canCreateContentSources: false,
   hasOrgSources: false,
   hasUsers: false,
   isOldAccount: false,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
@@ -23,14 +23,11 @@ const account = {
   isAdmin: true,
   canCreatePersonalSources: true,
   groups: [],
-  isCurated: false,
-  canCreateInvitations: true,
 };
 
 describe('OnboardingSteps', () => {
   describe('Shared Sources', () => {
     it('renders 0 sources state', () => {
-      setMockValues({ canCreateContentSources: true });
       const wrapper = shallow(<OnboardingSteps />);
 
       expect(wrapper.find(OnboardingCard)).toHaveLength(2);
@@ -47,13 +44,6 @@ describe('OnboardingSteps', () => {
       expect(wrapper.find(OnboardingCard).first().prop('description')).toEqual(
         'You have added 2 shared sources. Happy searching.'
       );
-    });
-
-    it('disables link when the user cannot create sources', () => {
-      setMockValues({ canCreateContentSources: false });
-      const wrapper = shallow(<OnboardingSteps />);
-
-      expect(wrapper.find(OnboardingCard).first().prop('actionPath')).toBe(undefined);
     });
   });
 
@@ -84,17 +74,6 @@ describe('OnboardingSteps', () => {
       expect(wrapper.find(OnboardingCard).last().prop('description')).toEqual(
         'Nice, you’ve invited colleagues to search with you.'
       );
-    });
-
-    it('disables link when the user cannot create invitations', () => {
-      setMockValues({
-        account: {
-          ...account,
-          canCreateInvitations: false,
-        },
-      });
-      const wrapper = shallow(<OnboardingSteps />);
-      expect(wrapper.find(OnboardingCard).last().prop('actionPath')).toBe(undefined);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { SOURCES_PATH, USERS_AND_ROLES_PATH } from '../../routes';
+import { ADD_SOURCE_PATH, USERS_AND_ROLES_PATH } from '../../routes';
 
 import { OnboardingCard } from './onboarding_card';
 import { OnboardingSteps, OrgNameOnboarding } from './onboarding_steps';
@@ -34,7 +34,7 @@ describe('OnboardingSteps', () => {
       const wrapper = shallow(<OnboardingSteps />);
 
       expect(wrapper.find(OnboardingCard)).toHaveLength(2);
-      expect(wrapper.find(OnboardingCard).first().prop('actionPath')).toBe(SOURCES_PATH);
+      expect(wrapper.find(OnboardingCard).first().prop('actionPath')).toBe(ADD_SOURCE_PATH);
       expect(wrapper.find(OnboardingCard).first().prop('description')).toBe(
         'Add shared sources for your organization to start searching.'
       );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
@@ -59,19 +59,9 @@ const ONBOARDING_USERS_CARD_DESCRIPTION = i18n.translate(
 export const OnboardingSteps: React.FC = () => {
   const {
     organization: { name, defaultOrgName },
-    account: { isCurated, canCreateInvitations },
   } = useValues(AppLogic);
 
-  const {
-    hasUsers,
-    hasOrgSources,
-    canCreateContentSources,
-    accountsCount,
-    sourcesCount,
-  } = useValues(OverviewLogic);
-
-  const accountsPath = canCreateInvitations || isCurated ? USERS_AND_ROLES_PATH : undefined;
-  const sourcesPath = canCreateContentSources || isCurated ? SOURCES_PATH : undefined;
+  const { hasUsers, hasOrgSources, accountsCount, sourcesCount } = useValues(OverviewLogic);
 
   const SOURCES_CARD_DESCRIPTION = i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.sourcesOnboardingCard.description',
@@ -114,7 +104,7 @@ export const OnboardingSteps: React.FC = () => {
               values: { label: accountsCount > 0 ? 'more' : '' },
             }
           )}
-          actionPath={accountsPath}
+          actionPath={USERS_AND_ROLES_PATH}
           complete={hasUsers}
         />
       </EuiFlexGrid>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
@@ -26,7 +26,7 @@ import { TelemetryLogic } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
 import sharedSourcesIcon from '../../components/shared/assets/source_icons/share_circle.svg';
 import { ContentSection } from '../../components/shared/content_section';
-import { SOURCES_PATH, USERS_AND_ROLES_PATH, ORG_SETTINGS_PATH } from '../../routes';
+import { ADD_SOURCE_PATH, USERS_AND_ROLES_PATH, ORG_SETTINGS_PATH } from '../../routes';
 
 import { OnboardingCard } from './onboarding_card';
 import { OverviewLogic } from './overview_logic';
@@ -99,7 +99,7 @@ export const OnboardingSteps: React.FC = () => {
               values: { label: sourcesCount > 0 ? 'more' : '' },
             }
           )}
-          actionPath={sourcesPath}
+          actionPath={ADD_SOURCE_PATH}
           complete={hasOrgSources}
         />
         <OnboardingCard

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.test.ts
@@ -29,7 +29,6 @@ describe('OverviewLogic', () => {
     const data = {
       accountsCount: 1,
       activityFeed: feed,
-      canCreateContentSources: true,
       hasOrgSources: true,
       hasUsers: true,
       isOldAccount: true,
@@ -49,7 +48,6 @@ describe('OverviewLogic', () => {
     it('will set server values', () => {
       expect(OverviewLogic.values.hasUsers).toEqual(true);
       expect(OverviewLogic.values.hasOrgSources).toEqual(true);
-      expect(OverviewLogic.values.canCreateContentSources).toEqual(true);
       expect(OverviewLogic.values.isOldAccount).toEqual(true);
       expect(OverviewLogic.values.sourcesCount).toEqual(1);
       expect(OverviewLogic.values.pendingInvitationsCount).toEqual(1);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
@@ -15,7 +15,6 @@ import { FeedActivity } from './recent_activity';
 interface OverviewServerData {
   hasUsers: boolean;
   hasOrgSources: boolean;
-  canCreateContentSources: boolean;
   isOldAccount: boolean;
   sourcesCount: number;
   pendingInvitationsCount: number;
@@ -50,12 +49,6 @@ export const OverviewLogic = kea<MakeLogicType<OverviewValues, OverviewActions>>
       false,
       {
         setServerData: (_, { hasOrgSources }) => hasOrgSources,
-      },
-    ],
-    canCreateContentSources: [
-      false,
-      {
-        setServerData: (_, { canCreateContentSources }) => canCreateContentSources,
       },
     ],
     isOldAccount: [

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -184,8 +184,6 @@ describe('callEnterpriseSearchConfigAPI', () => {
           groups: [],
           isAdmin: false,
           canCreatePersonalSources: false,
-          canCreateInvitations: false,
-          isCurated: false,
           viewedOnboardingPage: false,
         },
       },

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -126,9 +126,6 @@ export const callEnterpriseSearchConfigAPI = async ({
           isAdmin: !!data?.current_user?.workplace_search?.account?.is_admin,
           canCreatePersonalSources: !!data?.current_user?.workplace_search?.account
             ?.can_create_personal_sources,
-          canCreateInvitations: !!data?.current_user?.workplace_search?.account
-            ?.can_create_invitations,
-          isCurated: !!data?.current_user?.workplace_search?.account?.is_curated,
           viewedOnboardingPage: !!data?.current_user?.workplace_search?.account
             ?.viewed_onboarding_page,
         },


### PR DESCRIPTION
## Summary

This PR makes 3 changes:
1) Changes the "Add more sources" button's href from just `workplace_search/sources` to `workplace_search/sources/add` page. This change removed the need for `canCreateContentSources` variable, so in the following commit I removed it and a couple other redundant variables from the codebase.

Before:

https://user-images.githubusercontent.com/11838280/130625950-46adffd3-d4a1-4ad1-9e3b-a9b7fa8d9598.mp4

After:

https://user-images.githubusercontent.com/11838280/130626309-2a272cd2-84a9-4b5a-ad29-bb7481091151.mp4

2) Adds redirect from `workplace_search/p/` to `workplace_search/p/sources`. Before this route returned 404.

Before:

https://user-images.githubusercontent.com/11838280/130626031-58151dcb-a090-4751-a064-ca316794038f.mp4

After:

https://user-images.githubusercontent.com/11838280/130625408-2618af8a-061c-4bd7-83b5-063e66d48d7c.mp4

3) Fixes a bug where opening a page `workplace_search/p/sources/add` directly always redirected to `workplace_search/p/sources`. See commit description for more details.

Before:

https://user-images.githubusercontent.com/11838280/130626104-e0870c69-556d-476d-9113-10697fda0a59.mp4

After:

https://user-images.githubusercontent.com/11838280/130625513-a4214568-18d9-4bf6-90ef-f701adfe8d3f.mp4


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Closes https://github.com/elastic/workplace-search-team/issues/1938
Closes https://github.com/elastic/workplace-search-team/issues/1940