### PR TITLE
[Enterprise Search] Prevent long errors from breaking UI

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/add_field_modal/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/add_field_modal/index.tsx
@@ -99,7 +99,7 @@ export const SchemaAddFieldModal: React.FC<Props> = ({
                 helpText={fieldNameNote}
                 fullWidth
                 data-test-subj="SchemaAddFieldNameRow"
-                error={addFieldFormErrors}
+                error={<span className="eui-textBreakAll">{addFieldFormErrors}</span>}
                 isInvalid={!!addFieldFormErrors}
               >
                 <EuiFieldText


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1991

## Summary

When adding a field to a custom source's (or engine's) schema, if you make the field name really huge, it renders poorly. This PR adds a [utility class](https://elastic.github.io/eui/#/utilities/css-utility-classes) from EUI to enable the correct rendering

**Before**
![before](https://user-images.githubusercontent.com/1869731/130661907-a48903eb-7171-4313-87ea-1906bf800481.png)

**After**
![after](https://user-images.githubusercontent.com/1869731/130661913-c3bb9dc8-25f8-4c64-bd41-76cfb2230ee6.png)