### PR TITLE
Update project assigner for Fleet team

### DIFF
--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -21,5 +21,6 @@ jobs:
               {"label": "Feature:Input Controls", "projectNumber": 72, "columnName": "Inbox"},
               {"label": "Team:Security", "projectNumber": 320, "columnName": "Awaiting triage", "projectScope": "org"},
               {"label": "Team:Operations", "projectNumber": 314, "columnName": "Triage", "projectScope": "org"}
+              {"label": "Team:Fleet", "projectNumber": 490, "columnName": "Inbox", "projectScope": "org"}
             ]
           ghToken: ${{ secrets.PROJECT_ASSIGNER_TOKEN }}


### PR DESCRIPTION
## Summary

Add `Team:Fleet` issues to our [backlog project board](https://github.com/orgs/elastic/projects/490) automatically.