### PR TITLE
[Cases][Observability] Disabling sync alerts for observability

### DIFF
--- a/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_action_bar/index.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import { basicCase } from '../../containers/mock';
 import { CaseActionBar } from '.';
@@ -113,5 +114,25 @@ describe('CaseActionBar', () => {
         syncAlerts: false,
       },
     });
+  });
+
+  it('should not show the sync alerts toggle when alerting is disabled', () => {
+    const { queryByText } = render(
+      <TestProviders>
+        <CaseActionBar {...defaultProps} disableAlerting={true} />
+      </TestProviders>
+    );
+
+    expect(queryByText('Sync alerts')).not.toBeInTheDocument();
+  });
+
+  it('should show the sync alerts toggle when alerting is enabled', () => {
+    const { queryByText } = render(
+      <TestProviders>
+        <CaseActionBar {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(queryByText('Sync alerts')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/case_view/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/index.tsx
@@ -59,6 +59,7 @@ export interface CaseViewComponentProps {
    * **NOTE**: Do not hold on to the `.current` object, as it could become stale
    */
   refreshRef?: MutableRefObject<CaseViewRefreshPropInterface>;
+  hideSyncAlerts?: boolean;
 }
 
 export interface CaseViewProps extends CaseViewComponentProps {
@@ -101,6 +102,7 @@ export const CaseComponent = React.memo<CaseComponentProps>(
     useFetchAlertData,
     userCanCrud,
     refreshRef,
+    hideSyncAlerts = false,
   }) => {
     const [initLoadingData, setInitLoadingData] = useState(true);
     const init = useRef(true);
@@ -389,7 +391,7 @@ export const CaseComponent = React.memo<CaseComponentProps>(
               caseData={caseData}
               currentExternalIncident={currentExternalIncident}
               userCanCrud={userCanCrud}
-              disableAlerting={ruleDetailsNavigation == null}
+              disableAlerting={ruleDetailsNavigation == null || hideSyncAlerts}
               isLoading={isLoading && (updateKey === 'status' || updateKey === 'settings')}
               onRefresh={handleRefresh}
               onUpdateField={onUpdateField}
@@ -509,6 +511,7 @@ export const CaseView = React.memo(
     useFetchAlertData,
     userCanCrud,
     refreshRef,
+    hideSyncAlerts,
   }: CaseViewProps) => {
     const { data, isLoading, isError, fetchCase, updateCase } = useGetCase(caseId, subCaseId);
     if (isError) {
@@ -548,6 +551,7 @@ export const CaseView = React.memo(
               useFetchAlertData={useFetchAlertData}
               userCanCrud={userCanCrud}
               refreshRef={refreshRef}
+              hideSyncAlerts={hideSyncAlerts}
             />
           </OwnerProvider>
         </CasesTimelineIntegrationProvider>

--- a/x-pack/plugins/observability/public/components/app/cases/case_view/index.tsx
+++ b/x-pack/plugins/observability/public/components/app/cases/case_view/index.tsx
@@ -156,6 +156,7 @@ export const CaseView = React.memo(({ caseId, subCaseId, userCanCrud }: Props) =
           setSelectedAlertId(alertId);
         },
         userCanCrud,
+        hideSyncAlerts: true,
       })}
     </>
   );


### PR DESCRIPTION
Issue: https://github.com/elastic/kibana/issues/109940

This PR adds the ability to disable the sync alerts toggle in the UI within the observability context for cases. This is to address a bug where the sync alerts toggle is being shown when it shouldn't.

## Observability
![image](https://user-images.githubusercontent.com/56361221/130680911-c0b5cbbc-eaa3-416a-bf4f-0d39c3771012.png)


## Security Solution
![image](https://user-images.githubusercontent.com/56361221/130680955-71629bcf-d780-4a82-beb0-6338b0edbe27.png)
