### PR TITLE
[Canvas] Add default CSS if workpad CSS is missing

### DIFF
--- a/x-pack/plugins/canvas/public/components/workpad/workpad.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad/workpad.component.tsx
@@ -11,7 +11,11 @@ import Style from 'style-it';
 // @ts-expect-error
 import { WorkpadPage } from '../workpad_page';
 import { Fullscreen } from '../fullscreen';
-import { HEADER_BANNER_HEIGHT, WORKPAD_CANVAS_BUFFER } from '../../../common/lib/constants';
+import {
+  HEADER_BANNER_HEIGHT,
+  WORKPAD_CANVAS_BUFFER,
+  DEFAULT_WORKPAD_CSS,
+} from '../../../common/lib/constants';
 import { CommitFn, CanvasPage } from '../../../types';
 import { WorkpadShortcuts } from './workpad_shortcuts.component';
 
@@ -122,7 +126,7 @@ export const Workpad: FC<Props> = ({
 
             // NOTE: the data-shared-* attributes here are used for reporting
             return Style.it(
-              workpadCss,
+              workpadCss || DEFAULT_WORKPAD_CSS,
               <div
                 className={`canvasWorkpad ${isFullscreenProp ? 'fullscreen' : ''}`}
                 style={fsStyle}


### PR DESCRIPTION
## Summary

Related to: https://github.com/elastic/kibana/issues/94075

The style-it dependency that Canvas uses for placing custom CSS in a workpad will not render the parent element passed in to it if the CSS is empty. This fix supplies the default workpad CSS if for some reason there is no CSS in the workpad itself. 

This is a bit of a bandaid until we remove style-it from Canvas (See: https://github.com/elastic/kibana/issues/88715)