### PR TITLE
[Workplace Search] Fix text size for DLP callout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -283,7 +283,7 @@ export const Overview: React.FC = () => {
   const documentPermissions = (
     <>
       <EuiSpacer />
-      <EuiTitle size="s">
+      <EuiTitle size="xs">
         <h4>{DOCUMENT_PERMISSIONS_TITLE}</h4>
       </EuiTitle>
       <EuiSpacer size="m" />
@@ -305,7 +305,7 @@ export const Overview: React.FC = () => {
   const documentPermissionsDisabled = (
     <>
       <EuiSpacer />
-      <EuiTitle size="s">
+      <EuiTitle size="xs">
         <h4>{DOCUMENT_PERMISSIONS_TITLE}</h4>
       </EuiTitle>
       <EuiSpacer size="m" />
@@ -316,7 +316,7 @@ export const Overview: React.FC = () => {
               <EuiIcon size="l" type="iInCircle" color="subdued" />
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiText size="m">
+              <EuiText size="s">
                 <strong>{DOCUMENT_PERMISSIONS_DISABLED_TEXT}</strong>
               </EuiText>
               <EuiText size="s">


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1990

## Summary

The text size was off on some callouts for DLP. This standardizes them to match other sections. 

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/1869731/130688377-8220af39-671f-46cc-8938-63d8270fb4e5.png)  | ![after](https://user-images.githubusercontent.com/1869731/130688379-d1e2e3b6-217f-4c11-ac2d-bb725ac90ce9.png)  |

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)