### PR TITLE
Fix small multiple title in dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@elastic/apm-rum": "^5.8.0",
     "@elastic/apm-rum-react": "^1.2.11",
-    "@elastic/charts": "32.0.1",
+    "@elastic/charts": "32.0.2",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@7.14.0-canary.7",
     "@elastic/ems-client": "7.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@32.0.1":
-  version "32.0.1"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-32.0.1.tgz#cad81c83ab55b418d42fdbfdf500304f0cda7fd8"
-  integrity sha512-ov7Fu0nn2sBiZRU7bxKtHfN7B8Ppqh1zAORzb5+5ep23xXWv4voDzSGx/kW9n5In5RK9OVplRUQGstjJ4to8zA==
+"@elastic/charts@32.0.2":
+  version "32.0.2"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-32.0.2.tgz#95cd4cd78b9053b9a078baa6a7d13fbdf9b5659a"
+  integrity sha512-0RixmfrTfYzxaiD7FLuvYj2vND2+0EBCD67nz/KRGIKvvT6kdnd7mQJvYoXVi25Ju7MRV/WClzAhdSodNat+fg==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

This PR fixes the invisible panel title in dark mode when rendering small multiples of pie charts.
The fix was applied to directly to elastic-charts and backported to version 32.0.x https://github.com/elastic/elastic-charts/pull/1330

fix #109639


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
