### PR TITLE
Fixes bugs for product check in update and delete

### DIFF
--- a/src/core/server/saved_objects/service/lib/decorate_es_error.test.ts
+++ b/src/core/server/saved_objects/service/lib/decorate_es_error.test.ts
@@ -109,6 +109,19 @@ describe('savedObjectsClient/decorateEsError', () => {
     expect(SavedObjectsErrorHelpers.isNotFoundError(genericError)).toBe(true);
   });
 
+  it('makes NotFound errors generic NotFoundEsUnavailableError errors when response is from unsupported server', () => {
+    const error = new esErrors.ResponseError(
+      // explicitly override the headers
+      elasticsearchClientMock.createApiResponse({ statusCode: 404, headers: {} })
+    );
+    expect(SavedObjectsErrorHelpers.isNotFoundError(error)).toBe(false);
+    const genericError = decorateEsError(error);
+    expect(genericError).not.toBe(error);
+    expect(SavedObjectsErrorHelpers.isNotFoundError(error)).toBe(false);
+    expect(SavedObjectsErrorHelpers.isNotFoundError(genericError)).toBe(false);
+    expect(SavedObjectsErrorHelpers.isEsUnavailableError(genericError)).toBe(true);
+  });
+
   it('if saved objects index does not exist makes NotFound a SavedObjectsClient/generalError', () => {
     const error = new esErrors.ResponseError(
       elasticsearchClientMock.createApiResponse({

--- a/src/core/server/saved_objects/service/lib/decorate_es_error.test.ts
+++ b/src/core/server/saved_objects/service/lib/decorate_es_error.test.ts
@@ -117,7 +117,6 @@ describe('savedObjectsClient/decorateEsError', () => {
     expect(SavedObjectsErrorHelpers.isNotFoundError(error)).toBe(false);
     const genericError = decorateEsError(error);
     expect(genericError).not.toBe(error);
-    expect(SavedObjectsErrorHelpers.isNotFoundError(error)).toBe(false);
     expect(SavedObjectsErrorHelpers.isNotFoundError(genericError)).toBe(false);
     expect(SavedObjectsErrorHelpers.isEsUnavailableError(genericError)).toBe(true);
   });

--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -2398,27 +2398,19 @@ describe('SavedObjectsRepository', () => {
 
       it(`throws when ES is unable to find the document during delete`, async () => {
         client.delete.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            { result: 'not_found' },
-            {},
-            {}
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({ result: 'not_found' })
         );
-        await expectNotFoundEsUnavailableError(type, id);
+        await expectNotFoundError(type, id);
         expect(client.delete).toHaveBeenCalledTimes(1);
       });
 
       it(`throws when ES is unable to find the index during delete`, async () => {
         client.delete.mockResolvedValueOnce(
-          elasticsearchClientMock.createSuccessTransportRequestPromise(
-            {
-              error: { type: 'index_not_found_exception' },
-            },
-            {},
-            {}
-          )
+          elasticsearchClientMock.createSuccessTransportRequestPromise({
+            error: { type: 'index_not_found_exception' },
+          })
         );
-        await expectNotFoundEsUnavailableError(type, id);
+        await expectNotFoundError(type, id);
         expect(client.delete).toHaveBeenCalledTimes(1);
       });
 
@@ -3389,7 +3381,7 @@ describe('SavedObjectsRepository', () => {
         client.get.mockResolvedValueOnce(
           elasticsearchClientMock.createSuccessTransportRequestPromise(
             { found: false },
-            undefined,
+            { statusCode: 404 },
             {}
           )
         );

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -681,6 +681,10 @@ export class SavedObjectsRepository {
       { ignore: [404] }
     );
 
+    if (isNotFoundFromUnsupportedServer({ statusCode, headers })) {
+      throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(type, id);
+    }
+
     const deleted = body.result === 'deleted';
     if (deleted) {
       return {};
@@ -689,15 +693,9 @@ export class SavedObjectsRepository {
     const deleteDocNotFound = body.result === 'not_found';
     // @ts-expect-error @elastic/elasticsearch doesn't declare error on DeleteResponse
     const deleteIndexNotFound = body.error && body.error.type === 'index_not_found_exception';
-    const esServerSupported = isSupportedEsServer(headers);
     if (deleteDocNotFound || deleteIndexNotFound) {
-      if (esServerSupported) {
-        // see "404s from missing index" above
-        throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
-      } else {
-        // throw if we can't verify the response is from Elasticsearch
-        throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(type, id);
-      }
+      // see "404s from missing index" above
+      throw SavedObjectsErrorHelpers.createGenericNotFoundError(type, id);
     }
 
     throw new Error(
@@ -1068,7 +1066,7 @@ export class SavedObjectsRepository {
     );
     const indexNotFound = statusCode === 404;
     // check if we have the elasticsearch header when index is not found and if we do, ensure it is Elasticsearch
-    if (!isFoundGetResponse(body) && !isSupportedEsServer(headers)) {
+    if (indexNotFound && !isSupportedEsServer(headers)) {
       throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(type, id);
     }
     if (
@@ -1314,15 +1312,6 @@ export class SavedObjectsRepository {
         },
         _source_includes: ['namespace', 'namespaces', 'originId'],
         require_alias: true,
-      })
-      .then((res) => {
-        const indexNotFound = res.statusCode === 404;
-        const esServerSupported = isSupportedEsServer(res.headers);
-        // check if we have the elasticsearch header when index is not found and if we do, ensure it is Elasticsearch
-        if (indexNotFound && !esServerSupported) {
-          throw SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError(type, id);
-        }
-        return res;
       })
       .catch((err) => {
         if (SavedObjectsErrorHelpers.isEsUnavailableError(err)) {


### PR DESCRIPTION
## Summary

Adding integration tests for https://github.com/elastic/kibana/issues/107246 uncovered a couple of edge cases not handled in the original work. This PR fixes bugs in update and delete introduced in https://github.com/elastic/kibana/pull/107301.

In the original implementation for handling 404's in `delete`, we only verified that an error is from Elasticsearch when `body.found` is explicitly `not_found`. However, that might not be the case when the error originates from the proxy itself and we'll miss those.

In `update`, we [don't ignore 404's](https://github.com/elastic/kibana/blob/master/src/core/server/saved_objects/service/lib/repository.ts#L1304-L1317) and these are [caught if `retryCallCluster` throws](https://github.com/elastic/kibana/blob/master/src/core/server/saved_objects/service/lib/repository_es_client.ts#L37-L43) so we have to handle the product check on [NotFound errors in `decorateEsError`](https://github.com/elastic/kibana/blob/master/src/core/server/saved_objects/service/lib/decorate_es_error.ts#L65-L73). 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| False positives— An intermediate proxy doesn't forward x-elastic-product header. | Low | Low | As of 7.16, Kibana won't start unless the required headers are present. Until then, the type of error returned could either be a 404 or a 503, but it is still an error. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
(No breaking API changes)