### PR TITLE
[Fleet] Fix agent logs filtering from URL state

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
@@ -35,7 +35,9 @@ export const AgentLogs: React.FunctionComponent<
       >(
         {
           ...DEFAULT_LOGS_STATE,
-          ...getStateFromKbnUrl<AgentLogsState>(STATE_STORAGE_KEY, window.location.href),
+          ...getStateFromKbnUrl<AgentLogsState>(STATE_STORAGE_KEY, window.location.href, {
+            getFromHashQuery: false,
+          }),
         },
         {
           update: (state) => (updatedState) => ({ ...state, ...updatedState }),


### PR DESCRIPTION
## Summary

Resolves #109402

In #106267 we converted Fleet routing to not use hashes. For agent logs, we have links to pre-populate filters from the URL state. This is done by using Kibana's URL state management helper, `getStateFromKbnUrl`, which by default assumes the state is stored in the hash part of the URL. This PR passes in the right argument to retrieve it from the main query instead.
