### PR TITLE
[7.15] Fix small multiple title in dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@elastic/apm-rum": "^5.8.0",
     "@elastic/apm-rum-react": "^1.2.11",
-    "@elastic/charts": "34.1.1",
+    "@elastic/charts": "34.1.2",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.15.0-canary.3",
     "@elastic/ems-client": "7.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,10 +1389,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@34.1.1":
-  version "34.1.1"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-34.1.1.tgz#ad0a614448d7a3b28a77cc6d3a5ef5c89530ea34"
-  integrity sha512-9HFqjGZALURKg0uwuo0t91IMDUY1lnRTovnJJgTrE0zIkUtEIX/yL1gKJlVKLECJO6KrwIO1LcGhobtkVQkR/A==
+"@elastic/charts@34.1.2":
+  version "34.1.2"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-34.1.2.tgz#60c63b2bae9734948720e3935a570f9a3fd9aecd"
+  integrity sha512-Jy7wgcX6uJzJZt66Lmg94k1SPf606cpEBhA28GlZAg21kqTyYTHu1xJHYPqsidHCqqBvs3/YcoRl2BKEvZGsJA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

This PR fixes the invisible panel title in dark mode when rendering small multiples of pie charts.
The fix was applied directly to elastic-charts and backported to version 34.1.2 https://github.com/elastic/elastic-charts/pull/1330

fix #109639

The same fix, with a different ech version, was backported to 7.14.1 https://github.com/elastic/kibana/pull/109966

### QA/Reviewers
To check the fix:
- Create a simple pie chart visualization in Visualize
- Split the chart in multiples with a term agg (or anything else)
- Check if the text above each pie is visible (the term used to split charts)
- Go to advanced settings and turn on the dark mode
- Go back to the chart and check the text visibility 


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
