### PR TITLE
[RAC][Observability] Fix empty actions popover button

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -217,18 +217,22 @@ function ObservabilityActions({
 
   const actionsMenuItems = useMemo(() => {
     return [
-      timelines.getAddToExistingCaseButton({
-        event,
-        casePermissions,
-        appId: observabilityFeatureId,
-        onClose: afterCaseSelection,
-      }),
-      timelines.getAddToNewCaseButton({
-        event,
-        casePermissions,
-        appId: observabilityFeatureId,
-        onClose: afterCaseSelection,
-      }),
+      ...(casePermissions?.crud
+        ? [
+            timelines.getAddToExistingCaseButton({
+              event,
+              casePermissions,
+              appId: observabilityFeatureId,
+              onClose: afterCaseSelection,
+            }),
+            timelines.getAddToNewCaseButton({
+              event,
+              casePermissions,
+              appId: observabilityFeatureId,
+              onClose: afterCaseSelection,
+            }),
+          ]
+        : []),
       ...(alertPermissions.crud ? statusActionItems : []),
     ];
   }, [afterCaseSelection, casePermissions, timelines, event, statusActionItems, alertPermissions]);


### PR DESCRIPTION
## Summary

There was a bug when the user had no actions allowed, the button was still appearing with empty options:
![image](https://user-images.githubusercontent.com/17747913/130759349-ed69b6ab-74d4-437e-b9af-65b70b602f85.png)

Button hidden if no actions allowed:
![Captura de Pantalla 2021-08-25 a les 10 51 00](https://user-images.githubusercontent.com/17747913/130759782-051d5b9f-2864-4436-8b7a-af43e7e10042.png)
