### PR TITLE
[Fleet] Do not show upgrade available on latest version of package

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -63,12 +63,11 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
   // used in the InMemoryTable (flattens some values for search) as well as
   // the list of options that will be used in the filters dropdowns
   const [packagePolicies, namespaces] = useMemo((): [InMemoryPackagePolicy[], FilterOption[]] => {
-    const namespacesValues: string[] = [];
-    const inputTypesValues: string[] = [];
+    const namespacesValues: Set<string> = new Set();
     const mappedPackagePolicies = originalPackagePolicies.map<InMemoryPackagePolicy>(
       (packagePolicy) => {
-        if (packagePolicy.namespace && !namespacesValues.includes(packagePolicy.namespace)) {
-          namespacesValues.push(packagePolicy.namespace);
+        if (packagePolicy.namespace) {
+          namespacesValues.add(packagePolicy.namespace);
         }
 
         const updatableIntegrationRecord = updatableIntegrations.get(
@@ -91,10 +90,11 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
       }
     );
 
-    namespacesValues.sort(stringSortAscending);
-    inputTypesValues.sort(stringSortAscending);
+    const namespaceFilterOptions = [...namespacesValues]
+      .sort(stringSortAscending)
+      .map(toFilterOption);
 
-    return [mappedPackagePolicies, namespacesValues.map(toFilterOption)];
+    return [mappedPackagePolicies, namespaceFilterOptions];
   }, [originalPackagePolicies, updatableIntegrations]);
 
   const columns = useMemo(

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -78,7 +78,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
         const hasUpgrade =
           !!updatableIntegrationRecord &&
           updatableIntegrationRecord.policiesToUpgrade.some(
-            ({ id }) => id === packagePolicy.policy_id
+            ({ pkgPolicyId }) => pkgPolicyId === packagePolicy.id
           );
 
         return {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/settings.tsx
@@ -48,8 +48,8 @@ const UpdatesAvailableMsg = () => (
 );
 
 const LatestVersionLink = ({ name, version }: { name: string; version: string }) => {
-  const { getPath } = useLink();
-  const settingsPath = getPath('integration_details_settings', {
+  const { getHref } = useLink();
+  const settingsPath = getHref('integration_details_settings', {
     pkgkey: `${name}-${version}`,
   });
   return (


### PR DESCRIPTION
## Summary

fixes #109799 

If a policy contains an old version of a package as well as the latest, we were showing the upgrade button on both versions instead of just the latest.

Bonus fix: A broken link to the latest package in the package settings view.

Bonus refactor: use a set for collecting unique namespace values and remove unused var

### Checklist

(no checklist items applicable)