### PR TITLE
[ML] Fix bytes formatting and default message in the Anomaly detection jobs health rule type 

### DIFF
--- a/x-pack/plugins/ml/public/alerting/jobs_health_rule/register_jobs_health_alerting_rule.ts
+++ b/x-pack/plugins/ml/public/alerting/jobs_health_rule/register_jobs_health_alerting_rule.ts
@@ -92,18 +92,18 @@ export function registerJobsHealthAlertingRule(
 \\{\\{#context.results\\}\\}
   Job ID: \\{\\{job_id\\}\\}
   \\{\\{#datafeed_id\\}\\}Datafeed ID: \\{\\{datafeed_id\\}\\}
-  \\{\\{/datafeed_id\\}\\} \\{\\{#datafeed_state\\}\\}Datafeed state: \\{\\{datafeed_state\\}\\}
-  \\{\\{/datafeed_state\\}\\} \\{\\{#memory_status\\}\\}Memory status: \\{\\{memory_status\\}\\}
+  \\{\\{/datafeed_id\\}\\}\\{\\{#datafeed_state\\}\\}Datafeed state: \\{\\{datafeed_state\\}\\}
+  \\{\\{/datafeed_state\\}\\}\\{\\{#memory_status\\}\\}Memory status: \\{\\{memory_status\\}\\}
   \\{\\{/memory_status\\}\\}\\{\\{#model_bytes\\}\\}Model size: \\{\\{model_bytes\\}\\}
   \\{\\{/model_bytes\\}\\}\\{\\{#model_bytes_memory_limit\\}\\}Model memory limit: \\{\\{model_bytes_memory_limit\\}\\}
-  \\{\\{/model_bytes_memory_limit\\}\\} \\{\\{#peak_model_bytes\\}\\}Peak model bytes: \\{\\{peak_model_bytes\\}\\}
-  \\{\\{/peak_model_bytes\\}\\} \\{\\{#model_bytes_exceeded\\}\\}Model exceeded: \\{\\{model_bytes_exceeded\\}\\}
-  \\{\\{/model_bytes_exceeded\\}\\} \\{\\{#log_time\\}\\}Memory logging time: \\{\\{log_time\\}\\}
-  \\{\\{/log_time\\}\\} \\{\\{#failed_category_count\\}\\}Failed category count: \\{\\{failed_category_count\\}\\}
-  \\{\\{/failed_category_count\\}\\} \\{\\{#annotation\\}\\}Annotation: \\{\\{annotation\\}\\}
-  \\{\\{/annotation\\}\\} \\{\\{#missed_docs_count\\}\\}Number of missed documents: \\{\\{missed_docs_count\\}\\}
-  \\{\\{/missed_docs_count\\}\\} \\{\\{#end_timestamp\\}\\}Latest finalized bucket with missing docs: \\{\\{end_timestamp\\}\\}
-  \\{\\{/end_timestamp\\}\\} \\{\\{#errors\\}\\}Error message: \\{\\{message\\}\\} \\{\\{/errors\\}\\}
+  \\{\\{/model_bytes_memory_limit\\}\\}\\{\\{#peak_model_bytes\\}\\}Peak model bytes: \\{\\{peak_model_bytes\\}\\}
+  \\{\\{/peak_model_bytes\\}\\}\\{\\{#model_bytes_exceeded\\}\\}Model exceeded: \\{\\{model_bytes_exceeded\\}\\}
+  \\{\\{/model_bytes_exceeded\\}\\}\\{\\{#log_time\\}\\}Memory logging time: \\{\\{log_time\\}\\}
+  \\{\\{/log_time\\}\\}\\{\\{#failed_category_count\\}\\}Failed category count: \\{\\{failed_category_count\\}\\}
+  \\{\\{/failed_category_count\\}\\}\\{\\{#annotation\\}\\}Annotation: \\{\\{annotation\\}\\}
+  \\{\\{/annotation\\}\\}\\{\\{#missed_docs_count\\}\\}Number of missed documents: \\{\\{missed_docs_count\\}\\}
+  \\{\\{/missed_docs_count\\}\\}\\{\\{#end_timestamp\\}\\}Latest finalized bucket with missing docs: \\{\\{end_timestamp\\}\\}
+  \\{\\{/end_timestamp\\}\\}\\{\\{#errors\\}\\}Error message: \\{\\{message\\}\\} \\{\\{/errors\\}\\}
 \\{\\{/context.results\\}\\}
 `,
       }

--- a/x-pack/plugins/ml/public/alerting/jobs_health_rule/register_jobs_health_alerting_rule.ts
+++ b/x-pack/plugins/ml/public/alerting/jobs_health_rule/register_jobs_health_alerting_rule.ts
@@ -94,7 +94,11 @@ export function registerJobsHealthAlertingRule(
   \\{\\{#datafeed_id\\}\\}Datafeed ID: \\{\\{datafeed_id\\}\\}
   \\{\\{/datafeed_id\\}\\} \\{\\{#datafeed_state\\}\\}Datafeed state: \\{\\{datafeed_state\\}\\}
   \\{\\{/datafeed_state\\}\\} \\{\\{#memory_status\\}\\}Memory status: \\{\\{memory_status\\}\\}
-  \\{\\{/memory_status\\}\\} \\{\\{#log_time\\}\\}Memory logging time: \\{\\{log_time\\}\\}
+  \\{\\{/memory_status\\}\\}\\{\\{#model_bytes\\}\\}Model size: \\{\\{model_bytes\\}\\}
+  \\{\\{/model_bytes\\}\\}\\{\\{#model_bytes_memory_limit\\}\\}Model memory limit: \\{\\{model_bytes_memory_limit\\}\\}
+  \\{\\{/model_bytes_memory_limit\\}\\} \\{\\{#peak_model_bytes\\}\\}Peak model bytes: \\{\\{peak_model_bytes\\}\\}
+  \\{\\{/peak_model_bytes\\}\\} \\{\\{#model_bytes_exceeded\\}\\}Model exceeded: \\{\\{model_bytes_exceeded\\}\\}
+  \\{\\{/model_bytes_exceeded\\}\\} \\{\\{#log_time\\}\\}Memory logging time: \\{\\{log_time\\}\\}
   \\{\\{/log_time\\}\\} \\{\\{#failed_category_count\\}\\}Failed category count: \\{\\{failed_category_count\\}\\}
   \\{\\{/failed_category_count\\}\\} \\{\\{#annotation\\}\\}Annotation: \\{\\{annotation\\}\\}
   \\{\\{/annotation\\}\\} \\{\\{#missed_docs_count\\}\\}Number of missed documents: \\{\\{missed_docs_count\\}\\}

--- a/x-pack/plugins/ml/server/lib/alerts/jobs_health_service.test.ts
+++ b/x-pack/plugins/ml/server/lib/alerts/jobs_health_service.test.ts
@@ -93,6 +93,10 @@ describe('JobsHealthService', () => {
               model_size_stats: {
                 memory_status: j === 'test_job_01' ? 'hard_limit' : 'ok',
                 log_time: 1626935914540,
+                model_bytes: 1000000,
+                model_bytes_memory_limit: 800000,
+                peak_model_bytes: 1000000,
+                model_bytes_exceeded: 200000,
               },
             };
           }) as MlJobStats,
@@ -162,12 +166,21 @@ describe('JobsHealthService', () => {
 
   const getFieldsFormatRegistry = jest.fn().mockImplementation(() => {
     return Promise.resolve({
-      deserialize: jest.fn().mockImplementation(() => {
-        return {
-          convert: jest.fn().mockImplementation((v) => {
-            return new Date(v).toUTCString();
-          }),
-        };
+      deserialize: jest.fn().mockImplementation(({ id }: { id: string }) => {
+        if (id === 'date') {
+          return {
+            convert: jest.fn().mockImplementation((v) => {
+              return new Date(v).toUTCString();
+            }),
+          };
+        }
+        if (id === 'bytes') {
+          return {
+            convert: jest.fn().mockImplementation((v) => {
+              return `${Math.round(v / 1000)}KB`;
+            }),
+          };
+        }
       }),
     });
   }) as jest.Mocked<FieldFormatsRegistryProvider>;
@@ -358,6 +371,10 @@ describe('JobsHealthService', () => {
               job_id: 'test_job_01',
               log_time: 'Thu, 22 Jul 2021 06:38:34 GMT',
               memory_status: 'hard_limit',
+              model_bytes: '1000KB',
+              model_bytes_exceeded: '200KB',
+              model_bytes_memory_limit: '800KB',
+              peak_model_bytes: '1000KB',
             },
           ],
           message:

--- a/x-pack/plugins/ml/server/lib/alerts/register_jobs_monitoring_rule_type.ts
+++ b/x-pack/plugins/ml/server/lib/alerts/register_jobs_monitoring_rule_type.ts
@@ -31,10 +31,10 @@ export interface MmlTestResponse {
   job_id: string;
   memory_status: ModelSizeStats['memory_status'];
   log_time: ModelSizeStats['log_time'];
-  model_bytes: ModelSizeStats['model_bytes'];
-  model_bytes_memory_limit: ModelSizeStats['model_bytes_memory_limit'];
-  peak_model_bytes: ModelSizeStats['peak_model_bytes'];
-  model_bytes_exceeded: ModelSizeStats['model_bytes_exceeded'];
+  model_bytes: string;
+  model_bytes_memory_limit: string;
+  peak_model_bytes: string;
+  model_bytes_exceeded: string;
 }
 
 export interface NotStartedDatafeedResponse {


### PR DESCRIPTION
## Summary

- Fixes bytes formatting for the action context 
- Fixes the default message to prevent extra indentation 

Before: 

```
[003] Anomaly detection jobs health check result:
Job rt-ad-operational-hard-limit reached the hard model memory limit. Assign the job more memory and restore from a snapshot from prior to reaching the hard limit.
 Job ID: rt-ad-operational-hard-limit
   Memory status: hard_limit
  Memory logging time: Aug 25, 2021 @ 14:15:35.109
```

After:
```
[004] Anomaly detection jobs health check result:
Job rt-ad-operational-hard-limit reached the hard model memory limit. Assign the job more memory and restore from a snapshot from prior to reaching the hard limit.
 Job ID: rt-ad-operational-hard-limit
 Memory status: hard_limit
 Model size: 1.2MB
 Model memory limit: 1MB
 Peak model bytes: 1.2MB
 Model exceeded: 1.2KB
 Memory logging time: Aug 25, 2021 @ 14:15:35.109
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios