### PR TITLE
[Stack Integration] Change browser window size for APM test

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/apm/apm_smoke_test.js
+++ b/x-pack/test/stack_functional_integration/apps/apm/apm_smoke_test.js
@@ -14,7 +14,7 @@ export default function ({ getService, getPageObjects }) {
     const log = getService('log');
 
     before(async () => {
-      await browser.setWindowSize(1200, 800);
+      await browser.setWindowSize(1400, 1400);
       await PageObjects.common.navigateToApp('apm');
       await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
     });


### PR DESCRIPTION
After the change to EUI fonts the url for the APM service gets too big that it's overlapped by others columns, so this test increases the browser width in order to accommodate this.
![APM smoke test APM smoke test can navigate to APM app](https://user-images.githubusercontent.com/5196019/130818773-d290b159-709b-4159-9834-fd4379c0f0e6.png)
