### PR TITLE
[Security Solution][RAC] Hide filters on case view

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
@@ -6,12 +6,12 @@
  */
 
 import { EuiFocusTrap, EuiScreenReaderOnly } from '@elastic/eui';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DraggableId } from 'react-beautiful-dnd';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 
-import { ColumnHeaderOptions, DataProvider } from '../../../../common/types/timeline';
+import { ColumnHeaderOptions, DataProvider, TimelineId } from '../../../../common/types/timeline';
 import { stopPropagationAndPreventDefault } from '../../../../../timelines/public';
 import { SHOW_TOP_N_KEYBOARD_SHORTCUT } from './keyboard_shortcut_constants';
 import { useHoverActionItems } from './use_hover_action_items';
@@ -144,6 +144,7 @@ export const HoverActions: React.FC<Props> = React.memo(
     const [stKeyboardEvent, setStKeyboardEvent] = useState<React.KeyboardEvent>();
     const [isActive, setIsActive] = useState(false);
     const [isOverflowPopoverOpen, setIsOverflowPopoverOpen] = useState(false);
+    const isCaseView = useMemo(() => timelineId === TimelineId.casePage, [timelineId]);
     const onOverflowButtonClick = useCallback(() => {
       setIsActive((prev) => !prev);
       setIsOverflowPopoverOpen(!isOverflowPopoverOpen);
@@ -207,10 +208,11 @@ export const HoverActions: React.FC<Props> = React.memo(
       dataType,
       defaultFocusedButtonRef,
       draggableId,
-      enableOverflowButton,
+      enableOverflowButton: enableOverflowButton && !isCaseView,
       field,
       handleHoverActionClicked,
       hideTopN,
+      isCaseView,
       isObjectArray,
       isOverflowPopoverOpen,
       onFilterAdded,
@@ -245,7 +247,7 @@ export const HoverActions: React.FC<Props> = React.memo(
 
           {additionalContent != null && <AdditionalContent>{additionalContent}</AdditionalContent>}
 
-          {enableOverflowButton ? overflowActionItems : allActionItems}
+          {enableOverflowButton && !isCaseView ? overflowActionItems : allActionItems}
         </StyledHoverActionsContainer>
       </EuiFocusTrap>
     );

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiFocusTrap, EuiScreenReaderOnly } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { DraggableId } from 'react-beautiful-dnd';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
@@ -144,7 +144,6 @@ export const HoverActions: React.FC<Props> = React.memo(
     const [stKeyboardEvent, setStKeyboardEvent] = useState<React.KeyboardEvent>();
     const [isActive, setIsActive] = useState(false);
     const [isOverflowPopoverOpen, setIsOverflowPopoverOpen] = useState(false);
-    const isCaseView = useMemo(() => timelineId === TimelineId.casePage, [timelineId]);
     const onOverflowButtonClick = useCallback(() => {
       setIsActive((prev) => !prev);
       setIsOverflowPopoverOpen(!isOverflowPopoverOpen);
@@ -202,6 +201,8 @@ export const HoverActions: React.FC<Props> = React.memo(
       },
       [ownFocus, toggleTopN]
     );
+
+    const isCaseView = timelineId === TimelineId.casePage;
 
     const { overflowActionItems, allActionItems } = useHoverActionItems({
       dataProvider,

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.test.tsx
@@ -23,6 +23,7 @@ describe('useHoverActionItems', () => {
     field: 'signal.rule.name',
     handleHoverActionClicked: jest.fn(),
     hideTopN: false,
+    isCaseView: false,
     isObjectArray: false,
     ownFocus: false,
     showTopN: false,
@@ -156,6 +157,31 @@ describe('useHoverActionItems', () => {
       result.current.overflowActionItems[2].props.items.forEach((item: JSX.Element) => {
         expect(item.props['data-test-subj']).not.toEqual('hover-actions-toggle-column');
       });
+    });
+  });
+
+  test('should not have filter in, filter out, or toggle column', async () => {
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook(() => {
+        const testProps = {
+          ...defaultProps,
+          isCaseView: true,
+          enableOverflowButton: false,
+        };
+        return useHoverActionItems(testProps);
+      });
+      await waitForNextUpdate();
+
+      expect(result.current.allActionItems).toHaveLength(3);
+      expect(result.current.allActionItems[0].props['data-test-subj']).toEqual(
+        'hover-actions-add-timeline'
+      );
+      expect(result.current.allActionItems[1].props['data-test-subj']).toEqual(
+        'hover-actions-show-top-n'
+      );
+      expect(result.current.allActionItems[2].props['data-test-subj']).toEqual(
+        'hover-actions-copy-button'
+      );
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
@@ -32,6 +32,7 @@ export interface UseHoverActionItemsProps {
   field: string;
   handleHoverActionClicked: () => void;
   hideTopN: boolean;
+  isCaseView: boolean;
   isObjectArray: boolean;
   isOverflowPopoverOpen?: boolean;
   itemsToShow?: number;
@@ -60,6 +61,7 @@ export const useHoverActionItems = ({
   field,
   handleHoverActionClicked,
   hideTopN,
+  isCaseView,
   isObjectArray,
   isOverflowPopoverOpen,
   itemsToShow = 2,
@@ -119,9 +121,8 @@ export const useHoverActionItems = ({
    * in the case of `EnableOverflowButton`, we only need to hide all the items in the overflow popover as the chart's panel opens in the overflow popover, so non-overflowed actions are not affected.
    */
   const showFilters =
-    values != null && (enableOverflowButton || (!showTopN && !enableOverflowButton));
-
-  const shouldDisableColumnToggle = isObjectArray && field !== 'geo_point';
+    values != null && (enableOverflowButton || (!showTopN && !enableOverflowButton)) && !isCaseView;
+  const shouldDisableColumnToggle = (isObjectArray && field !== 'geo_point') || isCaseView;
 
   const allItems = useMemo(
     () =>
@@ -275,7 +276,7 @@ export const useHoverActionItems = ({
     () =>
       [
         ...allItems.slice(0, itemsToShow),
-        ...(enableOverflowButton && itemsToShow > 0
+        ...(enableOverflowButton && itemsToShow > 0 && itemsToShow < allItems.length
           ? [
               getOverflowButton({
                 closePopOver: handleHoverActionClicked,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/108852

The filter in, filter out, and toggle column hover actions are no longer visible in the case view as they don't have any useful functionality in that view.

<img width="1753" alt="Screen Shot 2021-08-25 at 11 29 28 AM" src="https://user-images.githubusercontent.com/17211684/130827225-ba84da3f-ea3f-4c93-9f20-4b32c54823c4.png">

<img width="1753" alt="Screen Shot 2021-08-25 at 11 29 47 AM" src="https://user-images.githubusercontent.com/17211684/130827270-e476466b-64d7-47f5-8493-47efa5b35402.png">

 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



