### PR TITLE
Adds 'triage_needed' label on security solution bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report_security_solution.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report_security_solution.md
@@ -2,7 +2,7 @@
 name: Bug report for Security Solution
 about: Help us identify bugs in Elastic Security, SIEM, and Endpoint so we can fix them!
 title: '[Security Solution]'
-labels: 'bug, Team: SecuritySolution'
+labels: 'bug, Team: SecuritySolution, triage_needed'
 ---
 
 **Describe the bug:**


### PR DESCRIPTION
## Summary

In Security Solution bug triaging flow we first triage those tickets that have the `triage_needed ` label. In order to don't miss any ticket, instead of adding this label manually, makes more sense to have it by default when reporting a ticket.