### PR TITLE
[DataViews] filter `apm-` sources when deciding which empty state to show

### DIFF
--- a/src/plugins/index_pattern_editor/public/components/empty_prompts/empty_prompts.test.tsx
+++ b/src/plugins/index_pattern_editor/public/components/empty_prompts/empty_prompts.test.tsx
@@ -95,4 +95,170 @@ describe('isUserDataIndex', () => {
     };
     expect(isUserDataIndex(fleetAssetIndex)).toBe(false);
   });
+
+  test('apm sources are not user sources', () => {
+    const apmSources: MatchedItem[] = [
+      {
+        name: 'apm-7.14.1-error',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-error',
+          indices: ['apm-7.14.1-error-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-error-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-error-000001',
+          aliases: ['apm-7.14.1-error'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-metric',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-metric',
+          indices: ['apm-7.14.1-metric-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-metric-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-metric-000001',
+          aliases: ['apm-7.14.1-metric'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-onboarding-2021.08.25',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-onboarding-2021.08.25',
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-profile',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-profile',
+          indices: ['apm-7.14.1-profile-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-profile-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-profile-000001',
+          aliases: ['apm-7.14.1-profile'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-span',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-span',
+          indices: ['apm-7.14.1-span-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-span-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-span-000001',
+          aliases: ['apm-7.14.1-span'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-transaction',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-transaction',
+          indices: ['apm-7.14.1-transaction-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-transaction-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-transaction-000001',
+          aliases: ['apm-7.14.1-transaction'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+    ];
+
+    expect(apmSources.some(isUserDataIndex)).toBe(false);
+  });
 });

--- a/src/plugins/index_pattern_editor/public/components/empty_prompts/empty_prompts.tsx
+++ b/src/plugins/index_pattern_editor/public/components/empty_prompts/empty_prompts.tsx
@@ -38,6 +38,9 @@ export function isUserDataIndex(source: MatchedItem) {
   if (source.name === FLEET_ASSETS_TO_IGNORE.METRICS_DATA_STREAM_TO_IGNORE) return false;
   if (source.name === FLEET_ASSETS_TO_IGNORE.METRICS_ENDPOINT_INDEX_TO_IGNORE) return false;
 
+  // filter out empty sources created by apm server
+  if (source.name.startsWith('apm-')) return false;
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/110060
This is a follow to https://github.com/elastic/kibana/pull/108887, we want to improve the onboarding experience and fix the "empty" state on the index pattern page.

When you create a new instance in a cloud and land into index pattern management we present an empty state. 

There are two states of "empty state": 

1. "No data" state 
![Screen Shot 2021-08-20 at 12 57 57](https://user-images.githubusercontent.com/7784120/130828113-a4707e7e-bfff-41a3-a813-d1dd26cc5d8a.png)


2. "No index patterns" state

![Screen Shot 2021-08-20 at 12 58 30](https://user-images.githubusercontent.com/7784120/130828157-9ab39072-6b2b-40e8-89f7-0ca53954f0ae.png)

----

Currently, when you land into kibana after creating a new instance in cloud there is a bunch of `apm-` indices created by default that we treat as user data (because they don't start with `.`). 

![Screen Shot 2021-08-20 at 10 51 26](https://user-images.githubusercontent.com/7784120/130828471-28cedbfa-bb3d-4db7-b73c-cee97f152958.png)

Because of those, we decide to show "No index patterns" state instead of "No data" state. 

This pr fixes it and filters out indices and aliases that start with `apm-` so now we will present the "no data" state in such cases.

----

I am not sure if there are any other edge cases we need to handle, to find these `apm-` indices I just created a new instance in cloud and made sure this pr ignore indices that prevent "no data" state to show up

