### PR TITLE
[Data] Update esaggs function to use count aggregation by default

### DIFF
--- a/src/plugins/data/common/search/expressions/esaggs/esaggs_fn.ts
+++ b/src/plugins/data/common/search/expressions/esaggs/esaggs_fn.ts
@@ -9,12 +9,13 @@
 import { i18n } from '@kbn/i18n';
 import { Observable } from 'rxjs';
 
-import { Datatable, ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
+import type { Datatable, ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
+import { buildExpressionFunction } from '../../../../../../plugins/expressions/common';
 
 import { IndexPatternExpressionType } from '../../../index_patterns/expressions';
 import { IndexPatternsContract } from '../../../index_patterns/index_patterns';
 
-import { AggsStart, AggExpressionType } from '../../aggs';
+import { AggsStart, AggExpressionType, aggCountFnName } from '../../aggs';
 import { ISearchStartSearchSource } from '../../search_source';
 
 import { KibanaContext } from '../kibana_context_type';
@@ -67,6 +68,7 @@ export const getEsaggsMeta: () => Omit<EsaggsExpressionFunctionDefinition, 'fn'>
     aggs: {
       types: ['agg_type'],
       multi: true,
+      default: `{${buildExpressionFunction(aggCountFnName, {}).toString()}}`,
       help: i18n.translate('data.search.functions.esaggs.aggConfigs.help', {
         defaultMessage: 'List of aggs configured with agg_type functions',
       }),

--- a/src/plugins/data/common/search/expressions/esaggs/esaggs_fn.ts
+++ b/src/plugins/data/common/search/expressions/esaggs/esaggs_fn.ts
@@ -67,7 +67,6 @@ export const getEsaggsMeta: () => Omit<EsaggsExpressionFunctionDefinition, 'fn'>
     aggs: {
       types: ['agg_type'],
       multi: true,
-      default: [],
       help: i18n.translate('data.search.functions.esaggs.aggConfigs.help', {
         defaultMessage: 'List of aggs configured with agg_type functions',
       }),

--- a/src/plugins/data/public/search/expressions/esaggs.test.ts
+++ b/src/plugins/data/public/search/expressions/esaggs.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { omit } from 'lodash';
 import { of as mockOf } from 'rxjs';
 import type { MockedKeys } from '@kbn/utility-types/jest';
 import type { ExecutionContext } from 'src/plugins/expressions/public';
@@ -88,6 +89,12 @@ describe('esaggs expression function - public', () => {
       {},
       args.aggs.map((agg) => agg.value)
     );
+  });
+
+  test('calls aggs.createAggConfigs with the empty aggs array when not provided', async () => {
+    await definition().fn(null, omit(args, 'aggs'), mockHandlers).toPromise();
+
+    expect(startDependencies.aggs.createAggConfigs).toHaveBeenCalledWith({}, []);
   });
 
   test('calls getEsaggsMeta to retrieve meta', () => {

--- a/src/plugins/data/public/search/expressions/esaggs.ts
+++ b/src/plugins/data/public/search/expressions/esaggs.ts
@@ -44,7 +44,7 @@ export function getFunctionDefinition({
         const indexPattern = await indexPatterns.create(args.index.value, true);
         const aggConfigs = aggs.createAggConfigs(
           indexPattern,
-          args.aggs!.map((agg) => agg.value)
+          args.aggs?.map((agg) => agg.value) ?? []
         );
         aggConfigs.hierarchical = args.metricsAtAllLevels;
 

--- a/src/plugins/data/server/search/expressions/esaggs.test.ts
+++ b/src/plugins/data/server/search/expressions/esaggs.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { omit } from 'lodash';
 import { of as mockOf } from 'rxjs';
 import type { MockedKeys } from '@kbn/utility-types/jest';
 import { KibanaRequest } from 'src/core/server';
@@ -96,6 +97,12 @@ describe('esaggs expression function - server', () => {
       {},
       args.aggs.map((agg) => agg.value)
     );
+  });
+
+  test('calls aggs.createAggConfigs with the empty aggs array when not provided', async () => {
+    await definition().fn(null, omit(args, 'aggs'), mockHandlers).toPromise();
+
+    expect(startDependencies.aggs.createAggConfigs).toHaveBeenCalledWith({}, []);
   });
 
   test('calls getEsaggsMeta to retrieve meta', () => {

--- a/src/plugins/data/server/search/expressions/esaggs.ts
+++ b/src/plugins/data/server/search/expressions/esaggs.ts
@@ -56,7 +56,7 @@ export function getFunctionDefinition({
         const indexPattern = await indexPatterns.create(args.index.value, true);
         const aggConfigs = aggs.createAggConfigs(
           indexPattern,
-          args.aggs!.map((agg) => agg.value)
+          args.aggs?.map((agg) => agg.value) ?? []
         );
 
         aggConfigs.hierarchical = args.metricsAtAllLevels;

--- a/x-pack/plugins/canvas/public/components/datatable/datatable.tsx
+++ b/x-pack/plugins/canvas/public/components/datatable/datatable.tsx
@@ -40,6 +40,8 @@ const getIcon = (type: DatatableColumnType | null) => {
 
 const getColumnName = (col: DatatableColumn) => (typeof col === 'string' ? col : col.name);
 
+const getColumnId = (col: DatatableColumn) => (typeof col === 'string' ? col : col.id);
+
 const getColumnType = (col: DatatableColumn) => col.meta?.type || null;
 
 const getFormattedValue = (val: any, type: any) => {
@@ -85,7 +87,7 @@ export const Datatable: FC<Props> = ({
                 <tr key={i} className="canvasDataTable__tr">
                   {datatable.columns.map((col) => (
                     <td key={`row-${i}-${getColumnName(col)}`} className="canvasDataTable__td">
-                      {getFormattedValue(row[getColumnName(col)], getColumnType(col))}
+                      {getFormattedValue(row[getColumnId(col)], getColumnType(col))}
                     </td>
                   ))}
                 </tr>


### PR DESCRIPTION
## Summary

This pull-request resolves #67525 by providing the default value for the `aggs` argument. Apart from that, it fixes the data table element in canvas to use column id instead of the column name since the name and id returned by the `esaggs` function are different.

Previously, the `esaggs` function didn't work without providing at least one value in the `aggs` argument. That bug was caused by an incorrect default value which was an empty array. The updated default value should not break any of the existing expressions since that wasn't working before.

The change can be tested in canvas using the following expression:
```
esaggs index={indexPatternLoad id="..."}
| render
```

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers
- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
