### PR TITLE
[7.14] chore(NA): moving @kbn/securitysolution-io-ts-alerting-types to babel transpiler (#109745)

### DIFF
--- a/packages/kbn-securitysolution-io-ts-alerting-types/.babelrc
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]  
+}

--- a/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-securitysolution-io-ts-alerting-types"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-io-ts-alerting-types"
@@ -26,27 +27,29 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-securitysolution-io-ts-types",
   "//packages/kbn-securitysolution-io-ts-utils",
-  "//packages/elastic-datemath",
   "@npm//fp-ts",
   "@npm//io-ts",
-  "@npm//lodash",
-  "@npm//moment",
-  "@npm//tslib",
   "@npm//uuid",
 ]
 
 TYPES_DEPS = [
-  "@npm//@types/flot",
+  "//packages/kbn-securitysolution-io-ts-types",
+  "//packages/kbn-securitysolution-io-ts-utils",
+  "@npm//fp-ts",
+  "@npm//io-ts",
   "@npm//@types/jest",
-  "@npm//@types/lodash",
   "@npm//@types/node",
   "@npm//@types/uuid"
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -57,23 +60,24 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  incremental = True,
-  out_dir = "target",
-  source_map = True,
+  emit_declaration_only = True,
+  incremental = False,
+  out_dir = "target_types",
   root_dir = "src",
+  source_map = True,
   tsconfig = ":tsconfig",
 )
 
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-alerting-types/package.json
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "io ts utilities and types to be shared with plugins from the security solution project",
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "private": true
 }

--- a/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "incremental": true,
-    "outDir": "target",
+    "emitDeclarationOnly": true,
+    "incremental": false,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-alerting-types/src",


### PR DESCRIPTION
Backports the following commits to 7.14:
 - chore(NA): moving @kbn/securitysolution-io-ts-alerting-types to babel transpiler (#109745)