### PR TITLE
[APM] Bugfix: Increase table columns for latency and throughput

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -101,7 +101,7 @@ export function getColumns({
     {
       field: 'latency',
       name: getLatencyColumnLabel(latencyAggregationType),
-      width: `${unit * 10}px`,
+      width: `${unit * 11}px`,
       render: (_, { serviceNodeName, latency }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.latency;
@@ -126,7 +126,7 @@ export function getColumns({
         'xpack.apm.serviceOverview.instancesTableColumnThroughput',
         { defaultMessage: 'Throughput' }
       ),
-      width: `${unit * 10}px`,
+      width: `${unit * 11}px`,
       render: (_, { serviceNodeName, throughput }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.throughput;

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -81,7 +81,7 @@ export function SparkPlot({
   return (
     <EuiFlexGroup
       justifyContent="spaceBetween"
-      gutterSize="m"
+      gutterSize="xs"
       responsive={false}
       alignItems="flexEnd"
     >

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -80,7 +80,7 @@ export function DependenciesTable(props: Props) {
       name: i18n.translate('xpack.apm.dependenciesTable.columnLatency', {
         defaultMessage: 'Latency (avg.)',
       }),
-      width: `${unit * 10}px`,
+      width: `${unit * 11}px`,
       render: (_, { currentStats, previousStats }) => {
         return (
           <SparkPlot
@@ -99,7 +99,7 @@ export function DependenciesTable(props: Props) {
       name: i18n.translate('xpack.apm.dependenciesTable.columnThroughput', {
         defaultMessage: 'Throughput',
       }),
-      width: `${unit * 10}px`,
+      width: `${unit * 11}px`,
       render: (_, { currentStats, previousStats }) => {
         return (
           <SparkPlot

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -71,7 +71,7 @@ export function getColumns({
       field: 'latency',
       sortable: true,
       name: getLatencyColumnLabel(latencyAggregationType),
-      width: `${unit * 10}px`,
+      width: `${unit * 11}px`,
       render: (_, { latency, name }) => {
         const currentTimeseries =
           transactionGroupDetailedStatistics?.currentPeriod?.[name]?.latency;
@@ -97,7 +97,7 @@ export function getColumns({
         'xpack.apm.serviceOverview.transactionsTableColumnThroughput',
         { defaultMessage: 'Throughput' }
       ),
-      width: `${unit * 10}px`,
+      width: `${unit * 11}px`,
       render: (_, { throughput, name }) => {
         const currentTimeseries =
           transactionGroupDetailedStatistics?.currentPeriod?.[name]?.throughput;


### PR DESCRIPTION
## Summary

Since increasing the sparkplot widths in https://github.com/elastic/kibana/pull/108516, a problem has arisen when the character size is increased.

![image](https://user-images.githubusercontent.com/4104278/130938458-31892da1-04b2-4aa4-be9c-0e4add3453d2.png)

## Solution

Increased the column widths for latency and throughput which commonly are variable in characters because they're duration and counts.

**Before**

<img width="1146" alt="CleanShot 2021-08-26 at 11 39 41@2x" src="https://user-images.githubusercontent.com/4104278/130940355-9027db11-1cfc-4b21-8b76-230d95cefd54.png">
<img width="1146" alt="CleanShot 2021-08-26 at 11 39 50@2x" src="https://user-images.githubusercontent.com/4104278/130940367-dde36c41-811c-40c0-b290-504a8410d0fc.png">
<img width="1645" alt="CleanShot 2021-08-26 at 11 39 56@2x" src="https://user-images.githubusercontent.com/4104278/130940374-a49f2b89-7d42-4bd4-a488-3235ccd84e40.png">

**After**

<img width="1148" alt="CleanShot 2021-08-26 at 11 35 54@2x" src="https://user-images.githubusercontent.com/4104278/130940400-69343504-d792-4b6a-b98d-7916d4c28f72.png">
<img width="1152" alt="CleanShot 2021-08-26 at 11 36 03@2x" src="https://user-images.githubusercontent.com/4104278/130940417-c19f635c-6d1c-4194-828f-7f140387e6aa.png">
<img width="1646" alt="CleanShot 2021-08-26 at 11 36 09@2x" src="https://user-images.githubusercontent.com/4104278/130940430-0dc3a72a-0523-4737-926d-981c3beeb869.png">
