### PR TITLE
[APM] Traces list: Decrease link size and impact indication

### DIFF
--- a/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
@@ -14,7 +14,7 @@ import {
   asTransactionRate,
 } from '../../../../common/utils/formatters';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
-import { truncate } from '../../../utils/style';
+import { truncate, unit } from '../../../utils/style';
 import { EmptyMessage } from '../../shared/EmptyMessage';
 import { ImpactBar } from '../../shared/ImpactBar';
 import { TransactionDetailLink } from '../../shared/Links/apm/transaction_detail_link';
@@ -111,7 +111,7 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
         </>
       </EuiToolTip>
     ),
-    width: '20%',
+    width: `${unit * 6}px`,
     align: 'left',
     sortable: true,
     render: (_, { impact }) => <ImpactBar value={impact} />,

--- a/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
@@ -24,7 +24,7 @@ import { ITableColumn, ManagedTable } from '../../shared/managed_table';
 type TraceGroup = APIReturnType<'GET /api/apm/traces'>['items'][0];
 
 const StyledTransactionLink = euiStyled(TransactionDetailLink)`
-  font-size: ${({ theme }) => theme.eui.euiFontSizeM};
+  font-size: ${({ theme }) => theme.eui.euiFontSizeS};
   ${truncate('100%')};
 `;
 


### PR DESCRIPTION
## Summary

- [x] Decreased the link size for Traces list
- [x] Decreased the impact indication column to make it consistent with other tables 

**Before**

<img width="927" alt="CleanShot 2021-08-26 at 11 54 31@2x" src="https://user-images.githubusercontent.com/4104278/130942845-95736ad4-7dca-4b83-ab51-615bb1f97794.png">

<img width="713" alt="CleanShot 2021-08-26 at 12 02 27@2x" src="https://user-images.githubusercontent.com/4104278/130943742-29b2ba7a-f1cd-44d9-89ab-729146d98247.png">

**After**

<img width="988" alt="CleanShot 2021-08-26 at 11 52 38@2x" src="https://user-images.githubusercontent.com/4104278/130942872-90cc14f0-b549-4d4e-a232-542edc7b5658.png">

<img width="465" alt="CleanShot 2021-08-26 at 12 01 08@2x" src="https://user-images.githubusercontent.com/4104278/130943636-726e3c08-8a11-4aad-9c5b-5bb522c7f4b2.png">

