### PR TITLE
[Canvas] Fixes Expression Failed Exit Button not Clickable .

### DIFF
--- a/src/plugins/expression_error/public/components/error/error.tsx
+++ b/src/plugins/expression_error/public/components/error/error.tsx
@@ -6,16 +6,23 @@
  * Side Public License, v 1.
  */
 
-import React, { FC } from 'react';
+import React, { FC, MouseEventHandler } from 'react';
+import { ClassNames } from '@emotion/react';
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { get } from 'lodash';
 import { ShowDebugging } from './show_debugging';
+
+const euiCallOutHeaderClassDef = `
+  .euiCallOutHeader__icon {
+    cursor: pointer;
+  }
+`;
 
 export interface Props {
   payload: {
     error: Error;
   };
+  onClose?: () => void;
 }
 
 const strings = {
@@ -29,20 +36,34 @@ const strings = {
     }),
 };
 
-export const Error: FC<Props> = ({ payload }) => {
-  const message = get(payload, 'error.message');
+export const Error: FC<Props> = ({ payload, onClose }) => {
+  const message = payload.error?.message;
+
+  const onCalloutClose: MouseEventHandler<HTMLDivElement> = (e) => {
+    e.stopPropagation();
+    const isHeaderCloseButton = (e.target as Element).classList.contains('euiCallOutHeader__icon');
+    if (isHeaderCloseButton) {
+      onClose?.();
+    }
+  };
 
   return (
-    <EuiCallOut
-      style={{ maxWidth: 500 }}
-      color="danger"
-      iconType="cross"
-      title={strings.getTitle()}
-    >
-      <p>{message ? strings.getDescription() : ''}</p>
-      {message && <p style={{ padding: '0 16px' }}>{message}</p>}
+    <ClassNames>
+      {({ css }) => (
+        <EuiCallOut
+          style={{ maxWidth: 500 }}
+          color="danger"
+          iconType="cross"
+          title={strings.getTitle()}
+          onClick={onCalloutClose}
+          className={css(euiCallOutHeaderClassDef)}
+        >
+          <p>{message ? strings.getDescription() : ''}</p>
+          {message && <p style={{ padding: '0 16px' }}>{message}</p>}
 
-      <ShowDebugging payload={payload} />
-    </EuiCallOut>
+          <ShowDebugging payload={payload} />
+        </EuiCallOut>
+      )}
+    </ClassNames>
   );
 };

--- a/src/plugins/expression_error/public/components/error/error.tsx
+++ b/src/plugins/expression_error/public/components/error/error.tsx
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import React, { FC, MouseEventHandler } from 'react';
+import React, { FC } from 'react';
 import { ClassNames } from '@emotion/react';
-import { EuiCallOut } from '@elastic/eui';
+import { EuiButtonIcon, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ShowDebugging } from './show_debugging';
 
@@ -39,13 +39,9 @@ const strings = {
 export const Error: FC<Props> = ({ payload, onClose }) => {
   const message = payload.error?.message;
 
-  const onCalloutClose: MouseEventHandler<HTMLDivElement> = (e) => {
-    e.stopPropagation();
-    const isHeaderCloseButton = (e.target as Element).classList.contains('euiCallOutHeader__icon');
-    if (isHeaderCloseButton) {
-      onClose?.();
-    }
-  };
+  const CloseIconButton = () => (
+    <EuiButtonIcon color="danger" iconType="cross" onClick={onClose} aria-hidden />
+  );
 
   return (
     <ClassNames>
@@ -53,9 +49,8 @@ export const Error: FC<Props> = ({ payload, onClose }) => {
         <EuiCallOut
           style={{ maxWidth: 500 }}
           color="danger"
-          iconType="cross"
+          iconType={CloseIconButton}
           title={strings.getTitle()}
-          onClick={onCalloutClose}
           className={css(euiCallOutHeaderClassDef)}
         >
           <p>{message ? strings.getDescription() : ''}</p>

--- a/src/plugins/expression_error/public/components/error/error.tsx
+++ b/src/plugins/expression_error/public/components/error/error.tsx
@@ -7,16 +7,9 @@
  */
 
 import React, { FC } from 'react';
-import { ClassNames } from '@emotion/react';
 import { EuiButtonIcon, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ShowDebugging } from './show_debugging';
-
-const euiCallOutHeaderClassDef = `
-  .euiCallOutHeader__icon {
-    cursor: pointer;
-  }
-`;
 
 export interface Props {
   payload: {
@@ -44,21 +37,16 @@ export const Error: FC<Props> = ({ payload, onClose }) => {
   );
 
   return (
-    <ClassNames>
-      {({ css }) => (
-        <EuiCallOut
-          style={{ maxWidth: 500 }}
-          color="danger"
-          iconType={CloseIconButton}
-          title={strings.getTitle()}
-          className={css(euiCallOutHeaderClassDef)}
-        >
-          <p>{message ? strings.getDescription() : ''}</p>
-          {message && <p style={{ padding: '0 16px' }}>{message}</p>}
+    <EuiCallOut
+      style={{ maxWidth: 500 }}
+      color="danger"
+      iconType={CloseIconButton}
+      title={strings.getTitle()}
+    >
+      <p>{message ? strings.getDescription() : ''}</p>
+      {message && <p style={{ padding: '0 16px' }}>{message}</p>}
 
-          <ShowDebugging payload={payload} />
-        </EuiCallOut>
-      )}
-    </ClassNames>
+      <ShowDebugging payload={payload} />
+    </EuiCallOut>
   );
 };

--- a/src/plugins/expression_error/public/components/error_component.tsx
+++ b/src/plugins/expression_error/public/components/error_component.tsx
@@ -28,6 +28,7 @@ function ErrorComponent({ onLoaded, parentNode, error }: ErrorComponentProps) {
   const [isPopoverOpen, setPopoverOpen] = useState<boolean>(false);
 
   const handlePopoverClick = () => setPopoverOpen(!isPopoverOpen);
+
   const closePopover = () => setPopoverOpen(false);
 
   const updateErrorView = useCallback(() => {
@@ -56,7 +57,7 @@ function ErrorComponent({ onLoaded, parentNode, error }: ErrorComponentProps) {
         }
         isOpen={isPopoverOpen}
       >
-        <Error payload={{ error }} />
+        <Error payload={{ error }} onClose={closePopover} />
       </EuiPopover>
     </div>
   );


### PR DESCRIPTION
#### Closes: https://github.com/elastic/kibana/issues/92643. 

Made `cross` icon at `Error` component clickable.  