### PR TITLE
[Security Solution] [Detections] Fixes opening alerts test in master

### DIFF
--- a/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/alerts.ts
@@ -25,7 +25,7 @@ import {
   TIMELINE_CONTEXT_MENU_BTN,
   SELECT_EVENT_CHECKBOX,
 } from '../screens/alerts';
-import { REFRESH_BUTTON } from '../screens/security_header';
+import { LOADING_INDICATOR, REFRESH_BUTTON } from '../screens/security_header';
 import { TIMELINE_COLUMN_SPINNER } from '../screens/timeline';
 import {
   UPDATE_ENRICHMENT_RANGE_BUTTON,
@@ -99,7 +99,8 @@ export const goToOpenedAlerts = () => {
   cy.get(OPENED_ALERTS_FILTER_BTN).click({ force: true });
   cy.get(REFRESH_BUTTON).should('not.have.text', 'Updating');
   cy.get(REFRESH_BUTTON).should('have.text', 'Refresh');
-  cy.get(TIMELINE_COLUMN_SPINNER).should('not.exist');
+  cy.get(LOADING_INDICATOR).should('exist');
+  cy.get(LOADING_INDICATOR).should('not.exist');
 };
 
 export const openFirstAlert = () => {


### PR DESCRIPTION
## Summary

In this PR we are fixing the flaky `Opening alerts` Cypress tests in master.

This is the failure we are getting:

`Timed out retrying after 60000ms: expected '<span.AlertCount-sc-1i6vtz8-27.bVREKt>' to have text '494 alerts', but the text was '4 alerts'`

That failure is happening after the alert is opened and we navigate to the opened alerts view to check that the number is correct.

Taking into account that after opening the alert we have 496 opened alerts and 4 closed, looks like that as Jenkins is a slow machine, we are not giving enough time to load the opened alerts and we are getting the number of the closed ones.

In order to solve this issue, instead of relying on the `[data-test-subj="timeline-loading-spinner"]` element (that looks like does not exist anymore in the source code), to wait until the alerts are properly loaded, we are relying now on the `'[data-test-subj="globalLoadingIndicator"]'` displayed on the global header of the application.

In further PRs we should walkthrough that non existent element and update the tests.

