### PR TITLE
[7.14] [DataViews] filter apm- sources when deciding which empty state to show(#110094) (#110094)

### DIFF
--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.test.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.test.tsx
@@ -98,4 +98,170 @@ describe('isUserDataIndex', () => {
     };
     expect(isUserDataIndex(fleetAssetIndex)).toBe(false);
   });
+
+  test('apm sources are not user sources', () => {
+    const apmSources: MatchedItem[] = [
+      {
+        name: 'apm-7.14.1-error',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-error',
+          indices: ['apm-7.14.1-error-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-error-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-error-000001',
+          aliases: ['apm-7.14.1-error'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-metric',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-metric',
+          indices: ['apm-7.14.1-metric-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-metric-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-metric-000001',
+          aliases: ['apm-7.14.1-metric'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-onboarding-2021.08.25',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-onboarding-2021.08.25',
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-profile',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-profile',
+          indices: ['apm-7.14.1-profile-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-profile-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-profile-000001',
+          aliases: ['apm-7.14.1-profile'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-span',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-span',
+          indices: ['apm-7.14.1-span-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-span-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-span-000001',
+          aliases: ['apm-7.14.1-span'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+      {
+        name: 'apm-7.14.1-transaction',
+        tags: [
+          {
+            key: 'alias',
+            name: 'Alias',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-transaction',
+          indices: ['apm-7.14.1-transaction-000001'],
+        },
+      },
+      {
+        name: 'apm-7.14.1-transaction-000001',
+        tags: [
+          {
+            key: 'index',
+            name: 'Index',
+            color: 'default',
+          },
+        ],
+        item: {
+          name: 'apm-7.14.1-transaction-000001',
+          aliases: ['apm-7.14.1-transaction'],
+          attributes: [ResolveIndexResponseItemIndexAttrs.OPEN],
+        },
+      },
+    ];
+
+    expect(apmSources.some(isUserDataIndex)).toBe(false);
+  });
 });

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -69,6 +69,9 @@ export function isUserDataIndex(source: MatchedItem) {
   if (source.name === FLEET_ASSETS_TO_IGNORE.METRICS_DATA_STREAM_TO_IGNORE) return false;
   if (source.name === FLEET_ASSETS_TO_IGNORE.METRICS_ENDPOINT_INDEX_TO_IGNORE) return false;
 
+  // filter out empty sources created by apm server
+  if (source.name.startsWith('apm-')) return false;
+
   return true;
 }
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DataViews] filter apm- sources when deciding which empty state to show(#110094) (#110094)