### PR TITLE
[Home app] Fix `this` references

### DIFF
--- a/src/plugins/home/public/application/components/home.tsx
+++ b/src/plugins/home/public/application/components/home.tsx
@@ -117,7 +117,7 @@ export class Home extends Component<HomeProps, State> {
     return this.props.directories.find((directory) => directory.id === id);
   }
 
-  getFeaturesByCategory(category: FeatureCatalogueCategory) {
+  private getFeaturesByCategory(category: FeatureCatalogueCategory) {
     return this.props.directories
       .filter((directory) => directory.showOnHomePage && directory.category === category)
       .sort((directoryA, directoryB) => (directoryA.order ?? -1) - (directoryB.order ?? -1));
@@ -177,7 +177,7 @@ export class Home extends Component<HomeProps, State> {
   private renderWelcome() {
     return (
       <Welcome
-        onSkip={this.skipWelcome}
+        onSkip={() => this.skipWelcome()}
         urlBasePath={this.props.urlBasePath}
         telemetry={this.props.telemetry}
       />

--- a/test/functional/apps/home/_welcome.ts
+++ b/test/functional/apps/home/_welcome.ts
@@ -26,5 +26,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.common.navigateToUrl('home', undefined, { disableWelcomePrompt: false });
       expect(await PageObjects.home.isWelcomeInterstitialDisplayed()).to.be(true);
     });
+
+    it('clicking on "Explore on my own" redirects to the "home" page', async () => {
+      await PageObjects.common.navigateToUrl('home', undefined, { disableWelcomePrompt: false });
+      expect(await PageObjects.home.isWelcomeInterstitialDisplayed()).to.be(true);
+      await PageObjects.common.clickAndValidate('skipWelcomeScreen', 'homeApp');
+    });
   });
 }

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -487,7 +487,11 @@ export class CommonPageObject extends FtrService {
     topOffset?: number
   ) {
     await this.testSubjects.click(clickTarget, undefined, topOffset);
-    const validate = isValidatorCssString ? this.find.byCssSelector : this.testSubjects.exists;
+    // Wrapping them in an arrow function so the methods below don't loose their internal `this` references
+    const validate = (validatorStr: string) =>
+      isValidatorCssString
+        ? this.find.byCssSelector(validatorStr)
+        : this.testSubjects.exists(validatorStr);
     await validate(validator);
   }
 }

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -487,11 +487,10 @@ export class CommonPageObject extends FtrService {
     topOffset?: number
   ) {
     await this.testSubjects.click(clickTarget, undefined, topOffset);
-    // Wrapping them in an arrow function so the methods below don't loose their internal `this` references
-    const validate = (validatorStr: string) =>
-      isValidatorCssString
-        ? this.find.byCssSelector(validatorStr)
-        : this.testSubjects.exists(validatorStr);
-    await validate(validator);
+    if (isValidatorCssString) {
+      await this.find.byCssSelector(validator);
+    } else {
+      await this.testSubjects.exists(validator);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Resolves #110133.

After refactoring to TS the `Home` component, we lost the `this` context of the `skipWelcome` method because we changed its declaration from `cost = arrow function` to `function in a class`. This PR adds an arrow function wrapper to the use of the method to fix this.

It also adds a new functional test to catch these issues in the future. While doing so, I noticed that the same issue was happening internally `PageObjects.common.clickAndValidate`.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
