### PR TITLE
[fieldFormats] remove reliance on `eslint-rule-no-export-all`

### DIFF
--- a/src/plugins/field_formats/common/index.ts
+++ b/src/plugins/field_formats/common/index.ts
@@ -51,5 +51,3 @@ export {
   IFieldFormat,
   FieldFormatsStartCommon,
 } from './types';
-
-export * from './errors';


### PR DESCRIPTION
Close https://github.com/elastic/kibana/issues/109901

Looks like nothing uses those exported errors (there is only a `FieldFormatNotFoundError`), so I decided to not even export them.
We can export it whenever someone needs it