### PR TITLE
[Canvas] Fixes Expression errors are not rendered as markdown.

### DIFF
--- a/src/plugins/expression_error/kibana.json
+++ b/src/plugins/expression_error/kibana.json
@@ -11,5 +11,5 @@
   "ui": true,
   "requiredPlugins": ["expressions", "presentationUtil"],
   "optionalPlugins": [],
-  "requiredBundles": []
+  "requiredBundles": ["kibanaReact"]
 }

--- a/src/plugins/expression_error/public/components/error/error.tsx
+++ b/src/plugins/expression_error/public/components/error/error.tsx
@@ -11,6 +11,7 @@ import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { get } from 'lodash';
 import { ShowDebugging } from './show_debugging';
+import { Markdown } from '../../../../kibana_react/public';
 
 export interface Props {
   payload: {
@@ -40,8 +41,11 @@ export const Error: FC<Props> = ({ payload }) => {
       title={strings.getTitle()}
     >
       <p>{message ? strings.getDescription() : ''}</p>
-      {message && <p style={{ padding: '0 16px' }}>{message}</p>}
-
+      {message && (
+        <p style={{ padding: '0 16px' }}>
+          <Markdown markdown={message} openLinksInNewTab={true} />
+        </p>
+      )}
       <ShowDebugging payload={payload} />
     </EuiCallOut>
   );


### PR DESCRIPTION
#### Closes: https://github.com/elastic/kibana/issues/110196. 

Added `Markdown` rendering of error message at `error` expression `renderer`.

##### Before:
<img width="526" alt="130947022-004a3fc8-eb54-4740-89b4-ef60131cd588" src="https://user-images.githubusercontent.com/22456368/130959133-8210220c-2d2d-48d6-b644-20cdfcd6e360.png">

##### After:
![Screenshot 2021-08-26 at 15 02 01](https://user-images.githubusercontent.com/22456368/130959213-09dcead3-4fa3-4535-9d66-fa9089c9d3af.png)
