### PR TITLE
[Security Solution] Show rule.description when displaying an alert view flyout

### DIFF
--- a/x-pack/plugins/security_solution/common/ecs/event/index.ts
+++ b/x-pack/plugins/security_solution/common/ecs/event/index.ts
@@ -54,4 +54,6 @@ export enum EventCode {
   MEMORY_SIGNATURE = 'memory_signature',
   // Memory Protection alert
   MALICIOUS_THREAD = 'malicious_thread',
+  // behavior
+  BEHAVIOR = 'behavior',
 }

--- a/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
@@ -829,6 +829,7 @@ export class EndpointDocGenerator extends BaseDataGenerator {
       },
       rule: {
         id: this.randomUUID(),
+        description: 'Behavior rule description',
       },
       event: {
         action: 'rule_detection',

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -376,6 +376,7 @@ export type AlertEvent = Partial<{
   }>;
   rule: Partial<{
     id: ECSField<string>;
+    description: ECSField<string>;
   }>;
   file: Partial<{
     owner: ECSField<string>;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/__snapshots__/alert_summary_view.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/__snapshots__/alert_summary_view.test.tsx.snap
@@ -1,5 +1,810 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AlertSummaryView Behavior event code renders additional summary rows 1`] = `
+.c1 {
+  line-height: 1.7rem;
+}
+
+.c0 .euiTableHeaderCell,
+.c0 .euiTableRowCell {
+  border: none;
+}
+
+.c0 .euiTableHeaderCell .euiTableCellContent {
+  padding: 0;
+}
+
+.c0 .flyoutOverviewDescription .hoverActions-active .timelines__hoverActionButton,
+.c0 .flyoutOverviewDescription .hoverActions-active .securitySolution__hoverActionButton {
+  opacity: 1;
+}
+
+.c0 .flyoutOverviewDescription:hover .timelines__hoverActionButton,
+.c0 .flyoutOverviewDescription:hover .securitySolution__hoverActionButton {
+  opacity: 1;
+}
+
+.c2 {
+  min-width: 138px;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2:focus-within .timelines__hoverActionButton,
+.c2:focus-within .securitySolution__hoverActionButton {
+  opacity: 1;
+}
+
+.c2:hover .timelines__hoverActionButton,
+.c2:hover .securitySolution__hoverActionButton {
+  opacity: 1;
+}
+
+.c2 .timelines__hoverActionButton,
+.c2 .securitySolution__hoverActionButton {
+  opacity: 0;
+}
+
+.c2 .timelines__hoverActionButton:focus,
+.c2 .securitySolution__hoverActionButton:focus {
+  opacity: 1;
+}
+
+.c3 {
+  padding: 4px 0;
+}
+
+<div
+  class="euiBasicTable c0"
+  data-test-subj="summary-view"
+>
+  <div>
+    <div
+      class="euiTableHeaderMobile"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+      >
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        />
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        />
+      </div>
+    </div>
+    <table
+      class="euiTable euiTable--compressed euiTable--responsive"
+      id="__table_generated-id"
+      tabindex="-1"
+    >
+      <caption
+        class="euiScreenReaderOnly euiTableCaption"
+      />
+      <thead>
+        <tr>
+          <td
+            class="euiTableHeaderCell"
+            data-test-subj="tableHeaderCell_title_0"
+            role="columnheader"
+            scope="col"
+            style="width: 220px;"
+          >
+            <span
+              class="euiTableCellContent"
+            >
+              <span
+                class="euiTableCellContent__text"
+              />
+            </span>
+          </td>
+          <td
+            class="euiTableHeaderCell"
+            data-test-subj="tableHeaderCell_description_1"
+            role="columnheader"
+            scope="col"
+          >
+            <span
+              class="euiTableCellContent"
+            >
+              <span
+                class="euiTableCellContent__text"
+              />
+            </span>
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Status
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="euiText euiText--extraSmall"
+                >
+                  open
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field signal.status. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-signal.status"
+                    field="signal.status"
+                    items="[object Object],[object Object]"
+                    value="open"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Timestamp
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="eventFieldsTable__fieldValue"
+                >
+                  <span
+                    class="euiToolTipAnchor"
+                  >
+                    Nov 25, 2020 @ 15:42:39.417
+                  </span>
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field @timestamp. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-@timestamp"
+                    field="@timestamp"
+                    items="[object Object],[object Object]"
+                    value="2020-11-25T15:42:39.417Z"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Rule
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="euiText euiText--extraSmall"
+                >
+                  xxx
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field signal.rule.name. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-signal.rule.name"
+                    field="signal.rule.name"
+                    items="[object Object],[object Object]"
+                    value="xxx"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Severity
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="euiText euiText--extraSmall"
+                >
+                  low
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field signal.rule.severity. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-signal.rule.severity"
+                    field="signal.rule.severity"
+                    items="[object Object],[object Object]"
+                    value="low"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Risk Score
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="euiText euiText--extraSmall"
+                >
+                  21
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field signal.rule.risk_score. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-signal.rule.risk_score"
+                    field="signal.rule.risk_score"
+                    items="[object Object],[object Object]"
+                    value="21"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                host.name
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="euiText euiText--extraSmall"
+                >
+                  windows-native
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field host.name. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-host.name"
+                    field="host.name"
+                    items="[object Object]"
+                    value="windows-native"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                user.name
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="euiText euiText--extraSmall"
+                >
+                  administrator
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field user.name. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-user.name"
+                    field="user.name"
+                    items="[object Object]"
+                    value="administrator"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                source.ip
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div>
+                <div
+                  class="eventFieldsTable__fieldValue"
+                >
+                  <span
+                    class="euiToolTipAnchor"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      data-test-subj="network-details"
+                      type="button"
+                    >
+                      185.156.74.3
+                    </button>
+                  </span>
+                </div>
+              </div>
+              <div
+                data-eui="EuiFocusTrap"
+              >
+                <div
+                  class="c2"
+                >
+                  <p
+                    class="euiScreenReaderOnly"
+                  >
+                    You are in a dialog, containing options for field source.ip. Press tab to navigate options. Press escape to exit.
+                  </p>
+                  <div
+                    data-test-subj="hover-actions-filter-for"
+                  >
+                    Filter button
+                  </div>
+                  <div
+                    data-test-subj="hover-actions-filter-out"
+                  >
+                    Filter out button
+                  </div>
+                  <div
+                    data-test-subj="more-actions-source.ip"
+                    field="source.ip"
+                    items="[object Object]"
+                    value="185.156.74.3"
+                  >
+                    Overflow button
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                destination.ip
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div
+                class="c3"
+              >
+                —
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Threshold Count
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div
+                class="c3"
+              >
+                —
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Threshold Terms
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div
+                class="c3"
+              >
+                —
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Threshold Cardinality
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div
+                class="c3"
+              >
+                —
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell"
+            style="width: 220px;"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--overflowingContent"
+            >
+              <h5
+                class="c1 euiTitle euiTitle--xxxsmall"
+              >
+                Rule description
+              </h5>
+            </div>
+          </td>
+          <td
+            class="euiTableRowCell"
+          >
+            <div
+              class="euiTableCellContent flyoutOverviewDescription euiTableCellContent--overflowingContent"
+            >
+              <div
+                class="c3"
+              >
+                —
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`AlertSummaryView Memory event code renders additional summary rows 1`] = `
 .c1 {
   line-height: 1.7rem;

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.test.tsx
@@ -100,4 +100,26 @@ describe('AlertSummaryView', () => {
     );
     expect(wrapper.find('div[data-test-subj="summary-view"]').render()).toMatchSnapshot();
   });
+  test('Behavior event code renders additional summary rows', () => {
+    const renderProps = {
+      ...props,
+      data: mockAlertDetailsData.map((item) => {
+        if (item.category === 'event' && item.field === 'event.code') {
+          return {
+            category: 'event',
+            field: 'event.code',
+            values: ['behavior'],
+            originalValue: ['behavior'],
+          };
+        }
+        return item;
+      }) as TimelineEventsDetailsItem[],
+    };
+    const wrapper = mount(
+      <TestProvidersComponent>
+        <AlertSummaryView {...renderProps} />
+      </TestProvidersComponent>
+    );
+    expect(wrapper.find('div[data-test-subj="summary-view"]').render()).toMatchSnapshot();
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/alert_summary_view.tsx
@@ -23,6 +23,7 @@ import {
   SIGNAL_STATUS,
   ALERTS_HEADERS_TARGET_IMPORT_HASH,
   TIMESTAMP,
+  ALERTS_HEADERS_RULE_DESCRIPTION,
 } from '../../../detections/components/alerts_table/translations';
 import {
   AGENT_STATUS_FIELD_NAME,
@@ -102,6 +103,11 @@ const memoryShellCodeAlertFields: EventSummaryField[] = [
   },
 ];
 
+const behaviorAlertFields: EventSummaryField[] = [
+  ...defaultDisplayFields,
+  { id: 'rule.description', label: ALERTS_HEADERS_RULE_DESCRIPTION },
+];
+
 const memorySignatureAlertFields: EventSummaryField[] = [
   ...defaultDisplayFields,
   { id: 'rule.name', label: ALERTS_HEADERS_RULE_NAME },
@@ -155,6 +161,8 @@ function getEventFieldsToDisplay({
       return memoryShellCodeAlertFields;
     case EventCode.MEMORY_SIGNATURE:
       return memorySignatureAlertFields;
+    case EventCode.BEHAVIOR:
+      return behaviorAlertFields;
   }
 
   switch (eventCategory) {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/translations.ts
@@ -73,6 +73,13 @@ export const ALERTS_HEADERS_RULE_NAME = i18n.translate(
   }
 );
 
+export const ALERTS_HEADERS_RULE_DESCRIPTION = i18n.translate(
+  'xpack.securitySolution.eventsViewer.alerts.defaultHeaders.ruleDescriptionTitle',
+  {
+    defaultMessage: 'Rule description',
+  }
+);
+
 export const ALERTS_HEADERS_VERSION = i18n.translate(
   'xpack.securitySolution.eventsViewer.alerts.defaultHeaders.versionTitle',
   {


### PR DESCRIPTION
## Summary

Fixes an usability bug for alert triage for Behavior alerts.

It shows the rule description field in the alerts flyout when displaying the alert view flyout

![image](https://user-images.githubusercontent.com/227916/130963935-12fa0233-af19-45ce-8571-fdeaaf77bfd8.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
