### PR TITLE
[RAC] Remove alerts from the table if user changes their workflow status

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -38,7 +38,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
-import React, { Suspense, useMemo, useState, useCallback } from 'react';
+import React, { Suspense, useMemo, useState, useCallback, useEffect } from 'react';
 import usePrevious from 'react-use/lib/usePrevious';
 import { get } from 'lodash';
 import {
@@ -305,9 +305,13 @@ export function AlertsTableTGrid(props: AlertsTableTGridProps) {
   );
 
   const [deletedEventIds, setDeletedEventIds] = useState<string[]>([]);
-  if (workflowStatus !== prevWorkflowStatus) {
-    setDeletedEventIds([]);
-  }
+
+  useEffect(() => {
+    if (workflowStatus !== prevWorkflowStatus) {
+      setDeletedEventIds([]);
+    }
+  }, [workflowStatus, prevWorkflowStatus]);
+
   const setEventsDeleted = useCallback<ObservabilityActionsProps['setEventsDeleted']>((action) => {
     if (action.isDeleted) {
       setDeletedEventIds((ids) => [...ids, ...action.eventIds]);


### PR DESCRIPTION
## Summary

Closes #109379 

When the user updates the workflow status of an alert we want to make sure it's not shown on the table anymore under the current workflow status filter.

The underlying TGrid keeps track of what rows have been deleted. We will use that mechanism to mark the rows as deleted when the user change the status of the alerts. If the user changes the filter, we reset the deleted IDs to make sure these show.