### PR TITLE
[Fleet] Fix upgrade link in Fleet policy table

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -237,7 +237,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
                   upgradePackagePolicyHref={`${getHref('upgrade_package_policy', {
                     policyId: agentPolicy.id,
                     packagePolicyId: packagePolicy.id,
-                  })}`}
+                  })}?from=fleet-policy-list`}
                 />
               );
             },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -71,8 +71,9 @@ export const EditPackagePolicyPage = memo(() => {
 
 export const EditPackagePolicyForm = memo<{
   packagePolicyId: string;
+  isUpgrade?: boolean;
   from?: EditPackagePolicyFrom;
-}>(({ packagePolicyId, from = 'edit' }) => {
+}>(({ packagePolicyId, isUpgrade = false, from = 'edit' }) => {
   const { application, notifications } = useStartServices();
   const {
     agents: { enabled: isFleetEnabled },
@@ -98,9 +99,6 @@ export const EditPackagePolicyForm = memo<{
     GetOnePackagePolicyResponse['item']
   >();
   const [dryRunData, setDryRunData] = useState<UpgradePackagePolicyDryRunResponse>();
-
-  const isUpgrade =
-    from === 'upgrade-from-fleet-policy-list' || from === 'upgrade-from-integrations-policy-list';
 
   const policyId = agentPolicy?.id ?? '';
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/upgrade_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/upgrade_package_policy_page/index.tsx
@@ -30,5 +30,5 @@ export const UpgradePackagePolicyPage = memo(() => {
     from = 'upgrade-from-integrations-policy-list';
   }
 
-  return <EditPackagePolicyForm packagePolicyId={packagePolicyId} from={from} />;
+  return <EditPackagePolicyForm packagePolicyId={packagePolicyId} from={from} isUpgrade />;
 });


### PR DESCRIPTION
## Summary

Fix "Upgrade Integration" link in Fleet -> Agent Policies -> Package Policy table.

Fixes #110195 

## Screen Recording

![Kapture 2021-08-26 at 09 17 22](https://user-images.githubusercontent.com/6766512/130969340-cc7c6e65-a98a-4400-9f34-9f529b3987ef.gif)


