### PR TITLE
[Fleet] Don't ignore "index: false" in integration index template 

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -174,6 +174,26 @@ describe('EPM template', () => {
     expect(template).toMatchSnapshot(path.basename(ymlPath));
   });
 
+  it('tests processing long field with index false', () => {
+    const longWithIndexFalseYml = `
+- name: longIndexFalse
+  type: long
+  index: false
+`;
+    const longWithIndexFalseMapping = {
+      properties: {
+        longIndexFalse: {
+          type: 'long',
+          index: false,
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(longWithIndexFalseYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(longWithIndexFalseMapping);
+  });
+
   it('tests processing text field with multi fields', () => {
     const textWithMultiFieldsLiteralYml = `
 - name: textWithMultiFields

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -277,7 +277,7 @@ function generateTextMapping(field: Field): IndexTemplateMapping {
 function getDefaultProperties(field: Field): Properties {
   const properties: Properties = {};
 
-  if (field.index) {
+  if (field.index !== undefined) {
     properties.index = field.index;
   }
   if (field.doc_values) {


### PR DESCRIPTION
## Summary

Fixes #109764 

If an integration had index set to false in an index template then it was being ignored.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
