### PR TITLE
[7.x] [Form lib] Allow dynamic data to be passed to validator functions (#109238)

### DIFF
--- a/src/plugins/es_ui_shared/static/forms/docs/core/use_async_validation_data.mdx
+++ b/src/plugins/es_ui_shared/static/forms/docs/core/use_async_validation_data.mdx
@@ -1,0 +1,36 @@
+---
+id: formLibCoreUseAsyncValidationData
+slug: /form-lib/core/use-async-validation-data
+title: useAsyncValidationData()
+summary: Provide dynamic data to your validators... asynchronously
+tags: ['forms', 'kibana', 'dev']
+date: 2021-08-20
+---
+
+**Returns:** `[Observable<T>, (nextValue: T|undefined) => void]`
+
+This hook creates for you an observable and a handler to update its value. You can then pass the observable directly to <DocLink id="formLibCoreUseField" section="validationData$" text="the field `validationData$` prop" />.  
+
+See an example on how to use this hook in the <DocLink id="formLibExampleValidation" section="asynchronous-dynamic-data-in-the-validator" text="asynchronous dynamic data in the validator" /> section.
+
+## Options
+
+### state (optional)
+
+**Type:** `any`  
+
+If you provide a state when calling the hook, the observable value will keep in sync with the state. 
+
+```js
+const MyForm = () => {
+  ...
+  const [indices, setIndices] = useState([]);
+  // Whenever the "indices" state changes, the "indices$" Observable will be updated
+  const [indices$] = useAsyncValidationData(indices);
+
+  ...
+
+  <UseField path="indexName" validationData$={indices$} />
+
+}
+```

--- a/src/plugins/es_ui_shared/static/forms/docs/core/use_field.mdx
+++ b/src/plugins/es_ui_shared/static/forms/docs/core/use_field.mdx
@@ -336,6 +336,18 @@ If you provide a `component` you can pass here any prop you want to forward to t
 
 By default if you don't provide a `defaultValue` prop to `<UseField />`, it will try to read the default value on <DocLink id="formLibCoreUseForm" section="defaultvalue" text="the form `defaultValue` object" />. If you want to prevent this behaviour you can set `readDefaultValueOnForm` to false. This can be usefull for dynamic fields, as <DocLink id="formLibExampleDynamicFields" text="you can see in the examples" />.
 
+### validationData
+
+Use this prop to pass down dynamic data to your field validator. The data is then accessible in the validator through the `customData.value` property.
+
+See an example on how to use this prop in the <DocLink id="formLibExampleValidation" section="dynamic-data-inside-your-validation" text="dynamic data inside your validation" /> section.
+
+### validationData$
+
+Use this prop to pass down an Observable into which you can send, asynchronously, dynamic data required inside your validation.
+
+See an example on how to use this prop in the <DocLink id="formLibExampleValidation" section="asynchronous-dynamic-data-in-the-validator" text="asynchronous dynamic data in the validator" /> section.
+
 ### onChange
 
 **Type:** `(value:T) => void`

--- a/src/plugins/es_ui_shared/static/forms/docs/examples/validation.mdx
+++ b/src/plugins/es_ui_shared/static/forms/docs/examples/validation.mdx
@@ -272,3 +272,138 @@ export const MyComponent = () => {
 ```
 
 Great, but that's **a lot** of code for a simple tags field input. Fortunatelly the `<ComboBoxField />` helper component takes care of all the heavy lifting for us. <DocLink id="formLibHelpersComponents" section="comboboxfield" text="Have a look at the example" />.
+
+## Dynamic data inside your validation
+
+If your validator requires dynamic data you can provide it through the `validationData` prop on the `<UseField />` component. The data is then available in the validator through the `customData.value` property.
+
+```typescript
+// Form schema
+const schema = {
+  name: {
+    validations: [{
+      validator: ({ customData: { value } }) => {
+        // value === [1, 2 ,3] as passed below
+      }
+    }]
+  }
+};
+
+// Component JSX
+<UseField path="name" validationData={[1, 2, 3]} />
+```
+
+### Asynchronous dynamic data in the validator
+
+There might be times where you validator requires dynamic data asynchronously that is not immediately available when the field value changes (and the validation is triggered) but at a later stage.
+
+Let's imagine that you have a form with an `indexName` text field and that you want to display below the form the list of indices in your cluster that match the index name entered by the user.
+
+You would probably have something like this
+
+```js
+const MyForm = () => {
+  const { form } = useForm();
+  const [{ indexName }] = useFormData({ watch: 'indexName' });
+  const [indices, setIndices] = useState([]);
+
+  const fetchIndices = useCallback(async () => {
+    const result = await httpClient.get(`/api/search/${indexName}`);
+    setIndices(result);
+  }, [indexName]);
+
+  // Whenever the indexName changes we fetch the indices
+  useEffet(() => {
+    fetchIndices();
+  }, [fetchIndices]);
+
+  return (
+    <>
+      <Form form={form}>
+        <UseField path="indexName" />
+      </Form>
+
+      /* Display the list of indices that match the index name entered */
+      <ul>
+        {indices.map((index, i) => <li key={i}>{index}</li>)}
+      </ul>
+    <>
+  );
+}
+```
+
+Great. Now let's imagine that you want to add a validation to the `indexName` field and mark it as invalid if it does not match at least one index in the cluster. For that you need to provide dynamic data (the list of indices fetched) which is not immediately accesible when the field value changes (and the validation kicks in). We need to ask the validation to **wait** until we have fetched the indices and then have access to the dynamic data.
+
+For that we will use the `validationData$` Observable that you can pass to the field. Whenever a value is sent to the observable (**after** the field value has changed, important!), it will be available in the validator through the `customData.provider()` handler.
+
+```js
+// form.schema.ts
+const schema = {
+  indexName: {
+    validations: [{
+      validator: async ({ value, customData: { provider } }) => {
+        // Whenever a new value is sent to the `validationData$` Observable
+        // the Promise will resolve with that value
+        const indices = await provider();
+
+        if (!indices.include(value)) {
+          return {
+            message: `This index does not match any of your indices`
+          }
+        }
+      }
+    }]
+  } as FieldConfig
+}
+
+// myform.tsx
+const MyForm = () => {
+  ...
+  const [indices, setIndices] = useState([]);
+  const [indices$, nextIndices] = useAsyncValidationData(); // Use the provided hook to create the Observable
+
+  const fetchIndices = useCallback(async () => {
+    const result = await httpClient.get(`/api/search/${indexName}`);
+    setIndices(result);
+    nextIndices(result); // Send the indices to your validator "provider()"
+  }, [indexName]);
+
+  // Whenever the indexName changes we fetch the indices
+  useEffet(() => {
+    fetchIndices();
+  }, [fetchIndices]);
+
+  return (
+    <>
+      <Form form={form}>
+        /* Pass the Observable to your field */
+        <UseField path="indexName" validationData$={indices$} />
+      </Form>
+
+      ...
+    <>
+  );
+}
+```
+
+Et voilà! We have provided dynamic data asynchronously to our validator.
+
+The above example could be simplified a bit by using the optional `state` argument of the `useAsyncValidationData(/* state */)` hook.
+
+```js
+const MyForm = () => {
+  ...
+  const [indices, setIndices] = useState([]);
+  // We don't need the second element of the array (the "nextIndices()" handler)
+  // as whenever the "indices" state changes the "indices$" Observable will receive its value
+  const [indices$] = useAsyncValidationData(indices);
+  
+  ...
+ 
+  const fetchIndices = useCallback(async () => {
+    const result = await httpClient.get(`/api/search/${indexName}`);
+    setIndices(result); // This will also update the Observable
+  }, [indexName]);
+
+  ...
+```

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { FunctionComponent } from 'react';
+import { Observable } from 'rxjs';
 
 import { FieldHook, FieldConfig, FormData } from '../types';
 import { useField } from '../hooks';
@@ -19,6 +20,31 @@ export interface Props<T, FormType = FormData, I = T> {
   component?: FunctionComponent<any>;
   componentProps?: Record<string, any>;
   readDefaultValueOnForm?: boolean;
+  /**
+   * Use this prop to pass down dynamic data **asynchronously** to your validators.
+   * Your validator accesses the dynamic data by resolving the provider() Promise.
+   * The Promise will resolve **when a new value is sent** to the validationData$ Observable.
+   *
+   * ```typescript
+   * validator: ({ customData }) => {
+   *   // Wait until a value is sent to the "validationData$" Observable
+   *   const dynamicData = await customData.provider();
+   * }
+   * ```
+   */
+  validationData$?: Observable<unknown>;
+  /**
+   * Use this prop to pass down dynamic data to your validators. The validation data
+   * is then accessible in your validator inside the `customData.value` property.
+   *
+   * ```typescript
+   * validator: ({ customData: { value: dynamicData } }) => {
+   *   // Validate with the dynamic data
+   *   if (dynamicData) { .. }
+   * }
+   * ```
+   */
+  validationData?: unknown;
   onChange?: (value: I) => void;
   onError?: (errors: string[] | null) => void;
   children?: (field: FieldHook<T, I>) => JSX.Element | null;
@@ -36,6 +62,8 @@ function UseFieldComp<T = unknown, FormType = FormData, I = T>(props: Props<T, F
     onChange,
     onError,
     children,
+    validationData: customValidationData,
+    validationData$: customValidationData$,
     ...rest
   } = props;
 
@@ -63,7 +91,10 @@ function UseFieldComp<T = unknown, FormType = FormData, I = T>(props: Props<T, F
     }
   }
 
-  const field = useField<T, FormType, I>(form, path, fieldConfig, onChange, onError);
+  const field = useField<T, FormType, I>(form, path, fieldConfig, onChange, onError, {
+    customValidationData$,
+    customValidationData,
+  });
 
   // Children prevails over anything else provided.
   if (children) {

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/index.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/index.ts
@@ -10,3 +10,4 @@ export { useField, InternalFieldConfig } from './use_field';
 export { useForm } from './use_form';
 export { useFormData } from './use_form_data';
 export { useFormIsModified } from './use_form_is_modified';
+export { useAsyncValidationData } from './use_async_validation_data';

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_async_validation_data.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_async_validation_data.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { useCallback, useRef, useMemo, useEffect } from 'react';
+import { Subject, Observable } from 'rxjs';
+
+export const useAsyncValidationData = <T = any>(state?: T) => {
+  const validationData$ = useRef<Subject<T>>();
+
+  const getValidationData$ = useCallback(() => {
+    if (validationData$.current === undefined) {
+      validationData$.current = new Subject();
+    }
+    return validationData$.current;
+  }, []);
+
+  const hook: [Observable<T>, (value?: T) => void] = useMemo(() => {
+    const subject = getValidationData$();
+
+    const observable = subject.asObservable();
+    const next = subject.next.bind(subject);
+
+    return [observable, next];
+  }, [getValidationData$]);
+
+  // Whenever the state changes we update the observable
+  useEffect(() => {
+    getValidationData$().next(state);
+  }, [state, getValidationData$]);
+
+  return hook;
+};

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
@@ -166,7 +166,7 @@ export function useForm<T extends FormData = FormData, I extends FormData = T>(
         return { areFieldsValid: true, isFormValid: true };
       }
 
-      const areFieldsValid = validationResult.every(Boolean);
+      const areFieldsValid = validationResult.every((res) => res.isValid);
 
       const validationResultByPath = fieldsToValidate.reduce((acc, field, i) => {
         acc[field.path] = validationResult[i].isValid;

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/index.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/index.ts
@@ -8,7 +8,7 @@
 
 // We don't export the "useField" hook as it is for internal use.
 // The consumer of the library must use the <UseField /> component to create a field
-export { useForm, useFormData, useFormIsModified } from './hooks';
+export { useForm, useFormData, useFormIsModified, useAsyncValidationData } from './hooks';
 export { getFieldValidityAndErrorMessage } from './helpers';
 
 export * from './form_context';

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/types.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/types.ts
@@ -193,6 +193,11 @@ export interface ValidationFuncArg<I extends FormData, V = unknown> {
   };
   formData: I;
   errors: readonly ValidationError[];
+  customData: {
+    /** Async handler that will resolve whenever a value is sent to the `validationData$` Observable */
+    provider: () => Promise<unknown>;
+    value: unknown;
+  };
 }
 
 export type ValidationFunc<

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/schema.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/schema.test.tsx
@@ -83,6 +83,7 @@ describe('stepRuleActions schema', () => {
         form: {} as FormHook,
         formData: jest.fn(),
         errors: [],
+        customData: { value: null, provider: () => Promise.resolve(null) },
       });
 
       expect(result).toEqual(undefined);
@@ -105,6 +106,7 @@ describe('stepRuleActions schema', () => {
         form: {} as FormHook,
         formData: jest.fn(),
         errors: [],
+        customData: { value: null, provider: () => Promise.resolve(null) },
       });
 
       expect(result).toEqual({
@@ -147,6 +149,7 @@ describe('stepRuleActions schema', () => {
         form: {} as FormHook,
         formData: jest.fn(),
         errors: [],
+        customData: { value: null, provider: () => Promise.resolve(null) },
       });
 
       expect(result).toEqual({


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Form lib] Allow dynamic data to be passed to validator functions (#109238)