### PR TITLE
[bazel] Disable backend keep alive

### DIFF
--- a/src/dev/ci_setup/.bazelrc-ci
+++ b/src/dev/ci_setup/.bazelrc-ci
@@ -11,6 +11,8 @@ build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://cloud.buildbuddy.io
 build --remote_cache=grpcs://cloud.buildbuddy.io
 build --remote_timeout=3600
+
+## Avoid to keep connections to build event backend connections alive across builds
 build --keep_backend_build_event_connections_alive=false
 
 ## Metadata settings

--- a/src/dev/ci_setup/.bazelrc-ci
+++ b/src/dev/ci_setup/.bazelrc-ci
@@ -11,6 +11,7 @@ build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://cloud.buildbuddy.io
 build --remote_cache=grpcs://cloud.buildbuddy.io
 build --remote_timeout=3600
+build --keep_backend_build_event_connections_alive=false
 
 ## Metadata settings
 build --build_metadata=ROLE=CI


### PR DESCRIPTION
In an attempt to resolve some of the failures we have been seeing

```
 info [bazel] ERROR: The Build Event Protocol upload failed: All retry attempts failed. DEADLINE_EXCEEDED: DEADLINE_EXCEEDED: deadline exceeded after 14.999900510s. [remote_addr=cloud.buildbuddy.io/34.82.173.239:443] DEADLINE_EXCEEDED: DEADLINE_EXCEEDED: deadline exceeded after 14.999900510s. [remote_addr=cloud.buildbuddy.io/34.82.173.239:443]
```