### PR TITLE
chore(NA): add missing browser targets on @kbn/security-solution packages

### DIFF
--- a/packages/kbn-securitysolution-hook-utils/.babelrc.browser
+++ b/packages/kbn-securitysolution-hook-utils/.babelrc.browser
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/webpack_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/kbn-securitysolution-hook-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-hook-utils/BUILD.bazel
@@ -50,6 +50,13 @@ jsts_transpiler(
   build_pkg_name = package_name(),
 )
 
+jsts_transpiler(
+  name = "target_web",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+  config_file = ".babelrc.browser"
+)
+
 ts_config(
   name = "tsconfig",
   src = "tsconfig.json",
@@ -76,7 +83,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node", ":target_web", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-hook-utils/package.json
+++ b/packages/kbn-securitysolution-hook-utils/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Security Solution utilities for React hooks",
   "license": "SSPL-1.0 OR Elastic License 2.0",
+  "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
   "types": "./target_types/index.d.ts",
   "private": true

--- a/packages/kbn-securitysolution-io-ts-alerting-types/.babelrc.browser
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/.babelrc.browser
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/webpack_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/BUILD.bazel
@@ -51,6 +51,13 @@ jsts_transpiler(
   build_pkg_name = package_name(),
 )
 
+jsts_transpiler(
+  name = "target_web",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+  config_file = ".babelrc.browser"
+)
+
 ts_config(
   name = "tsconfig",
   src = "tsconfig.json",
@@ -77,7 +84,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node", ":target_web", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-alerting-types/package.json
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "io ts utilities and types to be shared with plugins from the security solution project",
   "license": "SSPL-1.0 OR Elastic License 2.0",
+  "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
   "types": "./target_types/index.d.ts",
   "private": true


### PR DESCRIPTION
Those two previously merged @kbn/security-solution packages are being imported on browser code but missing browser bundles. This should shape off some browser bundle size from bundles using those.