### PR TITLE
[Stack Integration] Fix error text in encryption keys test for alert connectors

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
+++ b/x-pack/test/stack_functional_integration/apps/alerts/alerts_encryption_keys.js
@@ -43,8 +43,8 @@ export default ({ getPageObjects, getService }) => {
           await testConnector(connectorName);
           await retry.try(async () => {
             const executionFailureResultCallout = await testSubjects.find('executionFailureResult');
-            expect(await executionFailureResultCallout.getVisibleText()).to.match(
-              /Internal Server Error/
+            expect(await executionFailureResultCallout.getVisibleText()).to.be(
+              'Test failed to run\nThe following error was found:\nerror sending email\nDetails:\nMail command failed: 550 5.7.1 Relaying denied'
             );
           });
           expect(true).to.be(true);


### PR DESCRIPTION
This changes the text we have in the test to the new, more verbose one. 
![Encryption Rotation encryption key rotation with email connectors without the key used to create it should show a failure callout](https://user-images.githubusercontent.com/5196019/130991957-364cdfa8-8e3e-4515-8f23-03d5273e8abc.png)
