### PR TITLE
[Security Solutions] Removes ElasticSearch deprecation and makes it harder to import it from the wrong package

### DIFF
--- a/packages/kbn-securitysolution-es-utils/src/index.ts
+++ b/packages/kbn-securitysolution-es-utils/src/index.ts
@@ -12,7 +12,6 @@ export * from './decode_version';
 export * from './delete_all_index';
 export * from './delete_policy';
 export * from './delete_template';
-export * from './elasticsearch_client';
 export * from './encode_hit_version';
 export * from './get_index_aliases';
 export * from './get_index_count';

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -17,14 +17,17 @@ import type { ListArray, ExceptionListItemSchema } from '@kbn/securitysolution-i
 import { MAX_EXCEPTION_LIST_SIZE } from '@kbn/securitysolution-list-constants';
 import { hasLargeValueList } from '@kbn/securitysolution-list-utils';
 import { parseScheduleDates } from '@kbn/securitysolution-io-ts-utils';
-import { ElasticsearchClient } from '@kbn/securitysolution-es-utils';
 
 import {
   TimestampOverrideOrUndefined,
   Privilege,
   RuleExecutionStatus,
 } from '../../../../common/detection_engine/schemas/common/schemas';
-import { Logger, SavedObjectsClientContract } from '../../../../../../../src/core/server';
+import {
+  ElasticsearchClient,
+  Logger,
+  SavedObjectsClientContract,
+} from '../../../../../../../src/core/server';
 import {
   AlertInstanceContext,
   AlertInstanceState,


### PR DESCRIPTION
## Summary

Removes ElasticSearch deprecation and makes it harder to import it from the wrong package. I accidentally exposed a deprecated `ElasticSearch` from a package we do not want to expose and everyone's IDE is suggesting it rather than the correct one from Kibana core.

* Removes the type from the exports within the package
* Fixes the instance that is trying to import it in favor of the correct one.

