### PR TITLE
[7.x] chore(NA): moving @kbn/securitysolution-io-ts-types to babel transpiler (#110097)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -115,7 +115,7 @@ pageLoadAssetSize:
   expressionShape: 34008
   expressionTagcloud: 27505
   esUiShared: 213076
-  expressions: 239282
+  expressions: 239290
   securitySolution: 232514
   share: 100298
   snapshotRestore: 63225

--- a/packages/kbn-securitysolution-io-ts-types/.babelrc
+++ b/packages/kbn-securitysolution-io-ts-types/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/kbn-securitysolution-io-ts-types/.babelrc.browser
+++ b/packages/kbn-securitysolution-io-ts-types/.babelrc.browser
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/webpack_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
+++ b/packages/kbn-securitysolution-io-ts-types/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-securitysolution-io-ts-types"
 PKG_REQUIRE_NAME = "@kbn/securitysolution-io-ts-types"
@@ -26,26 +27,34 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-SRC_DEPS = [
+RUNTIME_DEPS = [
   "//packages/kbn-securitysolution-io-ts-utils",
-  "//packages/elastic-datemath",
   "@npm//fp-ts",
   "@npm//io-ts",
-  "@npm//lodash",
-  "@npm//moment",
-  "@npm//tslib",
   "@npm//uuid",
 ]
 
 TYPES_DEPS = [
-  "@npm//@types/flot",
+  "//packages/kbn-securitysolution-io-ts-utils",
+  "@npm//fp-ts",
+  "@npm//io-ts",
   "@npm//@types/jest",
-  "@npm//@types/lodash",
   "@npm//@types/node",
   "@npm//@types/uuid"
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
+
+jsts_transpiler(
+  name = "target_web",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+  config_file = ".babelrc.browser"
+)
 
 ts_config(
   name = "tsconfig",
@@ -57,22 +66,23 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
+  name = "tsc_types",
   args = ['--pretty'],
   srcs = SRCS,
-  deps = DEPS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  out_dir = "target",
-  source_map = True,
+  emit_declaration_only = True,
+  out_dir = "target_types",
   root_dir = "src",
+  source_map = True,
   tsconfig = ":tsconfig",
 )
 
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = DEPS + [":tsc"],
+  deps = RUNTIME_DEPS + [":target_node", ":target_web", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 )

--- a/packages/kbn-securitysolution-io-ts-types/package.json
+++ b/packages/kbn-securitysolution-io-ts-types/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "io ts utilities and types to be shared with plugins from the security solution project",
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "browser": "target_web/index.js",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "private": true
 }

--- a/packages/kbn-securitysolution-io-ts-types/tsconfig.json
+++ b/packages/kbn-securitysolution-io-ts-types/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "outDir": "target",
+    "emitDeclarationOnly": true,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-securitysolution-io-ts-types/src",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore(NA): moving @kbn/securitysolution-io-ts-types to babel transpiler (#110097)