### PR TITLE
Remove index pattern placeholder advanced setting

### DIFF
--- a/src/plugins/data/common/constants.ts
+++ b/src/plugins/data/common/constants.ts
@@ -33,7 +33,6 @@ export const UI_SETTINGS = {
   TIMEPICKER_REFRESH_INTERVAL_DEFAULTS: 'timepicker:refreshIntervalDefaults',
   TIMEPICKER_QUICK_RANGES: 'timepicker:quickRanges',
   TIMEPICKER_TIME_DEFAULTS: 'timepicker:timeDefaults',
-  INDEXPATTERN_PLACEHOLDER: 'indexPattern:placeholder',
   FILTERS_PINNED_BY_DEFAULT: 'filters:pinnedByDefault',
   FILTERS_EDITOR_SUGGEST_VALUES: 'filterEditor:suggestValues',
   AUTOCOMPLETE_USE_TIMERANGE: 'autocomplete:useTimeRange',

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -454,17 +454,6 @@ export function getUiSettings(): Record<string, UiSettingsParams<unknown>> {
         })
       ),
     },
-    [UI_SETTINGS.INDEXPATTERN_PLACEHOLDER]: {
-      name: i18n.translate('data.advancedSettings.indexPatternPlaceholderTitle', {
-        defaultMessage: 'Index pattern placeholder',
-      }),
-      value: '',
-      description: i18n.translate('data.advancedSettings.indexPatternPlaceholderText', {
-        defaultMessage:
-          'The placeholder for the "Index pattern name" field in "Management > Index Patterns > Create Index Pattern".',
-      }),
-      schema: schema.string(),
-    },
     [UI_SETTINGS.FILTERS_PINNED_BY_DEFAULT]: {
       name: i18n.translate('data.advancedSettings.pinFiltersTitle', {
         defaultMessage: 'Pin filters by default',

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -709,8 +709,6 @@
     "data.advancedSettings.histogram.maxBarsTitle": "バケットの最大数",
     "data.advancedSettings.historyLimitText": "履歴があるフィールド (例：クエリインプット) に個の数の最近の値が表示されます",
     "data.advancedSettings.historyLimitTitle": "履歴制限数",
-    "data.advancedSettings.indexPatternPlaceholderText": "「管理 > インデックスパターン > インデックスパターンを作成」で使用される「インデックスパターン名」フィールドのプレースホルダーです。",
-    "data.advancedSettings.indexPatternPlaceholderTitle": "インデックスパターンのプレースホルダー",
     "data.advancedSettings.metaFieldsText": "_source の外にあり、ドキュメントが表示される時に融合されるフィールドです",
     "data.advancedSettings.metaFieldsTitle": "メタフィールド",
     "data.advancedSettings.pinFiltersText": "フィルターがデフォルトでグローバル (ピン付けされた状態) になるかの設定です",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -712,8 +712,6 @@
     "data.advancedSettings.histogram.maxBarsTitle": "最大存储桶数",
     "data.advancedSettings.historyLimitText": "在具有历史记录（例如查询输入）的字段中，显示此数目的最近值",
     "data.advancedSettings.historyLimitTitle": "历史记录限制",
-    "data.advancedSettings.indexPatternPlaceholderText": "在“管理”>“索引模式”>“创建索引模式”中“索引模式名称”字段的占位符。",
-    "data.advancedSettings.indexPatternPlaceholderTitle": "索引模式占位符",
     "data.advancedSettings.metaFieldsText": "_source 之外存在的、在显示我们的文档时将合并进其中的字段",
     "data.advancedSettings.metaFieldsTitle": "元字段",
     "data.advancedSettings.pinFiltersText": "筛选是否应默认有全局状态（置顶）",


### PR DESCRIPTION
## Summary

Removes the index pattern placeholder advanced setting -

<img width="1123" alt="Screen Shot 2021-08-24 at 5 33 59 PM" src="https://user-images.githubusercontent.com/216176/131029718-dcbbb2f2-f744-44e5-bc54-6fcdf41194c4.png">

This wasn't properly implemented in the new index pattern creation flyout - https://github.com/elastic/kibana/pull/101853 . The reason why it was implemented is no longer relevant - https://github.com/elastic/kibana/issues/5818

### Release notes

The index pattern placeholder advanced setting has been removed as part of the redesign of the new index pattern creation flyout.