### PR TITLE
[Security Solutions][Detection Engine] Changes the loading of indexes in tests from beforeEach() to before()

### DIFF
--- a/x-pack/test/detection_engine_api_integration/basic/tests/create_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/create_rules.ts
@@ -46,15 +46,21 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('creating rules', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should create a single rule with a rule_id', async () => {

--- a/x-pack/test/detection_engine_api_integration/basic/tests/create_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/create_rules_bulk.ts
@@ -49,15 +49,21 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     describe('creating rules in bulk', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should create a single rule with a rule_id', async () => {

--- a/x-pack/test/detection_engine_api_integration/basic/tests/find_statuses.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/find_statuses.ts
@@ -26,16 +26,22 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
 
   describe('find_statuses', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
     });
 
     afterEach(async () => {
       await deleteSignalsIndex(supertest);
       await deleteAllAlerts(supertest);
       await deleteAllRulesStatuses(es);
-      await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
     });
 
     it('should return an empty find statuses body correctly if no statuses are loaded', async () => {

--- a/x-pack/test/detection_engine_api_integration/basic/tests/open_close_signals.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/open_close_signals.ts
@@ -66,15 +66,22 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('tests with auditbeat data', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await deleteAllAlerts(supertest);
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
+
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should be able to execute and get 10 signals', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/add_actions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/add_actions.ts
@@ -29,15 +29,21 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('add_actions', () => {
     describe('adding actions', () => {
-      beforeEach(async () => {
+      before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      beforeEach(async () => {
         await createSignalsIndex(supertest);
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should be able to create a new webhook action and attach it to a rule', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/aliases.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/aliases.ts
@@ -28,15 +28,21 @@ export default ({ getService }: FtrProviderContext) => {
   }
 
   describe('Tests involving aliases of source indexes and the signals index', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/security_solution/alias');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/security_solution/alias');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/security_solution/alias');
     });
 
     afterEach(async () => {
       await deleteSignalsIndex(supertest);
       await deleteAllAlerts(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/security_solution/alias');
     });
 
     it('should keep the original alias value such as "host_alias" from a source index when the value is indexed', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_endpoint_exceptions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_endpoint_exceptions.ts
@@ -32,13 +32,23 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for endpoints', () => {
-    beforeEach(async () => {
-      await createSignalsIndex(supertest);
-      await createListsIndex(supertest);
+    before(async () => {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/rule_exceptions/endpoint_without_host_type'
       );
       await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/agent');
+    });
+
+    after(async () => {
+      await esArchiver.unload(
+        'x-pack/test/functional/es_archives/rule_exceptions/endpoint_without_host_type'
+      );
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/agent');
+    });
+
+    beforeEach(async () => {
+      await createSignalsIndex(supertest);
+      await createListsIndex(supertest);
     });
 
     afterEach(async () => {
@@ -46,10 +56,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload(
-        'x-pack/test/functional/es_archives/rule_exceptions/endpoint_without_host_type'
-      );
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/agent');
     });
 
     describe('no exceptions set', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_exceptions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_exceptions.ts
@@ -63,17 +63,23 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('create_rules_with_exceptions', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+    });
+
     describe('creating rules with exceptions', () => {
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
         await deleteAllExceptions(es);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       describe('elastic admin', () => {
@@ -529,16 +535,22 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       describe('tests with auditbeat data', () => {
+        before(async () => {
+          await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+        });
+
+        after(async () => {
+          await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+        });
+
         beforeEach(async () => {
           await createSignalsIndex(supertest);
-          await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
         });
 
         afterEach(async () => {
           await deleteSignalsIndex(supertest);
           await deleteAllAlerts(supertest);
           await deleteAllExceptions(es);
-          await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
         });
 
         it('should be able to execute against an exception list that does not include valid entries and get back 10 signals', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules.ts
@@ -59,15 +59,21 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('creating rules', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       describe('elastic admin', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules_bulk.ts
@@ -54,15 +54,21 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     describe('creating rules in bulk', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should create a single rule with a rule_id', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_threat_matching.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_threat_matching.ts
@@ -68,15 +68,21 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('creating threat match rule', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should create a single rule with a rule_id', async () => {
@@ -106,16 +112,22 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('tests with auditbeat data', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await deleteAllAlerts(supertest);
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should be able to execute and get 10 signals when doing a specific query', async () => {
@@ -399,11 +411,11 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       describe('indicator enrichment', () => {
-        beforeEach(async () => {
+        before(async () => {
           await esArchiver.load('x-pack/test/functional/es_archives/filebeat/threat_intel');
         });
 
-        afterEach(async () => {
+        after(async () => {
           await esArchiver.unload('x-pack/test/functional/es_archives/filebeat/threat_intel');
         });
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/date.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/date.ts
@@ -33,10 +33,17 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type date', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/date');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/date');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/date');
     });
 
     afterEach(async () => {
@@ -44,7 +51,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/date');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/double.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/double.ts
@@ -33,11 +33,21 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type double', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/double');
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/double_as_string');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/double');
+      await esArchiver.unload(
+        'x-pack/test/functional/es_archives/rule_exceptions/double_as_string'
+      );
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/double');
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/double_as_string');
     });
 
     afterEach(async () => {
@@ -45,10 +55,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/double');
-      await esArchiver.unload(
-        'x-pack/test/functional/es_archives/rule_exceptions/double_as_string'
-      );
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/float.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/float.ts
@@ -33,11 +33,19 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type float', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/float');
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/float_as_string');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/float');
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/float_as_string');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/float');
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/float_as_string');
     });
 
     afterEach(async () => {
@@ -45,8 +53,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/float');
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/float_as_string');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/integer.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/integer.ts
@@ -33,11 +33,21 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type integer', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/integer');
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/integer_as_string');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/integer');
+      await esArchiver.unload(
+        'x-pack/test/functional/es_archives/rule_exceptions/integer_as_string'
+      );
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/integer');
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/integer_as_string');
     });
 
     afterEach(async () => {
@@ -45,10 +55,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/integer');
-      await esArchiver.unload(
-        'x-pack/test/functional/es_archives/rule_exceptions/integer_as_string'
-      );
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/ip.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/ip.ts
@@ -33,10 +33,17 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type ip', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/ip');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/ip');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/ip');
     });
 
     afterEach(async () => {
@@ -44,7 +51,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/ip');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/ip_array.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/ip_array.ts
@@ -33,10 +33,17 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type ip', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/ip_as_array');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/ip_as_array');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/ip_as_array');
     });
 
     afterEach(async () => {
@@ -44,7 +51,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/ip_as_array');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/keyword.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/keyword.ts
@@ -33,10 +33,17 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type keyword', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/keyword');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/keyword');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/keyword');
     });
 
     afterEach(async () => {
@@ -44,7 +51,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/keyword');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/keyword_array.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/keyword_array.ts
@@ -33,10 +33,19 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type keyword', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/keyword_as_array');
+    });
+
+    after(async () => {
+      await esArchiver.unload(
+        'x-pack/test/functional/es_archives/rule_exceptions/keyword_as_array'
+      );
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/keyword_as_array');
     });
 
     afterEach(async () => {
@@ -44,9 +53,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload(
-        'x-pack/test/functional/es_archives/rule_exceptions/keyword_as_array'
-      );
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/long.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/long.ts
@@ -33,11 +33,19 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type long', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/long');
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/long_as_string');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/long');
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/long_as_string');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/long');
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/long_as_string');
     });
 
     afterEach(async () => {
@@ -45,8 +53,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/long');
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/long_as_string');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/text.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/text.ts
@@ -33,13 +33,20 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const es = getService('es');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/107911
-  describe.skip('Rule exception operators for data type text', () => {
+  describe('Rule exception operators for data type text', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/text');
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/text_no_spaces');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/text');
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/text_no_spaces');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/text');
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/text_no_spaces');
     });
 
     afterEach(async () => {
@@ -47,12 +54,9 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/text');
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/text_no_spaces');
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/107856
-    describe.skip('"is" operator', () => {
+    describe('"is" operator', () => {
       it('should find all the text from the data set when no exceptions are set on the rule', async () => {
         const rule = getRuleForSignalTesting(['text']);
         const { id } = await createRule(supertest, rule);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/text_array.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/exception_operators_data_types/text_array.ts
@@ -33,10 +33,17 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
 
   describe('Rule exception operators for data type text', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/text_as_array');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/text_as_array');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
       await createListsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_exceptions/text_as_array');
     });
 
     afterEach(async () => {
@@ -44,7 +51,6 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllAlerts(supertest);
       await deleteAllExceptions(es);
       await deleteListsIndex(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_exceptions/text_as_array');
     });
 
     describe('"is" operator', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
@@ -26,16 +26,22 @@ export default ({ getService }: FtrProviderContext): void => {
   const esArchiver = getService('esArchiver');
 
   describe('find_statuses', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
     });
 
     afterEach(async () => {
       await deleteSignalsIndex(supertest);
       await deleteAllAlerts(supertest);
       await deleteAllRulesStatuses(es);
-      await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
     });
 
     it('should return an empty find statuses body correctly if no statuses are loaded', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/generating_signals.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/generating_signals.ts
@@ -56,11 +56,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('Signals from audit beat are of the expected structure', () => {
-      beforeEach(async () => {
+      before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
-      afterEach(async () => {
+      after(async () => {
         await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
@@ -1135,11 +1135,11 @@ export default ({ getService }: FtrProviderContext) => {
      * underneath the signal object and no errors when they do have a clash.
      */
     describe('Signals generated from name clashes', () => {
-      beforeEach(async () => {
+      before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/signals/numeric_name_clash');
       });
 
-      afterEach(async () => {
+      after(async () => {
         await esArchiver.unload('x-pack/test/functional/es_archives/signals/numeric_name_clash');
       });
 
@@ -1292,11 +1292,11 @@ export default ({ getService }: FtrProviderContext) => {
      * the signal object and no errors when they do have a clash.
      */
     describe('Signals generated from object clashes', () => {
-      beforeEach(async () => {
+      before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/signals/object_clash');
       });
 
-      afterEach(async () => {
+      after(async () => {
         await esArchiver.unload('x-pack/test/functional/es_archives/signals/object_clash');
       });
 
@@ -1451,11 +1451,11 @@ export default ({ getService }: FtrProviderContext) => {
      * value of the signal will be taken from the mapped field of the source event.
      */
     describe('Signals generated from events with custom severity and risk score fields', () => {
-      beforeEach(async () => {
+      before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/signals/severity_risk_overrides');
       });
 
-      afterEach(async () => {
+      after(async () => {
         await esArchiver.unload(
           'x-pack/test/functional/es_archives/signals/severity_risk_overrides'
         );
@@ -1600,16 +1600,22 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('Signals generated from events with name override field', async () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await deleteSignalsIndex(supertest);
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should generate signals with name_override field', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/keyword_family/const_keyword.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/keyword_family/const_keyword.ts
@@ -36,17 +36,23 @@ export default ({ getService }: FtrProviderContext) => {
   }
 
   describe('Rule detects against a keyword of event.dataset', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_keyword_family/const_keyword');
+    });
+
+    after(async () => {
+      await esArchiver.unload(
+        'x-pack/test/functional/es_archives/rule_keyword_family/const_keyword'
+      );
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_keyword_family/const_keyword');
     });
 
     afterEach(async () => {
       await deleteSignalsIndex(supertest);
       await deleteAllAlerts(supertest);
-      await esArchiver.unload(
-        'x-pack/test/functional/es_archives/rule_keyword_family/const_keyword'
-      );
     });
 
     describe('"kql" rule type', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/keyword_family/keyword.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/keyword_family/keyword.ts
@@ -37,15 +37,21 @@ export default ({ getService }: FtrProviderContext) => {
   }
 
   describe('Rule detects against a keyword of event.dataset', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
+    });
+
     beforeEach(async () => {
       await createSignalsIndex(supertest);
-      await esArchiver.load('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
     });
 
     afterEach(async () => {
       await deleteSignalsIndex(supertest);
       await deleteAllAlerts(supertest);
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
     });
 
     describe('"kql" rule type', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/keyword_family/keyword_mixed_with_const.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/keyword_family/keyword_mixed_with_const.ts
@@ -35,19 +35,25 @@ export default ({ getService }: FtrProviderContext) => {
   }
 
   describe('Rule detects against a keyword and constant_keyword of event.dataset', () => {
-    beforeEach(async () => {
-      await createSignalsIndex(supertest);
+    before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/rule_keyword_family/const_keyword');
       await esArchiver.load('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
+    });
+
+    after(async () => {
+      await esArchiver.unload(
+        'x-pack/test/functional/es_archives/rule_keyword_family/const_keyword'
+      );
+      await esArchiver.unload('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
+    });
+
+    beforeEach(async () => {
+      await createSignalsIndex(supertest);
     });
 
     afterEach(async () => {
       await deleteSignalsIndex(supertest);
       await deleteAllAlerts(supertest);
-      await esArchiver.unload(
-        'x-pack/test/functional/es_archives/rule_keyword_family/const_keyword'
-      );
-      await esArchiver.unload('x-pack/test/functional/es_archives/rule_keyword_family/keyword');
     });
 
     describe('"kql" rule type', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/open_close_signals.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/open_close_signals.ts
@@ -68,15 +68,22 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       describe('tests with auditbeat data', () => {
+        before(async () => {
+          await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+        });
+
+        after(async () => {
+          await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+        });
+
         beforeEach(async () => {
           await deleteAllAlerts(supertest);
           await createSignalsIndex(supertest);
-          await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
         });
+
         afterEach(async () => {
           await deleteSignalsIndex(supertest);
           await deleteAllAlerts(supertest);
-          await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
         });
 
         it('should be able to execute and get 10 signals', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/runtime.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/runtime.ts
@@ -29,16 +29,22 @@ export default ({ getService }: FtrProviderContext) => {
   }
 
   describe('Tests involving runtime fields of source indexes and the signals index', () => {
+    before(async () => {
+      await esArchiver.load('x-pack/test/functional/es_archives/security_solution/runtime');
+    });
+
+    after(async () => {
+      await esArchiver.unload('x-pack/test/functional/es_archives/security_solution/runtime');
+    });
+
     describe('Regular runtime field mappings', () => {
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/security_solution/runtime');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/security_solution/runtime');
       });
 
       it('should copy normal non-runtime data set from the source index into the signals index in the same position when the target is ECS compatible', async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/timestamps.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/timestamps.ts
@@ -239,15 +239,21 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('Signals generated from events with timestamp override field and ensures search_after continues to work when documents are missing timestamp override field', () => {
+      before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
       beforeEach(async () => {
         await createSignalsIndex(supertest);
-        await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       describe('KQL', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/update_actions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/update_actions.ts
@@ -36,15 +36,21 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('update_actions', () => {
     describe('updating actions', () => {
-      beforeEach(async () => {
+      before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      after(async () => {
+        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
+      });
+
+      beforeEach(async () => {
         await createSignalsIndex(supertest);
       });
 
       afterEach(async () => {
         await deleteSignalsIndex(supertest);
         await deleteAllAlerts(supertest);
-        await esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts');
       });
 
       it('should be able to create a new webhook action and update a rule with the webhook action', async () => {


### PR DESCRIPTION
## Summary

Changes the loading of indexes in tests from beforeEach() to before()

Hoping this fixes some flake we have seen recently. If it doesn't, at least tests should run faster and be less flake overall. If these two below do begin acting up again I will then probably resort to wrapping the individual tests around retry blocks or removing the tests.

Also found one area within `x-pack/test/detection_engine_api_integration/security_and_spaces/tests/generating_signals.ts` where we do a `load` twice but I fixed it to the `load`/`unload` pattern.

Issues this should fix:
* https://github.com/elastic/kibana/issues/107911
* https://github.com/elastic/kibana/issues/107856

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
