### PR TITLE
[Security Solution] Fixes failing tests on master

### DIFF
--- a/x-pack/plugins/security_solution/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/alerts.ts
@@ -41,8 +41,6 @@ export const ACKNOWLEDGED_ALERTS_FILTER_BTN = '[data-test-subj="acknowledgedAler
 
 export const LOADING_ALERTS_PANEL = '[data-test-subj="loading-alerts-panel"]';
 
-export const LOADING_SPINNER = '[data-test-subj="LoadingPanelTimeline"]';
-
 export const MANAGE_ALERT_DETECTION_RULES_BTN = '[data-test-subj="manage-alert-detection-rules"]';
 
 export const MARK_ALERT_ACKNOWLEDGED_BTN = '[data-test-subj="acknowledged-alert-status"]';

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -14,7 +14,6 @@ import {
   ThreatIndicatorRule,
   ThresholdRule,
 } from '../objects/rule';
-import { LOADING_SPINNER } from '../screens/alerts';
 import {
   ABOUT_CONTINUE_BTN,
   ABOUT_EDIT_TAB,
@@ -94,6 +93,7 @@ import {
   EMAIL_CONNECTOR_USER_INPUT,
   EMAIL_CONNECTOR_PASSWORD_INPUT,
 } from '../screens/create_new_rule';
+import { LOADING_INDICATOR } from '../screens/security_header';
 import { TOAST_ERROR } from '../screens/shared';
 import { SERVER_SIDE_EVENT_COUNT } from '../screens/timeline';
 import { TIMELINE } from '../screens/timelines';
@@ -532,7 +532,8 @@ export const waitForAlertsToPopulate = async (alertCountThreshold = 1) => {
   cy.waitUntil(
     () => {
       refreshPage();
-      cy.get(LOADING_SPINNER).should('not.exist');
+      cy.get(LOADING_INDICATOR).should('exist');
+      cy.get(LOADING_INDICATOR).should('not.exist');
       return cy
         .get(SERVER_SIDE_EVENT_COUNT)
         .invoke('text')


### PR DESCRIPTION
## Summary

In this PR we are changing the loading indicator when waiting for the alerts table, to another one more reliable in order to fix all the failing tests in master branch.
