### PR TITLE
[Archive Migration][Partial] discover apps-home

### DIFF
--- a/test/functional/apps/getting_started/_shakespeare.ts
+++ b/test/functional/apps/getting_started/_shakespeare.ts
@@ -65,6 +65,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await security.testUser.restoreDefaults();
+      await esArchiver.unload('test/functional/fixtures/es_archiver/getting_started/shakespeare');
+      await kibanaServer.uiSettings.replace({});
     });
 
     it('should create shakespeare index pattern', async function () {

--- a/test/functional/apps/home/_navigation.ts
+++ b/test/functional/apps/home/_navigation.ts
@@ -14,11 +14,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'header', 'home', 'timePicker']);
   const appsMenu = getService('appsMenu');
   const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
 
   describe('Kibana browser back navigation should work', function describeIndexTests() {
     before(async () => {
-      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/discover');
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');
+      await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
+    });
+
+    after(async () => {
+      await kibanaServer.importExport.unload('test/functional/fixtures/kbn_archiver/discover');
     });
 
     it('detect navigate back issues', async () => {

--- a/test/functional/apps/home/_navigation.ts
+++ b/test/functional/apps/home/_navigation.ts
@@ -18,13 +18,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('Kibana browser back navigation should work', function describeIndexTests() {
     before(async () => {
-      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
-      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
+      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');
     });
 
     after(async () => {
       await kibanaServer.importExport.unload('test/functional/fixtures/kbn_archiver/discover');
+      await kibanaServer.uiSettings.replace({});
     });
 
     it('detect navigate back issues', async () => {


### PR DESCRIPTION
Comes from https://github.com/elastic/kibana/pull/102827

Helps with https://github.com/elastic/kibana/pull/108503

Unload the shakespeare data in the previous suite, 
and replace the ui settings with an empty object literal,
so to prepare the home suite to run from a clean state.

Additionally, set the default index to `logstash-*` in 
the home suite.

Only include the changes under the
test/functional/apps/home folder.
