### PR TITLE
[7.x] [Lens] Remove deprecated `IFieldType` (#109825)

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -23,10 +23,10 @@ import { createMemoryHistory } from 'history';
 import {
   esFilters,
   FilterManager,
-  IFieldType,
   IndexPattern,
   Query,
 } from '../../../../../src/plugins/data/public';
+import type { FieldSpec } from '../../../../../src/plugins/data/common';
 import { TopNavMenuData } from '../../../../../src/plugins/navigation/public';
 import { LensByValueInput } from '../embeddable/embeddable';
 import { SavedObjectReference } from '../../../../../src/core/types';
@@ -146,7 +146,7 @@ describe('Lens App', () => {
   it('updates global filters with store state', async () => {
     const services = makeDefaultServices(sessionIdSubject);
     const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-    const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
+    const pinnedField = ({ name: 'pinnedField' } as unknown) as FieldSpec;
     const pinnedFilter = esFilters.buildExistsFilter(pinnedField, indexPattern);
     services.data.query.filterManager.getFilters = jest.fn().mockImplementation(() => {
       return [];
@@ -644,8 +644,8 @@ describe('Lens App', () => {
 
       it('saves app filters and does not save pinned filters', async () => {
         const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-        const field = ({ name: 'myfield' } as unknown) as IFieldType;
-        const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
+        const field = ({ name: 'myfield' } as unknown) as FieldSpec;
+        const pinnedField = ({ name: 'pinnedField' } as unknown) as FieldSpec;
         const unpinned = esFilters.buildExistsFilter(field, indexPattern);
         const pinned = esFilters.buildExistsFilter(pinnedField, indexPattern);
         await act(async () => {
@@ -857,7 +857,7 @@ describe('Lens App', () => {
     it('updates the filters when the user changes them', async () => {
       const { instance, services, lensStore } = await mountWith({});
       const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-      const field = ({ name: 'myfield' } as unknown) as IFieldType;
+      const field = ({ name: 'myfield' } as unknown) as FieldSpec;
       expect(lensStore.getState()).toEqual({
         lens: expect.objectContaining({
           filters: [],
@@ -912,7 +912,7 @@ describe('Lens App', () => {
         }),
       });
       const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-      const field = ({ name: 'myfield' } as unknown) as IFieldType;
+      const field = ({ name: 'myfield' } as unknown) as FieldSpec;
       act(() =>
         services.data.query.filterManager.setFilters([
           esFilters.buildExistsFilter(field, indexPattern),
@@ -1047,8 +1047,8 @@ describe('Lens App', () => {
         })
       );
       const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-      const field = ({ name: 'myfield' } as unknown) as IFieldType;
-      const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
+      const field = ({ name: 'myfield' } as unknown) as FieldSpec;
+      const pinnedField = ({ name: 'pinnedField' } as unknown) as FieldSpec;
       const unpinned = esFilters.buildExistsFilter(field, indexPattern);
       const pinned = esFilters.buildExistsFilter(pinnedField, indexPattern);
       FilterManager.setFiltersStore([pinned], esFilters.FilterStateStore.GLOBAL_STATE);
@@ -1104,8 +1104,8 @@ describe('Lens App', () => {
         })
       );
       const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-      const field = ({ name: 'myfield' } as unknown) as IFieldType;
-      const pinnedField = ({ name: 'pinnedField' } as unknown) as IFieldType;
+      const field = ({ name: 'myfield' } as unknown) as FieldSpec;
+      const pinnedField = ({ name: 'pinnedField' } as unknown) as FieldSpec;
       const unpinned = esFilters.buildExistsFilter(field, indexPattern);
       const pinned = esFilters.buildExistsFilter(pinnedField, indexPattern);
       FilterManager.setFiltersStore([pinned], esFilters.FilterStateStore.GLOBAL_STATE);

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -28,7 +28,8 @@ import { ReactWrapper } from 'enzyme';
 import { DragDrop, ChildDragDropProvider } from '../../../drag_drop';
 import { fromExpression } from '@kbn/interpreter/common';
 import { coreMock } from 'src/core/public/mocks';
-import { esFilters, IFieldType, IndexPattern } from '../../../../../../../src/plugins/data/public';
+import { esFilters, IndexPattern } from '../../../../../../../src/plugins/data/public';
+import type { FieldSpec } from '../../../../../../../src/plugins/data/common';
 import { UiActionsStart } from '../../../../../../../src/plugins/ui_actions/public';
 import { uiActionsPluginMock } from '../../../../../../../src/plugins/ui_actions/public/mocks';
 import { TriggerContract } from '../../../../../../../src/plugins/ui_actions/public/triggers';
@@ -419,7 +420,7 @@ describe('workspace_panel', () => {
     expect(expressionRendererMock).toHaveBeenCalledTimes(1);
 
     const indexPattern = ({ id: 'index1' } as unknown) as IndexPattern;
-    const field = ({ name: 'myfield' } as unknown) as IFieldType;
+    const field = ({ name: 'myfield' } as unknown) as FieldSpec;
 
     await act(async () => {
       instance.setProps({

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
@@ -664,7 +664,14 @@ describe('IndexPattern Data Panel', () => {
               ...props.indexPatterns['1'],
               fields: [
                 ...props.indexPatterns['1'].fields,
-                { name: '_id', displayName: '_id', meta: true, type: 'string' },
+                {
+                  name: '_id',
+                  displayName: '_id',
+                  meta: true,
+                  type: 'string',
+                  searchable: true,
+                  aggregatable: true,
+                },
               ],
             },
           }}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile.test.tsx
@@ -81,6 +81,7 @@ describe('percentile', () => {
           displayName: 'bytes',
           type: 'number',
           esTypes: ['long'],
+          searchable: true,
           aggregatable: true,
         })
       ).toEqual({
@@ -97,6 +98,7 @@ describe('percentile', () => {
           displayName: 'response_time',
           type: 'histogram',
           esTypes: ['histogram'],
+          searchable: true,
           aggregatable: true,
         })
       ).toEqual({
@@ -113,6 +115,7 @@ describe('percentile', () => {
           displayName: 'origin',
           type: 'string',
           esTypes: ['keyword'],
+          searchable: true,
           aggregatable: true,
         })
       ).toBeUndefined();

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.test.tsx
@@ -96,9 +96,23 @@ const defaultOptions = {
     id: '1',
     title: 'my_index_pattern',
     hasRestrictions: false,
-    fields: [{ name: sourceField, type: 'number', displayName: sourceField }],
+    fields: [
+      {
+        name: sourceField,
+        type: 'number',
+        displayName: sourceField,
+        searchable: true,
+        aggregatable: true,
+      },
+    ],
     getFieldByName: getFieldByNameFactory([
-      { name: sourceField, type: 'number', displayName: sourceField },
+      {
+        name: sourceField,
+        type: 'number',
+        displayName: sourceField,
+        searchable: true,
+        aggregatable: true,
+      },
     ]),
   },
   operationDefinitionMap: {},

--- a/x-pack/plugins/lens/public/indexpattern_datasource/types.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/types.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { IFieldType } from 'src/plugins/data/common';
-import { IndexPatternColumn, IncompleteColumn } from './operations';
-import { IndexPatternAggRestrictions } from '../../../../../src/plugins/data/public';
-import { DragDropIdentifier } from '../drag_drop/providers';
+import type { IndexPatternColumn, IncompleteColumn } from './operations';
+import type { IndexPatternAggRestrictions } from '../../../../../src/plugins/data/public';
+import type { FieldSpec } from '../../../../../src/plugins/data/common';
+import type { DragDropIdentifier } from '../drag_drop/providers';
 
 export {
   FieldBasedIndexPatternColumn,
@@ -57,7 +57,7 @@ export interface IndexPattern {
   hasRestrictions: boolean;
 }
 
-export type IndexPatternField = IFieldType & {
+export type IndexPatternField = FieldSpec & {
   displayName: string;
   aggregationRestrictions?: Partial<IndexPatternAggRestrictions>;
   meta?: boolean;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Lens] Remove deprecated `IFieldType` (#109825)