### PR TITLE
[7.x] [TSVB] Remove deprecated `IFieldType` (#110404)

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/agg.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/agg.tsx
@@ -13,14 +13,13 @@ import { aggToComponent } from '../lib/agg_to_component';
 import { isMetricEnabled } from '../../lib/check_ui_restrictions';
 import { UnsupportedAgg } from './unsupported_agg';
 import { TemporaryUnsupportedAgg } from './temporary_unsupported_agg';
-import type { Metric, Panel, Series } from '../../../../common/types';
+import type { Metric, Panel, Series, SanitizedFieldType } from '../../../../common/types';
 import { DragHandleProps } from '../../../types';
 import { TimeseriesUIRestrictions } from '../../../../common/ui_restrictions';
-import { IFieldType } from '../../../../../data/common/index_patterns/fields';
 
 interface AggProps extends HTMLAttributes<HTMLElement> {
   disableDelete: boolean;
-  fields: IFieldType[];
+  fields: Record<string, SanitizedFieldType[]>;
   model: Metric;
   panel: Panel;
   series: Series;

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/aggs.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/aggs.tsx
@@ -15,9 +15,8 @@ import { Agg } from './agg';
 import { seriesChangeHandler } from '../lib/series_change_handler';
 import { handleAdd, handleDelete } from '../lib/collection_actions';
 import { newMetricAggFn } from '../lib/new_metric_agg_fn';
-import type { Panel, Series } from '../../../../common/types';
+import type { Panel, Series, SanitizedFieldType } from '../../../../common/types';
 import type { TimeseriesUIRestrictions } from '../../../../common/ui_restrictions';
-import { IFieldType } from '../../../../../data/common/index_patterns/fields';
 
 const DROPPABLE_ID = 'aggs_dnd';
 
@@ -25,7 +24,7 @@ export interface AggsProps {
   name: keyof Series;
   panel: Panel;
   model: Series;
-  fields: IFieldType[];
+  fields: Record<string, SanitizedFieldType[]>;
   uiRestrictions: TimeseriesUIRestrictions;
   onChange(): void;
 }

--- a/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.test.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/search_strategies/strategies/abstract_search_strategy.test.ts
@@ -10,7 +10,7 @@ import { IndexPatternsService } from '../../../../../data/common';
 
 import { from } from 'rxjs';
 import { AbstractSearchStrategy } from './abstract_search_strategy';
-import type { IFieldType } from '../../../../../data/common';
+import type { FieldSpec } from '../../../../../data/common';
 import type { CachedIndexPatternFetcher } from '../lib/cached_index_pattern_fetcher';
 import type {
   VisTypeTimeseriesRequestHandlerContext,
@@ -21,7 +21,7 @@ class FooSearchStrategy extends AbstractSearchStrategy {}
 
 describe('AbstractSearchStrategy', () => {
   let abstractSearchStrategy: AbstractSearchStrategy;
-  let mockedFields: IFieldType[];
+  let mockedFields: FieldSpec[];
   let requestContext: VisTypeTimeseriesRequestHandlerContext;
 
   beforeEach(() => {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [TSVB] Remove deprecated `IFieldType` (#110404)