### PR TITLE
[7.x] Don't add split part of UI if we have one series (#109483)

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_with_splits.js
@@ -40,7 +40,8 @@ export function visWithSplits(WrappedComponent) {
       [model, palettesService, syncColors, visData]
     );
 
-    if (!model || !visData || !visData[model.id]) return <WrappedComponent {...props} />;
+    if (!model || !visData || !visData[model.id] || visData[model.id].series.length === 1)
+      return <WrappedComponent {...props} />;
     if (visData[model.id].series.every((s) => s.id.split(':').length === 1)) {
       return <WrappedComponent {...props} />;
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Don't add split part of UI if we have one series (#109483)