### PR TITLE
[Lens] Fix filters reappearing in the saved object when saving

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -37,6 +37,7 @@ import {
   navigateAway,
   LensRootStore,
   loadInitial,
+  LensAppState,
   LensState,
 } from '../state_management';
 import { getPreloadedState } from '../state_management/lens_slice';
@@ -186,8 +187,9 @@ export async function mountApp(
     embeddableEditorIncomingState,
     initialContext,
   };
+  const emptyState = getPreloadedState(storeDeps) as LensAppState;
   const lensStore: LensRootStore = makeConfigureStore(storeDeps, {
-    lens: getPreloadedState(storeDeps),
+    lens: emptyState,
   } as DeepPartial<LensState>);
 
   const EditorRenderer = React.memo(
@@ -200,7 +202,8 @@ export async function mountApp(
       );
       trackUiEvent('loaded');
       const initialInput = getInitialInput(props.id, props.editByValue);
-      lensStore.dispatch(loadInitial({ redirectCallback, initialInput }));
+
+      lensStore.dispatch(loadInitial({ redirectCallback, initialInput, emptyState }));
 
       return (
         <Provider store={lensStore}>

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
@@ -230,7 +230,7 @@ describe('editor_frame', () => {
         await mountWithProvider(<EditorFrame {...props} />, {
           data: props.plugins.data,
           preloadedState: {
-            visualization: { activeId: 'testVis', state: null },
+            visualization: { activeId: 'testVis', state: {} },
             datasourceStates: {
               testDatasource: {
                 isLoading: false,
@@ -285,7 +285,7 @@ describe('editor_frame', () => {
         await mountWithProvider(<EditorFrame {...props} />, {
           data: props.plugins.data,
           preloadedState: {
-            visualization: { activeId: 'testVis', state: null },
+            visualization: { activeId: 'testVis', state: {} },
             datasourceStates: {
               testDatasource: {
                 isLoading: false,

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.tsx
@@ -45,7 +45,8 @@ export function EditorFrame(props: EditorFrameProps) {
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
   const datasourceStates = useLensSelector(selectDatasourceStates);
   const visualization = useLensSelector(selectVisualization);
-  const allLoaded = useLensSelector(selectAreDatasourcesLoaded);
+  const areDatasourcesLoaded = useLensSelector(selectAreDatasourcesLoaded);
+  const isVisualizationLoaded = !!visualization.state;
   const framePublicAPI: FramePublicAPI = useLensSelector((state) =>
     selectFramePublicAPI(state, datasourceMap)
   );
@@ -95,7 +96,7 @@ export function EditorFrame(props: EditorFrameProps) {
           />
         }
         configPanel={
-          allLoaded && (
+          areDatasourcesLoaded && (
             <ConfigPanelWrapper
               core={props.core}
               datasourceMap={datasourceMap}
@@ -105,7 +106,8 @@ export function EditorFrame(props: EditorFrameProps) {
           )
         }
         workspacePanel={
-          allLoaded && (
+          areDatasourcesLoaded &&
+          isVisualizationLoaded && (
             <WorkspacePanel
               core={props.core}
               plugins={props.plugins}
@@ -119,7 +121,7 @@ export function EditorFrame(props: EditorFrameProps) {
           )
         }
         suggestionsPanel={
-          allLoaded && (
+          areDatasourcesLoaded && (
             <SuggestionPanelWrapper
               ExpressionRenderer={props.ExpressionRenderer}
               datasourceMap={datasourceMap}

--- a/x-pack/plugins/lens/public/mocks.tsx
+++ b/x-pack/plugins/lens/public/mocks.tsx
@@ -208,12 +208,14 @@ export const defaultDoc = ({
   savedObjectId: '1234',
   title: 'An extremely cool default document!',
   expression: 'definitely a valid expression',
+  visualizationType: 'testVis',
   state: {
     query: 'kuery',
     filters: [{ query: { match_phrase: { src: 'test' } } }],
     datasourceStates: {
       testDatasource: 'datasource',
     },
+    visualization: {},
   },
   references: [{ type: 'index-pattern', id: '1', name: 'index-pattern-0' }],
 } as unknown) as Document;

--- a/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
@@ -23,7 +23,8 @@ export const initMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAP
         store,
         storeDeps,
         action.payload.redirectCallback,
-        action.payload.initialInput
+        action.payload.initialInput,
+        action.payload.emptyState
       );
     } else if (lensSlice.actions.navigateAway.match(action)) {
       return unsubscribeFromExternalContext();

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
@@ -7,7 +7,8 @@
 
 import { MiddlewareAPI } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
-import { setState } from '..';
+import { i18n } from '@kbn/i18n';
+import { LensAppState, setState } from '..';
 import { updateLayer, updateVisualizationState, LensStoreDeps } from '..';
 import { LensEmbeddableInput, LensByReferenceInput } from '../../embeddable/embeddable';
 import { getInitialDatasourceId } from '../../utils';
@@ -17,7 +18,40 @@ import {
   getVisualizeFieldSuggestions,
   switchToSuggestion,
 } from '../../editor_frame_service/editor_frame/suggestion_helpers';
-import { getPersistedDoc } from '../../app_plugin/save_modal_container';
+import { LensAppServices } from '../../app_plugin/types';
+import { getFullPath, LENS_EMBEDDABLE_TYPE } from '../../../common/constants';
+import { Document, injectFilterReferences } from '../../persistence';
+
+export const getPersisted = async ({
+  initialInput,
+  lensServices,
+}: {
+  initialInput: LensEmbeddableInput;
+  lensServices: LensAppServices;
+}): Promise<{ doc: Document } | undefined> => {
+  const { notifications, attributeService } = lensServices;
+  let doc: Document;
+
+  try {
+    const { ...attributes } = await attributeService.unwrapAttributes(initialInput);
+
+    doc = {
+      ...initialInput,
+      ...attributes,
+      type: LENS_EMBEDDABLE_TYPE,
+    };
+
+    return {
+      doc,
+    };
+  } catch (e) {
+    notifications.toasts.addDanger(
+      i18n.translate('xpack.lens.app.docLoadingError', {
+        defaultMessage: 'Error loading saved document',
+      })
+    );
+  }
+};
 
 export function loadInitial(
   store: MiddlewareAPI,
@@ -29,11 +63,13 @@ export function loadInitial(
     initialContext,
   }: LensStoreDeps,
   redirectCallback: (savedObjectId?: string) => void,
-  initialInput?: LensEmbeddableInput
+  initialInput?: LensEmbeddableInput,
+  emptyState?: LensAppState
 ) {
   const { getState, dispatch } = store;
-  const { attributeService, chrome, notifications, data, dashboardFeatureFlag } = lensServices;
+  const { attributeService, notifications, data, dashboardFeatureFlag } = lensServices;
   const { persistedDoc } = getState().lens;
+
   if (
     !initialInput ||
     (attributeService.inputIsRefType(initialInput) &&
@@ -61,6 +97,7 @@ export function loadInitial(
         );
         dispatch(
           setState({
+            ...emptyState,
             datasourceStates,
             isLoading: false,
           })
@@ -109,17 +146,23 @@ export function loadInitial(
         redirectCallback();
       });
   }
-  getPersistedDoc({
-    initialInput,
-    attributeService,
-    data,
-    chrome,
-    notifications,
-  })
+  getPersisted({ initialInput, lensServices })
     .then(
-      (doc) => {
-        if (doc) {
-          const currentSessionId = data.search.session.getSessionId();
+      (persisted) => {
+        if (persisted) {
+          const { doc } = persisted;
+          if (attributeService.inputIsRefType(initialInput)) {
+            lensServices.chrome.recentlyAccessed.add(
+              getFullPath(initialInput.savedObjectId),
+              doc.title,
+              initialInput.savedObjectId
+            );
+          }
+          // Don't overwrite any pinned filters
+          data.query.filterManager.setAppFilters(
+            injectFilterReferences(doc.state.filters, doc.references)
+          );
+
           const docDatasourceStates = Object.entries(doc.state.datasourceStates).reduce(
             (stateMap, [datasourceId, datasourceState]) => ({
               ...stateMap,
@@ -142,6 +185,8 @@ export function loadInitial(
           )
             .then((result) => {
               const activeDatasourceId = getInitialDatasourceId(datasourceMap, doc);
+
+              const currentSessionId = data.search.session.getSessionId();
 
               dispatch(
                 setState({

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.ts
@@ -33,7 +33,7 @@ export const getPersisted = async ({
   let doc: Document;
 
   try {
-    const { ...attributes } = await attributeService.unwrapAttributes(initialInput);
+    const attributes = await attributeService.unwrapAttributes(initialInput);
 
     doc = {
       ...initialInput,

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -12,6 +12,7 @@ import { getInitialDatasourceId, getResolvedDateRange } from '../utils';
 import { LensAppState, LensStoreDeps } from './types';
 
 export const initialState: LensAppState = {
+  persistedDoc: undefined,
   searchSessionId: '',
   filters: [],
   query: { language: 'kuery', query: '' },
@@ -299,6 +300,7 @@ export const lensSlice = createSlice({
       payload: PayloadAction<{
         initialInput?: LensEmbeddableInput;
         redirectCallback: (savedObjectId?: string) => void;
+        emptyState: LensAppState;
       }>
     ) => state,
   },

--- a/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
@@ -444,7 +444,7 @@ export const getXyVisualization = ({
   },
 
   getWarningMessages(state, frame) {
-    if (state?.layers.length === 0 || !frame.activeData) {
+    if (!state || state?.layers.length === 0 || !frame.activeData) {
       return;
     }
 

--- a/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
@@ -444,7 +444,7 @@ export const getXyVisualization = ({
   },
 
   getWarningMessages(state, frame) {
-    if (!state || state?.layers.length === 0 || !frame.activeData) {
+    if (state?.layers.length === 0 || !frame.activeData) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/110248

Also fixes the issue with loading empty document from the search bar. To reproduce, load existing document and then search for Lens new document in the top search bar - the bug was caused by not properly cleaning initial state for the empty state. 

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
