### PR TITLE
[7.x] [Lens] should register "suffix" field formatter in setup lifecycle (#110218)

### DIFF
--- a/x-pack/plugins/lens/common/suffix_formatter/index.ts
+++ b/x-pack/plugins/lens/common/suffix_formatter/index.ts
@@ -28,9 +28,11 @@ export const unitSuffixesLong: Record<TimeScaleUnit, string> = {
   d: i18n.translate('xpack.lens.fieldFormats.longSuffix.d', { defaultMessage: 'per day' }),
 };
 
-export function getSuffixFormatter(formatFactory: FormatFactory): FieldFormatInstanceType {
+export const suffixFormatterId = 'suffix';
+
+export function getSuffixFormatter(getFormatFactory: () => FormatFactory): FieldFormatInstanceType {
   return class SuffixFormatter extends FieldFormat {
-    static id = 'suffix';
+    static id = suffixFormatterId;
     static hidden = true; // Don't want this format to appear in index pattern editor
     static title = i18n.translate('xpack.lens.fieldFormats.suffix.title', {
       defaultMessage: 'Suffix',
@@ -51,9 +53,10 @@ export function getSuffixFormatter(formatFactory: FormatFactory): FieldFormatIns
       const nestedFormatter = this.param('id');
       const nestedParams = this.param('params');
 
-      const formattedValue = formatFactory({ id: nestedFormatter, params: nestedParams }).convert(
-        val
-      );
+      const formattedValue = getFormatFactory()({
+        id: nestedFormatter,
+        params: nestedParams,
+      }).convert(val);
 
       // do not add suffixes to empty strings
       if (formattedValue === '') {

--- a/x-pack/plugins/lens/common/suffix_formatter/suffix_formatter.test.ts
+++ b/x-pack/plugins/lens/common/suffix_formatter/suffix_formatter.test.ts
@@ -12,7 +12,7 @@ describe('suffix formatter', () => {
   it('should call nested formatter and apply suffix', () => {
     const convertMock = jest.fn((x) => x);
     const formatFactory = jest.fn(() => ({ convert: convertMock }));
-    const SuffixFormatter = getSuffixFormatter((formatFactory as unknown) as FormatFactory);
+    const SuffixFormatter = getSuffixFormatter(() => (formatFactory as unknown) as FormatFactory);
     const nestedParams = { abc: 123 };
     const formatterInstance = new SuffixFormatter({
       unit: 'h',
@@ -30,7 +30,7 @@ describe('suffix formatter', () => {
   it('should not add suffix to empty strings', () => {
     const convertMock = jest.fn((x) => '');
     const formatFactory = jest.fn(() => ({ convert: convertMock }));
-    const SuffixFormatter = getSuffixFormatter((formatFactory as unknown) as FormatFactory);
+    const SuffixFormatter = getSuffixFormatter(() => (formatFactory as unknown) as FormatFactory);
     const nestedParams = { abc: 123 };
     const formatterInstance = new SuffixFormatter({
       unit: 'h',
@@ -46,7 +46,7 @@ describe('suffix formatter', () => {
   it('should be a hidden formatter', () => {
     const convertMock = jest.fn((x) => '');
     const formatFactory = jest.fn(() => ({ convert: convertMock }));
-    const SuffixFormatter = getSuffixFormatter((formatFactory as unknown) as FormatFactory);
+    const SuffixFormatter = getSuffixFormatter(() => (formatFactory as unknown) as FormatFactory);
     expect(SuffixFormatter.hidden).toBe(true);
   });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CoreSetup } from 'kibana/public';
-import { Storage } from '../../../../../src/plugins/kibana_utils/public';
+import { createStartServicesGetter, Storage } from '../../../../../src/plugins/kibana_utils/public';
 import type { ExpressionsSetup } from '../../../../../src/plugins/expressions/public';
 import type { ChartsPluginSetup } from '../../../../../src/plugins/charts/public';
 import type { IndexPatternFieldEditorStart } from '../../../../../src/plugins/index_pattern_field_editor/public';
@@ -14,7 +14,7 @@ import type {
   DataPublicPluginSetup,
   DataPublicPluginStart,
 } from '../../../../../src/plugins/data/public';
-import type { Datasource, EditorFrameSetup } from '../types';
+import type { EditorFrameSetup } from '../types';
 import type { UiActionsStart } from '../../../../../src/plugins/ui_actions/public';
 import type {
   FieldFormatsStart,
@@ -57,29 +57,37 @@ export class IndexPatternDatasource {
         counterRate,
         getTimeScale,
         getSuffixFormatter,
+        suffixFormatterId,
       } = await import('../async_services');
-      return core
-        .getStartServices()
-        .then(([coreStart, { indexPatternFieldEditor, uiActions, data, fieldFormats }]) => {
-          const suffixFormatter = getSuffixFormatter(fieldFormats.deserialize);
-          if (!fieldFormats.has(suffixFormatter.id)) {
-            // todo: this code should be executed on setup phase.
-            fieldFormatsSetup.register([suffixFormatter]);
-          }
-          expressions.registerFunction(getTimeScale(() => getTimeZone(core.uiSettings)));
-          expressions.registerFunction(counterRate);
-          expressions.registerFunction(renameColumns);
-          expressions.registerFunction(formatColumn);
-          return getIndexPatternDatasource({
-            core: coreStart,
-            fieldFormats,
-            storage: new Storage(localStorage),
-            data,
-            charts,
-            indexPatternFieldEditor,
-            uiActions,
-          });
-        }) as Promise<Datasource>;
+
+      if (!fieldFormatsSetup.has(suffixFormatterId)) {
+        const startServices = createStartServicesGetter(core.getStartServices);
+        const suffixFormatter = getSuffixFormatter(
+          () => startServices().plugins.fieldFormats.deserialize
+        );
+
+        fieldFormatsSetup.register([suffixFormatter]);
+      }
+
+      expressions.registerFunction(getTimeScale(() => getTimeZone(core.uiSettings)));
+      expressions.registerFunction(counterRate);
+      expressions.registerFunction(renameColumns);
+      expressions.registerFunction(formatColumn);
+
+      const [
+        coreStart,
+        { indexPatternFieldEditor, uiActions, data, fieldFormats },
+      ] = await core.getStartServices();
+
+      return getIndexPatternDatasource({
+        core: coreStart,
+        fieldFormats,
+        storage: new Storage(localStorage),
+        data,
+        charts,
+        indexPatternFieldEditor,
+        uiActions,
+      });
     });
   }
 }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -76,7 +76,11 @@ export {
   counterRate,
 } from '../../common/expressions';
 export { FormatColumnArgs, supportedFormats, formatColumn } from '../../common/expressions';
-export { getSuffixFormatter, unitSuffixesLong } from '../../common/suffix_formatter';
+export {
+  getSuffixFormatter,
+  unitSuffixesLong,
+  suffixFormatterId,
+} from '../../common/suffix_formatter';
 export { getTimeScale, TimeScaleArgs } from '../../common/expressions';
 export { renameColumns } from '../../common/expressions';
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Lens] should register "suffix" field formatter in setup lifecycle (#110218)