### PR TITLE
[APM] Set preference to any value for APM searches

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
@@ -95,6 +95,7 @@ export function createApmEventClient({
         ...withPossibleLegacyDataFilter,
         ignore_throttled: !includeFrozen,
         ignore_unavailable: true,
+        preference: 'any',
       };
 
       // only "search" operation is currently supported

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
@@ -131,6 +131,7 @@ describe('setupRequest', () => {
         },
         ignore_unavailable: true,
         ignore_throttled: true,
+        preference: 'any',
       });
     });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/102725

If the cluster state and selected shards do not change, searches using the same <custom-string> value are routed to the same shards in the same order, improving performance of the search requests.

## What was done

- Add preference param to the search request wrapper
- Fix unit tests


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios