### PR TITLE
 [APM] Logs tab seems to show logs from incorrect service(s)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_logs/index.test.ts
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { getInfrastructureKQLFilter } from './';
+
+describe('service logs', () => {
+  describe('getInfrastructureKQLFilter', () => {
+    it('filter by container id', () => {
+      expect(
+        getInfrastructureKQLFilter({
+          serviceInfrastructure: {
+            containerIds: ['foo', 'bar'],
+            hostNames: ['baz', `quz`],
+          },
+        })
+      ).toEqual('container.id: "foo" or container.id: "bar"');
+    });
+    it('filter by host names', () => {
+      expect(
+        getInfrastructureKQLFilter({
+          serviceInfrastructure: {
+            containerIds: [],
+            hostNames: ['baz', `quz`],
+          },
+        })
+      ).toEqual('host.name: "baz" or host.name: "quz"');
+    });
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
@@ -18,7 +18,6 @@ import { APIReturnType } from '../../../services/rest/createCallApmApi';
 import {
   CONTAINER_ID,
   HOSTNAME,
-  POD_NAME,
 } from '../../../../common/elasticsearch_fieldnames';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import { useTimeRange } from '../../../hooks/use_time_range';
@@ -55,8 +54,7 @@ export function ServiceLogs() {
   const noInfrastructureData = useMemo(() => {
     return (
       isEmpty(data?.serviceInfrastructure?.containerIds) &&
-      isEmpty(data?.serviceInfrastructure?.hostNames) &&
-      isEmpty(data?.serviceInfrastructure?.podNames)
+      isEmpty(data?.serviceInfrastructure?.hostNames)
     );
   }, [data]);
 
@@ -93,16 +91,15 @@ export function ServiceLogs() {
   );
 }
 
-const getInfrastructureKQLFilter = (
+export const getInfrastructureKQLFilter = (
   data?: APIReturnType<'GET /api/apm/services/{serviceName}/infrastructure'>
 ) => {
   const containerIds = data?.serviceInfrastructure?.containerIds ?? [];
   const hostNames = data?.serviceInfrastructure?.hostNames ?? [];
-  const podNames = data?.serviceInfrastructure?.podNames ?? [];
 
-  return [
-    ...containerIds.map((id) => `${CONTAINER_ID}: "${id}"`),
-    ...hostNames.map((id) => `${HOSTNAME}: "${id}"`),
-    ...podNames.map((id) => `${POD_NAME}: "${id}"`),
-  ].join(' or ');
+  const kqlFilter = containerIds.length
+    ? containerIds.map((id) => `${CONTAINER_ID}: "${id}"`)
+    : hostNames.map((id) => `${HOSTNAME}: "${id}"`);
+
+  return kqlFilter.join(' or ');
 };

--- a/x-pack/plugins/apm/server/lib/services/get_service_infrastructure.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_infrastructure.ts
@@ -14,7 +14,6 @@ import {
   SERVICE_NAME,
   CONTAINER_ID,
   HOSTNAME,
-  POD_NAME,
 } from '../../../common/elasticsearch_fieldnames';
 
 export const getServiceInfrastructure = async ({
@@ -61,12 +60,6 @@ export const getServiceInfrastructure = async ({
             size: 500,
           },
         },
-        podNames: {
-          terms: {
-            field: POD_NAME,
-            size: 500,
-          },
-        },
       },
     },
   });
@@ -74,13 +67,11 @@ export const getServiceInfrastructure = async ({
   return {
     containerIds:
       response.aggregations?.containerIds?.buckets.map(
-        (bucket) => bucket.key
+        (bucket) => bucket.key as string
       ) ?? [],
     hostNames:
-      response.aggregations?.hostNames?.buckets.map((bucket) => bucket.key) ??
-      [],
-    podNames:
-      response.aggregations?.podNames?.buckets.map((bucket) => bucket.key) ??
-      [],
+      response.aggregations?.hostNames?.buckets.map(
+        (bucket) => bucket.key as string
+      ) ?? [],
   };
 };


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/110062

before:
<img width="1443" alt="Screen Shot 2021-08-30 at 10 00 02" src="https://user-images.githubusercontent.com/55978943/131353042-8921c067-344b-477d-9e10-20c03a81c0c4.png">

After:
<img width="1468" alt="Screen Shot 2021-08-30 at 10 01 52" src="https://user-images.githubusercontent.com/55978943/131353061-5cd4cb73-e8ea-42aa-a4c9-d402c319ed2f.png">
