### PR TITLE
chore(NA): moving @kbn/securitysolution-list-utils to babel transpiler

### DIFF
--- a/packages/kbn-securitysolution-list-utils/.babelrc
+++ b/packages/kbn-securitysolution-list-utils/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/node_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/kbn-securitysolution-list-utils/.babelrc.browser
+++ b/packages/kbn-securitysolution-list-utils/.babelrc.browser
@@ -1,0 +1,4 @@
+{
+  "presets": ["@kbn/babel-preset/webpack_preset"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_project")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "pkg_npm")
+load("//src/dev/bazel:index.bzl", "jsts_transpiler")
 
 PKG_BASE_NAME = "kbn-securitysolution-list-utils"
 
@@ -27,23 +28,31 @@ NPM_MODULE_EXTRA_FILES = [
   "README.md",
 ]
 
-SRC_DEPS = [
-  "//packages/kbn-i18n",
-  "//packages/kbn-securitysolution-list-constants",
-  "//packages/kbn-securitysolution-io-ts-list-types",
-  "//packages/kbn-securitysolution-utils",
+RUNTIME_DEPS = [
   "//packages/kbn-es-query",
+  "//packages/kbn-i18n",
+  "//packages/kbn-securitysolution-io-ts-list-types",
+  "//packages/kbn-securitysolution-list-constants",
+  "//packages/kbn-securitysolution-utils",
   "@npm//lodash",
-  "@npm//tslib",
 ]
 
 TYPES_DEPS = [
+  "//packages/kbn-es-query",
+  "//packages/kbn-i18n",
+  "//packages/kbn-securitysolution-io-ts-list-types",
+  "//packages/kbn-securitysolution-list-constants",
+  "//packages/kbn-securitysolution-utils",
   "@npm//@types/jest",
   "@npm//@types/lodash",
   "@npm//@types/node",
 ]
 
-DEPS = SRC_DEPS + TYPES_DEPS
+jsts_transpiler(
+  name = "target_node",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+)
 
 ts_config(
   name = "tsconfig",
@@ -55,24 +64,26 @@ ts_config(
 )
 
 ts_project(
-  name = "tsc",
-  srcs = SRCS,
+  name = "tsc_types",
   args = ["--pretty"],
+  srcs = SRCS,
+  deps = TYPES_DEPS,
   declaration = True,
   declaration_map = True,
-  out_dir = "target",
+  emit_declaration_only = True,
+  out_dir = "target_types",
   root_dir = "src",
   source_map = True,
   tsconfig = ":tsconfig",
-  deps = DEPS,
 )
 
 js_library(
   name = PKG_BASE_NAME,
-  package_name = PKG_REQUIRE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
+  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
-  deps = DEPS + [":tsc"],
+
 )
 
 pkg_npm(

--- a/packages/kbn-securitysolution-list-utils/BUILD.bazel
+++ b/packages/kbn-securitysolution-list-utils/BUILD.bazel
@@ -54,6 +54,13 @@ jsts_transpiler(
   build_pkg_name = package_name(),
 )
 
+jsts_transpiler(
+  name = "target_web",
+  srcs = SRCS,
+  build_pkg_name = package_name(),
+  config_file = ".babelrc.browser"
+)
+
 ts_config(
   name = "tsconfig",
   src = "tsconfig.json",
@@ -80,7 +87,7 @@ ts_project(
 js_library(
   name = PKG_BASE_NAME,
   srcs = NPM_MODULE_EXTRA_FILES,
-  deps = RUNTIME_DEPS + [":target_node", ":tsc_types"],
+  deps = RUNTIME_DEPS + [":target_node", ":target_web", ":tsc_types"],
   package_name = PKG_REQUIRE_NAME,
   visibility = ["//visibility:public"],
 

--- a/packages/kbn-securitysolution-list-utils/package.json
+++ b/packages/kbn-securitysolution-list-utils/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "security solution list utilities",
   "license": "SSPL-1.0 OR Elastic License 2.0",
+  "browser": "./target_web/index.js",
   "main": "./target_node/index.js",
   "types": "./target_types/index.d.ts",
   "private": true

--- a/packages/kbn-securitysolution-list-utils/package.json
+++ b/packages/kbn-securitysolution-list-utils/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "security solution list utilities",
   "license": "SSPL-1.0 OR Elastic License 2.0",
-  "main": "./target/index.js",
-  "types": "./target/index.d.ts",
+  "main": "./target_node/index.js",
+  "types": "./target_types/index.d.ts",
   "private": true
 }

--- a/packages/kbn-securitysolution-list-utils/tsconfig.json
+++ b/packages/kbn-securitysolution-list-utils/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "outDir": "target",
+    "emitDeclarationOnly": true,
+    "outDir": "target_types",
     "rootDir": "src",
     "sourceMap": true,
     "sourceRoot": "../../../../packages/kbn-securitysolution-list-utils/src",


### PR DESCRIPTION
One step forward on #69706

That PR moves the @kbn/securitysolution-list-utils from using tsc compiler to babel transpiler to produce the js outputs.