### PR TITLE
[ML] fix heatmap label colors

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -280,10 +280,10 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
     return { x: selection.times.map((v) => v * 1000), y: selection.lanes };
   }, [selection, swimlaneData, swimlaneType]);
 
-  const swimLaneConfig: HeatmapSpec['config'] = useMemo(() => {
+  const swimLaneConfig = useMemo<HeatmapSpec['config']>(() => {
     if (!showSwimlane) return {};
 
-    return {
+    const config: HeatmapSpec['config'] = {
       onBrushEnd: (e: HeatmapBrushEvent) => {
         if (!e.cells.length) return;
 
@@ -318,7 +318,7 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
       yAxisLabel: {
         visible: true,
         width: Y_AXIS_LABEL_WIDTH,
-        fill: euiTheme.euiTextSubduedColor,
+        textColor: euiTheme.euiTextSubduedColor,
         padding: Y_AXIS_LABEL_PADDING,
         formatter: (laneLabel: string) => {
           return laneLabel === '' ? EMPTY_FIELD_VALUE_LABEL : laneLabel;
@@ -327,7 +327,7 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
       },
       xAxisLabel: {
         visible: true,
-        fill: euiTheme.euiTextSubduedColor,
+        textColor: euiTheme.euiTextSubduedColor,
         formatter: (v: number) => {
           timeBuckets.setInterval(`${swimlaneData.interval}s`);
           const scaledDateFormat = timeBuckets.getScaledDateFormat();
@@ -346,6 +346,8 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
       ...(showLegend ? { maxLegendHeight: LEGEND_HEIGHT } : {}),
       timeZone: 'UTC',
     };
+
+    return config;
   }, [
     showSwimlane,
     swimlaneType,


### PR DESCRIPTION
## Summary

Fixes issue caused by an intentional breaking change to `@elastic/charts` (https://github.com/elastic/elastic-charts/pull/1286). All other breaking changes we fixed in https://github.com/elastic/kibana/pull/108766 but this one slipped through as types were not, but now are, being enforced.

This PR is an initial fix for https://github.com/elastic/elastic-charts/issues/1335 to correct the label coloring. The issue should remain open to address proper theming of heatmap charts.

This bug is verified to only be in `7.15` and no prior release. 🎉 

![Image 2021-08-30 at 1 30 31 PM](https://user-images.githubusercontent.com/19007109/131388074-524f5f70-251d-4936-b4b2-4053d3e33094.jpg)


### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
