### PR TITLE
Change legacy audit logger deprecation warning in docs (master)

### DIFF
--- a/docs/settings/security-settings.asciidoc
+++ b/docs/settings/security-settings.asciidoc
@@ -371,7 +371,7 @@ xpack.security.audit.appender.type: rolling-file
 
 [NOTE]
 ============
-deprecated:[7.15.0,"In 8.0 and later, the legacy audit logger will be removed, and this setting will enable the ECS audit logger with a default appender."] To enable the legacy audit logger only specify:
+deprecated:[7.15.0,"The legacy audit logger will be removed in an upcoming version, and this setting will enable the ECS audit logger with a default appender."] To enable the legacy audit logger only specify:
 
 [source,yaml]
 ----------------------------------------


### PR DESCRIPTION
Partially resolves #82578.

Master-branch-only docs change for #110527; that PR targets 7.x and will be backported to 7.15.