### PR TITLE
[Reporting] Remove `any` from public/poller

### DIFF
--- a/x-pack/plugins/reporting/common/poller.ts
+++ b/x-pack/plugins/reporting/common/poller.ts
@@ -8,20 +8,20 @@
 import _ from 'lodash';
 
 interface PollerOptions {
-  functionToPoll: () => Promise<any>;
+  functionToPoll: () => Promise<void>;
   pollFrequencyInMillis: number;
   trailing?: boolean;
   continuePollingOnError?: boolean;
   pollFrequencyErrorMultiplier?: number;
-  successFunction?: (...args: any) => any;
-  errorFunction?: (error: Error) => any;
+  successFunction?: (...args: unknown[]) => void;
+  errorFunction?: (error: Error) => void;
 }
 
 // @TODO Maybe move to observables someday
 export class Poller {
-  private readonly functionToPoll: () => Promise<any>;
-  private readonly successFunction: (...args: any) => any;
-  private readonly errorFunction: (error: Error) => any;
+  private readonly functionToPoll: () => Promise<void>;
+  private readonly successFunction: (...args: unknown[]) => void;
+  private readonly errorFunction: (error: Error) => void;
   private _isRunning: boolean;
   private _timeoutId: NodeJS.Timeout | null;
   private pollFrequencyInMillis: number;

--- a/x-pack/plugins/reporting/common/poller.ts
+++ b/x-pack/plugins/reporting/common/poller.ts
@@ -17,7 +17,6 @@ interface PollerOptions {
   errorFunction?: (error: Error) => void;
 }
 
-// @TODO Maybe move to observables someday
 export class Poller {
   private readonly functionToPoll: () => Promise<void>;
   private readonly successFunction: (...args: unknown[]) => void;


### PR DESCRIPTION
## Summary
Part of removing `any` usage from Reporting.

The `any` usage has high and low fruit. The `public/poller` module is possibly the lowest fruit area.

This PR replaces a large number of `any` instances from the reporting poller in the UI.