### PR TITLE
[Reporting] Remove `any` from pdf job compatibility shim

### DIFF
--- a/x-pack/plugins/reporting/public/management/report_listing.tsx
+++ b/x-pack/plugins/reporting/public/management/report_listing.tsx
@@ -51,7 +51,7 @@ class ReportListingUi extends Component<Props, State> {
   private isInitialJobsFetch: boolean;
   private licenseSubscription?: Subscription;
   private mounted?: boolean;
-  private poller?: any;
+  private poller?: Poller;
 
   constructor(props: Props) {
     super(props);
@@ -119,7 +119,7 @@ class ReportListingUi extends Component<Props, State> {
 
   public componentWillUnmount() {
     this.mounted = false;
-    this.poller.stop();
+    this.poller?.stop();
 
     if (this.licenseSubscription) {
       this.licenseSubscription.unsubscribe();

--- a/x-pack/plugins/reporting/public/notifier/job_completion_notifications.ts
+++ b/x-pack/plugins/reporting/public/notifier/job_completion_notifications.ts
@@ -9,11 +9,11 @@ import { JOB_COMPLETION_NOTIFICATIONS_SESSION_KEY } from '../../common/constants
 
 type JobId = string;
 
-const set = (jobs: any) => {
+const set = (jobs: string[]) => {
   sessionStorage.setItem(JOB_COMPLETION_NOTIFICATIONS_SESSION_KEY, JSON.stringify(jobs));
 };
 
-const getAll = () => {
+const getAll = (): string[] => {
   const sessionValue = sessionStorage.getItem(JOB_COMPLETION_NOTIFICATIONS_SESSION_KEY);
   return sessionValue ? JSON.parse(sessionValue) : [];
 };

--- a/x-pack/plugins/reporting/server/browsers/safe_child_process.ts
+++ b/x-pack/plugins/reporting/server/browsers/safe_child_process.ts
@@ -10,7 +10,7 @@ import { take, share, mapTo, delay, tap } from 'rxjs/operators';
 import { LevelLogger } from '../lib';
 
 interface IChild {
-  kill: (signal: string) => Promise<any>;
+  kill: (signal: string) => Promise<void>;
 }
 
 // Our process can get sent various signals, and when these occur we wish to

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf/create_job/compatibility_shim.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf/create_job/compatibility_shim.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { KibanaRequest } from 'kibana/server';
+import type { KibanaRequest, SavedObjectsClientContract } from 'kibana/server';
 import { url as urlUtils } from '../../../../../../../src/plugins/kibana_utils/server';
 import type { LevelLogger } from '../../../lib';
 import type { CreateJobFn, ReportingRequestHandlerContext } from '../../../types';
@@ -20,9 +20,9 @@ function isLegacyJob(
 const getSavedObjectTitle = async (
   objectType: string,
   savedObjectId: string,
-  savedObjectsClient: any
+  savedObjectsClient: SavedObjectsClientContract
 ) => {
-  const savedObject = await savedObjectsClient.get(objectType, savedObjectId);
+  const savedObject = await savedObjectsClient.get<{ title: string }>(objectType, savedObjectId);
   return savedObject.attributes.title;
 };
 

--- a/x-pack/plugins/reporting/server/types.ts
+++ b/x-pack/plugins/reporting/server/types.ts
@@ -63,7 +63,7 @@ export { BaseParams, BasePayload };
 export type CreateJobFn<JobParamsType = BaseParams, JobPayloadType = BasePayload> = (
   jobParams: JobParamsType,
   context: ReportingRequestHandlerContext,
-  request: KibanaRequest<any, any, any, any>
+  request: KibanaRequest
 ) => Promise<JobPayloadType>;
 
 // default fn type for RunTaskFnFactory


### PR DESCRIPTION
Part of removing any usage from Reporting.

The PDF job compatibility shim has an instance of `any` that is completely unnecessary. This PR replaces the ambiguous code with the proper types.