### PR TITLE
[RAC][Rule Registry] Put index upgrade logic under a feature flag

### DIFF
--- a/x-pack/plugins/rule_registry/server/config.ts
+++ b/x-pack/plugins/rule_registry/server/config.ts
@@ -17,6 +17,9 @@ export const config = {
       legacyMultiTenancy: schema.object({
         enabled: schema.boolean({ defaultValue: false }),
       }),
+      indexUpgrade: schema.object({
+        enabled: schema.boolean({ defaultValue: false }),
+      }),
     }),
   }),
 };

--- a/x-pack/plugins/rule_registry/server/plugin.ts
+++ b/x-pack/plugins/rule_registry/server/plugin.ts
@@ -103,6 +103,7 @@ export class RuleRegistryPlugin
       logger,
       kibanaVersion,
       isWriteEnabled: isWriteEnabled(this.config, this.legacyConfig),
+      isIndexUpgradeEnabled: this.config.unsafe.indexUpgrade.enabled,
       getClusterClient: async () => {
         const deps = await startDependencies;
         return deps.core.elasticsearch.client.asInternalUser;

--- a/x-pack/plugins/rule_registry/server/rule_data_plugin_service/resource_installer.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_plugin_service/resource_installer.ts
@@ -29,6 +29,7 @@ interface ConstructorOptions {
   getClusterClient: () => Promise<ElasticsearchClient>;
   logger: Logger;
   isWriteEnabled: boolean;
+  isIndexUpgradeEnabled: boolean;
 }
 
 export class ResourceInstaller {
@@ -115,6 +116,7 @@ export class ResourceInstaller {
   public async installIndexLevelResources(indexInfo: IndexInfo): Promise<void> {
     await this.installWithTimeout(`resources for index ${indexInfo.baseName}`, async () => {
       const { componentTemplates, ilmPolicy } = indexInfo.indexOptions;
+      const { isIndexUpgradeEnabled } = this.options;
 
       if (ilmPolicy != null) {
         await this.createOrUpdateLifecyclePolicy({
@@ -138,9 +140,11 @@ export class ResourceInstaller {
         })
       );
 
-      // TODO: Update all existing namespaced index templates matching this index' base name
+      if (isIndexUpgradeEnabled) {
+        // TODO: Update all existing namespaced index templates matching this index' base name
 
-      await this.updateIndexMappings(indexInfo);
+        await this.updateIndexMappings(indexInfo);
+      }
     });
   }
 

--- a/x-pack/plugins/rule_registry/server/rule_data_plugin_service/rule_data_plugin_service.ts
+++ b/x-pack/plugins/rule_registry/server/rule_data_plugin_service/rule_data_plugin_service.ts
@@ -22,6 +22,7 @@ interface ConstructorOptions {
   logger: Logger;
   kibanaVersion: string;
   isWriteEnabled: boolean;
+  isIndexUpgradeEnabled: boolean;
 }
 
 /**
@@ -43,6 +44,7 @@ export class RuleDataPluginService {
       getClusterClient: options.getClusterClient,
       logger: options.logger,
       isWriteEnabled: options.isWriteEnabled,
+      isIndexUpgradeEnabled: options.isIndexUpgradeEnabled,
     });
 
     this.installCommonResources = Promise.resolve(right('ok'));


### PR DESCRIPTION
**Ticket:** https://github.com/elastic/kibana/issues/110594

## Summary

This PR adds a feature flag around the logic that finds existing Alerts as Data indices and upgrades the mappings or rolls the index if the mappings can't be upgraded in place.

**IMPORTANT:**

- **The feature flag is switched off by default**. This is intentional, because we need to **disable the upgrade logic in 7.15.0**.
- **This is a temporary measure**. We're going to work on fixing the index upgrade logic asap and ship it before the next release that makes any mapping changes, possibly as soon as 7.15.1.
- Developers will need to enable it in their local kibana configs this way:

    ```yaml
    xpack.ruleRegistry.unsafe.indexUpgrade.enabled: true
    ```

Please check the ticket for the background of this fix.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
