### PR TITLE
[7.x] Split KibanaApp into VisEditors and DataDiscovery (#110588)

### DIFF
--- a/dev_docs/building_blocks.mdx
+++ b/dev_docs/building_blocks.mdx
@@ -62,7 +62,7 @@ Check out the Lens Embeddable if you wish to show users visualizations based on 
  and <DocLink id="kibBuildingBlocks" section="ui-actions--triggers" text="UI Actions"/>. Using the same configuration, it's also possible to link to
  a prefilled Lens editor, allowing the user to drill deeper and explore their data.
 
-**Github labels**: `Team:KibanaApp`, `Feature:Lens`
+**Github labels**: `Team:VisEditors`, `Feature:Lens`
 
 ### Map Embeddable
 

--- a/src/plugins/advanced_settings/kibana.json
+++ b/src/plugins/advanced_settings/kibana.json
@@ -7,7 +7,7 @@
   "optionalPlugins": ["home", "usageCollection"],
   "requiredBundles": ["kibanaReact", "kibanaUtils", "home", "esUiShared"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/src/plugins/chart_expressions/expression_tagcloud/kibana.json
+++ b/src/plugins/chart_expressions/expression_tagcloud/kibana.json
@@ -8,8 +8,8 @@
   "requiredBundles": ["kibanaUtils"],
   "optionalPlugins": [],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Expression Tagcloud plugin adds a `tagcloud` renderer and function to the expression plugin. The renderer will display the `Wordcloud` chart."
 }

--- a/src/plugins/charts/kibana.json
+++ b/src/plugins/charts/kibana.json
@@ -5,7 +5,7 @@
   "ui": true,
   "requiredPlugins": ["expressions"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/src/plugins/discover/kibana.json
+++ b/src/plugins/discover/kibana.json
@@ -18,8 +18,8 @@
   "optionalPlugins": ["home", "share", "usageCollection"],
   "requiredBundles": ["kibanaUtils", "home", "kibanaReact", "fieldFormats"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Data Discovery",
+    "githubTeam": "kibana-data-discovery"
   },
   "description": "This plugin contains the Discover application and the saved search embeddable."
 }

--- a/src/plugins/kibana_legacy/kibana.json
+++ b/src/plugins/kibana_legacy/kibana.json
@@ -4,7 +4,7 @@
   "server": true,
   "ui": true,
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/src/plugins/management/kibana.json
+++ b/src/plugins/management/kibana.json
@@ -6,7 +6,7 @@
   "optionalPlugins": ["home", "share"],
   "requiredBundles": ["kibanaReact", "kibanaUtils", "home"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/src/plugins/timelion/kibana.json
+++ b/src/plugins/timelion/kibana.json
@@ -17,7 +17,7 @@
     "kibanaLegacy"
   ],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/src/plugins/url_forwarding/kibana.json
+++ b/src/plugins/url_forwarding/kibana.json
@@ -4,8 +4,8 @@
   "server": false,
   "ui": true,
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "requiredPlugins": ["kibanaLegacy"]
 }

--- a/src/plugins/vis_default_editor/kibana.json
+++ b/src/plugins/vis_default_editor/kibana.json
@@ -5,8 +5,8 @@
   "optionalPlugins": ["visualize"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "data", "fieldFormats"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "The default editor used in most aggregation-based visualizations."
 }

--- a/src/plugins/vis_type_metric/kibana.json
+++ b/src/plugins/vis_type_metric/kibana.json
@@ -7,8 +7,8 @@
   "requiredPlugins": ["data", "visualizations", "charts", "expressions"],
   "requiredBundles": ["kibanaUtils", "visDefaultEditor"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Registers the Metric aggregation-based visualization."
 }

--- a/src/plugins/vis_type_table/kibana.json
+++ b/src/plugins/vis_type_table/kibana.json
@@ -17,8 +17,8 @@
   ],
   "optionalPlugins": ["usageCollection"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Registers the datatable aggregation-based visualization. Currently it contains two implementations, the one based on EUI datagrid and the angular one. The second one is going to be removed in future minors."
 }

--- a/src/plugins/vis_type_tagcloud/kibana.json
+++ b/src/plugins/vis_type_tagcloud/kibana.json
@@ -6,8 +6,8 @@
   "requiredPlugins": ["data", "expressions", "visualizations", "charts"],
   "requiredBundles": ["kibanaReact", "visDefaultEditor"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Registers the tagcloud visualization. It is based on elastic-charts wordcloud."
 

--- a/src/plugins/vis_type_timelion/kibana.json
+++ b/src/plugins/vis_type_timelion/kibana.json
@@ -7,8 +7,8 @@
   "requiredPlugins": ["visualizations", "data", "expressions", "charts"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "visDefaultEditor"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Registers the timelion visualization. Also contains the backend for both timelion app and timelion visualization."
 }

--- a/src/plugins/vis_type_timeseries/kibana.json
+++ b/src/plugins/vis_type_timeseries/kibana.json
@@ -8,8 +8,8 @@
   "optionalPlugins": ["usageCollection"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "fieldFormats"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Registers the TSVB visualization. TSVB has its one editor, works with index patterns and index strings and contains 6 types of charts: timeseries, topN, table. markdown, metric and gauge."
 }

--- a/src/plugins/vis_type_vega/kibana.json
+++ b/src/plugins/vis_type_vega/kibana.json
@@ -7,8 +7,8 @@
   "optionalPlugins": ["home","usageCollection"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "visDefaultEditor", "esUiShared"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Registers the vega visualization. Is the elastic version of vega and vega-lite libraries."
 }

--- a/src/plugins/vis_types/pie/kibana.json
+++ b/src/plugins/vis_types/pie/kibana.json
@@ -7,9 +7,8 @@
     "requiredBundles": ["visDefaultEditor"],
     "extraPublicDirs": ["common/index"],
     "owner": {
-      "name": "Kibana App",
-      "githubTeam": "kibana-app"
+      "name": "Vis Editors",
+      "githubTeam": "kibana-vis-editors"
     },
     "description": "Contains the pie chart implementation using the elastic-charts library. The goal is to eventually deprecate the old implementation and keep only this. Until then, the library used is defined by the Legacy charts library advanced setting."
   }
-  

--- a/src/plugins/vis_types/vislib/kibana.json
+++ b/src/plugins/vis_types/vislib/kibana.json
@@ -6,8 +6,8 @@
   "requiredPlugins": ["charts", "data", "expressions", "visualizations", "kibanaLegacy"],
   "requiredBundles": ["kibanaUtils", "visDefaultEditor", "visTypeXy", "visTypePie", "fieldFormats"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Contains the vislib visualizations. These are the classical area/line/bar, pie, gauge/goal and heatmap charts. We want to replace them with elastic-charts."
 }

--- a/src/plugins/vis_types/xy/kibana.json
+++ b/src/plugins/vis_types/xy/kibana.json
@@ -7,8 +7,8 @@
   "requiredBundles": ["kibanaUtils", "visDefaultEditor"],
   "extraPublicDirs": ["common/index"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Contains the new xy-axis chart using the elastic-charts library, which will eventually replace the vislib xy-axis charts including bar, area, and line."
 }

--- a/src/plugins/visualizations/kibana.json
+++ b/src/plugins/visualizations/kibana.json
@@ -15,8 +15,8 @@
   "requiredBundles": ["kibanaUtils", "discover"],
   "extraPublicDirs": ["common/constants", "common/prepare_log_table", "common/expression_functions"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Contains the shared architecture among all the legacy visualizations, e.g. the visualization type registry or the visualization embeddable."
 }

--- a/src/plugins/visualize/kibana.json
+++ b/src/plugins/visualize/kibana.json
@@ -26,8 +26,8 @@
     "discover"
   ],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Contains the visualize application which includes the listing page and the app frame, which will load the visualization's editor."
 }

--- a/test/plugin_functional/plugins/kbn_tp_custom_visualizations/kibana.json
+++ b/test/plugin_functional/plugins/kbn_tp_custom_visualizations/kibana.json
@@ -1,5 +1,9 @@
 {
   "id": "kbnTpCustomVisualizations",
+  "owner": {
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
+  },
   "version": "0.0.1",
   "kibanaVersion": "kibana",
   "requiredPlugins": [

--- a/x-pack/examples/embedded_lens_example/kibana.json
+++ b/x-pack/examples/embedded_lens_example/kibana.json
@@ -14,7 +14,7 @@
   "optionalPlugins": [],
   "requiredBundles": [],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/x-pack/plugins/discover_enhanced/kibana.json
+++ b/x-pack/plugins/discover_enhanced/kibana.json
@@ -9,7 +9,7 @@
   "configPath": ["xpack", "discoverEnhanced"],
   "requiredBundles": ["kibanaUtils", "data"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Data Discovery",
+    "githubTeam": "kibana-data-discovery"
   }
 }

--- a/x-pack/plugins/graph/kibana.json
+++ b/x-pack/plugins/graph/kibana.json
@@ -9,7 +9,7 @@
   "configPath": ["xpack", "graph"],
   "requiredBundles": ["kibanaUtils", "kibanaReact", "home"],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   }
 }

--- a/x-pack/plugins/lens/kibana.json
+++ b/x-pack/plugins/lens/kibana.json
@@ -41,8 +41,8 @@
     "fieldFormats"
   ],
   "owner": {
-    "name": "Kibana App",
-    "githubTeam": "kibana-app"
+    "name": "Vis Editors",
+    "githubTeam": "kibana-vis-editors"
   },
   "description": "Visualization editor allowing to quickly and easily configure compelling visualizations to use on dashboards and canvas workpads. Exposes components to embed visualizations and link into the Lens editor from within other apps in Kibana."
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Split KibanaApp into VisEditors and DataDiscovery (#110588)