### PR TITLE
chore(NA): check for used dependencies on multiple level plugins

### DIFF
--- a/src/dev/build/tasks/package_json/find_used_dependencies.ts
+++ b/src/dev/build/tasks/package_json/find_used_dependencies.ts
@@ -29,9 +29,9 @@ export async function findUsedDependencies(listedPkgDependencies: any, baseDir: 
   ];
 
   const discoveredPluginEntries = await globby([
-    normalize(Path.resolve(baseDir, `src/plugins/*/server/index.js`)),
+    normalize(Path.resolve(baseDir, `src/plugins/**/server/index.js`)),
     `!${normalize(Path.resolve(baseDir, `/src/plugins/**/public`))}`,
-    normalize(Path.resolve(baseDir, `x-pack/plugins/*/server/index.js`)),
+    normalize(Path.resolve(baseDir, `x-pack/plugins/**/server/index.js`)),
     `!${normalize(Path.resolve(baseDir, `/x-pack/plugins/**/public`))}`,
   ]);
 


### PR DESCRIPTION
It allows that task to search for server code on multiple depth levels instead of just one.