### PR TITLE
[CI] Disable baseline_trigger job

### DIFF
--- a/.ci/Jenkinsfile_baseline_trigger
+++ b/.ci/Jenkinsfile_baseline_trigger
@@ -1,5 +1,7 @@
 #!/bin/groovy
 
+return
+
 def MAXIMUM_COMMITS_TO_CHECK = 10
 def MAXIMUM_COMMITS_TO_BUILD = 5
 


### PR DESCRIPTION
This job is [moving to Buildkite](https://buildkite.com/elastic/kibana-on-merge). This disables the job in a way that we can easily revert if there are any issues. If it goes well, we will delete the Jenkins job and related files in the repo.