### PR TITLE
[renovate] cleanup and disable dependency dashboard 

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,12 +13,11 @@
   baseBranches: [
     'master',
     '7.x',
-    '7.13',
+    '7.15',
   ],
   prConcurrentLimit: 0,
   prHourlyLimit: 0,
   separateMajorMinor: false,
-  masterIssue: true,
   rangeStrategy: 'bump',
   semanticCommits: false,
   vulnerabilityAlerts: {
@@ -40,7 +39,7 @@
         packageNames: ['@elastic/charts'],
         reviewers: ['markov00', 'nickofthyme'],
         matchBaseBranches: ['master'],
-        labels: ['release_note:skip', 'v8.0.0', 'v7.14.0', 'auto-backport'],
+        labels: ['release_note:skip', 'v8.0.0', 'v7.16.0', 'auto-backport'],
         enabled: true,
       },
       {

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   extends: [
     'config:base',
+    ':disableDependencyDashboard',
   ],
   ignorePaths: [
     '**/__fixtures__/**',


### PR DESCRIPTION
- Disables the [renovate dependency dashboard](https://github.com/elastic/kibana/issues/37388) - we've never used it.
	- https://docs.renovatebot.com/configuration-options/#dependencydashboard
	- > Starting from version v26.0.0 the "Dependency Dashboard" is enabled by default as part of the commonly-used config:base preset.
- Updates base branch 7.13 -> 7.15
- Updates the target branch label for charts.