### PR TITLE
[DOCS] Removes coming tag from 7.14.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -62,8 +62,6 @@ Review important information about the {kib} 7.14.x releases.
 [[release-notes-7.14.1]]
 == {kib} 7.14.1
 
-coming::[7.14.1]
-
 For information about the 7.14.1 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 7.14.1 release notes.