### PR TITLE
Ignore elasticsearch-js product check warning by name

### DIFF
--- a/src/setup_node_env/exit_on_warning.js
+++ b/src/setup_node_env/exit_on_warning.js
@@ -34,8 +34,7 @@ var IGNORE_WARNINGS = [
     //  that the security features are blocking such check.
     //  Such emit is causing Node.js to crash unless we explicitly catch it.
     //  We need to discard that warning
-    message:
-      'The client is unable to verify that the server is Elasticsearch due to security privileges on the server side. Some functionality may not be compatible if the server is running an unsupported product.',
+    name: 'ProductNotSupportedSecurityError',
   },
 ];
 


### PR DESCRIPTION
In development, we terminate the node process when warnings are emitted.
There are a few temporary exceptions.

Warnings are parsed with the operating system's EOL.  On Windows this
parse is failing for the product check error in elasticsearch-js: 
the warning is always delimited by '\n'.  Instead of
ignoring this warning by message, we check for the warning name.

Testing - Unix based and Windows:
1) node scripts/es
1) node scripts/kibana (this will not setup dev auth, causing an error)
1) The emitted warning should not cause the process to termina.
