### PR TITLE
[7.15] [Reporting/Docs] Clarify reporting user access control options (#110545)

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -279,16 +279,15 @@ NOTE: This setting exists for backwards compatibility, but is unused and hardcod
 [[reporting-advanced-settings]]
 ==== Security settings
 
-[[xpack-reporting-roles-enabled]] `xpack.reporting.roles.enabled`::
-deprecated:[7.14.0,This setting must be set to `false` in 8.0.] When `true`, grants users access to the {report-features} by assigning reporting roles, specified by `xpack.reporting.roles.allow`. Granting access to users this way is deprecated. Set to `false` and use {kibana-ref}/kibana-privileges.html[{kib} privileges] instead. Defaults to `true`.
+With Security enabled, Reporting has two forms of access control: each user can only access their own reports, and custom roles determine who has privilege to generate reports. When Reporting is configured with <<kibana-privileges, {kib} application privileges>>, you can control the spaces and applications where users are allowed to generate reports.
 
 [NOTE]
 ============================================================================
-In 7.x, the default value of `xpack.reporting.roles.enabled` is `true`. To migrate users to the
-new method of securing access to *Reporting*, you must set `xpack.reporting.roles.enabled: false`. In the next major version of {kib}, `false` will be the only valid configuration.
+The `xpack.reporting.roles` settings are for a deprecated system of access control in Reporting. It does not allow API Keys to generate reports, and it doesn't allow {kib} application privileges. We recommend you explicitly turn off reporting's deprecated access control feature by adding `xpack.reporting.roles.enabled: false` in kibana.yml. This will enable application privileges for reporting, as described in <<grant-user-access, granting users access to reporting>>.
 ============================================================================
 
-`xpack.reporting.roles.allow`::
-deprecated:[7.14.0,This setting will be removed in 8.0.] Specifies the roles, in addition to superusers, that can generate reports, using the {ref}/security-api.html#security-role-apis[{es} role management APIs]. Requires `xpack.reporting.roles.enabled` to be `true`. Granting access to users this way is deprecated. Use {kibana-ref}/kibana-privileges.html[{kib} privileges] instead. Defaults to `[ "reporting_user" ]`.
+[[xpack-reporting-roles-enabled]] `xpack.reporting.roles.enabled`::
+deprecated:[7.14.0,The default for this setting will be `false` in an upcoming version of {kib}.] Sets access control to a set of assigned reporting roles, specified by `xpack.reporting.roles.allow`. Defaults to `true`.
 
-NOTE: Each user has access to only their own reports.
+`xpack.reporting.roles.allow`::
+deprecated:[7.14.0] In addition to superusers, specifies the roles that can generate reports using the {ref}/security-api.html#security-role-apis[{es} role management APIs]. Requires `xpack.reporting.roles.enabled` to be `true`. Defaults to `[ "reporting_user" ]`.

--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -41,11 +41,16 @@ To troubleshoot the problem, start the {kib} server with environment variables t
 [float]
 [[grant-user-access]]
 === Grant users access to reporting
+When security is enabled, you grant users access to generate reports with <<kibana-privileges, {kib} application privileges>>, which allow you to create custom roles that control the spaces and applications where users generate reports.
 
-When security is enabled, access to the {report-features} is controlled by roles and <<kibana-privileges, privileges>>. With privileges, you can define custom roles that grant *Reporting* privileges as sub-features of {kib} applications. To grant users permission to generate reports and view their reports in *Reporting*, create and assign the reporting role.
-
-[[reporting-app-users]]
-NOTE: In 7.12.0 and earlier, you grant access to the {report-features} by assigning users the `reporting_user` role in {es}. 
+. Enable application privileges in Reporting. To enable, turn off the default user access control features in `kibana.yml`:
++
+[source,yaml]
+------------------------------------
+xpack.reporting.roles.enabled: false
+------------------------------------
++
+NOTE: If you use the default settings, you can still create a custom role that grants reporting privileges. The default role is `reporting_user`. This behavior is being deprecated and does not allow application-level access controls for {report-features}, and does not allow API keys or authentication tokens to authorize report generation. Refer to <<reporting-advanced-settings, reporting security settings>> for information and caveats about the deprecated access control features.
 
 . Create the reporting role. 
 
@@ -90,10 +95,12 @@ If the *Reporting* option is unavailable, contact your administrator, or <<repor
 
 .. Click *Update user*.
 
+Granting the privilege to generate reports also grants the user the privilege to view their reports in *Stack Management > Reporting*. Users can only access their own reports.
+
 [float]
 [[reporting-roles-user-api]]
 ==== Grant access with the role API
-You can also use the {ref}/security-api-put-role.html[role API] to grant access to the reporting features. Grant the reporting role to users in combination with other roles that grant read access to the data in {es}, and at least read access in the applications where users can generate reports.
+With <<grant-user-access, {kib} application privileges>> enabled in Reporting, you can also use the {ref}/security-api-put-role.html[role API] to grant access to the {report-features}. Grant custom reporting roles to users in combination with other roles that grant read access to the data in {es}, and at least read access in the applications where users can generate reports.
 
 [source, sh]
 ---------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Reporting/Docs] Clarify reporting user access control options (#110545)