### PR TITLE
[7.x] [Reporting] Remove `any` from public/poller (#110539)

### DIFF
--- a/x-pack/plugins/reporting/common/poller.ts
+++ b/x-pack/plugins/reporting/common/poller.ts
@@ -8,20 +8,19 @@
 import _ from 'lodash';
 
 interface PollerOptions {
-  functionToPoll: () => Promise<any>;
+  functionToPoll: () => Promise<void>;
   pollFrequencyInMillis: number;
   trailing?: boolean;
   continuePollingOnError?: boolean;
   pollFrequencyErrorMultiplier?: number;
-  successFunction?: (...args: any) => any;
-  errorFunction?: (error: Error) => any;
+  successFunction?: (...args: unknown[]) => void;
+  errorFunction?: (error: Error) => void;
 }
 
-// @TODO Maybe move to observables someday
 export class Poller {
-  private readonly functionToPoll: () => Promise<any>;
-  private readonly successFunction: (...args: any) => any;
-  private readonly errorFunction: (error: Error) => any;
+  private readonly functionToPoll: () => Promise<void>;
+  private readonly successFunction: (...args: unknown[]) => void;
+  private readonly errorFunction: (error: Error) => void;
   private _isRunning: boolean;
   private _timeoutId: NodeJS.Timeout | null;
   private pollFrequencyInMillis: number;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Reporting] Remove `any` from public/poller (#110539)