### PR TITLE
Improve color picker handling in SavedObjects tagging test

### DIFF
--- a/x-pack/test/functional/page_objects/tag_management_page.ts
+++ b/x-pack/test/functional/page_objects/tag_management_page.ts
@@ -23,7 +23,6 @@ type TagFormValidation = FillTagFormFields;
  */
 class TagModal extends FtrService {
   private readonly browser = this.ctx.getService('browser');
-  private readonly find = this.ctx.getService('find');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly retry = this.ctx.getService('retry');
   private readonly header = this.ctx.getPageObject('header');

--- a/x-pack/test/functional/page_objects/tag_management_page.ts
+++ b/x-pack/test/functional/page_objects/tag_management_page.ts
@@ -22,6 +22,7 @@ type TagFormValidation = FillTagFormFields;
  * Sub page object to manipulate the create/edit tag modal.
  */
 class TagModal extends FtrService {
+  private readonly find = this.ctx.getService('find');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly retry = this.ctx.getService('retry');
   private readonly header = this.ctx.getPageObject('header');
@@ -57,8 +58,12 @@ class TagModal extends FtrService {
     }
     if (fields.color !== undefined) {
       await this.testSubjects.setValue('~createModalField-color', fields.color);
-      // Wait for the popover to be closable before moving to the next input
-      await new Promise((res) => setTimeout(res, 200));
+      // Close the popover before moving to the next input, as it can get in the way of interacting with other elements
+      await this.testSubjects.existOrFail('euiSaturation');
+      await this.retry.try(async () => {
+        await this.find.clickByCssSelector('.euiModalHeader');
+        await this.testSubjects.missingOrFail('euiSaturation', { timeout: 250 });
+      });
     }
     if (fields.description !== undefined) {
       await this.testSubjects.click('createModalField-description');

--- a/x-pack/test/functional/page_objects/tag_management_page.ts
+++ b/x-pack/test/functional/page_objects/tag_management_page.ts
@@ -22,6 +22,7 @@ type TagFormValidation = FillTagFormFields;
  * Sub page object to manipulate the create/edit tag modal.
  */
 class TagModal extends FtrService {
+  private readonly browser = this.ctx.getService('browser');
   private readonly find = this.ctx.getService('find');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly retry = this.ctx.getService('retry');
@@ -61,7 +62,9 @@ class TagModal extends FtrService {
       // Close the popover before moving to the next input, as it can get in the way of interacting with other elements
       await this.testSubjects.existOrFail('euiSaturation');
       await this.retry.try(async () => {
-        await this.find.clickByCssSelector('.euiModalHeader');
+        if (await this.testSubjects.exists('euiSaturation', { timeout: 10 })) {
+          await this.browser.pressKeys(this.browser.keys.ENTER);
+        }
         await this.testSubjects.missingOrFail('euiSaturation', { timeout: 250 });
       });
     }


### PR DESCRIPTION
Split out from #104022.

I'm encountering this error:

```
fail: saved objects tagging - functional tests create tag allows to create the tag once the errors are fixed
             │      <span class="term-fg31">Error: retry.try timeout: ElementClickInterceptedError: element click intercepted: Element &lt;button class="euiButton euiButton--primary euiButton--fill" type="button" data-test-subj="createModalConfirmButton"&gt;...&lt;/button&gt; is not clickable at point (1021, 575). Other element would receive the click: &lt;div class="euiSaturation__saturation"&gt;&lt;/div&gt;</span>
```

frequently in Buildkite: https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify/builds/32#cadd3868-6de7-42cb-a200-2e22da58bda2

I believe the error is happening because the tests are likely executing faster. The color picker ends up not being dismissed and sitting in front of the modal's submit button.

This change moves to a more explicit handling of the color picker modal, rather than relying on a timeout + moving focus to a different textarea.