### PR TITLE
[RAC] Reset fields button fix

### DIFF
--- a/x-pack/plugins/security_solution/common/types/timeline/store.ts
+++ b/x-pack/plugins/security_solution/common/types/timeline/store.ts
@@ -48,6 +48,7 @@ export interface TimelinePersistInput {
   expandedDetail?: TimelineExpandedDetail;
   filters?: Filter[];
   columns: ColumnHeaderOptions[];
+  defaultColumns?: ColumnHeaderOptions[];
   itemsPerPage?: number;
   indexNames: string[];
   kqlQuery?: {

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -78,6 +78,7 @@ type Props = OwnProps & PropsFromRedux;
 const StatefulEventsViewerComponent: React.FC<Props> = ({
   createTimeline,
   columns,
+  defaultColumns,
   dataProviders,
   defaultCellActions,
   deletedEventIds,
@@ -127,6 +128,7 @@ const StatefulEventsViewerComponent: React.FC<Props> = ({
       createTimeline({
         id,
         columns,
+        defaultColumns,
         excludedRowRendererIds,
         indexNames: selectedPatterns,
         sort,
@@ -241,6 +243,7 @@ const makeMapStateToProps = () => {
     const timeline: TimelineModel = getTimeline(state, id) ?? defaultModel;
     const {
       columns,
+      defaultColumns,
       dataProviders,
       deletedEventIds,
       excludedRowRendererIds,
@@ -254,6 +257,7 @@ const makeMapStateToProps = () => {
 
     return {
       columns,
+      defaultColumns,
       dataProviders,
       deletedEventIds,
       excludedRowRendererIds,


### PR DESCRIPTION
## Summary

Solves the issue: https://github.com/elastic/kibana/issues/110524

- Fixes the _Reset Fields_ button in the Alerts table that was resetting always to basic headers.