### PR TITLE
[Upgrade Assistant] Remove version from UA nav title

### DIFF
--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -24810,7 +24810,6 @@
     "xpack.uiActionsEnhanced.drilldowns.urlDrilldownCollectConfig.urlTemplateVariablesHelpLinkText": "ヘルプ",
     "xpack.uiActionsEnhanced.drilldowns.urlDrilldownValidation.urlFormatErrorMessage": "無効な形式：{message}",
     "xpack.uiActionsEnhanced.drilldowns.urlDrilldownValidation.urlFormatGeneralErrorMessage": "無効なフォーマット。例：{exampleUrl}",
-    "xpack.upgradeAssistant.appTitle": "{version} アップグレードアシスタント",
     "xpack.upgradeAssistant.breadcrumb.esDeprecationsLabel": "Elasticsearchの廃止予定",
     "xpack.upgradeAssistant.breadcrumb.kibanaDeprecationsLabel": "Kibanaの廃止予定",
     "xpack.upgradeAssistant.breadcrumb.overviewLabel": "アップグレードアシスタント",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -25221,7 +25221,6 @@
     "xpack.uiActionsEnhanced.drilldowns.urlDrilldownCollectConfig.urlTemplateVariablesHelpLinkText": "帮助",
     "xpack.uiActionsEnhanced.drilldowns.urlDrilldownValidation.urlFormatErrorMessage": "格式无效：{message}",
     "xpack.uiActionsEnhanced.drilldowns.urlDrilldownValidation.urlFormatGeneralErrorMessage": "格式无效。例如：{exampleUrl}",
-    "xpack.upgradeAssistant.appTitle": "{version} 升级助手",
     "xpack.upgradeAssistant.breadcrumb.esDeprecationsLabel": "Elasticsearch 弃用",
     "xpack.upgradeAssistant.breadcrumb.kibanaDeprecationsLabel": "Kibana 弃用",
     "xpack.upgradeAssistant.breadcrumb.overviewLabel": "升级助手",

--- a/x-pack/plugins/upgrade_assistant/public/plugin.ts
+++ b/x-pack/plugins/upgrade_assistant/public/plugin.ts
@@ -34,8 +34,7 @@ export class UpgradeAssistantUIPlugin
     };
 
     const pluginName = i18n.translate('xpack.upgradeAssistant.appTitle', {
-      defaultMessage: '{version} Upgrade Assistant',
-      values: { version: `${kibanaVersionInfo.nextMajor}.0` },
+      defaultMessage: 'Upgrade Assistant',
     });
 
     appRegistrar.registerApp({


### PR DESCRIPTION
This PR removes the version number from the Upgrade Assistant nav link.

<img width="263" alt="Screen Shot 2021-08-31 at 8 28 21 PM" src="https://user-images.githubusercontent.com/5226211/131592844-1284254e-c13c-46c6-9af7-45d4ae40bd76.png">

<img width="274" alt="Screen Shot 2021-08-31 at 8 30 09 PM" src="https://user-images.githubusercontent.com/5226211/131592862-1603957c-492a-41dd-96df-7fbbab3c3dd0.png">
