### PR TITLE
[data views] Create data views service and use in index pattern management 

### DIFF
--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -62,7 +62,13 @@ export const indexPatterns = {
   flattenHitWrapper,
 };
 
-export { IndexPatternsContract, IndexPattern, IndexPatternField, TypeMeta } from './index_patterns';
+export {
+  IndexPatternsContract,
+  DataViewsContract,
+  IndexPattern,
+  IndexPatternField,
+  TypeMeta,
+} from './index_patterns';
 
 export {
   IIndexPattern,

--- a/src/plugins/data/public/index_patterns/index.ts
+++ b/src/plugins/data/public/index_patterns/index.ts
@@ -23,6 +23,9 @@ export {
   IndexPatternsContract,
   IndexPattern,
   IndexPatternsApiClient,
+  DataViewsService,
+  DataViewsContract,
+  DataView,
 } from './index_patterns';
 export { UiSettingsPublicToCommon } from './ui_settings_wrapper';
 export { SavedObjectsClientPublicToCommon } from './saved_objects_client_wrapper';

--- a/src/plugins/data/public/mocks.ts
+++ b/src/plugins/data/public/mocks.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { DataPlugin, IndexPatternsContract } from '.';
+import { DataPlugin, DataViewsContract } from '.';
 import { fieldFormatsServiceMock } from '../../field_formats/public/mocks';
 import { searchServiceMock } from './search/mocks';
 import { queryServiceMock } from './query/mocks';
@@ -38,6 +38,20 @@ const createSetupContract = (): Setup => {
 
 const createStartContract = (): Start => {
   const queryStartMock = queryServiceMock.createStartContract();
+  const dataViews = ({
+    find: jest.fn((search) => [{ id: search, title: search }]),
+    createField: jest.fn(() => {}),
+    createFieldList: jest.fn(() => []),
+    ensureDefaultIndexPattern: jest.fn(),
+    make: () => ({
+      fieldsFetcher: {
+        fetchForWildcard: jest.fn(),
+      },
+    }),
+    get: jest.fn().mockReturnValue(Promise.resolve({})),
+    clearCache: jest.fn(),
+  } as unknown) as DataViewsContract;
+
   return {
     actions: {
       createFiltersFromValueClickAction: jest.fn().mockResolvedValue(['yes']),
@@ -51,19 +65,11 @@ const createStartContract = (): Start => {
       IndexPatternSelect: jest.fn(),
       SearchBar: jest.fn().mockReturnValue(null),
     },
-    indexPatterns: ({
-      find: jest.fn((search) => [{ id: search, title: search }]),
-      createField: jest.fn(() => {}),
-      createFieldList: jest.fn(() => []),
-      ensureDefaultIndexPattern: jest.fn(),
-      make: () => ({
-        fieldsFetcher: {
-          fetchForWildcard: jest.fn(),
-        },
-      }),
-      get: jest.fn().mockReturnValue(Promise.resolve({})),
-      clearCache: jest.fn(),
-    } as unknown) as IndexPatternsContract,
+    dataViews,
+    /**
+     * @deprecated Use dataViews service instead. All index pattern interfaces were renamed.
+     */
+    indexPatterns: dataViews,
     nowProvider: createNowProviderMock(),
   };
 };

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -197,6 +197,7 @@ export class DataPublicPlugin
       autocomplete: this.autocomplete.start(),
       fieldFormats,
       indexPatterns,
+      dataViews: indexPatterns,
       query,
       search,
       nowProvider: this.nowProvider,

--- a/src/plugins/data/public/types.ts
+++ b/src/plugins/data/public/types.ts
@@ -17,7 +17,7 @@ import { AutocompleteSetup, AutocompleteStart } from './autocomplete';
 import { createFiltersFromRangeSelectAction, createFiltersFromValueClickAction } from './actions';
 import { ISearchSetup, ISearchStart } from './search';
 import { QuerySetup, QueryStart } from './query';
-import { IndexPatternsContract } from './index_patterns';
+import { DataViewsContract } from './index_patterns';
 import { IndexPatternSelectProps, StatefulSearchBarProps } from './ui';
 import { UsageCollectionSetup, UsageCollectionStart } from '../../usage_collection/public';
 import { Setup as InspectorSetup } from '../../inspector/public';
@@ -77,10 +77,16 @@ export interface DataPublicPluginStart {
    */
   autocomplete: AutocompleteStart;
   /**
-   * index patterns service
-   * {@link IndexPatternsContract}
+   * data views service
+   * {@link DataViewsContract}
    */
-  indexPatterns: IndexPatternsContract;
+  dataViews: DataViewsContract;
+  /**
+   * index patterns service
+   * {@link DataViewsContract}
+   * @deprecated Use dataViews service instead.  All index pattern interfaces were renamed.
+   */
+  indexPatterns: DataViewsContract;
   /**
    * search service
    * {@link ISearchStart}

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern.tsx
@@ -88,7 +88,7 @@ export const EditIndexPattern = withRouter(
     const removePattern = () => {
       async function doRemove() {
         if (indexPattern.id === defaultIndex) {
-          const indexPatterns = await data.indexPatterns.getIdsWithTitle();
+          const indexPatterns = await data.dataViews.getIdsWithTitle();
           uiSettings.remove('defaultIndex');
           const otherPatterns = filter(indexPatterns, (pattern) => {
             return pattern.id !== indexPattern.id;
@@ -99,7 +99,7 @@ export const EditIndexPattern = withRouter(
           }
         }
         if (indexPattern.id) {
-          Promise.resolve(data.indexPatterns.delete(indexPattern.id)).then(function () {
+          Promise.resolve(data.dataViews.delete(indexPattern.id)).then(function () {
             history.push('');
           });
         }

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -77,13 +77,13 @@ export const IndexPatternTable = ({
     (async function () {
       const gettedIndexPatterns: IndexPatternTableItem[] = await getIndexPatterns(
         uiSettings.get('defaultIndex'),
-        data.indexPatterns
+        data.dataViews
       );
       setIndexPatterns(gettedIndexPatterns);
       setIsLoadingIndexPatterns(false);
       if (
         gettedIndexPatterns.length === 0 ||
-        !(await data.indexPatterns.hasUserIndexPattern().catch(() => false))
+        !(await data.dataViews.hasUserIndexPattern().catch(() => false))
       ) {
         setShowCreateDialog(true);
       }


### PR DESCRIPTION
## Summary

Simple renaming of services. Created the dataViews service and deprecated the indexPatterns service. Used in the index pattern management plugin to verify that it works. 

Addresses https://github.com/elastic/kibana/issues/103978