### PR TITLE
Bump the Node.js version used by Docker in CI

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,7 +1,7 @@
 # NOTE: This Dockerfile is ONLY used to run certain tasks in CI. It is not used to run Kibana or as a distributable.
 # If you're looking for the Kibana Docker image distributable, please see: src/dev/build/tasks/os_packages/docker_generator/templates/dockerfile.template.ts
 
-ARG NODE_VERSION=14.17.5
+ARG NODE_VERSION=14.17.6
 
 FROM node:${NODE_VERSION} AS base
 


### PR DESCRIPTION
This is a follow up to PR #110654 where the Node.js version required by Kibana was upgraded.