### PR TITLE
[Fleet] Only show upgrade button on older versions of package policy

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -220,7 +220,7 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
           const hasUpgrade =
             !!updatableIntegrationRecord &&
             updatableIntegrationRecord.policiesToUpgrade.some(
-              ({ id }) => id === packagePolicy.policy_id
+              ({ pkgPolicyId }) => pkgPolicyId === packagePolicy.id
             );
 
           return (


### PR DESCRIPTION
## Summary

Fixes #109799  

Do not show the upgrade button against up-to-date package policies. (a continuation of #110066)

<img width="1296" alt="Screenshot 2021-09-01 at 09 16 30" src="https://user-images.githubusercontent.com/3315046/131640830-8a8ee103-e73e-4433-83ba-a70a9edb9305.png">

### Checklist

None apply, I can't see existing tests for this area and the table is quite a complicated component. 
