### PR TITLE
[Elasticsearch] Skip the Product Check on the scopeable client

### DIFF
--- a/src/core/server/elasticsearch/client/configure_client.test.ts
+++ b/src/core/server/elasticsearch/client/configure_client.test.ts
@@ -10,6 +10,7 @@ import { Buffer } from 'buffer';
 import { Readable } from 'stream';
 
 import { RequestEvent, errors } from '@elastic/elasticsearch';
+import type { Client } from '@elastic/elasticsearch';
 import type {
   TransportRequestOptions,
   TransportRequestParams,
@@ -18,7 +19,6 @@ import type {
 
 import { parseClientOptionsMock, ClientMock } from './configure_client.test.mocks';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
-import { EventEmitter } from 'events';
 import type { ElasticsearchClientConfig } from './client_config';
 import { configureClient } from './configure_client';
 
@@ -32,7 +32,10 @@ const createFakeConfig = (
 };
 
 const createFakeClient = () => {
-  const client = new EventEmitter();
+  const actualEs = jest.requireActual('@elastic/elasticsearch');
+  const client = new actualEs.Client({
+    nodes: ['http://localhost'], // Enforcing `nodes` because it's mandatory
+  });
   jest.spyOn(client, 'on');
   return client;
 };
@@ -66,6 +69,14 @@ const createApiResponse = <T>({
     } as any,
   };
 };
+
+function getProductCheckValue(client: Client) {
+  const tSymbol = Object.getOwnPropertySymbols(client.transport || client).filter(
+    (symbol) => symbol.description === 'product check'
+  )[0];
+  // @ts-expect-error `tSymbol` is missing in the index signature of Transport
+  return (client.transport || client)[tSymbol];
+}
 
 describe('configureClient', () => {
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
@@ -115,6 +126,24 @@ describe('configureClient', () => {
 
     expect(client.on).toHaveBeenCalledTimes(1);
     expect(client.on).toHaveBeenCalledWith('response', expect.any(Function));
+  });
+
+  describe('Product check', () => {
+    it('should not skip the product check for the unscoped client', () => {
+      const client = configureClient(config, { logger, type: 'test', scoped: false });
+      expect(getProductCheckValue(client)).toBe(0);
+    });
+
+    it('should skip the product check for the scoped client', () => {
+      const client = configureClient(config, { logger, type: 'test', scoped: true });
+      expect(getProductCheckValue(client)).toBe(2);
+    });
+
+    it('should skip the product check for the children of the scoped client', () => {
+      const client = configureClient(config, { logger, type: 'test', scoped: true });
+      const asScoped = client.child({ headers: { 'x-custom-header': 'Custom value' } });
+      expect(getProductCheckValue(asScoped)).toBe(2);
+    });
   });
 
   describe('Client logging', () => {


### PR DESCRIPTION
## Summary

For reasoning of why this is needed, read the description of the issue #110675. This PR implements the option 3 as a simple workaround, and the least intrusive solution, while we discuss a better long-term solution: basically, it skips the product check on the scopeable client, relying on the validations already performed by the internal client.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
