### PR TITLE
[TSVB] Add migration script for 'drop_last_bucket' value

### DIFF
--- a/src/plugins/visualizations/server/embeddable/visualize_embeddable_factory.ts
+++ b/src/plugins/visualizations/server/embeddable/visualize_embeddable_factory.ts
@@ -16,6 +16,7 @@ import {
   commonMigrateVislibPie,
   commonAddEmptyValueColorRule,
   commonMigrateTagCloud,
+  commonAddDropLastBucketIntoTSVBModel,
 } from '../migrations/visualization_common_migrations';
 
 const byValueAddSupportOfDualIndexSelectionModeInTSVB = (state: SerializableRecord) => {
@@ -29,6 +30,13 @@ const byValueHideTSVBLastValueIndicator = (state: SerializableRecord) => {
   return {
     ...state,
     savedVis: commonHideTSVBLastValueIndicator(state.savedVis),
+  };
+};
+
+const byValueAddDropLastBucketIntoTSVBModel = (state: SerializableRecord) => {
+  return {
+    ...state,
+    savedVis: commonAddDropLastBucketIntoTSVBModel(state.savedVis),
   };
 };
 
@@ -72,7 +80,12 @@ export const visualizeEmbeddableFactory = (): EmbeddableRegistryDefinition => {
           byValueRemoveDefaultIndexPatternAndTimeFieldFromTSVBModel
         )(state),
       '7.14.0': (state) =>
-        flow(byValueAddEmptyValueColorRule, byValueMigrateVislibPie, byValueMigrateTagcloud)(state),
+        flow(
+          byValueAddEmptyValueColorRule,
+          byValueMigrateVislibPie,
+          byValueMigrateTagcloud,
+          byValueAddDropLastBucketIntoTSVBModel
+        )(state),
     },
   };
 };

--- a/src/plugins/visualizations/server/migrations/visualization_common_migrations.ts
+++ b/src/plugins/visualizations/server/migrations/visualization_common_migrations.ts
@@ -26,16 +26,14 @@ export const commonAddDropLastBucketIntoTSVBModel = (visState: any) => {
       ...visState,
       params: {
         ...visState.params,
-        series: visState.params.series
-          ? visState.params.series.map((s: any) =>
-              s.override_index_pattern
-                ? {
-                    ...s,
-                    series_drop_last_bucket: s.series_drop_last_bucket ?? 1,
-                  }
-                : s
-            )
-          : undefined,
+        series: visState.params?.series?.map((s: any) =>
+          s.override_index_pattern
+            ? {
+                ...s,
+                series_drop_last_bucket: s.series_drop_last_bucket ?? 1,
+              }
+            : s
+        ),
         drop_last_bucket: visState.params.drop_last_bucket ?? 1,
       },
     };

--- a/src/plugins/visualizations/server/migrations/visualization_common_migrations.ts
+++ b/src/plugins/visualizations/server/migrations/visualization_common_migrations.ts
@@ -20,6 +20,29 @@ export const commonAddSupportOfDualIndexSelectionModeInTSVB = (visState: any) =>
   return visState;
 };
 
+export const commonAddDropLastBucketIntoTSVBModel = (visState: any) => {
+  if (visState && visState.type === 'metrics') {
+    return {
+      ...visState,
+      params: {
+        ...visState.params,
+        series: visState.params.series
+          ? visState.params.series.map((s: any) =>
+              s.override_index_pattern
+                ? {
+                    ...s,
+                    series_drop_last_bucket: s.series_drop_last_bucket ?? 1,
+                  }
+                : s
+            )
+          : undefined,
+        drop_last_bucket: visState.params.drop_last_bucket ?? 1,
+      },
+    };
+  }
+  return visState;
+};
+
 export const commonHideTSVBLastValueIndicator = (visState: any) => {
   if (visState && visState.type === 'metrics' && visState.params.type !== 'timeseries') {
     return {

--- a/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.test.ts
+++ b/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.test.ts
@@ -2133,7 +2133,7 @@ describe('migration visualization', () => {
       },
     });
 
-    it('should add "drop last bucket" into model if it not exist', () => {
+    it('should add "drop_last_bucket" into model if it not exist', () => {
       const params = {};
       const migratedTestDoc = migrate(createTestDocWithType(params));
       const { params: migratedParams } = JSON.parse(migratedTestDoc.attributes.visState);
@@ -2145,7 +2145,7 @@ describe('migration visualization', () => {
       `);
     });
 
-    it('should add "series_drop last bucket" into model if it not exist', () => {
+    it('should add "series_drop_last_bucket" into model if it not exist', () => {
       const params = {
         series: [
           {

--- a/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.test.ts
+++ b/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.test.ts
@@ -2115,6 +2115,87 @@ describe('migration visualization', () => {
     });
   });
 
+  describe('7.14.0 tsvb - add drop last bucket into TSVB model', () => {
+    const migrate = (doc: any) =>
+      visualizationSavedObjectTypeMigrations['7.14.0'](
+        doc as Parameters<SavedObjectMigrationFn>[0],
+        savedObjectMigrationContext
+      );
+
+    const createTestDocWithType = (params: any) => ({
+      attributes: {
+        title: 'My Vis',
+        description: 'This is my super cool vis.',
+        visState: `{
+          "type":"metrics",
+          "params": ${JSON.stringify(params)}
+        }`,
+      },
+    });
+
+    it('should add "drop last bucket" into model if it not exist', () => {
+      const params = {};
+      const migratedTestDoc = migrate(createTestDocWithType(params));
+      const { params: migratedParams } = JSON.parse(migratedTestDoc.attributes.visState);
+
+      expect(migratedParams).toMatchInlineSnapshot(`
+        Object {
+          "drop_last_bucket": 1,
+        }
+      `);
+    });
+
+    it('should add "series_drop last bucket" into model if it not exist', () => {
+      const params = {
+        series: [
+          {
+            override_index_pattern: 1,
+          },
+          {
+            override_index_pattern: 1,
+          },
+          { override_index_pattern: 0 },
+          {},
+          {
+            override_index_pattern: 1,
+            series_drop_last_bucket: 0,
+          },
+          {
+            override_index_pattern: 1,
+            series_drop_last_bucket: 1,
+          },
+        ],
+      };
+      const migratedTestDoc = migrate(createTestDocWithType(params));
+      const { params: migratedParams } = JSON.parse(migratedTestDoc.attributes.visState);
+
+      expect(migratedParams.series).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "override_index_pattern": 1,
+            "series_drop_last_bucket": 1,
+          },
+          Object {
+            "override_index_pattern": 1,
+            "series_drop_last_bucket": 1,
+          },
+          Object {
+            "override_index_pattern": 0,
+          },
+          Object {},
+          Object {
+            "override_index_pattern": 1,
+            "series_drop_last_bucket": 0,
+          },
+          Object {
+            "override_index_pattern": 1,
+            "series_drop_last_bucket": 1,
+          },
+        ]
+      `);
+    });
+  });
+
   describe('7.14.0 update pie visualization defaults', () => {
     const migrate = (doc: any) =>
       visualizationSavedObjectTypeMigrations['7.14.0'](

--- a/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.ts
+++ b/src/plugins/visualizations/server/migrations/visualization_saved_object_migrations.ts
@@ -18,6 +18,7 @@ import {
   commonMigrateVislibPie,
   commonAddEmptyValueColorRule,
   commonMigrateTagCloud,
+  commonAddDropLastBucketIntoTSVBModel,
 } from './visualization_common_migrations';
 
 const migrateIndexPattern: SavedObjectMigrationFn<any, any> = (doc) => {
@@ -945,6 +946,23 @@ const hideTSVBLastValueIndicator: SavedObjectMigrationFn<any, any> = (doc) => {
   return doc;
 };
 
+const addDropLastBucketIntoTSVBModel: SavedObjectMigrationFn<any, any> = (doc) => {
+  try {
+    const visState = JSON.parse(doc.attributes.visState);
+    const newVisState = commonAddDropLastBucketIntoTSVBModel(visState);
+    return {
+      ...doc,
+      attributes: {
+        ...doc.attributes,
+        visState: JSON.stringify(newVisState),
+      },
+    };
+  } catch (e) {
+    // Let it go, the data is invalid and we'll leave it as is
+  }
+  return doc;
+};
+
 const removeDefaultIndexPatternAndTimeFieldFromTSVBModel: SavedObjectMigrationFn<any, any> = (
   doc
 ) => {
@@ -1100,6 +1118,7 @@ export const visualizationSavedObjectTypeMigrations = {
     addEmptyValueColorRule,
     migrateVislibPie,
     migrateTagCloud,
-    replaceIndexPatternReference
+    replaceIndexPatternReference,
+    addDropLastBucketIntoTSVBModel
   ),
 };


### PR DESCRIPTION
Fix regression of #97257

## Summary

By default, `drop_last_bucket` / `series_drop_last_bucket` is not defined in the model. This caused a problem when upgrading to version 7.14 as the default value was changed in #97257. As a result - after updating, saved visualizations show different data

### What was done in that PR: 
- added a migration script that adds the required property to the model
- migration script was added for byRef and byValue visualizations

