### PR TITLE
[ML] Add job audit messages API integration tests

### DIFF
--- a/x-pack/plugins/ml/.gitignore
+++ b/x-pack/plugins/ml/.gitignore
@@ -1,1 +1,2 @@
 routes_doc
+server/routes/apidoc_scripts/header.md

--- a/x-pack/plugins/ml/server/routes/job_audit_messages.ts
+++ b/x-pack/plugins/ml/server/routes/job_audit_messages.ts
@@ -101,7 +101,7 @@ export function jobAuditMessagesRoutes({ router, routeGuard }: RouteInitializati
   /**
    * @apiGroup JobAuditMessages
    *
-   * @api {put} /api/ml/job_audit_messages/clear_messages/{jobId} Index annotation
+   * @api {put} /api/ml/job_audit_messages/clear_messages Index annotation
    * @apiName ClearJobAuditMessages
    * @apiDescription Clear the job audit messages.
    *

--- a/x-pack/test/api_integration/apis/ml/index.ts
+++ b/x-pack/test/api_integration/apis/ml/index.ts
@@ -77,6 +77,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./filters'));
     loadTestFile(require.resolve('./indices'));
     loadTestFile(require.resolve('./job_validation'));
+    loadTestFile(require.resolve('./job_audit_messages'));
     loadTestFile(require.resolve('./jobs'));
     loadTestFile(require.resolve('./modules'));
     loadTestFile(require.resolve('./results'));

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import { getJobConfig } from './index';
 import { USER } from '../../../../functional/services/ml/security_common';
 import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
-import expect from '../../../../../../../../../../private/var/tmp/_bazel_darnautov/1afe62330ff0d9ae1ca2013aad33fd76/execroot/kibana/bazel-out/darwin-fastbuild/bin/packages/kbn-expect';
 
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { omit } from 'lodash';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { getJobConfig } from './index';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+import expect from '../../../../../../../../../../private/var/tmp/_bazel_darnautov/1afe62330ff0d9ae1ca2013aad33fd76/execroot/kibana/bazel-out/darwin-fastbuild/bin/packages/kbn-expect';
+
+export default ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  describe('clear_messages', function () {
+    before(async () => {
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
+      await ml.testResources.setKibanaTimeZoneToUTC();
+
+      for (const jobConfig of getJobConfig(1)) {
+        await ml.api.createAnomalyDetectionJob(jobConfig);
+      }
+    });
+
+    after(async () => {
+      await ml.api.cleanMlIndices();
+    });
+
+    it('should mark audit messages as cleared for provided job', async () => {
+      const timestamp = Date.now();
+
+      const { body } = await supertest
+        .put(`/api/ml/job_audit_messages/clear_messages`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS)
+        .send({
+          jobId: 'test_get_job_audit_messages_1',
+          notificationIndices: ['.ml-notifications-000002'],
+        })
+        .expect(200);
+
+      expect(body.success).to.eql(true);
+      expect(body.last_cleared).to.be.above(timestamp);
+
+      const { body: getBody } = await supertest
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(200);
+
+      expect(getBody.messages.length).to.eql(1);
+
+      expect(omit(getBody.messages[0], 'timestamp')).to.eql({
+        job_id: 'test_get_job_audit_messages_1',
+        message: 'Job created',
+        level: 'info',
+        node_name: 'node-01',
+        job_type: 'anomaly_detector',
+        cleared: true,
+      });
+    });
+
+    it('should not mark audit messages as cleared for the user with ML read permissions', async () => {
+      const { body } = await supertest
+        .put(`/api/ml/job_audit_messages/clear_messages`)
+        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+        .set(COMMON_REQUEST_HEADERS)
+        .send({
+          jobId: 'test_get_job_audit_messages_1',
+          notificationIndices: ['.ml-notifications-000002'],
+        })
+        .expect(403);
+      expect(body.error).to.eql('Forbidden');
+      expect(body.message).to.eql('Forbidden');
+    });
+
+    it('should not mark audit messages as cleared for unauthorized user', async () => {
+      const { body } = await supertest
+        .put(`/api/ml/job_audit_messages/clear_messages`)
+        .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
+        .set(COMMON_REQUEST_HEADERS)
+        .send({
+          jobId: 'test_get_job_audit_messages_1',
+          notificationIndices: ['.ml-notifications-000002'],
+        })
+        .expect(403);
+      expect(body.error).to.eql('Forbidden');
+      expect(body.message).to.eql('Forbidden');
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -22,7 +22,7 @@ export default ({ getService }: FtrProviderContext) => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
-      for (const jobConfig of getJobConfig(1)) {
+      for (const jobConfig of getJobConfig(2)) {
         await ml.api.createAnomalyDetectionJob(jobConfig);
       }
     });
@@ -71,7 +71,7 @@ export default ({ getService }: FtrProviderContext) => {
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
         .set(COMMON_REQUEST_HEADERS)
         .send({
-          jobId: 'test_get_job_audit_messages_1',
+          jobId: 'test_get_job_audit_messages_2',
           notificationIndices: ['.ml-notifications-000002'],
         })
         .expect(403);
@@ -79,7 +79,7 @@ export default ({ getService }: FtrProviderContext) => {
       expect(body.message).to.eql('Forbidden');
 
       const { body: getBody } = await supertest
-        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_2`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
         .expect(200);
@@ -93,7 +93,7 @@ export default ({ getService }: FtrProviderContext) => {
         .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
         .set(COMMON_REQUEST_HEADERS)
         .send({
-          jobId: 'test_get_job_audit_messages_1',
+          jobId: 'test_get_job_audit_messages_2',
           notificationIndices: ['.ml-notifications-000002'],
         })
         .expect(403);
@@ -101,7 +101,7 @@ export default ({ getService }: FtrProviderContext) => {
       expect(body.message).to.eql('Forbidden');
 
       const { body: getBody } = await supertest
-        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_2`)
         .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
         .set(COMMON_REQUEST_HEADERS)
         .expect(200);

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -77,6 +77,14 @@ export default ({ getService }: FtrProviderContext) => {
         .expect(403);
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
+
+      const { body: getBody } = await supertest
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(200);
+
+      expect(getBody.messages[0].cleared).to.not.eql(true);
     });
 
     it('should not mark audit messages as cleared for unauthorized user', async () => {
@@ -91,6 +99,14 @@ export default ({ getService }: FtrProviderContext) => {
         .expect(403);
       expect(body.error).to.eql('Forbidden');
       expect(body.message).to.eql('Forbidden');
+
+      const { body: getBody } = await supertest
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(200);
+
+      expect(getBody.messages[0].cleared).to.not.eql(true);
     });
   });
 };

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { omit } from 'lodash';
+import { omit, keyBy } from 'lodash';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
 import { USER } from '../../../../functional/services/ml/security_common';
@@ -39,14 +39,17 @@ export default ({ getService }: FtrProviderContext) => {
         .expect(200);
 
       expect(body.messages.length).to.eql(2);
-      expect(omit(body.messages[0], 'timestamp')).to.eql({
+
+      const messagesDict = keyBy(body.messages, 'job_id');
+
+      expect(omit(messagesDict.test_get_job_audit_messages_2, 'timestamp')).to.eql({
         job_id: 'test_get_job_audit_messages_2',
         message: 'Job created',
         level: 'info',
         node_name: 'node-01',
         job_type: 'anomaly_detector',
       });
-      expect(omit(body.messages[1], 'timestamp')).to.eql({
+      expect(omit(messagesDict.test_get_job_audit_messages_1, 'timestamp')).to.eql({
         job_id: 'test_get_job_audit_messages_1',
         message: 'Job created',
         level: 'info',

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { omit } from 'lodash';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { getJobConfig } from './index';
+
+export default ({ getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+
+  describe('get_job_audit_messages', function () {
+    before(async () => {
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
+      await ml.testResources.setKibanaTimeZoneToUTC();
+
+      for (const jobConfig of getJobConfig(2)) {
+        await ml.api.createAnomalyDetectionJob(jobConfig);
+      }
+    });
+
+    after(async () => {
+      await ml.api.cleanMlIndices();
+    });
+
+    it('should fetch all audit messages', async () => {
+      const { body } = await supertest
+        .get(`/api/ml/job_audit_messages/messages`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(200);
+
+      expect(body.messages.length).to.eql(2);
+      expect(omit(body.messages[0], 'timestamp')).to.eql({
+        job_id: 'test_get_job_audit_messages_2',
+        message: 'Job created',
+        level: 'info',
+        node_name: 'node-01',
+        job_type: 'anomaly_detector',
+      });
+      expect(omit(body.messages[1], 'timestamp')).to.eql({
+        job_id: 'test_get_job_audit_messages_1',
+        message: 'Job created',
+        level: 'info',
+        node_name: 'node-01',
+        job_type: 'anomaly_detector',
+      });
+      expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
+    });
+
+    it('should fetch audit messages for specified job', async () => {
+      const { body } = await supertest
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(200);
+
+      expect(body.messages.length).to.eql(1);
+      expect(omit(body.messages[0], 'timestamp')).to.eql({
+        job_id: 'test_get_job_audit_messages_1',
+        message: 'Job created',
+        level: 'info',
+        node_name: 'node-01',
+        job_type: 'anomaly_detector',
+      });
+      expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
+    });
+
+    it('should fetch audit messages for user with ML read permissions', async () => {
+      const { body } = await supertest
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(200);
+
+      expect(body.messages.length).to.eql(1);
+      expect(omit(body.messages[0], 'timestamp')).to.eql({
+        job_id: 'test_get_job_audit_messages_1',
+        message: 'Job created',
+        level: 'info',
+        node_name: 'node-01',
+        job_type: 'anomaly_detector',
+      });
+      expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
+    });
+
+    it('should not allow to fetch audit messages for unauthorized user', async () => {
+      const { body } = await supertest
+        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+        .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
+        .set(COMMON_REQUEST_HEADERS)
+        .expect(403);
+
+      expect(body.error).to.eql('Forbidden');
+      expect(body.message).to.eql('Forbidden');
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/index.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/index.ts
@@ -11,6 +11,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('job_audit_messages', function () {
     loadTestFile(require.resolve('./get_job_audit_messages'));
+    loadTestFile(require.resolve('./clear_messages'));
   });
 }
 

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/index.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/index.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MlJob } from '@elastic/elasticsearch/api/types';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('job_audit_messages', function () {
+    loadTestFile(require.resolve('./get_job_audit_messages'));
+  });
+}
+
+export const getJobConfig = (numOfJobs: number) => {
+  return new Array(numOfJobs).fill(null).map(
+    (v, i) =>
+      (({
+        job_id: `test_get_job_audit_messages_${i + 1}`,
+        description: 'job_audit_messages',
+        groups: ['farequote', 'automated', 'single-metric'],
+        analysis_config: {
+          bucket_span: '15m',
+          influencers: [],
+          detectors: [
+            {
+              function: 'mean',
+              field_name: 'responsetime',
+            },
+            {
+              function: 'min',
+              field_name: 'responsetime',
+            },
+          ],
+        },
+        data_description: { time_field: '@timestamp' },
+        analysis_limits: { model_memory_limit: '10mb' },
+      } as unknown) as MlJob)
+  );
+};


### PR DESCRIPTION
## Summary

Part of #106113

Adds API Internation tests for the job audit messages.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios