### PR TITLE
[Timeline] Show cases create flyout with timeline open

### DIFF
--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
@@ -87,7 +87,6 @@ const CreateCaseFlyoutComponent: React.FC<CreateCaseModalProps> = ({
       <StyledFlyout
         onClose={onCloseFlyout}
         data-test-subj="create-case-flyout"
-        // ownFocus={false}
         maskProps={{ className: maskOverlayClassName }}
       >
         <EuiFlyoutHeader hasBorder>

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody } from '@elastic/eui';
 
 import * as i18n from '../translations';
@@ -27,6 +27,23 @@ const StyledFlyout = styled(EuiFlyout)`
     z-index: ${theme.eui.euiZModal};
   `}
 `;
+
+const maskOverlayClassName = 'create-case-flyout-mask-overlay';
+
+/**
+ * We need to target the mask overlay which is a parent element
+ * of the flyout.
+ * A global style is needed to target a parent element.
+ */
+
+const GlobalStyle = createGlobalStyle<{ theme: { eui: { euiZModal: number } } }>`
+  .${maskOverlayClassName} {
+    ${({ theme }) => `
+    z-index: ${theme.eui.euiZModal};
+  `}
+  }
+`;
+
 // Adding bottom padding because timeline's
 // bottom bar gonna hide the submit button.
 const StyledEuiFlyoutBody = styled(EuiFlyoutBody)`
@@ -65,16 +82,24 @@ const CreateCaseFlyoutComponent: React.FC<CreateCaseModalProps> = ({
     };
   }, [afterCaseCreated, onCloseFlyout, onSuccess, appId]);
   return (
-    <StyledFlyout onClose={onCloseFlyout} data-test-subj="create-case-flyout">
-      <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
-          <h2>{i18n.CREATE_TITLE}</h2>
-        </EuiTitle>
-      </EuiFlyoutHeader>
-      <StyledEuiFlyoutBody>
-        <FormWrapper>{cases.getCreateCase(createCaseProps)}</FormWrapper>
-      </StyledEuiFlyoutBody>
-    </StyledFlyout>
+    <>
+      <GlobalStyle />
+      <StyledFlyout
+        onClose={onCloseFlyout}
+        data-test-subj="create-case-flyout"
+        // ownFocus={false}
+        maskProps={{ className: maskOverlayClassName }}
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2>{i18n.CREATE_TITLE}</h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <StyledEuiFlyoutBody>
+          <FormWrapper>{cases.getCreateCase(createCaseProps)}</FormWrapper>
+        </StyledEuiFlyoutBody>
+      </StyledFlyout>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

When a user tries to add an alert to a case and tries to create a new case, the case flyout is hidden under the timeline page.

The `EuiFlyout` is surrounded by an overlay mask. The following style is applied only to the `EuiFlyout` element.

```
const StyledFlyout = styled(EuiFlyout)`
  ${({ theme }) => `
    z-index: ${theme.eui.euiZModal};
  `}
`
```

So even though the element has an index bigger than the timeline's the overlay (parent element) has smaller z-index and the flyout is hidden. To fix this issue the z-index of the parent element (overlay mask) of the flyout needs to change to a number bigger than the timeline's. This PR fixes this issue.

https://user-images.githubusercontent.com/7871006/131689427-8fedaea8-357b-4a86-9152-9b6b7311842d.mp4

Issue: https://github.com/elastic/kibana/issues/110628

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
