### PR TITLE
[Security Solution] [Endpoint] Fix wrong nested package object assignation in policy delete response

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -429,9 +429,9 @@ class PackagePolicyService {
           name: packagePolicy.name,
           success: true,
           package: {
-            name: packagePolicy.name,
-            title: '',
-            version: packagePolicy.version || '',
+            name: packagePolicy.package?.name || '',
+            title: packagePolicy.package?.title || '',
+            version: packagePolicy.package?.version || '',
           },
         });
       } catch (error) {


### PR DESCRIPTION
## Summary
This was pretended to be fixed in other pr that was merged in 7.16 so adding this fix directly to 7.15.
Fix on 7.16 (and master): https://github.com/elastic/kibana/pull/108347/files#diff-3c2c778705d1b16042158c84def8fa9129aaf694f05217944a8231434d5104c1R431-R433


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
