### PR TITLE
[CI] Removes all verbose flags

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo "--- yarn install and bootstrap"
-yarn kbn bootstrap --verbose
+yarn kbn bootstrap
 
 ###
 ### upload ts-refs-cache artifacts as quickly as possible so they are available for download

--- a/.buildkite/scripts/build_kibana_plugins.sh
+++ b/.buildkite/scripts/build_kibana_plugins.sh
@@ -18,8 +18,7 @@ node scripts/build_kibana_platform_plugins \
   --scan-dir "$XPACK_DIR/test/licensing_plugin/plugins" \
   --scan-dir "$XPACK_DIR/test/usage_collection/plugins" \
   --scan-dir "$XPACK_DIR/test/security_functional/fixtures/common" \
-  --scan-dir "$XPACK_DIR/examples" \
-  --verbose
+  --scan-dir "$XPACK_DIR/examples"
 
 echo "--- Archive built plugins"
 shopt -s globstar

--- a/test/scripts/checks/commit/commit_check_runner.sh
+++ b/test/scripts/checks/commit/commit_check_runner.sh
@@ -7,7 +7,7 @@ If you want, you can still manually install the pre-commit hook locally by runni
 !!!!!!!!!!!!!!!!!!!!!!!!!!!
 "
 
-  node scripts/precommit_hook.js --ref HEAD~1..HEAD --max-files 200 --verbose
+  node scripts/precommit_hook.js --ref HEAD~1..HEAD --max-files 200
 }
 
 run_quick_commit_checks

--- a/test/scripts/jenkins_unit.sh
+++ b/test/scripts/jenkins_unit.sh
@@ -28,10 +28,10 @@ if [[ -z "$CODE_COVERAGE" ]] ; then
   ./test/scripts/checks/test_hardening.sh
 else
   echo " -> Running jest tests with coverage"
-  node scripts/jest --ci --verbose --maxWorkers=8 --coverage || true;
+  node scripts/jest --ci --maxWorkers=8 --coverage || true;
 
   echo " -> Running jest integration tests with coverage"
-  node scripts/jest_integration --ci --verbose --coverage || true;
+  node scripts/jest_integration --ci --coverage || true;
 
   echo " -> Combine code coverage in a single report"
   yarn nyc report --nycrc-path src/dev/code_coverage/nyc_config/nyc.jest.config.js

--- a/test/scripts/jenkins_xpack_build_plugins.sh
+++ b/test/scripts/jenkins_xpack_build_plugins.sh
@@ -16,5 +16,4 @@ node scripts/build_kibana_platform_plugins \
   --scan-dir "$XPACK_DIR/test/security_functional/fixtures/common" \
   --scan-dir "$KIBANA_DIR/examples" \
   --scan-dir "$XPACK_DIR/examples" \
-  --workers 12 \
-  --verbose
+  --workers 12

--- a/test/scripts/test/jest_integration.sh
+++ b/test/scripts/test/jest_integration.sh
@@ -3,4 +3,4 @@
 source src/dev/ci_setup/setup_env.sh
 
 checks-reporter-with-killswitch "Jest Integration Tests" \
-  node scripts/jest_integration --ci --verbose
+  node scripts/jest_integration --ci

--- a/test/scripts/test/jest_unit.sh
+++ b/test/scripts/test/jest_unit.sh
@@ -3,4 +3,4 @@
 source src/dev/ci_setup/setup_env.sh
 
 checks-reporter-with-killswitch "Jest Unit Tests" \
-  node scripts/jest --ci --verbose --maxWorkers=6
+  node scripts/jest --ci --maxWorkers=6


### PR DESCRIPTION
Reduces log volume by ~46 MB (375,990 KB - 329,947 KB).

Verbose shouldn't be the default. We can add it when we need to debug something.