### PR TITLE
[ci-stats] retry calls to ci-stats slower

### DIFF
--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -221,11 +221,12 @@ export class CiStatsReporter {
           ? `${error.response.status} response`
           : 'no response';
 
+        const seconds = attempt * 10;
         this.log.warning(
-          `failed to reach ci-stats service [reason=${reason}], retrying in ${attempt} seconds`
+          `failed to reach ci-stats service, retrying in ${seconds} seconds, [reason=${reason}], [error=${error.message}]`
         );
 
-        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+        await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
       }
     }
   }

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -59656,8 +59656,9 @@ class CiStatsReporter {
 
 
         const reason = error !== null && error !== void 0 && (_error$response = error.response) !== null && _error$response !== void 0 && _error$response.status ? `${error.response.status} response` : 'no response';
-        this.log.warning(`failed to reach ci-stats service [reason=${reason}], retrying in ${attempt} seconds`);
-        await new Promise(resolve => setTimeout(resolve, attempt * 1000));
+        const seconds = attempt * 10;
+        this.log.warning(`failed to reach ci-stats service, retrying in ${seconds} seconds, [reason=${reason}], [error=${error.message}]`);
+        await new Promise(resolve => setTimeout(resolve, seconds * 1000));
       }
     }
   }


### PR DESCRIPTION
We're seeing some momentary Cloud Run failures leading to requests to ci-stats failing. The client already does retries but they're currently relatively fast, and we're seeing these issues last about a minute, so this slows down the retries. Additionally I've added the error message to the logs.