### PR TITLE
[ci] Handle ci-stats HTTP errors a little better to avoid accidentally printing credentials

### DIFF
--- a/.buildkite/scripts/lifecycle/build_status.js
+++ b/.buildkite/scripts/lifecycle/build_status.js
@@ -7,11 +7,11 @@ const { BuildkiteClient } = require('kibana-buildkite-library');
     console.log(status.success ? 'true' : 'false');
     process.exit(0);
   } catch (ex) {
+    console.error('Buildkite API Error', ex.message);
     if (ex.response) {
-      console.error('HTTP Error Response Body', ex.response.data);
       console.error('HTTP Error Response Status', ex.response.status);
+      console.error('HTTP Error Response Body', ex.response.data);
     }
-    console.error(ex);
     process.exit(1);
   }
 })();

--- a/.buildkite/scripts/lifecycle/ci_stats_complete.js
+++ b/.buildkite/scripts/lifecycle/ci_stats_complete.js
@@ -4,7 +4,11 @@ const { CiStats } = require('kibana-buildkite-library');
   try {
     await CiStats.onComplete();
   } catch (ex) {
-    console.error(ex);
+    console.error('CI Stats Error', ex.message);
+    if (ex.response) {
+      console.error('HTTP Error Response Status', ex.response.status);
+      console.error('HTTP Error Response Body', ex.response.data);
+    }
     process.exit(1);
   }
 })();

--- a/.buildkite/scripts/lifecycle/ci_stats_start.js
+++ b/.buildkite/scripts/lifecycle/ci_stats_start.js
@@ -4,7 +4,11 @@ const { CiStats } = require('kibana-buildkite-library');
   try {
     await CiStats.onStart();
   } catch (ex) {
-    console.error(ex);
+    console.error('CI Stats Error', ex.message);
+    if (ex.response) {
+      console.error('HTTP Error Response Status', ex.response.status);
+      console.error('HTTP Error Response Body', ex.response.data);
+    }
     process.exit(1);
   }
 })();


### PR DESCRIPTION
For HTTP/axios errors, printing out the full error object results in request headers, including `Authorization` headers being printed out. Let's just print enough information to be able to understand the error in most cases.