### PR TITLE
[7.x] [task manager] provide better diagnostics when task manager performance is degraded (#109741)

### DIFF
--- a/x-pack/plugins/alerting/server/health/get_state.test.ts
+++ b/x-pack/plugins/alerting/server/health/get_state.test.ts
@@ -216,8 +216,8 @@ describe('getHealthServiceStatusWithRetryAndErrorHandling', () => {
       })
     ).toPromise();
 
-    expect(status.level).toEqual(ServiceStatusLevels.unavailable);
-    expect(status.summary).toEqual('Alerting framework is unavailable');
+    expect(status.level).toEqual(ServiceStatusLevels.degraded);
+    expect(status.summary).toEqual('Alerting framework is degraded');
     expect(status.meta).toBeUndefined();
   });
 
@@ -275,8 +275,8 @@ describe('getHealthServiceStatusWithRetryAndErrorHandling', () => {
       }),
       retryDelay
     ).subscribe((status) => {
-      expect(status.level).toEqual(ServiceStatusLevels.unavailable);
-      expect(status.summary).toEqual('Alerting framework is unavailable');
+      expect(status.level).toEqual(ServiceStatusLevels.degraded);
+      expect(status.summary).toEqual('Alerting framework is degraded');
       expect(status.meta).toEqual({ error: err });
     });
 

--- a/x-pack/plugins/alerting/server/health/get_state.ts
+++ b/x-pack/plugins/alerting/server/health/get_state.ts
@@ -73,9 +73,7 @@ const getHealthServiceStatus = async (
   const level =
     doc.state?.health_status === HealthStatus.OK
       ? ServiceStatusLevels.available
-      : doc.state?.health_status === HealthStatus.Warning
-      ? ServiceStatusLevels.degraded
-      : ServiceStatusLevels.unavailable;
+      : ServiceStatusLevels.degraded;
   return {
     level,
     summary: LEVEL_SUMMARY[level.toString()],
@@ -102,10 +100,10 @@ export const getHealthServiceStatusWithRetryAndErrorHandling = (
       );
     }),
     catchError((error) => {
-      logger.warn(`Alerting framework is unavailable due to the error: ${error}`);
+      logger.warn(`Alerting framework is degraded due to the error: ${error}`);
       return of({
-        level: ServiceStatusLevels.unavailable,
-        summary: LEVEL_SUMMARY[ServiceStatusLevels.unavailable.toString()],
+        level: ServiceStatusLevels.degraded,
+        summary: LEVEL_SUMMARY[ServiceStatusLevels.degraded.toString()],
         meta: { error },
       });
     })

--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -240,7 +240,7 @@ export class AlertingPlugin {
     );
 
     const serviceStatus$ = new BehaviorSubject<ServiceStatus>({
-      level: ServiceStatusLevels.unavailable,
+      level: ServiceStatusLevels.degraded,
       summary: 'Alerting is initializing',
     });
     core.status.set(serviceStatus$);

--- a/x-pack/plugins/task_manager/server/lib/log_health_metrics.test.ts
+++ b/x-pack/plugins/task_manager/server/lib/log_health_metrics.test.ts
@@ -50,12 +50,15 @@ describe('logHealthMetrics', () => {
     (calculateHealthStatus as jest.Mock<HealthStatus>).mockImplementation(() => HealthStatus.Error);
     logHealthMetrics(health, logger, config);
 
-    expect((logger as jest.Mocked<Logger>).warn.mock.calls[0][0] as string).toBe(
-      `Detected potential performance issue with Task Manager. Set 'xpack.task_manager.monitored_stats_health_verbose_log.enabled: true' in your Kibana.yml to enable debug logging`
-    );
-    expect((logger as jest.Mocked<Logger>).warn.mock.calls[1][0] as string).toBe(
-      `Detected potential performance issue with Task Manager. Set 'xpack.task_manager.monitored_stats_health_verbose_log.enabled: true' in your Kibana.yml to enable debug logging`
-    );
+    const debugCalls = (logger as jest.Mocked<Logger>).debug.mock.calls;
+    const performanceMessage = /^Task Manager detected a degradation in performance/;
+    const lastStatsMessage = /^Latest Monitored Stats: \{.*\}$/;
+    expect(debugCalls[0][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[1][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[2][0] as string).toMatch(performanceMessage);
+    expect(debugCalls[3][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[4][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[5][0] as string).toMatch(performanceMessage);
   });
 
   it('should not log a warning message to enable verbose logging when the status goes from Warning to OK', () => {

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
@@ -7,11 +7,19 @@
 
 import { CapacityEstimationParams, estimateCapacity } from './capacity_estimation';
 import { HealthStatus, RawMonitoringStats } from './monitoring_stats_stream';
+import { mockLogger } from '../test_utils';
 
 describe('estimateCapacity', () => {
+  const logger = mockLogger();
+
+  beforeAll(() => {
+    jest.resetAllMocks();
+  });
+
   test('estimates the max throughput per minute based on the workload and the assumed kibana instances', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -67,6 +75,7 @@ describe('estimateCapacity', () => {
   test('reduces the available capacity per kibana when average task duration exceeds the poll interval', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -124,6 +133,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput per minute when duration by persistence is empty', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -160,6 +170,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput per minute based on the workload and the assumed kibana instances when there are tasks that repeat each hour or day', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -215,6 +226,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput available when there are no active Kibana', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -271,6 +283,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput available to handle the workload when there are multiple active kibana instances', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -332,6 +345,7 @@ describe('estimateCapacity', () => {
 
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -412,6 +426,7 @@ describe('estimateCapacity', () => {
 
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -493,6 +508,7 @@ describe('estimateCapacity', () => {
   test('marks estimated capacity as OK state when workload and load suggest capacity is sufficient', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -557,6 +573,7 @@ describe('estimateCapacity', () => {
   test('marks estimated capacity as Warning state when capacity is insufficient for recent spikes of non-recurring workload, but sufficient for the recurring workload', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -618,6 +635,7 @@ describe('estimateCapacity', () => {
   test('marks estimated capacity as Error state when workload and load suggest capacity is insufficient', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -679,6 +697,7 @@ describe('estimateCapacity', () => {
   test('recommmends a 20% increase in kibana when a spike in non-recurring tasks forces recurring task capacity to zero', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -754,6 +773,7 @@ describe('estimateCapacity', () => {
   test('recommmends a 20% increase in kibana when a spike in non-recurring tasks in a system with insufficient capacity even for recurring tasks', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {

--- a/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.ts
@@ -136,6 +136,7 @@ export function createMonitoringStatsStream(
 }
 
 export function summarizeMonitoringStats(
+  logger: Logger,
   {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     last_update,
@@ -143,7 +144,7 @@ export function summarizeMonitoringStats(
   }: MonitoringStats,
   config: TaskManagerConfig
 ): RawMonitoringStats {
-  const summarizedStats = withCapacityEstimate({
+  const summarizedStats = withCapacityEstimate(logger, {
     ...(configuration
       ? {
           configuration: {
@@ -156,7 +157,7 @@ export function summarizeMonitoringStats(
       ? {
           runtime: {
             timestamp: runtime.timestamp,
-            ...summarizeTaskRunStat(runtime.value, config),
+            ...summarizeTaskRunStat(logger, runtime.value, config),
           },
         }
       : {}),

--- a/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.test.ts
@@ -10,6 +10,7 @@ import { Subject, Observable } from 'rxjs';
 import stats from 'stats-lite';
 import sinon from 'sinon';
 import { take, tap, bufferCount, skip, map } from 'rxjs/operators';
+import { mockLogger } from '../test_utils';
 
 import { ConcreteTaskInstance, TaskStatus } from '../task';
 import {
@@ -36,9 +37,11 @@ import { configSchema } from '../config';
 
 describe('Task Run Statistics', () => {
   let fakeTimer: sinon.SinonFakeTimers;
+  const logger = mockLogger();
 
   beforeAll(() => {
     fakeTimer = sinon.useFakeTimers();
+    jest.resetAllMocks();
   });
 
   afterAll(() => fakeTimer.restore());
@@ -77,7 +80,7 @@ describe('Task Run Statistics', () => {
           // Use 'summarizeTaskRunStat' to receive summarize stats
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
-            value: summarizeTaskRunStat(value, getTaskManagerConfig()).value,
+            value: summarizeTaskRunStat(logger, value, getTaskManagerConfig()).value,
           })),
           take(runAtDrift.length),
           bufferCount(runAtDrift.length)
@@ -145,7 +148,7 @@ describe('Task Run Statistics', () => {
           // Use 'summarizeTaskRunStat' to receive summarize stats
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
-            value: summarizeTaskRunStat(value, getTaskManagerConfig()).value,
+            value: summarizeTaskRunStat(logger, value, getTaskManagerConfig()).value,
           })),
           take(runDurations.length * 2),
           bufferCount(runDurations.length * 2)
@@ -241,7 +244,7 @@ describe('Task Run Statistics', () => {
           // Use 'summarizeTaskRunStat' to receive summarize stats
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
-            value: summarizeTaskRunStat(value, getTaskManagerConfig()).value,
+            value: summarizeTaskRunStat(logger, value, getTaskManagerConfig()).value,
           })),
           take(10),
           bufferCount(10)
@@ -321,6 +324,7 @@ describe('Task Run Statistics', () => {
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
             value: summarizeTaskRunStat(
+              logger,
               value,
               getTaskManagerConfig({
                 monitored_task_execution_thresholds: {
@@ -449,7 +453,7 @@ describe('Task Run Statistics', () => {
           // Use 'summarizeTaskRunStat' to receive summarize stats
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
-            value: summarizeTaskRunStat(value, getTaskManagerConfig({})).value,
+            value: summarizeTaskRunStat(logger, value, getTaskManagerConfig({})).value,
           })),
           take(taskEvents.length),
           bufferCount(taskEvents.length)
@@ -590,7 +594,7 @@ describe('Task Run Statistics', () => {
           // Use 'summarizeTaskRunStat' to receive summarize stats
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
-            value: summarizeTaskRunStat(value, getTaskManagerConfig({})).value,
+            value: summarizeTaskRunStat(logger, value, getTaskManagerConfig({})).value,
           })),
           take(taskEvents.length),
           bufferCount(taskEvents.length)
@@ -707,7 +711,7 @@ describe('Task Run Statistics', () => {
           // Use 'summarizeTaskRunStat' to receive summarize stats
           map(({ key, value }: AggregatedStat<TaskRunStat>) => ({
             key,
-            value: summarizeTaskRunStat(value, getTaskManagerConfig()).value,
+            value: summarizeTaskRunStat(logger, value, getTaskManagerConfig()).value,
           })),
           tap(() => {
             expectedTimestamp.push(new Date().toISOString());

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -95,6 +95,14 @@ export class TaskManagerPlugin
       this.config!
     );
 
+    core.status.derivedStatus$.subscribe((status) =>
+      this.logger.debug(`status core.status.derivedStatus now set to ${status.level}`)
+    );
+    serviceStatus$.subscribe((status) =>
+      this.logger.debug(`status serviceStatus now set to ${status.level}`)
+    );
+
+    // here is where the system status is updated
     core.status.set(
       combineLatest([core.status.derivedStatus$, serviceStatus$]).pipe(
         map(([derivedStatus, serviceStatus]) =>

--- a/x-pack/plugins/task_manager/server/routes/health.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.test.ts
@@ -20,7 +20,7 @@ import {
   RawMonitoringStats,
   summarizeMonitoringStats,
 } from '../monitoring';
-import { ServiceStatusLevels } from 'src/core/server';
+import { ServiceStatusLevels, Logger } from 'src/core/server';
 import { configSchema, TaskManagerConfig } from '../config';
 import { calculateHealthStatusMock } from '../lib/calculate_health_status.mock';
 import { FillPoolResult } from '../lib/fill_pool';
@@ -30,14 +30,14 @@ jest.mock('../lib/log_health_metrics', () => ({
 }));
 
 describe('healthRoute', () => {
+  const logger = loggingSystemMock.create().get();
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('registers the route', async () => {
     const router = httpServiceMock.createRouter();
-
-    const logger = loggingSystemMock.create().get();
     healthRoute(router, of(), logger, uuid.v4(), getTaskManagerConfig());
 
     const [config] = router.get.mock.calls[0];
@@ -47,7 +47,6 @@ describe('healthRoute', () => {
 
   it('logs the Task Manager stats at a fixed interval', async () => {
     const router = httpServiceMock.createRouter();
-    const logger = loggingSystemMock.create().get();
     const calculateHealthStatus = calculateHealthStatusMock.create();
     calculateHealthStatus.mockImplementation(() => HealthStatus.OK);
     const { logHealthMetrics } = jest.requireMock('../lib/log_health_metrics');
@@ -87,19 +86,22 @@ describe('healthRoute', () => {
       id,
       timestamp: expect.any(String),
       status: expect.any(String),
-      ...ignoreCapacityEstimation(summarizeMonitoringStats(mockStat, getTaskManagerConfig({}))),
+      ...ignoreCapacityEstimation(
+        summarizeMonitoringStats(logger, mockStat, getTaskManagerConfig({}))
+      ),
     });
     expect(logHealthMetrics.mock.calls[1][0]).toMatchObject({
       id,
       timestamp: expect.any(String),
       status: expect.any(String),
-      ...ignoreCapacityEstimation(summarizeMonitoringStats(nextMockStat, getTaskManagerConfig({}))),
+      ...ignoreCapacityEstimation(
+        summarizeMonitoringStats(logger, nextMockStat, getTaskManagerConfig({}))
+      ),
     });
   });
 
   it(`logs at a warn level if the status is warning`, async () => {
     const router = httpServiceMock.createRouter();
-    const logger = loggingSystemMock.create().get();
     const calculateHealthStatus = calculateHealthStatusMock.create();
     calculateHealthStatus.mockImplementation(() => HealthStatus.Warning);
     const { logHealthMetrics } = jest.requireMock('../lib/log_health_metrics');
@@ -141,7 +143,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnRuntimeStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnRuntimeStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[1][0]).toMatchObject({
@@ -149,7 +151,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnConfigurationStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnConfigurationStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[2][0]).toMatchObject({
@@ -157,7 +159,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnWorkloadStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnWorkloadStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[3][0]).toMatchObject({
@@ -165,14 +167,13 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnEphemeralStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnEphemeralStat, getTaskManagerConfig({}))
       ),
     });
   });
 
   it(`logs at an error level if the status is error`, async () => {
     const router = httpServiceMock.createRouter();
-    const logger = loggingSystemMock.create().get();
     const calculateHealthStatus = calculateHealthStatusMock.create();
     calculateHealthStatus.mockImplementation(() => HealthStatus.Error);
     const { logHealthMetrics } = jest.requireMock('../lib/log_health_metrics');
@@ -214,7 +215,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorRuntimeStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorRuntimeStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[1][0]).toMatchObject({
@@ -222,7 +223,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorConfigurationStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorConfigurationStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[2][0]).toMatchObject({
@@ -230,7 +231,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorWorkloadStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorWorkloadStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[3][0]).toMatchObject({
@@ -238,7 +239,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorEphemeralStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorEphemeralStat, getTaskManagerConfig({}))
       ),
     });
   });
@@ -251,7 +252,7 @@ describe('healthRoute', () => {
     const { serviceStatus$ } = healthRoute(
       router,
       stats$,
-      loggingSystemMock.create().get(),
+      logger,
       uuid.v4(),
       getTaskManagerConfig({
         monitored_stats_required_freshness: 1000,
@@ -269,7 +270,7 @@ describe('healthRoute', () => {
 
     stats$.next(
       mockHealthStats({
-        last_update: new Date(Date.now() - 1500).toISOString(),
+        last_update: new Date(Date.now() - 3001).toISOString(),
       })
     );
 
@@ -278,6 +279,7 @@ describe('healthRoute', () => {
         status: 'error',
         ...ignoreCapacityEstimation(
           summarizeMonitoringStats(
+            logger,
             mockHealthStats({
               last_update: expect.any(String),
               stats: {
@@ -307,9 +309,15 @@ describe('healthRoute', () => {
     });
 
     expect(await serviceStatus).toMatchObject({
-      level: ServiceStatusLevels.unavailable,
-      summary: 'Task Manager is unavailable',
+      level: ServiceStatusLevels.degraded,
+      summary: 'Task Manager is unhealthy',
     });
+    const debugCalls = (logger as jest.Mocked<Logger>).debug.mock.calls as string[][];
+    const warnMessage = /^setting HealthStatus.Warning because assumedAverageRecurringRequiredThroughputPerMinutePerKibana/;
+    const found = debugCalls
+      .map((arr) => arr[0])
+      .find((message) => message.match(warnMessage) != null);
+    expect(found).toMatch(warnMessage);
   });
 
   it('returns a error status if the workload stats have not been updated within the required cold freshness', async () => {
@@ -320,7 +328,7 @@ describe('healthRoute', () => {
     healthRoute(
       router,
       stats$,
-      loggingSystemMock.create().get(),
+      logger,
       uuid.v4(),
       getTaskManagerConfig({
         monitored_stats_required_freshness: 5000,
@@ -352,6 +360,7 @@ describe('healthRoute', () => {
         status: 'error',
         ...ignoreCapacityEstimation(
           summarizeMonitoringStats(
+            logger,
             mockHealthStats({
               last_update: expect.any(String),
               stats: {
@@ -388,7 +397,7 @@ describe('healthRoute', () => {
     healthRoute(
       router,
       stats$,
-      loggingSystemMock.create().get(),
+      logger,
       uuid.v4(),
       getTaskManagerConfig({
         monitored_stats_required_freshness: 1000,
@@ -399,7 +408,7 @@ describe('healthRoute', () => {
     await sleep(0);
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const last_successful_poll = new Date(Date.now() - 2000).toISOString();
+    const last_successful_poll = new Date(Date.now() - 3001).toISOString();
     stats$.next(
       mockHealthStats({
         stats: {
@@ -423,6 +432,7 @@ describe('healthRoute', () => {
         status: 'error',
         ...ignoreCapacityEstimation(
           summarizeMonitoringStats(
+            logger,
             mockHealthStats({
               last_update: expect.any(String),
               stats: {

--- a/x-pack/plugins/task_manager/server/routes/health.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.ts
@@ -62,8 +62,8 @@ export function healthRoute(
   const requiredHotStatsFreshness: number = config.monitored_stats_required_freshness;
 
   function getHealthStatus(monitoredStats: MonitoringStats) {
-    const summarizedStats = summarizeMonitoringStats(monitoredStats, config);
-    const status = calculateHealthStatus(summarizedStats, config);
+    const summarizedStats = summarizeMonitoringStats(logger, monitoredStats, config);
+    const status = calculateHealthStatus(summarizedStats, config, logger);
     const now = Date.now();
     const timestamp = new Date(now).toISOString();
     return { id: taskManagerId, timestamp, status, ...summarizedStats };
@@ -118,9 +118,7 @@ export function withServiceStatus(
   const level =
     monitoredHealth.status === HealthStatus.OK
       ? ServiceStatusLevels.available
-      : monitoredHealth.status === HealthStatus.Warning
-      ? ServiceStatusLevels.degraded
-      : ServiceStatusLevels.unavailable;
+      : ServiceStatusLevels.degraded;
   return [
     monitoredHealth,
     {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [task manager] provide better diagnostics when task manager performance is degraded (#109741)