### PR TITLE
[7.14] [task manager] provide better diagnostics when task manager performance is degraded (#109741)

### DIFF
--- a/x-pack/plugins/alerting/server/health/get_state.test.ts
+++ b/x-pack/plugins/alerting/server/health/get_state.test.ts
@@ -211,8 +211,8 @@ describe('getHealthServiceStatusWithRetryAndErrorHandling', () => {
       })
     ).toPromise();
 
-    expect(status.level).toEqual(ServiceStatusLevels.unavailable);
-    expect(status.summary).toEqual('Alerting framework is unavailable');
+    expect(status.level).toEqual(ServiceStatusLevels.degraded);
+    expect(status.summary).toEqual('Alerting framework is degraded');
     expect(status.meta).toBeUndefined();
   });
 
@@ -268,8 +268,8 @@ describe('getHealthServiceStatusWithRetryAndErrorHandling', () => {
       }),
       retryDelay
     ).subscribe((status) => {
-      expect(status.level).toEqual(ServiceStatusLevels.unavailable);
-      expect(status.summary).toEqual('Alerting framework is unavailable');
+      expect(status.level).toEqual(ServiceStatusLevels.degraded);
+      expect(status.summary).toEqual('Alerting framework is degraded');
       expect(status.meta).toEqual({ error: err });
     });
 

--- a/x-pack/plugins/alerting/server/health/get_state.ts
+++ b/x-pack/plugins/alerting/server/health/get_state.ts
@@ -73,9 +73,7 @@ const getHealthServiceStatus = async (
   const level =
     doc.state?.health_status === HealthStatus.OK
       ? ServiceStatusLevels.available
-      : doc.state?.health_status === HealthStatus.Warning
-      ? ServiceStatusLevels.degraded
-      : ServiceStatusLevels.unavailable;
+      : ServiceStatusLevels.degraded;
   return {
     level,
     summary: LEVEL_SUMMARY[level.toString()],
@@ -102,10 +100,10 @@ export const getHealthServiceStatusWithRetryAndErrorHandling = (
       );
     }),
     catchError((error) => {
-      logger.warn(`Alerting framework is unavailable due to the error: ${error}`);
+      logger.warn(`Alerting framework is degraded due to the error: ${error}`);
       return of({
-        level: ServiceStatusLevels.unavailable,
-        summary: LEVEL_SUMMARY[ServiceStatusLevels.unavailable.toString()],
+        level: ServiceStatusLevels.degraded,
+        summary: LEVEL_SUMMARY[ServiceStatusLevels.degraded.toString()],
         meta: { error },
       });
     })

--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -234,7 +234,7 @@ export class AlertingPlugin {
     );
 
     const serviceStatus$ = new BehaviorSubject<ServiceStatus>({
-      level: ServiceStatusLevels.unavailable,
+      level: ServiceStatusLevels.degraded,
       summary: 'Alerting is initializing',
     });
     core.status.set(serviceStatus$);

--- a/x-pack/plugins/task_manager/server/lib/calculate_health_status.ts
+++ b/x-pack/plugins/task_manager/server/lib/calculate_health_status.ts
@@ -9,32 +9,42 @@ import { isString } from 'lodash';
 import { JsonValue } from '@kbn/common-utils';
 import { HealthStatus, RawMonitoringStats } from '../monitoring';
 import { TaskManagerConfig } from '../config';
+import { Logger } from '../../../../../src/core/server';
 
 export function calculateHealthStatus(
   summarizedStats: RawMonitoringStats,
-  config: TaskManagerConfig
+  config: TaskManagerConfig,
+  logger: Logger
 ): HealthStatus {
   const now = Date.now();
 
-  // if "hot" health stats are any more stale than monitored_stats_required_freshness (pollInterval +1s buffer by default)
-  // consider the system unhealthy
-  const requiredHotStatsFreshness: number = config.monitored_stats_required_freshness;
+  // if "hot" health stats are any more stale than monitored_stats_required_freshness
+  // times a multiplier, consider the system unhealthy
+  const requiredHotStatsFreshness: number = config.monitored_stats_required_freshness * 3;
 
-  // if "cold" health stats are any more stale than the configured refresh (+ a buffer), consider the system unhealthy
+  // if "cold" health stats are any more stale than the configured refresh
+  // times a multiplier, consider the system unhealthy
   const requiredColdStatsFreshness: number = config.monitored_aggregated_stats_refresh_rate * 1.5;
 
-  /**
-   * If the monitored stats aren't fresh, return a red status
-   */
-  const healthStatus =
-    hasStatus(summarizedStats.stats, HealthStatus.Error) ||
-    hasExpiredHotTimestamps(summarizedStats, now, requiredHotStatsFreshness) ||
-    hasExpiredColdTimestamps(summarizedStats, now, requiredColdStatsFreshness)
-      ? HealthStatus.Error
-      : hasStatus(summarizedStats.stats, HealthStatus.Warning)
-      ? HealthStatus.Warning
-      : HealthStatus.OK;
-  return healthStatus;
+  if (hasStatus(summarizedStats.stats, HealthStatus.Error)) {
+    return HealthStatus.Error;
+  }
+
+  if (hasExpiredHotTimestamps(summarizedStats, now, requiredHotStatsFreshness)) {
+    logger.debug('setting HealthStatus.Error because of expired hot timestamps');
+    return HealthStatus.Error;
+  }
+
+  if (hasExpiredColdTimestamps(summarizedStats, now, requiredColdStatsFreshness)) {
+    logger.debug('setting HealthStatus.Error because of expired cold timestamps');
+    return HealthStatus.Error;
+  }
+
+  if (hasStatus(summarizedStats.stats, HealthStatus.Warning)) {
+    return HealthStatus.Warning;
+  }
+
+  return HealthStatus.OK;
 }
 
 function hasStatus(stats: RawMonitoringStats['stats'], status: HealthStatus): boolean {

--- a/x-pack/plugins/task_manager/server/lib/log_health_metrics.test.ts
+++ b/x-pack/plugins/task_manager/server/lib/log_health_metrics.test.ts
@@ -50,12 +50,15 @@ describe('logHealthMetrics', () => {
     (calculateHealthStatus as jest.Mock<HealthStatus>).mockImplementation(() => HealthStatus.Error);
     logHealthMetrics(health, logger, config);
 
-    expect((logger as jest.Mocked<Logger>).warn.mock.calls[0][0] as string).toBe(
-      `Detected potential performance issue with Task Manager. Set 'xpack.task_manager.monitored_stats_health_verbose_log.enabled: true' in your Kibana.yml to enable debug logging`
-    );
-    expect((logger as jest.Mocked<Logger>).warn.mock.calls[1][0] as string).toBe(
-      `Detected potential performance issue with Task Manager. Set 'xpack.task_manager.monitored_stats_health_verbose_log.enabled: true' in your Kibana.yml to enable debug logging`
-    );
+    const debugCalls = (logger as jest.Mocked<Logger>).debug.mock.calls;
+    const performanceMessage = /^Task Manager detected a degradation in performance/;
+    const lastStatsMessage = /^Latest Monitored Stats: \{.*\}$/;
+    expect(debugCalls[0][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[1][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[2][0] as string).toMatch(performanceMessage);
+    expect(debugCalls[3][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[4][0] as string).toMatch(lastStatsMessage);
+    expect(debugCalls[5][0] as string).toMatch(performanceMessage);
   });
 
   it('should not log a warning message to enable verbose logging when the status goes from Warning to OK', () => {

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
@@ -7,11 +7,19 @@
 
 import { CapacityEstimationParams, estimateCapacity } from './capacity_estimation';
 import { HealthStatus, RawMonitoringStats } from './monitoring_stats_stream';
+import { mockLogger } from '../test_utils';
 
 describe('estimateCapacity', () => {
+  const logger = mockLogger();
+
+  beforeAll(() => {
+    jest.resetAllMocks();
+  });
+
   test('estimates the max throughput per minute based on the workload and the assumed kibana instances', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -67,6 +75,7 @@ describe('estimateCapacity', () => {
   test('reduces the available capacity per kibana when average task duration exceeds the poll interval', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -124,6 +133,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput per minute when duration by persistence is empty', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -160,6 +170,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput per minute based on the workload and the assumed kibana instances when there are tasks that repeat each hour or day', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -215,6 +226,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput available when there are no active Kibana', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -271,6 +283,7 @@ describe('estimateCapacity', () => {
   test('estimates the max throughput available to handle the workload when there are multiple active kibana instances', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -332,6 +345,7 @@ describe('estimateCapacity', () => {
 
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -412,6 +426,7 @@ describe('estimateCapacity', () => {
 
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -493,6 +508,7 @@ describe('estimateCapacity', () => {
   test('marks estimated capacity as OK state when workload and load suggest capacity is sufficient', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -557,6 +573,7 @@ describe('estimateCapacity', () => {
   test('marks estimated capacity as Warning state when capacity is insufficient for recent spikes of non-recurring workload, but sufficient for the recurring workload', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -618,6 +635,7 @@ describe('estimateCapacity', () => {
   test('marks estimated capacity as Error state when workload and load suggest capacity is insufficient', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -679,6 +697,7 @@ describe('estimateCapacity', () => {
   test('recommmends a 20% increase in kibana when a spike in non-recurring tasks forces recurring task capacity to zero', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {
@@ -754,6 +773,7 @@ describe('estimateCapacity', () => {
   test('recommmends a 20% increase in kibana when a spike in non-recurring tasks in a system with insufficient capacity even for recurring tasks', async () => {
     expect(
       estimateCapacity(
+        logger,
         mockStats(
           { max_workers: 10, poll_interval: 3000 },
           {

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
@@ -12,6 +12,7 @@ import { RawMonitoringStats, RawMonitoredStat, HealthStatus } from './monitoring
 import { AveragedStat } from './task_run_calcultors';
 import { TaskPersistenceTypes } from './task_run_statistics';
 import { asErr, asOk, map, Result } from '../lib/result_type';
+import { Logger } from '../../../../../src/core/server';
 
 export interface CapacityEstimationStat extends JsonObject {
   observed: {
@@ -44,6 +45,7 @@ function isCapacityEstimationParams(
 }
 
 export function estimateCapacity(
+  logger: Logger,
   capacityStats: CapacityEstimationParams
 ): RawMonitoredStat<CapacityEstimationStat> {
   const workload = capacityStats.workload.value;
@@ -183,13 +185,13 @@ export function estimateCapacity(
     averageCapacityUsedByNonRecurringAndEphemeralTasksPerKibana +
     averageRecurringRequiredPerMinute / assumedKibanaInstances;
 
+  const status = getHealthStatus(logger, {
+    assumedRequiredThroughputPerMinutePerKibana,
+    assumedAverageRecurringRequiredThroughputPerMinutePerKibana,
+    capacityPerMinutePerKibana,
+  });
   return {
-    status:
-      assumedRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana
-        ? HealthStatus.OK
-        : assumedAverageRecurringRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana
-        ? HealthStatus.Warning
-        : HealthStatus.Error,
+    status,
     timestamp: new Date().toISOString(),
     value: {
       observed: mapValues(
@@ -220,13 +222,43 @@ export function estimateCapacity(
   };
 }
 
+interface GetHealthStatusParams {
+  assumedRequiredThroughputPerMinutePerKibana: number;
+  assumedAverageRecurringRequiredThroughputPerMinutePerKibana: number;
+  capacityPerMinutePerKibana: number;
+}
+
+function getHealthStatus(logger: Logger, params: GetHealthStatusParams): HealthStatus {
+  const {
+    assumedRequiredThroughputPerMinutePerKibana,
+    assumedAverageRecurringRequiredThroughputPerMinutePerKibana,
+    capacityPerMinutePerKibana,
+  } = params;
+  if (assumedRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana) {
+    return HealthStatus.OK;
+  }
+
+  if (assumedAverageRecurringRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana) {
+    logger.debug(
+      `setting HealthStatus.Warning because assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) < capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`
+    );
+    return HealthStatus.Warning;
+  }
+
+  logger.debug(
+    `setting HealthStatus.Error because assumedRequiredThroughputPerMinutePerKibana (${assumedRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana}) AND assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`
+  );
+  return HealthStatus.Error;
+}
+
 export function withCapacityEstimate(
+  logger: Logger,
   monitoredStats: RawMonitoringStats['stats']
 ): RawMonitoringStats['stats'] {
   if (isCapacityEstimationParams(monitoredStats)) {
     return {
       ...monitoredStats,
-      capacity_estimation: estimateCapacity(monitoredStats),
+      capacity_estimation: estimateCapacity(logger, monitoredStats),
     };
   }
   return monitoredStats;

--- a/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.ts
@@ -116,6 +116,7 @@ export function createMonitoringStatsStream(
 }
 
 export function summarizeMonitoringStats(
+  logger: Logger,
   {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     last_update,
@@ -123,7 +124,7 @@ export function summarizeMonitoringStats(
   }: MonitoringStats,
   config: TaskManagerConfig
 ): RawMonitoringStats {
-  const summarizedStats = withCapacityEstimate({
+  const summarizedStats = withCapacityEstimate(logger, {
     ...(configuration
       ? {
           configuration: {
@@ -136,7 +137,7 @@ export function summarizeMonitoringStats(
       ? {
           runtime: {
             timestamp: runtime.timestamp,
-            ...summarizeTaskRunStat(runtime.value, config),
+            ...summarizeTaskRunStat(logger, runtime.value, config),
           },
         }
       : {}),

--- a/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/task_run_statistics.ts
@@ -35,6 +35,7 @@ import {
 import { HealthStatus } from './monitoring_stats_stream';
 import { TaskPollingLifecycle } from '../polling_lifecycle';
 import { TaskExecutionFailureThreshold, TaskManagerConfig } from '../config';
+import { Logger } from '../../../../../src/core/server';
 
 export enum TaskPersistence {
   Recurring = 'recurring',
@@ -325,6 +326,7 @@ const DEFAULT_PERSISTENCE_FREQUENCIES = {
 };
 
 export function summarizeTaskRunStat(
+  logger: Logger,
   {
     polling: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -383,6 +385,7 @@ export function summarizeTaskRunStat(
           executionResultFrequency,
           (typedResultFrequencies, taskType) =>
             summarizeTaskExecutionResultFrequencyStat(
+              logger,
               {
                 ...DEFAULT_TASK_RUN_FREQUENCIES,
                 ...calculateFrequency<TaskRunResult>(typedResultFrequencies),
@@ -398,16 +401,35 @@ export function summarizeTaskRunStat(
 }
 
 function summarizeTaskExecutionResultFrequencyStat(
+  logger: Logger,
   resultFrequencySummary: ResultFrequency,
   executionErrorThreshold: TaskExecutionFailureThreshold
 ): ResultFrequencySummary {
+  const status = getHealthStatus(logger, resultFrequencySummary, executionErrorThreshold);
   return {
     ...resultFrequencySummary,
-    status:
-      resultFrequencySummary.Failed > executionErrorThreshold.warn_threshold
-        ? resultFrequencySummary.Failed > executionErrorThreshold.error_threshold
-          ? HealthStatus.Error
-          : HealthStatus.Warning
-        : HealthStatus.OK,
+    status,
   };
+}
+
+function getHealthStatus(
+  logger: Logger,
+  resultFrequencySummary: ResultFrequency,
+  executionErrorThreshold: TaskExecutionFailureThreshold
+): HealthStatus {
+  if (resultFrequencySummary.Failed > executionErrorThreshold.warn_threshold) {
+    if (resultFrequencySummary.Failed > executionErrorThreshold.error_threshold) {
+      logger.debug(
+        `setting HealthStatus.Error because resultFrequencySummary.Failed (${resultFrequencySummary.Failed}) > error_threshold (${executionErrorThreshold.error_threshold})`
+      );
+      return HealthStatus.Error;
+    } else {
+      logger.debug(
+        `setting HealthStatus.Warning because resultFrequencySummary.Failed (${resultFrequencySummary.Failed}) > warn_threshold (${executionErrorThreshold.warn_threshold})`
+      );
+      return HealthStatus.Warning;
+    }
+  }
+
+  return HealthStatus.OK;
 }

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -87,6 +87,14 @@ export class TaskManagerPlugin
       this.config!
     );
 
+    core.status.derivedStatus$.subscribe((status) =>
+      this.logger.debug(`status core.status.derivedStatus now set to ${status.level}`)
+    );
+    serviceStatus$.subscribe((status) =>
+      this.logger.debug(`status serviceStatus now set to ${status.level}`)
+    );
+
+    // here is where the system status is updated
     core.status.set(
       combineLatest([core.status.derivedStatus$, serviceStatus$]).pipe(
         map(([derivedStatus, serviceStatus]) =>

--- a/x-pack/plugins/task_manager/server/routes/health.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.test.ts
@@ -158,14 +158,6 @@ describe('healthRoute', () => {
         summarizeMonitoringStats(logger, warnWorkloadStat, getTaskManagerConfig({}))
       ),
     });
-    expect(logHealthMetrics.mock.calls[3][0]).toMatchObject({
-      id,
-      timestamp: expect.any(String),
-      status: expect.any(String),
-      ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(logger, warnEphemeralStat, getTaskManagerConfig({}))
-      ),
-    });
   });
 
   it(`logs at an error level if the status is error`, async () => {
@@ -225,14 +217,6 @@ describe('healthRoute', () => {
       status: expect.any(String),
       ...ignoreCapacityEstimation(
         summarizeMonitoringStats(logger, errorWorkloadStat, getTaskManagerConfig({}))
-      ),
-    });
-    expect(logHealthMetrics.mock.calls[3][0]).toMatchObject({
-      id,
-      timestamp: expect.any(String),
-      status: expect.any(String),
-      ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(logger, errorEphemeralStat, getTaskManagerConfig({}))
       ),
     });
   });

--- a/x-pack/plugins/task_manager/server/routes/health.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.test.ts
@@ -20,7 +20,7 @@ import {
   RawMonitoringStats,
   summarizeMonitoringStats,
 } from '../monitoring';
-import { ServiceStatusLevels } from 'src/core/server';
+import { ServiceStatusLevels, Logger } from 'src/core/server';
 import { configSchema, TaskManagerConfig } from '../config';
 import { calculateHealthStatusMock } from '../lib/calculate_health_status.mock';
 
@@ -29,14 +29,14 @@ jest.mock('../lib/log_health_metrics', () => ({
 }));
 
 describe('healthRoute', () => {
+  const logger = loggingSystemMock.create().get();
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('registers the route', async () => {
     const router = httpServiceMock.createRouter();
-
-    const logger = loggingSystemMock.create().get();
     healthRoute(router, of(), logger, uuid.v4(), getTaskManagerConfig());
 
     const [config] = router.get.mock.calls[0];
@@ -46,7 +46,6 @@ describe('healthRoute', () => {
 
   it('logs the Task Manager stats at a fixed interval', async () => {
     const router = httpServiceMock.createRouter();
-    const logger = loggingSystemMock.create().get();
     const calculateHealthStatus = calculateHealthStatusMock.create();
     calculateHealthStatus.mockImplementation(() => HealthStatus.OK);
     const { logHealthMetrics } = jest.requireMock('../lib/log_health_metrics');
@@ -86,19 +85,22 @@ describe('healthRoute', () => {
       id,
       timestamp: expect.any(String),
       status: expect.any(String),
-      ...ignoreCapacityEstimation(summarizeMonitoringStats(mockStat, getTaskManagerConfig({}))),
+      ...ignoreCapacityEstimation(
+        summarizeMonitoringStats(logger, mockStat, getTaskManagerConfig({}))
+      ),
     });
     expect(logHealthMetrics.mock.calls[1][0]).toMatchObject({
       id,
       timestamp: expect.any(String),
       status: expect.any(String),
-      ...ignoreCapacityEstimation(summarizeMonitoringStats(nextMockStat, getTaskManagerConfig({}))),
+      ...ignoreCapacityEstimation(
+        summarizeMonitoringStats(logger, nextMockStat, getTaskManagerConfig({}))
+      ),
     });
   });
 
   it(`logs at a warn level if the status is warning`, async () => {
     const router = httpServiceMock.createRouter();
-    const logger = loggingSystemMock.create().get();
     const calculateHealthStatus = calculateHealthStatusMock.create();
     calculateHealthStatus.mockImplementation(() => HealthStatus.Warning);
     const { logHealthMetrics } = jest.requireMock('../lib/log_health_metrics');
@@ -137,7 +139,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnRuntimeStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnRuntimeStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[1][0]).toMatchObject({
@@ -145,7 +147,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnConfigurationStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnConfigurationStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[2][0]).toMatchObject({
@@ -153,14 +155,21 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(warnWorkloadStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, warnWorkloadStat, getTaskManagerConfig({}))
+      ),
+    });
+    expect(logHealthMetrics.mock.calls[3][0]).toMatchObject({
+      id,
+      timestamp: expect.any(String),
+      status: expect.any(String),
+      ...ignoreCapacityEstimation(
+        summarizeMonitoringStats(logger, warnEphemeralStat, getTaskManagerConfig({}))
       ),
     });
   });
 
   it(`logs at an error level if the status is error`, async () => {
     const router = httpServiceMock.createRouter();
-    const logger = loggingSystemMock.create().get();
     const calculateHealthStatus = calculateHealthStatusMock.create();
     calculateHealthStatus.mockImplementation(() => HealthStatus.Error);
     const { logHealthMetrics } = jest.requireMock('../lib/log_health_metrics');
@@ -199,7 +208,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorRuntimeStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorRuntimeStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[1][0]).toMatchObject({
@@ -207,7 +216,7 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorConfigurationStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorConfigurationStat, getTaskManagerConfig({}))
       ),
     });
     expect(logHealthMetrics.mock.calls[2][0]).toMatchObject({
@@ -215,7 +224,15 @@ describe('healthRoute', () => {
       timestamp: expect.any(String),
       status: expect.any(String),
       ...ignoreCapacityEstimation(
-        summarizeMonitoringStats(errorWorkloadStat, getTaskManagerConfig({}))
+        summarizeMonitoringStats(logger, errorWorkloadStat, getTaskManagerConfig({}))
+      ),
+    });
+    expect(logHealthMetrics.mock.calls[3][0]).toMatchObject({
+      id,
+      timestamp: expect.any(String),
+      status: expect.any(String),
+      ...ignoreCapacityEstimation(
+        summarizeMonitoringStats(logger, errorEphemeralStat, getTaskManagerConfig({}))
       ),
     });
   });
@@ -228,7 +245,7 @@ describe('healthRoute', () => {
     const serviceStatus$ = healthRoute(
       router,
       stats$,
-      loggingSystemMock.create().get(),
+      logger,
       uuid.v4(),
       getTaskManagerConfig({
         monitored_stats_required_freshness: 1000,
@@ -246,7 +263,7 @@ describe('healthRoute', () => {
 
     stats$.next(
       mockHealthStats({
-        last_update: new Date(Date.now() - 1500).toISOString(),
+        last_update: new Date(Date.now() - 3001).toISOString(),
       })
     );
 
@@ -255,6 +272,7 @@ describe('healthRoute', () => {
         status: 'error',
         ...ignoreCapacityEstimation(
           summarizeMonitoringStats(
+            logger,
             mockHealthStats({
               last_update: expect.any(String),
               stats: {
@@ -281,9 +299,15 @@ describe('healthRoute', () => {
     });
 
     expect(await serviceStatus).toMatchObject({
-      level: ServiceStatusLevels.unavailable,
-      summary: 'Task Manager is unavailable',
+      level: ServiceStatusLevels.degraded,
+      summary: 'Task Manager is unhealthy',
     });
+    const debugCalls = (logger as jest.Mocked<Logger>).debug.mock.calls as string[][];
+    const warnMessage = /^setting HealthStatus.Warning because assumedAverageRecurringRequiredThroughputPerMinutePerKibana/;
+    const found = debugCalls
+      .map((arr) => arr[0])
+      .find((message) => message.match(warnMessage) != null);
+    expect(found).toMatch(warnMessage);
   });
 
   it('returns a error status if the workload stats have not been updated within the required cold freshness', async () => {
@@ -294,7 +318,7 @@ describe('healthRoute', () => {
     healthRoute(
       router,
       stats$,
-      loggingSystemMock.create().get(),
+      logger,
       uuid.v4(),
       getTaskManagerConfig({
         monitored_stats_required_freshness: 5000,
@@ -326,6 +350,7 @@ describe('healthRoute', () => {
         status: 'error',
         ...ignoreCapacityEstimation(
           summarizeMonitoringStats(
+            logger,
             mockHealthStats({
               last_update: expect.any(String),
               stats: {
@@ -359,7 +384,7 @@ describe('healthRoute', () => {
     healthRoute(
       router,
       stats$,
-      loggingSystemMock.create().get(),
+      logger,
       uuid.v4(),
       getTaskManagerConfig({
         monitored_stats_required_freshness: 1000,
@@ -370,7 +395,7 @@ describe('healthRoute', () => {
     await sleep(0);
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const last_successful_poll = new Date(Date.now() - 2000).toISOString();
+    const last_successful_poll = new Date(Date.now() - 3001).toISOString();
     stats$.next(
       mockHealthStats({
         stats: {
@@ -394,6 +419,7 @@ describe('healthRoute', () => {
         status: 'error',
         ...ignoreCapacityEstimation(
           summarizeMonitoringStats(
+            logger,
             mockHealthStats({
               last_update: expect.any(String),
               stats: {

--- a/x-pack/plugins/task_manager/server/routes/health.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.ts
@@ -59,8 +59,8 @@ export function healthRoute(
   const requiredHotStatsFreshness: number = config.monitored_stats_required_freshness;
 
   function getHealthStatus(monitoredStats: MonitoringStats) {
-    const summarizedStats = summarizeMonitoringStats(monitoredStats, config);
-    const status = calculateHealthStatus(summarizedStats, config);
+    const summarizedStats = summarizeMonitoringStats(logger, monitoredStats, config);
+    const status = calculateHealthStatus(summarizedStats, config, logger);
     const now = Date.now();
     const timestamp = new Date(now).toISOString();
     return { id: taskManagerId, timestamp, status, ...summarizedStats };
@@ -113,9 +113,7 @@ export function withServiceStatus(
   const level =
     monitoredHealth.status === HealthStatus.OK
       ? ServiceStatusLevels.available
-      : monitoredHealth.status === HealthStatus.Warning
-      ? ServiceStatusLevels.degraded
-      : ServiceStatusLevels.unavailable;
+      : ServiceStatusLevels.degraded;
   return [
     monitoredHealth,
     {


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [task manager] provide better diagnostics when task manager performance is degraded (#109741)