### PR TITLE
[DOC] Update Persist Keystore via Docker

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -93,9 +93,9 @@ services:
       - ./kibana.yml:/usr/share/kibana/config/kibana.yml
 --------------------------------------------
 
-==== Persisting the Kibana keystore
+==== Persist the {kib} keystore
 
-By default, Kibana will auto-generate a keystore file for secure settings at start up. If you want to persist your {kibana-ref}/secure-settings.html[secure settings], you must use the `kibana-keystore` utility to bind-mount the keystore's parent-directory to the container. For example
+By default, {kib] auto-generates a keystore file for secure settings at startup. To persist your {kibana-ref}/secure-settings.html[secure settings], use the `kibana-keystore` utility to bind-mount the parent directory of the keystore to the container. For example:
 
 [source,sh]
 ----

--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -93,6 +93,16 @@ services:
       - ./kibana.yml:/usr/share/kibana/config/kibana.yml
 --------------------------------------------
 
+==== Persisting the Kibana keystore
+
+By default, Kibana will auto-generate a keystore file for secure settings at start up. If you want to persist your {kibana-ref}/secure-settings.html[secure settings], you must use the `kibana-keystore` utility to bind-mount the keystore's parent-directory to the container. For example
+
+[source,sh]
+----
+docker run -it --rm -v full_path_to/config:/usr/share/kibana/config -v full_path_to/data:/usr/share/kibana/data docker.elastic.co/kibana/kibana:7.14.0 bin/kibana-keystore create
+docker run -it --rm -v full_path_to/config:/usr/share/kibana/config -v full_path_to/data:/usr/share/kibana/data docker.elastic.co/kibana/kibana:7.14.0 bin/kibana-keystore add test_keystore_setting
+----
+
 [float]
 [[environment-variable-config]]
 ==== Environment variable configuration


### PR DESCRIPTION
## Summary
From feedback from ES Devs summarized in [this Elastic Discuss](https://discuss.elastic.co/t/persist-elasticsearch-kibana-keystores-with-docker/283099), Adding to [this doc section](https://www.elastic.co/guide/en/kibana/7.14/docker.html#bind-mount-config) information on persisting keystores. [ES related PR](https://github.com/elastic/elasticsearch/pull/77155)

![image](https://user-images.githubusercontent.com/26751266/131751546-be0c24d0-6fbd-4104-8051-5cf7e082e5b3.png)

### Checklist
Delete any items that are not applicable to this PR.

### For maintainers
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
