### PR TITLE
[Discover] Remove export* syntax

### DIFF
--- a/x-pack/plugins/discover_enhanced/common/index.ts
+++ b/x-pack/plugins/discover_enhanced/common/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { Config } from './config';
+export type { Config } from './config';

--- a/x-pack/plugins/discover_enhanced/common/index.ts
+++ b/x-pack/plugins/discover_enhanced/common/index.ts
@@ -5,7 +5,4 @@
  * 2.0.
  */
 
-// TODO: https://github.com/elastic/kibana/issues/110900
-/* eslint-disable @kbn/eslint/no_export_all */
-
-export * from './config';
+export { Config } from './config';


### PR DESCRIPTION
This PR removes export* syntax from plugin index files

resolves #110900
