### PR TITLE
[SOR] normalize initialNamespaces for `create` and `bulkCreate`

### DIFF
--- a/src/core/server/saved_objects/service/lib/repository.test.js
+++ b/src/core/server/saved_objects/service/lib/repository.test.js
@@ -555,6 +555,25 @@ describe('SavedObjectsRepository', () => {
         await test(namespace);
       });
 
+      it(`normalizes initialNamespaces from 'default' to undefined`, async () => {
+        const test = async (namespace) => {
+          const objects = [{ ...obj1, type: 'dashboard', initialNamespaces: ['default'] }];
+          await bulkCreateSuccess(objects, { namespace, overwrite: true });
+          const body = [
+            { index: expect.objectContaining({ _id: `dashboard:${obj1.id}` }) },
+            expect.not.objectContaining({ namespace: 'default' }),
+          ];
+          expect(client.bulk).toHaveBeenCalledWith(
+            expect.objectContaining({ body }),
+            expect.anything()
+          );
+          client.bulk.mockClear();
+          client.mget.mockClear();
+        };
+        await test(undefined);
+        await test(namespace);
+      });
+
       it(`doesn't add namespaces to request body for any types that are not multi-namespace`, async () => {
         const test = async (namespace) => {
           const objects = [obj1, { ...obj2, type: NAMESPACE_AGNOSTIC_TYPE }];
@@ -2067,6 +2086,24 @@ describe('SavedObjectsRepository', () => {
           expect.objectContaining({
             id: `${MULTI_NAMESPACE_TYPE}:${id}`,
             body: expect.objectContaining({ namespaces: [ns2, ns3] }),
+          }),
+          expect.anything()
+        );
+      });
+
+      it(`normalizes initialNamespaces from 'default' to undefined`, async () => {
+        await savedObjectsRepository.create('dashboard', attributes, {
+          id,
+          namespace,
+          initialNamespaces: ['default'],
+        });
+
+        expect(client.create).toHaveBeenCalledTimes(1);
+        expect(client.create).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            id: `dashboard:${id}`,
+            body: expect.not.objectContaining({ namespace: 'default' }),
           }),
           expect.anything()
         );

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -301,7 +301,9 @@ export class SavedObjectsRepository {
     let savedObjectNamespaces: string[] | undefined;
 
     if (this._registry.isSingleNamespace(type)) {
-      savedObjectNamespace = initialNamespaces ? initialNamespaces[0] : namespace;
+      savedObjectNamespace = initialNamespaces
+        ? normalizeNamespace(initialNamespaces[0])
+        : namespace;
     } else if (this._registry.isMultiNamespace(type)) {
       if (id && overwrite) {
         // we will overwrite a multi-namespace saved object if it exists; if that happens, ensure we preserve its included namespaces
@@ -476,7 +478,9 @@ export class SavedObjectsRepository {
         versionProperties = getExpectedVersionProperties(version, actualResult);
       } else {
         if (this._registry.isSingleNamespace(object.type)) {
-          savedObjectNamespace = initialNamespaces ? initialNamespaces[0] : namespace;
+          savedObjectNamespace = initialNamespaces
+            ? normalizeNamespace(initialNamespaces[0])
+            : namespace;
         } else if (this._registry.isMultiNamespace(object.type)) {
           savedObjectNamespaces = initialNamespaces || getSavedObjectNamespaces(namespace);
         }


### PR DESCRIPTION
## Summary

Extracted from https://github.com/elastic/kibana/pull/109196

Fix a bug causing single namespaceType objects created by specifying `initialNamespaces: ['default']` to have a `default:` prefix in their id (e.g `default:foo:42` instead of `foo:42`), effectively corrupting them and making it impossible to then retrieve them.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

