### PR TITLE
[Security Solution] Fix exceptions page table pagination

### DIFF
--- a/packages/kbn-securitysolution-io-ts-list-types/src/typescript_types/index.ts
+++ b/packages/kbn-securitysolution-io-ts-list-types/src/typescript_types/index.ts
@@ -40,7 +40,7 @@ export interface UseExceptionListsProps {
   http: HttpStart;
   namespaceTypes: NamespaceType[];
   notifications: NotificationsStart;
-  pagination?: Pagination;
+  initialPagination?: Pagination;
   showTrustedApps: boolean;
   showEventFilters: boolean;
 }

--- a/x-pack/plugins/lists/common/schemas/response/found_exception_list_schema.mock.ts
+++ b/x-pack/plugins/lists/common/schemas/response/found_exception_list_schema.mock.ts
@@ -12,6 +12,6 @@ import { getExceptionListSchemaMock } from './exception_list_schema.mock';
 export const getFoundExceptionListSchemaMock = (): FoundExceptionListSchema => ({
   data: [getExceptionListSchemaMock()],
   page: 1,
-  per_page: 1,
+  per_page: 20,
   total: 1,
 });

--- a/x-pack/plugins/lists/public/exceptions/hooks/use_exception_lists.test.ts
+++ b/x-pack/plugins/lists/public/exceptions/hooks/use_exception_lists.test.ts
@@ -41,13 +41,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })
@@ -62,7 +62,8 @@ describe('useExceptionLists', () => {
           perPage: 20,
           total: 0,
         },
-        null,
+        expect.any(Function),
+        expect.any(Function),
       ]);
     });
   });
@@ -77,13 +78,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })
@@ -100,10 +101,11 @@ describe('useExceptionLists', () => {
         expectedListItemsResult,
         {
           page: 1,
-          perPage: 1,
+          perPage: 20,
           total: 1,
         },
-        result.current[3],
+        expect.any(Function),
+        expect.any(Function),
       ]);
     });
   });
@@ -117,13 +119,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: true,
         })
@@ -153,13 +155,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })
@@ -189,13 +191,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: true,
           showTrustedApps: false,
         })
@@ -225,13 +227,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })
@@ -264,13 +266,13 @@ describe('useExceptionLists', () => {
             name: 'Sample Endpoint',
           },
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })
@@ -302,9 +304,9 @@ describe('useExceptionLists', () => {
           errorMessage,
           filterOptions,
           http,
+          initialPagination,
           namespaceTypes,
           notifications,
-          pagination,
           showEventFilters,
           showTrustedApps,
         }) =>
@@ -312,9 +314,9 @@ describe('useExceptionLists', () => {
             errorMessage,
             filterOptions,
             http,
+            initialPagination,
             namespaceTypes,
             notifications,
-            pagination,
             showEventFilters,
             showTrustedApps,
           }),
@@ -323,13 +325,13 @@ describe('useExceptionLists', () => {
             errorMessage: 'Uh oh',
             filterOptions: {},
             http: mockKibanaHttpService,
-            namespaceTypes: ['single'],
-            notifications: mockKibanaNotificationsService,
-            pagination: {
+            initialPagination: {
               page: 1,
               perPage: 20,
               total: 0,
             },
+            namespaceTypes: ['single'],
+            notifications: mockKibanaNotificationsService,
             showEventFilters: false,
             showTrustedApps: false,
           },
@@ -344,13 +346,13 @@ describe('useExceptionLists', () => {
         errorMessage: 'Uh oh',
         filterOptions: {},
         http: mockKibanaHttpService,
-        namespaceTypes: ['single', 'agnostic'],
-        notifications: mockKibanaNotificationsService,
-        pagination: {
+        initialPagination: {
           page: 1,
           perPage: 20,
           total: 0,
         },
+        namespaceTypes: ['single', 'agnostic'],
+        notifications: mockKibanaNotificationsService,
         showEventFilters: false,
         showTrustedApps: false,
       });
@@ -372,13 +374,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })
@@ -390,8 +392,8 @@ describe('useExceptionLists', () => {
 
       expect(typeof result.current[3]).toEqual('function');
 
-      if (result.current[3] != null) {
-        result.current[3]();
+      if (result.current[4] != null) {
+        result.current[4]();
       }
       // NOTE: Only need one call here because hook already initilaized
       await waitForNextUpdate();
@@ -411,13 +413,13 @@ describe('useExceptionLists', () => {
           errorMessage: 'Uh oh',
           filterOptions: {},
           http: mockKibanaHttpService,
-          namespaceTypes: ['single', 'agnostic'],
-          notifications: mockKibanaNotificationsService,
-          pagination: {
+          initialPagination: {
             page: 1,
             perPage: 20,
             total: 0,
           },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
           showEventFilters: false,
           showTrustedApps: false,
         })

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/columns.tsx
@@ -15,8 +15,9 @@ import { FormatUrl } from '../../../../../../common/components/link_to';
 import * as i18n from './translations';
 import { ExceptionListInfo } from './use_all_exception_lists';
 import { ExceptionOverflowDisplay } from './exceptions_overflow_display';
+import { ExceptionsTableItem } from './types';
 
-export type AllExceptionListsColumns = EuiBasicTableColumn<ExceptionListInfo>;
+export type AllExceptionListsColumns = EuiBasicTableColumn<ExceptionsTableItem>;
 
 export const getAllExceptionListsColumns = (
   onExport: (arg: { id: string; listId: string; namespaceType: NamespaceType }) => () => void,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExceptionListInfo } from './use_all_exception_lists';
+
+export interface ExceptionsTableItem extends ExceptionListInfo {
+  isDeleting: boolean;
+  isExporting: boolean;
+}


### PR DESCRIPTION
**Addresses: https://github.com/elastic/kibana/issues/105744**

## Summary

- Implemented pagination for the exceptions page table
- Fixed minor type inaccuracies in the `detection_engine/rules/all/exceptions/exceptions_table.tsx ` component.
- Refactored `useExceptionLists` hooks, so now it:
  - Handles pagination properly
  - Doesn't display `AbortError` to users

All table pagination controls work properly now:

https://user-images.githubusercontent.com/1938181/131992994-f164757e-6da2-472f-98a5-8e765ad444a4.mov



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios