### PR TITLE
[Security Solution] Use useMemo to keep filterManager in sync

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
@@ -91,12 +91,12 @@ export const useHoverActionItems = ({
     kibana.services.data.query.filterManager,
   ]);
   const getManageTimeline = useMemo(() => timelineSelectors.getManageTimelineById(), []);
-  const { filterManager: activeFilterMananager } = useDeepEqualSelector((state) =>
+  const { filterManager: activeFilterManager } = useDeepEqualSelector((state) =>
     getManageTimeline(state, timelineId ?? '')
   );
   const filterManager = useMemo(
-    () => (timelineId === TimelineId.active ? activeFilterMananager : filterManagerBackup),
-    [timelineId, activeFilterMananager, filterManagerBackup]
+    () => (timelineId === TimelineId.active ? activeFilterManager : filterManagerBackup),
+    [timelineId, activeFilterManager, filterManagerBackup]
   );
 
   //  Regarding data from useManageTimeline:

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/query_tab_content/index.tsx
@@ -193,7 +193,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   } = useSourcererScope(SourcererScopeName.timeline);
 
   const { uiSettings } = useKibana().services;
-  const [filterManager] = useState<FilterManager>(new FilterManager(uiSettings));
+  const filterManager = useMemo(() => new FilterManager(uiSettings), [uiSettings]);
   const esQueryConfig = useMemo(() => esQuery.getEsQueryConfig(uiSettings), [uiSettings]);
   const kqlQuery: {
     query: string;


### PR DESCRIPTION
## Summary

This PR introduces a minor change to help keep the `filterManager` in sync by making use of useMemo in place of useState.


https://user-images.githubusercontent.com/17211684/131886138-667e6ae8-88d0-47ba-98bb-95446f8a371e.mp4

