### PR TITLE
[Security Solution][Detection Alerts] Fixes alert page refresh issues

### DIFF
--- a/x-pack/plugins/security_solution/public/common/store/inputs/selectors.ts
+++ b/x-pack/plugins/security_solution/public/common/store/inputs/selectors.ts
@@ -57,7 +57,7 @@ export const globalTimeRangeSelector = createSelector(selectGlobal, (global) => 
 
 export const globalPolicySelector = createSelector(selectGlobal, (global) => global.policy);
 
-export const globalQuery = createSelector(selectGlobal, (global) => global.queries);
+export const globalQuery = () => createSelector(selectGlobal, (global) => global.queries);
 
 export const globalQueryByIdSelector = () => createSelector(selectGlobalQuery, (query) => query);
 

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -172,6 +172,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
             title = i18n.OPENED_ALERT_SUCCESS_TOAST(updated);
             break;
           case 'acknowledged':
+          case 'in-progress':
             title = i18n.ACKNOWLEDGED_ALERT_SUCCESS_TOAST(updated);
         }
         displaySuccessToast(title, dispatchToaster);
@@ -191,6 +192,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
           title = i18n.OPENED_ALERT_FAILED_TOAST;
           break;
         case 'acknowledged':
+        case 'in-progress':
           title = i18n.ACKNOWLEDGED_ALERT_FAILED_TOAST;
       }
       displayErrorToast(title, [error.message], dispatchToaster);

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -131,7 +131,7 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
     if (timelineId === TimelineId.active) {
       refetchQuery([timelineQuery]);
     } else {
-      refetchQuery([globalQuery]);
+      refetchQuery(globalQuery);
     }
   }, [timelineId, globalQuery, timelineQuery]);
 
@@ -234,11 +234,11 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
 };
 
 const makeMapStateToProps = () => {
-  const getGlobalQuery = inputsSelectors.globalQueryByIdSelector();
+  const getGlobalQueries = inputsSelectors.globalQuery();
   const getTimelineQuery = inputsSelectors.timelineQueryByIdSelector();
   const mapStateToProps = (state: State, { timelineId }: AlertContextMenuProps) => {
     return {
-      globalQuery: getGlobalQuery(state, timelineId),
+      globalQuery: getGlobalQueries(state),
       timelineQuery: getTimelineQuery(state, timelineId),
     };
   };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/alert_context_menu.tsx
@@ -105,24 +105,6 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
     );
   }, [disabled, onButtonClick, ariaLabel]);
 
-  const {
-    exceptionModalType,
-    onAddExceptionCancel,
-    onAddExceptionConfirm,
-    onAddExceptionTypeClick,
-    ruleIndices,
-  } = useExceptionModal({
-    ruleIndex: ecsRowData?.signal?.rule?.index,
-    refetch,
-    timelineId,
-  });
-
-  const {
-    closeAddEventFilterModal,
-    isAddEventFilterModalOpen,
-    onAddEventFilterClick,
-  } = useEventFilterModal();
-
   const refetchQuery = (newQueries: inputsModel.GlobalQuery[]) => {
     newQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
   };
@@ -134,6 +116,24 @@ const AlertContextMenuComponent: React.FC<AlertContextMenuProps & PropsFromRedux
       refetchQuery(globalQuery);
     }
   }, [timelineId, globalQuery, timelineQuery]);
+
+  const {
+    exceptionModalType,
+    onAddExceptionCancel,
+    onAddExceptionConfirm,
+    onAddExceptionTypeClick,
+    ruleIndices,
+  } = useExceptionModal({
+    ruleIndex: ecsRowData?.signal?.rule?.index,
+    refetch: refetchAll,
+    timelineId,
+  });
+
+  const {
+    closeAddEventFilterModal,
+    isAddEventFilterModalOpen,
+    onAddEventFilterClick,
+  } = useEventFilterModal();
 
   const { actionItems: statusActionItems } = useAlertsActions({
     alertStatus,

--- a/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/take_action_dropdown/index.tsx
@@ -9,7 +9,8 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { EuiContextMenuPanel, EuiButton, EuiPopover } from '@elastic/eui';
 import type { ExceptionListType } from '@kbn/securitysolution-io-ts-list-types';
 import { isEmpty } from 'lodash/fp';
-import { TimelineEventsDetailsItem } from '../../../../common';
+import { connect, ConnectedProps } from 'react-redux';
+import { TimelineEventsDetailsItem, TimelineId } from '../../../../common';
 import { TAKE_ACTION } from '../alerts_table/alerts_utility_bar/translations';
 import { useExceptionActions } from '../alerts_table/timeline_actions/use_add_exception_actions';
 import { useAlertsActions } from '../alerts_table/timeline_actions/use_alerts_actions';
@@ -23,6 +24,7 @@ import { Status } from '../../../../common/detection_engine/schemas/common/schem
 import { isAlertFromEndpointAlert } from '../../../common/utils/endpoint_alert_check';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useAddToCaseActions } from '../alerts_table/timeline_actions/use_add_to_case_actions';
+import { inputsModel, inputsSelectors, State } from '../../../common/store';
 
 interface ActionsData {
   alertStatus: Status;
@@ -46,7 +48,7 @@ export interface TakeActionDropdownProps {
   timelineId: string;
 }
 
-export const TakeActionDropdown = React.memo(
+export const TakeActionDropdownComponent = React.memo(
   ({
     detailsData,
     ecsData,
@@ -59,7 +61,9 @@ export const TakeActionDropdown = React.memo(
     onAddIsolationStatusClick,
     refetch,
     timelineId,
-  }: TakeActionDropdownProps) => {
+    globalQuery,
+    timelineQuery,
+  }: TakeActionDropdownProps & PropsFromRedux) => {
     const tGridEnabled = useIsExperimentalFeatureEnabled('tGridEnabled');
 
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -141,12 +145,24 @@ export const TakeActionDropdown = React.memo(
       closePopoverHandler();
     }, [closePopoverHandler]);
 
+    const refetchQuery = (newQueries: inputsModel.GlobalQuery[]) => {
+      newQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
+    };
+
+    const refetchAll = useCallback(() => {
+      if (timelineId === TimelineId.active) {
+        refetchQuery([timelineQuery]);
+      } else {
+        refetchQuery(globalQuery);
+      }
+    }, [timelineId, globalQuery, timelineQuery]);
+
     const { actionItems: statusActionItems } = useAlertsActions({
       alertStatus: actionsData.alertStatus,
       closePopover: closePopoverAndFlyout,
       eventId: actionsData.eventId,
       indexName,
-      refetch,
+      refetch: refetchAll,
       timelineId,
     });
 
@@ -216,3 +232,21 @@ export const TakeActionDropdown = React.memo(
     ) : null;
   }
 );
+
+const makeMapStateToProps = () => {
+  const getGlobalQueries = inputsSelectors.globalQuery();
+  const getTimelineQuery = inputsSelectors.timelineQueryByIdSelector();
+  const mapStateToProps = (state: State, { timelineId }: TakeActionDropdownProps) => {
+    return {
+      globalQuery: getGlobalQueries(state),
+      timelineQuery: getTimelineQuery(state, timelineId),
+    };
+  };
+  return mapStateToProps;
+};
+
+const connector = connect(makeMapStateToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export const TakeActionDropdown = connector(React.memo(TakeActionDropdownComponent));

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/__snapshots__/index.test.tsx.snap
@@ -1229,7 +1229,7 @@ Array [
                     <div
                       className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <Memo()
+                      <Connect(Component)
                         detailsData={null}
                         ecsData={
                           Object {
@@ -1390,7 +1390,182 @@ Array [
                         onAddExceptionTypeClick={[Function]}
                         onAddIsolationStatusClick={[Function]}
                         timelineId="test"
-                      />
+                      >
+                        <Memo()
+                          detailsData={null}
+                          dispatch={[Function]}
+                          ecsData={
+                            Object {
+                              "_id": "1",
+                              "destination": Object {
+                                "ip": Array [
+                                  "192.168.0.3",
+                                ],
+                                "port": Array [
+                                  6343,
+                                ],
+                              },
+                              "event": Object {
+                                "action": Array [
+                                  "Action",
+                                ],
+                                "category": Array [
+                                  "Access",
+                                ],
+                                "id": Array [
+                                  "1",
+                                ],
+                                "module": Array [
+                                  "nginx",
+                                ],
+                                "severity": Array [
+                                  3,
+                                ],
+                              },
+                              "geo": Object {
+                                "country_iso_code": Array [
+                                  "xx",
+                                ],
+                                "region_name": Array [
+                                  "xx",
+                                ],
+                              },
+                              "host": Object {
+                                "ip": Array [
+                                  "192.168.0.1",
+                                ],
+                                "name": Array [
+                                  "apache",
+                                ],
+                              },
+                              "signal": Object {
+                                "rule": Object {
+                                  "created_at": Array [
+                                    "2020-01-10T21:11:45.839Z",
+                                  ],
+                                  "created_by": Array [
+                                    "elastic",
+                                  ],
+                                  "description": Array [
+                                    "24/7",
+                                  ],
+                                  "enabled": Array [
+                                    true,
+                                  ],
+                                  "false_positives": Array [
+                                    "test-1",
+                                  ],
+                                  "filters": Array [],
+                                  "from": Array [
+                                    "now-300s",
+                                  ],
+                                  "id": Array [
+                                    "b5ba41ab-aaf3-4f43-971b-bdf9434ce0ea",
+                                  ],
+                                  "immutable": Array [
+                                    false,
+                                  ],
+                                  "index": Array [
+                                    "auditbeat-*",
+                                  ],
+                                  "interval": Array [
+                                    "5m",
+                                  ],
+                                  "language": Array [
+                                    "kuery",
+                                  ],
+                                  "max_signals": Array [
+                                    100,
+                                  ],
+                                  "note": Array [
+                                    "# this is some markdown documentation",
+                                  ],
+                                  "output_index": Array [
+                                    ".siem-signals-default",
+                                  ],
+                                  "query": Array [
+                                    "user.name: root or user.name: admin",
+                                  ],
+                                  "references": Array [
+                                    "www.test.co",
+                                  ],
+                                  "risk_score": Array [
+                                    "21",
+                                  ],
+                                  "rule_id": Array [
+                                    "rule-id-1",
+                                  ],
+                                  "saved_id": Array [
+                                    "Garrett's IP",
+                                  ],
+                                  "severity": Array [
+                                    "low",
+                                  ],
+                                  "tags": Array [],
+                                  "threat": Array [],
+                                  "timeline_id": Array [
+                                    "1234-2136-11ea-9864-ebc8cc1cb8c2",
+                                  ],
+                                  "timeline_title": Array [
+                                    "Untitled timeline",
+                                  ],
+                                  "to": Array [
+                                    "now",
+                                  ],
+                                  "type": Array [
+                                    "saved_query",
+                                  ],
+                                  "updated_at": Array [
+                                    "2020-01-10T21:11:45.839Z",
+                                  ],
+                                  "updated_by": Array [
+                                    "elastic",
+                                  ],
+                                  "version": Array [
+                                    "1",
+                                  ],
+                                },
+                              },
+                              "source": Object {
+                                "ip": Array [
+                                  "192.168.0.1",
+                                ],
+                                "port": Array [
+                                  80,
+                                ],
+                              },
+                              "timestamp": "2018-11-05T19:03:25.937Z",
+                              "user": Object {
+                                "id": Array [
+                                  "1",
+                                ],
+                                "name": Array [
+                                  "john.dee",
+                                ],
+                              },
+                            }
+                          }
+                          globalQuery={Array []}
+                          handleOnEventClosed={[Function]}
+                          indexName="my-index"
+                          isHostIsolationPanelOpen={false}
+                          loadingEventDetails={true}
+                          onAddEventFilterClick={[Function]}
+                          onAddExceptionTypeClick={[Function]}
+                          onAddIsolationStatusClick={[Function]}
+                          timelineId="test"
+                          timelineQuery={
+                            Object {
+                              "id": "",
+                              "inspect": null,
+                              "isInspected": false,
+                              "loading": false,
+                              "refetch": null,
+                              "selectedInspectIndex": 0,
+                            }
+                          }
+                        />
+                      </Connect(Component)>
                     </div>
                   </EuiFlexItem>
                 </div>
@@ -2088,7 +2263,7 @@ Array [
                   <div
                     className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <Memo()
+                    <Connect(Component)
                       detailsData={null}
                       ecsData={
                         Object {
@@ -2249,7 +2424,182 @@ Array [
                       onAddExceptionTypeClick={[Function]}
                       onAddIsolationStatusClick={[Function]}
                       timelineId="test"
-                    />
+                    >
+                      <Memo()
+                        detailsData={null}
+                        dispatch={[Function]}
+                        ecsData={
+                          Object {
+                            "_id": "1",
+                            "destination": Object {
+                              "ip": Array [
+                                "192.168.0.3",
+                              ],
+                              "port": Array [
+                                6343,
+                              ],
+                            },
+                            "event": Object {
+                              "action": Array [
+                                "Action",
+                              ],
+                              "category": Array [
+                                "Access",
+                              ],
+                              "id": Array [
+                                "1",
+                              ],
+                              "module": Array [
+                                "nginx",
+                              ],
+                              "severity": Array [
+                                3,
+                              ],
+                            },
+                            "geo": Object {
+                              "country_iso_code": Array [
+                                "xx",
+                              ],
+                              "region_name": Array [
+                                "xx",
+                              ],
+                            },
+                            "host": Object {
+                              "ip": Array [
+                                "192.168.0.1",
+                              ],
+                              "name": Array [
+                                "apache",
+                              ],
+                            },
+                            "signal": Object {
+                              "rule": Object {
+                                "created_at": Array [
+                                  "2020-01-10T21:11:45.839Z",
+                                ],
+                                "created_by": Array [
+                                  "elastic",
+                                ],
+                                "description": Array [
+                                  "24/7",
+                                ],
+                                "enabled": Array [
+                                  true,
+                                ],
+                                "false_positives": Array [
+                                  "test-1",
+                                ],
+                                "filters": Array [],
+                                "from": Array [
+                                  "now-300s",
+                                ],
+                                "id": Array [
+                                  "b5ba41ab-aaf3-4f43-971b-bdf9434ce0ea",
+                                ],
+                                "immutable": Array [
+                                  false,
+                                ],
+                                "index": Array [
+                                  "auditbeat-*",
+                                ],
+                                "interval": Array [
+                                  "5m",
+                                ],
+                                "language": Array [
+                                  "kuery",
+                                ],
+                                "max_signals": Array [
+                                  100,
+                                ],
+                                "note": Array [
+                                  "# this is some markdown documentation",
+                                ],
+                                "output_index": Array [
+                                  ".siem-signals-default",
+                                ],
+                                "query": Array [
+                                  "user.name: root or user.name: admin",
+                                ],
+                                "references": Array [
+                                  "www.test.co",
+                                ],
+                                "risk_score": Array [
+                                  "21",
+                                ],
+                                "rule_id": Array [
+                                  "rule-id-1",
+                                ],
+                                "saved_id": Array [
+                                  "Garrett's IP",
+                                ],
+                                "severity": Array [
+                                  "low",
+                                ],
+                                "tags": Array [],
+                                "threat": Array [],
+                                "timeline_id": Array [
+                                  "1234-2136-11ea-9864-ebc8cc1cb8c2",
+                                ],
+                                "timeline_title": Array [
+                                  "Untitled timeline",
+                                ],
+                                "to": Array [
+                                  "now",
+                                ],
+                                "type": Array [
+                                  "saved_query",
+                                ],
+                                "updated_at": Array [
+                                  "2020-01-10T21:11:45.839Z",
+                                ],
+                                "updated_by": Array [
+                                  "elastic",
+                                ],
+                                "version": Array [
+                                  "1",
+                                ],
+                              },
+                            },
+                            "source": Object {
+                              "ip": Array [
+                                "192.168.0.1",
+                              ],
+                              "port": Array [
+                                80,
+                              ],
+                            },
+                            "timestamp": "2018-11-05T19:03:25.937Z",
+                            "user": Object {
+                              "id": Array [
+                                "1",
+                              ],
+                              "name": Array [
+                                "john.dee",
+                              ],
+                            },
+                          }
+                        }
+                        globalQuery={Array []}
+                        handleOnEventClosed={[Function]}
+                        indexName="my-index"
+                        isHostIsolationPanelOpen={false}
+                        loadingEventDetails={true}
+                        onAddEventFilterClick={[Function]}
+                        onAddExceptionTypeClick={[Function]}
+                        onAddIsolationStatusClick={[Function]}
+                        timelineId="test"
+                        timelineQuery={
+                          Object {
+                            "id": "",
+                            "inspect": null,
+                            "isInspected": false,
+                            "loading": false,
+                            "refetch": null,
+                            "selectedInspectIndex": 0,
+                          }
+                        }
+                      />
+                    </Connect(Component)>
                   </div>
                 </EuiFlexItem>
               </div>

--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
@@ -19,7 +19,12 @@ import { Direction, EntityType } from '../../../../common/search_strategy';
 import type { DocValueFields } from '../../../../common/search_strategy';
 import type { CoreStart } from '../../../../../../../src/core/public';
 import type { BrowserFields } from '../../../../common/search_strategy/index_fields';
-import { TGridCellAction, TimelineId, TimelineTabs } from '../../../../common/types/timeline';
+import {
+  BulkActionsProp,
+  TGridCellAction,
+  TimelineId,
+  TimelineTabs,
+} from '../../../../common/types/timeline';
 
 import type {
   CellValueElementProps,
@@ -95,6 +100,7 @@ const SECURITY_ALERTS_CONSUMERS = [AlertConsumers.SIEM];
 export interface TGridIntegratedProps {
   additionalFilters: React.ReactNode;
   browserFields: BrowserFields;
+  bulkActions?: BulkActionsProp;
   columns: ColumnHeaderOptions[];
   data?: DataPublicPluginStart;
   dataProviders: DataProvider[];
@@ -135,6 +141,7 @@ export interface TGridIntegratedProps {
 const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
   additionalFilters,
   browserFields,
+  bulkActions = true,
   columns,
   data,
   dataProviders,
@@ -334,6 +341,7 @@ const TGridIntegratedComponent: React.FC<TGridIntegratedProps> = ({
                           hasAlertsCrud={hasAlertsCrud}
                           activePage={pageInfo.activePage}
                           browserFields={browserFields}
+                          bulkActions={bulkActions}
                           filterQuery={filterQuery}
                           data={nonDeletedEvents}
                           defaultCellActions={defaultCellActions}


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/108244

Fixes refresh problems on the Alert and rule details page when alerts status is updated and the table updates but the histogram and count table don't unless a hard refresh is run.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
