### PR TITLE
[NavigationalSearch] Catch errors from individual providers

### DIFF
--- a/x-pack/plugins/global_search/public/services/search_service.test.ts
+++ b/x-pack/plugins/global_search/public/services/search_service.test.ts
@@ -272,6 +272,43 @@ describe('SearchService', () => {
         });
       });
 
+      it('catches errors from providers', async () => {
+        const { registerResultProvider } = service.setup({
+          config: createConfig(),
+        });
+
+        getTestScheduler().run(({ expectObservable, hot }) => {
+          registerResultProvider(
+            createProvider('A', {
+              source: hot('a---c-|', {
+                a: [providerResult('A1'), providerResult('A2')],
+                c: [providerResult('A3')],
+              }),
+            })
+          );
+          registerResultProvider(
+            createProvider('B', {
+              source: hot(
+                '-b-#  ',
+                {
+                  b: [providerResult('B1')],
+                },
+                new Error('something went bad')
+              ),
+            })
+          );
+
+          const { find } = service.start(startDeps());
+          const results = find({ term: 'foobar' }, {});
+
+          expectObservable(results).toBe('ab--c-|', {
+            a: expectedBatch('A1', 'A2'),
+            b: expectedBatch('B1'),
+            c: expectedBatch('A3'),
+          });
+        });
+      });
+
       it('return mixed server/client providers results', async () => {
         const { registerResultProvider } = service.setup({
           config: createConfig(),
@@ -300,6 +337,33 @@ describe('SearchService', () => {
             a: expectedBatch('P1'),
             b: expectedBatch('P2'),
             c: expectedBatch('S1', 'S2'),
+          });
+        });
+      });
+
+      it('catches errors from the server', async () => {
+        const { registerResultProvider } = service.setup({
+          config: createConfig(),
+        });
+
+        getTestScheduler().run(({ expectObservable, hot }) => {
+          fetchServerResultsMock.mockReturnValue(hot('#', {}, new Error('fetch error')));
+
+          registerResultProvider(
+            createProvider('A', {
+              source: hot('a-b-|', {
+                a: [providerResult('P1')],
+                b: [providerResult('P2')],
+              }),
+            })
+          );
+
+          const { find } = service.start(startDeps());
+          const results = find({ term: 'foobar' }, {});
+
+          expectObservable(results).toBe('a-b-|', {
+            a: expectedBatch('P1'),
+            b: expectedBatch('P2'),
           });
         });
       });

--- a/x-pack/plugins/global_search/public/services/search_service.ts
+++ b/x-pack/plugins/global_search/public/services/search_service.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { merge, Observable, timer, throwError } from 'rxjs';
-import { map, takeUntil } from 'rxjs/operators';
+import { merge, Observable, timer, throwError, EMPTY } from 'rxjs';
+import { map, takeUntil, catchError } from 'rxjs/operators';
 import { uniq } from 'lodash';
 import { duration } from 'moment';
 import { i18n } from '@kbn/i18n';
@@ -177,16 +177,16 @@ export class SearchService {
     const serverResults$ = fetchServerResults(this.http!, params, {
       preference,
       aborted$,
-    });
+    }).pipe(catchError(() => EMPTY));
 
     const providersResults$ = [...this.providers.values()].map((provider) =>
       provider.find(params, providerOptions).pipe(
+        catchError(() => EMPTY),
         takeInArray(this.maxProviderResults),
         takeUntil(aborted$),
         map((results) => results.map((r) => processResult(r)))
       )
     );
-
     return merge(...providersResults$, serverResults$).pipe(
       map((results) => ({
         results,

--- a/x-pack/plugins/global_search/server/services/search_service.ts
+++ b/x-pack/plugins/global_search/server/services/search_service.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { Observable, timer, merge, throwError } from 'rxjs';
-import { map, takeUntil } from 'rxjs/operators';
+import { Observable, timer, merge, throwError, EMPTY } from 'rxjs';
+import { map, takeUntil, catchError } from 'rxjs/operators';
 import { uniq } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { KibanaRequest, CoreStart, IBasePath } from 'src/core/server';
@@ -174,6 +174,7 @@ export class SearchService {
 
     const providersResults$ = [...this.providers.values()].map((provider) =>
       provider.find(params, findOptions, context).pipe(
+        catchError(() => EMPTY),
         takeInArray(this.maxProviderResults),
         takeUntil(aborted$),
         map((results) => results.map((r) => processResult(r)))


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/110778

Catch potential errors from the result providers to avoid that an error from a provider breaks the whole result observable.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

## Release Note

Fix an issue with the navigational search that could cause non-administrator users to not being able to see the search results