### PR TITLE
[7.x] Resurrect deprecated and removed authentication settings. (#110835)

### DIFF
--- a/x-pack/plugins/security/server/authentication/providers/saml.test.ts
+++ b/x-pack/plugins/security/server/authentication/providers/saml.test.ts
@@ -595,7 +595,7 @@ describe('SAMLAuthenticationProvider', () => {
           ),
         ],
         [
-          'current session is is expired',
+          'current session is expired',
           Promise.reject(
             new errors.ResponseError(securityMock.createApiResponse({ statusCode: 401, body: {} }))
           ),

--- a/x-pack/plugins/security/server/config.test.ts
+++ b/x-pack/plugins/security/server/config.test.ts
@@ -179,53 +179,53 @@ describe('config schema', () => {
   describe('public', () => {
     it('properly validates `protocol`', async () => {
       expect(ConfigSchema.validate({ public: { protocol: 'http' } }).public).toMatchInlineSnapshot(`
-                                        Object {
-                                          "protocol": "http",
-                                        }
-                              `);
+        Object {
+          "protocol": "http",
+        }
+      `);
 
       expect(ConfigSchema.validate({ public: { protocol: 'https' } }).public)
         .toMatchInlineSnapshot(`
-                                        Object {
-                                          "protocol": "https",
-                                        }
-                              `);
+        Object {
+          "protocol": "https",
+        }
+      `);
 
       expect(() => ConfigSchema.validate({ public: { protocol: 'ftp' } }))
         .toThrowErrorMatchingInlineSnapshot(`
-"[public.protocol]: types that failed validation:
-- [public.protocol.0]: expected value to equal [http]
-- [public.protocol.1]: expected value to equal [https]"
-`);
+        "[public.protocol]: types that failed validation:
+        - [public.protocol.0]: expected value to equal [http]
+        - [public.protocol.1]: expected value to equal [https]"
+      `);
 
       expect(() => ConfigSchema.validate({ public: { protocol: 'some-protocol' } }))
         .toThrowErrorMatchingInlineSnapshot(`
-"[public.protocol]: types that failed validation:
-- [public.protocol.0]: expected value to equal [http]
-- [public.protocol.1]: expected value to equal [https]"
-`);
+        "[public.protocol]: types that failed validation:
+        - [public.protocol.0]: expected value to equal [http]
+        - [public.protocol.1]: expected value to equal [https]"
+      `);
     });
 
     it('properly validates `hostname`', async () => {
       expect(ConfigSchema.validate({ public: { hostname: 'elastic.co' } }).public)
         .toMatchInlineSnapshot(`
-                                                                                                Object {
-                                                                                                  "hostname": "elastic.co",
-                                                                                                }
-                                                                        `);
+        Object {
+          "hostname": "elastic.co",
+        }
+      `);
 
       expect(ConfigSchema.validate({ public: { hostname: '192.168.1.1' } }).public)
         .toMatchInlineSnapshot(`
-                                                                                                Object {
-                                                                                                  "hostname": "192.168.1.1",
-                                                                                                }
-                                                                        `);
+        Object {
+          "hostname": "192.168.1.1",
+        }
+      `);
 
       expect(ConfigSchema.validate({ public: { hostname: '::1' } }).public).toMatchInlineSnapshot(`
-                                                                                                Object {
-                                                                                                  "hostname": "::1",
-                                                                                                }
-                                                                        `);
+        Object {
+          "hostname": "::1",
+        }
+      `);
 
       expect(() =>
         ConfigSchema.validate({ public: { hostname: 'http://elastic.co' } })
@@ -242,22 +242,22 @@ describe('config schema', () => {
 
     it('properly validates `port`', async () => {
       expect(ConfigSchema.validate({ public: { port: 1234 } }).public).toMatchInlineSnapshot(`
-                                        Object {
-                                          "port": 1234,
-                                        }
-                              `);
+        Object {
+          "port": 1234,
+        }
+      `);
 
       expect(ConfigSchema.validate({ public: { port: 0 } }).public).toMatchInlineSnapshot(`
-                                        Object {
-                                          "port": 0,
-                                        }
-                              `);
+        Object {
+          "port": 0,
+        }
+      `);
 
       expect(ConfigSchema.validate({ public: { port: 65535 } }).public).toMatchInlineSnapshot(`
-                                        Object {
-                                          "port": 65535,
-                                        }
-                              `);
+        Object {
+          "port": 65535,
+        }
+      `);
 
       expect(() =>
         ConfigSchema.validate({ public: { port: -1 } })

--- a/x-pack/plugins/security/server/config_deprecations.test.ts
+++ b/x-pack/plugins/security/server/config_deprecations.test.ts
@@ -332,7 +332,7 @@ describe('Config Deprecations', () => {
     const { messages } = applyConfigDeprecations(cloneDeep(config));
     expect(messages).toMatchInlineSnapshot(`
       Array [
-        "\\"xpack.security.authc.providers.saml.<provider-name>.maxRedirectURLSize\\" is is no longer used.",
+        "\\"xpack.security.authc.providers.saml.<provider-name>.maxRedirectURLSize\\" is no longer used.",
       ]
     `);
   });

--- a/x-pack/plugins/security/server/config_deprecations.ts
+++ b/x-pack/plugins/security/server/config_deprecations.ts
@@ -122,7 +122,7 @@ export const securityConfigDeprecationProvider: ConfigDeprecationProvider = ({
         }),
         message: i18n.translate('xpack.security.deprecations.maxRedirectURLSizeMessage', {
           defaultMessage:
-            '"xpack.security.authc.providers.saml.<provider-name>.maxRedirectURLSize" is is no longer used.',
+            '"xpack.security.authc.providers.saml.<provider-name>.maxRedirectURLSize" is no longer used.',
         }),
         correctiveActions: {
           manualSteps: [

--- a/x-pack/test/security_api_integration/oidc.config.ts
+++ b/x-pack/test/security_api_integration/oidc.config.ts
@@ -50,7 +50,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
         `--plugin-path=${plugin}`,
-        `--xpack.security.authc.providers=${JSON.stringify(['oidc', 'basic'])}`,
+        `--xpack.security.authProviders=${JSON.stringify(['oidc', 'basic'])}`,
         '--xpack.security.authc.oidc.realm="oidc1"',
       ],
     },


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Resurrect deprecated and removed authentication settings. (#110835)