### PR TITLE
Handle bulkGet errors on package retrieval from ES storage

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -217,7 +217,10 @@ export async function getPackageFromSource(options: {
         installedPkg.package_assets,
         savedObjectsClient
       );
-      logger.debug(`retrieved installed package ${pkgName}-${pkgVersion} from ES`);
+
+      if (res) {
+        logger.debug(`retrieved installed package ${pkgName}-${pkgVersion} from ES`);
+      }
     }
     // for packages not in cache or package storage and installed from registry, check registry
     if (!res && pkgInstallSource === 'registry') {


### PR DESCRIPTION
## Summary

Adds error handling and logging for the case where not all package assets can be successfully retrieved from storage. Now in this case, we'll fallback to attempting to fetch the package from the registry when we can't successfully retrieve all the assets from ES for some reason.

This came up on the edge-oblt cluster on the latest 8.0.0 snapshot. In my analysis of that cluster, I'm not seeing any assets that are actually missing, so I currently suspect a different bug that may be produced by something in the SOC. In particular, this recent change seems relevant: https://github.com/elastic/kibana/pull/109967

This additional logging and fallback behavior should help us nail down the root cause.

@nchaulet any recommendations on where to add tests for this? The best place would be unit tests on this archive storage code, but it seems we don't have this yet. Outside of that option I don't see any good options since I'm not yet sure of the root cause here to be able to reproduce.
