### PR TITLE
[7.x] [Cases] Do not show status dropdown on modal cases selector (#111101)

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx
@@ -203,7 +203,8 @@ export const AllCasesGeneric = React.memo<AllCasesGenericProps>(
       handleIsLoading,
       isLoadingCases: loading,
       refreshCases,
-      showActions,
+      // isSelectorView is boolean | undefined. We need to convert it to a boolean.
+      isSelectorView: !!isSelectorView,
       userCanCrud,
       connectors,
     });

--- a/x-pack/plugins/cases/public/components/all_cases/columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns.tsx
@@ -72,7 +72,7 @@ export interface GetCasesColumn {
   handleIsLoading: (a: boolean) => void;
   isLoadingCases: string[];
   refreshCases?: (a?: boolean) => void;
-  showActions: boolean;
+  isSelectorView: boolean;
   userCanCrud: boolean;
   connectors?: ActionConnector[];
 }
@@ -84,7 +84,7 @@ export const useCasesColumns = ({
   handleIsLoading,
   isLoadingCases,
   refreshCases,
-  showActions,
+  isSelectorView,
   userCanCrud,
   connectors = [],
 }: GetCasesColumn): CasesColumns[] => {
@@ -281,38 +281,42 @@ export const useCasesColumns = ({
         return getEmptyTagValue();
       },
     },
-    {
-      name: i18n.STATUS,
-      render: (theCase: Case) => {
-        if (theCase?.subCases == null || theCase.subCases.length === 0) {
-          if (theCase.status == null || theCase.type === CaseType.collection) {
-            return getEmptyTagValue();
-          }
-          return (
-            <StatusContextMenu
-              currentStatus={theCase.status}
-              disabled={!userCanCrud || isLoadingCases.length > 0}
-              onStatusChanged={(status) =>
-                handleDispatchUpdate({
-                  updateKey: 'status',
-                  updateValue: status,
-                  caseId: theCase.id,
-                  version: theCase.version,
-                })
+    ...(!isSelectorView
+      ? [
+          {
+            name: i18n.STATUS,
+            render: (theCase: Case) => {
+              if (theCase?.subCases == null || theCase.subCases.length === 0) {
+                if (theCase.status == null || theCase.type === CaseType.collection) {
+                  return getEmptyTagValue();
+                }
+                return (
+                  <StatusContextMenu
+                    currentStatus={theCase.status}
+                    disabled={!userCanCrud || isLoadingCases.length > 0}
+                    onStatusChanged={(status) =>
+                      handleDispatchUpdate({
+                        updateKey: 'status',
+                        updateValue: status,
+                        caseId: theCase.id,
+                        version: theCase.version,
+                      })
+                    }
+                  />
+                );
               }
-            />
-          );
-        }
 
-        const badges = getSubCasesStatusCountsBadges(theCase.subCases);
-        return badges.map(({ color, count }, index) => (
-          <EuiBadge key={index} color={color}>
-            {count}
-          </EuiBadge>
-        ));
-      },
-    },
-    ...(showActions
+              const badges = getSubCasesStatusCountsBadges(theCase.subCases);
+              return badges.map(({ color, count }, index) => (
+                <EuiBadge key={index} color={color}>
+                  {count}
+                </EuiBadge>
+              ));
+            },
+          },
+        ]
+      : []),
+    ...(userCanCrud && !isSelectorView
       ? [
           {
             name: (

--- a/x-pack/plugins/cases/public/components/all_cases/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/index.test.tsx
@@ -144,7 +144,7 @@ describe('AllCasesGeneric', () => {
     filterStatus: CaseStatuses.open,
     handleIsLoading: jest.fn(),
     isLoadingCases: [],
-    showActions: true,
+    isSelectorView: false,
     userCanCrud: true,
   };
 
@@ -377,7 +377,7 @@ describe('AllCasesGeneric', () => {
         isLoadingCases: [],
         filterStatus: CaseStatuses.open,
         handleIsLoading: jest.fn(),
-        showActions: false,
+        isSelectorView: true,
         userCanCrud: true,
       })
     );
@@ -925,5 +925,28 @@ describe('AllCasesGeneric', () => {
         wrapper.find('[data-test-subj="configure-case-button"]').first().prop('isDisabled')
       ).toBeFalsy();
     });
+  });
+
+  it('should not render status when isSelectorView=true', async () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases {...defaultAllCasesProps} isSelectorView={true} />
+      </TestProviders>
+    );
+
+    const { result } = renderHook<GetCasesColumn, CasesColumns[]>(() =>
+      useCasesColumns({
+        ...defaultColumnArgs,
+        isSelectorView: true,
+      })
+    );
+
+    expect(result.current.find((i) => i.name === 'Status')).toBeFalsy();
+
+    await waitFor(() => {
+      expect(wrapper.find('[data-test-subj="cases-table"]').exists()).toBeTruthy();
+    });
+
+    expect(wrapper.find('[data-test-subj="case-view-status-dropdown"]').exists()).toBeFalsy();
   });
 });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Cases] Do not show status dropdown on modal cases selector (#111101)