### PR TITLE
[Fleet] Stop loading js-yaml in main plugin bundle

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -34,7 +34,7 @@ pageLoadAssetSize:
   indexPatternManagement: 28222
   indexPatternEditor: 25000
   infra: 184320
-  fleet: 465774
+  fleet: 250000
   ingestPipelines: 58003
   inputControlVis: 172675
   inspector: 148711

--- a/x-pack/plugins/fleet/common/services/full_agent_policy_to_yaml.ts
+++ b/x-pack/plugins/fleet/common/services/full_agent_policy_to_yaml.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { safeDump } from 'js-yaml';
+import type { safeDump } from 'js-yaml';
 
 import type { FullAgentPolicy } from '../types';
 
@@ -25,8 +25,8 @@ const POLICY_KEYS_ORDER = [
   'input',
 ];
 
-export const fullAgentPolicyToYaml = (policy: FullAgentPolicy): string => {
-  return safeDump(policy, {
+export const fullAgentPolicyToYaml = (policy: FullAgentPolicy, toYaml: typeof safeDump): string => {
+  return toYaml(policy, {
     skipInvalid: true,
     sortKeys: (keyA: string, keyB: string) => {
       const indexA = POLICY_KEYS_ORDER.indexOf(keyA);

--- a/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/validate_package_policy.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { safeLoad } from 'js-yaml';
+
 import { installationStatuses } from '../constants';
 import type { PackageInfo, NewPackagePolicy, RegistryPolicyTemplate } from '../types';
 
@@ -371,13 +373,13 @@ describe('Fleet - validatePackagePolicy()', () => {
     };
 
     it('returns no errors for valid package policy', () => {
-      expect(validatePackagePolicy(validPackagePolicy, mockPackage)).toEqual(
+      expect(validatePackagePolicy(validPackagePolicy, mockPackage, safeLoad)).toEqual(
         noErrorsValidationResults
       );
     });
 
     it('returns errors for invalid package policy', () => {
-      expect(validatePackagePolicy(invalidPackagePolicy, mockPackage)).toEqual({
+      expect(validatePackagePolicy(invalidPackagePolicy, mockPackage, safeLoad)).toEqual({
         name: ['Name is required'],
         description: null,
         namespace: null,
@@ -423,7 +425,11 @@ describe('Fleet - validatePackagePolicy()', () => {
         enabled: false,
       }));
       expect(
-        validatePackagePolicy({ ...validPackagePolicy, inputs: disabledInputs }, mockPackage)
+        validatePackagePolicy(
+          { ...validPackagePolicy, inputs: disabledInputs },
+          mockPackage,
+          safeLoad
+        )
       ).toEqual(noErrorsValidationResults);
     });
 
@@ -439,7 +445,8 @@ describe('Fleet - validatePackagePolicy()', () => {
       expect(
         validatePackagePolicy(
           { ...invalidPackagePolicy, inputs: inputsWithDisabledStreams },
-          mockPackage
+          mockPackage,
+          safeLoad
         )
       ).toEqual({
         name: ['Name is required'],
@@ -485,10 +492,14 @@ describe('Fleet - validatePackagePolicy()', () => {
 
     it('returns no errors for packages with no package policies', () => {
       expect(
-        validatePackagePolicy(validPackagePolicy, {
-          ...mockPackage,
-          policy_templates: undefined,
-        })
+        validatePackagePolicy(
+          validPackagePolicy,
+          {
+            ...mockPackage,
+            policy_templates: undefined,
+          },
+          safeLoad
+        )
       ).toEqual({
         name: null,
         description: null,
@@ -496,10 +507,14 @@ describe('Fleet - validatePackagePolicy()', () => {
         inputs: null,
       });
       expect(
-        validatePackagePolicy(validPackagePolicy, {
-          ...mockPackage,
-          policy_templates: [],
-        })
+        validatePackagePolicy(
+          validPackagePolicy,
+          {
+            ...mockPackage,
+            policy_templates: [],
+          },
+          safeLoad
+        )
       ).toEqual({
         name: null,
         description: null,
@@ -510,10 +525,14 @@ describe('Fleet - validatePackagePolicy()', () => {
 
     it('returns no errors for packages with no inputs', () => {
       expect(
-        validatePackagePolicy(validPackagePolicy, {
-          ...mockPackage,
-          policy_templates: [{} as RegistryPolicyTemplate],
-        })
+        validatePackagePolicy(
+          validPackagePolicy,
+          {
+            ...mockPackage,
+            policy_templates: [{} as RegistryPolicyTemplate],
+          },
+          safeLoad
+        )
       ).toEqual({
         name: null,
         description: null,
@@ -521,10 +540,14 @@ describe('Fleet - validatePackagePolicy()', () => {
         inputs: null,
       });
       expect(
-        validatePackagePolicy(validPackagePolicy, {
-          ...mockPackage,
-          policy_templates: [({ inputs: [] } as unknown) as RegistryPolicyTemplate],
-        })
+        validatePackagePolicy(
+          validPackagePolicy,
+          {
+            ...mockPackage,
+            policy_templates: [({ inputs: [] } as unknown) as RegistryPolicyTemplate],
+          },
+          safeLoad
+        )
       ).toEqual({
         name: null,
         description: null,
@@ -539,7 +562,8 @@ describe('Fleet - validatePackagePolicy()', () => {
       expect(
         validatePackagePolicy(
           INVALID_AWS_POLICY as NewPackagePolicy,
-          (AWS_PACKAGE as unknown) as PackageInfo
+          (AWS_PACKAGE as unknown) as PackageInfo,
+          safeLoad
         )
       ).toMatchSnapshot();
     });
@@ -549,7 +573,8 @@ describe('Fleet - validatePackagePolicy()', () => {
         validationHasErrors(
           validatePackagePolicy(
             VALID_AWS_POLICY as NewPackagePolicy,
-            (AWS_PACKAGE as unknown) as PackageInfo
+            (AWS_PACKAGE as unknown) as PackageInfo,
+            safeLoad
           )
         )
       ).toBe(false);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_yaml_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_yaml_flyout.tsx
@@ -8,6 +8,7 @@
 import React, { memo } from 'react';
 import styled from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { safeDump } from 'js-yaml';
 import {
   EuiCodeBlock,
   EuiFlexGroup,
@@ -54,7 +55,7 @@ export const AgentPolicyYamlFlyout = memo<{ policyId: string; onClose: () => voi
       </EuiCallOut>
     ) : (
       <EuiCodeBlock language="yaml" isCopyable fontSize="m" whiteSpace="pre">
-        {fullAgentPolicyToYaml(yamlData!.item)}
+        {fullAgentPolicyToYaml(yamlData!.item, safeDump)}
       </EuiCodeBlock>
     );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
 import type { ApplicationStart } from 'kibana/public';
+import { safeLoad } from 'js-yaml';
 
 import { toMountPoint } from '../../../../../../../../../src/plugins/kibana_react/public';
 import type {
@@ -191,7 +192,8 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
       if (packageInfo) {
         const newValidationResult = validatePackagePolicy(
           newPackagePolicy || packagePolicy,
-          packageInfo
+          packageInfo,
+          safeLoad
         );
         setValidationResults(newValidationResult);
         // eslint-disable-next-line no-console

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/has_invalid_but_required_var.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/has_invalid_but_required_var.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { safeLoad } from 'js-yaml';
+
 import type { PackagePolicyConfigRecord, RegistryVarsEntry } from '../../../../types';
 
 import { validatePackagePolicyConfig } from './';
@@ -25,7 +27,8 @@ export const hasInvalidButRequiredVar = (
               validatePackagePolicyConfig(
                 packagePolicyVars[registryVar.name],
                 registryVar,
-                registryVar.name
+                registryVar.name,
+                safeLoad
               )?.length)
         )
     )

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -9,6 +9,7 @@ import React, { useState, useEffect, useCallback, useMemo, memo } from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { safeLoad } from 'js-yaml';
 import {
   EuiButtonEmpty,
   EuiButton,
@@ -201,7 +202,9 @@ export const EditPackagePolicyForm = memo<{
 
             if (packageData?.response) {
               setPackageInfo(packageData.response);
-              setValidationResults(validatePackagePolicy(newPackagePolicy, packageData.response));
+              setValidationResults(
+                validatePackagePolicy(newPackagePolicy, packageData.response, safeLoad)
+              );
               setFormState('VALID');
             }
           }
@@ -239,7 +242,8 @@ export const EditPackagePolicyForm = memo<{
       if (packageInfo) {
         const newValidationResult = validatePackagePolicy(
           newPackagePolicy || packagePolicy,
-          packageInfo
+          packageInfo,
+          safeLoad
         );
         setValidationResults(newValidationResult);
         // eslint-disable-next-line no-console

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -21,6 +21,7 @@ import {
 import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { safeDump } from 'js-yaml';
 
 import { useStartServices, useLink, sendGetOneAgentPolicyFull } from '../../hooks';
 import { fullAgentPolicyToYaml, agentPolicyRouteService } from '../../services';
@@ -71,7 +72,7 @@ export const StandaloneInstructions = React.memo<Props>(({ agentPolicy, agentPol
     fetchFullPolicy();
   }, [selectedPolicyId, notifications.toasts]);
 
-  const yaml = useMemo(() => fullAgentPolicyToYaml(fullAgentPolicy), [fullAgentPolicy]);
+  const yaml = useMemo(() => fullAgentPolicyToYaml(fullAgentPolicy, safeDump), [fullAgentPolicy]);
   const steps = [
     DownloadStep(),
     !agentPolicy

--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -8,6 +8,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 import type { RequestHandler, ResponseHeaders } from 'src/core/server';
 import bluebird from 'bluebird';
+import { safeDump } from 'js-yaml';
 
 import { fullAgentPolicyToYaml } from '../../../common/services';
 import { appContextService, agentPolicyService, packagePolicyService } from '../../services';
@@ -269,7 +270,7 @@ export const downloadFullAgentPolicy: RequestHandler<
       standalone: request.query.standalone === true,
     });
     if (fullAgentPolicy) {
-      const body = fullAgentPolicyToYaml(fullAgentPolicy);
+      const body = fullAgentPolicyToYaml(fullAgentPolicy, safeDump);
       const headers: ResponseHeaders = {
         'content-type': 'text/x-yaml',
         'content-disposition': `attachment; filename="elastic-agent.yml"`,

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -16,6 +16,7 @@ import type {
   SavedObjectsClientContract,
 } from 'src/core/server';
 import uuid from 'uuid';
+import { safeLoad } from 'js-yaml';
 
 import type { AuthenticatedUser } from '../../../security/server';
 import {
@@ -988,7 +989,7 @@ export function overridePackageInputs(
     inputs,
   };
 
-  const validationResults = validatePackagePolicy(resultingPackagePolicy, packageInfo);
+  const validationResults = validatePackagePolicy(resultingPackagePolicy, packageInfo, safeLoad);
 
   if (validationHasErrors(validationResults)) {
     const responseFormattedValidationErrors = Object.entries(getFlattenedObject(validationResults))


### PR DESCRIPTION
## Summary

Related to #95863

Removes the imports for `js-yaml` in `x-pack/plugins/fleet/common` to avoid loading this heavy library on page load and wait until it's actually needed. In the future we may want to consider using a smaller library or moving this logic to the server-side (in a secure fashion).

cc @hop-dev I know you were interested in this area. There's still a lot of room for additional improvement to get under 100kb, this was just the biggest chunk of low hanging fruit and was blocking my progress on #111131