### PR TITLE
Update sync workflow to only run on elastic/kibana

### DIFF
--- a/.github/workflows/sync-main-branch.yml
+++ b/.github/workflows/sync-main-branch.yml
@@ -9,6 +9,7 @@ jobs:
   sync_latest_from_upstream:
     runs-on: ubuntu-latest
     name: Sync latest commits from master branch
+    if: github.repository == "elastic/kibana"
 
     steps:
       - name: Checkout target repo


### PR DESCRIPTION
The action was running on forks when pushed to master. This adds a conditional to ensure it's on the `elastic/kibana` repository.