### PR TITLE
[Uptime] Fix ML alert not allowed in Uptime app

### DIFF
--- a/x-pack/plugins/uptime/server/kibana.index.ts
+++ b/x-pack/plugins/uptime/server/kibana.index.ts
@@ -46,7 +46,11 @@ export const initServerWithKibana = (
     management: {
       insightsAndAlerting: ['triggersActions'],
     },
-    alerting: ['xpack.uptime.alerts.tls', 'xpack.uptime.alerts.monitorStatus'],
+    alerting: [
+      'xpack.uptime.alerts.tls',
+      'xpack.uptime.alerts.monitorStatus',
+      'xpack.uptime.alerts.durationAnomaly',
+    ],
     privileges: {
       all: {
         app: ['uptime', 'kibana'],
@@ -58,10 +62,18 @@ export const initServerWithKibana = (
         },
         alerting: {
           rule: {
-            all: ['xpack.uptime.alerts.tls', 'xpack.uptime.alerts.monitorStatus'],
+            all: [
+              'xpack.uptime.alerts.tls',
+              'xpack.uptime.alerts.monitorStatus',
+              'xpack.uptime.alerts.durationAnomaly',
+            ],
           },
           alert: {
-            all: ['xpack.uptime.alerts.tls', 'xpack.uptime.alerts.monitorStatus'],
+            all: [
+              'xpack.uptime.alerts.tls',
+              'xpack.uptime.alerts.monitorStatus',
+              'xpack.uptime.alerts.durationAnomaly',
+            ],
           },
         },
         management: {
@@ -79,10 +91,18 @@ export const initServerWithKibana = (
         },
         alerting: {
           rule: {
-            read: ['xpack.uptime.alerts.tls', 'xpack.uptime.alerts.monitorStatus'],
+            read: [
+              'xpack.uptime.alerts.tls',
+              'xpack.uptime.alerts.monitorStatus',
+              'xpack.uptime.alerts.durationAnomaly',
+            ],
           },
           alert: {
-            read: ['xpack.uptime.alerts.tls', 'xpack.uptime.alerts.monitorStatus'],
+            read: [
+              'xpack.uptime.alerts.tls',
+              'xpack.uptime.alerts.monitorStatus',
+              'xpack.uptime.alerts.durationAnomaly',
+            ],
           },
         },
         management: {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/111151.

Today, users trying to create an anomaly detection alert in the Uptime app encounter problems. This patch updates the privileges defined by the plugin to make this problem go away.

## Testing

I've included some detail steps for this PR testing. We will run all these steps on the `master` branch first so you can confirm that you're seeing the issue.

0. Checkout Kibana `master` branch.
1. Start Elasticsearch with security enabled and TLS. Simplest way is to `yarn es snapshot --ssl`.
2. Start Heartbeat. You'll need to specify an Elasticsearch output section of your config like:
```
output.elasticsearch: 
  hosts: ["localhost:9200"] 
  protocol: "https" 
  username: "elastic" 
  password: "changeme" 
  ssl.verification_mode: "none" 
```
**NOTE:** you will also need at least one running monitor, the default config monitor is fine.

3.  Start Kibana, `yarn start --no-base-path --ssl`
4. Define a role with access to heartbeat indices and the uptime app. Run a curl script like:
```
curl --insecure -u elastic:changeme -X PUT "https://localhost:5601/api/security/role/kibana_ml_role" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
{
  "metadata" : {
    "version" : 1
  },
  "elasticsearch": {
    "cluster" : [ "all" ],
    "indices" : [
      {
        "names": [ "heartbeat*" ],
        "privileges": [ "all" ]
      }
    ]
  },
  "kibana": [
    {
      "base": [],
      "feature": {
        "uptime": [
          "all"
        ]
      },
      "spaces": [
        "*"
      ]
    }
  ]
}
'
```
5. Define a user with index privileges for Heartbeat indices, and the `machine_learning_admin` and (our custom-created) `kibana_ml_role`:
```
curl -X POST -u elastic:changeme --insecure "https://localhost:9200/_security/user/test-ml" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
{
  "password" : "testuser",
  "roles" : [ "machine_learning_admin", "kibana_ml_role" ],
  "full_name" : "Test User",
  "email" : "test@test.test"
}
'
```
6. Start a trial license:
```
curl --insecure -u elastic:changeme -X POST "https://localhost:9200/_license/start_trial?acknowledge=true&pretty"
```
7. Log into Kibana as user `test-ml` with password `testuser`.
8. Navigate to Uptime UI.
9. Drill into a monitor's detail page, and click the `Enable anomaly detection` button.
  ![image](https://user-images.githubusercontent.com/18429259/132036147-5944c2c9-7333-4ce9-924e-57f5d7385f32.png)
10. Create an ML job using the create button.
  ![image](https://user-images.githubusercontent.com/18429259/132036228-4f0f1204-904f-453d-a531-49450b8b2ee3.png)
11. When the flyout updates to create a new rule, attempt to do so. You should see an error toast. 
  ![image](https://user-images.githubusercontent.com/18429259/132036324-21b6d297-9d1c-4d04-bda7-a2004e413d09.png)
12. At this point, checkout this PR.
13. After Kibana server restarts, refresh the page and go through the rule creation flow once more. This time, you should be able to create the rule. 
  ![image](https://user-images.githubusercontent.com/18429259/132036453-34013606-2c93-45e8-b486-380b86084c22.png) 
  ![image](https://user-images.githubusercontent.com/18429259/132036530-23d14567-a4aa-4434-9820-c53d303062f4.png)
  ![image](https://user-images.githubusercontent.com/18429259/132036718-da3931b0-5371-4a8f-b5b7-dbfcb9cbc6f1.png)

14. Navigate to the Rules and Connectors view, and observe your newly-create rule.
  ![image](https://user-images.githubusercontent.com/18429259/132036962-9a70a8d4-6308-4efc-a274-897d0e903639.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
