### PR TITLE
Update sync workflow to only run on elastic/kibana

### DIFF
--- a/.github/workflows/sync-main-branch.yml
+++ b/.github/workflows/sync-main-branch.yml
@@ -9,6 +9,7 @@ jobs:
   sync_latest_from_upstream:
     runs-on: ubuntu-latest
     name: Sync latest commits from master branch
+    if: github.repository == 'elastic/kibana'
 
     steps:
       - name: Checkout target repo


### PR DESCRIPTION
A second go at this, appears Github doesn't appreciate [double-quotes](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#literals).

I tested in another repository with [this common](https://github.com/tylersmalley/test-migration/commit/84e4ebb4490eaf4a4e4936abc3c3938700fa5924), which shows the [action was skipped](https://github.com/tylersmalley/test-migration/runs/3508229098?check_suite_focus=true). 