### PR TITLE
[+Doc] ERROR: Kibana server not yet ready

### DIFF
--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -41,13 +41,7 @@ For JSON-formatted server status details, use the `localhost:5601/api/status` AP
 [[not-ready]]
 === {kib} not ready
 
-During install or post upgrade, you may infrequently encounter the Kibana start up error
-
-```
-Kibana server is not ready yet 
-```
-
-If this occurs, to investigate, check
+If you receive an error that the {kib} `server is not ready`, check the following:
 
 * The {es} connectivity: 
 +

--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -49,10 +49,15 @@ Kibana server is not ready yet
 
 If this occurs, to investigate, check
 
-1. Elasticsearch connectivity `curl -XGET elasticsearch_ip_or_hostname:9200/`
-2. Kibana logs
-    - Linux, DEB or RPM package: `/var/log/kibana/kibana.log`
-    - Linux, tar.gz package: `$KIBANA_HOME/log/kibana.log`
-    - Windows: `$KIBANA_HOME\log\kibana.log`
-3. `.kibana*`index health statuses
+* The {es} connectivity: 
++
+[source,sh]
+----
+`curl -XGET elasticsearch_ip_or_hostname:9200/`
+----
+* The {kib} logs:
+** Linux, DEB or RPM package: `/var/log/kibana/kibana.log`
+** Linux, tar.gz package: `$KIBANA_HOME/log/kibana.log`
+** Windows: `$KIBANA_HOME\log\kibana.log`
+* The health status of `.kibana*` indices
 

--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -37,4 +37,22 @@ image::images/kibana-status-page-7_14_0.png[Kibana server status page]
 
 For JSON-formatted server status details, use the `localhost:5601/api/status` API endpoint. 
 
+[float]
+[[not-ready]]
+=== {kib} not ready
+
+During install or post upgrade, you may infrequently encounter the Kibana start up error
+
+```
+Kibana server is not ready yet 
+```
+
+If this occurs, to investigate, check
+
+1. Elasticsearch connectivity `curl -XGET elasticsearch_ip_or_hostname:9200/`
+2. Kibana logs
+    - Linux, DEB or RPM package: `/var/log/kibana/kibana.log`
+    - Linux, tar.gz package: `$KIBANA_HOME/log/kibana.log`
+    - Windows: `$KIBANA_HOME\log\kibana.log`
+3. `.kibana*`index health statuses
 


### PR DESCRIPTION
## Summary

Adds section to bottom of [Kibana start-up](https://www.elastic.co/guide/en/kibana/current/access.html#status) for `Kibana server is not ready yet` error since second top Elastic Discuss post last 30d ([specific](https://discuss.elastic.co/t/error-kibana-server-is-not-ready-yet/156834/21) & [general](https://discuss.elastic.co/t/kibana-server-is-not-ready-yet/241217)). Copying @markwalkom's work. -- 🙏🏼 to Kibana Docs team

### Checklist
Delete any items that are not applicable to this PR.

### Risk Matrix

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)