### PR TITLE
Update UA to consume snapshotsUrl as provided by the Cloud plugin.

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/backup_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/backup_step.tsx
@@ -30,7 +30,7 @@ export const getBackupStep = ({ cloud, cloudBackupStatusResponse }: Props): EuiS
       children: (
         <CloudBackup
           cloudBackupStatusResponse={cloudBackupStatusResponse!}
-          cloudSnapshotsUrl={`${cloud!.deploymentUrl}/elasticsearch/snapshots`}
+          cloudSnapshotsUrl={cloud!.snapshotsUrl!}
         />
       ),
     };


### PR DESCRIPTION
This functionality was added via https://github.com/elastic/kibana/pull/110915