### PR TITLE
[data views] Unskip test - _id is not aggregatable

### DIFF
--- a/test/api_integration/apis/index_patterns/fields_for_wildcard_route/response.js
+++ b/test/api_integration/apis/index_patterns/fields_for_wildcard_route/response.js
@@ -84,8 +84,7 @@ export default function ({ getService }) {
         .then(ensureFieldsAreSorted);
     });
 
-    // https://github.com/elastic/kibana/issues/79813
-    it.skip('always returns a field for all passed meta fields', async () => {
+    it('always returns a field for all passed meta fields', async () => {
       await supertest
         .get('/api/index_patterns/_fields_for_wildcard')
         .query({
@@ -95,7 +94,7 @@ export default function ({ getService }) {
         .expect(200, {
           fields: [
             {
-              aggregatable: true,
+              aggregatable: false,
               name: '_id',
               esTypes: ['_id'],
               readFromDocValues: false,


### PR DESCRIPTION
## Summary

Restoring a skipped test. Simply needed to update test to reflect that the `_id` field isn't aggregatable.

Closes: https://github.com/elastic/kibana/issues/79813