### PR TITLE
[7.14] Reduce calling canFilter significantly (#108515)

### DIFF
--- a/src/plugins/vis_type_pie/public/utils/get_legend_actions.tsx
+++ b/src/plugins/vis_type_pie/public/utils/get_legend_actions.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { EuiContextMenuPanelDescriptor, EuiIcon, EuiPopover, EuiContextMenu } from '@elastic/eui';
@@ -29,7 +29,7 @@ export const getLegendActions = (
   return ({ series: [pieSeries] }) => {
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [isfilterable, setIsfilterable] = useState(true);
-    const filterData = getFilterEventData(pieSeries);
+    const filterData = useMemo(() => getFilterEventData(pieSeries), [pieSeries]);
 
     useEffect(() => {
       (async () => setIsfilterable(await canFilter(filterData, actions)))();

--- a/src/plugins/vis_type_xy/public/utils/get_legend_actions.tsx
+++ b/src/plugins/vis_type_xy/public/utils/get_legend_actions.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { EuiContextMenuPanelDescriptor, EuiIcon, EuiPopover, EuiContextMenu } from '@elastic/eui';
@@ -24,9 +24,11 @@ export const getLegendActions = (
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [isfilterable, setIsfilterable] = useState(false);
     const series = xySeries as XYChartSeriesIdentifier;
-    const filterData = getFilterEventData(series);
+    const filterData = useMemo(() => getFilterEventData(series), [series]);
 
-    (async () => setIsfilterable(await canFilter(filterData)))();
+    useEffect(() => {
+      (async () => setIsfilterable(await canFilter(filterData)))();
+    }, [filterData]);
 
     if (!isfilterable || !filterData) {
       return null;


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Reduce calling canFilter significantly (#108515)