### PR TITLE
[Security Solution][Detections] Fixes 'Allows a rule to be edited' cypress test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/objects/connector.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/connector.ts
@@ -12,6 +12,7 @@ export interface EmailConnector {
   port: string;
   user: string;
   password: string;
+  service: string;
 }
 
 export const getEmailConnector = (): EmailConnector => ({
@@ -21,4 +22,5 @@ export const getEmailConnector = (): EmailConnector => ({
   port: '80',
   user: 'username',
   password: 'password',
+  service: 'Other',
 });

--- a/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/create_new_rule.ts
@@ -40,6 +40,8 @@ export const EMAIL_CONNECTOR_USER_INPUT = '[data-test-subj="emailUserInput"]';
 
 export const EMAIL_CONNECTOR_PASSWORD_INPUT = '[data-test-subj="emailPasswordInput"]';
 
+export const EMAIL_CONNECTOR_SERVICE_SELECTOR = '[data-test-subj="emailServiceSelectInput"]';
+
 export const ADD_FALSE_POSITIVE_BTN =
   '[data-test-subj="detectionEngineStepAboutRuleFalsePositives"] .euiButtonEmpty__text';
 

--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -92,6 +92,7 @@ import {
   EMAIL_CONNECTOR_PORT_INPUT,
   EMAIL_CONNECTOR_USER_INPUT,
   EMAIL_CONNECTOR_PASSWORD_INPUT,
+  EMAIL_CONNECTOR_SERVICE_SELECTOR,
 } from '../screens/create_new_rule';
 import { LOADING_INDICATOR } from '../screens/security_header';
 import { TOAST_ERROR } from '../screens/shared';
@@ -402,6 +403,7 @@ export const fillIndexAndIndicatorIndexPattern = (
 
 export const fillEmailConnectorForm = (connector: EmailConnector = getEmailConnector()) => {
   cy.get(CONNECTOR_NAME_INPUT).type(connector.name);
+  cy.get(EMAIL_CONNECTOR_SERVICE_SELECTOR).select(connector.service);
   cy.get(EMAIL_CONNECTOR_FROM_INPUT).type(connector.from);
   cy.get(EMAIL_CONNECTOR_HOST_INPUT).type(connector.host);
   cy.get(EMAIL_CONNECTOR_PORT_INPUT).type(connector.port);


### PR DESCRIPTION
## Summary

In this PR we are fixing the 'Allows a rule to be edited' cypress test that is failing in master.

As part of this test, when editing a rule, we add a new `Action` for that, we are creating an `Email connector`. Looks like the UX of the creation for that specific connector has changed.

Before:

<img width="639" alt="Screenshot 2021-09-06 at 09 06 38" src="https://user-images.githubusercontent.com/17427073/132174822-4d78779c-19d8-4f63-b973-f88500add063.png">

Now:

<img width="782" alt="Screenshot 2021-09-06 at 09 12 44" src="https://user-images.githubusercontent.com/17427073/132175452-fc10e2a7-3f79-4c63-b73f-c4051ca5ec34.png">

In this PR we are accommodating the test to the new design, selecting the service we want to use.