### PR TITLE
[RAC] [Observability] Disable RAC feature flags again

### DIFF
--- a/x-pack/plugins/observability/server/index.ts
+++ b/x-pack/plugins/observability/server/index.ts
@@ -29,8 +29,8 @@ export const config = {
       index: schema.string({ defaultValue: 'observability-annotations' }),
     }),
     unsafe: schema.object({
-      alertingExperience: schema.object({ enabled: schema.boolean({ defaultValue: true }) }),
-      cases: schema.object({ enabled: schema.boolean({ defaultValue: true }) }),
+      alertingExperience: schema.object({ enabled: schema.boolean({ defaultValue: false }) }),
+      cases: schema.object({ enabled: schema.boolean({ defaultValue: false }) }),
     }),
   }),
 };

--- a/x-pack/plugins/rule_registry/server/config.ts
+++ b/x-pack/plugins/rule_registry/server/config.ts
@@ -11,7 +11,7 @@ export const config = {
   schema: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
     write: schema.object({
-      enabled: schema.boolean({ defaultValue: true }),
+      enabled: schema.boolean({ defaultValue: false }),
     }),
     unsafe: schema.object({
       legacyMultiTenancy: schema.object({

--- a/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
+++ b/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
@@ -64,7 +64,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const navLinks = await appsMenu.readLinks();
         expect(navLinks.map((link) => link.text)).to.eql([
           'Overview',
-          'Alerts',
           'APM',
           'User Experience',
           'Stack Management',
@@ -117,13 +116,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows apm navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql([
-          'Overview',
-          'Alerts',
-          'APM',
-          'User Experience',
-          'Stack Management',
-        ]);
+        expect(navLinks).to.eql(['Overview', 'APM', 'User Experience', 'Stack Management']);
       });
 
       it('can navigate to APM app', async () => {

--- a/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -62,7 +62,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows metrics navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Metrics', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Metrics', 'Stack Management']);
       });
 
       describe('infrastructure landing page without data', () => {
@@ -160,7 +160,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows metrics navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Metrics', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Metrics', 'Stack Management']);
       });
 
       describe('infrastructure landing page without data', () => {

--- a/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
@@ -59,7 +59,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows logs navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Logs', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Logs', 'Stack Management']);
       });
 
       describe('logs landing page without data', () => {
@@ -122,7 +122,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows logs navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Logs', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Logs', 'Stack Management']);
       });
 
       describe('logs landing page without data', () => {

--- a/x-pack/test/functional/apps/observability/feature_controls/observability_security.ts
+++ b/x-pack/test/functional/apps/observability/feature_controls/observability_security.ts
@@ -65,8 +65,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       it('shows observability/cases navlink', async () => {
-        const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.contain('Cases');
+        const navLinks = (await appsMenu.readLinks()).map((link) => link.text).slice(0, 2);
+        expect(navLinks).to.eql(['Overview', 'Cases']);
       });
 
       it(`landing page shows "Create new case" button`, async () => {
@@ -133,8 +133,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       it('shows observability/cases navlink', async () => {
-        const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.contain('Cases');
+        const navLinks = (await appsMenu.readLinks()).map((link) => link.text).slice(0, 2);
+        expect(navLinks).to.eql(['Overview', 'Cases']);
       });
 
       it(`landing page shows disabled "Create new case" button`, async () => {

--- a/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
+++ b/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
@@ -68,7 +68,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const navLinks = await appsMenu.readLinks();
         expect(navLinks.map((link) => link.text)).to.eql([
           'Overview',
-          'Alerts',
           'Uptime',
           'Stack Management',
         ]);
@@ -122,7 +121,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows uptime navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Uptime', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Uptime', 'Stack Management']);
       });
 
       it('can navigate to Uptime app', async () => {


### PR DESCRIPTION
## :memo: Summary

This changes the default values for the three Observability RAC feature flags to be disabled by default.

Reverts elastic/kibana#109113