### PR TITLE
[ML] Fixes REST API docs for results service routes

### DIFF
--- a/x-pack/plugins/ml/server/routes/anomaly_detectors.ts
+++ b/x-pack/plugins/ml/server/routes/anomaly_detectors.ts
@@ -680,7 +680,7 @@ export function jobRoutes({ router, routeGuard }: RouteInitialization) {
   /**
    * @apiGroup AnomalyDetectors
    *
-   * @api {post} /api/ml/anomaly_detectors/:jobId/model_snapshots/:snapshotId/_update update model snapshot by snapshot ID
+   * @api {post} /api/ml/anomaly_detectors/:jobId/model_snapshots/:snapshotId/_update Update model snapshot by snapshot ID
    * @apiName UpdateModelSnapshotsById
    * @apiDescription Updates the model snapshot for the specified snapshot ID
    *

--- a/x-pack/plugins/ml/server/routes/filters.ts
+++ b/x-pack/plugins/ml/server/routes/filters.ts
@@ -47,9 +47,9 @@ export function filtersRoutes({ router, routeGuard }: RouteInitialization) {
   /**
    * @apiGroup Filters
    *
-   * @api {get} /api/ml/filters Gets filters - size limit has been explicitly set to 1000
+   * @api {get} /api/ml/filters Get filters
    * @apiName GetFilters
-   * @apiDescription Retrieves the list of filters which are used for custom rules in anomaly detection.
+   * @apiDescription Retrieves the list of filters which are used for custom rules in anomaly detection. Sets the size limit explicitly to return a maximum of 1000.
    *
    * @apiSuccess {Boolean} success
    * @apiSuccess {Object[]} filters list of filters

--- a/x-pack/plugins/ml/server/routes/job_audit_messages.ts
+++ b/x-pack/plugins/ml/server/routes/job_audit_messages.ts
@@ -101,7 +101,7 @@ export function jobAuditMessagesRoutes({ router, routeGuard }: RouteInitializati
   /**
    * @apiGroup JobAuditMessages
    *
-   * @api {put} /api/ml/job_audit_messages/clear_messages Index annotation
+   * @api {put} /api/ml/job_audit_messages/clear_messages Clear messages
    * @apiName ClearJobAuditMessages
    * @apiDescription Clear the job audit messages.
    *

--- a/x-pack/plugins/ml/server/routes/modules.ts
+++ b/x-pack/plugins/ml/server/routes/modules.ts
@@ -533,7 +533,7 @@ export function dataRecognizer({ router, routeGuard }: RouteInitialization) {
   /**
    * @apiGroup Modules
    *
-   * @api {post} /api/ml/modules/jobs_exist/:moduleId Check if module jobs exist
+   * @api {get} /api/ml/modules/jobs_exist/:moduleId Check if module jobs exist
    * @apiName CheckExistingModuleJobs
    * @apiDescription Check whether the jobs in the module with the specified ID exist in the
    *      current list of jobs. The check runs a test to see if any of the jobs in existence

--- a/x-pack/plugins/ml/server/routes/results_service.ts
+++ b/x-pack/plugins/ml/server/routes/results_service.ts
@@ -106,9 +106,9 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {post} /api/ml/results/anomalies_table_data Prepare anomalies records for table display
+   * @api {post} /api/ml/results/anomalies_table_data Get anomalies records for table display
    * @apiName GetAnomaliesTableData
-   * @apiDescription Retrieves anomaly records for an anomaly detection job and formats them for anomalies table display
+   * @apiDescription Retrieves anomaly records for an anomaly detection job and formats them for anomalies table display.
    *
    * @apiSchema (body) anomaliesTableDataSchema
    */
@@ -138,7 +138,7 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {post} /api/ml/results/category_definition Returns category definition
+   * @api {post} /api/ml/results/category_definition Get category definition
    * @apiName GetCategoryDefinition
    * @apiDescription Returns the definition of the category with the specified ID and job ID
    *
@@ -170,7 +170,7 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {post} /api/ml/results/max_anomaly_score Returns the maximum anomaly_score
+   * @api {post} /api/ml/results/max_anomaly_score Get the maximum anomaly_score
    * @apiName GetMaxAnomalyScore
    * @apiDescription Returns the maximum anomaly score of the bucket results for the request job ID(s) and time range
    *
@@ -202,7 +202,7 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {post} /api/ml/results/category_examples Returns category examples
+   * @api {post} /api/ml/results/category_examples Get category examples
    * @apiName GetCategoryExamples
    * @apiDescription Returns examples for the categories with the specified IDs from the job with the supplied ID
    *
@@ -266,8 +266,10 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {post} /api/ml/results/anomaly_search Performs a search on the anomaly results index
+   * @api {post} /api/ml/results/anomaly_search Run a search on the anomaly results index
    * @apiName AnomalySearch
+   * @apiDescription Runs the supplied query against the anomaly results index for the specified job IDs.
+   * @apiSchema (body) anomalySearchSchema
    */
   router.post(
     {
@@ -295,7 +297,7 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {get} /api/ml/results/:jobId/categorizer_stats
+   * @api {get} /api/ml/results/:jobId/categorizer_stats Return categorizer statistics
    * @apiName GetCategorizerStats
    * @apiDescription Returns the categorizer stats for the specified job ID
    * @apiSchema (params) jobIdSchema
@@ -327,7 +329,7 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {get} /api/ml/results/category_stopped_partitions
+   * @api {get} /api/ml/results/category_stopped_partitions Get partitions that have stopped being categorized
    * @apiName GetCategoryStoppedPartitions
    * @apiDescription Returns information on the partitions that have stopped being categorized due to the categorization status changing from ok to warn. Can return either the list of stopped partitions for each job, or just the list of job IDs.
    * @apiSchema (body) getCategorizerStoppedPartitionsSchema

--- a/x-pack/plugins/ml/server/routes/results_service.ts
+++ b/x-pack/plugins/ml/server/routes/results_service.ts
@@ -329,7 +329,7 @@ export function resultsServiceRoutes({ router, routeGuard }: RouteInitialization
   /**
    * @apiGroup ResultsService
    *
-   * @api {get} /api/ml/results/category_stopped_partitions Get partitions that have stopped being categorized
+   * @api {post} /api/ml/results/category_stopped_partitions Get partitions that have stopped being categorized
    * @apiName GetCategoryStoppedPartitions
    * @apiDescription Returns information on the partitions that have stopped being categorized due to the categorization status changing from ok to warn. Can return either the list of stopped partitions for each job, or just the list of job IDs.
    * @apiSchema (body) getCategorizerStoppedPartitionsSchema

--- a/x-pack/plugins/ml/server/routes/saved_objects.ts
+++ b/x-pack/plugins/ml/server/routes/saved_objects.ts
@@ -61,7 +61,7 @@ export function savedObjectsRoutes(
    * @apiName SyncJobSavedObjects
    * @apiDescription Synchronizes saved objects for jobs. Saved objects will be created for jobs which are missing them,
    *                 and saved objects will be deleted for jobs which no longer exist.
-   *                 Updated missing datafeed IDs in saved objects for datafeeds which exist, and
+   *                 Updates missing datafeed IDs in saved objects for datafeeds which exist, and
    *                 removes datafeed IDs for datafeeds which no longer exist.
    *
    */

--- a/x-pack/plugins/ml/server/routes/saved_objects.ts
+++ b/x-pack/plugins/ml/server/routes/saved_objects.ts
@@ -59,10 +59,10 @@ export function savedObjectsRoutes(
    *
    * @api {get} /api/ml/saved_objects/sync Sync job saved objects
    * @apiName SyncJobSavedObjects
-   * @apiDescription Create saved objects for jobs which are missing them.
-   *                 Delete saved objects for jobs which no longer exist.
-   *                 Update missing datafeed ids in saved objects for datafeeds which exist.
-   *                 Remove datafeed ids for datafeeds which no longer exist.
+   * @apiDescription Synchronizes saved objects for jobs. Saved objects will be created for jobs which are missing them,
+   *                 and saved objects will be deleted for jobs which no longer exist.
+   *                 Updated missing datafeed IDs in saved objects for datafeeds which exist, and
+   *                 removes datafeed IDs for datafeeds which no longer exist.
    *
    */
   router.get(
@@ -217,9 +217,9 @@ export function savedObjectsRoutes(
   /**
    * @apiGroup JobSavedObjects
    *
-   * @api {get} /api/ml/saved_objects/jobs_spaces All spaces in all jobs
+   * @api {get} /api/ml/saved_objects/jobs_spaces Get all jobs and their spaces
    * @apiName JobsSpaces
-   * @apiDescription List all jobs and their spaces
+   * @apiDescription List all jobs and their spaces.
    *
    */
   router.get(


### PR DESCRIPTION
## Summary

Fixes the `api` tags for a couple of the results service REST API routes which was resulting in them not being listed in the API docs.

- `/api/ml/results/:jobId/categorizer_stats`
- `/api/ml/results/category_stopped_partitions`

Also makes a few minor text edits to other route descriptions.


