### PR TITLE
Remove `any`s in drilldowns plugin

### DIFF
--- a/x-pack/plugins/drilldowns/url_drilldown/public/lib/url_drilldown.test.ts
+++ b/x-pack/plugins/drilldowns/url_drilldown/public/lib/url_drilldown.test.ts
@@ -262,7 +262,7 @@ describe('UrlDrilldown', () => {
         indexPatterns: [{ id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }],
       }
     );
-    const data: any = {
+    const data = {
       data: [
         createPoint({ field: 'field0', value: 'value0' }),
         createPoint({ field: 'field1', value: 'value1' }),

--- a/x-pack/plugins/drilldowns/url_drilldown/public/lib/variables/context_variables.ts
+++ b/x-pack/plugins/drilldowns/url_drilldown/public/lib/variables/context_variables.ts
@@ -54,7 +54,7 @@ export interface ContextValues {
   panel: PanelValues;
 }
 
-function hasSavedObjectId(obj: Record<string, any>): obj is { savedObjectId: string } {
+function hasSavedObjectId(obj: Record<string, unknown>): obj is { savedObjectId: string } {
   return 'savedObjectId' in obj && typeof obj.savedObjectId === 'string';
 }
 
@@ -64,12 +64,13 @@ function hasSavedObjectId(obj: Record<string, any>): obj is { savedObjectId: str
  */
 function getIndexPatternIds(output: EmbeddableOutput): string[] {
   function hasIndexPatterns(
-    _output: Record<string, any>
+    _output: unknown
   ): _output is { indexPatterns: Array<{ id?: string }> } {
     return (
-      'indexPatterns' in _output &&
-      Array.isArray(_output.indexPatterns) &&
-      _output.indexPatterns.length > 0
+      typeof _output === 'object' &&
+      !!_output &&
+      Array.isArray((_output as { indexPatterns: unknown[] }).indexPatterns) &&
+      (_output as { indexPatterns: Array<{ id?: string }> }).indexPatterns.length > 0
     );
   }
   return hasIndexPatterns(output)

--- a/x-pack/plugins/drilldowns/url_drilldown/public/lib/variables/event_variables.test.ts
+++ b/x-pack/plugins/drilldowns/url_drilldown/public/lib/variables/event_variables.test.ts
@@ -53,7 +53,10 @@ describe('VALUE_CLICK_TRIGGER', () => {
 
   describe('handles undefined, null or missing values', () => {
     test('undefined or missing values are removed from the result scope', () => {
-      const point = createPoint({ field: undefined } as any);
+      const point = createPoint(({ field: undefined } as unknown) as {
+        field: string;
+        value: string | null | number | boolean;
+      });
       const eventScope = getEventScopeValues({
         data: { data: [point] },
       }) as ValueClickTriggerEventScope;

--- a/x-pack/plugins/drilldowns/url_drilldown/public/lib/variables/util.ts
+++ b/x-pack/plugins/drilldowns/url_drilldown/public/lib/variables/util.ts
@@ -15,7 +15,7 @@ export const toPrimitiveOrUndefined = (v: unknown): Primitive | undefined => {
   return String(v);
 };
 
-export const deleteUndefinedKeys = <T extends Record<string, any>>(obj: T): T => {
+export const deleteUndefinedKeys = <T extends Record<string, unknown>>(obj: T): T => {
   Object.keys(obj).forEach((key) => {
     if (obj[key] === undefined) {
       delete obj[key];


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
