### PR TITLE
[7.x] [APM] Uses doc link service instead of ElasticDocsLink for linking dropped transaction spans (#110964)

### DIFF
--- a/docs/development/core/public/kibana-plugin-core-public.doclinksstart.links.md
+++ b/docs/development/core/public/kibana-plugin-core-public.doclinksstart.links.md
@@ -12,6 +12,7 @@ readonly links: {
         readonly apm: {
             readonly kibanaSettings: string;
             readonly supportedServiceMaps: string;
+            readonly droppedTransactionSpans: string;
             readonly upgrading: string;
             readonly metaData: string;
         };

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -34,6 +34,7 @@ export class DocLinksService {
         apm: {
           kibanaSettings: `${KIBANA_DOCS}apm-settings-in-kibana.html`,
           supportedServiceMaps: `${KIBANA_DOCS}service-maps.html#service-maps-supported`,
+          droppedTransactionSpans: `${APM_DOCS}get-started/${DOC_LINK_VERSION}/transaction-spans.html#dropped-spans`,
           upgrading: `${APM_DOCS}server/${DOC_LINK_VERSION}/upgrading.html`,
           metaData: `${APM_DOCS}get-started/${DOC_LINK_VERSION}/metadata.html`,
         },
@@ -463,6 +464,7 @@ export interface DocLinksStart {
     readonly apm: {
       readonly kibanaSettings: string;
       readonly supportedServiceMaps: string;
+      readonly droppedTransactionSpans: string;
       readonly upgrading: string;
       readonly metaData: string;
     };

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -477,6 +477,7 @@ export interface DocLinksStart {
         readonly apm: {
             readonly kibanaSettings: string;
             readonly supportedServiceMaps: string;
+            readonly droppedTransactionSpans: string;
             readonly upgrading: string;
             readonly metaData: string;
         };

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/transaction_flyout/DroppedSpansWarning.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/transaction_flyout/DroppedSpansWarning.tsx
@@ -5,17 +5,18 @@
  * 2.0.
  */
 
-import { EuiCallOut, EuiHorizontalRule } from '@elastic/eui';
+import { EuiCallOut, EuiHorizontalRule, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { Transaction } from '../../../../../../../../typings/es_schemas/ui/transaction';
-import { ElasticDocsLink } from '../../../../../../shared/Links/ElasticDocsLink';
+import { useApmPluginContext } from '../../../../../../../context/apm_plugin/use_apm_plugin_context';
 
 export function DroppedSpansWarning({
   transactionDoc,
 }: {
   transactionDoc: Transaction;
 }) {
+  const { docLinks } = useApmPluginContext().core;
   const dropped = transactionDoc.transaction.span_count?.dropped;
   if (!dropped) {
     return null;
@@ -32,18 +33,14 @@ export function DroppedSpansWarning({
             values: { dropped },
           }
         )}{' '}
-        <ElasticDocsLink
-          section="/apm/get-started"
-          path="/transaction-spans.html#dropped-spans"
-          target="_blank"
-        >
+        <EuiLink href={docLinks.links.apm.droppedTransactionSpans}>
           {i18n.translate(
             'xpack.apm.transactionDetails.transFlyout.callout.learnMoreAboutDroppedSpansLinkText',
             {
               defaultMessage: 'Learn more about dropped spans.',
             }
           )}
-        </ElasticDocsLink>
+        </EuiLink>
       </EuiCallOut>
       <EuiHorizontalRule />
     </React.Fragment>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Uses doc link service instead of ElasticDocsLink for linking dropped transaction spans (#110964)