### PR TITLE
[7.x] [Discover] Remove export* syntax (#110934)

### DIFF
--- a/x-pack/plugins/discover_enhanced/common/index.ts
+++ b/x-pack/plugins/discover_enhanced/common/index.ts
@@ -5,7 +5,4 @@
  * 2.0.
  */
 
-// TODO: https://github.com/elastic/kibana/issues/110900
-/* eslint-disable @kbn/eslint/no_export_all */
-
-export * from './config';
+export type { Config } from './config';


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Discover] Remove export* syntax (#110934)