### PR TITLE
[Security Solution] Add overflowwrap anywhere to  policy name in endpoint overflow

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/endpoint_policy_link.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/endpoint_policy_link.tsx
@@ -44,7 +44,12 @@ export const EndpointPolicyLink = memo<
 
   return (
     // eslint-disable-next-line @elastic/eui/href-or-on-click
-    <EuiLink href={toRouteUrl} onClick={clickHandler} {...otherProps}>
+    <EuiLink
+      style={{ overflowWrap: 'anywhere' }}
+      href={toRouteUrl}
+      onClick={clickHandler}
+      {...otherProps}
+    >
       {children}
     </EuiLink>
   );

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/endpoint_policy_link.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/endpoint_policy_link.tsx
@@ -45,7 +45,7 @@ export const EndpointPolicyLink = memo<
   return (
     // eslint-disable-next-line @elastic/eui/href-or-on-click
     <EuiLink
-      style={{ overflowWrap: 'anywhere' }}
+      className={'eui-textBreakWord'}
       href={toRouteUrl}
       onClick={clickHandler}
       {...otherProps}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/102866

It adds overflowWrap: 'anywhere' for long single-worded policy names.

Before
![image](https://user-images.githubusercontent.com/227916/132317815-a2a96a14-2c2e-4961-b48d-9b651746f65a.png)

after
![image](https://user-images.githubusercontent.com/227916/132317837-d99000bc-19eb-4c66-a81e-8d8d5a37db55.png)


