### PR TITLE
[Security Solution] styling for reason popover

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.test.tsx
@@ -144,5 +144,22 @@ describe('reasonColumnRenderer', () => {
 
       expect(wrapper.queryByTestId('test-row-render')).toBeInTheDocument();
     });
+
+    it('the popover always contains a class that hides it when an overlay (e.g. the inspect modal) is displayed', () => {
+      const renderedColumn = reasonColumnRenderer.renderColumn({
+        ...defaultProps,
+        ecsData: validEcs,
+        rowRenderers,
+        browserFields,
+      });
+
+      const wrapper = render(<TestProviders>{renderedColumn}</TestProviders>);
+
+      fireEvent.click(wrapper.getByTestId('reason-cell-button'));
+
+      expect(wrapper.getByRole('dialog')).toHaveClass(
+        'euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--right withHoverActions__popover'
+      );
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
@@ -123,7 +123,6 @@ const ReasonCell: React.FC<{
           anchorPosition="rightCenter"
           closePopover={handleClosePopOver}
           panelClassName="withHoverActions__popover"
-          data-test-subj="reason-popover"
           button={button}
         >
           <EuiPopoverTitle paddingSize="s">

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/reason_column_renderer.tsx
@@ -122,6 +122,8 @@ const ReasonCell: React.FC<{
           isOpen={isOpen}
           anchorPosition="rightCenter"
           closePopover={handleClosePopOver}
+          panelClassName="withHoverActions__popover"
+          data-test-subj="reason-popover"
           button={button}
         >
           <EuiPopoverTitle paddingSize="s">


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/110954

<img width="1671" alt="Screenshot 2021-09-07 at 11 57 27" src="https://user-images.githubusercontent.com/6295984/132333653-c058a6a6-4399-4a48-8fc0-f8f2d57b8692.png">
<img width="1677" alt="Screenshot 2021-09-07 at 11 57 41" src="https://user-images.githubusercontent.com/6295984/132333651-1ceb43e2-7dd6-4a8f-92ca-2cc0577345ab.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


