### PR TITLE
[Stack Monitoring] Update overview page data on refresh interval

### DIFF
--- a/x-pack/plugins/monitoring/public/application/global_state_context.tsx
+++ b/x-pack/plugins/monitoring/public/application/global_state_context.tsx
@@ -7,6 +7,8 @@
 import React, { createContext } from 'react';
 import { GlobalState } from '../url_state';
 import { MonitoringStartPluginDependencies } from '../types';
+import { TimeRange, RefreshInterval } from '../../../../../src/plugins/data/public';
+import { Legacy } from '../legacy_shims';
 
 interface GlobalStateProviderProps {
   query: MonitoringStartPluginDependencies['data']['query'];
@@ -14,10 +16,13 @@ interface GlobalStateProviderProps {
 }
 
 export interface State {
+  [key: string]: unknown;
   cluster_uuid?: string;
   ccs?: any;
   inSetupMode?: boolean;
   save?: () => void;
+  time?: TimeRange;
+  refreshInterval?: RefreshInterval;
 }
 
 export const GlobalStateContext = createContext({} as State);
@@ -45,13 +50,13 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     },
   };
 
-  const localState: { [key: string]: unknown } = {};
+  const localState: State = {};
   const state = new GlobalState(
     query,
     toasts,
     fakeAngularRootScope,
     fakeAngularLocation,
-    localState
+    localState as { [key: string]: unknown }
   );
 
   const initialState: any = state.getState();
@@ -62,11 +67,19 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     localState[key] = initialState[key];
   }
 
+  localState.refreshInterval = { value: 10000, pause: false };
+
   localState.save = () => {
     const newState = { ...localState };
     delete newState.save;
     state.setState(newState);
   };
+
+  const { value, pause } = Legacy.shims.timefilter.getRefreshInterval();
+  if (!value && pause) {
+    Legacy.shims.timefilter.setRefreshInterval(localState.refreshInterval);
+    localState.save?.();
+  }
 
   return <GlobalStateContext.Provider value={localState}>{children}</GlobalStateContext.Provider>;
 };

--- a/x-pack/plugins/monitoring/public/application/pages/cluster/overview_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/cluster/overview_page.tsx
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import React, { useContext } from 'react';
+import React, { useContext, useState, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { CODE_PATH_ALL } from '../../../../common/constants';
 import { PageTemplate } from '../page_template';
-import { useClusters } from '../../hooks/use_clusters';
+import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { GlobalStateContext } from '../../global_state_context';
 import { TabMenuItem } from '../page_template';
-import { PageLoading } from '../../../components';
 import { Overview } from '../../../components/cluster/overview';
 import { ExternalConfigContext } from '../../external_config_context';
 import { SetupModeRenderer } from '../../setup_mode/setup_mode_renderer';
 import { SetupModeContext } from '../../../components/setup_mode/setup_mode_context';
+import { STANDALONE_CLUSTER_CLUSTER_UUID } from '../../../../common/constants';
 
 const CODE_PATHS = [CODE_PATH_ALL];
 interface SetupModeProps {
@@ -26,10 +26,14 @@ interface SetupModeProps {
 }
 
 export const ClusterOverview: React.FC<{}> = () => {
-  // TODO: check how many requests with useClusters
   const state = useContext(GlobalStateContext);
   const externalConfig = useContext(ExternalConfigContext);
-  const { clusters, loaded } = useClusters(state.cluster_uuid, state.ccs, CODE_PATHS);
+  const { services } = useKibana<{ data: any }>();
+  const clusterUuid = state.cluster_uuid;
+  const ccs = state.ccs;
+  const [clusters, setClusters] = useState([] as any);
+  const [loaded, setLoaded] = useState<boolean | null>(false);
+
   let tabs: TabMenuItem[] = [];
 
   const title = i18n.translate('xpack.monitoring.cluster.overviewTitle', {
@@ -53,27 +57,62 @@ export const ClusterOverview: React.FC<{}> = () => {
     ];
   }
 
+  const getPageData = useCallback(async () => {
+    const bounds = services.data?.query.timefilter.timefilter.getBounds();
+    let url = '../api/monitoring/v1/clusters';
+    if (clusterUuid) {
+      url += `/${clusterUuid}`;
+    }
+
+    try {
+      const response = await services.http?.fetch(url, {
+        method: 'POST',
+        body: JSON.stringify({
+          ccs,
+          timeRange: {
+            min: bounds.min.toISOString(),
+            max: bounds.max.toISOString(),
+          },
+          codePaths: CODE_PATHS,
+        }),
+      });
+
+      setClusters(formatClusters(response));
+    } catch (err) {
+      // TODO: handle errors
+    } finally {
+      setLoaded(true);
+    }
+  }, [ccs, clusterUuid, services.data?.query.timefilter.timefilter, services.http]);
+
   return (
-    <PageTemplate title={title} pageTitle={pageTitle} tabs={tabs}>
-      {loaded ? (
-        <SetupModeRenderer
-          render={({ setupMode, flyoutComponent, bottomBarComponent }: SetupModeProps) => (
-            <SetupModeContext.Provider value={{ setupModeSupported: true }}>
-              {flyoutComponent}
-              <Overview
-                cluster={clusters[0]}
-                alerts={[]}
-                setupMode={setupMode}
-                showLicenseExpiration={externalConfig.showLicenseExpiration}
-              />
-              {/* <EnableAlertsModal alerts={this.alerts} /> */}
-              {bottomBarComponent}
-            </SetupModeContext.Provider>
-          )}
-        />
-      ) : (
-        <PageLoading />
-      )}
+    <PageTemplate title={title} pageTitle={pageTitle} tabs={tabs} getPageData={getPageData}>
+      <SetupModeRenderer
+        render={({ setupMode, flyoutComponent, bottomBarComponent }: SetupModeProps) => (
+          <SetupModeContext.Provider value={{ setupModeSupported: true }}>
+            {flyoutComponent}
+            <Overview
+              cluster={clusters[0]}
+              alerts={[]}
+              setupMode={setupMode}
+              showLicenseExpiration={externalConfig.showLicenseExpiration}
+            />
+            {/* <EnableAlertsModal alerts={this.alerts} /> */}
+            {bottomBarComponent}
+          </SetupModeContext.Provider>
+        )}
+      />
     </PageTemplate>
   );
 };
+
+function formatClusters(clusters: any) {
+  return clusters.map(formatCluster);
+}
+
+function formatCluster(cluster: any) {
+  if (cluster.cluster_uuid === STANDALONE_CLUSTER_CLUSTER_UUID) {
+    cluster.cluster_name = 'Standalone Cluster';
+  }
+  return cluster;
+}

--- a/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
@@ -6,9 +6,11 @@
  */
 
 import { EuiTab, EuiTabs } from '@elastic/eui';
-import React from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { useTitle } from '../hooks/use_title';
 import { MonitoringToolbar } from '../../components/shared/toolbar';
+import { MonitoringTimeContainer } from './use_monitoring_time';
+import { PageLoading } from '../../components';
 
 export interface TabMenuItem {
   id: string;
@@ -22,14 +24,40 @@ interface PageTemplateProps {
   title: string;
   pageTitle?: string;
   tabs?: TabMenuItem[];
+  getPageData?: () => Promise<void>;
 }
 
-export const PageTemplate: React.FC<PageTemplateProps> = ({ title, pageTitle, tabs, children }) => {
+export const PageTemplate: React.FC<PageTemplateProps> = ({
+  title,
+  pageTitle,
+  tabs,
+  getPageData,
+  children,
+}) => {
   useTitle('', title);
+
+  const { currentTimerange } = useContext(MonitoringTimeContainer.Context);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    getPageData?.()
+      .catch((err) => {
+        // TODO: handle errors
+      })
+      .finally(() => {
+        setLoaded(true);
+      });
+  }, [getPageData, currentTimerange]);
+
+  const onRefresh = () => {
+    getPageData?.().catch((err) => {
+      // TODO: handle errors
+    });
+  };
 
   return (
     <div className="app-container">
-      <MonitoringToolbar pageTitle={pageTitle} />
+      <MonitoringToolbar pageTitle={pageTitle} onRefresh={onRefresh} />
       {tabs && (
         <EuiTabs>
           {tabs.map((item, idx) => {
@@ -47,7 +75,7 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({ title, pageTitle, ta
           })}
         </EuiTabs>
       )}
-      <div>{children}</div>
+      <div>{!getPageData ? children : loaded ? children : <PageLoading />}</div>
     </div>
   );
 };

--- a/x-pack/plugins/monitoring/public/application/pages/use_monitoring_time.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/use_monitoring_time.tsx
@@ -6,6 +6,7 @@
  */
 import { useCallback, useState } from 'react';
 import createContainer from 'constate';
+import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 
 interface TimeOptions {
   from: string;
@@ -19,14 +20,19 @@ export const DEFAULT_TIMERANGE: TimeOptions = {
   interval: '>=10s',
 };
 
+const DEFAULT_REFRESH_INTERVAL_VALUE = 10000;
+const DEFAULT_REFRESH_INTERVAL_PAUSE = false;
+
 export const useMonitoringTime = () => {
+  const { services } = useKibana<{ data: any }>();
   const defaultTimeRange = {
-    from: 'now-1h',
-    to: 'now',
-    interval: DEFAULT_TIMERANGE.interval,
+    ...DEFAULT_TIMERANGE,
+    ...services.data?.query.timefilter.timefilter.getTime(),
   };
-  const [refreshInterval, setRefreshInterval] = useState(5000);
-  const [isPaused, setIsPaused] = useState(false);
+
+  const { value, pause } = services.data?.query.timefilter.timefilter.getRefreshInterval();
+  const [refreshInterval, setRefreshInterval] = useState(value || DEFAULT_REFRESH_INTERVAL_VALUE);
+  const [isPaused, setIsPaused] = useState(pause || DEFAULT_REFRESH_INTERVAL_PAUSE);
   const [currentTimerange, setTimeRange] = useState<TimeOptions>(defaultTimeRange);
 
   const handleTimeChange = useCallback(

--- a/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
+++ b/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
@@ -17,9 +17,10 @@ import { MonitoringTimeContainer } from '../../application/pages/use_monitoring_
 
 interface MonitoringToolbarProps {
   pageTitle?: string;
+  onRefresh?: () => void;
 }
 
-export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle }) => {
+export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle, onRefresh }) => {
   const {
     currentTimerange,
     handleTimeChange,
@@ -72,7 +73,7 @@ export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle 
             start={currentTimerange.from}
             end={currentTimerange.to}
             onTimeChange={onTimeChange}
-            onRefresh={() => {}}
+            onRefresh={onRefresh}
             isPaused={isPaused}
             refreshInterval={refreshInterval}
             onRefreshChange={onRefreshChange}

--- a/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
+++ b/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
@@ -14,6 +14,8 @@ import {
 } from '@elastic/eui';
 import React, { useContext, useCallback } from 'react';
 import { MonitoringTimeContainer } from '../../application/pages/use_monitoring_time';
+import { GlobalStateContext } from '../../application/global_state_context';
+import { Legacy } from '../../legacy_shims';
 
 interface MonitoringToolbarProps {
   pageTitle?: string;
@@ -29,6 +31,7 @@ export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle,
     setIsPaused,
     isPaused,
   } = useContext(MonitoringTimeContainer.Context);
+  const state = useContext(GlobalStateContext);
 
   const onTimeChange = useCallback(
     (selectedTime: { start: string; end: string; isInvalid: boolean }) => {
@@ -36,16 +39,28 @@ export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle,
         return;
       }
       handleTimeChange(selectedTime.start, selectedTime.end);
+      state.time = {
+        from: selectedTime.start,
+        to: selectedTime.end,
+      };
+      Legacy.shims.timefilter.setTime(state.time);
+      state.save?.();
     },
-    [handleTimeChange]
+    [handleTimeChange, state]
   );
 
   const onRefreshChange = useCallback(
     ({ refreshInterval: ri, isPaused: isP }: OnRefreshChangeProps) => {
       setRefreshInterval(ri);
       setIsPaused(isP);
+      state.refreshInterval = {
+        pause: isP,
+        value: ri,
+      };
+      Legacy.shims.timefilter.setRefreshInterval(state.refreshInterval);
+      state.save?.();
     },
-    [setRefreshInterval, setIsPaused]
+    [setRefreshInterval, setIsPaused, state]
   );
 
   return (


### PR DESCRIPTION
## Summary
This PR handles in React the page data updates on refresh interval.
It also keeps in sync time and refresh parameters between the URL, the datepicker, and the global state.

### How to test
* Set `monitoring.ui.render_react_app: true` in `kibana.dev.yml` to render the react app.
* When landing on the overview page, the data shown is being updated every 10 sec.
* When the time is changed in the date picker, the URL is updated and, when the request is inspected in the Chrome dev tools, the time range send is the same selected in the date picker.
* When the refresh interval is changed in the datepicker, the URL is updated and requests are sent according the new interval
* If the refresh interval is paused, the URL is updated and no more requests are sent.

NOTE: the request for the overview page looks like: `/api/monitoring/v1/clusters/:cluster_Uuid`