### PR TITLE
[App Search] Reorder ingestion methods

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.tsx
@@ -59,6 +59,19 @@ export const DocumentCreationButtons: React.FC<Props> = ({ disabled = false }) =
       <EuiSpacer />
       <EuiFlexGrid columns={2}>
         <EuiFlexItem>
+          <EuiCardTo
+            display="subdued"
+            title={i18n.translate(
+              'xpack.enterpriseSearch.appSearch.documentCreation.buttons.crawl',
+              { defaultMessage: 'Use the Crawler' }
+            )}
+            description=""
+            icon={<EuiIcon type="globe" size="xxl" color="primary" />}
+            to={crawlerLink}
+            isDisabled={disabled}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
           <EuiCard
             display="subdued"
             title={i18n.translate(
@@ -94,19 +107,6 @@ export const DocumentCreationButtons: React.FC<Props> = ({ disabled = false }) =
             description=""
             icon={<EuiIcon type="editorCodeBlock" size="xxl" color="primary" />}
             onClick={() => openDocumentCreation('api')}
-            isDisabled={disabled}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCardTo
-            display="subdued"
-            title={i18n.translate(
-              'xpack.enterpriseSearch.appSearch.documentCreation.buttons.crawl',
-              { defaultMessage: 'Use the Crawler' }
-            )}
-            description=""
-            icon={<EuiIcon type="globe" size="xxl" color="primary" />}
-            to={crawlerLink}
             isDisabled={disabled}
           />
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Kibana lists the crawler as the last option for content ingestion into App Search

<img width="1419" alt="Screen Shot 2021-09-01 at 4 14 55 PM" src="https://user-images.githubusercontent.com/3467/131746495-f11558fa-e576-4c47-bfc1-0b029c32116d.png">

while the standalone UI lists it as the first ingestion mechanism

<img width="1419" alt="Screen Shot 2021-09-01 at 4 17 30 PM" src="https://user-images.githubusercontent.com/3467/131746594-d6db7a7c-29aa-444a-b5c5-e7a30749dffa.png">

---

This PR makes the crawler the first option in the list in Kibana as well.