### PR TITLE
[APM] Set start date of APM ML job to -4 weeks

### DIFF
--- a/x-pack/plugins/apm/server/lib/anomaly_detection/create_anomaly_detection_jobs.ts
+++ b/x-pack/plugins/apm/server/lib/anomaly_detection/create_anomaly_detection_jobs.ts
@@ -9,6 +9,7 @@ import { Logger } from 'kibana/server';
 import uuid from 'uuid/v4';
 import { snakeCase } from 'lodash';
 import Boom from '@hapi/boom';
+import moment from 'moment';
 import { ML_ERRORS } from '../../../common/anomaly_detection';
 import { ProcessorEvent } from '../../../common/processor_event';
 import { environmentQuery } from '../../../common/utils/environment_query';
@@ -87,6 +88,7 @@ async function createAnomalyDetectionJob({
       groups: [APM_ML_JOB_GROUP],
       indexPatternName,
       applyToAllSpaces: true,
+      start: moment().subtract(4, 'weeks').valueOf(),
       query: {
         bool: {
           filter: [


### PR DESCRIPTION
Closes #111045.

Specifies `start` for `ml.modules.setup` to -4 weeks, to prevent the ML job from processing a very big time range.