### PR TITLE
[RAC][Metrics UI] Link inventory threshold alerts to a specific timestamp in the metrics app

### DIFF
--- a/x-pack/plugins/infra/public/alerting/inventory/rule_data_formatters.ts
+++ b/x-pack/plugins/infra/public/alerting/inventory/rule_data_formatters.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { ALERT_REASON } from '@kbn/rule-data-utils';
+import { TIMESTAMP, ALERT_REASON } from '@kbn/rule-data-utils';
 import { ObservabilityRuleTypeFormatter } from '../../../../observability/public';
 
 export const formatReason: ObservabilityRuleTypeFormatter = ({ fields }) => {
   const reason = fields[ALERT_REASON] ?? '-';
-  const link = '/app/metrics/inventory'; // TODO https://github.com/elastic/kibana/issues/106497
+  const link = `/app/metrics/link-to/inventory?time=${Date.parse(fields[TIMESTAMP])}`;
 
   return {
     reason,

--- a/x-pack/plugins/infra/public/pages/link_to/link_to_metrics.test.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/link_to_metrics.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Route, Router, Switch } from 'react-router-dom';
+import { httpServiceMock } from 'src/core/public/mocks';
+import { KibanaContextProvider, KibanaPageTemplate } from 'src/plugins/kibana_react/public';
+
+import { RedirectToInventory } from './redirect_to_inventory';
+
+const renderRoutes = (routes: React.ReactElement) => {
+  const history = createMemoryHistory();
+  const services = {
+    http: httpServiceMock.createStartContract(),
+    data: {
+      indexPatterns: {},
+    },
+    observability: {
+      navigation: {
+        PageTemplate: KibanaPageTemplate,
+      },
+    },
+  };
+  const renderResult = render(
+    <KibanaContextProvider services={services}>
+      <Router history={history}>{routes}</Router>
+    </KibanaContextProvider>
+  );
+
+  return {
+    ...renderResult,
+    history,
+    services,
+  };
+};
+
+describe('LinkToMetricsInventoryPage', () => {
+  describe('default route', () => {
+    it('Redirects to the inventory at a given time', () => {
+      const { history } = renderRoutes(
+        <Switch>
+          <Route path="/link-to" component={RedirectToInventory} />
+        </Switch>
+      );
+
+      history.push('/link-to?time=1630936800000');
+
+      expect(history.location.pathname).toEqual('/inventory');
+      expect(history.location.search).toContain('currentTime:1630936800000');
+    });
+  });
+});

--- a/x-pack/plugins/infra/public/pages/link_to/link_to_metrics.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/link_to_metrics.tsx
@@ -11,6 +11,7 @@ import { match as RouteMatch, Redirect, Route, Switch } from 'react-router-dom';
 import { RedirectToNodeDetail } from './redirect_to_node_detail';
 import { RedirectToHostDetailViaIP } from './redirect_to_host_detail_via_ip';
 import { inventoryModels } from '../../../common/inventory_models';
+import { RedirectToInventory } from './redirect_to_inventory';
 
 interface LinkToPageProps {
   match: RouteMatch<{}>;
@@ -29,6 +30,7 @@ export const LinkToMetricsPage: React.FC<LinkToPageProps> = (props) => {
         path={`${props.match.url}/host-detail-via-ip/:hostIp`}
         component={RedirectToHostDetailViaIP}
       />
+      <Route path={`${props.match.url}/inventory`} component={RedirectToInventory} />
       <Redirect to="/" />
     </Switch>
   );

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_inventory.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_inventory.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { parse } from 'query-string';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+// FIXME? There has to be a way to get these defaults from somewhere else in the metrics app
+const QUERY_STRING_TEMPLATE =
+  "?waffleTime=(currentTime:{{time}},isAutoReloading:!f)&waffleFilter=(expression:'',kind:kuery)&waffleOptions=(accountId:'',autoBounds:!t,boundsOverride:(max:1,min:0),customMetrics:!(),customOptions:!(),groupBy:!(),legend:(palette:cool,reverseColors:!f,steps:10),metric:(type:cpu),nodeType:host,region:'',sort:(by:name,direction:desc),view:map)";
+
+export const RedirectToInventory: React.FC<RouteComponentProps> = ({ location }) => {
+  const parsedQueryString = parseQueryString(location.search);
+
+  const inventoryQueryString = QUERY_STRING_TEMPLATE.replace(/{{(\w+)}}/, (_, key) =>
+    parsedQueryString[key].toString()
+  );
+
+  return <Redirect to={'/inventory' + inventoryQueryString} />;
+};
+
+function parseQueryString(search: string): Record<string, string> {
+  if (search.length === 0) {
+    return {};
+  }
+
+  const obj = parse(search.substring(1));
+
+  // Force all values into `string`
+  for (const key in obj) {
+    if (Object.hasOwnProperty.call(obj, key)) {
+      if (!obj[key]) {
+        delete obj[key];
+      }
+      if (Array.isArray(obj.key)) {
+        obj[key] = obj[key]![0];
+      }
+    }
+  }
+
+  return obj as Record<string, string>;
+}


### PR DESCRIPTION
## Summary

Closes #106497

I've added a new `/metrics/link-to` handler to allow linking to a specific timestamp in the inventory app, and used it in the alert formatter to link to the `@timestamp`. The link generation is naive. I appreciate if someone from the `metrics` part of @elastic/logs-metrics-ui could give me pointers on how to generate that link.

I've made the assumption that the user will be interested in the point in time where the alert has changed. For example if the alert is resolved, we link to the resolution timestamp. If this assumption is incorrect please let me know.