### PR TITLE
[7.14] [Uptime] [Synthetics Integration] fix content typo (#110088)

### DIFF
--- a/x-pack/plugins/uptime/public/components/fleet_package/http/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/http/simple_fields.tsx
@@ -185,7 +185,7 @@ export const HTTPSimpleFields = memo<Props>(({ validate }) => {
         helpText={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.tags.helpText"
-            defaultMessage="A list of tags that will be sent with the monitor event. Press enter to add a new tab. Displayed in Uptime and enables searching by tag."
+            defaultMessage="A list of tags that will be sent with the monitor event. Press enter to add a new tag. Displayed in Uptime and enables searching by tag."
           />
         }
       >

--- a/x-pack/plugins/uptime/public/components/fleet_package/icmp/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/icmp/simple_fields.tsx
@@ -189,7 +189,7 @@ export const ICMPSimpleFields = memo<Props>(({ validate }) => {
         helpText={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.tags.helpText"
-            defaultMessage="A list of tags that will be sent with the monitor event. Press enter to add a new tab. Displayed in Uptime and enables searching by tag."
+            defaultMessage="A list of tags that will be sent with the monitor event. Press enter to add a new tag. Displayed in Uptime and enables searching by tag."
           />
         }
       >

--- a/x-pack/plugins/uptime/public/components/fleet_package/tcp/simple_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/tcp/simple_fields.tsx
@@ -156,7 +156,7 @@ export const TCPSimpleFields = memo<Props>(({ validate }) => {
         helpText={
           <FormattedMessage
             id="xpack.uptime.createPackagePolicy.stepConfigure.monitorIntegrationSettingsSection.tags.helpText"
-            defaultMessage="A list of tags that will be sent with the monitor event. Press enter to add a new tab. Displayed in Uptime and enables searching by tag."
+            defaultMessage="A list of tags that will be sent with the monitor event. Press enter to add a new tag. Displayed in Uptime and enables searching by tag."
           />
         }
       >


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Uptime] [Synthetics Integration] fix content typo (#110088)