### PR TITLE
[build] Remove empty optimize directory

### DIFF
--- a/src/dev/build/tasks/create_empty_dirs_and_files_task.ts
+++ b/src/dev/build/tasks/create_empty_dirs_and_files_task.ts
@@ -12,9 +12,6 @@ export const CreateEmptyDirsAndFiles: Task = {
   description: 'Creating some empty directories and files to prevent file-permission issues',
 
   async run(config, log, build) {
-    await Promise.all([
-      mkdirp(build.resolvePath('plugins')),
-      mkdirp(build.resolvePath('data/optimize')),
-    ]);
+    await Promise.all([mkdirp(build.resolvePath('plugins')), mkdirp(build.resolvePath('data'))]);
   },
 };


### PR DESCRIPTION
This folder is no longer used.

Previous attempt was incorrectly removing the data folder - https://github.com/elastic/kibana/pull/109014.  This doesn't need to be backported, the change already exists in 7.x.
