### PR TITLE
[Canvas] Adds Save and Return Workflow

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/expression_types/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/expression_types/embeddable.ts
@@ -6,12 +6,11 @@
  */
 
 import { ExpressionTypeDefinition } from '../../../../../src/plugins/expressions';
-import { EmbeddableInput } from '../../../../../src/plugins/embeddable/common/';
+import { EmbeddableInput } from '../../types';
 import { EmbeddableTypes } from './embeddable_types';
 
 export const EmbeddableExpressionType = 'embeddable';
 export { EmbeddableTypes, EmbeddableInput };
-
 export interface EmbeddableExpression<Input extends EmbeddableInput> {
   /**
    * The type of the expression result

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
@@ -6,14 +6,8 @@
  */
 
 import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
-import { TimeRange } from 'src/plugins/data/public';
-import { Filter } from '@kbn/es-query';
-import { ExpressionValueFilter } from '../../../types';
-import {
-  EmbeddableExpressionType,
-  EmbeddableExpression,
-  EmbeddableInput as Input,
-} from '../../expression_types';
+import { ExpressionValueFilter, EmbeddableInput } from '../../../types';
+import { EmbeddableExpressionType, EmbeddableExpression } from '../../expression_types';
 import { getFunctionHelp } from '../../../i18n';
 import { SavedObjectReference } from '../../../../../../src/core/types';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
@@ -27,12 +21,6 @@ interface Arguments {
 const defaultTimeRange = {
   from: 'now-15m',
   to: 'now',
-};
-
-export type EmbeddableInput = Input & {
-  timeRange?: TimeRange;
-  filters?: Filter[];
-  savedObjectId: string;
 };
 
 const baseEmbeddableInput = {

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_lens.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_lens.ts
@@ -9,9 +9,8 @@ import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
 import { PaletteOutput } from 'src/plugins/charts/common';
 import { Filter as DataFilter } from '@kbn/es-query';
 import { TimeRange } from 'src/plugins/data/common';
-import { EmbeddableInput } from 'src/plugins/embeddable/common';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
-import { ExpressionValueFilter, TimeRange as TimeRangeArg } from '../../../types';
+import { ExpressionValueFilter, EmbeddableInput, TimeRange as TimeRangeArg } from '../../../types';
 import {
   EmbeddableTypes,
   EmbeddableExpressionType,
@@ -27,7 +26,7 @@ interface Arguments {
 }
 
 export type SavedLensInput = EmbeddableInput & {
-  id: string;
+  savedObjectId: string;
   timeRange?: TimeRange;
   filters: DataFilter[];
   palette?: PaletteOutput;
@@ -73,18 +72,19 @@ export function savedLens(): ExpressionFunctionDefinition<
       },
     },
     type: EmbeddableExpressionType,
-    fn: (input, args) => {
+    fn: (input, { id, timerange, title, palette }) => {
       const filters = input ? input.and : [];
 
       return {
         type: EmbeddableExpressionType,
         input: {
-          id: args.id,
+          id,
+          savedObjectId: id,
           filters: getQueryFilters(filters),
-          timeRange: args.timerange || defaultTimeRange,
-          title: args.title === null ? undefined : args.title,
+          timeRange: timerange || defaultTimeRange,
+          title: title === null ? undefined : title,
           disableTriggers: true,
-          palette: args.palette,
+          palette,
         },
         embeddableType: EmbeddableTypes.lens,
         generatedAt: Date.now(),

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_map.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_map.ts
@@ -30,7 +30,7 @@ const defaultTimeRange = {
   to: 'now',
 };
 
-type Output = EmbeddableExpression<MapEmbeddableInput>;
+type Output = EmbeddableExpression<MapEmbeddableInput & { savedObjectId: string }>;
 
 export function savedMap(): ExpressionFunctionDefinition<
   'savedMap',
@@ -85,8 +85,9 @@ export function savedMap(): ExpressionFunctionDefinition<
       return {
         type: EmbeddableExpressionType,
         input: {
-          attributes: { title: '' },
           id: args.id,
+          attributes: { title: '' },
+          savedObjectId: args.id,
           filters: getQueryFilters(filters),
           timeRange: args.timerange || defaultTimeRange,
           refreshConfig: {

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
@@ -25,7 +25,7 @@ interface Arguments {
   title: string | null;
 }
 
-type Output = EmbeddableExpression<VisualizeInput>;
+type Output = EmbeddableExpression<VisualizeInput & { savedObjectId: string }>;
 
 const defaultTimeRange = {
   from: 'now-15m',
@@ -94,6 +94,7 @@ export function savedVisualization(): ExpressionFunctionDefinition<
         type: EmbeddableExpressionType,
         input: {
           id,
+          savedObjectId: id,
           disableTriggers: true,
           timeRange: timerange || defaultTimeRange,
           filters: getQueryFilters(filters),

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { toExpression } from './embeddable';
+import { EmbeddableInput } from '../../../../types';
+import { decode } from '../../../../common/lib/embeddable_dataurl';
+import { fromExpression } from '@kbn/interpreter/common';
+
+describe('toExpression', () => {
+  describe('by-reference embeddable input', () => {
+    const baseEmbeddableInput = {
+      id: 'elementId',
+      savedObjectId: 'embeddableId',
+      filters: [],
+    };
+
+    it('converts to an embeddable expression', () => {
+      const input: EmbeddableInput = baseEmbeddableInput;
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      expect(ast.type).toBe('expression');
+      expect(ast.chain[0].function).toBe('embeddable');
+      expect(ast.chain[0].arguments.type[0]).toBe('visualization');
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config.savedObjectId).toStrictEqual(input.savedObjectId);
+    });
+
+    it('includes optional input values', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: 'title',
+        timeRange: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+      expect(config).toHaveProperty('timeRange');
+      expect(config.timeRange).toHaveProperty('from', input.timeRange?.from);
+      expect(config.timeRange).toHaveProperty('to', input.timeRange?.to);
+    });
+
+    it('includes empty panel title', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: '',
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+    });
+  });
+
+  describe('by-value embeddable input', () => {
+    const baseEmbeddableInput = {
+      id: 'elementId',
+      disableTriggers: true,
+      filters: [],
+    };
+    it('converts to an embeddable expression', () => {
+      const input: EmbeddableInput = baseEmbeddableInput;
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      expect(ast.type).toBe('expression');
+      expect(ast.chain[0].function).toBe('embeddable');
+      expect(ast.chain[0].arguments.type[0]).toBe('visualization');
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+      expect(config.filters).toStrictEqual(input.filters);
+      expect(config.disableTriggers).toStrictEqual(input.disableTriggers);
+    });
+
+    it('includes optional input values', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: 'title',
+        timeRange: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+      expect(config).toHaveProperty('timeRange');
+      expect(config.timeRange).toHaveProperty('from', input.timeRange?.from);
+      expect(config.timeRange).toHaveProperty('to', input.timeRange?.to);
+    });
+
+    it('includes empty panel title', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: '',
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+    });
+  });
+});

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.test.ts
@@ -11,7 +11,8 @@ import { fromExpression, Ast } from '@kbn/interpreter/common';
 import { chartPluginMock } from 'src/plugins/charts/public/mocks';
 
 const baseEmbeddableInput = {
-  id: 'embeddableId',
+  id: 'elementId',
+  savedObjectId: 'embeddableId',
   filters: [],
 };
 
@@ -27,7 +28,7 @@ describe('toExpression', () => {
     expect(ast.type).toBe('expression');
     expect(ast.chain[0].function).toBe('savedLens');
 
-    expect(ast.chain[0].arguments.id).toStrictEqual([input.id]);
+    expect(ast.chain[0].arguments.id).toStrictEqual([input.savedObjectId]);
 
     expect(ast.chain[0].arguments).not.toHaveProperty('title');
     expect(ast.chain[0].arguments).not.toHaveProperty('timerange');

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.ts
@@ -14,7 +14,7 @@ export function toExpression(input: SavedLensInput, palettes: PaletteRegistry): 
 
   expressionParts.push('savedLens');
 
-  expressionParts.push(`id="${input.id}"`);
+  expressionParts.push(`id="${input.savedObjectId}"`);
 
   if (input.title !== undefined) {
     expressionParts.push(`title="${input.title}"`);

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { toExpression } from './map';
-import { MapEmbeddableInput } from '../../../../../../plugins/maps/public/embeddable';
 import { fromExpression, Ast } from '@kbn/interpreter/common';
 
 const baseSavedMapInput = {
+  id: 'elementId',
   attributes: { title: '' },
-  id: 'embeddableId',
+  savedObjectId: 'embeddableId',
   filters: [],
   isLayerTOCOpen: false,
   refreshConfig: {
@@ -23,7 +23,7 @@ const baseSavedMapInput = {
 
 describe('toExpression', () => {
   it('converts to a savedMap expression', () => {
-    const input: MapEmbeddableInput = {
+    const input = {
       ...baseSavedMapInput,
     };
 
@@ -33,7 +33,7 @@ describe('toExpression', () => {
     expect(ast.type).toBe('expression');
     expect(ast.chain[0].function).toBe('savedMap');
 
-    expect(ast.chain[0].arguments.id).toStrictEqual([input.id]);
+    expect(ast.chain[0].arguments.id).toStrictEqual([input.savedObjectId]);
 
     expect(ast.chain[0].arguments).not.toHaveProperty('title');
     expect(ast.chain[0].arguments).not.toHaveProperty('center');
@@ -41,7 +41,7 @@ describe('toExpression', () => {
   });
 
   it('includes optional input values', () => {
-    const input: MapEmbeddableInput = {
+    const input = {
       ...baseSavedMapInput,
       mapCenter: {
         lat: 1,
@@ -73,7 +73,7 @@ describe('toExpression', () => {
   });
 
   it('includes empty panel title', () => {
-    const input: MapEmbeddableInput = {
+    const input = {
       ...baseSavedMapInput,
       title: '',
     };

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { MapEmbeddableInput } from '../../../../../../plugins/maps/public/embeddable';
+import { MapEmbeddableInput } from '../../../../../../plugins/maps/public';
 
-export function toExpression(input: MapEmbeddableInput): string {
+export function toExpression(input: MapEmbeddableInput & { savedObjectId: string }): string {
   const expressionParts = [] as string[];
 
   expressionParts.push('savedMap');
-  expressionParts.push(`id="${input.id}"`);
+
+  expressionParts.push(`id="${input.savedObjectId}"`);
 
   if (input.title !== undefined) {
     expressionParts.push(`title="${input.title}"`);

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.test.ts
@@ -9,7 +9,8 @@ import { toExpression } from './visualization';
 import { fromExpression, Ast } from '@kbn/interpreter/common';
 
 const baseInput = {
-  id: 'embeddableId',
+  id: 'elementId',
+  savedObjectId: 'embeddableId',
 };
 
 describe('toExpression', () => {
@@ -24,7 +25,7 @@ describe('toExpression', () => {
     expect(ast.type).toBe('expression');
     expect(ast.chain[0].function).toBe('savedVisualization');
 
-    expect(ast.chain[0].arguments.id).toStrictEqual([input.id]);
+    expect(ast.chain[0].arguments.id).toStrictEqual([input.savedObjectId]);
   });
 
   it('includes timerange if given', () => {

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.ts
@@ -7,11 +7,11 @@
 
 import { VisualizeInput } from 'src/plugins/visualizations/public';
 
-export function toExpression(input: VisualizeInput): string {
+export function toExpression(input: VisualizeInput & { savedObjectId: string }): string {
   const expressionParts = [] as string[];
 
   expressionParts.push('savedVisualization');
-  expressionParts.push(`id="${input.id}"`);
+  expressionParts.push(`id="${input.savedObjectId}"`);
 
   if (input.title !== undefined) {
     expressionParts.push(`title="${input.title}"`);

--- a/x-pack/plugins/canvas/common/lib/embeddable_dataurl.ts
+++ b/x-pack/plugins/canvas/common/lib/embeddable_dataurl.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EmbeddableInput } from '../../canvas_plugin_src/expression_types';
+import { EmbeddableInput } from '../../types';
 
 export const encode = (input: Partial<EmbeddableInput>) =>
   Buffer.from(JSON.stringify(input)).toString('base64');

--- a/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -85,9 +85,10 @@ export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
       };
 
       // If by-value is enabled, we'll handle both by-reference and by-value embeddables
-      // with the new generic `embeddable` function
+      // with the new generic `embeddable` function.
+      // Otherwise we fallback to the embeddable type specific expressions.
       if (isByValueEnabled) {
-        const config = encode({ id });
+        const config = encode({ savedObjectId: id });
         partialElement.expression = `embeddable config="${config}" 
   type="${type}" 
 | render`;

--- a/x-pack/plugins/canvas/public/components/hooks/workpad/index.tsx
+++ b/x-pack/plugins/canvas/public/components/hooks/workpad/index.tsx
@@ -6,3 +6,5 @@
  */
 
 export { useDownloadWorkpad, useDownloadRenderedWorkpad } from './use_download_workpad';
+
+export { useIncomingEmbeddable } from './use_incoming_embeddable';

--- a/x-pack/plugins/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
+++ b/x-pack/plugins/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { CANVAS_APP } from '../../../../common/lib';
+import { encode } from '../../../../common/lib/embeddable_dataurl';
+import { useEmbeddablesService, useLabsService } from '../../../services';
+// @ts-expect-error unconverted file
+import { addElement } from '../../../state/actions/elements';
+// @ts-expect-error unconverted file
+import { selectToplevelNodes } from '../../../state/actions/transient';
+
+import {
+  updateEmbeddableExpression,
+  fetchEmbeddableRenderable,
+} from '../../../state/actions/embeddable';
+import { clearValue } from '../../../state/actions/resolved_args';
+
+export const useIncomingEmbeddable = (pageId: string) => {
+  const embeddablesService = useEmbeddablesService();
+  const labsService = useLabsService();
+  const dispatch = useDispatch();
+  const isByValueEnabled = labsService.isProjectEnabled('labs:canvas:byValueEmbeddable');
+  const stateTransferService = embeddablesService.getStateTransfer();
+
+  // fetch incoming embeddable from state transfer service.
+  const incomingEmbeddable = stateTransferService.getIncomingEmbeddablePackage(CANVAS_APP, true);
+
+  useEffect(() => {
+    if (isByValueEnabled && incomingEmbeddable) {
+      const { embeddableId, input, type } = incomingEmbeddable;
+
+      const config = encode(input);
+      const expression = `embeddable config="${config}"
+  type="${type}" 
+| render`;
+
+      if (embeddableId) {
+        // clear out resolved arg for old embeddable
+        const argumentPath = [embeddableId, 'expressionRenderable'];
+        dispatch(clearValue({ path: argumentPath }));
+
+        // update existing embeddable expression
+        dispatch(
+          updateEmbeddableExpression({ elementId: embeddableId, embeddableExpression: expression })
+        );
+
+        // update resolved args
+        dispatch(fetchEmbeddableRenderable(embeddableId));
+
+        // select new embeddable element
+        dispatch(selectToplevelNodes([embeddableId]));
+      } else {
+        dispatch(addElement(pageId, { expression }));
+      }
+    }
+  }, [dispatch, pageId, incomingEmbeddable, isByValueEnabled]);
+};

--- a/x-pack/plugins/canvas/public/components/workpad/workpad.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad/workpad.tsx
@@ -27,6 +27,7 @@ import { WorkpadRoutingContext } from '../../routes/workpad';
 import { usePlatformService } from '../../services';
 import { Workpad as WorkpadComponent, Props } from './workpad.component';
 import { State } from '../../../types';
+import { useIncomingEmbeddable } from '../hooks';
 
 type ContainerProps = Pick<Props, 'registerLayout' | 'unregisterLayout'>;
 
@@ -57,6 +58,9 @@ export const Workpad: FC<ContainerProps> = (props) => {
       zoomScale: getZoomScale(state),
     };
   });
+
+  const pageId = propsFromState.pages[propsFromState.selectedPageNumber - 1].id;
+  useIncomingEmbeddable(pageId);
 
   const fetchAllRenderables = useCallback(() => {
     dispatch(fetchAllRenderablesAction());

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/__stories__/element_menu.stories.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/__stories__/element_menu.stories.tsx
@@ -130,5 +130,9 @@ You can use standard Markdown in here, but you can also access your piped-in dat
 };
 
 storiesOf('components/WorkpadHeader/ElementMenu', module).add('default', () => (
-  <ElementMenu elements={testElements} addElement={action('addElement')} />
+  <ElementMenu
+    elements={testElements}
+    addElement={action('addElement')}
+    createNewEmbeddable={action('createNewEmbeddable')}
+  />
 ));

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
@@ -18,6 +18,7 @@ import { ElementSpec } from '../../../../types';
 import { flattenPanelTree } from '../../../lib/flatten_panel_tree';
 import { AssetManager } from '../../asset_manager';
 import { SavedElementsModal } from '../../saved_elements_modal';
+import { useLabsService } from '../../../services';
 
 interface CategorizedElementLists {
   [key: string]: ElementSpec[];
@@ -112,7 +113,7 @@ const categorizeElementsByType = (elements: ElementSpec[]): { [key: string]: Ele
   return categories;
 };
 
-interface Props {
+export interface Props {
   /**
    * Dictionary of elements from elements registry
    */
@@ -120,10 +121,20 @@ interface Props {
   /**
    * Handler for adding a selected element to the workpad
    */
-  addElement: (element: ElementSpec) => void;
+  addElement: (element: Partial<ElementSpec>) => void;
+  /**
+   * Crete new embeddable
+   */
+  createNewEmbeddable: () => void;
 }
 
-export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) => {
+export const ElementMenu: FunctionComponent<Props> = ({
+  elements,
+  addElement,
+  createNewEmbeddable,
+}) => {
+  const labsService = useLabsService();
+  const isByValueEnabled = labsService.isProjectEnabled('labs:canvas:byValueEmbeddable');
   const [isAssetModalVisible, setAssetModalVisible] = useState(false);
   const [isSavedElementsModalVisible, setSavedElementsModalVisible] = useState(false);
 
@@ -199,6 +210,18 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
             closePopover();
           },
         },
+        // TODO: Remove this menu option. This is a temporary menu options just for testing,
+        // will be removed once toolbar is implemented
+        isByValueEnabled
+          ? {
+              name: 'Lens',
+              icon: <EuiIcon type="lensApp" size="m" />,
+              onClick: () => {
+                createNewEmbeddable();
+                closePopover();
+              },
+            }
+          : {},
       ],
     };
   };

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.tsx
@@ -5,4 +5,34 @@
  * 2.0.
  */
 
-export * from './element_menu.component';
+import React, { FC, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { trackCanvasUiMetric, METRIC_TYPE } from '../../../../public/lib/ui_metric';
+import { CANVAS_APP } from '../../../../common/lib';
+import { ElementMenu as Component, Props } from './element_menu.component';
+import { useEmbeddablesService } from '../../../services';
+
+export const ElementMenu: FC<Omit<Props, 'createNewEmbeddable'>> = (props) => {
+  const embeddablesService = useEmbeddablesService();
+  const stateTransferService = embeddablesService.getStateTransfer();
+  const { pathname, search } = useLocation();
+
+  const createNewEmbeddable = useCallback(() => {
+    const path = '#/';
+    const appId = 'lens';
+
+    if (trackCanvasUiMetric) {
+      trackCanvasUiMetric(METRIC_TYPE.CLICK, `${appId}:create`);
+    }
+
+    stateTransferService.navigateToEditor(appId, {
+      path,
+      state: {
+        originatingApp: CANVAS_APP,
+        originatingPath: `#/${pathname}${search}`,
+      },
+    });
+  }, [pathname, search, stateTransferService]);
+
+  return <Component {...props} createNewEmbeddable={createNewEmbeddable} />;
+};

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -122,7 +122,12 @@ export class CanvasPlugin
 
         const { pluginServices } = await import('./services');
         pluginServices.setRegistry(
-          pluginServiceRegistry.start({ coreStart, startPlugins, initContext: this.initContext })
+          pluginServiceRegistry.start({
+            coreStart,
+            startPlugins,
+            appUpdater: this.appUpdater,
+            initContext: this.initContext,
+          })
         );
 
         // Load application bundle

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -46,9 +46,11 @@ export const useWorkpad = (
           workpad.aliasId = aliasId;
         }
 
-        dispatch(setAssets(assets));
-        dispatch(setWorkpad(workpad, { loadPages }));
-        dispatch(setZoomScale(1));
+        if (storedWorkpad.id !== workpadId || storedWorkpad.aliasId !== aliasId) {
+          dispatch(setAssets(assets));
+          dispatch(setWorkpad(workpad, { loadPages }));
+          dispatch(setZoomScale(1));
+        }
 
         if (outcome === 'aliasMatch' && platformService.redirectLegacyUrl && aliasId) {
           platformService.redirectLegacyUrl(`#${getRedirectPath(aliasId)}`, getWorkpadLabel());
@@ -57,7 +59,17 @@ export const useWorkpad = (
         setError(e as Error | string);
       }
     })();
-  }, [workpadId, dispatch, setError, loadPages, workpadService, getRedirectPath, platformService]);
+  }, [
+    workpadId,
+    dispatch,
+    setError,
+    loadPages,
+    workpadService,
+    getRedirectPath,
+    platformService,
+    storedWorkpad.id,
+    storedWorkpad.aliasId,
+  ]);
 
   return [storedWorkpad.id === workpadId ? storedWorkpad : undefined, error];
 };

--- a/x-pack/plugins/canvas/public/services/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/embeddables.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { EmbeddableFactory } from '../../../../../src/plugins/embeddable/public';
+import {
+  EmbeddableFactory,
+  EmbeddableStateTransfer,
+} from '../../../../../src/plugins/embeddable/public';
 
 export interface CanvasEmbeddablesService {
   getEmbeddableFactories: () => IterableIterator<EmbeddableFactory>;
+  getStateTransfer: () => EmbeddableStateTransfer;
 }

--- a/x-pack/plugins/canvas/public/services/kibana/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/embeddables.ts
@@ -16,4 +16,5 @@ export type EmbeddablesServiceFactory = KibanaPluginServiceFactory<
 
 export const embeddablesServiceFactory: EmbeddablesServiceFactory = ({ startPlugins }) => ({
   getEmbeddableFactories: startPlugins.embeddable.getEmbeddableFactories,
+  getStateTransfer: startPlugins.embeddable.getStateTransfer,
 });

--- a/x-pack/plugins/canvas/public/services/stubs/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/embeddables.ts
@@ -14,4 +14,5 @@ const noop = (..._args: any[]): any => {};
 
 export const embeddablesServiceFactory: EmbeddablesServiceFactory = () => ({
   getEmbeddableFactories: noop,
+  getStateTransfer: noop,
 });

--- a/x-pack/plugins/canvas/types/embeddables.ts
+++ b/x-pack/plugins/canvas/types/embeddables.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TimeRange } from 'src/plugins/data/public';
+import { Filter } from '@kbn/es-query';
+import { EmbeddableInput as Input } from '../../../../src/plugins/embeddable/common/';
+
+export type EmbeddableInput = Input & {
+  timeRange?: TimeRange;
+  filters?: Filter[];
+  savedObjectId?: string;
+};

--- a/x-pack/plugins/canvas/types/index.ts
+++ b/x-pack/plugins/canvas/types/index.ts
@@ -9,6 +9,7 @@ export * from '../../../../src/plugins/expressions/common';
 export * from './assets';
 export * from './canvas';
 export * from './elements';
+export * from './embeddables';
 export * from './filters';
 export * from './functions';
 export * from './renderers';


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/108439.
Related to https://github.com/elastic/kibana/issues/81812.
~~Blocked by #104499.~~

This introduces the save and return flow for creating new by-value embeddables in Canvas and adds support for rendering by-value embeddables in the embeddable renderer.

Note: The Lens option in the `Add element` menu was only added temporarily for test. It'll be removed in a future PR that introduces a new menu for create new non-native visualizations in Canvas.

### Known issues to be addressed in future PRs
- ~~editing an embeddable and returning will add a new element instead of updating the existing one~~ fixed

### Outstanding bugs (will be addressed in separate PRs)
- [x] Save and return takes you to Canvas home instead of workpad you left #115118

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
