### PR TITLE
[7.x] [Reporting] Removed `any` from public (#110993)

### DIFF
--- a/x-pack/plugins/reporting/common/types.ts
+++ b/x-pack/plugins/reporting/common/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SerializableRecord } from '@kbn/utility-types';
+import type { Ensure, SerializableRecord } from '@kbn/utility-types';
 
 export interface PageSizeParams {
   pageMarginTop: number;
@@ -21,15 +21,21 @@ export interface PdfImageSize {
   height?: number;
 }
 
-export interface Size {
-  width: number;
-  height: number;
-}
+export type Size = Ensure<
+  {
+    width: number;
+    height: number;
+  },
+  SerializableRecord
+>;
 
-export interface LayoutParams {
-  id: string;
-  dimensions?: Size;
-}
+export type LayoutParams = Ensure<
+  {
+    id: string;
+    dimensions?: Size;
+  },
+  SerializableRecord
+>;
 
 export interface ReportDocumentHead {
   _id: string;
@@ -50,13 +56,16 @@ export interface TaskRunResult {
   warnings?: string[];
 }
 
-export interface BaseParams {
-  layout?: LayoutParams;
-  objectType: string;
-  title: string;
-  browserTimezone: string; // to format dates in the user's time zone
-  version: string; // to handle any state migrations
-}
+export type BaseParams = Ensure<
+  {
+    layout?: LayoutParams;
+    objectType: string;
+    title: string;
+    browserTimezone: string; // to format dates in the user's time zone
+    version: string; // to handle any state migrations
+  },
+  SerializableRecord
+>;
 
 // base params decorated with encrypted headers that come into runJob functions
 export interface BasePayload extends BaseParams {

--- a/x-pack/plugins/reporting/public/lib/license_check.test.ts
+++ b/x-pack/plugins/reporting/public/lib/license_check.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { LicenseCheck } from '../shared_imports';
 import { checkLicense } from './license_check';
 
 describe('License check', () => {
@@ -42,7 +43,7 @@ describe('License check', () => {
   });
 
   it('shows and enables links if state is not known', () => {
-    expect(checkLicense({ state: 'PONYFOO' } as any)).toEqual({
+    expect(checkLicense(({ state: 'PONYFOO' } as unknown) as LicenseCheck)).toEqual({
       enableLinks: true,
       showLinks: true,
       message: '',

--- a/x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts
+++ b/x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 import { stringify } from 'query-string';
-import rison, { RisonObject } from 'rison-node';
+import rison from 'rison-node';
+import type { HttpFetchQuery } from 'src/core/public';
 import { HttpSetup, IUiSettingsClient } from 'src/core/public';
 import {
   API_BASE_GENERATE,
@@ -45,7 +45,7 @@ interface IReportingAPI {
   // Helpers
   getReportURL(jobId: string): string;
   getReportingJobPath<T>(exportType: string, jobParams: BaseParams & T): string; // Return a URL to queue a job, with the job params encoded in the query string of the URL. Used for copying POST URL
-  createReportingJob(exportType: string, jobParams: any): Promise<Job>; // Sends a request to queue a job, with the job params in the POST body
+  createReportingJob<T>(exportType: string, jobParams: BaseParams & T): Promise<Job>; // Sends a request to queue a job, with the job params in the POST body
   getServerBasePath(): string; // Provides the raw server basePath to allow it to be stripped out from relativeUrls in job params
 
   // CRUD
@@ -93,7 +93,7 @@ export class ReportingAPIClient implements IReportingAPI {
   }
 
   public async list(page = 0, jobIds: string[] = []) {
-    const query = { page } as any;
+    const query: HttpFetchQuery = { page };
     if (jobIds.length > 0) {
       // Only getting the first 10, to prevent URL overflows
       query.ids = jobIds.slice(0, 10).join(',');
@@ -143,14 +143,14 @@ export class ReportingAPIClient implements IReportingAPI {
   }
 
   public getReportingJobPath(exportType: string, jobParams: BaseParams) {
-    const risonObject: RisonObject = jobParams as Record<string, any>;
-    const params = stringify({ jobParams: rison.encode(risonObject) });
+    const params = stringify({
+      jobParams: rison.encode(jobParams),
+    });
     return `${this.http.basePath.prepend(API_BASE_GENERATE)}/${exportType}?${params}`;
   }
 
   public async createReportingJob(exportType: string, jobParams: BaseParams) {
-    const risonObject: RisonObject = jobParams as Record<string, any>;
-    const jobParamsRison = rison.encode(risonObject);
+    const jobParamsRison = rison.encode(jobParams);
     const resp: { job: ReportApiJSON } = await this.http.post(
       `${API_BASE_GENERATE}/${exportType}`,
       {

--- a/x-pack/plugins/reporting/public/management/__snapshots__/report_listing.test.tsx.snap
+++ b/x-pack/plugins/reporting/public/management/__snapshots__/report_listing.test.tsx.snap
@@ -693,9 +693,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -894,9 +916,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -1095,9 +1139,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -1707,9 +1773,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -1908,9 +1996,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -2109,9 +2219,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -2703,9 +2835,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -2951,9 +3105,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -3152,9 +3328,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -3768,9 +3966,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -4018,9 +4238,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -4221,9 +4463,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -4817,9 +5081,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -5065,9 +5351,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -5266,9 +5574,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -5860,9 +6190,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -6108,9 +6460,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -6309,9 +6683,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -6903,9 +7299,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -7151,9 +7569,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -7352,9 +7792,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -7983,9 +8445,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -8231,9 +8715,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -8432,9 +8938,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={
@@ -9063,9 +9591,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <ReportDownloadButton
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -9311,9 +9861,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                               <InjectIntl(ReportInfoButtonUi)
                                 apiClient={
                                   Object {
-                                    "list": [Function],
+                                    "list": [MockFunction] {
+                                      "calls": Array [
+                                        Array [
+                                          0,
+                                        ],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                     "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                    "total": [Function],
+                                    "total": [MockFunction] {
+                                      "calls": Array [
+                                        Array [],
+                                      ],
+                                      "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": Promise {},
+                                        },
+                                      ],
+                                    },
                                   }
                                 }
                                 capabilities={
@@ -9512,9 +10084,31 @@ exports[`ReportListing Report job listing with some items 1`] = `
                                 <ReportInfoButtonUi
                                   apiClient={
                                     Object {
-                                      "list": [Function],
+                                      "list": [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            0,
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                       "migrateReportingIndicesIlmPolicy": [MockFunction],
-                                      "total": [Function],
+                                      "total": [MockFunction] {
+                                        "calls": Array [
+                                          Array [],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": Promise {},
+                                          },
+                                        ],
+                                      },
                                     }
                                   }
                                   capabilities={

--- a/x-pack/plugins/reporting/public/management/report_listing.test.tsx
+++ b/x-pack/plugins/reporting/public/management/report_listing.test.tsx
@@ -6,10 +6,12 @@
  */
 
 import { registerTestBed } from '@kbn/test/jest';
-import { UnwrapPromise } from '@kbn/utility-types';
+import type { SerializableRecord, UnwrapPromise } from '@kbn/utility-types';
+import type { DeeplyMockedKeys } from '@kbn/utility-types/jest';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { ListingProps as Props, ReportListing } from '.';
 import type { NotificationsSetup } from '../../../../../src/core/public';
 import {
   applicationServiceMock,
@@ -18,12 +20,11 @@ import {
 } from '../../../../../src/core/public/mocks';
 import type { LocatorPublic, SharePluginSetup } from '../../../../../src/plugins/share/public';
 import type { ILicense } from '../../../licensing/public';
-import { IlmPolicyMigrationStatus, ReportApiJSON } from '../../common/types';
+import type { IlmPolicyMigrationStatus, ReportApiJSON } from '../../common/types';
 import { IlmPolicyStatusContextProvider } from '../lib/ilm_policy_status_context';
 import { Job } from '../lib/job';
 import { InternalApiClientProvider, ReportingAPIClient } from '../lib/reporting_api_client';
 import { KibanaContextProvider } from '../shared_imports';
-import { ListingProps as Props, ReportListing } from '.';
 
 jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => {
   return {
@@ -206,11 +207,11 @@ const mockJobs: ReportApiJSON[] = [
   }),
 ];
 
-const reportingAPIClient = {
-  list: () => Promise.resolve(mockJobs.map((j) => new Job(j))),
-  total: () => Promise.resolve(18),
+const reportingAPIClient = ({
+  list: jest.fn(() => Promise.resolve(mockJobs.map((j) => new Job(j)))),
+  total: jest.fn(() => Promise.resolve(18)),
   migrateReportingIndicesIlmPolicy: jest.fn(),
-} as any;
+} as unknown) as DeeplyMockedKeys<ReportingAPIClient>;
 
 const validCheck = {
   check: () => ({
@@ -220,8 +221,8 @@ const validCheck = {
 };
 
 const license$ = {
-  subscribe: (handler: any) => {
-    return handler(validCheck);
+  subscribe: (handler: unknown) => {
+    return (handler as Function)(validCheck);
   },
 } as Observable<ILicense>;
 
@@ -239,7 +240,7 @@ const mockPollConfig = {
 describe('ReportListing', () => {
   let httpService: ReturnType<typeof httpServiceMock.createSetupContract>;
   let applicationService: ReturnType<typeof applicationServiceMock.createStartContract>;
-  let ilmLocator: undefined | LocatorPublic<any>;
+  let ilmLocator: undefined | LocatorPublic<SerializableRecord>;
   let urlService: SharePluginSetup['url'];
   let testBed: UnwrapPromise<ReturnType<typeof setup>>;
   let toasts: NotificationsSetup['toasts'];
@@ -303,7 +304,7 @@ describe('ReportListing', () => {
     };
     ilmLocator = ({
       getUrl: jest.fn(),
-    } as unknown) as LocatorPublic<any>;
+    } as unknown) as LocatorPublic<SerializableRecord>;
 
     urlService = ({
       locators: {
@@ -325,11 +326,11 @@ describe('ReportListing', () => {
 
   it('subscribes to license changes, and unsubscribes on dismount', async () => {
     const unsubscribeMock = jest.fn();
-    const subMock = {
+    const subMock = ({
       subscribe: jest.fn().mockReturnValue({
         unsubscribe: unsubscribeMock,
       }),
-    } as any;
+    } as unknown) as Observable<ILicense>;
 
     await runSetup({ license$: subMock });
 
@@ -344,7 +345,7 @@ describe('ReportListing', () => {
       httpService = httpServiceMock.createSetupContract();
       ilmLocator = ({
         getUrl: jest.fn(),
-      } as unknown) as LocatorPublic<any>;
+      } as unknown) as LocatorPublic<SerializableRecord>;
 
       urlService = ({
         locators: {

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -8,9 +8,12 @@
 import * as Rx from 'rxjs';
 import { first } from 'rxjs/operators';
 import { CoreStart } from 'src/core/public';
+import type { SearchSource } from 'src/plugins/data/common';
+import type { SavedSearch } from 'src/plugins/discover/public';
 import { coreMock } from '../../../../../src/core/public/mocks';
-import { LicensingPluginSetup } from '../../../licensing/public';
+import type { ILicense, LicensingPluginSetup } from '../../../licensing/public';
 import { ReportingAPIClient } from '../lib/reporting_api_client';
+import type { ActionContext } from './get_csv_panel_action';
 import { ReportingCsvPanelAction } from './get_csv_panel_action';
 
 type LicenseResults = 'valid' | 'invalid' | 'unavailable' | 'expired';
@@ -19,9 +22,9 @@ const core = coreMock.createSetup();
 let apiClient: ReportingAPIClient;
 
 describe('GetCsvReportPanelAction', () => {
-  let context: any;
-  let mockLicense$: any;
-  let mockSearchSource: any;
+  let context: ActionContext;
+  let mockLicense$: (state?: LicenseResults) => Rx.Observable<ILicense>;
+  let mockSearchSource: SearchSource;
   let mockStartServicesPayload: [CoreStart, object, unknown];
   let mockStartServices$: Rx.Subject<typeof mockStartServicesPayload>;
 
@@ -54,15 +57,15 @@ describe('GetCsvReportPanelAction', () => {
       null,
     ];
 
-    mockSearchSource = {
+    mockSearchSource = ({
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
       getField: jest.fn(),
       getSerializedFields: jest.fn().mockImplementation(() => ({})),
-    };
+    } as unknown) as SearchSource;
 
-    context = {
+    context = ({
       embeddable: {
         type: 'search',
         getSavedSearch: () => {
@@ -78,7 +81,7 @@ describe('GetCsvReportPanelAction', () => {
           },
         }),
       },
-    } as any;
+    } as unknown) as ActionContext;
   });
 
   it('translates empty embeddable context into job params', async () => {
@@ -105,18 +108,18 @@ describe('GetCsvReportPanelAction', () => {
   });
 
   it('translates embeddable context into job params', async () => {
-    mockSearchSource = {
+    mockSearchSource = ({
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
       getField: jest.fn(),
       getSerializedFields: jest.fn().mockImplementation(() => ({ testData: 'testDataValue' })),
-    };
+    } as unknown) as SearchSource;
     context.embeddable.getSavedSearch = () => {
-      return {
+      return ({
         searchSource: mockSearchSource,
         columns: ['column_a', 'column_b'],
-      };
+      } as unknown) as SavedSearch;
     };
 
     const panel = new ReportingCsvPanelAction({

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.tsx
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.tsx
@@ -29,7 +29,7 @@ function isSavedSearchEmbeddable(
   return embeddable.type === SEARCH_EMBEDDABLE_TYPE;
 }
 
-interface ActionContext {
+export interface ActionContext {
   embeddable: ISearchEmbeddable;
 }
 

--- a/x-pack/plugins/reporting/public/share_context_menu/reporting_panel_content.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/reporting_panel_content.tsx
@@ -18,7 +18,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@kbn/i18n/react';
 import React, { Component, ReactElement } from 'react';
-import { ToastsSetup, IUiSettingsClient } from 'src/core/public';
+import { IUiSettingsClient, ToastsSetup } from 'src/core/public';
 import url from 'url';
 import { toMountPoint } from '../../../../../src/plugins/kibana_react/public';
 import {
@@ -41,7 +41,7 @@ export interface ReportingPanelProps {
   layoutId?: string;
   objectId?: string;
   getJobParams: () => Omit<BaseParams, 'browserTimezone' | 'version'>;
-  options?: ReactElement<any> | null;
+  options?: ReactElement | null;
   isDirty?: boolean;
   onClose?: () => void;
 }
@@ -277,7 +277,7 @@ class ReportingPanelContentUi extends Component<Props, State> {
           this.props.onClose();
         }
       })
-      .catch((error: any) => {
+      .catch((error) => {
         this.props.toasts.addError(error, {
           title: intl.formatMessage({
             id: 'xpack.reporting.panelContent.notification.reportingErrorTitle',

--- a/x-pack/plugins/reporting/public/shared_imports.ts
+++ b/x-pack/plugins/reporting/public/shared_imports.ts
@@ -5,18 +5,14 @@
  * 2.0.
  */
 
-export type {
-  SharePluginSetup,
-  SharePluginStart,
-  LocatorPublic,
-} from '../../../../src/plugins/share/public';
+export type { SharePluginSetup, SharePluginStart, LocatorPublic } from 'src/plugins/share/public';
 
 export { useRequest, UseRequestResponse } from '../../../../src/plugins/es_ui_shared/public';
 
 export { KibanaContextProvider } from '../../../../src/plugins/kibana_react/public';
 
 import { useKibana as _useKibana } from '../../../../src/plugins/kibana_react/public';
-import { KibanaContext } from './types';
+import type { KibanaContext } from './types';
 export const useKibana = () => _useKibana<KibanaContext>();
 
 export type { SerializableRecord } from '@kbn/utility-types';
@@ -24,3 +20,5 @@ export type { SerializableRecord } from '@kbn/utility-types';
 export type { UiActionsSetup, UiActionsStart } from 'src/plugins/ui_actions/public';
 
 export type { ManagementAppMountParams } from 'src/plugins/management/public';
+
+export type { LicenseCheck } from '../../licensing/public';


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Reporting] Removed `any` from public (#110993)