### PR TITLE
[docs/docker] Include server.shutdownTimeout in default configuration

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -145,6 +145,7 @@ images:
 
 [horizontal]
 `server.host`:: `"0.0.0.0"`
+`server.shutdownTimeout`:: `"5s"`
 `elasticsearch.hosts`:: `http://elasticsearch:9200`
 `monitoring.ui.container.elasticsearch.enabled`:: `true`
 


### PR DESCRIPTION
Updates our Docker documentation describing default settings with `server.shutdownTimeout`.  This was setting was added in 7.14.0 with https://github.com/elastic/kibana/pull/100494.  