### PR TITLE
[Draft] [7.x] Added support for 7.x for the event log client to search across legacy IDs (#109365)

### DIFF
--- a/x-pack/plugins/event_log/server/es/cluster_client_adapter.test.ts
+++ b/x-pack/plugins/event_log/server/es/cluster_client_adapter.test.ts
@@ -31,6 +31,7 @@ beforeEach(() => {
     logger,
     elasticsearchClientPromise: Promise.resolve(clusterClient),
     wait: () => Promise.resolve(true),
+    kibanaVersion: '8.0.0'
   });
 });
 

--- a/x-pack/plugins/event_log/server/es/cluster_client_adapter.test.ts
+++ b/x-pack/plugins/event_log/server/es/cluster_client_adapter.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
     logger,
     elasticsearchClientPromise: Promise.resolve(clusterClient),
     wait: () => Promise.resolve(true),
-    kibanaVersion: '8.0.0'
+    kibanaVersion: '8.0.0',
   });
 });
 

--- a/x-pack/plugins/event_log/server/es/context.ts
+++ b/x-pack/plugins/event_log/server/es/context.ts
@@ -54,6 +54,7 @@ class EsContextImpl implements EsContext {
       logger: params.logger,
       elasticsearchClientPromise: params.elasticsearchClientPromise,
       wait: () => this.readySignal.wait(),
+      kibanaVersion: params.kibanaVersion,
     });
   }
 


### PR DESCRIPTION
… 
## Summary

Fixed support for backporting Event log legacy ids search in 7.x Kibana versions