### PR TITLE
[RAC][Security Solution] [Timeline] Use correct z-index for timeline global footer

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -42,7 +42,6 @@ const StyledKibanaPageTemplate = styled(KibanaPageTemplate)<{
     transform: ${(
       { $isShowingTimelineOverlay } // Since the bottom bar wraps the whole overlay now, need to override any transforms when it is open
     ) => ($isShowingTimelineOverlay ? 'none' : 'translateY(calc(100% - 50px))')};
-    z-index: ${({ theme }) => theme.eui.euiZLevel8};
 
     .${IS_DRAGGING_CLASS_NAME} & {
       // When a drag is in process the bottom flyout should slide up to allow a drop


### PR DESCRIPTION
## Summary

Resolves #109427

I believe that the z-index for this footer was only ever overridden due to a bug in eui with EuiBottomBar, and using the default z-index of 1000-3 results in the data grid pagination being usable full screen, and all other modals, flyouts and callouts in the security solution still work as before with proper z-index.
Datagrid:
![image](https://user-images.githubusercontent.com/56408403/132452674-0883b1d9-d67e-4ffd-9066-65de0fc35c01.png)
Create new case:
![image](https://user-images.githubusercontent.com/56408403/132452693-66ac9b9b-1c30-4d01-b57e-5cf0eea15a13.png)
Alert detail:
![image](https://user-images.githubusercontent.com/56408403/132452720-8f885687-efc1-4b8b-8c67-e4594c48a370.png)
Alert detail w/add to case modal
![image](https://user-images.githubusercontent.com/56408403/132452771-2b40d588-99e0-4a2c-af8d-d8f0fbb01a5a.png)
Cases callout:
![image](https://user-images.githubusercontent.com/56408403/132452797-7f8e9602-7302-409e-9d28-ad97b8cb8963.png)




- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


