### PR TITLE
Improve xpack.security.enabled deprecation warning

### DIFF
--- a/x-pack/plugins/security/server/config_deprecations.test.ts
+++ b/x-pack/plugins/security/server/config_deprecations.test.ts
@@ -342,7 +342,7 @@ describe('Config Deprecations', () => {
     expect(migrated).toEqual(config);
     expect(messages).toMatchInlineSnapshot(`
       Array [
-        "Disabling the security plugin \\"xpack.security.enabled\\" will only be supported by disable security in Elasticsearch.",
+        "Enabling or disabling the security plugin from Kibana using xpack.security.enabled is deprecated. This should instead be controlled by Elasticsearch.",
       ]
     `);
   });

--- a/x-pack/plugins/security/server/config_deprecations.ts
+++ b/x-pack/plugins/security/server/config_deprecations.ts
@@ -139,16 +139,18 @@ export const securityConfigDeprecationProvider: ConfigDeprecationProvider = ({
     if (settings?.xpack?.security?.enabled === false) {
       addDeprecation({
         title: i18n.translate('xpack.security.deprecations.enabledTitle', {
-          defaultMessage: 'Disabling the security plugin "xpack.security.enabled" is deprecated',
+          defaultMessage: 'Setting xpack.security.enabled is deprecated',
         }),
         message: i18n.translate('xpack.security.deprecations.enabledMessage', {
           defaultMessage:
-            'Disabling the security plugin "xpack.security.enabled" will only be supported by disable security in Elasticsearch.',
+            'Enabling or disabling the security plugin from Kibana using xpack.security.enabled is deprecated. This should instead be controlled by Elasticsearch.',
         }),
+        documentationUrl:
+          'https://www.elastic.co/guide/en/kibana/current/security-settings-kb.html#general-security-settings',
         correctiveActions: {
           manualSteps: [
             i18n.translate('xpack.security.deprecations.enabled.manualStepOneMessage', {
-              defaultMessage: `Remove "xpack.security.enabled" from your Kibana configuration.`,
+              defaultMessage: `Remove xpack.security.enabled from your Kibana configuration.`,
             }),
             i18n.translate('xpack.security.deprecations.enabled.manualStepTwoMessage', {
               defaultMessage: `To turn off security features, disable them in Elasticsearch instead.`,


### PR DESCRIPTION
Updated the deprecation warning for `xpack.security.enabled` based on the new guidelines.

Screenshot of new deprecation warning inside of the Upgrade Assistant:

![image](https://user-images.githubusercontent.com/10602/132482805-2f62e657-a954-42d6-9e23-627d7e2de966.png)

Closes #54023