### PR TITLE
[Security Solution][Endpoint] Do not validate TA creation form with soft errors when required name field is empty

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.test.tsx
@@ -110,6 +110,9 @@ describe('When using the Trusted App Form', () => {
   const getAllValidationErrors = (): HTMLElement[] => {
     return Array.from(renderResult.container.querySelectorAll('.euiFormErrorText'));
   };
+  const getAllValidationWarnings = (): HTMLElement[] => {
+    return Array.from(renderResult.container.querySelectorAll('.euiFormHelpText'));
+  };
 
   beforeEach(() => {
     resetHTMLElementOffsetWidth = forceHTMLElementOffsetWidth();
@@ -406,6 +409,49 @@ describe('When using the Trusted App Form', () => {
               operator: 'included',
               type: 'match',
               value: 'e50fb1a0e5fff590ece385082edc6c41',
+            },
+          ],
+        },
+      });
+    });
+
+    it('should not validate form to true if name input is empty', () => {
+      const props = {
+        name: 'some name',
+        description: '',
+        effectScope: {
+          type: 'global',
+        },
+        os: OperatingSystem.WINDOWS,
+        entries: [
+          { field: ConditionEntryField.PATH, operator: 'included', type: 'wildcard', value: 'x' },
+        ],
+      } as NewTrustedApp;
+
+      formProps.trustedApp = props;
+      render();
+
+      formProps.trustedApp = {
+        ...props,
+        name: '',
+      };
+      rerender();
+
+      expect(getAllValidationErrors()).toHaveLength(0);
+      expect(getAllValidationWarnings()).toHaveLength(1);
+      expect(formProps.onChange).toHaveBeenLastCalledWith({
+        isValid: false,
+        item: {
+          name: '',
+          description: '',
+          os: OperatingSystem.WINDOWS,
+          effectScope: { type: 'global' },
+          entries: [
+            {
+              field: ConditionEntryField.PATH,
+              operator: 'included',
+              type: 'wildcard',
+              value: 'x',
             },
           ],
         },

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.test.tsx
@@ -195,7 +195,7 @@ describe('When using the Trusted App Form', () => {
       expect(getConditionRemoveButton(defaultCondition).disabled).toBe(true);
     });
 
-    it('should display 2 options for Field', () => {
+    it('should display 3 options for Field for Windows', () => {
       const conditionFieldSelect = getConditionFieldSelect(getCondition());
       reactTestingLibrary.act(() => {
         fireEvent.click(conditionFieldSelect, { button: 1 });
@@ -205,6 +205,7 @@ describe('When using the Trusted App Form', () => {
           '.euiSuperSelect__listbox button.euiSuperSelect__item'
         )
       ).map((button) => button.textContent);
+      expect(options.length).toEqual(3);
       expect(options).toEqual([
         'Hashmd5, sha1, or sha256',
         'PathThe full path of the application',

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
@@ -161,8 +161,12 @@ const validateFormValues = (values: MaybeImmutable<NewTrustedApp>): ValidationRe
       } else if (
         !isPathValid({ os: values.os, field: entry.field, type: entry.type, value: entry.value })
       ) {
-        // show soft warnings and thus allow entry
-        isValid = true;
+        if (!values.name.trim()) {
+          isValid = false;
+        } else {
+          // show soft warnings and thus allow entry
+          isValid = true;
+        }
         addResultToValidation(
           validation,
           'entries',

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/create_trusted_app_form.tsx
@@ -161,12 +161,6 @@ const validateFormValues = (values: MaybeImmutable<NewTrustedApp>): ValidationRe
       } else if (
         !isPathValid({ os: values.os, field: entry.field, type: entry.type, value: entry.value })
       ) {
-        if (!values.name.trim()) {
-          isValid = false;
-        } else {
-          // show soft warnings and thus allow entry
-          isValid = true;
-        }
         addResultToValidation(
           validation,
           'entries',


### PR DESCRIPTION
## Summary

Fixes a bug when the **Path** field input values result in soft warnings and not errors. This ends up as validating the form even though the required **Name** field is empty.

**Screenshot**
![ta-create-form](https://user-images.githubusercontent.com/1849116/132487065-5945034e-a67b-44ee-bc53-6d084d918cc8.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)