### PR TITLE
[7.x] Fix flaky migrations tests (#111365)

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes.test.ts
@@ -67,6 +67,8 @@ describe('migration v2', () => {
     await root.setup();
     await expect(root.start()).resolves.toBeTruthy();
 
+    // After plugins start, some saved objects are deleted/recreated, so we
+    // wait a bit for the count to settle.
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
     const esClient: ElasticsearchClient = esServer.es.getClient();

--- a/src/core/server/saved_objects/migrationsv2/test_helpers/retry.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/test_helpers/retry.test.ts
@@ -8,8 +8,7 @@
 
 import { retryAsync } from './retry_async';
 
-// FLAKY: https://github.com/elastic/kibana/issues/110970
-describe.skip('retry', () => {
+describe('retry', () => {
   it('retries throwing functions until they succeed', async () => {
     let i = 0;
     await expect(
@@ -53,6 +52,8 @@ describe.skip('retry', () => {
       },
       { retryAttempts: 3, retryDelayMs: 100 }
     );
-    expect(Date.now() - now).toBeGreaterThanOrEqual(200);
+    // Would expect it to take 200ms but seems like timing inaccuracies
+    // sometimes causes the duration to be measured as 199ms
+    expect(Date.now() - now).toBeGreaterThanOrEqual(199);
   });
 });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix flaky migrations tests (#111365)