### PR TITLE
[7.15] Fix flaky migrations tests (#111365)

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/test_helpers/retry.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/test_helpers/retry.test.ts
@@ -52,6 +52,8 @@ describe('retry', () => {
       },
       { retryAttempts: 3, retryDelayMs: 100 }
     );
-    expect(Date.now() - now).toBeGreaterThanOrEqual(200);
+    // Would expect it to take 200ms but seems like timing inaccuracies
+    // sometimes causes the duration to be measured as 199ms
+    expect(Date.now() - now).toBeGreaterThanOrEqual(199);
   });
 });


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Fix flaky migrations tests (#111365)