### PR TITLE
[ML] Fix "Exclude jobs or groups" control

### DIFF
--- a/x-pack/plugins/ml/public/alerting/jobs_health_rule/anomaly_detection_jobs_health_rule_trigger.tsx
+++ b/x-pack/plugins/ml/public/alerting/jobs_health_rule/anomaly_detection_jobs_health_rule_trigger.tsx
@@ -20,6 +20,7 @@ import { TestsSelectionControl } from './tests_selection_control';
 import { isPopulatedObject } from '../../../common';
 import { ALL_JOBS_SELECTION } from '../../../common/constants/alerts';
 import { BetaBadge } from '../beta_badge';
+import { isDefined } from '../../../common/types/guards';
 
 export type MlAnomalyAlertTriggerProps = AlertTypeParamsExpressionProps<MlAnomalyDetectionJobsHealthRuleParams>;
 
@@ -78,6 +79,19 @@ const AnomalyDetectionJobsHealthRuleTrigger: FC<MlAnomalyAlertTriggerProps> = ({
                 defaultMessage: 'Jobs',
               }),
               options: jobs.map((v) => ({ label: v.job_id })),
+            },
+            {
+              label: i18n.translate('xpack.ml.jobSelector.groupOptionsLabel', {
+                defaultMessage: 'Groups',
+              }),
+              options: [
+                ...new Set(
+                  jobs
+                    .map((v) => v.groups)
+                    .flat()
+                    .filter((v) => isDefined(v) && !alertParams.includeJobs.groupIds?.includes(v))
+                ),
+              ].map((v) => ({ label: v! })),
             },
           ]);
         });


### PR DESCRIPTION
## Summary

Fixed group selection for the exclude control for the Anomaly detection jobs health rule type, allowing groups to be added to the list of excludes.

![image](https://user-images.githubusercontent.com/5236598/132513636-0b3bad8c-08a7-48c8-9b67-5e7084eb1bfa.png)
