### PR TITLE
[ML] Functional tests - omit node_name in job message assertions

### DIFF
--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/clear_messages.ts
@@ -65,11 +65,10 @@ export default ({ getService }: FtrProviderContext) => {
 
       expect(getBody.messages.length).to.eql(1);
 
-      expect(omit(getBody.messages[0], 'timestamp')).to.eql({
+      expect(omit(getBody.messages[0], ['timestamp', 'node_name'])).to.eql({
         job_id: 'test_get_job_audit_messages_1',
         message: 'Job created',
         level: 'info',
-        node_name: 'node-01',
         job_type: 'anomaly_detector',
         cleared: true,
       });

--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
@@ -42,18 +42,16 @@ export default ({ getService }: FtrProviderContext) => {
 
       const messagesDict = keyBy(body.messages, 'job_id');
 
-      expect(omit(messagesDict.test_get_job_audit_messages_2, 'timestamp')).to.eql({
+      expect(omit(messagesDict.test_get_job_audit_messages_2, ['timestamp', 'node_name'])).to.eql({
         job_id: 'test_get_job_audit_messages_2',
         message: 'Job created',
         level: 'info',
-        node_name: 'node-01',
         job_type: 'anomaly_detector',
       });
-      expect(omit(messagesDict.test_get_job_audit_messages_1, 'timestamp')).to.eql({
+      expect(omit(messagesDict.test_get_job_audit_messages_1, ['timestamp', 'node_name'])).to.eql({
         job_id: 'test_get_job_audit_messages_1',
         message: 'Job created',
         level: 'info',
-        node_name: 'node-01',
         job_type: 'anomaly_detector',
       });
       expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
@@ -67,11 +65,10 @@ export default ({ getService }: FtrProviderContext) => {
         .expect(200);
 
       expect(body.messages.length).to.eql(1);
-      expect(omit(body.messages[0], 'timestamp')).to.eql({
+      expect(omit(body.messages[0], ['timestamp', 'node_name'])).to.eql({
         job_id: 'test_get_job_audit_messages_1',
         message: 'Job created',
         level: 'info',
-        node_name: 'node-01',
         job_type: 'anomaly_detector',
       });
       expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
@@ -85,11 +82,10 @@ export default ({ getService }: FtrProviderContext) => {
         .expect(200);
 
       expect(body.messages.length).to.eql(1);
-      expect(omit(body.messages[0], 'timestamp')).to.eql({
+      expect(omit(body.messages[0], ['timestamp', 'node_name'])).to.eql({
         job_id: 'test_get_job_audit_messages_1',
         message: 'Job created',
         level: 'info',
-        node_name: 'node-01',
         job_type: 'anomaly_detector',
       });
       expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);


### PR DESCRIPTION
## Summary

This PR removes the `node_name` from job audit message assertions as it can vary depending on test environments, particularly in cloud.
