### PR TITLE
Share history package via shared deps

### DIFF
--- a/packages/kbn-ui-shared-deps/src/entry.js
+++ b/packages/kbn-ui-shared-deps/src/entry.js
@@ -55,3 +55,4 @@ export const KbnAnalytics = require('@kbn/analytics');
 export const KbnStd = require('@kbn/std');
 export const SaferLodashSet = require('@elastic/safer-lodash-set');
 export const RisonNode = require('rison-node');
+export const History = require('history');

--- a/packages/kbn-ui-shared-deps/src/index.js
+++ b/packages/kbn-ui-shared-deps/src/index.js
@@ -100,6 +100,7 @@ exports.externals = {
   '@kbn/std': '__kbnSharedDeps__.KbnStd',
   '@elastic/safer-lodash-set': '__kbnSharedDeps__.SaferLodashSet',
   'rison-node': '__kbnSharedDeps__.RisonNode',
+  history: '__kbnSharedDeps__.History',
 };
 
 /**


### PR DESCRIPTION
## Summary

Make the `history` package a shared dep. Since our central core routing logic is based on it a lot of plugins need to import it. It's not such a big win as I hoped for, but it's still a couple of kilobytes of the page load bundle size (and a couple of more of the async chunks), thus I think it might still be worth it.

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~
