### PR TITLE
[config] Deprecate `KIBANA_PATH_CONF` in favor of `KBN_PATH_CONF`

### DIFF
--- a/packages/kbn-utils/src/path/index.ts
+++ b/packages/kbn-utils/src/path/index.ts
@@ -15,7 +15,7 @@ const isString = (v: any): v is string => typeof v === 'string';
 
 const CONFIG_PATHS = [
   process.env.KBN_PATH_CONF && join(process.env.KBN_PATH_CONF, 'kibana.yml'),
-  process.env.KIBANA_PATH_CONF && join(process.env.KIBANA_PATH_CONF, 'kibana.yml'),
+  process.env.KIBANA_PATH_CONF && join(process.env.KIBANA_PATH_CONF, 'kibana.yml'), // deprecated
   process.env.CONFIG_PATH, // deprecated
   join(REPO_ROOT, 'config/kibana.yml'),
   '/etc/kibana/kibana.yml',
@@ -23,7 +23,7 @@ const CONFIG_PATHS = [
 
 const CONFIG_DIRECTORIES = [
   process.env.KBN_PATH_CONF,
-  process.env.KIBANA_PATH_CONF,
+  process.env.KIBANA_PATH_CONF, // deprecated
   join(REPO_ROOT, 'config'),
   '/etc/kibana',
 ].filter(isString);

--- a/src/core/server/config/deprecation/core_deprecations.test.ts
+++ b/src/core/server/config/deprecation/core_deprecations.test.ts
@@ -36,6 +36,24 @@ describe('core deprecations', () => {
     });
   });
 
+  describe('kibanaPathConf', () => {
+    it('logs a warning if KIBANA_PATH_CONF environ variable is set', () => {
+      process.env.KIBANA_PATH_CONF = 'somepath';
+      const { messages } = applyCoreDeprecations();
+      expect(messages).toMatchInlineSnapshot(`
+        Array [
+          "Environment variable \\"KIBANA_PATH_CONF\\" is deprecated. It has been replaced with \\"KBN_PATH_CONF\\" pointing to a config folder",
+        ]
+      `);
+    });
+
+    it('does not log a warning if KIBANA_PATH_CONF environ variable is unset', () => {
+      delete process.env.KIBANA_PATH_CONF;
+      const { messages } = applyCoreDeprecations();
+      expect(messages).toHaveLength(0);
+    });
+  });
+
   describe('dataPath', () => {
     it('logs a warning if DATA_PATH environ variable is set', () => {
       process.env.DATA_PATH = 'somepath';

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -8,6 +8,19 @@
 
 import { ConfigDeprecationProvider, ConfigDeprecation } from '@kbn/config';
 
+const kibanaPathConf: ConfigDeprecation = (settings, fromPath, addDeprecation) => {
+  if (process.env?.KIBANA_PATH_CONF) {
+    addDeprecation({
+      message: `Environment variable "KIBANA_PATH_CONF" is deprecated. It has been replaced with "KBN_PATH_CONF" pointing to a config folder`,
+      correctiveActions: {
+        manualSteps: [
+          'Use "KBN_PATH_CONF" instead of "KIBANA_PATH_CONF" to point to a config folder.',
+        ],
+      },
+    });
+  }
+};
+
 const configPathDeprecation: ConfigDeprecation = (settings, fromPath, addDeprecation) => {
   if (process.env?.CONFIG_PATH) {
     addDeprecation({
@@ -415,6 +428,7 @@ export const coreDeprecationProvider: ConfigDeprecationProvider = ({ rename, unu
   rename('server.xsrf.whitelist', 'server.xsrf.allowlist'),
   rewriteCorsSettings,
   configPathDeprecation,
+  kibanaPathConf,
   dataPathDeprecation,
   rewriteBasePathDeprecation,
   cspRulesDeprecation,


### PR DESCRIPTION
This setting was used for setting the config folder path around ~7.8 but mostly left undocumented.  `KBN_PATH_CONF` was introduced in documentation in 7.12 and should be the way to configure this folder going forward.

Release note
Deprecates environment variable `KIBANA_PATH_CONF` in favor of `KBN_PATH_CONF`.  Behavior remains the same. 