### PR TITLE
[CI] Disable running ES Snapshots pipelines in Jenkins for everything above 6.8

### DIFF
--- a/.ci/es-snapshots/Jenkinsfile_trigger_build_es
+++ b/.ci/es-snapshots/Jenkinsfile_trigger_build_es
@@ -1,5 +1,8 @@
 #!/bin/groovy
 
+// Disable this pipeline, as it is now in Buildkite. Revert to re-enable.
+return
+
 if (!params.branches_yaml) {
   error "'branches_yaml' parameter must be specified"
 }

--- a/.ci/es-snapshots/Jenkinsfile_trigger_build_es
+++ b/.ci/es-snapshots/Jenkinsfile_trigger_build_es
@@ -1,13 +1,7 @@
 #!/bin/groovy
 
-// Disable this pipeline, as it is now in Buildkite. Revert to re-enable.
-return
-
-if (!params.branches_yaml) {
-  error "'branches_yaml' parameter must be specified"
-}
-
-def branches = readYaml text: params.branches_yaml
+// Only run this pipeline for 6.8. Higher branches are now running in Buildkite.
+def branches = ['6.8']
 
 branches.each { branch ->
   build(


### PR DESCRIPTION
They are now running in Buildkite, after #100843

Reverting this PR/commit will re-enable automatically triggering the pipeline. The build/verify jobs in Jenkins can still be run manually, if there ends up being a problem with Buildkite.