### PR TITLE
Fix extra white space on the alert table when page size is 50 or 100

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/body/height_hack.ts
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/height_hack.ts
@@ -7,9 +7,6 @@
 
 import { useState, useLayoutEffect } from 'react';
 
-// That could be different from security and observability. Get it as parameter?
-const INITIAL_DATA_GRID_HEIGHT = 967;
-
 // It will recalculate DataGrid height after this time interval.
 const TIME_INTERVAL = 50;
 
@@ -18,7 +15,16 @@ const TIME_INTERVAL = 50;
  * 3 (three) is a number, numeral and digit. It is the natural number following 2 and preceding 4, and is the smallest
  * odd prime number and the only prime preceding a square number. It has religious or cultural significance in many societies.
  */
+
 const MAGIC_GAP = 3;
+
+// Hard coded height for every page size
+const DATA_GRID_HEIGHT_BY_PAGE_SIZE: { [key: number]: number } = {
+  10: 457,
+  25: 967,
+  50: 1817,
+  100: 3517,
+};
 
 /**
  * HUGE HACK!!!
@@ -30,13 +36,15 @@ const MAGIC_GAP = 3;
  * Please delete me and allow DataGrid to calculate its height when the bug is fixed.
  */
 export const useDataGridHeightHack = (pageSize: number, rowCount: number) => {
-  const [height, setHeight] = useState(INITIAL_DATA_GRID_HEIGHT);
+  const [height, setHeight] = useState(DATA_GRID_HEIGHT_BY_PAGE_SIZE[pageSize]);
 
   useLayoutEffect(() => {
     setTimeout(() => {
       const gridVirtualized = document.querySelector('#body-data-grid .euiDataGrid__virtualized');
 
-      if (
+      if (rowCount === pageSize) {
+        setHeight(DATA_GRID_HEIGHT_BY_PAGE_SIZE[pageSize]);
+      } else if (
         gridVirtualized &&
         gridVirtualized.children[0].clientHeight !== gridVirtualized.clientHeight // check if it has vertical scroll
       ) {


### PR DESCRIPTION
## Summary

When selecting 50 or 100 items per page the table has some extra white space.

<img width="1492" alt="Screenshot 2021-09-08 at 17 41 38" src="https://user-images.githubusercontent.com/1490444/132542141-812f82c8-16e1-4577-a67d-ee93835b76e8.png">

The bug also happens when filtering out the number of alerts in the table and then removing the filter.
![Sep-08-2021 17-50-50_low](https://user-images.githubusercontent.com/1490444/132646090-2f7631cd-10fe-4a22-8cf6-f1956be19414.gif)



It happens because the hack to calculate the height based on the content doesn't work when the table is smaller than the content. For some reason, DataGrid sets the inner height bigger than it should...

So, I added a hack on top of the hack. I hard-coded the size of the table for every page size. Then the calculation of the page height based on the content will only happen when `alertsQuantity < pageSize`.

FYI: This hack is a workaround to calculate alert table height while EUI team doesn't fix this bug: https://github.com/elastic/eui/issues/5030


