### PR TITLE
[Discover] Improve async loading doc tabs

### DIFF
--- a/src/plugins/discover/public/application/components/source_viewer/source_viewer.tsx
+++ b/src/plugins/discover/public/application/components/source_viewer/source_viewer.tsx
@@ -127,3 +127,7 @@ export const SourceViewer = ({
     />
   );
 };
+
+// Required for usage in React.lazy
+// eslint-disable-next-line import/no-default-export
+export default SourceViewer;

--- a/src/plugins/discover/public/application/components/table/table.tsx
+++ b/src/plugins/discover/public/application/components/table/table.tsx
@@ -145,3 +145,7 @@ export const DocViewerTable = ({
     />
   );
 };
+
+// Required for usage in React.lazy
+// eslint-disable-next-line import/no-default-export
+export default DocViewerTable;

--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -27,6 +27,7 @@ import { KibanaLegacySetup, KibanaLegacyStart } from 'src/plugins/kibana_legacy/
 import { UrlForwardingSetup, UrlForwardingStart } from 'src/plugins/url_forwarding/public';
 import { HomePublicPluginSetup } from 'src/plugins/home/public';
 import { Start as InspectorPublicPluginStart } from 'src/plugins/inspector/public';
+import { EuiLoadingContent } from '@elastic/eui';
 import { DataPublicPluginStart, DataPublicPluginSetup, esFilters } from '../../data/public';
 import { SavedObjectLoader, SavedObjectsStart } from '../../saved_objects/public';
 import { createKbnUrlTracker } from '../../kibana_utils/public';
@@ -34,7 +35,6 @@ import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
 import { UrlGeneratorState } from '../../share/public';
 import { DocViewInput, DocViewInputFn } from './application/doc_views/doc_views_types';
 import { DocViewsRegistry } from './application/doc_views/doc_views_registry';
-import { DocViewerTable } from './application/components/table/table';
 import {
   setDocViewsRegistry,
   setUrlTracker,
@@ -59,13 +59,19 @@ import { SearchEmbeddableFactory } from './application/embeddable';
 import { UsageCollectionSetup } from '../../usage_collection/public';
 import { replaceUrlHashQuery } from '../../kibana_utils/public/';
 import { IndexPatternFieldEditorStart } from '../../../plugins/index_pattern_field_editor/public';
-import { SourceViewer } from './application/components/source_viewer/source_viewer';
+import { DeferredSpinner } from './shared';
 
 declare module '../../share/public' {
   export interface UrlGeneratorStateMapping {
     [DISCOVER_APP_URL_GENERATOR]: UrlGeneratorState<DiscoverUrlGeneratorState>;
   }
 }
+
+const DocViewerTable = React.lazy(() => import('./application/components/table/table'));
+
+const SourceViewer = React.lazy(
+  () => import('./application/components/source_viewer/source_viewer')
+);
 
 /**
  * @public
@@ -232,7 +238,17 @@ export class DiscoverPlugin
         defaultMessage: 'Table',
       }),
       order: 10,
-      component: DocViewerTable,
+      component: (props) => (
+        <React.Suspense
+          fallback={
+            <DeferredSpinner>
+              <EuiLoadingContent />
+            </DeferredSpinner>
+          }
+        >
+          <DocViewerTable {...props} />
+        </React.Suspense>
+      ),
     });
     this.docViewsRegistry.addDocView({
       title: i18n.translate('discover.docViews.json.jsonTitle', {
@@ -240,12 +256,20 @@ export class DiscoverPlugin
       }),
       order: 20,
       component: ({ hit, indexPattern }) => (
-        <SourceViewer
-          index={hit._index}
-          id={hit._id}
-          indexPatternId={indexPattern?.id || ''}
-          hasLineNumbers
-        />
+        <React.Suspense
+          fallback={
+            <DeferredSpinner>
+              <EuiLoadingContent />
+            </DeferredSpinner>
+          }
+        >
+          <SourceViewer
+            index={hit._index}
+            id={hit._id}
+            indexPatternId={indexPattern?.id || ''}
+            hasLineNumbers
+          />
+        </React.Suspense>
       ),
     });
 

--- a/src/plugins/discover/public/shared/components.tsx
+++ b/src/plugins/discover/public/shared/components.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+
+/**
+ * A component that shows it children with a 300ms delay. This is good for wrapping
+ * loading spinners for tasks that might potentially be very fast (e.g. loading async chunks).
+ * That way we don't show a quick flash of the spinner before the actual content and will only
+ * show the spinner once loading takes a bit longer (more than 300ms).
+ */
+export const DeferredSpinner: React.FC = ({ children }) => {
+  const timeoutRef = useRef<number>();
+  const [showContent, setShowContent] = useState(false);
+  useEffect(() => {
+    timeoutRef.current = window.setTimeout(() => {
+      setShowContent(true);
+    }, 300);
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return showContent ? <React.Fragment>{children}</React.Fragment> : null;
+};

--- a/src/plugins/discover/public/shared/index.ts
+++ b/src/plugins/discover/public/shared/index.ts
@@ -12,3 +12,5 @@
 export async function loadSharingDataHelpers() {
   return await import('../application/apps/main/utils/get_sharing_data');
 }
+
+export { DeferredSpinner } from './components';


### PR DESCRIPTION
## Summary

Improve page load bundle size of Discover by making sure the implementation of the doc tabs are not loaded before actually rendered.


### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~
