### PR TITLE
[7.15] Ensure name columns are not cut off on APM tables (#111046)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/index.tsx
@@ -22,7 +22,7 @@ import {
   UxLocalUIFilterName,
   uxLocalUIFilterNames,
 } from '../../../../../common/ux_ui_filter';
-import { useBreakPoints } from '../../../../hooks/use_break_points';
+import { useBreakpoints } from '../../../../hooks/use_breakpoints';
 import { FieldValueSuggestions } from '../../../../../../observability/public';
 import { URLFilter } from '../URLFilter';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
@@ -84,7 +84,7 @@ function LocalUIFilters() {
     return dataFilters;
   }, [environment, serviceName]);
 
-  const { isSmall } = useBreakPoints();
+  const { isSmall } = useBreakpoints();
 
   const title = (
     <EuiTitle size="s">

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/RumDashboard.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/RumDashboard.tsx
@@ -11,11 +11,11 @@ import { UXMetrics } from './UXMetrics';
 import { ImpactfulMetrics } from './ImpactfulMetrics';
 import { PageLoadAndViews } from './Panels/PageLoadAndViews';
 import { VisitorBreakdownsPanel } from './Panels/VisitorBreakdowns';
-import { useBreakPoints } from '../../../hooks/use_break_points';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { ClientMetrics } from './ClientMetrics';
 
 export function RumDashboard() {
-  const { isSmall } = useBreakPoints();
+  const { isSmall } = useBreakpoints();
 
   return (
     <EuiFlexGroup direction={isSmall ? 'row' : 'column'} gutterSize="s">

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/RumHome.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/RumHome.tsx
@@ -15,7 +15,7 @@ import { DatePicker } from '../../shared/DatePicker';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import { EnvironmentFilter } from '../../shared/EnvironmentFilter';
 import { UserPercentile } from './UserPercentile';
-import { useBreakPoints } from '../../../hooks/use_break_points';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 
 export const UX_LABEL = i18n.translate('xpack.apm.ux.title', {
   defaultMessage: 'Dashboard',
@@ -25,7 +25,7 @@ export function RumHome() {
   const { observability } = useApmPluginContext();
   const PageTemplateComponent = observability.navigation.PageTemplate;
 
-  const { isSmall, isXXL } = useBreakPoints();
+  const { isSmall, isXXL } = useBreakpoints();
 
   const envStyle = isSmall ? {} : { maxWidth: 500 };
 
@@ -57,7 +57,7 @@ export function RumHome() {
 }
 
 function PageHeader() {
-  const { isSmall } = useBreakPoints();
+  const { isSmall } = useBreakpoints();
 
   const envStyle = isSmall ? {} : { maxWidth: 400 };
 

--- a/x-pack/plugins/apm/public/components/app/Settings/agent_configurations/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/agent_configurations/List/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiEmptyPrompt,
   EuiHealth,
   EuiToolTip,
+  RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
@@ -180,7 +181,7 @@ export function AgentConfigurationList({
       render: (_, { service }) => getOptionLabel(service.environment),
     },
     {
-      align: 'right',
+      align: RIGHT_ALIGNMENT,
       field: '@timestamp',
       name: i18n.translate(
         'xpack.apm.agentConfig.configTable.lastUpdatedColumnLabel',

--- a/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/jobs_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/jobs_list.tsx
@@ -12,6 +12,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -38,7 +39,7 @@ const columns: Array<ITableColumn<Jobs[0]>> = [
   },
   {
     field: 'job_id',
-    align: 'right',
+    align: RIGHT_ALIGNMENT,
     name: i18n.translate(
       'xpack.apm.settings.anomalyDetection.jobList.actionColumnLabel',
       { defaultMessage: 'Action' }

--- a/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/custom_link_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/custom_link_table.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiText,
+  RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
@@ -50,7 +51,7 @@ export function CustomLinkTable({ items = [], onCustomLinkSelected }: Props) {
     },
     {
       width: '160px',
-      align: 'right',
+      align: RIGHT_ALIGNMENT,
       field: '@timestamp',
       name: i18n.translate(
         'xpack.apm.settings.customizeUI.customLink.table.lastUpdated',

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/index.tsx
@@ -27,7 +27,7 @@ import {
   getKueryBarBoolFilter,
   kueryBarPlaceholder,
 } from '../../../../common/backends';
-import { useBreakPoints } from '../../../hooks/use_break_points';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 
 export function BackendDetailOverview() {
   const {
@@ -63,7 +63,7 @@ export function BackendDetailOverview() {
     backendName,
   });
 
-  const largeScreenOrSmaller = useBreakPoints().isLarge;
+  const largeScreenOrSmaller = useBreakpoints().isLarge;
 
   return (
     <ApmBackendContextProvider>

--- a/x-pack/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
@@ -17,6 +17,7 @@ import {
   EuiBetaBadge,
   EuiBadge,
   EuiToolTip,
+  RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useHistory } from 'react-router-dom';
@@ -120,12 +121,12 @@ export function FailedTransactionsCorrelations({
 
   const history = useHistory();
 
-  const failedTransactionsCorrelationsColumns: Array<
-    EuiBasicTableColumn<FailedTransactionsCorrelationValue>
-  > = useMemo(() => {
-    const percentageColumns: Array<
-      EuiBasicTableColumn<FailedTransactionsCorrelationValue>
-    > = inspectEnabled
+  const failedTransactionsCorrelationsColumns: Array<EuiBasicTableColumn<
+    FailedTransactionsCorrelationValue
+  >> = useMemo(() => {
+    const percentageColumns: Array<EuiBasicTableColumn<
+      FailedTransactionsCorrelationValue
+    >> = inspectEnabled
       ? [
           {
             width: '100px',
@@ -198,7 +199,6 @@ export function FailedTransactionsCorrelations({
       : [];
     return [
       {
-        width: '80px',
         field: 'normalizedScore',
         name: (
           <>
@@ -210,7 +210,8 @@ export function FailedTransactionsCorrelations({
             )}
           </>
         ),
-        render: (normalizedScore: number) => {
+        align: RIGHT_ALIGNMENT,
+        render: (_, { normalizedScore }) => {
           return (
             <>
               <ImpactBar size="m" value={normalizedScore * 100} />

--- a/x-pack/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/failed_transactions_correlations.tsx
@@ -121,12 +121,12 @@ export function FailedTransactionsCorrelations({
 
   const history = useHistory();
 
-  const failedTransactionsCorrelationsColumns: Array<EuiBasicTableColumn<
-    FailedTransactionsCorrelationValue
-  >> = useMemo(() => {
-    const percentageColumns: Array<EuiBasicTableColumn<
-      FailedTransactionsCorrelationValue
-    >> = inspectEnabled
+  const failedTransactionsCorrelationsColumns: Array<
+    EuiBasicTableColumn<FailedTransactionsCorrelationValue>
+  > = useMemo(() => {
+    const percentageColumns: Array<
+      EuiBasicTableColumn<FailedTransactionsCorrelationValue>
+    > = inspectEnabled
       ? [
           {
             width: '100px',

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/List/index.tsx
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiIconTip, EuiToolTip } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiIconTip,
+  EuiToolTip,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
@@ -150,7 +155,7 @@ function ErrorGroupList({ items, serviceName }: Props) {
         name: '',
         field: 'handled',
         sortable: false,
-        align: 'right',
+        align: RIGHT_ALIGNMENT,
         render: (_, { handled }) =>
           handled === false && (
             <EuiBadge color="warning">
@@ -181,7 +186,7 @@ function ErrorGroupList({ items, serviceName }: Props) {
             defaultMessage: 'Latest occurrence',
           }
         ),
-        align: 'right',
+        align: RIGHT_ALIGNMENT,
         render: (_, { latestOccurrenceAt }) =>
           latestOccurrenceAt ? (
             <TimestampTooltip time={latestOccurrenceAt} timeUnit="minutes" />

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -45,9 +45,7 @@ import { HealthBadge } from './HealthBadge';
 
 type ServiceListAPIResponse = APIReturnType<'GET /api/apm/services'>;
 type Items = ServiceListAPIResponse['items'];
-type ServicesDetailedStatisticsAPIResponse = APIReturnType<
-  'GET /api/apm/services/detailed_statistics'
->;
+type ServicesDetailedStatisticsAPIResponse = APIReturnType<'GET /api/apm/services/detailed_statistics'>;
 
 type ServiceListItem = ValuesType<Items>;
 

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -11,16 +11,13 @@ import {
   EuiIcon,
   EuiText,
   EuiToolTip,
+  RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { TypeOf } from '@kbn/typed-react-router-config';
 import { orderBy } from 'lodash';
 import React, { useMemo } from 'react';
 import { ValuesType } from 'utility-types';
-import {
-  BreakPoints,
-  useBreakPoints,
-} from '../../../../hooks/use_break_points';
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
 import { ServiceHealthStatus } from '../../../../../common/service_health_status';
 import {
@@ -33,21 +30,24 @@ import {
   asTransactionRate,
 } from '../../../../../common/utils/formatters';
 import { useApmParams } from '../../../../hooks/use_apm_params';
+import { Breakpoints, useBreakpoints } from '../../../../hooks/use_breakpoints';
+import { useFallbackToTransactionsFetcher } from '../../../../hooks/use_fallback_to_transactions_fetcher';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { unit } from '../../../../utils/style';
 import { ApmRoutes } from '../../../routing/apm_route_config';
+import { AggregatedTransactionsBadge } from '../../../shared/aggregated_transactions_badge';
 import { EnvironmentBadge } from '../../../shared/EnvironmentBadge';
+import { ListMetric } from '../../../shared/list_metric';
 import { ITableColumn, ManagedTable } from '../../../shared/managed_table';
 import { ServiceLink } from '../../../shared/service_link';
-import { HealthBadge } from './HealthBadge';
-import { ServiceListMetric } from './ServiceListMetric';
 import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
-import { useFallbackToTransactionsFetcher } from '../../../../hooks/use_fallback_to_transactions_fetcher';
-import { AggregatedTransactionsBadge } from '../../../shared/aggregated_transactions_badge';
+import { HealthBadge } from './HealthBadge';
 
 type ServiceListAPIResponse = APIReturnType<'GET /api/apm/services'>;
 type Items = ServiceListAPIResponse['items'];
-type ServicesDetailedStatisticsAPIResponse = APIReturnType<'GET /api/apm/services/detailed_statistics'>;
+type ServicesDetailedStatisticsAPIResponse = APIReturnType<
+  'GET /api/apm/services/detailed_statistics'
+>;
 
 type ServiceListItem = ValuesType<Items>;
 
@@ -66,14 +66,14 @@ export function getServiceColumns({
   query,
   showTransactionTypeColumn,
   comparisonData,
-  breakPoints,
+  breakpoints,
 }: {
   query: TypeOf<ApmRoutes, '/services'>['query'];
   showTransactionTypeColumn: boolean;
-  breakPoints: BreakPoints;
+  breakpoints: Breakpoints;
   comparisonData?: ServicesDetailedStatisticsAPIResponse;
 }): Array<ITableColumn<ServiceListItem>> {
-  const { isSmall, isLarge, isXl } = breakPoints;
+  const { isSmall, isLarge, isXl } = breakpoints;
   const showWhenSmallOrGreaterThanLarge = isSmall || !isLarge;
   const showWhenSmallOrGreaterThanXL = isSmall || !isXl;
   return [
@@ -97,7 +97,6 @@ export function getServiceColumns({
       name: i18n.translate('xpack.apm.servicesTable.nameColumnLabel', {
         defaultMessage: 'Name',
       }),
-      width: '40%',
       sortable: true,
       render: (_, { serviceName, agentName, transactionType }) => (
         <TruncateWithTooltip
@@ -152,7 +151,7 @@ export function getServiceColumns({
       sortable: true,
       dataType: 'number',
       render: (_, { serviceName, latency }) => (
-        <ServiceListMetric
+        <ListMetric
           series={comparisonData?.currentPeriod[serviceName]?.latency}
           comparisonSeries={
             comparisonData?.previousPeriod[serviceName]?.latency
@@ -162,8 +161,7 @@ export function getServiceColumns({
           valueLabel={asMillisecondDuration(latency || 0)}
         />
       ),
-      align: 'left',
-      width: showWhenSmallOrGreaterThanLarge ? `${unit * 10}px` : 'auto',
+      align: RIGHT_ALIGNMENT,
     },
     {
       field: 'throughput',
@@ -173,7 +171,7 @@ export function getServiceColumns({
       sortable: true,
       dataType: 'number',
       render: (_, { serviceName, throughput }) => (
-        <ServiceListMetric
+        <ListMetric
           series={comparisonData?.currentPeriod[serviceName]?.throughput}
           comparisonSeries={
             comparisonData?.previousPeriod[serviceName]?.throughput
@@ -183,8 +181,7 @@ export function getServiceColumns({
           valueLabel={asTransactionRate(throughput)}
         />
       ),
-      align: 'left',
-      width: showWhenSmallOrGreaterThanLarge ? `${unit * 10}px` : 'auto',
+      align: RIGHT_ALIGNMENT,
     },
     {
       field: 'transactionErrorRate',
@@ -196,7 +193,7 @@ export function getServiceColumns({
       render: (_, { serviceName, transactionErrorRate }) => {
         const valueLabel = asPercent(transactionErrorRate, 1);
         return (
-          <ServiceListMetric
+          <ListMetric
             series={
               comparisonData?.currentPeriod[serviceName]?.transactionErrorRate
             }
@@ -209,8 +206,7 @@ export function getServiceColumns({
           />
         );
       },
-      align: 'left',
-      width: showWhenSmallOrGreaterThanLarge ? `${unit * 10}px` : 'auto',
+      align: RIGHT_ALIGNMENT,
     },
   ];
 }
@@ -228,7 +224,7 @@ export function ServiceList({
   comparisonData,
   isLoading,
 }: Props) {
-  const breakPoints = useBreakPoints();
+  const breakpoints = useBreakpoints();
   const displayHealthStatus = items.some((item) => 'healthStatus' in item);
 
   const showTransactionTypeColumn = items.some(
@@ -250,9 +246,9 @@ export function ServiceList({
         query,
         showTransactionTypeColumn,
         comparisonData,
-        breakPoints,
+        breakpoints,
       }),
-    [query, showTransactionTypeColumn, comparisonData, breakPoints]
+    [query, showTransactionTypeColumn, comparisonData, breakpoints]
   );
 
   const columns = displayHealthStatus

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
@@ -7,7 +7,7 @@
 
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { BreakPoints } from '../../../../hooks/use_break_points';
+import { Breakpoints } from '../../../../hooks/use_breakpoints';
 import { ServiceHealthStatus } from '../../../../../common/service_health_status';
 import { MockApmPluginContextWrapper } from '../../../../context/apm_plugin/mock_apm_plugin_context';
 import { mockMoment, renderWithTheme } from '../../../../utils/testHelpers';
@@ -90,11 +90,11 @@ describe('ServiceList', () => {
         const renderedColumns = getServiceColumns({
           query,
           showTransactionTypeColumn: true,
-          breakPoints: {
+          breakpoints: {
             isSmall: true,
             isLarge: true,
             isXl: true,
-          } as BreakPoints,
+          } as Breakpoints,
         }).map((c) =>
           c.render ? c.render!(service[c.field!], service) : service[c.field!]
         );
@@ -110,7 +110,7 @@ describe('ServiceList', () => {
         `);
         expect(renderedColumns[3]).toMatchInlineSnapshot(`"request"`);
         expect(renderedColumns[4]).toMatchInlineSnapshot(`
-          <ServiceListMetric
+          <ListMetric
             color="euiColorVis1"
             hideSeries={false}
             valueLabel="0 ms"
@@ -124,17 +124,17 @@ describe('ServiceList', () => {
         const renderedColumns = getServiceColumns({
           query,
           showTransactionTypeColumn: true,
-          breakPoints: {
+          breakpoints: {
             isSmall: false,
             isLarge: true,
             isXl: true,
-          } as BreakPoints,
+          } as Breakpoints,
         }).map((c) =>
           c.render ? c.render!(service[c.field!], service) : service[c.field!]
         );
         expect(renderedColumns.length).toEqual(5);
         expect(renderedColumns[2]).toMatchInlineSnapshot(`
-          <ServiceListMetric
+          <ListMetric
             color="euiColorVis1"
             hideSeries={true}
             valueLabel="0 ms"
@@ -147,11 +147,11 @@ describe('ServiceList', () => {
           const renderedColumns = getServiceColumns({
             query,
             showTransactionTypeColumn: true,
-            breakPoints: {
+            breakpoints: {
               isSmall: false,
               isLarge: false,
               isXl: true,
-            } as BreakPoints,
+            } as Breakpoints,
           }).map((c) =>
             c.render ? c.render!(service[c.field!], service) : service[c.field!]
           );
@@ -166,7 +166,7 @@ describe('ServiceList', () => {
             />
           `);
           expect(renderedColumns[3]).toMatchInlineSnapshot(`
-            <ServiceListMetric
+            <ListMetric
               color="euiColorVis1"
               hideSeries={false}
               valueLabel="0 ms"
@@ -180,32 +180,32 @@ describe('ServiceList', () => {
           const renderedColumns = getServiceColumns({
             query,
             showTransactionTypeColumn: true,
-            breakPoints: {
+            breakpoints: {
               isSmall: false,
               isLarge: false,
               isXl: false,
-            } as BreakPoints,
+            } as Breakpoints,
           }).map((c) =>
             c.render ? c.render!(service[c.field!], service) : service[c.field!]
           );
           expect(renderedColumns.length).toEqual(7);
           expect(renderedColumns[2]).toMatchInlineSnapshot(`
-          <EnvironmentBadge
-            environments={
-              Array [
-                "test",
-              ]
-            }
-          />
-        `);
+                      <EnvironmentBadge
+                        environments={
+                          Array [
+                            "test",
+                          ]
+                        }
+                      />
+                  `);
           expect(renderedColumns[3]).toMatchInlineSnapshot(`"request"`);
           expect(renderedColumns[4]).toMatchInlineSnapshot(`
-          <ServiceListMetric
-            color="euiColorVis1"
-            hideSeries={false}
-            valueLabel="0 ms"
-          />
-        `);
+            <ListMetric
+              color="euiColorVis1"
+              hideSeries={false}
+              valueLabel="0 ms"
+            />
+          `);
         });
       });
     });

--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -13,7 +13,7 @@ import { isRumAgentName, isIosAgentName } from '../../../../common/agent_name';
 import { AnnotationsContextProvider } from '../../../context/annotations/annotations_context';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { ChartPointerEventContextProvider } from '../../../context/chart_pointer_event/chart_pointer_event_context';
-import { useBreakPoints } from '../../../hooks/use_break_points';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { LatencyChart } from '../../shared/charts/latency_chart';
 import { TransactionBreakdownChart } from '../../shared/charts/transaction_breakdown_chart';
 import { TransactionErrorRateChart } from '../../shared/charts/transaction_error_rate_chart';
@@ -51,10 +51,16 @@ export function ServiceOverview() {
     replace(history, { query: { transactionType } });
   }
 
-  // The default EuiFlexGroup breaks at 768, but we want to break at 992, so we
+  const latencyChartHeight = 200;
+
+  // The default EuiFlexGroup breaks at 768, but we want to break at 1200, so we
   // observe the window width and set the flex directions of rows accordingly
-  const { isMedium } = useBreakPoints();
-  const rowDirection = isMedium ? 'column' : 'row';
+  const { isLarge } = useBreakpoints();
+  const isSingleColumn = isLarge;
+  const nonLatencyChartHeight = isSingleColumn
+    ? latencyChartHeight
+    : chartHeight;
+  const rowDirection = isSingleColumn ? 'column' : 'row';
   const isRumAgent = isRumAgentName(agentName);
   const isIosAgent = isIosAgentName(agentName);
 
@@ -81,7 +87,7 @@ export function ServiceOverview() {
           <EuiFlexItem>
             <EuiPanel hasBorder={true}>
               <LatencyChart
-                height={200}
+                height={latencyChartHeight}
                 environment={environment}
                 kuery={kuery}
               />
@@ -95,7 +101,7 @@ export function ServiceOverview() {
             >
               <EuiFlexItem grow={3}>
                 <ServiceOverviewThroughputChart
-                  height={chartHeight}
+                  height={nonLatencyChartHeight}
                   environment={environment}
                   kuery={kuery}
                 />
@@ -106,6 +112,7 @@ export function ServiceOverview() {
                     kuery={kuery}
                     environment={environment}
                     fixedHeight={true}
+                    isSingleColumn={isSingleColumn}
                   />
                 </EuiPanel>
               </EuiFlexItem>
@@ -120,7 +127,7 @@ export function ServiceOverview() {
               {!isRumAgent && (
                 <EuiFlexItem grow={3}>
                   <TransactionErrorRateChart
-                    height={chartHeight}
+                    height={nonLatencyChartHeight}
                     showAnnotations={false}
                     kuery={kuery}
                     environment={environment}
@@ -152,6 +159,7 @@ export function ServiceOverview() {
                   <EuiPanel hasBorder={true}>
                     <ServiceOverviewDependenciesTable
                       fixedHeight={true}
+                      isSingleColumn={isSingleColumn}
                       link={
                         <EuiLink href={dependenciesLink}>
                           {i18n.translate(
@@ -174,7 +182,7 @@ export function ServiceOverview() {
                 responsive={false}
               >
                 <ServiceOverviewInstancesChartAndTable
-                  chartHeight={chartHeight}
+                  chartHeight={nonLatencyChartHeight}
                   serviceName={serviceName}
                 />
               </EuiFlexGroup>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
@@ -21,11 +21,13 @@ import { getTimeRangeComparison } from '../../../shared/time_comparison/get_time
 
 interface ServiceOverviewDependenciesTableProps {
   fixedHeight?: boolean;
+  isSingleColumn?: boolean;
   link?: ReactNode;
 }
 
 export function ServiceOverviewDependenciesTable({
   fixedHeight,
+  isSingleColumn = true,
   link,
 }: ServiceOverviewDependenciesTableProps) {
   const {
@@ -125,6 +127,7 @@ export function ServiceOverviewDependenciesTable({
     <DependenciesTable
       dependencies={dependencies}
       fixedHeight={fixedHeight}
+      isSingleColumn={isSingleColumn}
       title={i18n.translate(
         'xpack.apm.serviceOverview.dependenciesTableTitle',
         {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { EuiBasicTableColumn } from '@elastic/eui';
+import { EuiBasicTableColumn, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { asInteger } from '../../../../../common/utils/formatters';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
-import { unit } from '../../../../utils/style';
 import { SparkPlot } from '../../../shared/charts/spark_plot';
 import { ErrorDetailLink } from '../../../shared/Links/apm/ErrorDetailLink';
 import { TimestampTooltip } from '../../../shared/TimestampTooltip';
@@ -58,11 +57,14 @@ export function getColumns({
           defaultMessage: 'Last seen',
         }
       ),
+      align: RIGHT_ALIGNMENT,
       render: (_, { lastSeen }) => {
-        return <TimestampTooltip time={lastSeen} timeUnit="minutes" />;
+        return (
+          <span style={{ overflow: 'hidden', whiteSpace: 'nowrap' }}>
+            <TimestampTooltip time={lastSeen} timeUnit="minutes" />
+          </span>
+        );
       },
-      width: `${unit * 9}px`,
-      align: 'right',
     },
     {
       field: 'occurrences',
@@ -72,7 +74,7 @@ export function getColumns({
           defaultMessage: 'Occurrences',
         }
       ),
-      width: `${unit * 12}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { occurrences, group_id: errorGroupId }) => {
         const currentPeriodTimeseries =
           errorGroupDetailedStatistics?.currentPeriod?.[errorGroupId]

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
@@ -23,7 +23,7 @@ import { ErrorOverviewLink } from '../../../shared/Links/apm/ErrorOverviewLink';
 import { TableFetchWrapper } from '../../../shared/table_fetch_wrapper';
 import { getTimeRangeComparison } from '../../../shared/time_comparison/get_time_range_comparison';
 import { OverviewTableContainer } from '../../../shared/overview_table_container';
-import { getColumns } from './get_column';
+import { getColumns } from './get_columns';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 
 interface Props {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -25,12 +25,11 @@ import {
   asTransactionRate,
 } from '../../../../../common/utils/formatters';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
-import { unit } from '../../../../utils/style';
-import { SparkPlot } from '../../../shared/charts/spark_plot';
 import { MetricOverviewLink } from '../../../shared/Links/apm/MetricOverviewLink';
 import { ServiceNodeMetricOverviewLink } from '../../../shared/Links/apm/ServiceNodeMetricOverviewLink';
-import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
+import { ListMetric } from '../../../shared/list_metric';
 import { getLatencyColumnLabel } from '../../../shared/transactions_table/get_latency_column_label';
+import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { InstanceActionsMenu } from './instance_actions_menu';
 
 type ServiceInstanceMainStatistics = APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
@@ -47,6 +46,7 @@ export function getColumns({
   itemIdToExpandedRowMap,
   toggleRowActionMenu,
   itemIdToOpenActionMenuRowMap,
+  shouldShowSparkPlots = true,
 }: {
   serviceName: string;
   agentName?: string;
@@ -57,6 +57,7 @@ export function getColumns({
   itemIdToExpandedRowMap: Record<string, ReactNode>;
   toggleRowActionMenu: (selectedServiceNodeName: string) => void;
   itemIdToOpenActionMenuRowMap: Record<string, boolean>;
+  shouldShowSparkPlots?: boolean;
 }): Array<EuiBasicTableColumn<MainStatsServiceInstanceItem>> {
   return [
     {
@@ -99,16 +100,17 @@ export function getColumns({
     {
       field: 'latency',
       name: getLatencyColumnLabel(latencyAggregationType),
-      width: `${unit * 11}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { serviceNodeName, latency }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.latency;
         const previousPeriodTimestamp =
           detailedStatsData?.previousPeriod?.[serviceNodeName]?.latency;
         return (
-          <SparkPlot
+          <ListMetric
             color="euiColorVis1"
             valueLabel={asMillisecondDuration(latency)}
+            hideSeries={!shouldShowSparkPlots}
             series={currentPeriodTimestamp}
             comparisonSeries={
               comparisonEnabled ? previousPeriodTimestamp : undefined
@@ -124,16 +126,17 @@ export function getColumns({
         'xpack.apm.serviceOverview.instancesTableColumnThroughput',
         { defaultMessage: 'Throughput' }
       ),
-      width: `${unit * 11}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { serviceNodeName, throughput }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.throughput;
         const previousPeriodTimestamp =
           detailedStatsData?.previousPeriod?.[serviceNodeName]?.throughput;
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis0"
+            hideSeries={!shouldShowSparkPlots}
             valueLabel={asTransactionRate(throughput)}
             series={currentPeriodTimestamp}
             comparisonSeries={
@@ -150,16 +153,17 @@ export function getColumns({
         'xpack.apm.serviceOverview.instancesTableColumnErrorRate',
         { defaultMessage: 'Failed transaction rate' }
       ),
-      width: `${unit * 8}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { serviceNodeName, errorRate }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.errorRate;
         const previousPeriodTimestamp =
           detailedStatsData?.previousPeriod?.[serviceNodeName]?.errorRate;
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis7"
+            hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(errorRate, 1)}
             series={currentPeriodTimestamp}
             comparisonSeries={
@@ -176,16 +180,17 @@ export function getColumns({
         'xpack.apm.serviceOverview.instancesTableColumnCpuUsage',
         { defaultMessage: 'CPU usage (avg.)' }
       ),
-      width: `${unit * 8}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { serviceNodeName, cpuUsage }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.cpuUsage;
         const previousPeriodTimestamp =
           detailedStatsData?.previousPeriod?.[serviceNodeName]?.cpuUsage;
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis2"
+            hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(cpuUsage, 1)}
             series={currentPeriodTimestamp}
             comparisonSeries={
@@ -202,16 +207,17 @@ export function getColumns({
         'xpack.apm.serviceOverview.instancesTableColumnMemoryUsage',
         { defaultMessage: 'Memory usage (avg.)' }
       ),
-      width: `${unit * 9}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { serviceNodeName, memoryUsage }) => {
         const currentPeriodTimestamp =
           detailedStatsData?.currentPeriod?.[serviceNodeName]?.memoryUsage;
         const previousPeriodTimestamp =
           detailedStatsData?.previousPeriod?.[serviceNodeName]?.memoryUsage;
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis3"
+            hideSeries={!shouldShowSparkPlots}
             valueLabel={asPercent(memoryUsage, 1)}
             series={currentPeriodTimestamp}
             comparisonSeries={

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
@@ -28,13 +28,9 @@ import { getColumns } from './get_columns';
 import { InstanceDetails } from './intance_details';
 import { useBreakpoints } from '../../../../hooks/use_breakpoints';
 
-type ServiceInstanceMainStatistics = APIReturnType<
-  'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'
->;
+type ServiceInstanceMainStatistics = APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type MainStatsServiceInstanceItem = ServiceInstanceMainStatistics['currentPeriod'][0];
-type ServiceInstanceDetailedStatistics = APIReturnType<
-  'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'
->;
+type ServiceInstanceDetailedStatistics = APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
 
 export interface TableOptions {
   pageIndex: number;

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
@@ -26,10 +26,15 @@ import {
 import { OverviewTableContainer } from '../../../shared/overview_table_container';
 import { getColumns } from './get_columns';
 import { InstanceDetails } from './intance_details';
+import { useBreakpoints } from '../../../../hooks/use_breakpoints';
 
-type ServiceInstanceMainStatistics = APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+type ServiceInstanceMainStatistics = APIReturnType<
+  'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'
+>;
 type MainStatsServiceInstanceItem = ServiceInstanceMainStatistics['currentPeriod'][0];
-type ServiceInstanceDetailedStatistics = APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
+type ServiceInstanceDetailedStatistics = APIReturnType<
+  'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'
+>;
 
 export interface TableOptions {
   pageIndex: number;
@@ -109,6 +114,10 @@ export function ServiceOverviewInstancesTable({
     setItemIdToExpandedRowMap(expandedRowMapValues);
   };
 
+  // Hide the spark plots if we're below 1600 px
+  const { isXl } = useBreakpoints();
+  const shouldShowSparkPlots = !isXl;
+
   const columns = getColumns({
     agentName,
     serviceName,
@@ -119,6 +128,7 @@ export function ServiceOverviewInstancesTable({
     itemIdToExpandedRowMap,
     toggleRowActionMenu,
     itemIdToOpenActionMenuRowMap,
+    shouldShowSparkPlots,
   });
 
   const pagination = {

--- a/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiIcon, EuiToolTip } from '@elastic/eui';
+import { EuiIcon, EuiToolTip, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
@@ -14,7 +14,7 @@ import {
   asTransactionRate,
 } from '../../../../common/utils/formatters';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
-import { truncate, unit } from '../../../utils/style';
+import { truncate } from '../../../utils/style';
 import { EmptyMessage } from '../../shared/EmptyMessage';
 import { ImpactBar } from '../../shared/ImpactBar';
 import { TransactionDetailLink } from '../../shared/Links/apm/transaction_detail_link';
@@ -111,8 +111,7 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
         </>
       </EuiToolTip>
     ),
-    width: `${unit * 6}px`,
-    align: 'left',
+    align: RIGHT_ALIGNMENT,
     sortable: true,
     render: (_, { impact }) => <ImpactBar value={impact} />,
   },

--- a/x-pack/plugins/apm/public/components/shared/ImpactBar/__snapshots__/ImpactBar.test.js.snap
+++ b/x-pack/plugins/apm/public/components/shared/ImpactBar/__snapshots__/ImpactBar.test.js.snap
@@ -5,6 +5,11 @@ exports[`ImpactBar component should render with default values 1`] = `
   color="primary"
   max={100}
   size="m"
+  style={
+    Object {
+      "width": "96px",
+    }
+  }
   value={25}
 />
 `;
@@ -14,6 +19,11 @@ exports[`ImpactBar component should render with overridden values 1`] = `
   color="danger"
   max={5}
   size="s"
+  style={
+    Object {
+      "width": "96px",
+    }
+  }
   value={2}
 />
 `;

--- a/x-pack/plugins/apm/public/components/shared/ImpactBar/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ImpactBar/index.tsx
@@ -7,6 +7,7 @@
 
 import { EuiProgress } from '@elastic/eui';
 import React from 'react';
+import { unit } from '../../../utils/style';
 
 // TODO: extend from EUI's EuiProgress prop interface
 export interface ImpactBarProps extends Record<string, unknown> {
@@ -16,6 +17,8 @@ export interface ImpactBarProps extends Record<string, unknown> {
   color?: string;
 }
 
+const style = { width: `${unit * 6}px` };
+
 export function ImpactBar({
   value,
   size = 'm',
@@ -24,6 +27,13 @@ export function ImpactBar({
   ...rest
 }: ImpactBarProps) {
   return (
-    <EuiProgress size={size} value={value} max={max} color={color} {...rest} />
+    <EuiProgress
+      size={size}
+      value={value}
+      max={max}
+      color={color}
+      style={style}
+      {...rest}
+    />
   );
 }

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -40,6 +40,8 @@ function hasValidTimeseries(
   return !!series?.some((point) => point.y !== null);
 }
 
+const flexGroupStyle = { overflow: 'hidden' };
+
 export function SparkPlot({
   color,
   series,
@@ -80,11 +82,15 @@ export function SparkPlot({
 
   return (
     <EuiFlexGroup
-      justifyContent="spaceBetween"
+      justifyContent="flexEnd"
       gutterSize="xs"
       responsive={false}
       alignItems="flexEnd"
+      style={flexGroupStyle}
     >
+      <EuiFlexItem grow={false} style={{ whiteSpace: 'nowrap' }}>
+        {valueLabel}
+      </EuiFlexItem>
       <EuiFlexItem grow={false}>
         {hasValidTimeseries(series) ? (
           <Chart size={chartSize}>
@@ -128,9 +134,6 @@ export function SparkPlot({
             <EuiIcon type="visLine" color={theme.eui.euiColorMediumShade} />
           </div>
         )}
-      </EuiFlexItem>
-      <EuiFlexItem grow={false} style={{ whiteSpace: 'nowrap' }}>
-        {valueLabel}
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiInMemoryTable,
   EuiTitle,
+  RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
@@ -20,13 +21,13 @@ import {
   asPercent,
   asTransactionRate,
 } from '../../../../common/utils/formatters';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
-import { unit } from '../../../utils/style';
-import { SparkPlot } from '../charts/spark_plot';
 import { ImpactBar } from '../ImpactBar';
+import { ListMetric } from '../list_metric';
+import { OverviewTableContainer } from '../overview_table_container';
 import { TableFetchWrapper } from '../table_fetch_wrapper';
 import { TruncateWithTooltip } from '../truncate_with_tooltip';
-import { OverviewTableContainer } from '../overview_table_container';
 
 export type DependenciesItem = Omit<
   ConnectionStatsItemWithComparisonData,
@@ -39,6 +40,7 @@ export type DependenciesItem = Omit<
 interface Props {
   dependencies: DependenciesItem[];
   fixedHeight?: boolean;
+  isSingleColumn?: boolean;
   link?: React.ReactNode;
   title: React.ReactNode;
   nameColumnTitle: React.ReactNode;
@@ -50,6 +52,7 @@ export function DependenciesTable(props: Props) {
   const {
     dependencies,
     fixedHeight,
+    isSingleColumn = true,
     link,
     title,
     nameColumnTitle,
@@ -64,6 +67,10 @@ export function DependenciesTable(props: Props) {
         hidePerPageOptions: true,
       }
     : {};
+
+  // SparkPlots should be hidden if we're in two-column view and size XL (1200px)
+  const { isXl } = useBreakpoints();
+  const shouldShowSparkPlots = isSingleColumn || !isXl;
 
   const columns: Array<EuiBasicTableColumn<DependenciesItem>> = [
     {
@@ -80,12 +87,13 @@ export function DependenciesTable(props: Props) {
       name: i18n.translate('xpack.apm.dependenciesTable.columnLatency', {
         defaultMessage: 'Latency (avg.)',
       }),
-      width: `${unit * 11}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { currentStats, previousStats }) => {
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis1"
+            hideSeries={!shouldShowSparkPlots}
             series={currentStats.latency.timeseries}
             comparisonSeries={previousStats?.latency.timeseries}
             valueLabel={asMillisecondDuration(currentStats.latency.value)}
@@ -99,12 +107,13 @@ export function DependenciesTable(props: Props) {
       name: i18n.translate('xpack.apm.dependenciesTable.columnThroughput', {
         defaultMessage: 'Throughput',
       }),
-      width: `${unit * 11}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { currentStats, previousStats }) => {
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis0"
+            hideSeries={!shouldShowSparkPlots}
             series={currentStats.throughput.timeseries}
             comparisonSeries={previousStats?.throughput.timeseries}
             valueLabel={asTransactionRate(currentStats.throughput.value)}
@@ -118,12 +127,13 @@ export function DependenciesTable(props: Props) {
       name: i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
         defaultMessage: 'Failed transaction rate',
       }),
-      width: `${unit * 10}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { currentStats, previousStats }) => {
         return (
-          <SparkPlot
+          <ListMetric
             compact
             color="euiColorVis7"
+            hideSeries={!shouldShowSparkPlots}
             series={currentStats.errorRate.timeseries}
             comparisonSeries={previousStats?.errorRate.timeseries}
             valueLabel={asPercent(currentStats.errorRate.value, 1)}
@@ -137,10 +147,10 @@ export function DependenciesTable(props: Props) {
       name: i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
         defaultMessage: 'Impact',
       }),
-      width: `${unit * 5}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { currentStats, previousStats }) => {
         return (
-          <EuiFlexGroup gutterSize="xs" direction="column">
+          <EuiFlexGroup alignItems="flexEnd" gutterSize="xs" direction="column">
             <EuiFlexItem>
               <ImpactBar value={currentStats.impact} size="m" />
             </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/shared/list_metric.tsx
+++ b/x-pack/plugins/apm/public/components/shared/list_metric.tsx
@@ -6,32 +6,19 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import React from 'react';
-import { Coordinate } from '../../../../../typings/timeseries';
-import { SparkPlot } from '../../../shared/charts/spark_plot';
+import React, { ComponentProps } from 'react';
+import { SparkPlot } from './charts/spark_plot';
 
-export function ServiceListMetric({
-  color,
-  series,
-  valueLabel,
-  comparisonSeries,
-  hideSeries = false,
-}: {
-  color: 'euiColorVis1' | 'euiColorVis0' | 'euiColorVis7';
-  series?: Coordinate[];
-  comparisonSeries?: Coordinate[];
-  valueLabel: React.ReactNode;
+interface ListMetricProps extends ComponentProps<typeof SparkPlot> {
   hideSeries?: boolean;
-}) {
+}
+
+export function ListMetric(props: ListMetricProps) {
+  const { hideSeries, ...sparkPlotProps } = props;
+  const { valueLabel } = sparkPlotProps;
+
   if (!hideSeries) {
-    return (
-      <SparkPlot
-        valueLabel={valueLabel}
-        series={series}
-        color={color}
-        comparisonSeries={comparisonSeries}
-      />
-    );
+    return <SparkPlot {...sparkPlotProps} />;
   }
 
   return (

--- a/x-pack/plugins/apm/public/components/shared/overview_table_container/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/overview_table_container/index.tsx
@@ -7,7 +7,7 @@
 
 import React, { ReactNode } from 'react';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
-import { useBreakPoints } from '../../../hooks/use_break_points';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 
 /**
  * The height for a table on a overview page. Is the height of a 5-row basic
@@ -62,7 +62,7 @@ export function OverviewTableContainer({
   fixedHeight?: boolean;
   isEmptyAndLoading: boolean;
 }) {
-  const { isMedium } = useBreakPoints();
+  const { isMedium } = useBreakpoints();
 
   return (
     <OverviewTableContainerDiv

--- a/x-pack/plugins/apm/public/components/shared/search_bar.tsx
+++ b/x-pack/plugins/apm/public/components/shared/search_bar.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { enableInspectEsQueries } from '../../../../observability/public';
 import { useApmPluginContext } from '../../context/apm_plugin/use_apm_plugin_context';
 import { useKibanaUrl } from '../../hooks/useKibanaUrl';
-import { useBreakPoints } from '../../hooks/use_break_points';
+import { useBreakpoints } from '../../hooks/use_breakpoints';
 import { DatePicker } from './DatePicker';
 import { KueryBar } from './kuery_bar';
 import { TimeComparison } from './time_comparison';
@@ -89,7 +89,7 @@ export function SearchBar({
   kueryBarBoolFilter,
   kueryBarPlaceholder,
 }: Props) {
-  const { isSmall, isMedium, isLarge, isXl, isXXL, isXXXL } = useBreakPoints();
+  const { isSmall, isMedium, isLarge, isXl, isXXL, isXXXL } = useBreakpoints();
 
   if (hidden) {
     return null;

--- a/x-pack/plugins/apm/public/components/shared/time_comparison/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/time_comparison/index.tsx
@@ -14,7 +14,9 @@ import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common'
 import { useUiTracker } from '../../../../../observability/public';
 import { getDateDifference } from '../../../../common/utils/formatters';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
-import { useBreakPoints } from '../../../hooks/use_break_points';
+import { useApmParams } from '../../../hooks/use_apm_params';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
+import { useTimeRange } from '../../../hooks/use_time_range';
 import * as urlHelpers from '../../shared/Links/url_helpers';
 import {
   getTimeRangeComparison,
@@ -150,7 +152,7 @@ export function getSelectOptions({
 export function TimeComparison() {
   const trackApmEvent = useUiTracker({ app: 'apm' });
   const history = useHistory();
-  const { isSmall } = useBreakPoints();
+  const { isSmall } = useBreakpoints();
   const {
     urlParams: { comparisonEnabled, comparisonType, exactStart, exactEnd },
   } = useUrlParams();

--- a/x-pack/plugins/apm/public/components/shared/time_comparison/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/time_comparison/index.tsx
@@ -14,9 +14,7 @@ import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common'
 import { useUiTracker } from '../../../../../observability/public';
 import { getDateDifference } from '../../../../common/utils/formatters';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
-import { useApmParams } from '../../../hooks/use_apm_params';
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
-import { useTimeRange } from '../../../hooks/use_time_range';
 import * as urlHelpers from '../../shared/Links/url_helpers';
 import {
   getTimeRangeComparison,

--- a/x-pack/plugins/apm/public/components/shared/transaction_type_select.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_type_select.tsx
@@ -10,7 +10,7 @@ import React, { FormEvent, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { useApmServiceContext } from '../../context/apm_service/use_apm_service_context';
-import { useBreakPoints } from '../../hooks/use_break_points';
+import { useBreakpoints } from '../../hooks/use_breakpoints';
 import * as urlHelpers from './Links/url_helpers';
 
 // The default transaction type (for non-RUM services) is "request". Set the
@@ -21,7 +21,7 @@ const EuiSelectWithWidth = styled(EuiSelect)`
 `;
 
 export function TransactionTypeSelect() {
-  const { isSmall } = useBreakPoints();
+  const { isSmall } = useBreakpoints();
   const { transactionTypes, transactionType } = useApmServiceContext();
   const history = useHistory();
 

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { EuiBasicTableColumn, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import {
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiFlexItem,
+  RIGHT_ALIGNMENT,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ValuesType } from 'utility-types';
@@ -16,10 +21,9 @@ import {
   asTransactionRate,
 } from '../../../../common/utils/formatters';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
-import { unit } from '../../../utils/style';
-import { SparkPlot } from '../charts/spark_plot';
 import { ImpactBar } from '../ImpactBar';
 import { TransactionDetailLink } from '../Links/apm/transaction_detail_link';
+import { ListMetric } from '../list_metric';
 import { TruncateWithTooltip } from '../truncate_with_tooltip';
 import { getLatencyColumnLabel } from './get_latency_column_label';
 
@@ -35,11 +39,13 @@ export function getColumns({
   latencyAggregationType,
   transactionGroupDetailedStatistics,
   comparisonEnabled,
+  shouldShowSparkPlots = true,
 }: {
   serviceName: string;
   latencyAggregationType?: LatencyAggregationType;
   transactionGroupDetailedStatistics?: TransactionGroupDetailedStatistics;
   comparisonEnabled?: boolean;
+  shouldShowSparkPlots?: boolean;
 }): Array<EuiBasicTableColumn<ServiceTransactionGroupItem>> {
   return [
     {
@@ -71,16 +77,17 @@ export function getColumns({
       field: 'latency',
       sortable: true,
       name: getLatencyColumnLabel(latencyAggregationType),
-      width: `${unit * 11}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { latency, name }) => {
         const currentTimeseries =
           transactionGroupDetailedStatistics?.currentPeriod?.[name]?.latency;
         const previousTimeseries =
           transactionGroupDetailedStatistics?.previousPeriod?.[name]?.latency;
         return (
-          <SparkPlot
+          <ListMetric
             color="euiColorVis1"
             compact
+            hideSeries={!shouldShowSparkPlots}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -97,7 +104,7 @@ export function getColumns({
         'xpack.apm.serviceOverview.transactionsTableColumnThroughput',
         { defaultMessage: 'Throughput' }
       ),
-      width: `${unit * 11}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { throughput, name }) => {
         const currentTimeseries =
           transactionGroupDetailedStatistics?.currentPeriod?.[name]?.throughput;
@@ -105,9 +112,10 @@ export function getColumns({
           transactionGroupDetailedStatistics?.previousPeriod?.[name]
             ?.throughput;
         return (
-          <SparkPlot
+          <ListMetric
             color="euiColorVis0"
             compact
+            hideSeries={!shouldShowSparkPlots}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -124,16 +132,17 @@ export function getColumns({
         'xpack.apm.serviceOverview.transactionsTableColumnErrorRate',
         { defaultMessage: 'Failed transaction rate' }
       ),
-      width: `${unit * 8}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { errorRate, name }) => {
         const currentTimeseries =
           transactionGroupDetailedStatistics?.currentPeriod?.[name]?.errorRate;
         const previousTimeseries =
           transactionGroupDetailedStatistics?.previousPeriod?.[name]?.errorRate;
         return (
-          <SparkPlot
+          <ListMetric
             color="euiColorVis7"
             compact
+            hideSeries={!shouldShowSparkPlots}
             series={currentTimeseries}
             comparisonSeries={
               comparisonEnabled ? previousTimeseries : undefined
@@ -150,7 +159,7 @@ export function getColumns({
         'xpack.apm.serviceOverview.transactionsTableColumnImpact',
         { defaultMessage: 'Impact' }
       ),
-      width: `${unit * 5}px`,
+      align: RIGHT_ALIGNMENT,
       render: (_, { name }) => {
         const currentImpact =
           transactionGroupDetailedStatistics?.currentPeriod?.[name]?.impact ??
@@ -158,7 +167,7 @@ export function getColumns({
         const previousImpact =
           transactionGroupDetailedStatistics?.previousPeriod?.[name]?.impact;
         return (
-          <EuiFlexGroup gutterSize="xs" direction="column">
+          <EuiFlexGroup alignItems="flexEnd" gutterSize="xs" direction="column">
             <EuiFlexItem>
               <ImpactBar value={currentImpact} size="m" />
             </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -28,6 +28,7 @@ import { getTimeRangeComparison } from '../time_comparison/get_time_range_compar
 import { OverviewTableContainer } from '../overview_table_container';
 import { getColumns } from './get_columns';
 import { ElasticDocsLink } from '../Links/ElasticDocsLink';
+import { useBreakpoints } from '../../../hooks/use_breakpoints';
 
 type ApiResponse = APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics'>;
 
@@ -57,6 +58,7 @@ const DEFAULT_SORT = {
 
 interface Props {
   hideViewTransactionsLink?: boolean;
+  isSingleColumn?: boolean;
   numberOfTransactionsPerPage?: number;
   showAggregationAccurateCallout?: boolean;
   environment: string;
@@ -67,6 +69,7 @@ interface Props {
 export function TransactionsTable({
   fixedHeight = false,
   hideViewTransactionsLink = false,
+  isSingleColumn = true,
   numberOfTransactionsPerPage = 5,
   showAggregationAccurateCallout = false,
   environment,
@@ -82,6 +85,10 @@ export function TransactionsTable({
     pageIndex: 0,
     sort: DEFAULT_SORT,
   });
+
+  // SparkPlots should be hidden if we're in two-column view and size XL (1200px)
+  const { isXl } = useBreakpoints();
+  const shouldShowSparkPlots = isSingleColumn || !isXl;
 
   const { pageIndex, sort } = tableOptions;
   const { direction, field } = sort;
@@ -216,6 +223,7 @@ export function TransactionsTable({
     latencyAggregationType,
     transactionGroupDetailedStatistics,
     comparisonEnabled,
+    shouldShowSparkPlots,
   });
 
   const isLoading = status === FETCH_STATUS.LOADING;

--- a/x-pack/plugins/apm/public/hooks/use_breakpoints.test.ts
+++ b/x-pack/plugins/apm/public/hooks/use_breakpoints.test.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { getScreenSizes } from './use_break_points';
+import { getScreenSizes } from './use_breakpoints';
 
-describe('use_break_points', () => {
+describe('use_breakpoints', () => {
   describe('getScreenSizes', () => {
     it('return xs when within 0px - 5740x', () => {
       expect(getScreenSizes(0)).toEqual({

--- a/x-pack/plugins/apm/public/hooks/use_breakpoints.ts
+++ b/x-pack/plugins/apm/public/hooks/use_breakpoints.ts
@@ -8,9 +8,13 @@
 import { useState } from 'react';
 import useWindowSize from 'react-use/lib/useWindowSize';
 import useDebounce from 'react-use/lib/useDebounce';
-import { isWithinMaxBreakpoint, isWithinMinBreakpoint } from '@elastic/eui';
+import {
+  getBreakpoint,
+  isWithinMaxBreakpoint,
+  isWithinMinBreakpoint,
+} from '@elastic/eui';
 
-export type BreakPoints = ReturnType<typeof getScreenSizes>;
+export type Breakpoints = ReturnType<typeof getScreenSizes>;
 
 export function getScreenSizes(windowWidth: number) {
   return {
@@ -24,17 +28,19 @@ export function getScreenSizes(windowWidth: number) {
   };
 }
 
-export function useBreakPoints() {
+export function useBreakpoints() {
   const { width } = useWindowSize();
+  const [breakpoint, setBreakpoint] = useState(getBreakpoint(width));
   const [screenSizes, setScreenSizes] = useState(getScreenSizes(width));
 
   useDebounce(
     () => {
+      setBreakpoint(getBreakpoint(width));
       setScreenSizes(getScreenSizes(width));
     },
     50,
     [width]
   );
 
-  return screenSizes;
+  return { ...screenSizes, breakpoint, width };
 }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Ensure name columns are not cut off on APM tables (#111046)