### PR TITLE
[CI] Reduce parallelism for tasks

### DIFF
--- a/vars/kibanaPipeline.groovy
+++ b/vars/kibanaPipeline.groovy
@@ -472,7 +472,7 @@ def withTasks(Map params = [:], Closure closure) {
 def allCiTasks() {
   parallel([
     general: {
-      withTasks {
+      withTasks([parallel: 20]) {
         tasks.check()
         tasks.lint()
         tasks.test()


### PR DESCRIPTION
We're getting memory spikes on CI. This is an attempt to reduce those spikes to stabilize CI until we moved to Buildkite in the coming weeks.