### PR TITLE
[7.15] [ML] APM Correlations: Fix API integration tests. (#111532)

### DIFF
--- a/x-pack/test/apm_api_integration/tests/correlations/errors_failed_transactions.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/errors_failed_transactions.ts
@@ -22,7 +22,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     query: {
       start: range.start,
       end: range.end,
-      fieldNames: 'user_agent.name,user_agent.os.name,url.original',
+      fieldNames: 'http.response.status_code,user_agent.name,user_agent.os.name,url.original',
       environment: 'ENVIRONMENT_ALL',
       kuery: '',
     },
@@ -40,8 +40,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/109660
-  registry.when.skip(
+  registry.when(
     'correlations errors failed transactions with data and default args',
     { config: 'trial', archives: ['apm_8.0.0'] },
     () => {
@@ -66,8 +65,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const sortedFieldNames = significantTerms.map(({ fieldName }) => fieldName).sort();
         expectSnapshot(sortedFieldNames).toMatchInline(`
           Array [
-            "user_agent.name",
-            "user_agent.name",
+            "http.response.status_code",
           ]
         `);
       });
@@ -76,7 +74,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const { significantTerms } = response.body;
         expectSnapshot(significantTerms.map((term) => term.timeseries.length)).toMatchInline(`
           Array [
-            31,
             31,
           ]
         `);

--- a/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.ts
@@ -225,7 +225,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       expect(typeof correlation).to.be('object');
       expect(correlation?.doc_count).to.be(31);
       expect(correlation?.score).to.be(83.70467673605746);
-      expect(correlation?.bg_count).to.be(31);
+      expect(correlation?.bg_count).to.be(60);
       expect(correlation?.fieldName).to.be('http.response.status_code');
       expect(correlation?.fieldValue).to.be(500);
       expect(typeof correlation?.pValue).to.be('number');

--- a/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.ts
@@ -35,7 +35,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     };
   };
 
-  registry.when('on trial license without data', { config: 'trial', archives: [] }, () => {
+  registry.when('failed transactions without data', { config: 'trial', archives: [] }, () => {
     it('queries the search strategy and returns results', async () => {
       const intialResponse = await supertest
         .post(`/internal/bsearch`)
@@ -124,8 +124,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/109703
-  registry.when.skip('on trial license with data', { config: 'trial', archives: ['8.0.0'] }, () => {
+  registry.when('failed transactions with data', { config: 'trial', archives: ['8.0.0'] }, () => {
     it('queries the search strategy and returns results', async () => {
       const intialResponse = await supertest
         .post(`/internal/bsearch`)
@@ -210,26 +209,25 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       expect(finalRawResponse?.overallHistogram).to.be(undefined);
 
       expect(finalRawResponse?.values.length).to.eql(
-        43,
-        `Expected 43 identified correlations, got ${finalRawResponse?.values.length}.`
+        30,
+        `Expected 30 identified correlations, got ${finalRawResponse?.values.length}.`
       );
 
       expect(finalRawResponse?.log.map((d: string) => d.split(': ')[1])).to.eql([
         'Identified 68 fieldCandidates.',
         'Identified correlations for 68 fields out of 68 candidates.',
-        'Identified 43 significant correlations relating to failed transactions.',
+        'Identified 30 significant correlations relating to failed transactions.',
       ]);
 
       const sortedCorrelations = finalRawResponse?.values.sort();
       const correlation = sortedCorrelations[0];
 
       expect(typeof correlation).to.be('object');
-      expect(correlation?.key).to.be('HTTP 5xx');
       expect(correlation?.doc_count).to.be(31);
-      expect(correlation?.score).to.be(100.17736139032642);
-      expect(correlation?.bg_count).to.be(60);
-      expect(correlation?.fieldName).to.be('transaction.result');
-      expect(correlation?.fieldValue).to.be('HTTP 5xx');
+      expect(correlation?.score).to.be(83.70467673605746);
+      expect(correlation?.bg_count).to.be(31);
+      expect(correlation?.fieldName).to.be('http.response.status_code');
+      expect(correlation?.fieldValue).to.be(500);
       expect(typeof correlation?.pValue).to.be('number');
       expect(typeof correlation?.normalizedScore).to.be('number');
       expect(typeof correlation?.failurePercentage).to.be('number');

--- a/x-pack/test/apm_api_integration/tests/correlations/latency_slow_transactions.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/latency_slow_transactions.ts
@@ -43,8 +43,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     }
   );
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/109583
-  registry.when.skip(
+  registry.when(
     'correlations latency slow transactions with data and default args',
     { config: 'trial', archives: ['apm_8.0.0'] },
     () => {
@@ -74,8 +73,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             "url.original",
             "user_agent.name",
             "user_agent.name",
-            "user_agent.name",
-            "user_agent.name",
             "user_agent.os.name",
           ]
         `);
@@ -85,8 +82,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const { significantTerms } = response.body;
         expectSnapshot(significantTerms.map((term) => term.distribution.length)).toMatchInline(`
           Array [
-            15,
-            15,
             15,
             15,
             15,


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [ML] APM Correlations: Fix API integration tests. (#111532)