### PR TITLE
[Enterprise Search] Fix a bug where users not populated

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/users_table.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { EuiBadge, EuiBasicTableColumn, EuiInMemoryTable, EuiTextColor } from '@elastic/eui';
 import type { EuiSearchBarOnChangeArgs } from '@elastic/eui';
@@ -57,6 +57,8 @@ const noItemsPlaceholder = <EuiTextColor color="subdued">&mdash;</EuiTextColor>;
 const invitationBadge = <EuiBadge color="hollow">{INVITATION_PENDING_LABEL}</EuiBadge>;
 const deactivatedBadge = <EuiBadge color="hollow">{DEACTIVATED_LABEL}</EuiBadge>;
 
+type Users = Array<Omit<SharedUser, 'elasticsearchUser | roleMapping'>>;
+
 export const UsersTable: React.FC<Props> = ({
   accessItemKey,
   singleUserRoleMappings,
@@ -72,9 +74,13 @@ export const UsersTable: React.FC<Props> = ({
     id: user.roleMapping.id,
     accessItems: (user.roleMapping as SharedRoleMapping)[accessItemKey],
     invitation: user.invitation,
-  })) as unknown) as Array<Omit<SharedUser, 'elasticsearchUser | roleMapping'>>;
+  })) as unknown) as Users;
 
-  const [items, setItems] = useState(users);
+  const [items, setItems] = useState([] as Users);
+
+  useEffect(() => {
+    setItems(users);
+  }, [singleUserRoleMappings]);
 
   const columns: Array<EuiBasicTableColumn<SharedUser>> = [
     {


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/109008, we fixed an issue where Role mappings were not populated on changes (adding/deleting). However, we did not apply the same fix for Users in the table under Role mappings. This PR does that.

**Before**

https://user-images.githubusercontent.com/1869731/132593286-abf9bd93-64cb-4ce3-8a34-741ad98ecf1d.mp4

**After**

https://user-images.githubusercontent.com/1869731/132593280-7edee667-e94b-438f-a98a-44e62c2c0458.mp4
