### PR TITLE
[Enterprise Search] Fix bug where flyout state was not reset

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.test.ts
@@ -418,6 +418,16 @@ describe('RoleMappingsLogic', () => {
 
         expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
+
+      it('resets roleMapping state', () => {
+        mount({
+          ...mappingsServerProps,
+          roleMapping: asRoleMapping,
+        });
+        RoleMappingsLogic.actions.initializeRoleMappings();
+
+        expect(RoleMappingsLogic.values.roleMapping).toEqual(null);
+      });
     });
 
     describe('initializeRoleMapping', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings_logic.ts
@@ -178,6 +178,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       null,
       {
         setRoleMapping: (_, { roleMapping }) => roleMapping,
+        initializeRoleMappings: () => null,
         resetState: () => null,
         closeUsersAndRolesFlyout: () => null,
       },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.test.ts
@@ -376,6 +376,16 @@ describe('RoleMappingsLogic', () => {
 
         expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
+
+      it('resets roleMapping state', () => {
+        mount({
+          ...mappingsServerProps,
+          roleMapping: wsRoleMapping,
+        });
+        RoleMappingsLogic.actions.initializeRoleMappings();
+
+        expect(RoleMappingsLogic.values.roleMapping).toEqual(null);
+      });
     });
 
     describe('initializeRoleMapping', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -168,6 +168,7 @@ export const RoleMappingsLogic = kea<MakeLogicType<RoleMappingsValues, RoleMappi
       null,
       {
         setRoleMapping: (_, { roleMapping }) => roleMapping,
+        initializeRoleMappings: () => null,
         resetState: () => null,
         closeUsersAndRolesFlyout: () => null,
       },


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2009

## Summary

This PR fixes a bug in both App Search and Workplace Search where the role mappings flyout state was not being cleared when updating a role mapping. The issue is that the state of the flyout is determined by the existence of a role mapping and this was not being cleared when the role mapping was saved.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
