### PR TITLE
[APM] Use new path syntax in waterfall

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/waterfall_item.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/waterfall_item.tsx
@@ -230,9 +230,9 @@ function RelatedErrors({
 }) {
   const apmRouter = useApmRouter();
   const theme = useTheme();
-  const { query } = useApmParams('/services/:serviceName/transactions/view');
+  const { query } = useApmParams('/services/{serviceName}/transactions/view');
 
-  const href = apmRouter.link(`/services/:serviceName/errors`, {
+  const href = apmRouter.link(`/services/{serviceName}/errors`, {
     path: { serviceName: item.doc.service.name },
     query: {
       ...query,


### PR DESCRIPTION
Use new route path syntax in the RelatedErrors component from the waterfall. The change was merged after https://github.com/elastic/kibana/pull/109812, but before pulling in changes from that branch, leading to type check errors in `main`.