### PR TITLE
Fix audit log tests

### DIFF
--- a/x-pack/plugins/security/server/audit/audit_service.test.ts
+++ b/x-pack/plugins/security/server/audit/audit_service.test.ts
@@ -29,7 +29,7 @@ import {
 jest.useFakeTimers();
 
 const createConfig = (settings: Partial<ConfigType['audit']>) => {
-  return ConfigSchema.validate(settings);
+  return ConfigSchema.validate({ audit: settings }).audit;
 };
 
 const logger = loggingSystemMock.createLogger();


### PR DESCRIPTION
This ensures that the config object given to the `AuditService` setup method is in fact the `xpack.security.audit.*` config options. Previously the entire `xpack.security.*` config object would be passed in.

The reason why this didn't fail the tests before was that both happen to have a similarly named config option called `enabled`, which these tests rely on.