### PR TITLE
Workplace Search remove extraneous tooltip from Recent Activity table

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
@@ -29,7 +29,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({ details }) => {
   const closePopover = () => setIsPopoverOpen(false);
   const formattedDetails = details.join('\n');
 
-  const tooltipPopoverTrigger = (
+  const popoverTrigger = (
     <EuiButtonIcon
       onClick={onButtonClick}
       color="text"
@@ -39,7 +39,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({ details }) => {
   );
 
   const infoPopover = (
-    <EuiPopover button={tooltipPopoverTrigger} isOpen={isPopoverOpen} closePopover={closePopover}>
+    <EuiPopover button={popoverTrigger} isOpen={isPopoverOpen} closePopover={closePopover}>
       <EuiCodeBlock
         language="bash"
         fontSize="m"

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
@@ -31,14 +31,12 @@ export const StatusItem: React.FC<StatusItemProps> = ({ details }) => {
   const formattedDetails = details.join('\n');
 
   const tooltipPopoverTrigger = (
-    <EuiToolTip position="top" content={STATUS_POPOVER_TOOLTIP}>
-      <EuiButtonIcon
-        onClick={onButtonClick}
-        color="text"
-        iconType="questionInCircle"
-        aria-label={STATUS_POPOVER_TOOLTIP}
-      />
-    </EuiToolTip>
+    <EuiButtonIcon
+      onClick={onButtonClick}
+      color="text"
+      iconType="questionInCircle"
+      aria-label={STATUS_POPOVER_TOOLTIP}
+    />
   );
 
   const infoPopover = (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx
@@ -11,7 +11,6 @@ import {
   EuiCopy,
   EuiButton,
   EuiButtonIcon,
-  EuiToolTip,
   EuiSpacer,
   EuiCodeBlock,
   EuiPopover,


### PR DESCRIPTION
Remove remove extraneous tooltip from Recent Activity table on the Source Overview page.

This resolves the following open issues:
[Source Overview table: extraneous tooltip? Click opens a popover on the same element #2011
](https://github.com/elastic/workplace-search-team/issues/2011)

## Summary

This PR changes the Recent Activity table:

| Before | After |
| - | - |
| ![132675418-b6da5096-b11f-4d3b-8df9-14dd523deca1](https://user-images.githubusercontent.com/7115017/132677317-2ced87ed-581b-4edb-9288-591f64a3cb56.gif) | ![Kapture 2021-09-09 at 12 22 22](https://user-images.githubusercontent.com/7115017/132677374-1f57ea6a-3bf7-49e7-920a-8032827fbeb8.gif) | 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
