### PR TITLE
[App Search] Make URLs in crawler validation messages clickable

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.test.tsx
@@ -44,7 +44,7 @@ describe('ValidationStepPanel', () => {
           action={action}
         />
       );
-      expect(wrapper.find('[data-test-subj="errorMessage"]').dive().text()).toContain(
+      expect(wrapper.find('[data-test-subj="errorMessage"]').childAt(0).text()).toContain(
         'Error message'
       );
       expect(wrapper.find('[data-test-subj="action"]')).toHaveLength(1);
@@ -58,7 +58,7 @@ describe('ValidationStepPanel', () => {
           action={action}
         />
       );
-      expect(wrapper.find('[data-test-subj="errorMessage"]').dive().text()).toContain(
+      expect(wrapper.find('[data-test-subj="errorMessage"]').childAt(0).text()).toContain(
         'Error message'
       );
       expect(wrapper.find('[data-test-subj="action"]')).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
@@ -7,7 +7,14 @@
 
 import React from 'react';
 
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiMarkdownFormat,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
 
 import { CrawlerDomainValidationStep } from '../../types';
 
@@ -26,9 +33,14 @@ export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
   action,
 }) => {
   const showErrorMessage = step.state === 'invalid' || step.state === 'warning';
+  const styleOverride = showErrorMessage ? { paddingBottom: 0 } : {};
 
   return (
-    <EuiPanel hasShadow={false} color={domainValidationStateToPanelColor(step.state)}>
+    <EuiPanel
+      hasShadow={false}
+      color={domainValidationStateToPanelColor(step.state)}
+      style={styleOverride}
+    >
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
           <ValidationStateIcon state={step.state} />
@@ -41,13 +53,14 @@ export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
       </EuiFlexGroup>
       {showErrorMessage && (
         <>
-          <EuiText size="s" data-test-subj="errorMessage">
-            <p>{step.message}</p>
-          </EuiText>
+          <EuiSpacer size="xs" />
+          <EuiMarkdownFormat textSize="s" data-test-subj="errorMessage">
+            {step.message || ''}
+          </EuiMarkdownFormat>
           {action && (
             <>
-              <EuiSpacer />
               {action}
+              <EuiSpacer />
             </>
           )}
         </>


### PR DESCRIPTION
## Summary

We present a few different domain validation messages (robots, content verification) that include URLs. We should make those URLs clickable.

<img width="1305" alt="CleanShot 2021-09-09 at 14 16 14@2x" src="https://user-images.githubusercontent.com/809707/132690733-b4afbb72-4e49-4862-9c13-b2829ca23f5c.png">

<img width="1305" alt="CleanShot 2021-09-09 at 14 18 06@2x" src="https://user-images.githubusercontent.com/809707/132685942-24ef1163-8e5b-4c1c-9a54-ce289511823f.png">