### PR TITLE
[7.x] [APM] Changes link version to master in APM links. (#111685)

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -35,9 +35,9 @@ export class DocLinksService {
           kibanaSettings: `${KIBANA_DOCS}apm-settings-in-kibana.html`,
           supportedServiceMaps: `${KIBANA_DOCS}service-maps.html#service-maps-supported`,
           customLinks: `${KIBANA_DOCS}custom-links.html`,
-          droppedTransactionSpans: `${APM_DOCS}get-started/${DOC_LINK_VERSION}/transaction-spans.html#dropped-spans`,
-          upgrading: `${APM_DOCS}server/${DOC_LINK_VERSION}/upgrading.html`,
-          metaData: `${APM_DOCS}get-started/${DOC_LINK_VERSION}/metadata.html`,
+          droppedTransactionSpans: `${APM_DOCS}get-started/master/transaction-spans.html#dropped-spans`,
+          upgrading: `${APM_DOCS}server/master/upgrading.html`,
+          metaData: `${APM_DOCS}get-started/master/metadata.html`,
         },
         canvas: {
           guide: `${KIBANA_DOCS}canvas.html`,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Changes link version to master in APM links. (#111685)