### PR TITLE
Alerting/poc show duration

### DIFF
--- a/x-pack/plugins/alerting/common/alert.ts
+++ b/x-pack/plugins/alerting/common/alert.ts
@@ -35,6 +35,7 @@ export enum AlertExecutionStatusErrorReasons {
 export interface AlertExecutionStatus {
   status: AlertExecutionStatuses;
   lastExecutionDate: Date;
+  lastDuration?: number;
   error?: {
     reason: AlertExecutionStatusErrorReasons;
     message: string;

--- a/x-pack/plugins/alerting/common/alert_instance_summary.ts
+++ b/x-pack/plugins/alerting/common/alert_instance_summary.ts
@@ -23,6 +23,11 @@ export interface AlertInstanceSummary {
   lastRun?: string;
   errorMessages: Array<{ date: string; message: string }>;
   instances: Record<string, AlertInstanceStatus>;
+  duration: {
+    average?: number;
+    max?: number;
+    min?: number;
+  };
 }
 
 export interface AlertInstanceStatus {

--- a/x-pack/plugins/alerting/server/lib/alert_execution_status.ts
+++ b/x-pack/plugins/alerting/server/lib/alert_execution_status.ts
@@ -30,13 +30,13 @@ export function executionStatusFromError(error: Error): AlertExecutionStatus {
   };
 }
 
-export function alertExecutionStatusToRaw({
-  lastExecutionDate,
-  status,
-  error,
-}: AlertExecutionStatus): RawAlertExecutionStatus {
+export function alertExecutionStatusToRaw(
+  { lastExecutionDate, status, error }: AlertExecutionStatus,
+  duration?: number
+): RawAlertExecutionStatus {
   return {
     lastExecutionDate: lastExecutionDate.toISOString(),
+    lastDuration: duration ?? null,
     status,
     // explicitly setting to null (in case undefined) due to partial update concerns
     error: error ?? null,
@@ -50,7 +50,7 @@ export function alertExecutionStatusFromRaw(
 ): AlertExecutionStatus | undefined {
   if (!rawAlertExecutionStatus) return undefined;
 
-  const { lastExecutionDate, status = 'unknown', error } = rawAlertExecutionStatus;
+  const { lastExecutionDate, lastDuration, status = 'unknown', error } = rawAlertExecutionStatus;
 
   let parsedDateMillis = lastExecutionDate ? Date.parse(lastExecutionDate) : Date.now();
   if (isNaN(parsedDateMillis)) {
@@ -64,7 +64,11 @@ export function alertExecutionStatusFromRaw(
   if (error) {
     return { lastExecutionDate: parsedDate, status, error };
   } else {
-    return { lastExecutionDate: parsedDate, status };
+    return {
+      ...(lastDuration ? { lastDuration } : {}),
+      lastExecutionDate: parsedDate,
+      status,
+    };
   }
 }
 

--- a/x-pack/plugins/alerting/server/routes/find_rules.ts
+++ b/x-pack/plugins/alerting/server/routes/find_rules.ts
@@ -91,8 +91,9 @@ const rewriteBodyRes: RewriteResponseCase<FindResult<AlertTypeParams>> = ({
         muted_alert_ids: mutedInstanceIds,
         scheduled_task_id: scheduledTaskId,
         execution_status: executionStatus && {
-          ...omit(executionStatus, 'lastExecutionDate'),
+          ...omit(executionStatus, 'lastExecutionDate', 'lastDuration'),
           last_execution_date: executionStatus.lastExecutionDate,
+          last_duration: executionStatus.lastDuration,
         },
         actions: actions.map(({ group, id, actionTypeId, params }) => ({
           group,

--- a/x-pack/plugins/alerting/server/saved_objects/mappings.json
+++ b/x-pack/plugins/alerting/server/saved_objects/mappings.json
@@ -101,6 +101,9 @@
           "lastExecutionDate": {
             "type": "date"
           },
+          "lastDuration": {
+            "type": "long"
+          },
           "error": {
             "properties": {
               "reason": {

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -601,7 +601,7 @@ export class TaskRunner<
 
     const client = this.context.internalSavedObjectsRepository;
     const attributes = {
-      executionStatus: alertExecutionStatusToRaw(executionStatus),
+      executionStatus: alertExecutionStatusToRaw(executionStatus, event.event?.duration),
     };
 
     try {

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -183,6 +183,7 @@ export interface AlertMeta extends SavedObjectAttributes {
 export interface RawAlertExecutionStatus extends SavedObjectAttributes {
   status: AlertExecutionStatuses;
   lastExecutionDate: string;
+  lastDuration: number | null;
   error: null | {
     reason: AlertExecutionStatusErrorReasons;
     message: string;

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/alert_api/common_transformations.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/alert_api/common_transformations.ts
@@ -22,9 +22,11 @@ const transformAction: RewriteRequestCase<AlertAction> = ({
 
 const transformExecutionStatus: RewriteRequestCase<AlertExecutionStatus> = ({
   last_execution_date: lastExecutionDate,
+  last_duration: lastDuration,
   ...rest
 }) => ({
   lastExecutionDate,
+  lastDuration,
   ...rest,
 });
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/alert_instances.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_details/components/alert_instances.tsx
@@ -8,7 +8,16 @@
 import React, { useState } from 'react';
 import moment, { Duration } from 'moment';
 import { i18n } from '@kbn/i18n';
-import { EuiBasicTable, EuiHealth, EuiSpacer, EuiToolTip } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiHealth,
+  EuiSpacer,
+  EuiToolTip,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCallOut,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 // @ts-ignore
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '@elastic/eui/lib/services';
 import { padStart, chunk } from 'lodash';
@@ -163,6 +172,52 @@ export function AlertInstances({
 
   return (
     <>
+      {alertInstanceSummary.duration && (
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiSpacer />
+            <EuiCallOut
+              title={i18n.translate(
+                'xpack.triggersActionsUI.sections.alertDetails.alerts.durationTitle',
+                {
+                  defaultMessage: 'Rule execution duration',
+                }
+              )}
+              color="primary"
+              iconType="clock"
+            >
+              <p>
+                <FormattedMessage
+                  id="xpack.triggersActionsUI.sections.alertDetails.alertInstances.durationText"
+                  defaultMessage="Average duration (nanoseconds): {average}"
+                  values={{
+                    average: alertInstanceSummary.duration.average,
+                  }}
+                />
+              </p>
+              <p>
+                <FormattedMessage
+                  id="xpack.triggersActionsUI.sections.alertDetails.alertInstances.durationText"
+                  defaultMessage="Max duration (nanoseconds): {max}"
+                  values={{
+                    max: alertInstanceSummary.duration.max,
+                  }}
+                />
+              </p>
+              <p>
+                <FormattedMessage
+                  id="xpack.triggersActionsUI.sections.alertDetails.alertInstances.durationText"
+                  defaultMessage="Min duration (nanoseconds): {min}"
+                  values={{
+                    min: alertInstanceSummary.duration.min,
+                  }}
+                />
+              </p>
+            </EuiCallOut>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      )}
+
       <EuiSpacer size="xl" />
       <input
         type="hidden"

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
@@ -396,6 +396,25 @@ export const AlertsList: React.FunctionComponent = () => {
       },
     },
     {
+      field: 'executionStatus.lastDuration',
+      name: '',
+      sortable: false,
+      width: '60px',
+      render: (_executionStatus: AlertExecutionStatus, item: AlertTableItem) => {
+        return item.executionStatus.lastDuration &&
+          item.executionStatus.lastDuration > 0 /* 300000000000*/ ? (
+          <EuiIconTip
+            type="clock"
+            color="danger"
+            content={`Last rule execution took ${item.executionStatus.lastDuration} nanoseconds, which is unusually long!`}
+            position="right"
+          />
+        ) : (
+          <></>
+        );
+      },
+    },
+    {
       field: 'alertType',
       name: i18n.translate(
         'xpack.triggersActionsUI.sections.alertsList.alertsListTable.columns.alertTypeTitle',


### PR DESCRIPTION
## Summary

Stores `lastDuration` information in rule execution status and surfaces this information in the rule list and rule details page

<img width="1514" alt="Screen Shot 2021-09-09 at 8 28 10 AM" src="https://user-images.githubusercontent.com/13104637/132706473-846ed6d3-0b37-484c-8b35-8ceb8de08d50.png">
<img width="1561" alt="Screen Shot 2021-09-09 at 9 21 54 AM" src="https://user-images.githubusercontent.com/13104637/132706484-20b31f25-2e81-4d44-9ba4-229b99480106.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
