### PR TITLE
[Security Solution] Fix incorrect number of alerts shows under External alert trend

### DIFF
--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/matrix_histogram/index.ts
@@ -34,6 +34,15 @@ export enum MatrixHistogramType {
   dns = 'dns',
 }
 
+export const MatrixHistogramTypeToAggName = {
+  [MatrixHistogramType.alerts]: 'aggregations.alertsGroup.buckets',
+  [MatrixHistogramType.anomalies]: 'aggregations.anomalyActionGroup.buckets',
+  [MatrixHistogramType.authentications]: 'aggregations.eventActionGroup.buckets',
+  [MatrixHistogramType.authenticationsEntities]: 'aggregations.events.buckets',
+  [MatrixHistogramType.dns]: 'aggregations.dns_name_query_count.buckets',
+  [MatrixHistogramType.events]: 'aggregations.eventActionGroup.buckets',
+};
+
 export interface MatrixHistogramRequestOptions extends RequestBasicOptions {
   timerange: TimerangeInput;
   histogramType: MatrixHistogramType;

--- a/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.test.ts
@@ -14,6 +14,22 @@ import { TestProviders } from '../../mock/test_providers';
 
 jest.mock('../../../common/lib/kibana');
 
+const basicResponse = {
+  isPartial: false,
+  isRunning: false,
+  total: 0,
+  loaded: 0,
+  rawResponse: {
+    took: 1,
+    timed_out: false,
+    hits: {
+      max_score: 0,
+      hits: [],
+      total: 0,
+    },
+  },
+};
+
 describe('useMatrixHistogram', () => {
   const props = {
     endDate: new Date(Date.now()).toISOString(),
@@ -56,6 +72,78 @@ describe('useMatrixHistogram', () => {
     const result2 = result.current[1];
 
     expect(result1).toBe(result2);
+  });
+
+  it("returns buckets for histogram Type 'events'", async () => {
+    const localProps = { ...props, histogramType: MatrixHistogramType.events };
+    const mockEventsSearchStrategyResponse = {
+      ...basicResponse,
+      rawResponse: {
+        ...basicResponse.rawResponse,
+        aggregations: {
+          eventActionGroup: {
+            doc_count_error_upper_bound: 0,
+            sum_other_doc_count: 0,
+            buckets: [
+              {
+                key: 'my dsn test buckets',
+                doc_count: 1,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    (useKibana().services.data.search.search as jest.Mock).mockReturnValueOnce({
+      subscribe: ({ next }: { next: Function }) => next(mockEventsSearchStrategyResponse),
+    });
+
+    const {
+      result: { current },
+    } = renderHook(() => useMatrixHistogram(localProps), {
+      wrapper: TestProviders,
+    });
+
+    expect(current[1].buckets).toBe(
+      mockEventsSearchStrategyResponse.rawResponse.aggregations?.eventActionGroup.buckets
+    );
+  });
+
+  it("returns buckets for histogram Type 'dns'", async () => {
+    const mockDnsSearchStrategyResponse = {
+      ...basicResponse,
+      rawResponse: {
+        ...basicResponse.rawResponse,
+        aggregations: {
+          dns_name_query_count: {
+            doc_count_error_upper_bound: 0,
+            sum_other_doc_count: 0,
+            buckets: [
+              {
+                key: 'my dsn test buckets',
+                doc_count: 1,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const localProps = { ...props, histogramType: MatrixHistogramType.dns };
+    (useKibana().services.data.search.search as jest.Mock).mockReturnValueOnce({
+      subscribe: ({ next }: { next: Function }) => next(mockDnsSearchStrategyResponse),
+    });
+
+    const {
+      result: { current },
+    } = renderHook(() => useMatrixHistogram(localProps), {
+      wrapper: TestProviders,
+    });
+
+    expect(current[1].buckets).toBe(
+      mockDnsSearchStrategyResponse.rawResponse.aggregations?.dns_name_query_count.buckets
+    );
   });
 });
 

--- a/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
@@ -19,6 +19,7 @@ import {
   MatrixHistogramRequestOptions,
   MatrixHistogramStrategyResponse,
   MatrixHistogramData,
+  MatrixHistogramTypeToAggName,
 } from '../../../../common/search_strategy/security_solution';
 import { isErrorResponse, isCompleteResponse } from '../../../../../../../src/plugins/data/common';
 import { getInspectResponse } from '../../../helpers';
@@ -132,8 +133,8 @@ export const useMatrixHistogram = ({
               if (isCompleteResponse(response)) {
                 const histogramBuckets: Buckets = getOr(
                   bucketEmpty,
-                  'rawResponse.aggregations.eventActionGroup.buckets',
-                  response
+                  MatrixHistogramTypeToAggName[histogramType],
+                  response.rawResponse
                 );
                 setLoading(false);
                 setMatrixHistogramResponse((prevResponse) => ({
@@ -165,7 +166,7 @@ export const useMatrixHistogram = ({
       asyncSearch();
       refetch.current = asyncSearch;
     },
-    [data.search, errorMessage, addError, addWarning]
+    [data.search, errorMessage, addError, addWarning, histogramType]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/index.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
+import { MatrixHistogramTypeToAggName } from '../../../../../../common';
 import { buildAlertsHistogramQuery } from './query.alerts_histogram.dsl';
 
 export const alertsMatrixHistogramConfig = {
   buildDsl: buildAlertsHistogramQuery,
-  aggName: 'aggregations.alertsGroup.buckets',
+  aggName: MatrixHistogramTypeToAggName.alerts,
   parseKey: 'alerts.buckets',
 };

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/index.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
+import { MatrixHistogramTypeToAggName } from '../../../../../../common';
 import { buildAnomaliesHistogramQuery } from './query.anomalies_histogram.dsl';
 
 export const anomaliesMatrixHistogramConfig = {
   buildDsl: buildAnomaliesHistogramQuery,
-  aggName: 'aggregations.anomalyActionGroup.buckets',
+  aggName: MatrixHistogramTypeToAggName.anomalies,
   parseKey: 'anomalies.buckets',
 };

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/index.ts
@@ -5,19 +5,20 @@
  * 2.0.
  */
 
+import { MatrixHistogramTypeToAggName } from '../../../../../../common';
 import { getEntitiesParser } from '../helpers';
 import { buildAuthenticationsHistogramQuery } from './query.authentications_histogram.dsl';
 import { buildAuthenticationsHistogramQueryEntities } from './query.authentications_histogram_entities.dsl';
 
 export const authenticationsMatrixHistogramConfig = {
   buildDsl: buildAuthenticationsHistogramQuery,
-  aggName: 'aggregations.eventActionGroup.buckets',
+  aggName: MatrixHistogramTypeToAggName.authentications,
   parseKey: 'events.buckets',
 };
 
 export const authenticationsMatrixHistogramEntitiesConfig = {
   buildDsl: buildAuthenticationsHistogramQueryEntities,
-  aggName: 'aggregations.events.buckets',
+  aggName: MatrixHistogramTypeToAggName.authenticationsEntities,
   parseKey: 'events.buckets',
   parser: getEntitiesParser,
 };

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/index.ts
@@ -7,10 +7,11 @@
 
 import { buildDnsHistogramQuery } from './query.dns_histogram.dsl';
 import { getDnsParsedData } from './helpers';
+import { MatrixHistogramTypeToAggName } from '../../../../../../common';
 
 export const dnsMatrixHistogramConfig = {
   buildDsl: buildDnsHistogramQuery,
-  aggName: 'aggregations.dns_name_query_count.buckets',
+  aggName: MatrixHistogramTypeToAggName.dns,
   parseKey: 'dns_question_name.buckets',
   parser: getDnsParsedData,
 };

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/index.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
+import { MatrixHistogramTypeToAggName } from '../../../../../../common';
 import { buildEventsHistogramQuery } from './query.events_histogram.dsl';
 
 export const eventsMatrixHistogramConfig = {
   buildDsl: buildEventsHistogramQuery,
-  aggName: 'aggregations.eventActionGroup.buckets',
+  aggName: MatrixHistogramTypeToAggName.events,
   parseKey: 'events.buckets',
 };


### PR DESCRIPTION
issue: #111679

## Summary

During a [previous fix](https://github.com/elastic/kibana/pull/111256), I broke the trend graph for External alerts. The reason is that I started counting the total of events based on the bucket. But every kind of `MatrixHistogramType`  has a different aggregation name. `eventActionGroup ` was wrongly hardcoded inside `useMatrixHistogram`. After this change, `buckets` should be returned for every type of MatrixHistogram.

https://user-images.githubusercontent.com/1490444/132718905-6b85513f-700c-4bf6-bd99-4cc6697387c7.mp4

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
