### PR TITLE
[ci] bump Jenkins worker memory and es JVM size

### DIFF
--- a/packages/kbn-es/src/cluster.js
+++ b/packages/kbn-es/src/cluster.js
@@ -278,7 +278,8 @@ exports.Cluster = class Cluster {
     // especially because we currently run many instances of ES on the same machine during CI
     // inital and max must be the same, so we only need to check the max
     if (!esJavaOpts.includes('Xmx')) {
-      esJavaOpts += ' -Xms1g -Xmx1g';
+      // 1536m === 1.5g
+      esJavaOpts += ' -Xms1536m -Xmx1536m';
     }
 
     this._log.debug('ES_JAVA_OPTS: %s', esJavaOpts.trim());

--- a/packages/kbn-es/src/integration_tests/cluster.test.js
+++ b/packages/kbn-es/src/integration_tests/cluster.test.js
@@ -368,7 +368,7 @@ describe('#run()', () => {
     const cluster = new Cluster({ log });
     await cluster.run();
 
-    expect(execa.mock.calls[0][2].env.ES_JAVA_OPTS).toEqual('-Xms1g -Xmx1g');
+    expect(execa.mock.calls[0][2].env.ES_JAVA_OPTS).toMatchInlineSnapshot(`"-Xms1536m -Xmx1536m"`);
   });
 
   it('allows Java heap to be overwritten', async () => {
@@ -378,7 +378,7 @@ describe('#run()', () => {
     const cluster = new Cluster({ log });
     await cluster.run();
 
-    expect(execa.mock.calls[0][2].env.ES_JAVA_OPTS).toEqual('-Xms5g -Xmx5g');
+    expect(execa.mock.calls[0][2].env.ES_JAVA_OPTS).toMatchInlineSnapshot(`"-Xms5g -Xmx5g"`);
   });
 });
 

--- a/vars/workers.groovy
+++ b/vars/workers.groovy
@@ -20,7 +20,7 @@ def label(size) {
     case 'xl-highmem':
       return 'docker && tests-xl-highmem'
     case 'xxl':
-      return 'docker && tests-xxl && gobld/machineType:custom-64-270336'
+      return 'docker && tests-xxl && gobld/machineType:custom-64-327680'
     case 'n2-standard-16':
       return 'docker && linux && immutable && gobld/machineType:n2-standard-16'
   }


### PR DESCRIPTION
We've seen a decent number of random failures in CI that seem to be caused by workers running low on memory, and the ES JVM needing more than 1GB of space in several cases.

Evidence of the JVM running out of memory looks like this:
```
info #
     # There is insufficient memory for the Java Runtime Environment to continue.
     # Native memory allocation (malloc) failed to allocate 8589934608 bytes for Chunk::new
info # An error report file with more information is saved as:
     # logs/hs_err_pid189095.log
info #
     # Compiler replay data is saved as:
     # /dev/shm/workspace/parallel/20/kibana/.es/job-kibana-ciGroup12-worker-20-es-test-cluster/replay_pid189095.log
```
We currently limit the JVM to 1g, so in this PR we've bumped the heap limit to 1.5gb.

Raising the JVM max heap means we need to bump the worker memory limit by at least 12gb (24 concurrent tasks * .5gb). Additionally though we see evidence that if multiple tasks start close together memory usage can spike to 100% and then lead to swapping which breaks a lot of things. A failure yesterday (with 1gb heaps) had the following memory usage:

![image](https://user-images.githubusercontent.com/1329312/132723114-d2d310d2-b8a3-4210-a611-174c81df96e6.png)

Our current workers have 270gb of memory, so I'm looking to bump the memory by 50gb to 320gb so that we can reduce the random issues while we complete the migration to BuildKite.

