### PR TITLE
[7.14] Drop the 'Displays the unmapped field on the table' test (#111741)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/ccs_integration/detection_alerts/alerts_details.spec.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { CELL_TEXT, JSON_LINES, TABLE_ROWS } from '../../screens/alerts_details';
+import { JSON_LINES } from '../../screens/alerts_details';
 
 import {
   expandFirstAlert,
   waitForAlertsIndexToBeCreated,
   waitForAlertsPanelToBeLoaded,
 } from '../../tasks/alerts';
-import { openJsonView, openTable, scrollJsonViewToBottom } from '../../tasks/alerts_details';
+import { openJsonView, scrollJsonViewToBottom } from '../../tasks/alerts_details';
 import { createCustomRuleActivated } from '../../tasks/api_calls/rules';
 import { cleanKibana } from '../../tasks/common';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
@@ -51,22 +51,5 @@ describe('Alert details with unmapped fields', () => {
         .eq(length - expectedUnmappedField.line)
         .should('have.text', expectedUnmappedField.text);
     });
-  });
-
-  it('Displays the unmapped field on the table', () => {
-    const expectedUnmmappedField = {
-      row: 56,
-      field: 'unmapped',
-      text: 'This is the unmapped field',
-    };
-
-    openTable();
-
-    cy.get(TABLE_ROWS)
-      .eq(expectedUnmmappedField.row)
-      .within(() => {
-        cy.get(CELL_TEXT).eq(0).should('have.text', expectedUnmmappedField.field);
-        cy.get(CELL_TEXT).eq(1).should('have.text', expectedUnmmappedField.text);
-      });
   });
 });


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Drop the 'Displays the unmapped field on the table' test (#111741)