### PR TITLE
[Security Solution] Correct the default user notification messages and tooltip text for Memory and Behavior

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
@@ -244,3 +244,4 @@ export const policyFactoryWithSupportedFeatures = (
  * Reflects what string the Endpoint will use when message field is default/empty
  */
 export const DefaultPolicyNotificationMessage = 'Elastic Security {action} {filename}';
+export const DefaultPolicyRuleNotificationMessage = 'Elastic Security {action} {rule}';

--- a/x-pack/plugins/security_solution/common/license/policy_config.test.ts
+++ b/x-pack/plugins/security_solution/common/license/policy_config.test.ts
@@ -11,6 +11,7 @@ import {
 } from './policy_config';
 import {
   DefaultPolicyNotificationMessage,
+  DefaultPolicyRuleNotificationMessage,
   policyFactory,
   policyFactoryWithSupportedFeatures,
   policyFactoryWithoutPaidFeatures,
@@ -367,7 +368,7 @@ describe('policy_config and licenses', () => {
       expect(retPolicy.windows.popup.memory_protection.message).not.toEqual(popupMessage);
 
       // need to invert the test, since it could be either value
-      expect(['', DefaultPolicyNotificationMessage]).toContain(
+      expect(['', DefaultPolicyRuleNotificationMessage]).toContain(
         retPolicy.windows.popup.memory_protection.message
       );
     });
@@ -391,7 +392,7 @@ describe('policy_config and licenses', () => {
       expect(retPolicy.windows.popup.behavior_protection.message).not.toEqual(popupMessage);
 
       // need to invert the test, since it could be either value
-      expect(['', DefaultPolicyNotificationMessage]).toContain(
+      expect(['', DefaultPolicyRuleNotificationMessage]).toContain(
         retPolicy.windows.popup.behavior_protection.message
       );
 
@@ -402,7 +403,7 @@ describe('policy_config and licenses', () => {
       expect(retPolicy.mac.popup.behavior_protection.message).not.toEqual(popupMessage);
 
       // need to invert the test, since it could be either value
-      expect(['', DefaultPolicyNotificationMessage]).toContain(
+      expect(['', DefaultPolicyRuleNotificationMessage]).toContain(
         retPolicy.mac.popup.behavior_protection.message
       );
 
@@ -415,7 +416,7 @@ describe('policy_config and licenses', () => {
       expect(retPolicy.linux.popup.behavior_protection.message).not.toEqual(popupMessage);
 
       // need to invert the test, since it could be either value
-      expect(['', DefaultPolicyNotificationMessage]).toContain(
+      expect(['', DefaultPolicyRuleNotificationMessage]).toContain(
         retPolicy.linux.popup.behavior_protection.message
       );
     });

--- a/x-pack/plugins/security_solution/common/license/policy_config.ts
+++ b/x-pack/plugins/security_solution/common/license/policy_config.ts
@@ -10,6 +10,7 @@ import { isAtLeast } from './license';
 import { PolicyConfig } from '../endpoint/types';
 import {
   DefaultPolicyNotificationMessage,
+  DefaultPolicyRuleNotificationMessage,
   policyFactoryWithoutPaidFeatures,
   policyFactoryWithSupportedFeatures,
 } from '../endpoint/models/policy_config';
@@ -113,7 +114,7 @@ function isEndpointMemoryPolicyValidForLicense(policy: PolicyConfig, license: IL
 
   if (
     policy.windows.popup.memory_protection.message !== '' &&
-    policy.windows.popup.memory_protection.message !== DefaultPolicyNotificationMessage
+    policy.windows.popup.memory_protection.message !== DefaultPolicyRuleNotificationMessage
   ) {
     return false;
   }
@@ -164,11 +165,11 @@ function isEndpointBehaviorPolicyValidForLicense(policy: PolicyConfig, license: 
   // Only Platinum or higher may change the behavior_protection message (which can be blank or what Endpoint defaults)
   if (
     (policy.windows.popup.behavior_protection.message !== '' &&
-      policy.windows.popup.behavior_protection.message !== DefaultPolicyNotificationMessage) ||
+      policy.windows.popup.behavior_protection.message !== DefaultPolicyRuleNotificationMessage) ||
     (policy.mac.popup.behavior_protection.message !== '' &&
-      policy.mac.popup.behavior_protection.message !== DefaultPolicyNotificationMessage) ||
+      policy.mac.popup.behavior_protection.message !== DefaultPolicyRuleNotificationMessage) ||
     (policy.linux.popup.behavior_protection.message !== '' &&
-      policy.linux.popup.behavior_protection.message !== DefaultPolicyNotificationMessage)
+      policy.linux.popup.behavior_protection.message !== DefaultPolicyRuleNotificationMessage)
   ) {
     return false;
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware.ts
@@ -6,7 +6,10 @@
  */
 
 import { IHttpFetchError } from 'kibana/public';
-import { DefaultPolicyNotificationMessage } from '../../../../../../common/endpoint/models/policy_config';
+import {
+  DefaultPolicyNotificationMessage,
+  DefaultPolicyRuleNotificationMessage,
+} from '../../../../../../common/endpoint/models/policy_config';
 import { PolicyDetailsState, UpdatePolicyResponse } from '../../types';
 import {
   policyIdFromParams,
@@ -50,20 +53,20 @@ export const policyDetailsMiddlewareFactory: ImmutableMiddlewareFactory<PolicyDe
         if (
           policyItem.inputs[0].config.policy.value.windows.popup.memory_protection.message === ''
         ) {
-          policyItem.inputs[0].config.policy.value.windows.popup.memory_protection.message = DefaultPolicyNotificationMessage;
+          policyItem.inputs[0].config.policy.value.windows.popup.memory_protection.message = DefaultPolicyRuleNotificationMessage;
         }
         if (
           policyItem.inputs[0].config.policy.value.windows.popup.behavior_protection.message === ''
         ) {
-          policyItem.inputs[0].config.policy.value.windows.popup.behavior_protection.message = DefaultPolicyNotificationMessage;
+          policyItem.inputs[0].config.policy.value.windows.popup.behavior_protection.message = DefaultPolicyRuleNotificationMessage;
         }
         if (policyItem.inputs[0].config.policy.value.mac.popup.behavior_protection.message === '') {
-          policyItem.inputs[0].config.policy.value.mac.popup.behavior_protection.message = DefaultPolicyNotificationMessage;
+          policyItem.inputs[0].config.policy.value.mac.popup.behavior_protection.message = DefaultPolicyRuleNotificationMessage;
         }
         if (
           policyItem.inputs[0].config.policy.value.linux.popup.behavior_protection.message === ''
         ) {
-          policyItem.inputs[0].config.policy.value.linux.popup.behavior_protection.message = DefaultPolicyNotificationMessage;
+          policyItem.inputs[0].config.policy.value.linux.popup.behavior_protection.message = DefaultPolicyRuleNotificationMessage;
         }
       } catch (error) {
         dispatch({

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/user_notification.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/user_notification.tsx
@@ -94,6 +94,38 @@ export const UserNotification = React.memo(
       [policyDetailsConfig, dispatch, protection, osList]
     );
 
+    const tooltipProtectionText = (protectionType: PolicyProtection) => {
+      if (protectionType === 'memory_protection') {
+        return i18n.translate(
+          'xpack.securitySolution.endpoint.policyDetail.memoryProtectionTooltip',
+          {
+            defaultMessage: 'memory threat',
+          }
+        );
+      } else if (protectionType === 'behavior_protection') {
+        return i18n.translate(
+          'xpack.securitySolution.endpoint.policyDetail.behaviorProtectionTooltip',
+          {
+            defaultMessage: 'malicious behavior',
+          }
+        );
+      } else {
+        return protectionType;
+      }
+    };
+
+    const tooltipBracketText = (protectionType: PolicyProtection) => {
+      if (protectionType === 'memory_protection' || protection === 'behavior_protection') {
+        return i18n.translate('xpack.securitySolution.endpoint.policyDetail.rule', {
+          defaultMessage: 'rule',
+        });
+      } else {
+        return i18n.translate('xpack.securitySolution.endpoint.policyDetail.filename', {
+          defaultMessage: 'filename',
+        });
+      }
+    };
+
     return (
       <>
         <EuiSpacer size="m" />
@@ -139,14 +171,17 @@ export const UserNotification = React.memo(
                         id="xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.a"
                         defaultMessage="Selecting the user notification option will display a notification to the host user when { protectionName } is prevented or detected."
                         values={{
-                          protectionName: protection,
+                          protectionName: tooltipProtectionText(protection),
                         }}
                       />
                       <EuiSpacer size="m" />
                       <FormattedMessage
                         id="xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.b"
                         defaultMessage="
-                    The user notification can be customized in the text box below. Bracketed tags can be used to dynamically populate the applicable action (such as prevented or detected) and the filename."
+                    The user notification can be customized in the text box below. Bracketed tags can be used to dynamically populate the applicable action (such as prevented or detected) and the { bracketText }."
+                        values={{
+                          bracketText: tooltipBracketText(protection),
+                        }}
                       />
                     </>
                   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/user_notification.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/user_notification.tsx
@@ -176,7 +176,7 @@ export const UserNotification = React.memo(
                       />
                       <EuiSpacer size="m" />
                       <FormattedMessage
-                        id="xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.b"
+                        id="xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.c"
                         defaultMessage="
                     The user notification can be customized in the text box below. Bracketed tags can be used to dynamically populate the applicable action (such as prevented or detected) and the { bracketText }."
                         values={{

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -22423,7 +22423,6 @@
     "xpack.securitySolution.endpoint.policyDetailsConfig.mac.events.network": "ネットワーク",
     "xpack.securitySolution.endpoint.policyDetailsConfig.mac.events.process": "プロセス",
     "xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.a": "ユーザー通知オプションを選択すると、{ protectionName }が防御または検出されたときに、ホストユーザーに通知を表示します。",
-    "xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.b": " ユーザー通知は、以下のテキストボックスでカスタマイズできます。括弧内のタグを使用すると、該当するアクション（防御または検出など）とファイル名を動的に入力できます。",
     "xpack.securitySolution.endpoint.policyDetailsConfig.protectionLevel": "保護レベル",
     "xpack.securitySolution.endpoint.policyDetailsConfig.userNotification": "ユーザー通知",
     "xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.dllDriverLoad": "DLL とドライバーの読み込み",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -22772,7 +22772,6 @@
     "xpack.securitySolution.endpoint.policyDetailsConfig.mac.events.network": "网络",
     "xpack.securitySolution.endpoint.policyDetailsConfig.mac.events.process": "进程",
     "xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.a": "选择用户通知选项后，在阻止或检测到{ protectionName }时将向主机用户显示通知。",
-    "xpack.securitySolution.endpoint.policyDetailsConfig.notifyUserTooltip.b": " 可在下方文本框中定制用户通知。括号中的标签可用于动态填充适用操作（如已阻止或已检测）和文件名。",
     "xpack.securitySolution.endpoint.policyDetailsConfig.protectionLevel": "防护级别",
     "xpack.securitySolution.endpoint.policyDetailsConfig.userNotification": "用户通知",
     "xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.dllDriverLoad": "DLL 和驱动程序加载",

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -306,7 +306,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                 },
               },
@@ -322,7 +322,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                 },
               },
@@ -348,11 +348,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   memory_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                   ransomware: {
                     enabled: true,
@@ -530,7 +530,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                 },
               },
@@ -546,7 +546,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                 },
               },
@@ -572,11 +572,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   memory_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                   ransomware: {
                     enabled: true,
@@ -751,7 +751,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                 },
               },
@@ -767,7 +767,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                 },
               },
@@ -793,11 +793,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
                   },
                   memory_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                   behavior_protection: {
                     enabled: true,
-                    message: 'Elastic Security {action} {filename}',
+                    message: 'Elastic Security {action} {rule}',
                   },
                   ransomware: {
                     enabled: true,


### PR DESCRIPTION
## Summary

Corrects the default user notification message and the tooltip text.  The Endpoint team is also adding functionality to recognize the `{rule}` bracket.

Bugs:
https://github.com/elastic/kibana/issues/111694
https://github.com/elastic/kibana/issues/111517

![image](https://user-images.githubusercontent.com/56395104/132765897-76315dca-6030-44e6-8c80-fb4c1bb3c9db.png)

![image](https://user-images.githubusercontent.com/56395104/132765915-e2df2dcf-4613-4402-a3b4-93154c7a1a34.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
