### PR TITLE
[7.15] 'kibana.alert.rule.from' should be mapped as 'keyword' (#111793)

### DIFF
--- a/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts
+++ b/x-pack/plugins/rule_registry/common/assets/field_maps/technical_rule_field_map.ts
@@ -120,7 +120,7 @@ export const technicalRuleFieldMap = {
     required: false,
   },
   [Fields.ALERT_RULE_FROM]: {
-    type: 'date',
+    type: 'keyword',
     array: false,
     required: false,
   },


### PR DESCRIPTION
Backports the following commits to 7.15:
 - 'kibana.alert.rule.from' should be mapped as 'keyword' (#111793)