### PR TITLE
[APM] Adding `lambda` icon

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/agent_icon/get_agent_icon.ts
+++ b/x-pack/plugins/apm/public/components/shared/agent_icon/get_agent_icon.ts
@@ -19,6 +19,7 @@ import goIcon from './icons/go.svg';
 import iosIcon from './icons/ios.svg';
 import darkIosIcon from './icons/ios_dark.svg';
 import javaIcon from './icons/java.svg';
+import lambdaIcon from './icons/lambda.svg';
 import nodeJsIcon from './icons/nodejs.svg';
 import ocamlIcon from './icons/ocaml.svg';
 import openTelemetryIcon from './icons/opentelemetry.svg';
@@ -37,6 +38,7 @@ const agentIcons: { [key: string]: string } = {
   go: goIcon,
   ios: iosIcon,
   java: javaIcon,
+  lambda: lambdaIcon,
   nodejs: nodeJsIcon,
   ocaml: ocamlIcon,
   opentelemetry: openTelemetryIcon,

--- a/x-pack/plugins/apm/public/components/shared/agent_icon/icons/lambda.svg
+++ b/x-pack/plugins/apm/public/components/shared/agent_icon/icons/lambda.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="13" r="12" fill="#FB7E14"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.41041 5V7.55399H9.48632L10.3389 10.2207L4 20.1737H7.11386L11.6364 13.4131L14.6019 21L19.2727 19.4977L18.5313 17.169L16.3813 17.8451L11.3398 5H7.41041Z" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/106552 - adds the `lambda` icon for Lambda service icons.

Please note Storybook has not been updated because the logic of when to show the `lambda` icon won't be tied to the agent name as we traditionally do, but instead if detected as a function will be placed alongside the agent name icon for the given service. Further description can be found in the related issue above.

**Storybook example just for visual that the icon is added**

<img width="532" alt="CleanShot 2021-09-10 at 10 50 43@2x" src="https://user-images.githubusercontent.com/4104278/132827601-4fb596cf-7512-4164-869d-8f29d28e5b20.png">


<img width="533" alt="CleanShot 2021-09-10 at 10 50 51@2x" src="https://user-images.githubusercontent.com/4104278/132827593-f7e50937-9e42-45bd-a092-4a6f35d73acd.png">
