### PR TITLE
[RAC][Security Solution] Change default page size to 10 and options to 10 and 25 

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/alerts_viewer/alerts_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/alerts_viewer/alerts_table.tsx
@@ -81,6 +81,7 @@ const AlertsTableComponent: React.FC<Props> = ({
   const { filterManager } = useKibana().services.data.query;
 
   const tGridEnabled = useIsExperimentalFeatureEnabled('tGridEnabled');
+  const itemsPerPageOptions: number[] = useMemo(() => [10, 25], []);
 
   useEffect(() => {
     dispatch(
@@ -112,6 +113,7 @@ const AlertsTableComponent: React.FC<Props> = ({
       end={endDate}
       entityType={entityType}
       id={timelineId}
+      itemsPerPageOptions={itemsPerPageOptions}
       renderCellValue={DefaultCellRenderer}
       rowRenderers={defaultRowRenderers}
       scopeId={SourcererScopeName.default}

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -66,6 +66,8 @@ export interface OwnProps {
   additionalFilters?: React.ReactNode;
   hasAlertsCrud?: boolean;
   unit?: (n: number) => string;
+  itemsPerPage?: number;
+  itemsPerPageOptions?: number[];
 }
 
 type Props = OwnProps & PropsFromRedux;
@@ -245,7 +247,15 @@ const makeMapStateToProps = () => {
   const getGlobalQuerySelector = inputsSelectors.globalQuerySelector();
   const getGlobalFiltersQuerySelector = inputsSelectors.globalFiltersQuerySelector();
   const getTimeline = timelineSelectors.getTimelineByIdSelector();
-  const mapStateToProps = (state: State, { id, defaultModel }: OwnProps) => {
+  const mapStateToProps = (
+    state: State,
+    {
+      id,
+      defaultModel,
+      itemsPerPage: passedItemsPerPage,
+      itemsPerPageOptions: passedItemsPerPageOptions,
+    }: OwnProps
+  ) => {
     const input: inputsModel.InputsRange = getInputsTimeline(state);
     const timeline: TimelineModel = getTimeline(state, id) ?? defaultModel;
     const {
@@ -271,8 +281,8 @@ const makeMapStateToProps = () => {
       filters: getGlobalFiltersQuerySelector(state),
       id,
       isLive: input.policy.kind === 'interval',
-      itemsPerPage,
-      itemsPerPageOptions,
+      itemsPerPage: passedItemsPerPage ?? itemsPerPage,
+      itemsPerPageOptions: passedItemsPerPageOptions ?? itemsPerPageOptions,
       kqlMode,
       query: getGlobalQuerySelector(state),
       sort,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -106,6 +106,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
   const { addWarning } = useAppToasts();
   // TODO: Once we are past experimental phase this code should be removed
   const ruleRegistryEnabled = useIsExperimentalFeatureEnabled('ruleRegistryEnabled');
+  const itemsPerPageOptions: number[] = useMemo(() => [10, 25], []);
 
   const getGlobalQuery = useCallback(
     (customFilters: Filter[]) => {
@@ -380,6 +381,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
       end={to}
       currentFilter={filterGroup}
       id={timelineId}
+      itemsPerPageOptions={itemsPerPageOptions}
       onRuleChange={onRuleChange}
       renderCellValue={RenderCellValue}
       rowRenderers={defaultRowRenderers}

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/events_query_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/events_query_tab_body.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { TimelineId } from '../../../../common/types/timeline';
@@ -71,6 +71,7 @@ const EventsQueryTabBodyComponent: React.FC<HostsComponentsQueryProps> = ({
   const { globalFullScreen } = useGlobalFullScreen();
 
   const tGridEnabled = useIsExperimentalFeatureEnabled('tGridEnabled');
+  const itemsPerPageOptions: number[] = useMemo(() => [10, 25], []);
 
   useEffect(() => {
     dispatch(
@@ -115,6 +116,7 @@ const EventsQueryTabBodyComponent: React.FC<HostsComponentsQueryProps> = ({
         end={endDate}
         entityType="events"
         id={TimelineId.hostsPageEvents}
+        itemsPerPageOptions={itemsPerPageOptions}
         renderCellValue={DefaultCellRenderer}
         rowRenderers={defaultRowRenderers}
         scopeId={SourcererScopeName.default}

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/defaults.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/defaults.ts
@@ -45,7 +45,7 @@ export const timelineDefaults: SubsetTimelineModel &
   isSelectAllChecked: false,
   isLoading: false,
   isSaving: false,
-  itemsPerPage: 25,
+  itemsPerPage: 10,
   itemsPerPageOptions: [10, 25, 50, 100],
   kqlMode: 'filter',
   kqlQuery: {


### PR DESCRIPTION
## Summary

Changes the default table size to 10, and removes 50 and 100 as choices for the alert table size for performance reasons in light of https://github.com/elastic/eui/issues/5162



