### PR TITLE
Bump EUI to v37.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.15.0-canary.3",
     "@elastic/ems-client": "7.15.0",
-    "@elastic/eui": "37.1.3",
+    "@elastic/eui": "37.1.4",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "^9.0.1-kibana3",
     "@elastic/maki": "6.3.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -75,7 +75,7 @@ export const LICENSE_OVERRIDES = {
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   'node-sql-parser@3.6.1': ['(GPL-2.0 OR MIT)'], // GPL-2.0* https://github.com/taozhi8833998/node-sql-parser
   '@elastic/ems-client@7.15.0': ['Elastic License 2.0'],
-  '@elastic/eui@37.1.3': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@37.1.4': ['SSPL-1.0 OR Elastic License 2.0'],
 
   // TODO can be removed if the https://github.com/jindw/xmldom/issues/239 is released
   'xmldom@0.1.27': ['MIT'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,10 +1487,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@37.1.3":
-  version "37.1.3"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-37.1.3.tgz#3a652a1bcfe24fe344edfcdfd355a4bba42ce774"
-  integrity sha512-PYklLcepl7NIDWJfd5z2sZ4OxuybuW1HegtdpOZCkiW39gliL5+3b41eExr5MQQlXcA3rL1yh/VpcJoRb/gK3w==
+"@elastic/eui@37.1.4":
+  version "37.1.4"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-37.1.4.tgz#e2000e8a5f64f57cc3dba5ce82caacdd50fd6de0"
+  integrity sha512-/LAaHeXGIwKfwiZATkND3rYibOu89wDyDdjQzGj2w7q5R+q73uPDEqLEc8AB9R9GIrTjw0vNVxgGuEISmUfLYA==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary

`eui@37.1.3` ⏩ `eui@37.1.4`

This is a backport of a bug fixes meant for 7.15, see https://github.com/elastic/eui/issues/5167 for more details

---

## [`37.1.4`](https://github.com/elastic/eui/tree/v37.1.4)

**Note: this release is a backport containing changes originally made in `37.7.0`**

**Bug fixes**

- Fixed [de]optimization bug in `EuiDataGrid` when cells are removed from the DOM via virtualization ([#5163](https://github.com/elastic/eui/pull/5163))