### PR TITLE
[7.x] Add deprecation warning when inline scripting is disabled (#111865)

### DIFF
--- a/src/core/server/elasticsearch/deprecations/deprecation_provider.ts
+++ b/src/core/server/elasticsearch/deprecations/deprecation_provider.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { RegisterDeprecationsConfig } from '../../deprecations';
+import { getScriptingDisabledDeprecations } from './scripting_disabled_deprecation';
+
+export const getElasticsearchDeprecationsProvider = (): RegisterDeprecationsConfig => {
+  return {
+    getDeprecations: async (context) => {
+      return [...(await getScriptingDisabledDeprecations({ esClient: context.esClient }))];
+    },
+  };
+};

--- a/src/core/server/elasticsearch/deprecations/index.ts
+++ b/src/core/server/elasticsearch/deprecations/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { getElasticsearchDeprecationsProvider } from './deprecation_provider';

--- a/src/core/server/elasticsearch/deprecations/is_scripting_disabled.test.ts
+++ b/src/core/server/elasticsearch/deprecations/is_scripting_disabled.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { estypes } from '@elastic/elasticsearch';
+import { elasticsearchServiceMock } from '../../elasticsearch/elasticsearch_service.mock';
+import { isInlineScriptingDisabled } from './is_scripting_disabled';
+
+describe('isInlineScriptingDisabled', () => {
+  let client: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
+
+  beforeEach(() => {
+    client = elasticsearchServiceMock.createElasticsearchClient();
+  });
+
+  const mockSettingsValue = (settings: estypes.ClusterGetSettingsResponse) => {
+    client.cluster.getSettings.mockReturnValue(
+      elasticsearchServiceMock.createSuccessTransportRequestPromise(settings)
+    );
+  };
+
+  it('returns `false` if all settings are empty', async () => {
+    mockSettingsValue({
+      transient: {},
+      persistent: {},
+      defaults: {},
+    });
+
+    expect(await isInlineScriptingDisabled({ client })).toEqual(false);
+  });
+
+  it('returns `false` if `defaults.script.allowed_types` is `inline`', async () => {
+    mockSettingsValue({
+      transient: {},
+      persistent: {},
+      defaults: {
+        'script.allowed_types': ['inline'],
+      },
+    });
+
+    expect(await isInlineScriptingDisabled({ client })).toEqual(false);
+  });
+
+  it('returns `true` if `defaults.script.allowed_types` is `none`', async () => {
+    mockSettingsValue({
+      transient: {},
+      persistent: {},
+      defaults: {
+        'script.allowed_types': ['none'],
+      },
+    });
+
+    expect(await isInlineScriptingDisabled({ client })).toEqual(true);
+  });
+
+  it('returns `true` if `defaults.script.allowed_types` is `stored`', async () => {
+    mockSettingsValue({
+      transient: {},
+      persistent: {},
+      defaults: {
+        'script.allowed_types': ['stored'],
+      },
+    });
+
+    expect(await isInlineScriptingDisabled({ client })).toEqual(true);
+  });
+
+  it('respect the persistent->defaults priority', async () => {
+    mockSettingsValue({
+      transient: {},
+      persistent: {
+        'script.allowed_types': ['inline'],
+      },
+      defaults: {
+        'script.allowed_types': ['stored'],
+      },
+    });
+
+    expect(await isInlineScriptingDisabled({ client })).toEqual(false);
+  });
+
+  it('respect the transient->persistent priority', async () => {
+    mockSettingsValue({
+      transient: {
+        'script.allowed_types': ['stored'],
+      },
+      persistent: {
+        'script.allowed_types': ['inline'],
+      },
+      defaults: {},
+    });
+
+    expect(await isInlineScriptingDisabled({ client })).toEqual(true);
+  });
+});

--- a/src/core/server/elasticsearch/deprecations/is_scripting_disabled.ts
+++ b/src/core/server/elasticsearch/deprecations/is_scripting_disabled.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ElasticsearchClient } from '../../elasticsearch';
+
+const scriptAllowedTypesKey = 'script.allowed_types';
+
+export const isInlineScriptingDisabled = async ({
+  client,
+}: {
+  client: ElasticsearchClient;
+}): Promise<boolean> => {
+  const { body: settings } = await client.cluster.getSettings({
+    include_defaults: true,
+    flat_settings: true,
+  });
+
+  // priority: transient -> persistent -> default
+  const scriptAllowedTypes: string[] =
+    settings.transient[scriptAllowedTypesKey] ??
+    settings.persistent[scriptAllowedTypesKey] ??
+    settings.defaults![scriptAllowedTypesKey] ??
+    [];
+
+  // when unspecified, the setting as a default `[]` value that means that both scriptings are allowed.
+  const scriptAllowed = scriptAllowedTypes.length === 0 || scriptAllowedTypes.includes('inline');
+
+  return !scriptAllowed;
+};

--- a/src/core/server/elasticsearch/deprecations/scripting_disabled_deprecation.test.mocks.ts
+++ b/src/core/server/elasticsearch/deprecations/scripting_disabled_deprecation.test.mocks.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const isInlineScriptingDisabledMock = jest.fn();
+jest.doMock('./is_scripting_disabled', () => ({
+  isInlineScriptingDisabled: isInlineScriptingDisabledMock,
+}));

--- a/src/core/server/elasticsearch/deprecations/scripting_disabled_deprecation.test.ts
+++ b/src/core/server/elasticsearch/deprecations/scripting_disabled_deprecation.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isInlineScriptingDisabledMock } from './scripting_disabled_deprecation.test.mocks';
+import { elasticsearchServiceMock } from '../../elasticsearch/elasticsearch_service.mock';
+import { getScriptingDisabledDeprecations } from './scripting_disabled_deprecation';
+
+describe('getScriptingDisabledDeprecations', () => {
+  let esClient: ReturnType<typeof elasticsearchServiceMock.createScopedClusterClient>;
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createScopedClusterClient();
+  });
+
+  afterEach(() => {
+    isInlineScriptingDisabledMock.mockReset();
+  });
+
+  it('calls `isInlineScriptingDisabled` with the correct arguments', async () => {
+    await getScriptingDisabledDeprecations({
+      esClient,
+    });
+
+    expect(isInlineScriptingDisabledMock).toHaveBeenCalledTimes(1);
+    expect(isInlineScriptingDisabledMock).toHaveBeenCalledWith({
+      client: esClient.asInternalUser,
+    });
+  });
+
+  it('returns no deprecations if scripting is not disabled', async () => {
+    isInlineScriptingDisabledMock.mockResolvedValue(false);
+
+    const deprecations = await getScriptingDisabledDeprecations({
+      esClient,
+    });
+
+    expect(deprecations).toHaveLength(0);
+  });
+
+  it('returns a deprecation if scripting is disabled', async () => {
+    isInlineScriptingDisabledMock.mockResolvedValue(true);
+
+    const deprecations = await getScriptingDisabledDeprecations({
+      esClient,
+    });
+
+    expect(deprecations).toHaveLength(1);
+    expect(deprecations[0]).toEqual({
+      title: expect.any(String),
+      message: expect.any(String),
+      level: 'critical',
+      requireRestart: false,
+      correctiveActions: {
+        manualSteps: expect.any(Array),
+      },
+    });
+  });
+});

--- a/src/core/server/elasticsearch/deprecations/scripting_disabled_deprecation.ts
+++ b/src/core/server/elasticsearch/deprecations/scripting_disabled_deprecation.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { DeprecationsDetails } from '../../deprecations';
+import { IScopedClusterClient } from '../../elasticsearch';
+import { isInlineScriptingDisabled } from './is_scripting_disabled';
+
+interface GetScriptingDisabledDeprecations {
+  esClient: IScopedClusterClient;
+}
+
+export const getScriptingDisabledDeprecations = async ({
+  esClient,
+}: GetScriptingDisabledDeprecations): Promise<DeprecationsDetails[]> => {
+  const deprecations: DeprecationsDetails[] = [];
+  if (await isInlineScriptingDisabled({ client: esClient.asInternalUser })) {
+    deprecations.push({
+      title: i18n.translate('core.elasticsearch.deprecations.scriptingDisabled.title', {
+        defaultMessage: 'Inline scripting is disabled on elasticsearch',
+      }),
+      message: i18n.translate('core.elasticsearch.deprecations.scriptingDisabled.message', {
+        defaultMessage:
+          'Starting in 8.0, Kibana will require inline scripting to be enabled,' +
+          'and will fail to start otherwise.',
+      }),
+      level: 'critical',
+      requireRestart: false,
+      correctiveActions: {
+        manualSteps: [
+          i18n.translate('core.elasticsearch.deprecations.scriptingDisabled.manualSteps.1', {
+            defaultMessage: 'Set `script.allowed_types=inline` in your elasticsearch config ',
+          }),
+        ],
+      },
+    });
+  }
+  return deprecations;
+};

--- a/src/core/server/elasticsearch/integration_tests/is_scripting_disabled.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/is_scripting_disabled.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  createTestServers,
+  TestElasticsearchUtils,
+  TestKibanaUtils,
+} from '../../../test_helpers/kbn_server';
+import { isInlineScriptingDisabled } from '../deprecations/is_scripting_disabled';
+
+describe('isInlineScriptingDisabled', () => {
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+
+  afterEach(async () => {
+    if (kibanaServer) {
+      await kibanaServer.stop();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+  });
+
+  const startServers = async ({ esArgs = [] }: { esArgs?: string[] } = {}) => {
+    const { startES, startKibana } = createTestServers({
+      adjustTimeout: jest.setTimeout,
+      settings: {
+        es: {
+          esArgs,
+        },
+      },
+    });
+
+    esServer = await startES();
+    kibanaServer = await startKibana();
+  };
+
+  it('returns false when `script.allowed_types` is unset', async () => {
+    await startServers({ esArgs: [] });
+
+    const disabled = await isInlineScriptingDisabled({
+      client: kibanaServer.coreStart.elasticsearch.client.asInternalUser,
+    });
+
+    expect(disabled).toEqual(false);
+  });
+
+  it('returns false when `script.allowed_types` is `inline`', async () => {
+    await startServers({ esArgs: ['script.allowed_types=inline'] });
+
+    const disabled = await isInlineScriptingDisabled({
+      client: kibanaServer.coreStart.elasticsearch.client.asInternalUser,
+    });
+
+    expect(disabled).toEqual(false);
+  });
+
+  it('returns true when `script.allowed_types` is `stored`', async () => {
+    await startServers({ esArgs: ['script.allowed_types=stored'] });
+
+    const disabled = await isInlineScriptingDisabled({
+      client: kibanaServer.coreStart.elasticsearch.client.asInternalUser,
+    });
+
+    expect(disabled).toEqual(true);
+  });
+
+  it('returns true when `script.allowed_types` is `none', async () => {
+    await startServers({ esArgs: ['script.allowed_types=none'] });
+
+    const disabled = await isInlineScriptingDisabled({
+      client: kibanaServer.coreStart.elasticsearch.client.asInternalUser,
+    });
+
+    expect(disabled).toEqual(true);
+  });
+});

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -206,6 +206,10 @@ export class Server {
       executionContext: executionContextSetup,
     });
 
+    const deprecationsSetup = this.deprecations.setup({
+      http: httpSetup,
+    });
+
     // setup i18n prior to any other service, to have translations ready
     const i18nServiceSetup = await this.i18n.setup({ http: httpSetup, pluginPaths });
 
@@ -214,6 +218,7 @@ export class Server {
     const elasticsearchServiceSetup = await this.elasticsearch.setup({
       http: httpSetup,
       executionContext: executionContextSetup,
+      deprecations: deprecationsSetup,
     });
 
     const metricsSetup = await this.metrics.setup({ http: httpSetup });
@@ -257,10 +262,6 @@ export class Server {
     });
 
     const loggingSetup = this.logging.setup();
-
-    const deprecationsSetup = this.deprecations.setup({
-      http: httpSetup,
-    });
 
     const coreSetup: InternalCoreSetup = {
       capabilities: capabilitiesSetup,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add deprecation warning when inline scripting is disabled (#111865)