### PR TITLE
[Workplace Search] better spacing around icon in Group filter popover

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.tsx
@@ -20,7 +20,7 @@ interface SourceOptionItemProps {
 }
 
 export const SourceOptionItem: React.FC<SourceOptionItemProps> = ({ source }) => (
-  <EuiFlexGroup gutterSize="m" justifyContent="flexStart" alignItems="center">
+  <EuiFlexGroup gutterSize="m" justifyContent="flexStart" alignItems="center" responsive={false}>
     <EuiFlexItem grow={false}>
       <SourceIcon {...source} size="s" />
     </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.tsx
@@ -20,9 +20,9 @@ interface SourceOptionItemProps {
 }
 
 export const SourceOptionItem: React.FC<SourceOptionItemProps> = ({ source }) => (
-  <EuiFlexGroup gutterSize="xs" justifyContent="flexStart" alignItems="center">
+  <EuiFlexGroup gutterSize="m" justifyContent="flexStart" alignItems="center">
     <EuiFlexItem grow={false}>
-      <SourceIcon {...source} size="l" />
+      <SourceIcon {...source} size="s" />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <TruncatedContent tooltipType="title" content={source.name} length={MAX_LENGTH} />


### PR DESCRIPTION
## Summary

This PR closes issue [Groups > Sources dropdown needs padding #2020](https://github.com/elastic/workplace-search-team/issues/2020)

The icons in the Group filter list need better spacing.

Large screen:
| Before | After |
|-|-|
| <img width="666" alt="Screenshot 2021-09-13 at 1 52 52 pm" src="https://user-images.githubusercontent.com/7115017/133086945-31f31765-afc1-49d4-8b4c-7c74031632eb.png"> | <img width="669" alt="Screenshot 2021-09-13 at 1 53 09 pm" src="https://user-images.githubusercontent.com/7115017/133086938-50318f0d-4698-4f02-bb0a-8656d13b864d.png"> |

Small screen:
| Before | After |
|-|-|
| <img width="526" alt="Screenshot 2021-09-13 at 2 16 09 pm" src="https://user-images.githubusercontent.com/7115017/133090363-753f344f-ba26-4741-ad53-88b113822c78.png"> | <img width="540" alt="Screenshot 2021-09-13 at 2 15 46 pm" src="https://user-images.githubusercontent.com/7115017/133090394-d536fc64-55d3-4dae-b06e-efe6c050f6a5.png"> |



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
