### PR TITLE
Add renovate config for platform security dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -74,6 +74,21 @@
         labels: ['Feature:Vega', 'Team:VisEditors'],
         enabled: true,
       },
+      {
+        groupName: 'platforms security modules',
+        packageNames: [
+          'broadcast-channel', 
+          'jsonwebtoken', '@types/jsonwebtoken', 
+          'node-forge', '@types/node-forge', 
+          'require-in-the-middle', 
+          'tough-cookie', '@types/tough-cookie',
+          'xml-crypto', '@types/xml-crypto'
+        ],
+        reviewers: ['team:kibana-security'],
+        matchBaseBranches: ['master', '7.x'],
+        labels: ['Team:Security'],
+        enabled: true,
+      },
     ],
   },
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -75,7 +75,7 @@
         enabled: true,
       },
       {
-        groupName: 'platforms security modules',
+        groupName: 'platform security modules',
         packageNames: [
           'broadcast-channel', 
           'jsonwebtoken', '@types/jsonwebtoken', 


### PR DESCRIPTION
[skip ci]
## Summary

Adds Renovate configuration for platform security dependencies. We might own other dependencies not captured in this list, but we can update this at any point as we discover them.
