### PR TITLE
[Event Log] Add missing import statement to schema generator template

### DIFF
--- a/x-pack/plugins/event_log/generated/schemas.ts
+++ b/x-pack/plugins/event_log/generated/schemas.ts
@@ -149,15 +149,15 @@ function ecsDate() {
   return schema.maybe(schema.string({ validate: validateDate }));
 }
 
-function ecsVersion() {
-  return schema.maybe(schema.string({ validate: validateVersion }));
-}
-
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 function validateDate(isoDate: string) {
   if (ISO_DATE_PATTERN.test(isoDate)) return;
   return 'string is not a valid ISO date: ' + isoDate;
+}
+
+function ecsVersion() {
+  return schema.maybe(schema.string({ validate: validateVersion }));
 }
 
 function validateVersion(version: string) {

--- a/x-pack/plugins/event_log/scripts/create_schemas.js
+++ b/x-pack/plugins/event_log/scripts/create_schemas.js
@@ -283,6 +283,7 @@ const SchemaFileTemplate = `
 // the event log
 
 import { schema, TypeOf } from '@kbn/config-schema';
+import semver from 'semver';
 
 type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };
 type DeepPartial<T> = {


### PR DESCRIPTION
## Summary

Added missing `import semver from 'semver';` to the schema generator template. Without it, running `node ./x-pack/plugins/event_log/scripts/create_schemas.js` produces a broken `generated/schemas.ts` artifact.