### PR TITLE
[ci-stats] retry requests that respond with a 500 or greater

### DIFF
--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -199,7 +199,7 @@ export class CiStatsReporter {
           throw error;
         }
 
-        if (error?.response && error.response.status < 502) {
+        if (error?.response && error.response.status < 500) {
           // error response from service was received so warn the user and move on
           this.log.warning(
             `error reporting ${bodyDesc} [status=${error.response.status}] [resp=${inspect(

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -59643,7 +59643,7 @@ class CiStatsReporter {
           throw error;
         }
 
-        if (error !== null && error !== void 0 && error.response && error.response.status < 502) {
+        if (error !== null && error !== void 0 && error.response && error.response.status < 500) {
           // error response from service was received so warn the user and move on
           this.log.warning(`error reporting ${bodyDesc} [status=${error.response.status}] [resp=${(0, _util.inspect)(error.response.data)}]`);
           return;


### PR DESCRIPTION
We should retry on any 500 status code, including 500 itself. I had assumed that 500 itself would represent an issue in the server which wasn't recoverable but that's not the case.