### PR TITLE
[Enterprise Search] Add a React Router helper for EuiListGroupItem

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
@@ -16,9 +16,23 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiLink, EuiButton, EuiButtonEmpty, EuiPanel, EuiCard } from '@elastic/eui';
+import {
+  EuiLink,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiListGroupItem,
+  EuiPanel,
+  EuiCard,
+} from '@elastic/eui';
 
-import { EuiLinkTo, EuiButtonTo, EuiButtonEmptyTo, EuiPanelTo, EuiCardTo } from './eui_components';
+import {
+  EuiLinkTo,
+  EuiButtonTo,
+  EuiButtonEmptyTo,
+  EuiListGroupItemTo,
+  EuiPanelTo,
+  EuiCardTo,
+} from './eui_components';
 
 describe('React Router EUI component helpers', () => {
   it('renders an EuiLink', () => {
@@ -37,6 +51,13 @@ describe('React Router EUI component helpers', () => {
     const wrapper = shallow(<EuiButtonEmptyTo to="/" />);
 
     expect(wrapper.find(EuiButtonEmpty)).toHaveLength(1);
+  });
+
+  it('renders an EuiListGroupItem', () => {
+    const wrapper = shallow(<EuiListGroupItemTo to="/" label="foo" />);
+
+    expect(wrapper.find(EuiListGroupItem)).toHaveLength(1);
+    expect(wrapper.find(EuiListGroupItem).prop('label')).toEqual('foo');
   });
 
   it('renders an EuiPanel', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
@@ -14,6 +14,8 @@ import {
   EuiButtonEmptyProps,
   EuiButtonProps,
   EuiLinkAnchorProps,
+  EuiListGroupItem,
+  EuiListGroupItemProps,
   EuiPanel,
   EuiCard,
   EuiCardProps,
@@ -67,3 +69,13 @@ export const EuiCardTo: React.FC<ReactRouterEuiCardProps> = ({
   shouldNotCreateHref,
   ...rest
 }) => <EuiCard {...rest} {...generateReactRouterProps({ to, onClick, shouldNotCreateHref })} />;
+
+type ReactRouterEuiListGroupItemProps = ReactRouterProps & EuiListGroupItemProps;
+export const EuiListGroupItemTo: React.FC<ReactRouterEuiListGroupItemProps> = ({
+  to,
+  onClick,
+  shouldNotCreateHref,
+  ...rest
+}) => (
+  <EuiListGroupItem {...rest} {...generateReactRouterProps({ to, onClick, shouldNotCreateHref })} />
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/index.ts
@@ -8,4 +8,11 @@
 export { letBrowserHandleEvent } from './link_events';
 export { createHref, CreateHrefOptions } from './create_href';
 export { generateReactRouterProps, ReactRouterProps } from './generate_react_router_props';
-export { EuiLinkTo, EuiButtonTo, EuiButtonEmptyTo, EuiPanelTo, EuiCardTo } from './eui_components';
+export {
+  EuiLinkTo,
+  EuiButtonTo,
+  EuiButtonEmptyTo,
+  EuiListGroupItemTo,
+  EuiPanelTo,
+  EuiCardTo,
+} from './eui_components';


### PR DESCRIPTION
## Summary

Adds a `EuiListGroupItemTo` helper component for `EuiListGroupItem` to our [existing set](https://github.com/elastic/kibana/blob/master/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx) of these components.

Will be used in https://github.com/elastic/workplace-search-team/issues/2012

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
