### PR TITLE
Better formatting document summary with images

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.scss
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.scss
@@ -1,0 +1,3 @@
+.rowFormatter__value img {
+  vertical-align: top;
+}

--- a/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.scss
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.scss
@@ -1,3 +1,7 @@
+// Special handling for images coming from the image field formatter
+// See discover_grid.scss for more explanation on those values
 .rowFormatter__value img {
-  vertical-align: top;
+  vertical-align: middle;
+  max-height: lineHeightFromBaseline(2) !important;
+  max-width: 500px !important;
 }

--- a/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.scss
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.scss
@@ -3,5 +3,5 @@
 .rowFormatter__value img {
   vertical-align: middle;
   max-height: lineHeightFromBaseline(2) !important;
-  max-width: 500px !important;
+  max-width: ($euiSizeXXL * 12.5) !important;
 }

--- a/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.tsx
@@ -11,6 +11,8 @@ import type { IndexPattern } from 'src/plugins/data/common';
 import { MAX_DOC_FIELDS_DISPLAYED } from '../../../../../../../common';
 import { getServices } from '../../../../../../kibana_services';
 
+import './row_formatter.scss';
+
 interface Props {
   defPairs: Array<[string, unknown]>;
 }
@@ -21,6 +23,7 @@ const TemplateComponent = ({ defPairs }: Props) => {
         <Fragment key={idx}>
           <dt>{pair[0]}:</dt>
           <dd
+            className="rowFormatter__value"
             // We  can dangerously set HTML here because this content is guaranteed to have been run through a valid field formatter first.
             dangerouslySetInnerHTML={{ __html: `${pair[1]}` }} // eslint-disable-line react/no-danger
           />{' '}

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
@@ -99,7 +99,7 @@
     // For most width-height-ratios that will never be hit, because we'd usually limit
     // it by the way smaller height. But images with very large width and very small height
     // might be limited by that.
-    max-width: 500px !important;
+    max-width: ($euiSizeXXL * 12.5) !important;
   }
 }
 

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
@@ -86,6 +86,10 @@
 
 .dscDiscoverGrid__descriptionListDescription {
   word-break: normal !important;
+
+  img {
+    vertical-align: middle;
+  }
 }
 
 @include euiBreakpoint('xs', 's', 'm') {

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
@@ -87,8 +87,19 @@
 .dscDiscoverGrid__descriptionListDescription {
   word-break: normal !important;
 
+  // Special handling for images coming from the image field formatter
   img {
+    // Align the images vertically centered with the text
     vertical-align: middle;
+    // Set the maximum height to the line-height. The used function is the same
+    // function used to calculate the line-height for the EuiDescriptionList Description.
+    // !important is required to overwrite the max-height on the element from the field formatter
+    max-height: lineHeightFromBaseline(2) !important;
+    // An arbitrary amount of width we don't want to go over, to not have very wide images.
+    // For most width-height-ratios that will never be hit, because we'd usually limit
+    // it by the way smaller height. But images with very large width and very small height
+    // might be limited by that.
+    max-width: 500px !important;
   }
 }
 

--- a/src/plugins/discover/public/application/components/discover_grid/get_render_cell_value.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/get_render_cell_value.tsx
@@ -110,6 +110,9 @@ export const getRenderCellValueFn = (
     });
 
     return (
+      // If you change the styling of this list (specifically something that will change the line-height)
+      // make sure to adjust the img overwrites attached to dscDiscoverGrid__descriptionListDescription
+      // in discover_grid.scss
       <EuiDescriptionList type="inline" compressed className="dscDiscoverGrid__descriptionList">
         {[...highlightPairs, ...sourcePairs].slice(0, maxDocFieldsDisplayed).map(([key, value]) => (
           <Fragment key={key}>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/106852

This PR improves formatting of the "Document" view in Discover showing a summary of the document, before columns have been configured.

Have not tested Safari, so would appreciate if one of the reviewers could test this in Safari.

### Legacy Table

**Before**
![screenshot-20210913-182655](https://user-images.githubusercontent.com/877229/133121589-ef43356a-b270-4d26-90d7-578fc998d2b8.png)

**After**
![screenshot-20210914-141416](https://user-images.githubusercontent.com/877229/133255624-100e017e-f97d-4f4a-ad56-13f0bd06bc20.png)


### Data Grid

**Before**
![screenshot-20210913-182807](https://user-images.githubusercontent.com/877229/133121725-9b2c7c63-226b-4a6e-95a1-aa307554c41f.png)

**After**
![screenshot-20210914-141345](https://user-images.githubusercontent.com/877229/133255576-7b20085b-3f12-4e25-bf9b-63564c39721f.png)



### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)