### PR TITLE
Fix wrong timepicker range when brushing

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/chart/histogram.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/chart/histogram.tsx
@@ -159,6 +159,7 @@ export function DiscoverHistogram({
         tooltip={tooltipProps}
         theme={chartTheme}
         baseTheme={chartBaseTheme}
+        allowBrushingLastHistogramBucket={true}
       />
       <Axis
         id="discover-histogram-left-axis"


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/111687 (for discover)

Fixes an issue where brushing on the last bar creates a timefilter in the wrong order. This property now allows brushing on the last bar properly, thus elastic chart will give us the correct times.

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~
