### PR TITLE
[7.x] [Actions] Telemetry for calling legacy routes (#111901)

### DIFF
--- a/x-pack/plugins/actions/common/index.ts
+++ b/x-pack/plugins/actions/common/index.ts
@@ -14,3 +14,4 @@ export * from './rewrite_request_case';
 
 export const BASE_ACTION_API_PATH = '/api/actions';
 export const INTERNAL_BASE_ACTION_API_PATH = '/internal/actions';
+export const ACTIONS_FEATURE_ID = 'actions';

--- a/x-pack/plugins/actions/server/lib/track_legacy_route_usage.test.ts
+++ b/x-pack/plugins/actions/server/lib/track_legacy_route_usage.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
+import { trackLegacyRouteUsage } from './track_legacy_route_usage';
+
+describe('trackLegacyRouteUsage', () => {
+  it('should call `usageCounter.incrementCounter`', () => {
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    trackLegacyRouteUsage('test', mockUsageCounter);
+    expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+      counterName: `legacyRoute_test`,
+      counterType: 'legacyApiUsage',
+      incrementBy: 1,
+    });
+  });
+
+  it('should do nothing if no usage counter is provided', () => {
+    let err;
+    try {
+      trackLegacyRouteUsage('test', undefined);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeUndefined();
+  });
+});

--- a/x-pack/plugins/actions/server/lib/track_legacy_route_usage.ts
+++ b/x-pack/plugins/actions/server/lib/track_legacy_route_usage.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UsageCounter } from 'src/plugins/usage_collection/server';
+
+export function trackLegacyRouteUsage(route: string, usageCounter?: UsageCounter) {
+  if (usageCounter) {
+    usageCounter.incrementCounter({
+      counterName: `legacyRoute_${route}`,
+      counterType: 'legacyApiUsage',
+      incrementBy: 1,
+    });
+  }
+}

--- a/x-pack/plugins/actions/server/plugin.ts
+++ b/x-pack/plugins/actions/server/plugin.ts
@@ -84,7 +84,7 @@ import { ensureSufficientLicense } from './lib/ensure_sufficient_license';
 import { renderMustacheObject } from './lib/mustache_renderer';
 import { getAlertHistoryEsIndex } from './preconfigured_connectors/alert_history_es_index/alert_history_es_index';
 import { createAlertHistoryIndexTemplate } from './preconfigured_connectors/alert_history_es_index/create_alert_history_index_template';
-import { AlertHistoryEsIndexConnectorId } from '../common';
+import { ACTIONS_FEATURE_ID, AlertHistoryEsIndexConnectorId } from '../common';
 import { EVENT_LOG_ACTIONS, EVENT_LOG_PROVIDER } from './constants/event_log';
 
 export interface PluginSetupContract {
@@ -263,8 +263,15 @@ export class ActionsPlugin implements Plugin<PluginSetupContract, PluginStartCon
       );
     }
 
+    // Usage counter for telemetry
+    const usageCounter = plugins.usageCollection?.createUsageCounter(ACTIONS_FEATURE_ID);
+
     // Routes
-    defineRoutes(core.http.createRouter<ActionsRequestHandlerContext>(), this.licenseState);
+    defineRoutes(
+      core.http.createRouter<ActionsRequestHandlerContext>(),
+      this.licenseState,
+      usageCounter
+    );
 
     // Cleanup failed execution task definition
     if (this.actionsConfig.cleanupFailedExecutionsTask.enabled) {

--- a/x-pack/plugins/actions/server/routes/index.ts
+++ b/x-pack/plugins/actions/server/routes/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { IRouter } from 'kibana/server';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { ILicenseState } from '../lib';
 import { ActionsRequestHandlerContext } from '../types';
 import { createActionRoute } from './create';
@@ -20,9 +21,10 @@ import { defineLegacyRoutes } from './legacy';
 
 export function defineRoutes(
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) {
-  defineLegacyRoutes(router, licenseState);
+  defineLegacyRoutes(router, licenseState, usageCounter);
 
   createActionRoute(router, licenseState);
   deleteActionRoute(router, licenseState);

--- a/x-pack/plugins/actions/server/routes/legacy/create.test.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/create.test.ts
@@ -11,10 +11,19 @@ import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './_mock_handler_arguments';
 import { actionsClientMock } from '../../actions_client.mock';
 import { verifyAccessAndContext } from '../verify_access_and_context';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 
 jest.mock('../verify_access_and_context.ts', () => ({
   verifyAccessAndContext: jest.fn(),
 }));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
+}));
+
+const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -127,5 +136,17 @@ describe('createActionRoute', () => {
     const [context, req, res] = mockHandlerArguments({ actionsClient }, {});
 
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const actionsClient = actionsClientMock.create();
+
+    createActionRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ actionsClient }, {});
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('create', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/actions/server/routes/legacy/create.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/create.ts
@@ -6,11 +6,13 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { IRouter } from 'kibana/server';
 import { ActionsRequestHandlerContext } from '../../types';
 import { ILicenseState } from '../../lib';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { verifyAccessAndContext } from '../verify_access_and_context';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 export const bodySchema = schema.object({
   name: schema.string(),
@@ -21,7 +23,8 @@ export const bodySchema = schema.object({
 
 export const createActionRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.post(
     {
@@ -34,6 +37,7 @@ export const createActionRoute = (
       verifyAccessAndContext(licenseState, async function (context, req, res) {
         const actionsClient = context.actions.getActionsClient();
         const action = req.body;
+        trackLegacyRouteUsage('create', usageCounter);
         return res.ok({
           body: await actionsClient.create({ action }),
         });

--- a/x-pack/plugins/actions/server/routes/legacy/delete.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/delete.ts
@@ -6,10 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { IRouter } from 'kibana/server';
 import { ILicenseState, verifyApiAccess, isErrorThatHandlesItsOwnResponse } from '../../lib';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { ActionsRequestHandlerContext } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -17,7 +19,8 @@ const paramSchema = schema.object({
 
 export const deleteActionRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.delete(
     {
@@ -33,6 +36,7 @@ export const deleteActionRoute = (
       }
       const actionsClient = context.actions.getActionsClient();
       const { id } = req.params;
+      trackLegacyRouteUsage('delete', usageCounter);
       try {
         await actionsClient.delete({ id });
         return res.noContent();

--- a/x-pack/plugins/actions/server/routes/legacy/execute.test.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/execute.test.ts
@@ -12,10 +12,19 @@ import { mockHandlerArguments } from './_mock_handler_arguments';
 import { verifyApiAccess, ActionTypeDisabledError, asHttpRequestExecutionSource } from '../../lib';
 import { actionsClientMock } from '../../actions_client.mock';
 import { ActionTypeExecutorResult } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 
 jest.mock('../../lib/verify_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
 }));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
+}));
+
+const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -191,5 +200,17 @@ describe('executeActionRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const actionsClient = actionsClientMock.create();
+
+    executeActionRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ actionsClient }, { body: {}, params: {} });
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('execute', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/actions/server/routes/legacy/execute.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/execute.ts
@@ -6,12 +6,14 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { IRouter } from 'kibana/server';
 import { ILicenseState, verifyApiAccess, isErrorThatHandlesItsOwnResponse } from '../../lib';
 
 import { ActionTypeExecutorResult, ActionsRequestHandlerContext } from '../../types';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { asHttpRequestExecutionSource } from '../../lib/action_execution_source';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -23,7 +25,8 @@ const bodySchema = schema.object({
 
 export const executeActionRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.post(
     {
@@ -43,6 +46,7 @@ export const executeActionRoute = (
       const actionsClient = context.actions.getActionsClient();
       const { params } = req.body;
       const { id } = req.params;
+      trackLegacyRouteUsage('execute', usageCounter);
       try {
         const body: ActionTypeExecutorResult<unknown> = await actionsClient.execute({
           params,

--- a/x-pack/plugins/actions/server/routes/legacy/get.test.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/get.test.ts
@@ -11,10 +11,19 @@ import { licenseStateMock } from '../../lib/license_state.mock';
 import { verifyApiAccess } from '../../lib';
 import { mockHandlerArguments } from './_mock_handler_arguments';
 import { actionsClientMock } from '../../actions_client.mock';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 
 jest.mock('../../lib/verify_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
 }));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
+}));
+
+const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -132,5 +141,17 @@ describe('getActionRoute', () => {
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
 
     expect(verifyApiAccess).toHaveBeenCalledWith(licenseState);
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const actionsClient = actionsClientMock.create();
+
+    getActionRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ actionsClient }, { params: { id: '1' } });
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('get', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/actions/server/routes/legacy/get.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/get.ts
@@ -6,10 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { IRouter } from 'kibana/server';
 import { ILicenseState, verifyApiAccess } from '../../lib';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { ActionsRequestHandlerContext } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -17,7 +19,8 @@ const paramSchema = schema.object({
 
 export const getActionRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.get(
     {
@@ -33,6 +36,7 @@ export const getActionRoute = (
       }
       const actionsClient = context.actions.getActionsClient();
       const { id } = req.params;
+      trackLegacyRouteUsage('get', usageCounter);
       return res.ok({
         body: await actionsClient.get({ id }),
       });

--- a/x-pack/plugins/actions/server/routes/legacy/get_all.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/get_all.ts
@@ -6,13 +6,16 @@
  */
 
 import { IRouter } from 'kibana/server';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { ILicenseState, verifyApiAccess } from '../../lib';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { ActionsRequestHandlerContext } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 export const getAllActionRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.get(
     {
@@ -26,6 +29,7 @@ export const getAllActionRoute = (
       }
       const actionsClient = context.actions.getActionsClient();
       const result = await actionsClient.getAll();
+      trackLegacyRouteUsage('getAll', usageCounter);
       return res.ok({
         body: result,
       });

--- a/x-pack/plugins/actions/server/routes/legacy/index.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { IRouter } from 'kibana/server';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { ILicenseState } from '../../lib';
 import { ActionsRequestHandlerContext } from '../../types';
 import { createActionRoute } from './create';
@@ -18,13 +19,14 @@ import { executeActionRoute } from './execute';
 
 export function defineLegacyRoutes(
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) {
-  createActionRoute(router, licenseState);
-  deleteActionRoute(router, licenseState);
-  getActionRoute(router, licenseState);
-  getAllActionRoute(router, licenseState);
-  updateActionRoute(router, licenseState);
-  listActionTypesRoute(router, licenseState);
-  executeActionRoute(router, licenseState);
+  createActionRoute(router, licenseState, usageCounter);
+  deleteActionRoute(router, licenseState, usageCounter);
+  getActionRoute(router, licenseState, usageCounter);
+  getAllActionRoute(router, licenseState, usageCounter);
+  updateActionRoute(router, licenseState, usageCounter);
+  listActionTypesRoute(router, licenseState, usageCounter);
+  executeActionRoute(router, licenseState, usageCounter);
 }

--- a/x-pack/plugins/actions/server/routes/legacy/list_action_types.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/list_action_types.ts
@@ -6,13 +6,16 @@
  */
 
 import { IRouter } from 'kibana/server';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { ILicenseState, verifyApiAccess } from '../../lib';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { ActionsRequestHandlerContext } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 export const listActionTypesRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.get(
     {
@@ -25,6 +28,7 @@ export const listActionTypesRoute = (
         return res.badRequest({ body: 'RouteHandlerContext is not registered for actions' });
       }
       const actionsClient = context.actions.getActionsClient();
+      trackLegacyRouteUsage('listActionTypes', usageCounter);
       return res.ok({
         body: await actionsClient.listTypes(),
       });

--- a/x-pack/plugins/actions/server/routes/legacy/update.test.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/update.test.ts
@@ -11,10 +11,19 @@ import { licenseStateMock } from '../../lib/license_state.mock';
 import { verifyApiAccess, ActionTypeDisabledError } from '../../lib';
 import { mockHandlerArguments } from './_mock_handler_arguments';
 import { actionsClientMock } from '../../actions_client.mock';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 
 jest.mock('../../lib/verify_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
 }));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
+}));
+
+const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -181,5 +190,20 @@ describe('updateActionRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const actionsClient = actionsClientMock.create();
+
+    updateActionRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.put.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { actionsClient },
+      { params: { id: '1' }, body: {} }
+    );
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('update', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/actions/server/routes/legacy/update.ts
+++ b/x-pack/plugins/actions/server/routes/legacy/update.ts
@@ -6,10 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { IRouter } from 'kibana/server';
 import { ILicenseState, verifyApiAccess, isErrorThatHandlesItsOwnResponse } from '../../lib';
 import { BASE_ACTION_API_PATH } from '../../../common';
 import { ActionsRequestHandlerContext } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -23,7 +25,8 @@ const bodySchema = schema.object({
 
 export const updateActionRoute = (
   router: IRouter<ActionsRequestHandlerContext>,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.put(
     {
@@ -41,6 +44,7 @@ export const updateActionRoute = (
       const actionsClient = context.actions.getActionsClient();
       const { id } = req.params;
       const { name, config, secrets } = req.body;
+      trackLegacyRouteUsage('update', usageCounter);
 
       try {
         return res.ok({


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Actions] Telemetry for calling legacy routes (#111901)