### PR TITLE
[7.x] [Alerting] Telemetry for calling legacy routes (#111885)

### DIFF
--- a/x-pack/plugins/alerting/server/lib/track_legacy_route_usage.test.ts
+++ b/x-pack/plugins/alerting/server/lib/track_legacy_route_usage.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
+import { trackLegacyRouteUsage } from './track_legacy_route_usage';
+
+describe('trackLegacyRouteUsage', () => {
+  it('should call `usageCounter.incrementCounter`', () => {
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    trackLegacyRouteUsage('test', mockUsageCounter);
+    expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+      counterName: `legacyRoute_test`,
+      counterType: 'legacyApiUsage',
+      incrementBy: 1,
+    });
+  });
+
+  it('should do nothing if no usage counter is provided', () => {
+    let err;
+    try {
+      trackLegacyRouteUsage('test', undefined);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeUndefined();
+  });
+});

--- a/x-pack/plugins/alerting/server/lib/track_legacy_route_usage.ts
+++ b/x-pack/plugins/alerting/server/lib/track_legacy_route_usage.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UsageCounter } from 'src/plugins/usage_collection/server';
+
+export function trackLegacyRouteUsage(route: string, usageCounter?: UsageCounter) {
+  if (usageCounter) {
+    usageCounter.incrementCounter({
+      counterName: `legacyRoute_${route}`,
+      counterType: 'legacyApiUsage',
+      incrementBy: 1,
+    });
+  }
+}

--- a/x-pack/plugins/alerting/server/routes/legacy/aggregate.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/aggregate.test.ts
@@ -11,8 +11,16 @@ import { licenseStateMock } from '../../lib/license_state.mock';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 
 const rulesClient = rulesClientMock.create();
+const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
+}));
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
@@ -138,5 +146,24 @@ describe('aggregateAlertRoute', () => {
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
 
     expect(verifyApiAccess).toHaveBeenCalledWith(licenseState);
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    aggregateAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { rulesClient },
+      {
+        query: {
+          default_search_operator: 'AND',
+        },
+      },
+      ['ok']
+    );
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('aggregate', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/aggregate.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/aggregate.ts
@@ -6,12 +6,14 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { renameKeys } from './../lib/rename_keys';
 import { FindOptions } from '../../rules_client';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 // config definition
 const querySchema = schema.object({
@@ -33,7 +35,11 @@ const querySchema = schema.object({
   filter: schema.maybe(schema.string()),
 });
 
-export const aggregateAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const aggregateAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.get(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/_aggregate`,
@@ -47,6 +53,8 @@ export const aggregateAlertRoute = (router: AlertingRouter, licenseState: ILicen
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
       const rulesClient = context.alerting.getRulesClient();
+
+      trackLegacyRouteUsage('aggregate', usageCounter);
 
       const query = req.query;
       const renameMap = {

--- a/x-pack/plugins/alerting/server/routes/legacy/create.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/create.test.ts
@@ -8,6 +8,7 @@
 import { MockedLogger, loggerMock } from '@kbn/logging/mocks';
 import { createAlertRoute } from './create';
 import { httpServiceMock } from 'src/core/server/mocks';
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
@@ -15,13 +16,17 @@ import { rulesClientMock } from '../../rules_client.mock';
 import { Alert } from '../../../common/alert';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
 import { encryptedSavedObjectsMock } from '../../../../encrypted_saved_objects/server/mocks';
-import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 let logger: MockedLogger;
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -460,5 +465,24 @@ describe('createAlertRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const encryptedSavedObjects = encryptedSavedObjectsMock.createSetup({ canEncrypt: true });
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    createAlertRoute({
+      router,
+      licenseState,
+      encryptedSavedObjects,
+      usageCounter: mockUsageCounter,
+    });
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, {}, ['ok']);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('create', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/create.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/create.test.ts
@@ -477,6 +477,7 @@ describe('createAlertRoute', () => {
     createAlertRoute({
       router,
       licenseState,
+      logger,
       encryptedSavedObjects,
       usageCounter: mockUsageCounter,
     });

--- a/x-pack/plugins/alerting/server/routes/legacy/create.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/create.ts
@@ -19,6 +19,7 @@ import {
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
 import { RouteOptions } from '..';
 import { countUsageOfPredefinedIds } from '../lib';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 export const bodySchema = schema.object({
   name: schema.string(),
@@ -67,6 +68,7 @@ export const createAlertRoute = ({ router, licenseState, logger, usageCounter }:
         const alert = req.body;
         const params = req.params;
         const notifyWhen = alert?.notifyWhen ? (alert.notifyWhen as AlertNotifyWhenType) : null;
+        trackLegacyRouteUsage('create', usageCounter);
 
         const spaceId = rulesClient.getSpaceId();
         const shouldWarnId = params?.id && spaceId !== undefined && spaceId !== 'default';

--- a/x-pack/plugins/alerting/server/routes/legacy/delete.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/delete.test.ts
@@ -5,17 +5,23 @@
  * 2.0.
  */
 
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { deleteAlertRoute } from './delete';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -105,5 +111,20 @@ describe('deleteAlertRoute', () => {
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
 
     expect(verifyApiAccess).toHaveBeenCalledWith(licenseState);
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    deleteAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.delete.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: { id: '1' } }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('delete', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/delete.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/delete.ts
@@ -6,16 +6,22 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const deleteAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const deleteAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.delete(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}`,
@@ -28,6 +34,7 @@ export const deleteAlertRoute = (router: AlertingRouter, licenseState: ILicenseS
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('delete', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       await rulesClient.delete({ id });

--- a/x-pack/plugins/alerting/server/routes/legacy/disable.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/disable.test.ts
@@ -4,18 +4,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { disableAlertRoute } from './disable';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -77,5 +82,20 @@ describe('disableAlertRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    disableAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: { id: '1' } }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('disable', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/disable.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/disable.ts
@@ -6,17 +6,23 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const disableAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const disableAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.post(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}/_disable`,
@@ -29,6 +35,7 @@ export const disableAlertRoute = (router: AlertingRouter, licenseState: ILicense
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('disable', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       try {

--- a/x-pack/plugins/alerting/server/routes/legacy/enable.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/enable.test.ts
@@ -4,18 +4,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { enableAlertRoute } from './enable';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -77,5 +82,20 @@ describe('enableAlertRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    enableAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: { id: '1' } }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('enable', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/enable.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/enable.ts
@@ -6,18 +6,24 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { handleDisabledApiKeysError } from './../lib/error_handler';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const enableAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const enableAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.post(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}/_enable`,
@@ -31,6 +37,7 @@ export const enableAlertRoute = (router: AlertingRouter, licenseState: ILicenseS
         if (!context.alerting) {
           return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
         }
+        trackLegacyRouteUsage('enable', usageCounter);
         const rulesClient = context.alerting.getRulesClient();
         const { id } = req.params;
         try {

--- a/x-pack/plugins/alerting/server/routes/legacy/find.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/find.test.ts
@@ -4,18 +4,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { findAlertRoute } from './find';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -139,5 +144,20 @@ describe('findAlertRoute', () => {
     expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: OMG]`);
 
     expect(verifyApiAccess).toHaveBeenCalledWith(licenseState);
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    findAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: {}, query: {} }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('find', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/find.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/find.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 
 import { ILicenseState } from '../../lib/license_state';
@@ -13,6 +14,7 @@ import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { renameKeys } from './../lib/rename_keys';
 import { FindOptions } from '../../rules_client';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 // config definition
 const querySchema = schema.object({
@@ -39,7 +41,11 @@ const querySchema = schema.object({
   filter: schema.maybe(schema.string()),
 });
 
-export const findAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const findAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.get(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/_find`,
@@ -52,6 +58,7 @@ export const findAlertRoute = (router: AlertingRouter, licenseState: ILicenseSta
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('find', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
 
       const query = req.query;

--- a/x-pack/plugins/alerting/server/routes/legacy/get.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/get.ts
@@ -6,16 +6,22 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import type { AlertingRouter } from '../../types';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const getAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const getAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.get(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}`,
@@ -28,6 +34,7 @@ export const getAlertRoute = (router: AlertingRouter, licenseState: ILicenseStat
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('get', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       return res.ok({

--- a/x-pack/plugins/alerting/server/routes/legacy/get_alert_instance_summary.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/get_alert_instance_summary.ts
@@ -6,10 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -21,7 +23,8 @@ const querySchema = schema.object({
 
 export const getAlertInstanceSummaryRoute = (
   router: AlertingRouter,
-  licenseState: ILicenseState
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
 ) => {
   router.get(
     {
@@ -36,6 +39,7 @@ export const getAlertInstanceSummaryRoute = (
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('instanceSummary', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       const { dateStart } = req.query;

--- a/x-pack/plugins/alerting/server/routes/legacy/get_alert_state.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/get_alert_state.ts
@@ -6,16 +6,22 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const getAlertStateRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const getAlertStateRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.get(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}/state`,
@@ -28,6 +34,7 @@ export const getAlertStateRoute = (router: AlertingRouter, licenseState: ILicens
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('state', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       const state = await rulesClient.getAlertState({ id });

--- a/x-pack/plugins/alerting/server/routes/legacy/health.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/health.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { healthRoute } from './health';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
@@ -13,10 +13,16 @@ import { encryptedSavedObjectsMock } from '../../../../encrypted_saved_objects/s
 import { rulesClientMock } from '../../rules_client.mock';
 import { HealthStatus } from '../../types';
 import { alertsMock } from '../../mocks';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
+
 const rulesClient = rulesClientMock.create();
 
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 const alerting = alertsMock.createStart();
@@ -255,5 +261,21 @@ describe('healthRoute', () => {
         isSufficientlySecure: true,
       },
     });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const encryptedSavedObjects = encryptedSavedObjectsMock.createSetup({ canEncrypt: true });
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    healthRoute(router, licenseState, encryptedSavedObjects, mockUsageCounter);
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: { id: '1' } }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('health', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/health.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/health.ts
@@ -5,16 +5,19 @@
  * 2.0.
  */
 
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { AlertingFrameworkHealth } from '../../types';
 import { EncryptedSavedObjectsPluginSetup } from '../../../../encrypted_saved_objects/server';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 export function healthRoute(
   router: AlertingRouter,
   licenseState: ILicenseState,
-  encryptedSavedObjects: EncryptedSavedObjectsPluginSetup
+  encryptedSavedObjects: EncryptedSavedObjectsPluginSetup,
+  usageCounter?: UsageCounter
 ) {
   router.get(
     {
@@ -26,6 +29,7 @@ export function healthRoute(
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('health', usageCounter);
       try {
         const isEsSecurityEnabled: boolean | null = licenseState.getIsSecurityEnabled();
         const alertingFrameworkHeath = await context.alerting.getFrameworkHealth();

--- a/x-pack/plugins/alerting/server/routes/legacy/index.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/index.ts
@@ -25,23 +25,23 @@ import { healthRoute } from './health';
 import { RouteOptions } from '..';
 
 export function defineLegacyRoutes(opts: RouteOptions) {
-  const { router, licenseState, encryptedSavedObjects } = opts;
+  const { router, licenseState, encryptedSavedObjects, usageCounter } = opts;
 
   createAlertRoute(opts);
-  aggregateAlertRoute(router, licenseState);
-  deleteAlertRoute(router, licenseState);
-  findAlertRoute(router, licenseState);
-  getAlertRoute(router, licenseState);
-  getAlertStateRoute(router, licenseState);
-  getAlertInstanceSummaryRoute(router, licenseState);
-  listAlertTypesRoute(router, licenseState);
-  updateAlertRoute(router, licenseState);
-  enableAlertRoute(router, licenseState);
-  disableAlertRoute(router, licenseState);
-  updateApiKeyRoute(router, licenseState);
-  muteAllAlertRoute(router, licenseState);
-  unmuteAllAlertRoute(router, licenseState);
-  muteAlertInstanceRoute(router, licenseState);
-  unmuteAlertInstanceRoute(router, licenseState);
-  healthRoute(router, licenseState, encryptedSavedObjects);
+  aggregateAlertRoute(router, licenseState, usageCounter);
+  deleteAlertRoute(router, licenseState, usageCounter);
+  findAlertRoute(router, licenseState, usageCounter);
+  getAlertRoute(router, licenseState, usageCounter);
+  getAlertStateRoute(router, licenseState, usageCounter);
+  getAlertInstanceSummaryRoute(router, licenseState, usageCounter);
+  listAlertTypesRoute(router, licenseState, usageCounter);
+  updateAlertRoute(router, licenseState, usageCounter);
+  enableAlertRoute(router, licenseState, usageCounter);
+  disableAlertRoute(router, licenseState, usageCounter);
+  updateApiKeyRoute(router, licenseState, usageCounter);
+  muteAllAlertRoute(router, licenseState, usageCounter);
+  unmuteAllAlertRoute(router, licenseState, usageCounter);
+  muteAlertInstanceRoute(router, licenseState, usageCounter);
+  unmuteAlertInstanceRoute(router, licenseState, usageCounter);
+  healthRoute(router, licenseState, encryptedSavedObjects, usageCounter);
 }

--- a/x-pack/plugins/alerting/server/routes/legacy/list_alert_types.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/list_alert_types.ts
@@ -4,13 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
-export const listAlertTypesRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const listAlertTypesRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.get(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/list_alert_types`,
@@ -21,6 +26,7 @@ export const listAlertTypesRoute = (router: AlertingRouter, licenseState: ILicen
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('listAlertTypes', usageCounter);
       return res.ok({
         body: Array.from(await context.alerting.getRulesClient().listAlertTypes()),
       });

--- a/x-pack/plugins/alerting/server/routes/legacy/mute_all.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/mute_all.test.ts
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { muteAllAlertRoute } from './mute_all';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -76,5 +82,20 @@ describe('muteAllAlertRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    muteAllAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: {}, body: {} }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('muteAll', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/mute_all.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/mute_all.ts
@@ -6,17 +6,23 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const muteAllAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const muteAllAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.post(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}/_mute_all`,
@@ -29,6 +35,7 @@ export const muteAllAlertRoute = (router: AlertingRouter, licenseState: ILicense
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('muteAll', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       try {

--- a/x-pack/plugins/alerting/server/routes/legacy/mute_instance.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/mute_instance.test.ts
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { muteAlertInstanceRoute } from './mute_instance';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -82,5 +88,20 @@ describe('muteAlertInstanceRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    muteAlertInstanceRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: {}, body: {} }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('muteInstance', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/unmute_all.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/unmute_all.test.ts
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { unmuteAllAlertRoute } from './unmute_all';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -76,5 +82,20 @@ describe('unmuteAllAlertRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    unmuteAllAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: {}, body: {} }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('unmuteAll', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/unmute_all.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/unmute_all.ts
@@ -6,17 +6,23 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const unmuteAllAlertRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const unmuteAllAlertRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.post(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}/_unmute_all`,
@@ -29,6 +35,7 @@ export const unmuteAllAlertRoute = (router: AlertingRouter, licenseState: ILicen
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('unmuteAll', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { id } = req.params;
       try {

--- a/x-pack/plugins/alerting/server/routes/legacy/unmute_instance.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/unmute_instance.ts
@@ -6,18 +6,24 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   alertId: schema.string(),
   alertInstanceId: schema.string(),
 });
 
-export const unmuteAlertInstanceRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const unmuteAlertInstanceRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.post(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{alertId}/alert_instance/{alertInstanceId}/_unmute`,
@@ -30,6 +36,7 @@ export const unmuteAlertInstanceRoute = (router: AlertingRouter, licenseState: I
       if (!context.alerting) {
         return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
       }
+      trackLegacyRouteUsage('unmuteInstance', usageCounter);
       const rulesClient = context.alerting.getRulesClient();
       const { alertId, alertInstanceId } = req.params;
       try {

--- a/x-pack/plugins/alerting/server/routes/legacy/update_api_key.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/update_api_key.test.ts
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { updateApiKeyRoute } from './update_api_key';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../../lib/license_state.mock';
 import { mockHandlerArguments } from './../_mock_handler_arguments';
 import { rulesClientMock } from '../../rules_client.mock';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const rulesClient = rulesClientMock.create();
 jest.mock('../../lib/license_api_access.ts', () => ({
   verifyApiAccess: jest.fn(),
+}));
+
+jest.mock('../../lib/track_legacy_route_usage', () => ({
+  trackLegacyRouteUsage: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -78,5 +84,20 @@ describe('updateApiKeyRoute', () => {
     await handler(context, req, res);
 
     expect(res.forbidden).toHaveBeenCalledWith({ body: { message: 'Fail' } });
+  });
+
+  it('should track every call', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    updateApiKeyRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.post.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ rulesClient }, { params: {}, body: {} }, [
+      'ok',
+    ]);
+    await handler(context, req, res);
+    expect(trackLegacyRouteUsage).toHaveBeenCalledWith('updateApiKey', mockUsageCounter);
   });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/update_api_key.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/update_api_key.ts
@@ -6,18 +6,24 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
 import type { AlertingRouter } from '../../types';
 import { ILicenseState } from '../../lib/license_state';
 import { verifyApiAccess } from '../../lib/license_api_access';
 import { LEGACY_BASE_ALERT_API_PATH } from '../../../common';
 import { handleDisabledApiKeysError } from './../lib/error_handler';
 import { AlertTypeDisabledError } from '../../lib/errors/alert_type_disabled';
+import { trackLegacyRouteUsage } from '../../lib/track_legacy_route_usage';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-export const updateApiKeyRoute = (router: AlertingRouter, licenseState: ILicenseState) => {
+export const updateApiKeyRoute = (
+  router: AlertingRouter,
+  licenseState: ILicenseState,
+  usageCounter?: UsageCounter
+) => {
   router.post(
     {
       path: `${LEGACY_BASE_ALERT_API_PATH}/alert/{id}/_update_api_key`,
@@ -31,6 +37,7 @@ export const updateApiKeyRoute = (router: AlertingRouter, licenseState: ILicense
         if (!context.alerting) {
           return res.badRequest({ body: 'RouteHandlerContext is not registered for alerting' });
         }
+        trackLegacyRouteUsage('updateApiKey', usageCounter);
         const rulesClient = context.alerting.getRulesClient();
         const { id } = req.params;
         try {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Alerting] Telemetry for calling legacy routes (#111885)