### PR TITLE
[7.15] [Discover] Fix a functional test 'index pattern with unmapped fields' (#111323)

### DIFF
--- a/test/functional/apps/discover/_indexpattern_with_unmapped_fields.ts
+++ b/test/functional/apps/discover/_indexpattern_with_unmapped_fields.ts
@@ -30,6 +30,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       await PageObjects.common.navigateToApp('discover');
+      await PageObjects.discover.selectIndexPattern('test-index-unmapped-fields');
     });
 
     after(async () => {


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Discover] Fix a functional test 'index pattern with unmapped fields' (#111323)