### PR TITLE
[DOCS] Removes coming tag from 8.0.0-alpha2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -18,8 +18,6 @@ Review important information about the {kib} 8.0.0 releases.
 [[release-notes-8.0.0-alpha2]]
 == {kib} 8.0.0-alpha2
 
-coming::[8.0.0-alpha2]
-
 Review the {kib} 8.0.0-alpha2 changes, then use the <<upgrade-assistant,Upgrade Assistant>> to complete the upgrade.
 
 [float]


### PR DESCRIPTION
## Summary

Removes `coming` tag from the 8.0.0-alpha2 release notes.