### PR TITLE
[Buildkite] Pull Request pipeline

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -19,7 +19,7 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution and Plugins
     agents:
-      queue: c2-8
+      queue: c2-16
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
 

--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -9,7 +9,7 @@ steps:
   - command: .buildkite/scripts/steps/build_kibana.sh
     label: Build Kibana Distribution and Plugins
     agents:
-      queue: c2-8
+      queue: c2-16
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
 

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -1,0 +1,11 @@
+steps:
+  - command: .buildkite/scripts/steps/functional/apm_cypress.sh
+    label: 'APM Cypress Tests'
+    agents:
+      queue: ci-group-6
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -15,7 +15,7 @@ steps:
     label: 'Default CI Group'
     parallelism: 13
     agents:
-      queue: ci-group-4d
+      queue: ci-group-6
     depends_on: build
     timeout_in_minutes: 120
     key: default-cigroup
@@ -27,7 +27,7 @@ steps:
   - command: CI_GROUP=Docker .buildkite/scripts/steps/functional/xpack_cigroup.sh
     label: 'Docker CI Group'
     agents:
-      queue: ci-group-4d
+      queue: ci-group-6
     depends_on: build
     timeout_in_minutes: 120
     key: default-cigroup-docker
@@ -40,7 +40,7 @@ steps:
     label: 'OSS CI Group'
     parallelism: 11
     agents:
-      queue: n2-2
+      queue: ci-group-4d
     depends_on: build
     timeout_in_minutes: 120
     key: oss-cigroup
@@ -118,14 +118,14 @@ steps:
   - command: .buildkite/scripts/steps/test/jest_integration.sh
     label: 'Jest Integration Tests'
     agents:
-      queue: jest
+      queue: n2-4
     timeout_in_minutes: 120
     key: jest-integration
 
   - command: .buildkite/scripts/steps/test/api_integration.sh
     label: 'API Integration Tests'
     agents:
-      queue: jest
+      queue: n2-2
     timeout_in_minutes: 120
     key: api-integration
 

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -38,7 +38,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/oss_cigroup.sh
     label: 'OSS CI Group'
-    parallelism: 12
+    parallelism: 11
     agents:
       queue: n2-2
     depends_on: build

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -1,0 +1,155 @@
+steps:
+  - command: .buildkite/scripts/lifecycle/pre_build.sh
+    label: Pre-Build
+
+  - wait
+
+  - command: .buildkite/scripts/steps/build_kibana.sh
+    label: Build Kibana Distribution and Plugins
+    agents:
+      queue: c2-16
+    key: build
+    if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
+
+  - command: .buildkite/scripts/steps/functional/xpack_cigroup.sh
+    label: 'Default CI Group'
+    parallelism: 13
+    agents:
+      queue: ci-group-4d
+    depends_on: build
+    timeout_in_minutes: 120
+    key: default-cigroup
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: CI_GROUP=Docker .buildkite/scripts/steps/functional/xpack_cigroup.sh
+    label: 'Docker CI Group'
+    agents:
+      queue: ci-group-4d
+    depends_on: build
+    timeout_in_minutes: 120
+    key: default-cigroup-docker
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/oss_cigroup.sh
+    label: 'OSS CI Group'
+    parallelism: 12
+    agents:
+      queue: n2-2
+    depends_on: build
+    timeout_in_minutes: 120
+    key: oss-cigroup
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/oss_accessibility.sh
+    label: 'OSS Accessibility Tests'
+    agents:
+      queue: ci-group-4d
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/xpack_accessibility.sh
+    label: 'Default Accessibility Tests'
+    agents:
+      queue: ci-group-6
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/oss_firefox.sh
+    label: 'OSS Firefox Tests'
+    agents:
+      queue: ci-group-4d
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/xpack_firefox.sh
+    label: 'Default Firefox Tests'
+    agents:
+      queue: ci-group-6
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/oss_misc.sh
+    label: 'OSS Misc Functional Tests'
+    agents:
+      queue: ci-group-4d
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/xpack_saved_object_field_metrics.sh
+    label: 'Saved Object Field Metrics'
+    agents:
+      queue: ci-group-6
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/test/jest_integration.sh
+    label: 'Jest Integration Tests'
+    agents:
+      queue: jest
+    timeout_in_minutes: 120
+    key: jest-integration
+
+  - command: .buildkite/scripts/steps/test/api_integration.sh
+    label: 'API Integration Tests'
+    agents:
+      queue: jest
+    timeout_in_minutes: 120
+    key: api-integration
+
+  - command: .buildkite/scripts/steps/test/jest.sh
+    label: 'Jest Tests'
+    agents:
+      queue: c2-16
+    timeout_in_minutes: 120
+    key: jest
+
+  - command: .buildkite/scripts/steps/lint.sh
+    label: 'Linting'
+    agents:
+      queue: n2-2
+    key: linting
+
+  - command: .buildkite/scripts/steps/checks.sh
+    label: 'Checks'
+    agents:
+      queue: c2-4
+    key: checks
+
+  - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
+    label: 'Build Storybooks'
+    agents:
+      queue: c2-4
+    key: storybooks

--- a/.buildkite/pipelines/pull_request/post_build.yml
+++ b/.buildkite/pipelines/pull_request/post_build.yml
@@ -1,0 +1,6 @@
+steps:
+  - wait: ~
+    continue_on_failure: true
+
+  - command: .buildkite/scripts/lifecycle/post_build.sh
+    label: Post-Build

--- a/.buildkite/pipelines/pull_request/security_solution.yml
+++ b/.buildkite/pipelines/pull_request/security_solution.yml
@@ -1,0 +1,11 @@
+steps:
+  - command: .buildkite/scripts/steps/functional/security_solution.sh
+    label: 'Security Solution Tests'
+    agents:
+      queue: ci-group-6
+    depends_on: build
+    timeout_in_minutes: 120
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1

--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -45,11 +45,19 @@ if is_pr; then
   export ghprbActualCommit="$BUILDKITE_COMMIT"
   export BUILD_URL="$BUILDKITE_BUILD_URL"
 
-  # set_git_merge_base # TODO for PRs
+  set_git_merge_base
+
+  # For backwards compatibility
+  export PR_MERGE_BASE="$GITHUB_PR_MERGE_BASE"
+  export PR_TARGET_BRANCH="$GITHUB_PR_TARGET_BRANCH"
 else
   export ELASTIC_APM_ACTIVE=true
   export CHECKS_REPORTER_ACTIVE=false
 fi
+
+# These are for backwards-compatibility
+export GIT_COMMIT="$BUILDKITE_COMMIT"
+export GIT_BRANCH="$BUILDKITE_BRANCH"
 
 export FLEET_PACKAGE_REGISTRY_PORT=6104
 export TEST_CORS_SERVER_PORT=6105

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -74,3 +74,15 @@ retry() {
     fi
   done
 }
+
+set_git_merge_base() {
+  GITHUB_PR_MERGE_BASE="$(buildkite-agent meta-data get merge-base --default '')"
+
+  if [[ ! "$GITHUB_PR_MERGE_BASE" ]]; then
+    git fetch origin "$GITHUB_PR_TARGET_BRANCH"
+    GITHUB_PR_MERGE_BASE="$(git merge-base HEAD FETCH_HEAD)"
+    buildkite-agent meta-data set merge-base "$GITHUB_PR_MERGE_BASE"
+  fi
+
+  export GITHUB_PR_MERGE_BASE
+}

--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -8,3 +8,12 @@ export BUILD_SUCCESSFUL
 "$(dirname "${0}")/commit_status_complete.sh"
 
 node "$(dirname "${0}")/ci_stats_complete.js"
+
+if [[ "$GITHUB_PR_NUMBER" ]]; then
+  DOCS_CHANGES_URL="https://kibana_$GITHUB_PR_NUMBER}.docs-preview.app.elstc.co/diff"
+  DOCS_CHANGES=$(curl --connect-timeout 10 -m 10 -sf "$DOCS_CHANGES_URL" || echo '')
+
+  if [[ "$DOCS_CHANGES" && "$DOCS_CHANGES" != "There aren't any differences!" ]]; then
+    buildkite-agent meta-data set pr_comment:docs_changes:head "* [Documentation Changes](${DOCS_CHANGES_URL})"
+  fi
+fi

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.js
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.js
@@ -56,7 +56,6 @@ const uploadPipeline = (pipelineContent) => {
 
     if (
       await doAnyChangesMatch([
-        /^.buildkite\//, // TODO remove me after testing
         /^x-pack\/plugins\/security_solution/,
         /^x-pack\/test\/security_solution_cypress/,
         /^x-pack\/plugins\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.js
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.js
@@ -1,0 +1,86 @@
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const { areChangesSkippable, doAnyChangesMatch } = require('kibana-buildkite-library');
+
+const SKIPPABLE_PATHS = [
+  /^docs\//,
+  /^rfcs\//,
+  /^.ci\/.+\.yml$/,
+  /^.ci\/es-snapshots\//,
+  /^.ci\/pipeline-library\//,
+  /^.ci\/Jenkinsfile_[^\/]+$/,
+  /^\.github\//,
+  /\.md$/,
+  /^\.backportrc\.json$/,
+];
+
+const REQUIRED_PATHS = [
+  // this file is auto-generated and changes to it need to be validated with CI
+  /^docs\/developer\/plugin-list.asciidoc$/,
+  // don't skip CI on prs with changes to plugin readme files /i is for case-insensitive matching
+  /\/plugins\/[^\/]+\/readme\.(md|asciidoc)$/i,
+];
+
+const getPipeline = (filename, removeSteps = true) => {
+  const str = fs.readFileSync(filename).toString();
+  return removeSteps ? str.replace(/^steps:/, '') : str;
+};
+
+const uploadPipeline = (pipelineContent) => {
+  const str =
+    typeof pipelineContent === 'string' ? pipelineContent : JSON.stringify(pipelineContent);
+
+  execSync('buildkite-agent pipeline upload', {
+    input: str,
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+};
+
+(async () => {
+  try {
+    const skippable = await areChangesSkippable(SKIPPABLE_PATHS, REQUIRED_PATHS);
+
+    if (skippable) {
+      console.log('All changes in PR are skippable. Skipping CI.');
+
+      // Since we skip everything, including post-build, we need to at least make sure the commit status gets set
+      execSync('BUILD_SUCCESSFUL=true .buildkite/scripts/lifecycle/commit_status_complete.sh', {
+        stdio: 'inherit',
+      });
+      process.exit(0);
+    }
+
+    const pipeline = [];
+
+    pipeline.push(getPipeline('.buildkite/pipelines/pull_request/base.yml', false));
+
+    if (
+      await doAnyChangesMatch([
+        /^.buildkite\//, // TODO remove me after testing
+        /^x-pack\/plugins\/security_solution/,
+        /^x-pack\/test\/security_solution_cypress/,
+        /^x-pack\/plugins\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
+        /^x-pack\/plugins\/triggers_actions_ui\/public\/application\/context\/actions_connectors_context\.tsx/,
+      ])
+    ) {
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/security_solution.yml'));
+    }
+
+    // Disabled for now, these are failing/disabled in Jenkins currently as well
+    // if (
+    //   await doAnyChangesMatch([
+    //     /^x-pack\/plugins\/apm/,
+    //   ])
+    // ) {
+    //   pipeline.push(getPipeline('.buildkite/pipelines/pull_request/apm_cypress.yml'));
+    // }
+
+    // TODO add dynamic steps here
+    pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
+
+    uploadPipeline(pipeline.join('\n'));
+  } catch (ex) {
+    console.error('PR pipeline generation error', ex.message);
+    process.exit(1);
+  }
+})();

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.js
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.js
@@ -75,7 +75,6 @@ const uploadPipeline = (pipelineContent) => {
     //   pipeline.push(getPipeline('.buildkite/pipelines/pull_request/apm_cypress.yml'));
     // }
 
-    // TODO add dynamic steps here
     pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
 
     uploadPipeline(pipeline.join('\n'));

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.sh
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+node .buildkite/scripts/pipelines/pull_request/pipeline.js

--- a/.buildkite/scripts/steps/functional/apm_cypress.sh
+++ b/.buildkite/scripts/steps/functional/apm_cypress.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/steps/functional/common.sh
+
+export JOB=kibana-apm-cypress
+
+echo "--- APM Cypress Tests"
+
+cd "$XPACK_DIR"
+
+checks-reporter-with-killswitch "APM Cypress Tests" \
+  node plugins/apm/scripts/test/e2e.js

--- a/.buildkite/scripts/steps/functional/security_solution.sh
+++ b/.buildkite/scripts/steps/functional/security_solution.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/steps/functional/common.sh
+
+export JOB=kibana-security-solution-chrome
+
+echo "--- Security Solution tests (Chrome)"
+
+cd "$XPACK_DIR"
+
+checks-reporter-with-killswitch "Security Solution Cypress Tests (Chrome)" \
+ node scripts/functional_tests \
+   --debug --bail \
+   --kibana-install-dir "$KIBANA_BUILD_LOCATION" \
+   --config test/security_solution_cypress/cli_config.ts

--- a/.buildkite/scripts/steps/storybooks/build_and_upload.js
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.js
@@ -98,6 +98,12 @@ const upload = () => {
       gsutil -q -m cp -r -z js,css,html,json,map,txt,svg '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/${process.env.BUILDKITE_COMMIT}/'
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp -z html 'index.html' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/latest/'
     `);
+
+    if (process.env.BUILDKITE_PULL_REQUEST && process.env.BUILDKITE_PULL_REQUEST !== 'false') {
+      exec(
+        `buildkite-agent meta-data set pr_comment:storybooks:head '* [Storybooks Preview](${STORYBOOK_BASE_URL})'`
+      );
+    }
   } finally {
     process.chdir(originalDirectory);
   }


### PR DESCRIPTION
[skip-ci]

Implement the remaining items to enable pull request pipelines in Buildkite. A lot of work was done elsewhere, e.g. in https://github.com/elastic/kibana-buildkite-build-bot for PR comments.

This PR does not enable PR comments for all PRs or disable PRs in Jenkins. However, it does allow PRs to opt-in to Buildkite PRs (like this one!) by:

- Adding `[skip-ci]` to the description, to make Jenkins not run CI
- Adding the `buildkite-ci` label

At that point, the PR will function as normal, except that it will run in Buildkite.

- Add remaining pipeline tasks not present in hourly pipeline (security solution, apm)
- Add missing environmental items only required for PRs, such as git merge base
- Add docs changes link and CI stats report for PR comments
- Fail build on bad CI stats report
- Add annotation for CI stats report
- Add storybooks preview url to PR comment

See here for an example of a build with failures: https://buildkite.com/elastic/kibana-pull-request/builds/58