### PR TITLE
[Reporting] Add config settings to telemetry for usage analysis

### DIFF
--- a/x-pack/plugins/reporting/server/config/index.ts
+++ b/x-pack/plugins/reporting/server/config/index.ts
@@ -54,4 +54,16 @@ export const config: PluginConfigDescriptor<ReportingConfigType> = {
       }
     },
   ],
+  exposeToUsage: {
+    capture: {
+      maxAttempts: true,
+      timeouts: { openUrl: true, renderComplete: true, waitForElements: true },
+      networkPolicy: false, // show as [redacted]
+      zoom: true,
+    },
+    csv: { maxSizeBytes: true, scroll: { size: true, duration: true } },
+    kibanaServer: false, // show as [redacted]
+    queue: { indexInterval: true, pollEnabled: true, timeout: true },
+    roles: { enabled: true },
+  },
 };


### PR DESCRIPTION
## Summary

This PR updates Reporting config to allow specific config settings to be collected for telemetry.

Documentation: https://github.com/elastic/kibana/blob/0f45381/docs/development/core/server/kibana-plugin-core-server.pluginconfigdescriptor.exposetousage.md

