### PR TITLE
[DOCS] Adds the 6.8.19 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -14,6 +14,7 @@
 
 Review important information about the {kib} 6.x.x releases.
 
+* <<release-notes-6.8.19>>
 * <<release-notes-6.8.18>>
 * <<release-notes-6.8.17>>
 * <<release-notes-6.8.16>>
@@ -106,6 +107,25 @@ Review important information about the {kib} 6.x.x releases.
 //[float]
 //=== Known issues
 ////
+
+[[release-notes-6.8.19]]
+== {kib} 6.8.19
+
+coming::[6.8.19]
+
+For information about the {kib} 6.8.19 release, review the following information.
+
+[float]
+[[breaking-changes-6.8.19]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and performance. Before you upgrade, review the <<breaking-changes,Breaking changes>>, then mitigate the impact to your application.
+
+[float]
+[[bug-fixes-and-enhancements-6.8.19]]
+=== Bug fixes and enhancements
+
+There are no user-facing changes in the 6.8.19 release.
 
 [[release-notes-6.8.18]]
 == {kib} 6.8.18


### PR DESCRIPTION
## Summary

Adds the [release notes for the 6.8.19 release](https://kibana_112041.docs-preview.app.elstc.co/guide/en/kibana/6.8/release-notes-6.8.19.html).