### PR TITLE
remove async lifecycle from global_search_bar plugin

### DIFF
--- a/x-pack/plugins/global_search_bar/public/plugin.tsx
+++ b/x-pack/plugins/global_search_bar/public/plugin.tsx
@@ -23,7 +23,7 @@ export interface GlobalSearchBarPluginStartDeps {
 }
 
 export class GlobalSearchBarPlugin implements Plugin<{}, {}> {
-  public async setup() {
+  public setup() {
     return {};
   }
 


### PR DESCRIPTION
## Summary

Change `globalSearchBar`'s client-side `setup` method to be synchronous

