### PR TITLE
[QA][SO INFO SVC] Add json only option

### DIFF
--- a/test/common/services/saved_object_info/index.ts
+++ b/test/common/services/saved_object_info/index.ts
@@ -8,7 +8,7 @@
 
 import { run } from '@kbn/dev-utils';
 import { pipe } from 'fp-ts/function';
-import { payload, noop, areValid, print, expectedFlags } from './utils';
+import { payload, noop, areValid, print, expectedFlags, format } from './utils';
 import { types } from './saved_object_info';
 
 export { SavedObjectInfoService } from './saved_object_info';
@@ -16,12 +16,15 @@ export { SavedObjectInfoService } from './saved_object_info';
 export const runSavedObjInfoSvc = () =>
   run(
     async ({ flags, log }) => {
-      const printWith = print(log);
+      const justJson: boolean = !!flags.json;
 
-      const getAndFormatAndPrint = async () =>
-        pipe(await types(flags.esUrl as string)(), payload, printWith());
+      const resolveDotKibana = async () => await types(flags.esUrl as string)();
 
-      return areValid(flags) ? getAndFormatAndPrint() : noop();
+      return areValid(flags)
+        ? justJson
+          ? pipe(await resolveDotKibana(), JSON.stringify.bind(null), log.write.bind(log))
+          : pipe(await resolveDotKibana(), format, payload, print(log)())
+        : noop();
     },
     {
       description: `

--- a/test/common/services/saved_object_info/utils.ts
+++ b/test/common/services/saved_object_info/utils.ts
@@ -30,7 +30,7 @@ export const print = (log: ToolingLog) => (msg: string | null = null) => ({
 }: {
   xs: any;
   count: number;
-}) => log.success(`\n### Saved Object Types ${msg || 'Count: ' + count}\n${xs}`);
+}) => log.write(`\n### Saved Object Types ${msg || 'Count: ' + count}\n${xs}`);
 
 export const expectedFlags = () => ({
   string: ['esUrl'],

--- a/test/common/services/saved_object_info/utils.ts
+++ b/test/common/services/saved_object_info/utils.ts
@@ -24,20 +24,25 @@ export const areValid = (flags: any) => {
   return true;
 };
 
-// @ts-ignore
-export const print = (log: ToolingLog) => (msg: string | null = null) => ({ xs, count }) =>
-  log.success(`\n### Saved Object Types ${msg || 'Count: ' + count}\n${xs}`);
+export const print = (log: ToolingLog) => (msg: string | null = null) => ({
+  xs,
+  count,
+}: {
+  xs: any;
+  count: number;
+}) => log.success(`\n### Saved Object Types ${msg || 'Count: ' + count}\n${xs}`);
 
 export const expectedFlags = () => ({
   string: ['esUrl'],
-  boolean: ['soTypes'],
+  boolean: ['soTypes', 'json'],
   help: `
 --esUrl             Required, tells the app which url to point to
 --soTypes           Not Required, tells the svc to show the types within the .kibana index
+--json              Not Required, tells the svc to show the types, with only json output.  Useful for piping into jq
         `,
 });
 
 export const payload = (xs: any) => ({
-  xs: format(xs),
+  xs,
   count: xs.length,
 });

--- a/test/common/services/saved_object_info/utils.ts
+++ b/test/common/services/saved_object_info/utils.ts
@@ -9,13 +9,22 @@
 import { inspect } from 'util';
 import { createFlagError, ToolingLog } from '@kbn/dev-utils';
 
-export const format = (obj: unknown) =>
-  inspect(obj, {
-    compact: false,
-    depth: 99,
-    breakLength: 80,
-    sorted: true,
-  });
+interface ResolvedPayload {
+  xs: any;
+  count: number;
+}
+
+export const format = (obj: any): ResolvedPayload => {
+  return {
+    xs: inspect(obj, {
+      compact: false,
+      depth: 99,
+      breakLength: 80,
+      sorted: true,
+    }),
+    count: obj.length,
+  };
+};
 
 export const noop = () => {};
 
@@ -27,10 +36,7 @@ export const areValid = (flags: any) => {
 export const print = (log: ToolingLog) => (msg: string | null = null) => ({
   xs,
   count,
-}: {
-  xs: any;
-  count: number;
-}) => log.write(`\n### Saved Object Types ${msg || 'Count: ' + count}\n${xs}`);
+}: ResolvedPayload) => log.write(`\n### Saved Object Types ${msg || 'Count: ' + count}\n${xs}`);
 
 export const expectedFlags = () => ({
   string: ['esUrl'],
@@ -42,7 +48,7 @@ export const expectedFlags = () => ({
         `,
 });
 
-export const payload = (xs: any) => ({
+export const payload = ({ xs, count }: ResolvedPayload) => ({
   xs,
-  count: xs.length,
+  count,
 });


### PR DESCRIPTION
## Summary

Small pr to make the so info svc, 
as easy to use as possible.

When --json is passed, only print out json,
such that piping to jq for follow-on parsing,
is easy.

## What it looks like

### Normal

`node scripts/saved_objs_info.js --esUrl http://elastic:changeme@localhost:9220 --soTypes`

The main difference here is that you see
the overall count of types of saved objects.
```
  ### Saved Object Types Count: 5
  [
    {
      doc_count: 5,
      key: 'canvas-workpad-template'
    },
    {
      doc_count: 1,
      key: 'apm-telemetry'
    },
    {
      doc_count: 1,
      key: 'config'
    },
    {
      doc_count: 1,
      key: 'event_loop_delays_daily'
    },
    {
      doc_count: 1,
      key: 'space'
    }
  ]
```

### Just json

`node scripts/saved_objs_info.js --esUrl http://elastic:changeme@localhost:9220 --json`
```
[{"key":"canvas-workpad-template","doc_count":5},{"key":"apm-telemetry","doc_count":1},{"key":"config","doc_count":1},{"key":"space","doc_count":1}]
```

### Just json with `jq`

`node scripts/saved_objs_info.js --esUrl http://elastic:changeme@localhost:9220 --soTypes --json | jq`

```
[
  {
    "key": "canvas-workpad-template",
    "doc_count": 5
  },
  {
    "key": "apm-telemetry",
    "doc_count": 1
  },
  {
    "key": "config",
    "doc_count": 1
  },
  {
    "key": "space",
    "doc_count": 1
  }
]
```

After piping to jq, all kind of things can be done.  
See the jq [tutorial](https://stedolan.github.io/jq/tutorial/)