### PR TITLE
[Cases] Fix hidden lens modal when creating case from flyout

### DIFF
--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
@@ -25,7 +25,7 @@ export interface CreateCaseModalProps {
 
 const StyledFlyout = styled(EuiFlyout)`
   ${({ theme }) => `
-    z-index: ${theme.eui.euiZModal};
+    z-index: ${theme.eui.euiZLevel5};
   `}
 `;
 
@@ -37,10 +37,10 @@ const maskOverlayClassName = 'create-case-flyout-mask-overlay';
  * A global style is needed to target a parent element.
  */
 
-const GlobalStyle = createGlobalStyle<{ theme: { eui: { euiZModal: number } } }>`
+const GlobalStyle = createGlobalStyle<{ theme: { eui: { euiZLevel5: number } } }>`
   .${maskOverlayClassName} {
     ${({ theme }) => `
-    z-index: ${theme.eui.euiZModal};
+    z-index: ${theme.eui.euiZLevel5};
   `}
   }
 `;


### PR DESCRIPTION
## Summary

If you attach an alert to a new case the cases flyout opens. Then if you try to add a lens to the case the modal is hidden behind the flyout make it impossible for the user to interact with it. This PR fixes this issue and ensures that the cases flyout is in front of the timeline but behind the lens modal.

**Video with the fix:**

https://user-images.githubusercontent.com/7871006/133244626-91418a87-746f-473b-8b7a-ad9dd19c2a89.mp4

Ref: https://github.com/elastic/kibana/issues/112057

### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
