### PR TITLE
Update renovate config for platform security modules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -85,8 +85,8 @@
           'xml-crypto', '@types/xml-crypto'
         ],
         reviewers: ['team:kibana-security'],
-        matchBaseBranches: ['master', '7.x'],
-        labels: ['Team:Security'],
+        matchBaseBranches: ['master'],
+        labels: ['Team:Security', 'release_note:skip', 'auto-backport'],
         enabled: true,
       },
     ],


### PR DESCRIPTION
[skip ci]

Updates the platform security renovate config to:
- Add the `release_note:skip` label
- Add the `auto-backport` label
- No longer target the `7.x` branch