### PR TITLE
[APM] Add 'unknown' to EventOutcome

### DIFF
--- a/x-pack/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
@@ -304,7 +304,7 @@ exports[`Span ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Span ERROR_PAGE_URL 1`] = `undefined`;
 
-exports[`Span EVENT_OUTCOME 1`] = `undefined`;
+exports[`Span EVENT_OUTCOME 1`] = `"unknown"`;
 
 exports[`Span FCP_FIELD 1`] = `undefined`;
 
@@ -541,7 +541,7 @@ exports[`Transaction ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Transaction ERROR_PAGE_URL 1`] = `undefined`;
 
-exports[`Transaction EVENT_OUTCOME 1`] = `undefined`;
+exports[`Transaction EVENT_OUTCOME 1`] = `"unknown"`;
 
 exports[`Transaction FCP_FIELD 1`] = `undefined`;
 

--- a/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
+++ b/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
@@ -30,6 +30,7 @@ describe('Transaction', () => {
       provider: 'gcp',
       region: 'europe-west1',
     },
+    event: { outcome: 'unknown' },
     http: {
       request: { method: 'GET' },
       response: { status_code: 200 },
@@ -87,6 +88,7 @@ describe('Span', () => {
       provider: 'gcp',
       region: 'europe-west1',
     },
+    event: { outcome: 'unknown' },
     processor: {
       name: 'transaction',
       event: 'span',

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/failure_badge.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/failure_badge.tsx
@@ -8,15 +8,15 @@
 import React from 'react';
 import { EuiBadge, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { EventOutcome } from '../../../../../../../typings/es_schemas/raw/fields/event_outcome';
 import { useTheme } from '../../../../../../hooks/use_theme';
-
 import { euiStyled } from '../../../../../../../../../../src/plugins/kibana_react/common';
 
 const ResetLineHeight = euiStyled.span`
   line-height: initial;
 `;
 
-export function FailureBadge({ outcome }: { outcome?: 'success' | 'failure' }) {
+export function FailureBadge({ outcome }: { outcome?: EventOutcome }) {
   const theme = useTheme();
 
   if (outcome !== 'failure') {

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/event_outcome.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/event_outcome.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type EventOutcome = 'success' | 'failure' | 'unknown';

--- a/x-pack/plugins/apm/typings/es_schemas/raw/span_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/span_raw.ts
@@ -6,6 +6,7 @@
  */
 
 import { APMBaseDoc } from './apm_base_doc';
+import { EventOutcome } from './fields/event_outcome';
 import { Stackframe } from './fields/stackframe';
 import { TimestampUs } from './fields/timestamp_us';
 
@@ -17,7 +18,7 @@ interface Processor {
 export interface SpanRaw extends APMBaseDoc {
   processor: Processor;
   trace: { id: string }; // trace is required
-  event?: { outcome?: 'success' | 'failure' };
+  event: { outcome: EventOutcome };
   service: {
     name: string;
     environment?: string;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/span_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/span_raw.ts
@@ -18,7 +18,7 @@ interface Processor {
 export interface SpanRaw extends APMBaseDoc {
   processor: Processor;
   trace: { id: string }; // trace is required
-  event: { outcome: EventOutcome };
+  event?: { outcome?: EventOutcome };
   service: {
     name: string;
     environment?: string;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/transaction_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/transaction_raw.ts
@@ -29,7 +29,7 @@ export interface TransactionRaw extends APMBaseDoc {
   processor: Processor;
   timestamp: TimestampUs;
   trace: { id: string }; // trace is required
-  event: { outcome: EventOutcome };
+  event?: { outcome?: EventOutcome };
   transaction: {
     duration: { us: number };
     id: string;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/transaction_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/transaction_raw.ts
@@ -8,6 +8,7 @@
 import { APMBaseDoc } from './apm_base_doc';
 import { Cloud } from './fields/cloud';
 import { Container } from './fields/container';
+import { EventOutcome } from './fields/event_outcome';
 import { Host } from './fields/host';
 import { Http } from './fields/http';
 import { Kubernetes } from './fields/kubernetes';
@@ -28,7 +29,7 @@ export interface TransactionRaw extends APMBaseDoc {
   processor: Processor;
   timestamp: TimestampUs;
   trace: { id: string }; // trace is required
-  event?: { outcome?: 'success' | 'failure' };
+  event: { outcome: EventOutcome };
   transaction: {
     duration: { us: number };
     id: string;


### PR DESCRIPTION
The `EventOutcome` type was missing an `"unknown"` value.

Related: https://github.com/elastic/apm-integration-testing/pull/1265