### PR TITLE
[ML] Re-enabling skipped date nanos test

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
@@ -114,8 +114,7 @@ export default function ({ getService }: FtrProviderContext) {
     },
   ];
 
-  // test skipped until https://github.com/elastic/elasticsearch/pull/77109 is fixed
-  describe.skip('job on data set with date_nanos time field', function () {
+  describe('job on data set with date_nanos time field', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/event_rate_nanos');


### PR DESCRIPTION
Test no longer needs to be skipped as https://github.com/elastic/elasticsearch/pull/77109 has been fixed.


