### PR TITLE
[7.15] [Discover/Reporting] Fix export that does not contain relative time filter (#110459)

### DIFF
--- a/src/plugins/data/common/query/timefilter/get_time.test.ts
+++ b/src/plugins/data/common/query/timefilter/get_time.test.ts
@@ -6,9 +6,11 @@
  * Side Public License, v 1.
  */
 
+import { RangeFilter } from '@kbn/es-query';
+import type { IIndexPattern } from '../..';
 import moment from 'moment';
 import sinon from 'sinon';
-import { getTime, getAbsoluteTimeRange } from './get_time';
+import { getTime, getRelativeTime, getAbsoluteTimeRange } from './get_time';
 
 describe('get_time', () => {
   describe('getTime', () => {
@@ -16,7 +18,7 @@ describe('get_time', () => {
       const clock = sinon.useFakeTimers(moment.utc([2000, 1, 1, 0, 0, 0, 0]).valueOf());
 
       const filter = getTime(
-        {
+        ({
           id: 'test',
           title: 'test',
           timeFieldName: 'date',
@@ -30,7 +32,7 @@ describe('get_time', () => {
               filterable: true,
             },
           ],
-        } as any,
+        } as unknown) as IIndexPattern,
         { from: 'now-60y', to: 'now' }
       );
       expect(filter!.range.date).toEqual({
@@ -45,7 +47,7 @@ describe('get_time', () => {
       const clock = sinon.useFakeTimers(moment.utc([2000, 1, 1, 0, 0, 0, 0]).valueOf());
 
       const filter = getTime(
-        {
+        ({
           id: 'test',
           title: 'test',
           timeFieldName: 'date',
@@ -67,13 +69,90 @@ describe('get_time', () => {
               filterable: true,
             },
           ],
-        } as any,
+        } as unknown) as IIndexPattern,
         { from: 'now-60y', to: 'now' },
         { fieldName: 'myCustomDate' }
       );
       expect(filter!.range.myCustomDate).toEqual({
         gte: '1940-02-01T00:00:00.000Z',
         lte: '2000-02-01T00:00:00.000Z',
+        format: 'strict_date_optional_time',
+      });
+      clock.restore();
+    });
+  });
+  describe('getRelativeTime', () => {
+    test('do not coerce relative time to absolute time when given flag', () => {
+      const filter = getRelativeTime(
+        ({
+          id: 'test',
+          title: 'test',
+          timeFieldName: 'date',
+          fields: [
+            {
+              name: 'date',
+              type: 'date',
+              esTypes: ['date'],
+              aggregatable: true,
+              searchable: true,
+              filterable: true,
+            },
+            {
+              name: 'myCustomDate',
+              type: 'date',
+              esTypes: ['date'],
+              aggregatable: true,
+              searchable: true,
+              filterable: true,
+            },
+          ],
+        } as unknown) as IIndexPattern,
+        { from: 'now-60y', to: 'now' },
+        { fieldName: 'myCustomDate' }
+      ) as RangeFilter;
+
+      expect(filter.range.myCustomDate).toEqual({
+        gte: 'now-60y',
+        lte: 'now',
+        format: 'strict_date_optional_time',
+      });
+    });
+    test('do not coerce relative time to absolute time when given flag - with mixed from and to times', () => {
+      const clock = sinon.useFakeTimers(moment.utc().valueOf());
+      const filter = getRelativeTime(
+        ({
+          id: 'test',
+          title: 'test',
+          timeFieldName: 'date',
+          fields: [
+            {
+              name: 'date',
+              type: 'date',
+              esTypes: ['date'],
+              aggregatable: true,
+              searchable: true,
+              filterable: true,
+            },
+            {
+              name: 'myCustomDate',
+              type: 'date',
+              esTypes: ['date'],
+              aggregatable: true,
+              searchable: true,
+              filterable: true,
+            },
+          ],
+        } as unknown) as IIndexPattern,
+        {
+          from: '2020-09-01T08:30:00.000Z',
+          to: 'now',
+        },
+        { fieldName: 'myCustomDate' }
+      ) as RangeFilter;
+
+      expect(filter.range.myCustomDate).toEqual({
+        gte: '2020-09-01T08:30:00.000Z',
+        lte: 'now',
         format: 'strict_date_optional_time',
       });
       clock.restore();

--- a/src/plugins/data/public/query/timefilter/timefilter.ts
+++ b/src/plugins/data/public/query/timefilter/timefilter.ts
@@ -17,6 +17,7 @@ import {
   calculateBounds,
   getAbsoluteTimeRange,
   getTime,
+  getRelativeTime,
   IIndexPattern,
   RefreshInterval,
   TimeRange,
@@ -27,7 +28,6 @@ import { createAutoRefreshLoop, AutoRefreshDoneFn } from './lib/auto_refresh_loo
 export { AutoRefreshDoneFn };
 
 // TODO: remove!
-
 export class Timefilter {
   // Fired when isTimeRangeSelectorEnabled \ isAutoRefreshSelectorEnabled are toggled
   private enabledUpdated$ = new BehaviorSubject(false);
@@ -178,8 +178,30 @@ export class Timefilter {
     }
   };
 
+  /**
+   * Create a time filter that coerces all time values to absolute time.
+   *
+   * This is useful for creating a filter that ensures all ES queries will fetch the exact same data
+   * and leverages ES query cache for performance improvement.
+   *
+   * One use case is keeping different elements embedded in the same UI in sync.
+   */
   public createFilter = (indexPattern: IIndexPattern, timeRange?: TimeRange) => {
     return getTime(indexPattern, timeRange ? timeRange : this._time, {
+      forceNow: this.nowProvider.get(),
+    });
+  };
+
+  /**
+   * Create a time filter that converts only absolute time to ISO strings, it leaves relative time
+   * values unchanged (e.g. "now-1").
+   *
+   * This is useful for sending datemath values to ES endpoints to generate reports over time.
+   *
+   * @note Consumers of this function need to ensure that the ES endpoint supports datemath.
+   */
+  public createRelativeFilter = (indexPattern: IIndexPattern, timeRange?: TimeRange) => {
+    return getRelativeTime(indexPattern, timeRange ? timeRange : this._time, {
       forceNow: this.nowProvider.get(),
     });
   };

--- a/src/plugins/data/public/query/timefilter/timefilter_service.mock.ts
+++ b/src/plugins/data/public/query/timefilter/timefilter_service.mock.ts
@@ -34,6 +34,7 @@ const createSetupContractMock = () => {
     getBounds: jest.fn(),
     calculateBounds: jest.fn(),
     createFilter: jest.fn(),
+    createRelativeFilter: jest.fn(),
     getRefreshIntervalDefaults: jest.fn(),
     getTimeDefaults: jest.fn(),
     getAbsoluteTime: jest.fn(),

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
@@ -114,6 +114,7 @@ export const getTopNavLinks = ({
         state.appStateContainer.getState(),
         services.uiSettings
       );
+
       services.share.toggleShareContextMenu({
         anchorElement,
         allowEmbed: false,

--- a/src/plugins/discover/public/application/apps/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/update_search_source.ts
@@ -54,7 +54,10 @@ export function updateSearchSource(
 
     // this is not the default index pattern, it determines that it's not of type rollup
     if (indexPatternsUtils.isDefault(indexPattern)) {
-      searchSource.setField('filter', data.query.timefilter.timefilter.createFilter(indexPattern));
+      searchSource.setField(
+        'filter',
+        data.query.timefilter.timefilter.createRelativeFilter(indexPattern)
+      );
     }
 
     if (useNewFieldsApi) {

--- a/x-pack/plugins/ml/public/embeddables/anomaly_charts/__snapshots__/embeddable_anomaly_charts_container.test.tsx.snap
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_charts/__snapshots__/embeddable_anomaly_charts_container.test.tsx.snap
@@ -33,6 +33,7 @@ Object {
   "timefilter": Object {
     "calculateBounds": [MockFunction],
     "createFilter": [MockFunction],
+    "createRelativeFilter": [MockFunction],
     "disableAutoRefreshSelector": [MockFunction],
     "disableTimeRangeSelector": [MockFunction],
     "enableAutoRefreshSelector": [MockFunction],

--- a/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
+++ b/x-pack/plugins/reporting/server/export_types/csv_searchsource/generate_csv/generate_csv.ts
@@ -291,7 +291,7 @@ export class CsvGenerator {
     const index = searchSource.getField('index');
 
     if (!index) {
-      throw new Error(`The search must have a revference to an index pattern!`);
+      throw new Error(`The search must have a reference to an index pattern!`);
     }
 
     const { maxSizeBytes, bom, escapeFormulaValues, scroll: scrollSettings } = settings;


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Discover/Reporting] Fix export that does not contain relative time filter (#110459)