### PR TITLE
[Workplace Search] Make Source Group links look like links

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -30,7 +30,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { EuiPanelTo, EuiListGroupItemTo } from '../../../../shared/react_router_helpers';
+import { EuiListGroupItemTo } from '../../../../shared/react_router_helpers';
 import { AppLogic } from '../../../app_logic';
 import aclImage from '../../../assets/supports_acl.svg';
 import { ComponentLoader } from '../../../components/shared/component_loader';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -237,13 +237,7 @@ export const Overview: React.FC = () => {
       <EuiPanel color="subdued">
         <EuiListGroup flush maxWidth={false} data-test-subj="GroupsSummary">
           {groups.map((group, index) => (
-            <EuiListGroupItemTo
-              label={group.name}
-              key={index}
-              to={getGroupPath(group.id)}
-              data-test-subj="SourceGroupLink"
-            >
-            </EuiListGroupItemTo>
+            <EuiListGroupItemTo label={group.name} key={index} to={getGroupPath(group.id)} data-test-subj="SourceGroupLink" />
           ))}
         </EuiListGroup>
       </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -15,7 +15,6 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiListGroup,
-  EuiListGroupItem,
   EuiListGroupItemTo,
   EuiLink,
   EuiPanel,
@@ -239,13 +238,13 @@ export const Overview: React.FC = () => {
       <EuiPanel color="subdued">
         <EuiListGroup flush={true} color="ghost" maxWidth={false} data-test-subj="GroupsSummary">
           {groups.map((group, index) => (
-            <EuiListGroupItem
+            <EuiListGroupItemTo
               label={group.name}
               key={index}
               to={getGroupPath(group.id)}
               data-test-subj="SourceGroupLink"
             >
-            </EuiListGroupItem>
+            </EuiListGroupItemTo>
           ))}
         </EuiListGroup>
       </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -237,7 +237,12 @@ export const Overview: React.FC = () => {
       <EuiPanel color="subdued">
         <EuiListGroup flush maxWidth={false} data-test-subj="GroupsSummary">
           {groups.map((group, index) => (
-            <EuiListGroupItemTo label={group.name} key={index} to={getGroupPath(group.id)} data-test-subj="SourceGroupLink" />
+            <EuiListGroupItemTo
+              label={group.name}
+              key={index}
+              to={getGroupPath(group.id)}
+              data-test-subj="SourceGroupLink"
+            />
           ))}
         </EuiListGroup>
       </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -14,6 +14,9 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiListGroup,
+  EuiListGroupItem,
+  EuiListGroupItemTo,
   EuiLink,
   EuiPanel,
   EuiSpacer,
@@ -233,22 +236,19 @@ export const Overview: React.FC = () => {
         <h5>{GROUP_ACCESS_TITLE}</h5>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiFlexGroup direction="column" gutterSize="s" data-test-subj="GroupsSummary">
-        {groups.map((group, index) => (
-          <EuiFlexItem key={index}>
-            <EuiPanelTo
-              hasShadow={false}
-              color="subdued"
+      <EuiPanel color="subdued">
+        <EuiListGroup flush={true} color="ghost" maxWidth={false} data-test-subj="GroupsSummary">
+          {groups.map((group, index) => (
+            <EuiListGroupItem
+              label={group.name}
+              key={index}
               to={getGroupPath(group.id)}
               data-test-subj="SourceGroupLink"
             >
-              <EuiText size="s" className="eui-textTruncate">
-                <strong>{group.name}</strong>
-              </EuiText>
-            </EuiPanelTo>
-          </EuiFlexItem>
-        ))}
-      </EuiFlexGroup>
+            </EuiListGroupItem>
+          ))}
+        </EuiListGroup>
+      </EuiPanel>
     </>
   );
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -15,7 +15,6 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiListGroup,
-  EuiListGroupItemTo,
   EuiLink,
   EuiPanel,
   EuiSpacer,
@@ -31,7 +30,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { EuiPanelTo } from '../../../../shared/react_router_helpers';
+import { EuiPanelTo, EuiListGroupItemTo } from '../../../../shared/react_router_helpers';
 import { AppLogic } from '../../../app_logic';
 import aclImage from '../../../assets/supports_acl.svg';
 import { ComponentLoader } from '../../../components/shared/component_loader';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -235,7 +235,7 @@ export const Overview: React.FC = () => {
       </EuiTitle>
       <EuiSpacer size="s" />
       <EuiPanel color="subdued">
-        <EuiListGroup flush={true} maxWidth={false} data-test-subj="GroupsSummary">
+        <EuiListGroup flush maxWidth={false} data-test-subj="GroupsSummary">
           {groups.map((group, index) => (
             <EuiListGroupItemTo
               label={group.name}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -235,7 +235,7 @@ export const Overview: React.FC = () => {
       </EuiTitle>
       <EuiSpacer size="s" />
       <EuiPanel color="subdued">
-        <EuiListGroup flush={true} color="ghost" maxWidth={false} data-test-subj="GroupsSummary">
+        <EuiListGroup flush={true} maxWidth={false} data-test-subj="GroupsSummary">
           {groups.map((group, index) => (
             <EuiListGroupItemTo
               label={group.name}


### PR DESCRIPTION
## Summary

This PR resolves [issue #2012](https://github.com/elastic/workplace-search-team/issues/2012)

The Group access list on the Overview page appears as panels but behaves as a link. This change makes the links look like links to better set user expectations.

| Before | After |
|-|-|
|  ![Kapture 2021-09-15 at 14 43 55](https://user-images.githubusercontent.com/7115017/133445142-9a8e2a9b-9f91-411f-9d78-b1111c35cca0.gif) | ![Kapture 2021-09-15 at 14 41 29](https://user-images.githubusercontent.com/7115017/133444885-e3d22a64-1aa3-4768-af8f-b663d3c265b0.gif) |

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
