### PR TITLE
[Workplace Search] Fix bug where non-admins shown broken admin dashboard

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -55,6 +55,7 @@ export const WORKPLACE_SEARCH_PLUGIN = {
     }
   ),
   URL: '/app/enterprise_search/workplace_search',
+  NON_ADMIN_URL: '/app/enterprise_search/workplace_search/p',
   SUPPORT_URL: 'https://discuss.elastic.co/c/enterprise-search/workplace-search/',
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
@@ -28,9 +28,10 @@ interface ProductCardProps {
     URL: string;
   };
   image: string;
+  url?: string;
 }
 
-export const ProductCard: React.FC<ProductCardProps> = ({ product, image }) => {
+export const ProductCard: React.FC<ProductCardProps> = ({ product, image, url }) => {
   const { sendEnterpriseSearchTelemetry } = useActions(TelemetryLogic);
   const { config } = useValues(KibanaLogic);
 
@@ -68,7 +69,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, image }) => {
       footer={
         <EuiButtonTo
           fill
-          to={product.URL}
+          to={url || product.URL}
           shouldNotCreateHref
           onClick={() =>
             sendEnterpriseSearchTelemetry({

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
@@ -11,6 +11,8 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
+import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
+
 import { LicenseCallout } from '../license_callout';
 import { ProductCard } from '../product_card';
 import { SetupGuideCta } from '../setup_guide';
@@ -18,10 +20,15 @@ import { TrialCallout } from '../trial_callout';
 
 import { ProductSelector } from './';
 
+const props = {
+  access: {},
+  isWorkplaceSearchAdmin: true,
+};
+
 describe('ProductSelector', () => {
   it('renders the overview page, product cards, & setup guide CTAs with no host set', () => {
     setMockValues({ config: { host: '' } });
-    const wrapper = shallow(<ProductSelector access={{}} />);
+    const wrapper = shallow(<ProductSelector {...props} />);
 
     expect(wrapper.find(ProductCard)).toHaveLength(2);
     expect(wrapper.find(SetupGuideCta)).toHaveLength(1);
@@ -30,10 +37,19 @@ describe('ProductSelector', () => {
 
   it('renders the license and trial callouts', () => {
     setMockValues({ config: { host: 'localhost' } });
-    const wrapper = shallow(<ProductSelector access={{}} />);
+    const wrapper = shallow(<ProductSelector {...props} />);
 
     expect(wrapper.find(TrialCallout)).toHaveLength(1);
     expect(wrapper.find(LicenseCallout)).toHaveLength(1);
+  });
+
+  it('passes correct URL when Workplace Search user is not an admin', () => {
+    setMockValues({ config: { host: '' } });
+    const wrapper = shallow(<ProductSelector {...props} isWorkplaceSearchAdmin={false} />);
+
+    expect(wrapper.find(ProductCard).last().prop('url')).toEqual(
+      WORKPLACE_SEARCH_PLUGIN.NON_ADMIN_URL
+    );
   });
 
   describe('access checks when host is set', () => {
@@ -43,7 +59,10 @@ describe('ProductSelector', () => {
 
     it('does not render the App Search card if the user does not have access to AS', () => {
       const wrapper = shallow(
-        <ProductSelector access={{ hasAppSearchAccess: false, hasWorkplaceSearchAccess: true }} />
+        <ProductSelector
+          {...props}
+          access={{ hasAppSearchAccess: false, hasWorkplaceSearchAccess: true }}
+        />
       );
 
       expect(wrapper.find(ProductCard)).toHaveLength(1);
@@ -52,7 +71,10 @@ describe('ProductSelector', () => {
 
     it('does not render the Workplace Search card if the user does not have access to WS', () => {
       const wrapper = shallow(
-        <ProductSelector access={{ hasAppSearchAccess: true, hasWorkplaceSearchAccess: false }} />
+        <ProductSelector
+          {...props}
+          access={{ hasAppSearchAccess: true, hasWorkplaceSearchAccess: false }}
+        />
       );
 
       expect(wrapper.find(ProductCard)).toHaveLength(1);
@@ -60,7 +82,7 @@ describe('ProductSelector', () => {
     });
 
     it('does not render any cards if the user does not have access', () => {
-      const wrapper = shallow(<ProductSelector access={{}} />);
+      const wrapper = shallow(<ProductSelector {...props} />);
 
       expect(wrapper.find(ProductCard)).toHaveLength(0);
     });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
@@ -34,15 +34,23 @@ interface ProductSelectorProps {
     hasAppSearchAccess?: boolean;
     hasWorkplaceSearchAccess?: boolean;
   };
+  isWorkplaceSearchAdmin: boolean;
 }
 
-export const ProductSelector: React.FC<ProductSelectorProps> = ({ access }) => {
+export const ProductSelector: React.FC<ProductSelectorProps> = ({
+  access,
+  isWorkplaceSearchAdmin,
+}) => {
   const { hasAppSearchAccess, hasWorkplaceSearchAccess } = access;
   const { config } = useValues(KibanaLogic);
 
   // If Enterprise Search hasn't been set up yet, show all products. Otherwise, only show products the user has access to
   const shouldShowAppSearchCard = !config.host || hasAppSearchAccess;
   const shouldShowWorkplaceSearchCard = !config.host || hasWorkplaceSearchAccess;
+
+  const WORKPLACE_SEARCH_URL = isWorkplaceSearchAdmin
+    ? WORKPLACE_SEARCH_PLUGIN.URL
+    : WORKPLACE_SEARCH_PLUGIN.NON_ADMIN_URL;
 
   return (
     <KibanaPageTemplate {...NO_DATA_PAGE_TEMPLATE_PROPS}>
@@ -84,7 +92,11 @@ export const ProductSelector: React.FC<ProductSelectorProps> = ({ access }) => {
         )}
         {shouldShowWorkplaceSearchCard && (
           <EuiFlexItem grow={false}>
-            <ProductCard product={WORKPLACE_SEARCH_PLUGIN} image={WorkplaceSearchImage} />
+            <ProductCard
+              product={WORKPLACE_SEARCH_PLUGIN}
+              url={WORKPLACE_SEARCH_URL}
+              image={WorkplaceSearchImage}
+            />
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.tsx
@@ -19,11 +19,12 @@ import { ProductSelector } from './components/product_selector';
 import { SetupGuide } from './components/setup_guide';
 import { ROOT_PATH, SETUP_GUIDE_PATH } from './routes';
 
-export const EnterpriseSearch: React.FC<InitialAppData> = ({ access = {} }) => {
+export const EnterpriseSearch: React.FC<InitialAppData> = ({ access = {}, workplaceSearch }) => {
   const { errorConnecting } = useValues(HttpLogic);
   const { config } = useValues(KibanaLogic);
 
   const showErrorConnecting = !!(config.host && errorConnecting);
+  const isWorkplaceSearchAdmin = !!workplaceSearch?.account?.isAdmin;
 
   return (
     <Switch>
@@ -31,7 +32,11 @@ export const EnterpriseSearch: React.FC<InitialAppData> = ({ access = {} }) => {
         <SetupGuide />
       </Route>
       <Route exact path={ROOT_PATH}>
-        {showErrorConnecting ? <ErrorConnecting /> : <ProductSelector access={access} />}
+        {showErrorConnecting ? (
+          <ErrorConnecting />
+        ) : (
+          <ProductSelector isWorkplaceSearchAdmin={isWorkplaceSearchAdmin} access={access} />
+        )}
       </Route>
     </Switch>
   );


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2016

## Summary

This PR handles the edge case where a user logs into Kibana directly and attempts to navigate to Workplace Search. In the past, all users were directed to the admin overview page. Non-admins should not be taken here, but to the Private Dashboard.

**Before**

https://user-images.githubusercontent.com/1869731/133317676-701a4456-6e0d-4f1f-b19d-d3d6ceb18ebb.mp4

**After**

https://user-images.githubusercontent.com/1869731/133317697-5a4e10a3-56ab-4974-85fc-eb976c1ec0c6.mp4

**Admin (after change - showing it still works)**

https://user-images.githubusercontent.com/1869731/133317713-2d3bcb92-af0d-42d1-a854-d96d80094c67.mp4


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
