### PR TITLE
Add first pass of autocomplete to input controls

### DIFF
--- a/src/plugins/dashboard/public/application/lib/build_dashboard_container.ts
+++ b/src/plugins/dashboard/public/application/lib/build_dashboard_container.ts
@@ -153,6 +153,27 @@ export const buildDashboardContainer = async ({
     );
   }
 
+  // TEMPORARY
+  const TEMP_FIELD = {
+    name: 'category.keyword',
+    type: 'string',
+    aggregatable: true,
+  };
+
+  const TEMP_INDEX_PATTERN = {
+    title: 'kibana_sample_data_ecommerce',
+    fields: [TEMP_FIELD],
+  };
+
+  const TEMP_INPUT = {
+    id: 'blah blah',
+    field: TEMP_FIELD,
+    indexPattern: TEMP_INDEX_PATTERN,
+    multiSelect: false,
+  };
+
+  dashboardContainer.addNewEmbeddable<EmbeddableInput>('optionsListControl', TEMP_INPUT);
+
   return dashboardContainer;
 };
 

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -271,26 +271,6 @@ export class DashboardPlugin
         dashboardContainerFactory
       );
 
-      /*
-      interface ValueSuggestionsGetFnArgs {
-  indexPattern: IIndexPattern;
-  field: IFieldType;
-  query: string;
-  useTimeRange?: boolean;
-  boolFilter?: any[];
-  signal?: AbortSignal;
-  method?: ValueSuggestionsMethod;
-}
-export interface OptionsListDataFetchProps {
-  field: string;
-  search?: string;
-  indexPattern: string;
-  query?: InputControlInput['query'];
-  filters?: InputControlInput['filters'];
-  timeRange?: InputControlInput['timeRange'];
-}
-*/
-
       const fetchControlOptions = (args: OptionsListDataFetchProps) => {
         const { indexPattern, field, search } = args;
 

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -12,6 +12,10 @@ import { filter, map } from 'rxjs/operators';
 
 import { Start as InspectorStartContract } from 'src/plugins/inspector/public';
 import { UrlForwardingSetup, UrlForwardingStart } from 'src/plugins/url_forwarding/public';
+import {
+  OptionsListEmbeddableFactory,
+  OptionsListDataFetchProps,
+} from '../../presentation_util/public';
 import { APP_WRAPPER_CLASS } from '../../../core/public';
 import {
   App,
@@ -187,6 +191,7 @@ export class DashboardPlugin
         return <ExitFullScreenButtonUi {...props} chrome={coreStart.chrome} />;
       };
       return {
+        autocomplete: deps.data.autocomplete,
         SavedObjectFinder: getSavedObjectFinder(coreStart.savedObjects, coreStart.uiSettings),
         showWriteControls: Boolean(coreStart.application.capabilities.dashboard.showWriteControls),
         notifications: coreStart.notifications,
@@ -265,6 +270,39 @@ export class DashboardPlugin
         dashboardContainerFactory.type,
         dashboardContainerFactory
       );
+
+      /*
+      interface ValueSuggestionsGetFnArgs {
+  indexPattern: IIndexPattern;
+  field: IFieldType;
+  query: string;
+  useTimeRange?: boolean;
+  boolFilter?: any[];
+  signal?: AbortSignal;
+  method?: ValueSuggestionsMethod;
+}
+export interface OptionsListDataFetchProps {
+  field: string;
+  search?: string;
+  indexPattern: string;
+  query?: InputControlInput['query'];
+  filters?: InputControlInput['filters'];
+  timeRange?: InputControlInput['timeRange'];
+}
+*/
+
+      const fetchControlOptions = (args: OptionsListDataFetchProps) => {
+        const { indexPattern, field, search } = args;
+
+        return coreStart.autocomplete.getValueSuggestions({
+          indexPattern,
+          field,
+          query: search || '',
+        });
+      };
+
+      const optionControlFactory = new OptionsListEmbeddableFactory(fetchControlOptions);
+      embeddable.registerEmbeddableFactory(optionControlFactory.type, optionControlFactory);
     });
 
     const placeholderFactory = new PlaceholderEmbeddableFactory();

--- a/src/plugins/presentation_util/kibana.json
+++ b/src/plugins/presentation_util/kibana.json
@@ -10,6 +10,6 @@
   "server": true,
   "ui": true,
   "extraPublicDirs": ["common/lib"],
-  "requiredPlugins": ["savedObjects"],
+  "requiredPlugins": ["savedObjects", "data", "embeddable"],
   "optionalPlugins": []
 }

--- a/src/plugins/presentation_util/public/components/input_controls/__stories__/flights.ts
+++ b/src/plugins/presentation_util/public/components/input_controls/__stories__/flights.ts
@@ -7,22 +7,18 @@
  */
 
 import { map, uniq } from 'lodash';
-import { EuiSelectableOption } from '@elastic/eui';
 
 import { flights } from '../../fixtures/flights';
 
 export type Flight = typeof flights[number];
 export type FlightField = keyof Flight;
 
-export const getOptions = (field: string) => uniq(map(flights, field)).sort();
+export const getFlightOptions = (field: string) => uniq(map(flights, field)).sort();
 
-export const getEuiSelectableOptions = (field: string, search?: string): EuiSelectableOption[] => {
-  const options = getOptions(field)
-    .map((option) => ({
-      label: option + '',
-      searchableLabel: option + '',
-    }))
-    .filter((option) => !search || option.label.toLowerCase().includes(search.toLowerCase()));
+export const getFlightSearchOptions = (field: string, search?: string): string[] => {
+  const options = getFlightOptions(field)
+    .map((option) => option + '')
+    .filter((option) => !search || option.toLowerCase().includes(search.toLowerCase()));
   if (options.length > 10) options.length = 10;
   return options;
 };

--- a/src/plugins/presentation_util/public/components/input_controls/__stories__/input_controls.stories.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/__stories__/input_controls.stories.tsx
@@ -10,8 +10,10 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
+import { IFieldType } from 'src/plugins/data/public';
+
 import { decorators } from './decorators';
-import { getEuiSelectableOptions, flightFields, flightFieldLabels, FlightField } from './flights';
+import { getFlightSearchOptions, flightFields, flightFieldLabels, FlightField } from './flights';
 import { OptionsListEmbeddableFactory, OptionsListEmbeddable } from '../control_types/options_list';
 import { ControlFrame } from '../control_frame/control_frame';
 
@@ -22,13 +24,34 @@ export default {
 };
 
 interface OptionsListStorybookArgs {
-  fields: string[];
+  fields: IFieldType[];
   twoLine: boolean;
 }
 
 const storybookArgs = {
   twoLine: false,
-  fields: ['OriginCityName', 'OriginWeather', 'DestCityName', 'DestWeather'],
+  fields: [
+    {
+      name: 'OriginCityName',
+      type: 'string',
+      aggregatable: true,
+    },
+    {
+      name: 'OriginWeather',
+      type: 'string',
+      aggregatable: true,
+    },
+    {
+      name: 'DestCityName',
+      type: 'string',
+      aggregatable: true,
+    },
+    {
+      name: 'DestWeather',
+      type: 'string',
+      aggregatable: true,
+    },
+  ],
 };
 
 const storybookArgTypes = {
@@ -50,7 +73,7 @@ const OptionsListStoryComponent = ({ fields, twoLine }: OptionsListStorybookArgs
     () =>
       new OptionsListEmbeddableFactory(
         ({ field, search }) =>
-          new Promise((r) => setTimeout(() => r(getEuiSelectableOptions(field, search)), 500))
+          new Promise((r) => setTimeout(() => r(getFlightSearchOptions(field.name, search)), 500))
       ),
     []
   );
@@ -60,10 +83,13 @@ const OptionsListStoryComponent = ({ fields, twoLine }: OptionsListStorybookArgs
       return optionsListEmbeddableFactory.create({
         field,
         id: '',
-        indexPattern: '',
+        indexPattern: {
+          title: '',
+          fields,
+        },
         multiSelect: true,
         twoLineLayout: twoLine,
-        title: flightFieldLabels[field as FlightField],
+        title: flightFieldLabels[field.name as FlightField],
       });
     });
     Promise.all(embeddableCreatePromises).then((newEmbeddables) => setEmbeddables(newEmbeddables));
@@ -72,7 +98,7 @@ const OptionsListStoryComponent = ({ fields, twoLine }: OptionsListStorybookArgs
   return (
     <EuiFlexGroup alignItems="center" wrap={true} gutterSize={'s'}>
       {embeddables.map((embeddable) => (
-        <EuiFlexItem key={embeddable.getInput().field}>
+        <EuiFlexItem key={embeddable.getInput().field.name}>
           <ControlFrame twoLine={twoLine} embeddable={embeddable} />
         </EuiFlexItem>
       ))}

--- a/src/plugins/presentation_util/public/components/input_controls/control_types/options_list/index.ts
+++ b/src/plugins/presentation_util/public/components/input_controls/control_types/options_list/index.ts
@@ -7,4 +7,8 @@
  */
 
 export { OptionsListEmbeddableFactory } from './options_list_embeddable_factory';
-export { OptionsListEmbeddable } from './options_list_embeddable';
+export {
+  OptionsListEmbeddable,
+  OptionsListDataFetcher,
+  OptionsListDataFetchProps,
+} from './options_list_embeddable';

--- a/src/plugins/presentation_util/public/components/input_controls/control_types/options_list/options_list_embeddable.tsx
+++ b/src/plugins/presentation_util/public/components/input_controls/control_types/options_list/options_list_embeddable.tsx
@@ -19,18 +19,6 @@ import { OptionsListComponent, OptionsListComponentState } from './options_list_
 import { Embeddable } from '../../../../../../embeddable/public';
 import { InputControlInput, InputControlOutput } from '../../embeddable/types';
 
-// TEMPORARY CONSTANT VALUES
-const TEMP_FIELD = {
-  name: 'data_stream.dataset',
-  type: 'string',
-  aggregatable: true,
-};
-
-const TEMP_INDEX_PATTERN = {
-  title: 'ecomm',
-  fields: [TEMP_FIELD],
-};
-
 const toggleAvailableOptions = (
   indices: number[],
   availableOptions: EuiSelectableOption[],

--- a/src/plugins/presentation_util/public/index.ts
+++ b/src/plugins/presentation_util/public/index.ts
@@ -54,6 +54,13 @@ export {
   SolutionToolbarPopover,
 } from './components/solution_toolbar';
 
+export {
+  OptionsListEmbeddableFactory,
+  OptionsListEmbeddable,
+  OptionsListDataFetcher,
+  OptionsListDataFetchProps,
+} from './components/input_controls/control_types/options_list';
+
 export function plugin() {
   return new PresentationUtilPlugin();
 }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
