### PR TITLE
[uptime] deep import to top level import for `index_pattern` item

### DIFF
--- a/x-pack/plugins/uptime/public/state/reducers/index_pattern.ts
+++ b/x-pack/plugins/uptime/public/state/reducers/index_pattern.ts
@@ -7,7 +7,7 @@
 
 import { handleActions, Action } from 'redux-actions';
 import { getIndexPattern, getIndexPatternSuccess, getIndexPatternFail } from '../actions';
-import type { IndexPattern } from '../../../../../../src/plugins/data/common/index_patterns';
+import type { IndexPattern } from '../../../../../../src/plugins/data/common';
 
 export interface IndexPatternState {
   index_pattern: IndexPattern | null;


### PR DESCRIPTION
 ## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047
