### PR TITLE
[transform] convert deep imports to top level imports for 'index_pattern' items

### DIFF
--- a/x-pack/plugins/transform/public/app/common/request.test.ts
+++ b/x-pack/plugins/transform/public/app/common/request.test.ts
@@ -29,7 +29,7 @@ import {
   PivotQuery,
 } from './request';
 import { LatestFunctionConfigUI } from '../../../common/types/transform';
-import { RuntimeField } from '../../../../../../src/plugins/data/common/index_patterns';
+import { RuntimeField } from '../../../../../../src/plugins/data/common';
 
 const simpleQuery: PivotQuery = { query_string: { query: 'airline:AAL' } };
 

--- a/x-pack/plugins/transform/public/app/hooks/use_index_data.test.tsx
+++ b/x-pack/plugins/transform/public/app/hooks/use_index_data.test.tsx
@@ -27,7 +27,7 @@ jest.mock('./use_api');
 
 import { useAppDependencies } from '../__mocks__/app_dependencies';
 import { MlSharedContext } from '../__mocks__/shared_context';
-import { RuntimeField } from '../../../../../../src/plugins/data/common/index_patterns';
+import { RuntimeField } from '../../../../../../src/plugins/data/common';
 
 const query: SimpleQuery = {
   query_string: {

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_create/step_create_form.tsx
@@ -50,7 +50,7 @@ import {
   PutTransformsLatestRequestSchema,
   PutTransformsPivotRequestSchema,
 } from '../../../../../../common/api_schemas/transforms';
-import type { RuntimeField } from '../../../../../../../../../src/plugins/data/common/index_patterns';
+import type { RuntimeField } from '../../../../../../../../../src/plugins/data/common';
 import { isPopulatedObject } from '../../../../../../common/shared_imports';
 import { isLatestTransform } from '../../../../../../common/types/transform';
 

--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/common.test.ts
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/common/common.test.ts
@@ -8,7 +8,7 @@
 import { getPivotDropdownOptions } from '../common';
 import { IndexPattern } from '../../../../../../../../../../src/plugins/data/public';
 import { FilterAggForm } from './filter_agg/components';
-import type { RuntimeField } from '../../../../../../../../../../src/plugins/data/common/index_patterns';
+import type { RuntimeField } from '../../../../../../../../../../src/plugins/data/common';
 
 describe('Transform: Define Pivot Common', () => {
   test('getPivotDropdownOptions()', () => {

--- a/x-pack/plugins/transform/public/app/services/es_index_service.ts
+++ b/x-pack/plugins/transform/public/app/services/es_index_service.ts
@@ -7,7 +7,7 @@
 
 import { HttpSetup, SavedObjectsClientContract } from 'kibana/public';
 import { API_BASE_PATH } from '../../../common/constants';
-import { IIndexPattern } from '../../../../../../src/plugins/data/common/index_patterns';
+import { IIndexPattern } from '../../../../../../src/plugins/data/common';
 
 export class IndexService {
   async canDeleteIndex(http: HttpSetup) {

--- a/x-pack/plugins/transform/server/routes/api/transforms.ts
+++ b/x-pack/plugins/transform/server/routes/api/transforms.ts
@@ -60,7 +60,7 @@ import { addBasePath } from '../index';
 import { isRequestTimeout, fillResultsWithTimeouts, wrapError, wrapEsError } from './error_utils';
 import { registerTransformsAuditMessagesRoutes } from './transforms_audit_messages';
 import { registerTransformNodesRoutes } from './transforms_nodes';
-import { IIndexPattern } from '../../../../../../src/plugins/data/common/index_patterns';
+import { IIndexPattern } from '../../../../../../src/plugins/data/common';
 import { isLatestTransform } from '../../../common/types/transform';
 import { isKeywordDuplicate } from '../../../common/utils/field_utils';
 


### PR DESCRIPTION
## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047
