### PR TITLE
[timelines] convert deep import to top level import for 'index_pattern' items

### DIFF
--- a/x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/index_fields/index.ts
@@ -12,9 +12,8 @@ import {
   IndexPatternsFetcher,
   ISearchStrategy,
   SearchStrategyDependencies,
+  FieldDescriptor,
 } from '../../../../../../src/plugins/data/server';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { FieldDescriptor } from '../../../../../../src/plugins/data/server/index_patterns';
 
 // TODO cleanup path
 import {

--- a/x-pack/plugins/timelines/server/search_strategy/index_fields/mock.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/index_fields/mock.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { FieldDescriptor } from '../../../../../../src/plugins/data/server/index_patterns';
+import { FieldDescriptor } from '../../../../../../src/plugins/data/server';
 
 export const mockAuditbeatIndexField: FieldDescriptor[] = [
   {


### PR DESCRIPTION
## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047
