### PR TITLE
[reporting] Move chromium user data to path.data

### DIFF
--- a/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/index.ts
@@ -7,9 +7,9 @@
 
 import apm from 'elastic-apm-node';
 import { i18n } from '@kbn/i18n';
+import { getDataPath } from '@kbn/utils';
 import del from 'del';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import puppeteer from 'puppeteer';
 import * as Rx from 'rxjs';
@@ -59,7 +59,7 @@ export class HeadlessChromiumDriverFactory {
       logger.warning(`Enabling the Chromium sandbox provides an additional layer of protection.`);
     }
 
-    this.userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chromium-'));
+    this.userDataDir = fs.mkdtempSync(path.join(getDataPath(), 'chromium-'));
     this.getChromiumArgs = (viewport: ViewportConfig) =>
       args({
         userDataDir: this.userDataDir,

--- a/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/start_logs.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/driver_factory/start_logs.ts
@@ -10,9 +10,10 @@ import { spawn } from 'child_process';
 import del from 'del';
 import { mkdtempSync } from 'fs';
 import { uniq } from 'lodash';
-import os, { tmpdir } from 'os';
+import os from 'os';
 import { join } from 'path';
 import { createInterface } from 'readline';
+import { getDataPath } from '@kbn/utils';
 import { fromEvent, merge, of, timer } from 'rxjs';
 import { catchError, map, reduce, takeUntil, tap } from 'rxjs/operators';
 import { ReportingCore } from '../../../';
@@ -61,7 +62,7 @@ export const browserStartLogs = (
   const config = core.getConfig();
   const proxy = config.get('capture', 'browser', 'chromium', 'proxy');
   const disableSandbox = config.get('capture', 'browser', 'chromium', 'disableSandbox');
-  const userDataDir = mkdtempSync(join(tmpdir(), 'chromium-'));
+  const userDataDir = mkdtempSync(join(getDataPath(), 'chromium-'));
 
   const platform = process.platform;
   const architecture = os.arch();


### PR DESCRIPTION
Currently reporting manages a Chromium profile in /tmp.  This contains
browser data and screenshots used to generate PDFs.  By moving this to
the data directory, we're able to inherit fs permissions created by the
deb and rpm packages, or user defined settings.
