### PR TITLE
[security solution] convert deep imports to top level imports for 'index_pattern' items

### DIFF
--- a/src/plugins/data/common/mocks.ts
+++ b/src/plugins/data/common/mocks.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export * from './index_patterns/fields/fields.mocks';

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.test.tsx
@@ -16,7 +16,7 @@ import { ExceptionBuilder } from '../../../../shared_imports';
 import { useAsync } from '@kbn/securitysolution-hook-utils';
 import { getExceptionListSchemaMock } from '../../../../../../lists/common/schemas/response/exception_list_schema.mock';
 import { useFetchIndex } from '../../../containers/source';
-import { stubIndexPattern } from 'src/plugins/data/common/index_patterns/index_pattern.stub';
+import { stubIndexPattern } from 'src/plugins/data/common/stubs';
 import { useAddOrUpdateException } from '../use_add_exception';
 import { useFetchOrCreateRuleExceptionList } from '../use_fetch_or_create_rule_exception_list';
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
@@ -39,7 +39,7 @@ import {
 import { getExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
 import { getEntryMatchMock } from '../../../../../lists/common/schemas/types/entry_match.mock';
 import { getCommentsArrayMock } from '../../../../../lists/common/schemas/types/comment.mock';
-import { fields } from '../../../../../../../src/plugins/data/common/index_patterns/fields/fields.mocks';
+import { fields } from '../../../../../../../src/plugins/data/common/mocks';
 import { ENTRIES, OLD_DATE_RELATIVE_TO_DATE_NOW } from '../../../../../lists/common/constants.mock';
 import { CodeSignature } from '../../../../common/ecs/file';
 import { IndexPatternBase } from '@kbn/es-query';

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/entry_item.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/entry_item.test.tsx
@@ -10,10 +10,7 @@ import React from 'react';
 import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
 import { EntryItem } from './entry_item';
-import {
-  fields,
-  getField,
-} from '../../../../../../../src/plugins/data/common/index_patterns/fields/fields.mocks';
+import { fields, getField } from '../../../../../../../src/plugins/data/common/mocks';
 import { IndexPattern } from 'src/plugins/data/public';
 
 jest.mock('../../../common/lib/kibana');

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.test.tsx
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import {
-  fields,
-  getField,
-} from '../../../../../../../src/plugins/data/common/index_patterns/fields/fields.mocks';
+import { fields, getField } from '../../../../../../../src/plugins/data/common/mocks';
 import { Entry, EmptyEntry, ThreatMapEntries, FormattedEntry } from './types';
 import { FieldSpec, IndexPattern } from '../../../../../../../src/plugins/data/common';
 import moment from 'moment-timezone';

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/index.test.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from 'styled-components';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/react';
 
-import { fields } from '../../../../../../../src/plugins/data/common/index_patterns/fields/fields.mocks';
+import { fields } from '../../../../../../../src/plugins/data/common/mocks';
 
 import { useKibana } from '../../../common/lib/kibana';
 

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/list_item.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/list_item.test.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from 'styled-components';
 import { mount } from 'enzyme';
 
 import { useKibana } from '../../../common/lib/kibana';
-import { fields } from '../../../../../../../src/plugins/data/common/index_patterns/fields/fields.mocks';
+import { fields } from '../../../../../../../src/plugins/data/common/mocks';
 
 import { ListItemComponent } from './list_item';
 import { ThreatMapEntries } from './types';

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.test.tsx
@@ -10,7 +10,7 @@ import { mount, shallow } from 'enzyme';
 import { ThemeProvider } from 'styled-components';
 import { act } from '@testing-library/react';
 
-import { stubIndexPattern } from 'src/plugins/data/common/index_patterns/index_pattern.stub';
+import { stubIndexPattern } from 'src/plugins/data/common/stubs';
 import { StepAboutRule } from '.';
 import { useFetchIndex } from '../../../../common/containers/source';
 import { mockAboutStepRule } from '../../../pages/detection_engine/rules/all/__mocks__/mock';


### PR DESCRIPTION
## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047