### PR TITLE
[observability] convert deep imports to top level imports for 'index_pattern' items

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/utils.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/utils.ts
@@ -7,7 +7,7 @@
 import rison, { RisonValue } from 'rison-node';
 import type { SeriesUrl, UrlFilter } from '../types';
 import type { AllSeries, AllShortSeries } from '../hooks/use_series_storage';
-import { IndexPattern } from '../../../../../../../../src/plugins/data/common/index_patterns';
+import { IndexPattern } from '../../../../../../../../src/plugins/data/common';
 import { esFilters, ExistsFilter } from '../../../../../../../../src/plugins/data/public';
 import { URL_KEYS } from './constants/url_constants';
 import { PersistableFilter } from '../../../../../../lens/common';

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/rtl_helpers.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/rtl_helpers.tsx
@@ -34,10 +34,7 @@ import * as useValuesListHook from '../../../hooks/use_values_list';
 import indexPatternData from './configurations/test_data/test_index_pattern.json';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { setIndexPatterns } from '../../../../../../../src/plugins/data/public/services';
-import {
-  IndexPattern,
-  IndexPatternsContract,
-} from '../../../../../../../src/plugins/data/common/index_patterns/index_patterns';
+import { IndexPattern, IndexPatternsContract } from '../../../../../../../src/plugins/data/common';
 import { createStubIndexPattern } from '../../../../../../../src/plugins/data/common/stubs';
 import { AppDataType, UrlFilter } from './types';
 import { dataPluginMock } from '../../../../../../../src/plugins/data/public/mocks';


### PR DESCRIPTION
## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047
