### PR TITLE
[discover] convert deep imports to top level imports for 'index_pattern' items

### DIFF
--- a/src/plugins/discover/public/__mocks__/index_pattern.ts
+++ b/src/plugins/discover/public/__mocks__/index_pattern.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { IIndexPatternFieldList } from '../../../data/common/index_patterns/fields';
+import { IIndexPatternFieldList } from '../../../data/common';
 import { IndexPattern } from '../../../data/common';
 import { indexPatterns } from '../../../data/public';
 

--- a/src/plugins/discover/public/__mocks__/index_pattern_with_timefield.ts
+++ b/src/plugins/discover/public/__mocks__/index_pattern_with_timefield.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { IIndexPatternFieldList } from '../../../data/common/index_patterns/fields';
+import { IIndexPatternFieldList } from '../../../data/common';
 import { IndexPattern } from '../../../data/common';
 import { indexPatterns } from '../../../data/public';
 

--- a/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.test.ts
@@ -8,7 +8,7 @@
 
 import ReactDOM from 'react-dom/server';
 import { formatRow, formatTopLevelObject } from './row_formatter';
-import { IndexPattern } from '../../../../../../../../data/common';
+import { IndexPattern } from '../../../../../../../../data/common/index_patterns/index_patterns';
 import { fieldFormatsMock } from '../../../../../../../../field_formats/common/mocks';
 import { setServices } from '../../../../../../kibana_services';
 import { DiscoverServices } from '../../../../../../build_services';

--- a/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/lib/row_formatter.test.ts
@@ -8,7 +8,7 @@
 
 import ReactDOM from 'react-dom/server';
 import { formatRow, formatTopLevelObject } from './row_formatter';
-import { IndexPattern } from '../../../../../../../../data/common/index_patterns/index_patterns';
+import { IndexPattern } from '../../../../../../../../data/common';
 import { fieldFormatsMock } from '../../../../../../../../field_formats/common/mocks';
 import { setServices } from '../../../../../../kibana_services';
 import { DiscoverServices } from '../../../../../../build_services';

--- a/src/plugins/discover/public/application/apps/main/components/sidebar/discover_index_pattern_management.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/sidebar/discover_index_pattern_management.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react';
 import { EuiButtonIcon, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DiscoverServices } from '../../../../../build_services';
-import { IndexPattern } from '../../../../../../../data/common/index_patterns/index_patterns';
+import { IndexPattern } from '../../../../../../../data/common';
 
 export interface DiscoverIndexPatternManagementProps {
   /**

--- a/src/plugins/discover/public/application/apps/main/components/sidebar/lib/group_fields.test.ts
+++ b/src/plugins/discover/public/application/apps/main/components/sidebar/lib/group_fields.test.ts
@@ -8,7 +8,7 @@
 
 import { groupFields } from './group_fields';
 import { getDefaultFieldFilter } from './field_filter';
-import { IndexPatternField } from '../../../../../../../../data/common/index_patterns/fields';
+import { IndexPatternField } from '../../../../../../../../data/common';
 
 const fields = [
   {

--- a/src/plugins/discover/public/application/apps/main/components/top_nav/on_save_search.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/on_save_search.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { SavedObjectSaveModal, showSaveModal } from '../../../../../../../saved_objects/public';
 import { SavedSearch } from '../../../../../saved_searches';
-import { IndexPattern } from '../../../../../../../data/common/index_patterns/index_patterns';
+import { IndexPattern } from '../../../../../../../data/common';
 import { DiscoverServices } from '../../../../../build_services';
 import { GetStateReturn } from '../../services/discover_state';
 import { setBreadcrumbsTitle } from '../../../../helpers/breadcrumbs';

--- a/src/plugins/discover/public/application/apps/main/utils/get_switch_index_pattern_app_state.test.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_switch_index_pattern_app_state.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { getSwitchIndexPatternAppState } from './get_switch_index_pattern_app_state';
-import { IndexPattern } from '../../../../../../data/common/index_patterns';
+import { IndexPattern } from '../../../../../../data/common';
 
 /**
  * Helper function returning an index pattern

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_cell_actions.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_cell_actions.tsx
@@ -9,7 +9,7 @@
 import React, { useContext } from 'react';
 import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { IndexPatternField } from '../../../../../data/common/index_patterns/fields';
+import { IndexPatternField } from '../../../../../data/common';
 import { DiscoverGridContext } from './discover_grid_context';
 
 export const FilterInBtn = ({


### PR DESCRIPTION
## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047
