### PR TITLE
[Discover] Change "missing fields" to "empty fields"

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/sidebar/discover_field_search.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/sidebar/discover_field_search.tsx
@@ -230,8 +230,8 @@ export function DiscoverFieldSearch({ onChange, value, types }: Props) {
     return (
       <EuiPopoverFooter paddingSize="s">
         <EuiSwitch
-          label={i18n.translate('discover.fieldChooser.filter.hideMissingFieldsLabel', {
-            defaultMessage: 'Hide missing fields',
+          label={i18n.translate('discover.fieldChooser.filter.hideEmptyFieldsLabel', {
+            defaultMessage: 'Hide empty fields',
           })}
           checked={values.missing}
           onChange={handleMissingChange}

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -2460,7 +2460,6 @@
     "discover.fieldChooser.filter.availableFieldsTitle": "利用可能なフィールド",
     "discover.fieldChooser.filter.fieldSelectorLabel": "{id}フィルターオプションの選択",
     "discover.fieldChooser.filter.filterByTypeLabel": "タイプでフィルタリング",
-    "discover.fieldChooser.filter.hideMissingFieldsLabel": "未入力のフィールドを非表示",
     "discover.fieldChooser.filter.indexAndFieldsSectionAriaLabel": "インデックスとフィールド",
     "discover.fieldChooser.filter.popularTitle": "人気",
     "discover.fieldChooser.filter.searchableLabel": "検索可能",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -2485,7 +2485,6 @@
     "discover.fieldChooser.filter.availableFieldsTitle": "可用字段",
     "discover.fieldChooser.filter.fieldSelectorLabel": "{id} 筛选选项的选择",
     "discover.fieldChooser.filter.filterByTypeLabel": "按类型筛选",
-    "discover.fieldChooser.filter.hideMissingFieldsLabel": "隐藏缺失字段",
     "discover.fieldChooser.filter.indexAndFieldsSectionAriaLabel": "索引和字段",
     "discover.fieldChooser.filter.popularTitle": "常见",
     "discover.fieldChooser.filter.searchableLabel": "可搜索",


### PR DESCRIPTION
## Summary

Change the "Hide missing fields" label to "Hide empty fields". This better represents what's actually happening, and also would be more aligned with the wording we use in Lens.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~