### PR TITLE
[7.x] Add deprecation message for xpack.spaces.enabled

### DIFF
--- a/x-pack/plugins/security/server/config_deprecations.test.ts
+++ b/x-pack/plugins/security/server/config_deprecations.test.ts
@@ -426,4 +426,53 @@ describe('Config Deprecations', () => {
     expect(migrated).toEqual(config);
     expect(messages).toHaveLength(0);
   });
+
+  it('warns when the spaces plugin is disabled', () => {
+    const config = {
+      xpack: {
+        security: {
+          session: { idleTimeout: 123, lifespan: 345 },
+        },
+        spaces: {
+          enabled: false,
+        },
+      },
+    };
+    const { messages, migrated } = applyConfigDeprecations(cloneDeep(config));
+    expect(migrated).toEqual(config);
+    expect(messages).toMatchInlineSnapshot(`
+      Array [
+        "Disabling the Spaces plugin will not be allowed in 8.0.",
+      ]
+    `);
+  });
+
+  it('does not warn when the spaces plugin is enabled', () => {
+    const config = {
+      xpack: {
+        security: {
+          session: { idleTimeout: 123, lifespan: 345 },
+        },
+        spaces: {
+          enabled: true,
+        },
+      },
+    };
+    const { messages, migrated } = applyConfigDeprecations(cloneDeep(config));
+    expect(migrated).toEqual(config);
+    expect(messages).toHaveLength(0);
+  });
+
+  it("does not warn when xpack.spaces.enabled isn't set", () => {
+    const config = {
+      xpack: {
+        security: {
+          session: { idleTimeout: 123, lifespan: 345 },
+        },
+      },
+    };
+    const { messages, migrated } = applyConfigDeprecations(cloneDeep(config));
+    expect(migrated).toEqual(config);
+    expect(messages).toHaveLength(0);
+  });
 });

--- a/x-pack/plugins/security/server/config_deprecations.ts
+++ b/x-pack/plugins/security/server/config_deprecations.ts
@@ -161,6 +161,25 @@ export const securityConfigDeprecationProvider: ConfigDeprecationProvider = ({
       });
     }
   },
+  (settings, fromPath, addDeprecation) => {
+    if (settings?.xpack?.spaces?.enabled === false) {
+      addDeprecation({
+        title: i18n.translate('xpack.spaces.deprecations.enabledTitle', {
+          defaultMessage: 'Setting "xpack.spaces.enabled" is deprecated',
+        }),
+        message: i18n.translate('xpack.spaces.deprecations.enabledMessage', {
+          defaultMessage: 'Disabling the Spaces plugin will not be allowed in 8.0.',
+        }),
+        correctiveActions: {
+          manualSteps: [
+            i18n.translate('xpack.spaces.deprecations.enabled.manualStepOneMessage', {
+              defaultMessage: `Remove "xpack.spaces.enabled" from kibana.yml.`,
+            }),
+          ],
+        },
+      });
+    }
+  },
   // Default values for session expiration timeouts.
   (settings, fromPath, addDeprecation) => {
     if (settings?.xpack?.security?.session?.idleTimeout === undefined) {


### PR DESCRIPTION
Fixes part of #82467

This PR adds a deprecation message if `xpack.spaces.enabled` is set to `false` in `kibana.yml`.

We could have expanded the scope and also shown the deprecation message if `xpack.spaces.enabled` was set to `true`, but to lessen the burden of upgrading to 8.0, we have decided that just checking for `false` is enough.

Here's how it will look in the Upgrade Assistant UI:

![image](https://user-images.githubusercontent.com/10602/133412950-99fcdd00-8058-4f97-a1b8-5c047c7c44e3.png)

## Release note

Deprecates disabling the Spaces plugin.