### PR TITLE
[Stack Monitoring] add missing mb field

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
+++ b/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
@@ -3787,6 +3787,7 @@ Object {
     "format": "0,0.[00]",
     "getDateHistogramSubAggs": [Function],
     "label": "Pipeline Throughput",
+    "mbField": "logstash.node.stats.pipelines.events.out",
     "timestampField": "logstash_stats.timestamp",
     "units": "e/s",
     "uuidField": "logstash_stats.logstash.uuid",

--- a/x-pack/plugins/monitoring/server/lib/metrics/logstash/metrics.js
+++ b/x-pack/plugins/monitoring/server/lib/metrics/logstash/metrics.js
@@ -439,6 +439,7 @@ export const metrics = {
   }),
   logstash_node_pipeline_throughput: new LogstashPipelineThroughputMetric({
     uuidField: 'logstash_stats.logstash.uuid', // TODO: add comment explaining why
+    mbField: 'logstash.node.stats.pipelines.events.out',
     field: 'logstash_stats.pipelines.events.out',
     label: pipelineThroughputLabel,
     description: pipelineThroughputDescription,


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/110719

The bug was introduced in https://github.com/elastic/kibana/pull/96205 for 7.14, causing the ES query to be incorrect as we were missing the field in one of the aggregations:

<img width="300" alt="Screenshot 2021-09-15 at 16 01 15" src="https://user-images.githubusercontent.com/2249229/133447860-1862c1b2-a00f-4ca6-84b9-efa47e9c3584.png">


### Reviewer notes
* I'm not sure if this is the correct field from where we have to get the data. I used the same field as defined [here](https://github.com/elastic/kibana/blob/5baa17ddab6e94e6fe5da3bfdf518f134612b36b/x-pack/plugins/monitoring/server/lib/metrics/logstash/metrics.js#L433) because it has the same field.
* The field added is used [here](https://github.com/elastic/kibana/blob/dc931289faee921f1697bd02aa3197e6b789933e/x-pack/plugins/monitoring/server/lib/metrics/logstash/classes.js#L325).


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
