### PR TITLE
[7.x] [Fleet] added monitoring_enabled to openapi (#112226)

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -2410,6 +2410,16 @@
           },
           "description": {
             "type": "string"
+          },
+          "monitoring_enabled": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "metrics",
+                "logs"
+              ]
+            }
           }
         }
       },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1513,6 +1513,13 @@ components:
           type: string
         description:
           type: string
+        monitoring_enabled:
+          type: array
+          items:
+            type: string
+            enum:
+              - metrics
+              - logs
     new_package_policy:
       title: New package policy
       type: object

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/new_agent_policy.yaml
@@ -7,3 +7,10 @@ properties:
     type: string
   description:
     type: string
+  monitoring_enabled:
+    type: array
+    items:
+      type: string
+      enum:
+        - metrics
+        - logs


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Fleet] added monitoring_enabled to openapi (#112226)