### PR TITLE
[7.x] [RAC] [Observability] Remove rac feature flags from default functional tests (#111942)

### DIFF
--- a/x-pack/test/api_integration/apis/features/features/features.ts
+++ b/x-pack/test/api_integration/apis/features/features/features.ts
@@ -113,7 +113,6 @@ export default function ({ getService }: FtrProviderContext) {
             'infrastructure',
             'logs',
             'maps',
-            'observabilityCases',
             'osquery',
             'uptime',
             'siem',

--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -33,7 +33,6 @@ export default function ({ getService }: FtrProviderContext) {
             stackAlerts: ['all', 'read'],
             ml: ['all', 'read'],
             siem: ['all', 'read', 'minimal_all', 'minimal_read', 'cases_all', 'cases_read'],
-            observabilityCases: ['all', 'read'],
             uptime: ['all', 'read'],
             infrastructure: ['all', 'read'],
             logs: ['all', 'read'],

--- a/x-pack/test/api_integration/apis/security/privileges_basic.ts
+++ b/x-pack/test/api_integration/apis/security/privileges_basic.ts
@@ -32,7 +32,6 @@ export default function ({ getService }: FtrProviderContext) {
             maps: ['all', 'read'],
             canvas: ['all', 'read'],
             infrastructure: ['all', 'read'],
-            observabilityCases: ['all', 'read'],
             logs: ['all', 'read'],
             uptime: ['all', 'read'],
             apm: ['all', 'read'],

--- a/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
+++ b/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
@@ -64,7 +64,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const navLinks = await appsMenu.readLinks();
         expect(navLinks.map((link) => link.text)).to.eql([
           'Overview',
-          'Alerts',
           'APM',
           'User Experience',
           'Stack Management',
@@ -117,13 +116,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows apm navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql([
-          'Overview',
-          'Alerts',
-          'APM',
-          'User Experience',
-          'Stack Management',
-        ]);
+        expect(navLinks).to.eql(['Overview', 'APM', 'User Experience', 'Stack Management']);
       });
 
       it('can navigate to APM app', async () => {

--- a/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -62,7 +62,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows metrics navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Metrics', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Metrics', 'Stack Management']);
       });
 
       describe('infrastructure landing page without data', () => {
@@ -160,7 +160,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows metrics navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Metrics', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Metrics', 'Stack Management']);
       });
 
       describe('infrastructure landing page without data', () => {

--- a/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
@@ -59,7 +59,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows logs navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Logs', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Logs', 'Stack Management']);
       });
 
       describe('logs landing page without data', () => {
@@ -122,7 +122,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows logs navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Logs', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Logs', 'Stack Management']);
       });
 
       describe('logs landing page without data', () => {

--- a/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
+++ b/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
@@ -68,7 +68,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const navLinks = await appsMenu.readLinks();
         expect(navLinks.map((link) => link.text)).to.eql([
           'Overview',
-          'Alerts',
           'Uptime',
           'Stack Management',
         ]);
@@ -122,7 +121,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows uptime navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Overview', 'Alerts', 'Uptime', 'Stack Management']);
+        expect(navLinks).to.eql(['Overview', 'Uptime', 'Stack Management']);
       });
 
       it('can navigate to Uptime app', async () => {

--- a/x-pack/test/functional/config.js
+++ b/x-pack/test/functional/config.js
@@ -91,9 +91,7 @@ export default async function ({ readConfigFile }) {
         '--xpack.encryptedSavedObjects.encryptionKey="DkdXazszSCYexXqz4YktBGHCRkV6hyNK"',
         '--xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled=true',
         '--savedObjects.maxImportPayloadBytes=10485760', // for OSS test management/_import_objects
-        '--xpack.observability.unsafe.cases.enabled=true',
         '--xpack.siem.enabled=true', // Used to trigger Kibana deprecation warning in UA (renamed config)
-        '--xpack.observability.unsafe.alertingExperience.enabled=true', // NOTE: Can be removed once enabled by default
       ],
     },
     uiSettings: {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [RAC] [Observability] Remove rac feature flags from default functional tests (#111942)