### PR TITLE
[file upload] convert deep imports to top level imports for 'index_pattern' items

### DIFF
--- a/x-pack/plugins/file_upload/server/utils/runtime_field_utils.ts
+++ b/x-pack/plugins/file_upload/server/utils/runtime_field_utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { estypes } from '@elastic/elasticsearch';
-import { RUNTIME_FIELD_TYPES } from '../../../../../src/plugins/data/common/index_patterns';
+import { RUNTIME_FIELD_TYPES } from '../../../../../src/plugins/data/common';
 
 type RuntimeType = typeof RUNTIME_FIELD_TYPES[number];
 


### PR DESCRIPTION
## Summary

Converting some deep imports to top level imports. This removes references to 'index_patterns' which will make the conversion to data views easier.

Split from https://github.com/elastic/kibana/pull/112047