### PR TITLE
[7.14] [DOC] Update Persist Keystore via Docker (#110917)

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -93,6 +93,16 @@ services:
       - ./kibana.yml:/usr/share/kibana/config/kibana.yml
 --------------------------------------------
 
+==== Persist the {kib} keystore
+
+By default, {kib] auto-generates a keystore file for secure settings at startup. To persist your {kibana-ref}/secure-settings.html[secure settings], use the `kibana-keystore` utility to bind-mount the parent directory of the keystore to the container. For example:
+
+[source,sh]
+----
+docker run -it --rm -v full_path_to/config:/usr/share/kibana/config -v full_path_to/data:/usr/share/kibana/data docker.elastic.co/kibana/kibana:7.14.0 bin/kibana-keystore create
+docker run -it --rm -v full_path_to/config:/usr/share/kibana/config -v full_path_to/data:/usr/share/kibana/data docker.elastic.co/kibana/kibana:7.14.0 bin/kibana-keystore add test_keystore_setting
+----
+
 [float]
 [[environment-variable-config]]
 ==== Environment variable configuration


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOC] Update Persist Keystore via Docker (#110917)