### PR TITLE
[7.x] [+Doc] ERROR: Kibana server not yet ready (#111230)

### DIFF
--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -37,4 +37,21 @@ image::images/kibana-status-page-7_14_0.png[Kibana server status page]
 
 For JSON-formatted server status details, use the `localhost:5601/api/status` API endpoint. 
 
+[float]
+[[not-ready]]
+=== {kib} not ready
+
+If you receive an error that the {kib} `server is not ready`, check the following:
+
+* The {es} connectivity: 
++
+[source,sh]
+----
+`curl -XGET elasticsearch_ip_or_hostname:9200/`
+----
+* The {kib} logs:
+** Linux, DEB or RPM package: `/var/log/kibana/kibana.log`
+** Linux, tar.gz package: `$KIBANA_HOME/log/kibana.log`
+** Windows: `$KIBANA_HOME\log\kibana.log`
+* The health status of `.kibana*` indices
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [+Doc] ERROR: Kibana server not yet ready (#111230)