### PR TITLE
[Fleet] Fix EPM api integration tests setup

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/bulk_upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/bulk_upgrade.ts
@@ -13,6 +13,7 @@ import {
   BulkInstallPackagesResponse,
   IBulkInstallPackageHTTPError,
 } from '../../../../plugins/fleet/common';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -24,6 +25,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('bulk package upgrade api', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
 
     describe('bulk package upgrade with a package already installed', async () => {
       beforeEach(async () => {

--- a/x-pack/test/fleet_api_integration/apis/epm/data_stream.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/data_stream.ts
@@ -9,6 +9,7 @@ import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -36,6 +37,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('datastreams', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
 
     beforeEach(async () => {
       await installPackage(pkgKey);

--- a/x-pack/test/fleet_api_integration/apis/epm/delete.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/delete.ts
@@ -7,11 +7,12 @@
 
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
-  const requiredPackage = 'system-0.13.3';
+  const requiredPackage = 'elastic_agent-0.0.7';
 
   const installPackage = async (pkgkey: string) => {
     await supertest
@@ -29,6 +30,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('delete and force delete scenarios', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     before(async () => {
       await installPackage(requiredPackage);
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/get.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -35,6 +36,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('EPM - get', () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     it('returns package info from the registry if it was installed from the registry', async function () {
       // this will install through the registry by default
       await installPackage(testPkgKey);

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -11,6 +11,7 @@ import expect from '@kbn/expect';
 
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -55,6 +56,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('installs packages from direct upload', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     afterEach(async () => {
       if (server) {
         // remove the packages just in case it being installed will affect other tests

--- a/x-pack/test/fleet_api_integration/apis/epm/install_error_rollback.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_error_rollback.ts
@@ -8,6 +8,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -29,6 +30,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('package installation error handling and rollback', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     beforeEach(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
@@ -8,6 +8,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -23,6 +24,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('installs packages that include settings and mappings overrides', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     after(async () => {
       if (server.enabled) {
         // remove the package just in case it being installed will affect other tests

--- a/x-pack/test/fleet_api_integration/apis/epm/install_prerelease.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_prerelease.ts
@@ -6,12 +6,13 @@
  */
 
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { warnAndSkipTest } from '../../helpers';
+import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
-export default function ({ getService }: FtrProviderContext) {
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
   const supertest = getService('supertest');
   const dockerServers = getService('dockerServers');
-  const log = getService('log');
 
   const testPackage = 'prerelease-0.1.0-dev.0+abc';
   const server = dockerServers.get('registry');
@@ -21,6 +22,8 @@ export default function ({ getService }: FtrProviderContext) {
   };
 
   describe('installs package that has a prerelease version', async () => {
+    skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     after(async () => {
       if (server.enabled) {
         // remove the package just in case it being installed will affect other tests
@@ -29,14 +32,10 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should install the package correctly', async function () {
-      if (server.enabled) {
-        await supertest
-          .post(`/api/fleet/epm/packages/${testPackage}`)
-          .set('kbn-xsrf', 'xxxx')
-          .expect(200);
-      } else {
-        warnAndSkipTest(this, log);
-      }
+      await supertest
+        .post(`/api/fleet/epm/packages/${testPackage}`)
+        .set('kbn-xsrf', 'xxxx')
+        .expect(200);
     });
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -10,6 +10,7 @@ import { sortBy } from 'lodash';
 import { AssetReference } from '../../../../plugins/fleet/common';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -35,8 +36,10 @@ export default function (providerContext: FtrProviderContext) {
   };
 
   describe('installs and uninstalls all assets', async () => {
+    skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
+
     describe('installs all assets when installing a package for the first time', async () => {
-      skipIfNoDockerRegistry(providerContext);
       before(async () => {
         if (!server.enabled) return;
         await installPackage(pkgKey);
@@ -56,7 +59,6 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('uninstalls all assets when uninstalling a package', async () => {
-      skipIfNoDockerRegistry(providerContext);
       before(async () => {
         if (!server.enabled) return;
         // these tests ensure that uninstall works properly so make sure that the package gets installed and uninstalled
@@ -287,7 +289,6 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('reinstalls all assets', async () => {
-      skipIfNoDockerRegistry(providerContext);
       before(async () => {
         if (!server.enabled) return;
         await installPackage(pkgKey);

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_multiple.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_multiple.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import fs from 'fs';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -70,6 +71,7 @@ export default function (providerContext: FtrProviderContext) {
   };
   describe('installs and uninstalls multiple packages side effects', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     before(async () => {
       if (!server.enabled) return;
       await installPackages([pkgKey, experimentalPkgKey, experimental2PkgKey]);

--- a/x-pack/test/fleet_api_integration/apis/epm/install_update.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_update.ts
@@ -12,6 +12,7 @@ import {
   PACKAGES_SAVED_OBJECT_TYPE,
   MAX_TIME_COMPLETE_INSTALL,
 } from '../../../../plugins/fleet/common';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -24,6 +25,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('installing and updating scenarios', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     after(async () => {
       await deletePackage('multiple_versions-0.3.0');
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/package_install_complete.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/package_install_complete.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../plugins/fleet/common';
 import { skipIfNoDockerRegistry } from '../../helpers';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -24,6 +25,7 @@ export default function (providerContext: FtrProviderContext) {
   const pkgUpdateVersion = '0.2.0';
   describe('setup checks packages completed install', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     describe('package install', async () => {
       before(async () => {
         if (!server.enabled) return;

--- a/x-pack/test/fleet_api_integration/apis/epm/setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/setup.ts
@@ -9,6 +9,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
 import { GetInfoResponse, Installed } from '../../../../plugins/fleet/common';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -17,6 +18,7 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('setup api', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
     describe('setup performs upgrades', async () => {
       const oldEndpointVersion = '0.13.0';
       beforeEach(async () => {

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -8,6 +8,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
@@ -35,6 +36,8 @@ export default function (providerContext: FtrProviderContext) {
 
   describe('updates all assets when updating a package to a different version', async () => {
     skipIfNoDockerRegistry(providerContext);
+    setupFleetAndAgents(providerContext);
+
     before(async () => {
       await installPackage(pkgKey);
       await installPackage(pkgUpdateKey);


### PR DESCRIPTION
## Summary

Resolve #112326 

EPM tests require Fleet to be correctly setup, tests are passing in CI because of a side effect of other tests but if you where trying to run individual test while developing the tests where failing.

