### PR TITLE
es_archiver empty-monitoring-index action

### DIFF
--- a/packages/kbn-es-archiver/src/actions/empty_monitoring_index.ts
+++ b/packages/kbn-es-archiver/src/actions/empty_monitoring_index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { KibanaClient } from '@elastic/elasticsearch/api/kibana';
+import { ToolingLog } from '@kbn/dev-utils';
+import { createStats, cleanMonitoringIndices } from '../lib';
+
+export async function emptyMonitoringIndexAction({
+  client,
+  log,
+}: {
+  client: KibanaClient;
+  log: ToolingLog;
+}) {
+  const stats = createStats('emptyMonitoringIndex', log);
+
+  await cleanMonitoringIndices({ client, stats, log });
+
+  return stats.toJSON();
+}

--- a/packages/kbn-es-archiver/src/actions/index.ts
+++ b/packages/kbn-es-archiver/src/actions/index.ts
@@ -11,4 +11,5 @@ export { loadAction } from './load';
 export { unloadAction } from './unload';
 export { rebuildAllAction } from './rebuild_all';
 export { emptyKibanaIndexAction } from './empty_kibana_index';
+export { emptyMonitoringIndexAction } from './empty_monitoring_index';
 export { editAction } from './edit';

--- a/packages/kbn-es-archiver/src/cli.ts
+++ b/packages/kbn-es-archiver/src/cli.ts
@@ -266,6 +266,14 @@ export function runCli() {
       },
     })
     .command({
+      name: 'empty-monitoring-index',
+      description:
+        '[internal] Delete any Monitoring indices that would be referenced by the Stack Monitoring application.',
+      async run({ esArchiver }) {
+        await esArchiver.emptyMonitoringIndex();
+      },
+    })
+    .command({
       name: 'rebuild-all [dir]',
       description:
         '[internal] read and write all archives within [dir] to remove any inconsistencies',

--- a/packages/kbn-es-archiver/src/es_archiver.ts
+++ b/packages/kbn-es-archiver/src/es_archiver.ts
@@ -20,6 +20,7 @@ import {
   rebuildAllAction,
   emptyKibanaIndexAction,
   editAction,
+  emptyMonitoringIndexAction,
 } from './actions';
 
 interface Options {
@@ -152,6 +153,16 @@ export class EsArchiver {
       client: this.client,
       log: this.log,
       kbnClient: this.kbnClient,
+    });
+  }
+
+  /**
+   * Delete any Monitoring indices that would be referenced by the Stack Monitoring application.
+   */
+  async emptyMonitoringIndex() {
+    return await emptyMonitoringIndexAction({
+      client: this.client,
+      log: this.log,
     });
   }
 

--- a/packages/kbn-es-archiver/src/lib/index.ts
+++ b/packages/kbn-es-archiver/src/lib/index.ts
@@ -15,6 +15,7 @@ export {
   deleteKibanaIndices,
   migrateKibanaIndex,
   cleanKibanaIndices,
+  cleanMonitoringIndices,
   createDefaultSpace,
 } from './indices';
 

--- a/packages/kbn-es-archiver/src/lib/indices/index.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/index.ts
@@ -15,3 +15,4 @@ export {
   cleanKibanaIndices,
   createDefaultSpace,
 } from './kibana_index';
+export { cleanMonitoringIndices } from './monitoring_index';

--- a/packages/kbn-es-archiver/src/lib/indices/monitoring_index.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/monitoring_index.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { inspect } from 'util';
+
+import type { KibanaClient } from '@elastic/elasticsearch/api/kibana';
+import { ToolingLog } from '@kbn/dev-utils';
+import { Stats } from '../stats';
+import { ES_CLIENT_HEADERS } from '../../client_headers';
+import { deleteIndex } from './delete_index';
+
+export async function cleanMonitoringIndices({
+  client,
+  stats,
+  log,
+}: {
+  client: KibanaClient;
+  stats: Stats;
+  log: ToolingLog;
+}) {
+  deleteMonitoringIndices({ client, stats, log });
+}
+
+/**
+ * Deletes all indices that start with `.monitoring`
+ */
+export async function deleteMonitoringIndices({
+  client,
+  stats,
+  log,
+}: {
+  client: KibanaClient;
+  stats: Stats;
+  log: ToolingLog;
+}) {
+  const indexNames = await fetchMonitoringIndices(client);
+  if (!indexNames.length) {
+    return;
+  }
+
+  await client.indices.putSettings(
+    {
+      index: indexNames,
+      body: { settings: { blocks: { read_only: false } } },
+    },
+    {
+      headers: ES_CLIENT_HEADERS,
+    }
+  );
+
+  await deleteIndex({
+    client,
+    stats,
+    index: indexNames,
+    log,
+  });
+
+  return indexNames;
+}
+
+async function fetchMonitoringIndices(client: KibanaClient) {
+  const resp = await client.cat.indices(
+    { index: '.monitoring-*', format: 'json' },
+    {
+      headers: ES_CLIENT_HEADERS,
+    }
+  );
+
+  if (!Array.isArray(resp.body)) {
+    throw new Error(`expected response to be an array ${inspect(resp.body)}`);
+  }
+
+  return resp.body.map((x: { index?: string }) => x.index).filter(isMonitoringIndex);
+}
+
+function isMonitoringIndex(index?: string): index is string {
+  return Boolean(index && /^\.monitoring-.*$/.test(index));
+}


### PR DESCRIPTION
## Summary

Adds a `node scripts/es_archiver.js empty-monitoring-index`

Should be runnable like this against the observablity-dev docker testing setup.

```
node scripts/es_archiver.js empty-monitoring-index --es-url https://elastic:changeme@localhost:9200 --es-ca ca.crt 
```

But you first have to grab the ca from the docker volume.

I also seem to be running into some stale javascript file issues, `yarn kbn bootstrap` seems to be needed to ensure you're using the latest local code.
