### PR TITLE
[RAC][Observability] filter out recovered alerts for next tracked alerts

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_lifecycle_executor.ts
@@ -296,7 +296,7 @@ export const createLifecycleExecutor = (
 
   const nextTrackedAlerts = Object.fromEntries(
     allEventsToIndex
-      .filter(({ event }) => event[ALERT_STATUS] !== 'closed')
+      .filter(({ event }) => event[ALERT_STATUS] !== ALERT_STATUS_RECOVERED)
       .map(({ event }) => {
         const alertId = event[ALERT_INSTANCE_ID]!;
         const alertUuid = event[ALERT_UUID]!;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/112265

`ALERT_STATUS` can be either `active` or `recovered`. We were wrongly using here the `WORKFLOW_STATUS` instead (which can be either `open` or `closed`)