### PR TITLE
[7.15] [Stack Monitoring] add missing mb field (#112251)

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
+++ b/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
@@ -3787,6 +3787,7 @@ Object {
     "format": "0,0.[00]",
     "getDateHistogramSubAggs": [Function],
     "label": "Pipeline Throughput",
+    "mbField": "logstash.node.stats.pipelines.events.out",
     "timestampField": "logstash_stats.timestamp",
     "units": "e/s",
     "uuidField": "logstash_stats.logstash.uuid",

--- a/x-pack/plugins/monitoring/server/lib/metrics/logstash/metrics.js
+++ b/x-pack/plugins/monitoring/server/lib/metrics/logstash/metrics.js
@@ -439,6 +439,7 @@ export const metrics = {
   }),
   logstash_node_pipeline_throughput: new LogstashPipelineThroughputMetric({
     uuidField: 'logstash_stats.logstash.uuid', // TODO: add comment explaining why
+    mbField: 'logstash.node.stats.pipelines.events.out',
     field: 'logstash_stats.pipelines.events.out',
     label: pipelineThroughputLabel,
     description: pipelineThroughputDescription,


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Stack Monitoring] add missing mb field (#112251)