### PR TITLE
[Stack monitoring] Elasticsearch nodes view migration

### DIFF
--- a/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
@@ -96,7 +96,7 @@ export function useTable(storageKey: string) {
     return sort;
   };
 
-  const [queryText, setQueryText] = useState('');
+  const [query, setQuery] = useState('');
 
   const onTableChange = () => {
     // we are already updating the state in fetchMoreData. We would need to check in react
@@ -115,9 +115,9 @@ export function useTable(storageKey: string) {
         index: pagination.pageIndex,
       },
       ...sorting,
-      queryText,
+      queryText: query,
     };
-  }, [pagination, queryText, sorting]);
+  }, [pagination, query, sorting]);
 
   const getPaginationTableProps = () => {
     return {
@@ -127,11 +127,11 @@ export function useTable(storageKey: string) {
       fetchMoreData: async ({
         page,
         sort,
-        query,
+        queryText,
       }: {
         page: Page;
         sort: Sorting;
-        query: string;
+        queryText: string;
       }) => {
         setPagination({
           ...pagination,
@@ -144,7 +144,7 @@ export function useTable(storageKey: string) {
           },
         });
         setSorting(cleanSortingData(sort));
-        setQueryText(query);
+        setQuery(queryText);
 
         setLocalStorageData(storage, {
           page,

--- a/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
@@ -124,7 +124,7 @@ export function useTable(storageKey: string) {
       sorting,
       pagination,
       onTableChange,
-      fetchMoreData: async ({
+      fetchMoreData: ({
         page,
         sort,
         queryText,

--- a/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useCallback } from 'react';
+import { EUI_SORT_ASCENDING } from '../../../common/constants';
+import { euiTableStorageGetter, euiTableStorageSetter } from '../../components/table';
+
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
+
+const DEFAULT_PAGINATION = {
+  pageSize: 20,
+  initialPageSize: 20,
+  pageIndex: 0,
+  initialPageIndex: 0,
+  pageSizeOptions: PAGE_SIZE_OPTIONS,
+};
+
+const verifyDataFromLocalStorage = (page) => {
+  if (!PAGE_SIZE_OPTIONS.includes(page.size)) {
+    page.size = 20;
+  }
+
+  return page;
+};
+
+export function useTable(storageKey) {
+  const storage = new Storage(window.localStorage);
+  const getLocalStorageData = euiTableStorageGetter(storageKey);
+  const setLocalStorageData = euiTableStorageSetter(storageKey);
+
+  const storageData = getLocalStorageData(storage);
+  // get initial state from localstorage
+  const [pagination, setPagination] = useState(
+    page ? verifyDataFromLocalStorage(storageData.page) : DEFAULT_PAGINATION
+  );
+
+  // get initial state from localStorage
+  const [sorting, setSorting] = useState({});
+  const cleanSortingData = (sortData) => {
+    const sort = sortData || { sort: {} };
+
+    if (!sort.sort.field) {
+      sort.sort.field = 'name';
+    }
+    if (!sort.sort.direction) {
+      sort.sort.direction = EUI_SORT_ASCENDING;
+    }
+
+    return sort;
+  };
+
+  const [queryText, setQueryText] = useState('');
+
+  const onTableChange = ({ page, sort }) => {
+    // we are already updating the state in fetchMoreData. We would need to check in react
+    // if both methods are needed or we can clean one of them
+    // TODO: check if we need this
+    // if (this.onTableChangeRender) {
+    //   this.onTableChangeRender();
+    // }
+  };
+  const getPaginationRouteOptions = useCallback(() => {
+    if (!pagination || !sorting) {
+      return {};
+    }
+
+    return {
+      pagination: {
+        size: pagination.pageSize,
+        index: pagination.pageIndex,
+      },
+      ...sorting,
+      queryText,
+    };
+  }, [pagination, queryText, sorting]);
+
+  const getPaginationTableProps = () => {
+    return {
+      sorting,
+      pagination,
+      onTableChange,
+      fetchMoreData: async ({ page, sort, query }) => {
+        setPagination({
+          initialPageSize: page.size,
+          pageSize: page.size,
+          initialPageIndex: page.index,
+          pageIndex: page.index,
+          pageSizeOptions: PAGE_SIZE_OPTIONS,
+        });
+        setSorting(cleanSortingData(sort));
+        setQueryText(query);
+      },
+    };
+  };
+
+  return {
+    getPaginationRouteOptions,
+    getPaginationTableProps,
+  };
+}

--- a/x-pack/plugins/monitoring/public/application/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/index.tsx
@@ -20,6 +20,7 @@ import { createPreserveQueryHistory } from './preserve_query_history';
 import { RouteInit } from './route_init';
 import { NoDataPage } from './pages/no_data';
 import { ElasticsearchOverviewPage } from './pages/elasticsearch/overview';
+import { ElasticsearchNodesPage } from './pages/elasticsearch/nodes_page';
 import { CODE_PATH_ELASTICSEARCH } from '../../common/constants';
 import { MonitoringTimeContainer } from './hooks/use_monitoring_time';
 import { BreadcrumbContainer } from './hooks/use_breadcrumbs';
@@ -78,11 +79,19 @@ const MonitoringApp: React.FC<{
 
                   {/* ElasticSearch Views */}
                   <RouteInit
+                    path="/elasticsearch/nodes"
+                    component={ElasticsearchNodesPage}
+                    codePaths={[CODE_PATH_ELASTICSEARCH]}
+                    fetchAllClusters={false}
+                  />
+
+                  <RouteInit
                     path="/elasticsearch"
                     component={ElasticsearchOverviewPage}
                     codePaths={[CODE_PATH_ELASTICSEARCH]}
                     fetchAllClusters={false}
                   />
+
                   <Redirect
                     to={{
                       pathname: '/loading',

--- a/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
@@ -33,7 +33,7 @@ export const ElasticsearchNodesPage: React.FC<ComponentProps> = ({ clusters }) =
   const cluster = find(clusters, {
     cluster_uuid: clusterUuid,
   });
-  const [data, setData] = useState(null);
+  const [data, setData] = useState({} as any);
 
   const title = i18n.translate('xpack.monitoring.elasticsearch.nodes.routeTitle', {
     defaultMessage: 'Elasticsearch - Nodes',

--- a/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useContext, useState, useCallback } from 'react';
+import { i18n } from '@kbn/i18n';
+import { find } from 'lodash';
+import { ElasticsearchTemplate } from './elasticsearch_template';
+import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
+import { GlobalStateContext } from '../../global_state_context';
+import { ExternalConfigContext } from '../../external_config_context';
+import { ElasticsearchNodes } from '../../../components/elasticsearch';
+import { ComponentProps } from '../../route_init';
+import { SetupModeRenderer } from '../../setup_mode/setup_mode_renderer';
+import { SetupModeContext } from '../../../components/setup_mode/setup_mode_context';
+import { useTable } from '../../hooks/use_table';
+
+interface SetupModeProps {
+  setupMode: any;
+  flyoutComponent: any;
+  bottomBarComponent: any;
+}
+
+export const ElasticsearchNodesPage: React.FC<ComponentProps> = ({ clusters }) => {
+  const globalState = useContext(GlobalStateContext);
+  const { showCgroupMetricsElasticsearch } = useContext(ExternalConfigContext);
+  const { services } = useKibana<{ data: any }>();
+  const { getPaginationRouteOptions, getPaginationTableProps } = useTable('elasticsearch.nodes');
+  const clusterUuid = globalState.cluster_uuid;
+  const ccs = globalState.ccs;
+  const cluster = find(clusters, {
+    cluster_uuid: clusterUuid,
+  });
+  const [data, setData] = useState(null);
+
+  const title = i18n.translate('xpack.monitoring.elasticsearch.nodes.routeTitle', {
+    defaultMessage: 'Elasticsearch - Nodes',
+  });
+
+  const pageTitle = i18n.translate('xpack.monitoring.elasticsearch.nodes.pageTitle', {
+    defaultMessage: 'Elasticsearch nodes',
+  });
+
+  const getPageData = useCallback(async () => {
+    const bounds = services.data?.query.timefilter.timefilter.getBounds();
+    const url = `../api/monitoring/v1/clusters/${clusterUuid}/elasticsearch/nodes`;
+    const response = await services.http?.fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({
+        ccs,
+        timeRange: {
+          min: bounds.min.toISOString(),
+          max: bounds.max.toISOString(),
+        },
+        ...getPaginationRouteOptions(),
+      }),
+    });
+
+    setData(response);
+  }, [
+    ccs,
+    clusterUuid,
+    services.data?.query.timefilter.timefilter,
+    services.http,
+    getPaginationRouteOptions,
+  ]);
+
+  return (
+    <ElasticsearchTemplate
+      title={title}
+      pageTitle={pageTitle}
+      getPageData={getPageData}
+      data-test-subj="elasticsearchOverviewPage"
+      cluster={cluster}
+    >
+      <div data-test-subj="elasticsearchNodesListingPage">
+        <SetupModeRenderer
+          render={({ setupMode, flyoutComponent, bottomBarComponent }: SetupModeProps) => (
+            <SetupModeContext.Provider value={{ setupModeSupported: true }}>
+              {flyoutComponent}
+              <ElasticsearchNodes
+                clusterStatus={data.clusterStatus}
+                clusterUuid={globalState.cluster_uuid}
+                setupMode={setupMode}
+                nodes={data.nodes}
+                alerts={{}}
+                showCgroupMetricsElasticsearch={showCgroupMetricsElasticsearch}
+                {...getPaginationTableProps()}
+                totalItemCount={data.totalNodeCount}
+              />
+              {bottomBarComponent}
+            </SetupModeContext.Provider>
+          )}
+        />
+      </div>
+    </ElasticsearchTemplate>
+  );
+};

--- a/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
@@ -27,9 +27,8 @@ export const ElasticsearchNodesPage: React.FC<ComponentProps> = ({ clusters }) =
   const globalState = useContext(GlobalStateContext);
   const { showCgroupMetricsElasticsearch } = useContext(ExternalConfigContext);
   const { services } = useKibana<{ data: any }>();
-  const { getPaginationRouteOptions, updateTotalItemCount, getPaginationTableProps } = useTable(
-    'elasticsearch.nodes'
-  );
+  const { getPaginationRouteOptions, updateTotalItemCount, getPaginationTableProps } =
+    useTable('elasticsearch.nodes');
   const clusterUuid = globalState.cluster_uuid;
   const ccs = globalState.ccs;
   const cluster = find(clusters, {

--- a/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/elasticsearch/nodes_page.tsx
@@ -27,7 +27,9 @@ export const ElasticsearchNodesPage: React.FC<ComponentProps> = ({ clusters }) =
   const globalState = useContext(GlobalStateContext);
   const { showCgroupMetricsElasticsearch } = useContext(ExternalConfigContext);
   const { services } = useKibana<{ data: any }>();
-  const { getPaginationRouteOptions, getPaginationTableProps } = useTable('elasticsearch.nodes');
+  const { getPaginationRouteOptions, updateTotalItemCount, getPaginationTableProps } = useTable(
+    'elasticsearch.nodes'
+  );
   const clusterUuid = globalState.cluster_uuid;
   const ccs = globalState.ccs;
   const cluster = find(clusters, {
@@ -59,12 +61,14 @@ export const ElasticsearchNodesPage: React.FC<ComponentProps> = ({ clusters }) =
     });
 
     setData(response);
+    updateTotalItemCount(response.totalNodeCount);
   }, [
     ccs,
     clusterUuid,
     services.data?.query.timefilter.timefilter,
     services.http,
     getPaginationRouteOptions,
+    updateTotalItemCount,
   ]);
 
   return (
@@ -88,7 +92,6 @@ export const ElasticsearchNodesPage: React.FC<ComponentProps> = ({ clusters }) =
                 alerts={{}}
                 showCgroupMetricsElasticsearch={showCgroupMetricsElasticsearch}
                 {...getPaginationTableProps()}
-                totalItemCount={data.totalNodeCount}
               />
               {bottomBarComponent}
             </SetupModeContext.Provider>

--- a/x-pack/plugins/monitoring/public/components/elasticsearch/index.d.ts
+++ b/x-pack/plugins/monitoring/public/components/elasticsearch/index.d.ts
@@ -6,3 +6,4 @@
  */
 
 export const ElasticsearchOverview: FunctionComponent<Props>;
+export const ElasticsearchNodes: FunctionComponent<Props>;

--- a/x-pack/plugins/monitoring/public/components/table/index.d.ts
+++ b/x-pack/plugins/monitoring/public/components/table/index.d.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const euiTableStorageGetter: (string) => any;
+export const euiTableStorageSetter: (string) => any;


### PR DESCRIPTION
## Summary
This PR is part of https://github.com/elastic/kibana/issues/111756

It migrates the Elasticsearch Nodes page to react.

It also adds a hook to manage table pagination. 

**NOTE**: the nodes view should be available when there is no data. This would be covered [here](https://github.com/elastic/kibana/issues/112215)
