### PR TITLE
[PoC] for shared Analytics no data view

### DIFF
--- a/src/plugins/kibana_react/public/page_template/analytics_no_data/analytics_no_data.tsx
+++ b/src/plugins/kibana_react/public/page_template/analytics_no_data/analytics_no_data.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import React from 'react';
+
+import { i18n } from '@kbn/i18n';
+import { DocLinksStart, HttpStart } from 'src/core/public';
+import { KibanaPageTemplate, KibanaPageTemplateProps } from '../';
+import { useKibana } from '../../../../kibana_react/public';
+
+export function AnalyticsNoData() {
+  const { services } = useKibana<{ docLinks: DocLinksStart; http: HttpStart }>();
+
+  const noDataConfig: KibanaPageTemplateProps['noDataConfig'] = {
+    solution: i18n.translate('kibanaOverview.noDataConfig.solutionName', {
+      defaultMessage: `Analytics`,
+    }),
+    logo: 'logoKibana',
+    actions: {
+      beats: {
+        href: services.http.basePath.prepend(`home#/tutorial_directory`),
+      },
+    },
+    docsLink: services.docLinks.links.kibana,
+  };
+
+  return <KibanaPageTemplate noDataConfig={noDataConfig} template="empty" />;
+}

--- a/src/plugins/kibana_react/public/page_template/analytics_no_data/index.ts
+++ b/src/plugins/kibana_react/public/page_template/analytics_no_data/index.ts
@@ -6,7 +6,4 @@
  * Side Public License, v 1.
  */
 
-export { KibanaPageTemplate, KibanaPageTemplateProps } from './page_template';
-export { KibanaPageTemplateSolutionNavAvatar } from './solution_nav';
-export * from './no_data_page';
 export { AnalyticsNoData } from './analytics_no_data';


### PR DESCRIPTION
## Summary

This is a proof of concept PR to suggest what we might do for #112109

Note: this shows the centralized template but does not show a centralized 'service' for checking the `isNewKibanaInstance` state. To the contrary, I've just copy/pasted the logic from the Overview page which reinforces the need to centralize this check as it will otherwise exist in every app and opens us up to inconsistencies for when the no-data view will display.

#### Preview of no-data view in Discover

<img width="1483" alt="Screen Shot 2021-09-15 at 12 32 48 PM" src="https://user-images.githubusercontent.com/446285/133635411-d96667b8-e94b-443d-8852-f5fb2f614031.png">
