### PR TITLE
[7.x] Fix .buildkite casing ignore (2c9484b2)

### DIFF
--- a/src/dev/precommit_hook/casing_check_config.js
+++ b/src/dev/precommit_hook/casing_check_config.js
@@ -67,7 +67,7 @@ export const IGNORE_FILE_GLOBS = [
   '**/BUILD.bazel',
 
   // Buildkite
-  '.buildkite/*',
+  '.buildkite/**/*',
 ];
 
 /**


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix .buildkite casing ignore (2c9484b2)