### PR TITLE
[ftr] filter configs before running to clean up log output

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
+++ b/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { relative } from 'path';
 
 import { ToolingLog } from '@kbn/dev-utils';
 
@@ -120,9 +119,6 @@ export class FunctionalTestRunner {
       ) {
         throw new Error('No tests defined.');
       }
-
-      // eslint-disable-next-line
-      console.log(`--- Running ${relative(process.cwd(), this.configFile)}`);
 
       const dockerServers = new DockerServersService(
         config.get('dockerServers'),

--- a/packages/kbn-test/src/functional_tests/tasks.ts
+++ b/packages/kbn-test/src/functional_tests/tasks.ts
@@ -9,7 +9,7 @@
 import { relative } from 'path';
 import * as Rx from 'rxjs';
 import { startWith, switchMap, take } from 'rxjs/operators';
-import { withProcRunner, ToolingLog } from '@kbn/dev-utils';
+import { withProcRunner, ToolingLog, REPO_ROOT } from '@kbn/dev-utils';
 import dedent from 'dedent';
 
 import {
@@ -72,37 +72,49 @@ export async function runTests(options: RunTestsParams) {
     log.warning('❗️❗️❗️');
   }
 
+  const log = options.createLogger();
+
+  if (options.assertNoneExcluded) {
+    log.write('--- asserting that all tests belong to a ciGroup');
+    for (const configPath of options.configs) {
+      log.info('loading', configPath);
+      log.indent(4);
+      try {
+        await assertNoneExcluded({ configPath, options: { ...options, log } });
+      } finally {
+        log.indent(-4);
+      }
+      continue;
+    }
+
+    return;
+  }
+
+  log.write('--- determining which ftr configs to run');
+  const configPathsWithTests: string[] = [];
   for (const configPath of options.configs) {
-    const log = options.createLogger();
-    const opts = {
-      ...options,
-      log,
-    };
-
-    log.info('Running', configPath);
-    log.indent(2);
-
-    if (options.assertNoneExcluded) {
-      await assertNoneExcluded({ configPath, options: opts });
-      continue;
+    log.info('testing', configPath);
+    log.indent(4);
+    try {
+      if (await hasTests({ configPath, options: { ...options, log } })) {
+        configPathsWithTests.push(configPath);
+      }
+    } finally {
+      log.indent(-4);
     }
+  }
 
-    if (!(await hasTests({ configPath, options: opts }))) {
-      log.info('Skipping', configPath, 'since all tests are excluded');
-      continue;
-    }
-
-    // eslint-disable-next-line no-console
-    console.log(`--- Running ${relative(process.cwd(), configPath)}`);
+  for (const configPath of configPathsWithTests) {
+    log.write(`--- Running ${relative(REPO_ROOT, configPath)}`);
 
     await withProcRunner(log, async (procs) => {
       const config = await readConfigFile(log, configPath);
 
       let es;
       try {
-        es = await runElasticsearch({ config, options: opts });
-        await runKibanaServer({ procs, config, options: opts });
-        await runFtr({ configPath, options: opts });
+        es = await runElasticsearch({ config, options: { ...options, log } });
+        await runKibanaServer({ procs, config, options });
+        await runFtr({ configPath, options: { ...options, log } });
       } finally {
         try {
           const delay = config.get('kbnTestServer.delayShutdown');


### PR DESCRIPTION
Rather than log about running every config listed we should filter the configs first, and then log about the configs we are actually running.