### PR TITLE
[7.14] Treat `react-beautiful-dnd` as `.essentialAnimation` in `accessibility:disableAnimations` contexts (#112429)

### DIFF
--- a/src/core/public/integrations/styles/disable_animations.css
+++ b/src/core/public/integrations/styles/disable_animations.css
@@ -1,4 +1,8 @@
-*:not(.essentialAnimation),
+/** 
+ * `react-beautiful-dnd` relies on `transition` for functionality
+ * https://github.com/elastic/kibana/issues/95133 
+ */
+*:not(.essentialAnimation):not([data-rbd-draggable-context-id]):not([data-rbd-droppable-context-id]),
 *:not(.essentialAnimation):before,
 *:not(.essentialAnimation):after {
   /**


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Treat `react-beautiful-dnd` as `.essentialAnimation` in `accessibility:disableAnimations` contexts (#112429)