### PR TITLE
Remove deprecated `kbn-system-api` header support

### DIFF
--- a/src/core/public/http/fetch.test.ts
+++ b/src/core/public/http/fetch.test.ts
@@ -245,32 +245,6 @@ describe('Fetch', () => {
       });
     });
 
-    // Deprecated header used by legacy platform pre-7.7. Remove in 8.x.
-    it('should not allow overwriting of kbn-system-api when asSystemRequest: true', async () => {
-      fetchMock.get('*', {});
-      await expect(
-        fetchInstance.fetch('/my/path', {
-          headers: { myHeader: 'foo', 'kbn-system-api': 'ANOTHER!' },
-          asSystemRequest: true,
-        })
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Invalid fetch headers, headers beginning with \\"kbn-\\" are not allowed: [kbn-system-api]"`
-      );
-    });
-
-    // Deprecated header used by legacy platform pre-7.7. Remove in 8.x.
-    it('should not allow overwriting of kbn-system-api when asSystemRequest: false', async () => {
-      fetchMock.get('*', {});
-      await expect(
-        fetchInstance.fetch('/my/path', {
-          headers: { myHeader: 'foo', 'kbn-system-api': 'ANOTHER!' },
-          asSystemRequest: false,
-        })
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Invalid fetch headers, headers beginning with \\"kbn-\\" are not allowed: [kbn-system-api]"`
-      );
-    });
-
     it('should return response', async () => {
       fetchMock.get('*', { foo: 'bar' });
       const json = await fetchInstance.fetch('/my/path');

--- a/src/core/server/http/router/request.test.ts
+++ b/src/core/server/http/router/request.test.ts
@@ -141,31 +141,6 @@ describe('KibanaRequest', () => {
       const kibanaRequest = KibanaRequest.from(request);
       expect(kibanaRequest.isSystemRequest).toBe(false);
     });
-
-    // Remove support for kbn-system-api header in 8.x. Only used by legacy platform.
-    it('is false when no kbn-system-api header is set', () => {
-      const request = httpServerMock.createRawRequest({
-        headers: { custom: 'one' },
-      });
-      const kibanaRequest = KibanaRequest.from(request);
-      expect(kibanaRequest.isSystemRequest).toBe(false);
-    });
-
-    it('is true when kbn-system-api header is set to true', () => {
-      const request = httpServerMock.createRawRequest({
-        headers: { custom: 'one', 'kbn-system-api': 'true' },
-      });
-      const kibanaRequest = KibanaRequest.from(request);
-      expect(kibanaRequest.isSystemRequest).toBe(true);
-    });
-
-    it('is false when kbn-system-api header is set to false', () => {
-      const request = httpServerMock.createRawRequest({
-        headers: { custom: 'one', 'kbn-system-api': 'false' },
-      });
-      const kibanaRequest = KibanaRequest.from(request);
-      expect(kibanaRequest.isSystemRequest).toBe(false);
-    });
   });
 
   describe('route.options.authRequired property', () => {

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -202,10 +202,7 @@ export class KibanaRequest<
 
     this.url = request.url;
     this.headers = deepFreeze({ ...request.headers });
-    this.isSystemRequest =
-      request.headers['kbn-system-request'] === 'true' ||
-      // Remove support for `kbn-system-api` in 8.x. Used only by legacy platform.
-      request.headers['kbn-system-api'] === 'true';
+    this.isSystemRequest = request.headers['kbn-system-request'] === 'true';
 
     // prevent Symbol exposure via Object.getOwnPropertySymbols()
     Object.defineProperty(this, requestSymbol, {


### PR DESCRIPTION
## Summary

Stumbled upon a tiny change, so decided to spend 5 min. to implement it.
Closes https://github.com/elastic/kibana/issues/55203

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| 3rd party plugins use the header | Low | Low | Some Kibana plugins created outside of the Kibana codebase might use this header even though it's considered to be an internal API. |


### Plugin API changes

Kibana removed support of deprecated `kbn-system-api` header. Instead, use `asSystemRequest` flag:
```js
const response = await core.http.get({
  path: '/url',
  asSystemRequest: true,
});
```