### PR TITLE
[APM] Fix Instances table filter option color

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/key_value_filter_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/key_value_filter_list/index.tsx
@@ -107,7 +107,7 @@ export function KeyValueFilterList({
                         { defaultMessage: 'Filter by value' }
                       )}
                     >
-                      <EuiIcon type="filter" color="black" size="m" />
+                      <EuiIcon type="filter" color="text" size="m" />
                     </EuiToolTip>
                   </EuiButtonEmpty>
                   <EuiText size="s">{value}</EuiText>


### PR DESCRIPTION
## Summary

Updated the icon color to `text` to support dark mode for the fill option in the Instances table.

**Before**

<img width="907" alt="CleanShot 2021-09-20 at 10 37 17@2x" src="https://user-images.githubusercontent.com/4104278/133976762-6443969e-c395-4c65-8fb0-acccbf836a73.png">

**After**

<img width="669" alt="CleanShot 2021-09-20 at 10 44 53@2x" src="https://user-images.githubusercontent.com/4104278/133976770-88232876-6165-47b4-aa8a-2191927baa08.png">


