### PR TITLE
[DOCS] Removes 6.8.19 coming tag from release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -111,8 +111,6 @@ Review important information about the {kib} 6.x.x releases.
 [[release-notes-6.8.19]]
 == {kib} 6.8.19
 
-coming::[6.8.19]
-
 For information about the {kib} 6.8.19 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 6.8.19 release notes.