### PR TITLE
[7.15] [ftr] filter configs before running to clean up log output (#112490)

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
+++ b/packages/kbn-test/src/functional_test_runner/functional_test_runner.ts
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { relative } from 'path';
 
 import { ToolingLog } from '@kbn/dev-utils';
 
@@ -120,9 +119,6 @@ export class FunctionalTestRunner {
       ) {
         throw new Error('No tests defined.');
       }
-
-      // eslint-disable-next-line
-      console.log(`--- Running ${relative(process.cwd(), this.configFile)}`);
 
       const dockerServers = new DockerServersService(
         config.get('dockerServers'),


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [ftr] filter configs before running to clean up log output (#112490)