### PR TITLE
Removes coming tag from 7.14.2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -63,8 +63,6 @@ Review important information about the {kib} 7.14.x releases.
 [[release-notes-7.14.2]]
 == {kib} 7.14.2
 
-coming::[7.14.2]
-
 Review the following information about the 7.14.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 7.14.2 release notes.