### PR TITLE
[Security Solution][Endpoint] Add a full width overlay for date picker

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/activity_log_date_range_picker/index.tsx
@@ -17,14 +17,14 @@ import { getActivityLogDataPaging } from '../../../../store/selectors';
 
 const DatePickerWrapper = styled.div`
   width: ${(props) => props.theme.eui.fractions.single.percentage};
-  background: white;
+  max-width: 350px;
 `;
 const StickyFlexItem = styled(EuiFlexItem)`
-  max-width: 350px;
+  background: ${(props) => `${props.theme.eui.euiHeaderBackgroundColor}`};
   position: sticky;
   top: ${(props) => props.theme.eui.euiSizeM};
   z-index: 1;
-  padding: ${(props) => `0 ${props.theme.eui.paddingSizes.m}`};
+  padding: ${(props) => `${props.theme.eui.paddingSizes.m}`};
 `;
 
 export const DateRangePicker = memo(() => {
@@ -67,7 +67,7 @@ export const DateRangePicker = memo(() => {
 
   return (
     <StickyFlexItem grow={false}>
-      <EuiFlexGroup justifyContent="flexEnd" responsive>
+      <EuiFlexGroup justifyContent="flexStart" responsive>
         <DatePickerWrapper>
           <EuiFlexItem>
             <EuiDatePickerRange


### PR DESCRIPTION
## Summary
Adds a full-width overlay for the Activity Log date picker container so that the content scroll looks better.
fixes elastic/kibana/issues/111935

before:
https://user-images.githubusercontent.com/61860752/133067616-be73ea10-f9e9-48f9-87fd-b544323a3417.mp4

**In this change:**
![date-picker-fixed](https://user-images.githubusercontent.com/1849116/133428670-99943654-461d-4f5b-94a3-cd3a340aa3d6.gif)

### Checklist

Delete any items that are not applicable to this PR.
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
