### PR TITLE
Update index settings link for Snapshot and Restore

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -387,7 +387,7 @@ export class DocLinksService {
         },
         snapshotRestore: {
           guide: `${KIBANA_DOCS}snapshot-repositories.html`,
-          changeIndexSettings: `${ELASTICSEARCH_DOCS}snapshots-restore-snapshot.html#change-index-settings-during-restore`,
+          changeIndexSettings: `${ELASTICSEARCH_DOCS}index-modules.html`,
           createSnapshot: `${ELASTICSEARCH_DOCS}snapshots-take-snapshot.html`,
           getSnapshot: `${ELASTICSEARCH_DOCS}get-snapshot-api.html`,
           registerSharedFileSystem: `${ELASTICSEARCH_DOCS}snapshots-register-repository.html#snapshots-filesystem-repository`,


### PR DESCRIPTION
## Summary

Updates the docs help link for index settings  in the Snapshot and Restore feature.

Currently, the link points to https://www.elastic.co/guide/en/elasticsearch/reference/7.14/snapshots-restore-snapshot.html#change-index-settings-during-restore, which primarily documents related restore snapshot API parameters.

With elastic/elasticsearch#76929, this section was removed. The new link covers all available index settings, which is a bit more relevant.

### Preview
<img width="1239" alt="Screen Shot 2021-09-20 at 2 03 12 PM" src="https://user-images.githubusercontent.com/40268737/134051796-49090b9b-87da-457f-885f-37264e191821.PNG">


