### PR TITLE
[7.x] [Alerting] Track fields usage in find api (#112096)

### DIFF
--- a/x-pack/plugins/alerting/server/routes/find_rules.test.ts
+++ b/x-pack/plugins/alerting/server/routes/find_rules.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 import { findRulesRoute } from './find_rules';
 import { httpServiceMock } from 'src/core/server/mocks';
 import { licenseStateMock } from '../lib/license_state.mock';
@@ -12,7 +12,6 @@ import { verifyApiAccess } from '../lib/license_api_access';
 import { mockHandlerArguments } from './_mock_handler_arguments';
 import { rulesClientMock } from '../rules_client.mock';
 import { trackLegacyTerminology } from './lib/track_legacy_terminology';
-import { usageCountersServiceMock } from 'src/plugins/usage_collection/server/usage_counters/usage_counters_service.mock';
 
 const rulesClient = rulesClientMock.create();
 const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
@@ -186,5 +185,41 @@ describe('findRulesRoute', () => {
       ['alertTypeId:1', 'message:foo'],
       'alertTypeId',
     ]);
+  });
+
+  it('should track calls to deprecated functionality', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    findRulesRoute(router, licenseState, mockUsageCounter);
+
+    const findResult = {
+      page: 1,
+      perPage: 1,
+      total: 0,
+      data: [],
+    };
+    rulesClient.find.mockResolvedValueOnce(findResult);
+
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { rulesClient },
+      {
+        params: {},
+        query: {
+          fields: ['foo', 'bar'],
+          per_page: 1,
+          page: 1,
+          default_search_operator: 'OR',
+        },
+      },
+      ['ok']
+    );
+    await handler(context, req, res);
+    expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+      counterName: `alertingFieldsUsage`,
+      counterType: 'alertingFieldsUsage',
+      incrementBy: 1,
+    });
   });
 });

--- a/x-pack/plugins/alerting/server/routes/find_rules.ts
+++ b/x-pack/plugins/alerting/server/routes/find_rules.ts
@@ -136,6 +136,14 @@ export const findRulesRoute = (
           search_fields: searchFieldsAsArray(req.query.search_fields),
         });
 
+        if (req.query.fields) {
+          usageCounter?.incrementCounter({
+            counterName: `alertingFieldsUsage`,
+            counterType: 'alertingFieldsUsage',
+            incrementBy: 1,
+          });
+        }
+
         const findResult = await rulesClient.find({ options });
         return res.ok({
           body: rewriteBodyRes(findResult),

--- a/x-pack/plugins/alerting/server/routes/legacy/find.test.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/find.test.ts
@@ -194,4 +194,30 @@ describe('findAlertRoute', () => {
       'alertTypeId',
     ]);
   });
+
+  it('should track calls to deprecated functionality', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+    const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
+    const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');
+
+    findAlertRoute(router, licenseState, mockUsageCounter);
+    const [, handler] = router.get.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { rulesClient },
+      {
+        params: {},
+        query: {
+          fields: ['foo', 'bar'],
+        },
+      },
+      ['ok']
+    );
+    await handler(context, req, res);
+    expect(mockUsageCounter.incrementCounter).toHaveBeenCalledWith({
+      counterName: `legacyAlertingFieldsUsage`,
+      counterType: 'alertingFieldsUsage',
+      incrementBy: 1,
+    });
+  });
 });

--- a/x-pack/plugins/alerting/server/routes/legacy/find.ts
+++ b/x-pack/plugins/alerting/server/routes/legacy/find.ts
@@ -89,6 +89,14 @@ export const findAlertRoute = (
           : [query.search_fields];
       }
 
+      if (query.fields) {
+        usageCounter?.incrementCounter({
+          counterName: `legacyAlertingFieldsUsage`,
+          counterType: 'alertingFieldsUsage',
+          incrementBy: 1,
+        });
+      }
+
       const findResult = await rulesClient.find({ options });
       return res.ok({
         body: findResult,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Alerting] Track fields usage in find api (#112096)