### PR TITLE
[Reporting] Address Canvas PDF test failing in Cloud

### DIFF
--- a/x-pack/test/functional/apps/canvas/reports.ts
+++ b/x-pack/test/functional/apps/canvas/reports.ts
@@ -198,7 +198,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           "
         `);
 
-        expect(res.get('content-length')).to.be('20725');
+        const contentLength = parseInt(res.get('content-length'), 10);
+        expect(contentLength >= 20725 && contentLength <= 20726).to.be(true); // contentLength can be between 20725 and 20726
       });
 
       it('downloaded PDF base64 string is correct without borders and logo', async function () {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/87713

Updates the functional test to allow the content length of the downloaded Canvas report to be between 20725 and 20726