### PR TITLE
Fixes bug with nested terms, one with other bucket and the other disabled

### DIFF
--- a/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
+++ b/src/plugins/data/common/search/aggs/buckets/_terms_other_bucket_helper.ts
@@ -129,7 +129,9 @@ export const buildOtherBucketAgg = (
   aggWithOtherBucket: IBucketAggConfig,
   response: any
 ) => {
-  const bucketAggs = aggConfigs.aggs.filter((agg) => agg.type.type === AggGroupNames.Buckets);
+  const bucketAggs = aggConfigs.aggs.filter(
+    (agg) => agg.type.type === AggGroupNames.Buckets && agg.enabled
+  );
   const index = bucketAggs.findIndex((agg) => agg.id === aggWithOtherBucket.id);
   const aggs = aggConfigs.toDsl();
   const indexPattern = aggWithOtherBucket.aggConfigs.indexPattern;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/112580

## When does it happen?

This bug happens when you have nested aggs and:
1. The first one in the order is disabled (it can be a terms agg, a date_histogram etc). It doesn't matter here if the Other bucket switch is enabled.
2. The second one is a terms agg, is enabled and has the `Group other values` switch enabled
![image](https://user-images.githubusercontent.com/17003240/134135967-00bb5a34-85b0-40a1-ab19-38491d56e342.png)

When we are changing the order it works because the enabled agg becomes the first one which is valid.

## What happens?
As described [here](https://github.com/elastic/kibana/issues/112580#issuecomment-923691298), the bucketAggs[0] is referred to the first agg in the order which in this specific case is the disabled one. For this reason it fails as it expects to receive an enabled aggregation.

## Solution
I filter out the disabled aggs as we don't need them to build the other bucket agg.
I also checked the `mergeOtherBucketAggResponse ` and the `updateMissingBucket ` methods.
- the `mergeOtherBucketAggResponse` doesn't have the logic of fetching the first bucket agg `bucketAggs[0]` so I think that is ok to leave it as it is. 
- the `updateMissingBucket` although receives the aggConfigs, it doesn't uses them.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
