### PR TITLE
[7.15] Fix unable to navigate away from 'Timeline' when additional filter is applied (#111369)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/endpoint/route_capture.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/route_capture.tsx
@@ -9,6 +9,8 @@ import React, { memo, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { AppLocation } from '../../../../common/endpoint/types';
+import { timelineActions } from '../../../timelines/store/timeline';
+import { TimelineId } from '../../../../../timelines/common';
 
 /**
  * This component should be used above all routes, but below the Provider.
@@ -17,6 +19,10 @@ import { AppLocation } from '../../../../common/endpoint/types';
 export const RouteCapture = memo(({ children }) => {
   const location: AppLocation = useLocation();
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(timelineActions.showTimeline({ id: TimelineId.active, show: false }));
+  }, [dispatch, location.pathname]);
 
   useEffect(() => {
     dispatch({ type: 'userChangedUrl', payload: location });

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.test.ts
@@ -7,13 +7,15 @@
 
 import '../../../mock/match_media';
 import { encodeIpv6 } from '../../../lib/helpers';
-import { getBreadcrumbsForRoute, setBreadcrumbs } from '.';
+import { getBreadcrumbsForRoute, useSetBreadcrumbs } from '.';
 import { HostsTableType } from '../../../../hosts/store/model';
 import { RouteSpyState, SiemRouteType } from '../../../utils/route/types';
 import { TabNavigationProps } from '../tab_navigation/types';
 import { NetworkRouteType } from '../../../../network/pages/navigation/types';
 import { TimelineTabs } from '../../../../../common/types/timeline';
 import { AdministrationSubTab } from '../../../../management/types';
+import { renderHook } from '@testing-library/react-hooks';
+import { TestProviders } from '../../../mock';
 
 const setBreadcrumbsMock = jest.fn();
 const chromeMock = {
@@ -438,35 +440,13 @@ describe('Navigation Breadcrumbs', () => {
         },
       ]);
     });
-
-    test('should set "timeline.isOpen" to false when timeline is open', () => {
-      const breadcrumbs = getBreadcrumbsForRoute(
-        {
-          ...getMockObject('timelines', '/', undefined),
-          timeline: {
-            activeTab: TimelineTabs.query,
-            id: 'TIMELINE_ID',
-            isOpen: true,
-            graphEventId: 'GRAPH_EVENT_ID',
-          },
-        },
-        getUrlForAppMock
-      );
-      expect(breadcrumbs).toEqual([
-        { text: 'Security', href: 'securitySolution/overview' },
-        {
-          text: 'Timelines',
-          href:
-            "securitySolution/timelines?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))&timeline=(activeTab:query,graphEventId:GRAPH_EVENT_ID,id:TIMELINE_ID,isOpen:!f)",
-        },
-      ]);
-    });
   });
 
   describe('setBreadcrumbs()', () => {
     test('should call chrome breadcrumb service with correct breadcrumbs', () => {
       const navigateToUrlMock = jest.fn();
-      setBreadcrumbs(
+      const { result } = renderHook(() => useSetBreadcrumbs(), { wrapper: TestProviders });
+      result.current(
         getMockObject('hosts', '/', hostName),
         chromeMock,
         getUrlForAppMock,

--- a/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/breadcrumbs/index.ts
@@ -7,6 +7,7 @@
 
 import { getOr, omit } from 'lodash/fp';
 
+import { useDispatch } from 'react-redux';
 import { ChromeBreadcrumb } from '../../../../../../../../src/core/public';
 import { APP_NAME, APP_ID } from '../../../../../common/constants';
 import { StartServices } from '../../../../types';
@@ -27,33 +28,40 @@ import {
   UebaRouteSpyState,
 } from '../../../utils/route/types';
 import { getAppOverviewUrl } from '../../link_to';
-
+import { timelineActions } from '../../../../../public/timelines/store/timeline';
+import { TimelineId } from '../../../../../common/types/timeline';
 import { TabNavigationProps } from '../tab_navigation/types';
 import { getSearch } from '../helpers';
 import { GetUrlForApp, NavigateToUrl, SearchNavTab } from '../types';
 
-export const setBreadcrumbs = (
-  spyState: RouteSpyState & TabNavigationProps,
-  chrome: StartServices['chrome'],
-  getUrlForApp: GetUrlForApp,
-  navigateToUrl: NavigateToUrl
-) => {
-  const breadcrumbs = getBreadcrumbsForRoute(spyState, getUrlForApp);
-  if (breadcrumbs) {
-    chrome.setBreadcrumbs(
-      breadcrumbs.map((breadcrumb) => ({
-        ...breadcrumb,
-        ...(breadcrumb.href && !breadcrumb.onClick
-          ? {
-              onClick: (ev) => {
-                ev.preventDefault();
-                navigateToUrl(breadcrumb.href!);
-              },
-            }
-          : {}),
-      }))
-    );
-  }
+export const useSetBreadcrumbs = () => {
+  const dispatch = useDispatch();
+  return (
+    spyState: RouteSpyState & TabNavigationProps,
+    chrome: StartServices['chrome'],
+    getUrlForApp: GetUrlForApp,
+    navigateToUrl: NavigateToUrl
+  ) => {
+    const breadcrumbs = getBreadcrumbsForRoute(spyState, getUrlForApp);
+    if (breadcrumbs) {
+      chrome.setBreadcrumbs(
+        breadcrumbs.map((breadcrumb) => ({
+          ...breadcrumb,
+          ...(breadcrumb.href && !breadcrumb.onClick
+            ? {
+                onClick: (ev) => {
+                  ev.preventDefault();
+
+                  dispatch(timelineActions.showTimeline({ id: TimelineId.active, show: false }));
+
+                  navigateToUrl(breadcrumb.href!);
+                },
+              }
+            : {}),
+        }))
+      );
+    }
+  };
 };
 
 const isNetworkRoutes = (spyState: RouteSpyState): spyState is NetworkRouteSpyState =>
@@ -79,14 +87,10 @@ const isRulesRoutes = (spyState: RouteSpyState): spyState is AdministrationRoute
 
 // eslint-disable-next-line complexity
 export const getBreadcrumbsForRoute = (
-  objectParam: RouteSpyState & TabNavigationProps,
+  object: RouteSpyState & TabNavigationProps,
   getUrlForApp: GetUrlForApp
 ): ChromeBreadcrumb[] | null => {
-  const spyState: RouteSpyState = omit('navTabs', objectParam);
-
-  // Sets `timeline.isOpen` to false in the state to avoid reopening the timeline on breadcrumb click. https://github.com/elastic/kibana/issues/100322
-  const object = { ...objectParam, timeline: { ...objectParam.timeline, isOpen: false } };
-
+  const spyState: RouteSpyState = omit('navTabs', object);
   const overviewPath = getUrlForApp(APP_ID, { deepLinkId: SecurityPageName.overview });
   const siemRootBreadcrumb: ChromeBreadcrumb = {
     text: APP_NAME,

--- a/x-pack/plugins/security_solution/public/common/components/navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/index.test.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 
 import { CONSTANTS } from '../url_state/constants';
 import { TabNavigationComponent } from './';
-import { setBreadcrumbs } from './breadcrumbs';
 import { navTabs } from '../../../app/home/home_navigations';
 import { HostsTableType } from '../../../hosts/store/model';
 import { RouteSpyState } from '../../utils/route/types';
@@ -28,8 +27,10 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+const mockSetBreadcrumbs = jest.fn();
+
 jest.mock('./breadcrumbs', () => ({
-  setBreadcrumbs: jest.fn(),
+  useSetBreadcrumbs: () => mockSetBreadcrumbs,
 }));
 const mockGetUrlForApp = jest.fn();
 const mockNavigateToUrl = jest.fn();
@@ -102,7 +103,7 @@ describe('SIEM Navigation', () => {
   };
   const wrapper = mount(<TabNavigationComponent {...mockProps} />);
   test('it calls setBreadcrumbs with correct path on mount', () => {
-    expect(setBreadcrumbs).toHaveBeenNthCalledWith(
+    expect(mockSetBreadcrumbs).toHaveBeenNthCalledWith(
       1,
       {
         detailName: undefined,
@@ -158,7 +159,7 @@ describe('SIEM Navigation', () => {
       tabName: 'authentications',
     });
     wrapper.update();
-    expect(setBreadcrumbs).toHaveBeenNthCalledWith(
+    expect(mockSetBreadcrumbs).toHaveBeenNthCalledWith(
       2,
       {
         detailName: undefined,

--- a/x-pack/plugins/security_solution/public/common/components/navigation/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/index.tsx
@@ -14,7 +14,7 @@ import { useKibana } from '../../lib/kibana';
 import { RouteSpyState } from '../../utils/route/types';
 import { useRouteSpy } from '../../utils/route/use_route_spy';
 import { makeMapStateToProps } from '../url_state/helpers';
-import { setBreadcrumbs } from './breadcrumbs';
+import { useSetBreadcrumbs } from './breadcrumbs';
 import { TabNavigation } from './tab_navigation';
 import { TabNavigationComponentProps, SecuritySolutionTabNavigationProps } from './types';
 
@@ -41,6 +41,8 @@ export const TabNavigationComponent: React.FC<
       chrome,
       application: { getUrlForApp, navigateToUrl },
     } = useKibana().services;
+
+    const setBreadcrumbs = useSetBreadcrumbs();
 
     useEffect(() => {
       if (pathName || pageName) {
@@ -79,6 +81,7 @@ export const TabNavigationComponent: React.FC<
       tabName,
       getUrlForApp,
       navigateToUrl,
+      setBreadcrumbs,
     ]);
 
     return (

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
@@ -17,6 +17,7 @@ import { useDeepEqualSelector } from '../../../hooks/use_selector';
 import { UrlInputsModel } from '../../../store/inputs/model';
 import { useRouteSpy } from '../../../utils/route/use_route_spy';
 import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
+import { TestProviders } from '../../../mock';
 
 jest.mock('../../../lib/kibana/kibana_react');
 jest.mock('../../../lib/kibana');
@@ -96,8 +97,9 @@ describe('useSecuritySolutionNavigation', () => {
   });
 
   it('should create navigation config', async () => {
-    const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(() =>
-      useSecuritySolutionNavigation()
+    const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(
+      () => useSecuritySolutionNavigation(),
+      { wrapper: TestProviders }
     );
 
     expect(result.current).toMatchInlineSnapshot(`
@@ -243,8 +245,9 @@ describe('useSecuritySolutionNavigation', () => {
   // TODO: Steph/ueba remove when no longer experimental
   it('should include ueba when feature flag is on', async () => {
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
-    const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(() =>
-      useSecuritySolutionNavigation()
+    const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(
+      () => useSecuritySolutionNavigation(),
+      { wrapper: TestProviders }
     );
 
     // @ts-ignore possibly undefined, but if undefined we want this test to fail
@@ -259,8 +262,9 @@ describe('useSecuritySolutionNavigation', () => {
           read: true,
         });
 
-        const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(() =>
-          useSecuritySolutionNavigation()
+        const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(
+          () => useSecuritySolutionNavigation(),
+          { wrapper: TestProviders }
         );
 
         const caseNavItem = (result.current?.items || [])[3].items?.find(
@@ -286,8 +290,9 @@ describe('useSecuritySolutionNavigation', () => {
           read: false,
         });
 
-        const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(() =>
-          useSecuritySolutionNavigation()
+        const { result } = renderHook<{}, KibanaPageTemplateProps['solutionNav']>(
+          () => useSecuritySolutionNavigation(),
+          { wrapper: TestProviders }
         );
 
         const caseNavItem = (result.current?.items || [])[3].items?.find(

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.tsx
@@ -8,7 +8,7 @@
 import { useEffect } from 'react';
 import { usePrimaryNavigation } from './use_primary_navigation';
 import { useKibana } from '../../../lib/kibana';
-import { setBreadcrumbs } from '../breadcrumbs';
+import { useSetBreadcrumbs } from '../breadcrumbs';
 import { makeMapStateToProps } from '../../url_state/helpers';
 import { useRouteSpy } from '../../../utils/route/use_route_spy';
 import { navTabs } from '../../../../app/home/home_navigations';
@@ -37,6 +37,9 @@ export const useSecuritySolutionNavigation = () => {
     const { ueba, ...rest } = enabledNavTabs;
     enabledNavTabs = rest;
   }
+
+  const setBreadcrumbs = useSetBreadcrumbs();
+
   useEffect(() => {
     if (pathName || pageName) {
       setBreadcrumbs(
@@ -74,6 +77,7 @@ export const useSecuritySolutionNavigation = () => {
     getUrlForApp,
     navigateToUrl,
     enabledNavTabs,
+    setBreadcrumbs,
   ]);
 
   return usePrimaryNavigation({

--- a/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index.test.tsx
@@ -23,6 +23,7 @@ import {
 import { UrlStateContainerPropTypes } from './types';
 import { useUrlStateHooks } from './use_url_state';
 import { waitFor } from '@testing-library/react';
+import { useLocation } from 'react-router-dom';
 
 let mockProps: UrlStateContainerPropTypes;
 
@@ -59,11 +60,12 @@ jest.mock('../../lib/kibana', () => ({
   },
 }));
 
-jest.mock('react-redux', () => {
-  const original = jest.requireActual('react-redux');
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+
   return {
     ...original,
-    useDispatch: () => jest.fn(),
+    useLocation: jest.fn(),
   };
 });
 
@@ -84,6 +86,11 @@ describe('UrlStateContainer', () => {
               pageName,
               detailName,
             }).relativeTimeSearch.undefinedQuery;
+
+            (useLocation as jest.Mock).mockReturnValue({
+              pathname: mockProps.pathName,
+            });
+
             mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
 
             expect(mockSetRelativeRangeDatePicker.mock.calls[1][0]).toEqual({
@@ -113,6 +120,11 @@ describe('UrlStateContainer', () => {
           (page, namespaceLower, namespaceUpper, examplePath, type, pageName, detailName) => {
             mockProps = getMockPropsObj({ page, examplePath, namespaceLower, pageName, detailName })
               .absoluteTimeSearch.undefinedQuery;
+
+            (useLocation as jest.Mock).mockReturnValue({
+              pathname: mockProps.pathName,
+            });
+
             mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
 
             expect(mockSetAbsoluteRangeDatePicker.mock.calls[1][0]).toEqual({
@@ -138,6 +150,11 @@ describe('UrlStateContainer', () => {
           (page, namespaceLower, namespaceUpper, examplePath, type, pageName, detailName) => {
             mockProps = getMockPropsObj({ page, examplePath, namespaceLower, pageName, detailName })
               .relativeTimeSearch.undefinedQuery;
+
+            (useLocation as jest.Mock).mockReturnValue({
+              pathname: mockProps.pathName,
+            });
+
             mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
 
             expect(mockSetFilterQuery.mock.calls[0][0]).toEqual({
@@ -162,6 +179,11 @@ describe('UrlStateContainer', () => {
               pageName,
               detailName,
             }).noSearch.definedQuery;
+
+            (useLocation as jest.Mock).mockReturnValue({
+              pathname: mockProps.pathName,
+            });
+
             mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
 
             expect(
@@ -176,6 +198,24 @@ describe('UrlStateContainer', () => {
         );
       });
     });
+
+    it("it doesn't update URL state when pathName and browserPAth are out of sync", () => {
+      mockProps = getMockPropsObj({
+        page: CONSTANTS.networkPage,
+        examplePath: '/network',
+        namespaceLower: 'network',
+        pageName: SecurityPageName.network,
+        detailName: undefined,
+      }).noSearch.undefinedQuery;
+
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: 'out of sync path',
+      });
+
+      mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
+
+      expect(mockHistory.replace).not.toHaveBeenCalled();
+    });
   });
 
   describe('After Initialization, keep Relative Date up to date for global only on alerts page', () => {
@@ -189,6 +229,11 @@ describe('UrlStateContainer', () => {
           pageName,
           detailName,
         }).relativeTimeSearch.undefinedQuery;
+
+        (useLocation as jest.Mock).mockReturnValue({
+          pathname: mockProps.pathName,
+        });
+
         const wrapper = mount(
           <HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />
         );

--- a/x-pack/plugins/security_solution/public/common/components/url_state/index_mocked.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index_mocked.test.tsx
@@ -15,6 +15,7 @@ import { CONSTANTS } from './constants';
 import { getFilterQuery, getMockPropsObj, mockHistory, testCases } from './test_dependencies';
 import { UrlStateContainerPropTypes } from './types';
 import { useUrlStateHooks } from './use_url_state';
+import { useLocation } from 'react-router-dom';
 
 let mockProps: UrlStateContainerPropTypes;
 
@@ -31,13 +32,9 @@ jest.mock('../../lib/kibana', () => ({
   }),
 }));
 
-jest.mock('react-redux', () => {
-  const original = jest.requireActual('react-redux');
-  return {
-    ...original,
-    useDispatch: () => jest.fn(),
-  };
-});
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
 
 describe('UrlStateContainer - lodash.throttle mocked to test update url', () => {
   afterEach(() => {
@@ -54,6 +51,11 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         pageName: SecurityPageName.network,
         detailName: undefined,
       }).noSearch.definedQuery;
+
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: mockProps.pathName,
+      });
+
       const wrapper = mount(
         <HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />
       );
@@ -105,6 +107,11 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         pageName: SecurityPageName.network,
         detailName: undefined,
       }).noSearch.undefinedQuery;
+
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: mockProps.pathName,
+      });
+
       const wrapper = mount(
         <HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />
       );
@@ -136,6 +143,10 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         pageName: SecurityPageName.network,
         detailName: undefined,
       }).noSearch.undefinedQuery;
+
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: mockProps.pathName,
+      });
 
       const wrapper = mount(
         <HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />
@@ -170,6 +181,10 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
         detailName: undefined,
       }).noSearch.undefinedQuery;
 
+      (useLocation as jest.Mock).mockReturnValue({
+        pathname: mockProps.pathName,
+      });
+
       const wrapper = mount(
         <HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />
       );
@@ -203,6 +218,11 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
           (page, namespaceLower, namespaceUpper, examplePath, type, pageName, detailName) => {
             mockProps = getMockPropsObj({ page, examplePath, namespaceLower, pageName, detailName })
               .noSearch.undefinedQuery;
+
+            (useLocation as jest.Mock).mockReturnValue({
+              pathname: mockProps.pathName,
+            });
+
             mount(<HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />);
 
             expect(mockHistory.replace.mock.calls[0][0]).toEqual({
@@ -239,6 +259,11 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
             pageName: SecurityPageName.network,
             detailName: undefined,
           }).noSearch.definedQuery;
+
+          (useLocation as jest.Mock).mockReturnValue({
+            pathname: mockProps.pathName,
+          });
+
           const wrapper = mount(
             <HookWrapper hookProps={mockProps} hook={(args) => useUrlStateHooks(args)} />
           );
@@ -249,7 +274,12 @@ describe('UrlStateContainer - lodash.throttle mocked to test update url', () => 
             "?sourcerer=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)),timeline:(linkTo:!(global),timerange:(from:'2019-05-16T23:10:43.696Z',fromStr:now-24h,kind:relative,to:'2019-05-17T23:10:43.697Z',toStr:now)))"
           );
 
+          (useLocation as jest.Mock).mockReturnValue({
+            pathname: updatedProps.pathName,
+          });
+
           wrapper.setProps({ hookProps: updatedProps });
+
           wrapper.update();
 
           expect(

--- a/x-pack/plugins/security_solution/public/common/components/url_state/test_dependencies.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/test_dependencies.ts
@@ -164,13 +164,7 @@ interface GetMockPropsObj {
   detailName: string | undefined;
 }
 
-export const getMockPropsObj = ({
-  page,
-  examplePath,
-  namespaceLower,
-  pageName,
-  detailName,
-}: GetMockPropsObj) => ({
+export const getMockPropsObj = ({ page, examplePath, pageName, detailName }: GetMockPropsObj) => ({
   noSearch: {
     undefinedQuery: getMockProps(
       {

--- a/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/use_url_state.tsx
@@ -9,7 +9,7 @@ import { difference, isEmpty } from 'lodash/fp';
 import { useEffect, useRef, useState } from 'react';
 import deepEqual from 'fast-deep-equal';
 
-import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { useKibana } from '../../lib/kibana';
 import { CONSTANTS, UrlStateType } from './constants';
 import {
@@ -32,9 +32,6 @@ import {
   UrlState,
 } from './types';
 import { TimelineUrl } from '../../../timelines/store/timeline/model';
-import { timelineActions } from '../../../timelines/store/timeline';
-import { TimelineId } from '../../../../../timelines/common';
-
 function usePrevious(value: PreviousLocationUrlState) {
   const ref = useRef<PreviousLocationUrlState>(value);
   useEffect(() => {
@@ -61,20 +58,20 @@ const updateTimelineAtinitialization = (
 export const useUrlStateHooks = ({
   detailName,
   indexPattern,
-  history,
   navTabs,
   pageName,
-  pathName,
-  search,
   setInitialStateFromUrl,
   updateTimeline,
   updateTimelineIsLoading,
   urlState,
+  search,
+  pathName,
+  history,
 }: UrlStateContainerPropTypes) => {
   const [isInitializing, setIsInitializing] = useState(true);
   const { filterManager, savedQueries } = useKibana().services.data.query;
+  const { pathname: browserPathName } = useLocation();
   const prevProps = usePrevious({ pathName, pageName, urlState });
-  const dispatch = useDispatch();
 
   const handleInitialize = (type: UrlStateType, needUpdate?: boolean) => {
     let mySearch = search;
@@ -175,6 +172,14 @@ export const useUrlStateHooks = ({
   };
 
   useEffect(() => {
+    // When browser location and store location are out of sync, skip the execution.
+    //  It happens in three scenarios:
+    //  * When changing urlState and quickly moving to a new location.
+    //  * Redirects as "security/hosts" -> "security/hosts/allHosts"
+    //  * It also happens once on every location change because browserPathName gets updated before pathName
+    // *Warning*: Removing this return would cause redirect loops that crashes the APP.
+    if (browserPathName !== pathName) return;
+
     const type: UrlStateType = getUrlType(pageName);
     if (isInitializing && pageName != null && pageName !== '') {
       handleInitialize(type);
@@ -226,10 +231,9 @@ export const useUrlStateHooks = ({
       });
     } else if (pathName !== prevProps.pathName) {
       handleInitialize(type, isDetectionsPages(pageName));
-      dispatch(timelineActions.showTimeline({ id: TimelineId.active, show: false }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isInitializing, history, pathName, pageName, prevProps, urlState, dispatch]);
+  }, [isInitializing, history, pathName, pageName, prevProps, urlState, browserPathName]);
 
   useEffect(() => {
     document.title = `${getTitle(pageName, detailName, navTabs)} - Kibana`;


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Fix unable to navigate away from 'Timeline' when additional filter is applied (#111369)