### PR TITLE
[Timelion] Better error details on expression evaluation

### DIFF
--- a/src/plugins/vis_types/timelion/public/helpers/timelion_request_handler.ts
+++ b/src/plugins/vis_types/timelion/public/helpers/timelion_request_handler.ts
@@ -120,7 +120,7 @@ export function getTimelionRequestHandler({
         const err = new Error(
           `${i18n.translate('timelion.requestHandlerErrorTitle', {
             defaultMessage: 'Timelion request error',
-          })}: ${e.body.title} ${e.body.message}`
+          })}:${e.body.title ? ' ' + e.body.title : ''} ${e.body.message}`
         );
         err.stack = e.stack;
         throw err;

--- a/src/plugins/vis_types/timelion/server/handlers/chain_runner.js
+++ b/src/plugins/vis_types/timelion/server/handlers/chain_runner.js
@@ -25,7 +25,15 @@ export default function chainRunner(tlConfig) {
   let sheet;
 
   function throwWithCell(cell, exception) {
-    throw new Error(' in cell #' + (cell + 1) + ': ' + exception.message);
+    throw new Error(
+      i18n.translate('timelion.serverSideErrors.errorInCell', {
+        defaultMessage: ' in cell #{number}: {message}',
+        values: {
+          number: cell + 1,
+          message: exception.message,
+        },
+      })
+    );
   }
 
   // Invokes a modifier function, resolving arguments into series as needed

--- a/src/plugins/vis_types/timelion/server/routes/run.ts
+++ b/src/plugins/vis_types/timelion/server/routes/run.ts
@@ -94,15 +94,18 @@ export function runRoute(
         allowedGraphiteUrls: configManager.getGraphiteUrls(),
         esShardTimeout: configManager.getEsShardTimeout(),
       });
-      const chainRunner = chainRunnerFn(tlConfig);
-      const sheet = await Bluebird.all(chainRunner.processRequest(request.body));
-
-      return response.ok({
-        body: {
-          sheet,
-          stats: chainRunner.getStats(),
-        },
-      });
+      try {
+        const chainRunner = chainRunnerFn(tlConfig);
+        const sheet = await Bluebird.all(chainRunner.processRequest(request.body));
+        return response.ok({
+          body: {
+            sheet,
+            stats: chainRunner.getStats(),
+          },
+        });
+      } catch (e) {
+        return response.badRequest({ body: { message: e.message } });
+      }
     })
   );
 }


### PR DESCRIPTION
## Summary

Fixes (partially) #107399
This is a first part of the fix for the linked issue: now the server can send more details about the error due to expression evaluation and the client can show it.

<img width="456" alt="Screenshot 2021-09-21 at 14 51 29" src="https://user-images.githubusercontent.com/924948/134173854-90c654ce-39fa-41a9-8d2f-b38291e70fe6.png">

Next step should be probably to provide better error messages from the server side.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
