### PR TITLE
[7.x] [Reporting/Discover/Search Sessions] Only use relative time filter when generating share data (#112588)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
@@ -112,7 +112,7 @@ export const getTopNavLinks = ({
       const sharingData = await getSharingData(
         searchSource,
         state.appStateContainer.getState(),
-        services.uiSettings
+        services
       );
 
       services.share.toggleShareContextMenu({

--- a/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.test.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.test.ts
@@ -7,32 +7,37 @@
  */
 
 import { Capabilities, IUiSettingsClient } from 'kibana/public';
-import { IndexPattern } from 'src/plugins/data/public';
+import type { IndexPattern } from 'src/plugins/data/public';
+import type { DiscoverServices } from '../../../../build_services';
+import { dataPluginMock } from '../../../../../../data/public/mocks';
 import { createSearchSourceMock } from '../../../../../../data/common/search/search_source/mocks';
 import { DOC_HIDE_TIME_COLUMN_SETTING, SORT_DEFAULT_ORDER_SETTING } from '../../../../../common';
 import { indexPatternMock } from '../../../../__mocks__/index_pattern';
 import { getSharingData, showPublicUrlSwitch } from './get_sharing_data';
 
 describe('getSharingData', () => {
-  let mockConfig: IUiSettingsClient;
+  let services: DiscoverServices;
 
   beforeEach(() => {
-    mockConfig = {
-      get: (key: string) => {
-        if (key === SORT_DEFAULT_ORDER_SETTING) {
-          return 'desc';
-        }
-        if (key === DOC_HIDE_TIME_COLUMN_SETTING) {
+    services = {
+      data: dataPluginMock.createStartContract(),
+      uiSettings: {
+        get: (key: string) => {
+          if (key === SORT_DEFAULT_ORDER_SETTING) {
+            return 'desc';
+          }
+          if (key === DOC_HIDE_TIME_COLUMN_SETTING) {
+            return false;
+          }
           return false;
-        }
-        return false;
+        },
       },
-    } as unknown as IUiSettingsClient;
+    } as DiscoverServices;
   });
 
   test('returns valid data for sharing', async () => {
     const searchSourceMock = createSearchSourceMock({ index: indexPatternMock });
-    const result = await getSharingData(searchSourceMock, { columns: [] }, mockConfig);
+    const result = await getSharingData(searchSourceMock, { columns: [] }, services);
     expect(result).toMatchInlineSnapshot(`
       Object {
         "columns": Array [],
@@ -53,7 +58,7 @@ describe('getSharingData', () => {
     const result = await getSharingData(
       searchSourceMock,
       { columns: ['column_a', 'column_b'] },
-      mockConfig
+      services
     );
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -90,7 +95,7 @@ describe('getSharingData', () => {
           'cool-field-6',
         ],
       },
-      mockConfig
+      services
     );
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -116,7 +121,7 @@ describe('getSharingData', () => {
   });
 
   test('fields conditionally do not have prepended timeField', async () => {
-    mockConfig = {
+    services.uiSettings = {
       get: (key: string) => {
         if (key === DOC_HIDE_TIME_COLUMN_SETTING) {
           return true;
@@ -141,7 +146,7 @@ describe('getSharingData', () => {
           'cool-field-6',
         ],
       },
-      mockConfig
+      services
     );
     expect(result).toMatchInlineSnapshot(`
       Object {

--- a/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.ts
@@ -6,8 +6,10 @@
  * Side Public License, v 1.
  */
 
-import type { Capabilities, IUiSettingsClient } from 'kibana/public';
-import { ISearchSource } from '../../../../../../data/common';
+import type { Capabilities } from 'kibana/public';
+import type { IUiSettingsClient } from 'src/core/public';
+import type { DataPublicPluginStart } from 'src/plugins/data/public';
+import type { ISearchSource } from 'src/plugins/data/common';
 import { DOC_HIDE_TIME_COLUMN_SETTING, SORT_DEFAULT_ORDER_SETTING } from '../../../../../common';
 import type { SavedSearch, SortOrder } from '../../../../saved_searches/types';
 import { getSortForSearchSource } from '../components/doc_table';
@@ -19,8 +21,9 @@ import { AppState } from '../services/discover_state';
 export async function getSharingData(
   currentSearchSource: ISearchSource,
   state: AppState | SavedSearch,
-  config: IUiSettingsClient
+  services: { uiSettings: IUiSettingsClient; data: DataPublicPluginStart }
 ) {
+  const { uiSettings: config, data } = services;
   const searchSource = currentSearchSource.createCopy();
   const index = searchSource.getField('index')!;
 
@@ -28,6 +31,8 @@ export async function getSharingData(
     'sort',
     getSortForSearchSource(state.sort as SortOrder[], index, config.get(SORT_DEFAULT_ORDER_SETTING))
   );
+  // When sharing externally we preserve relative time values
+  searchSource.setField('filter', data.query.timefilter.timefilter.createRelativeFilter(index));
   searchSource.removeField('highlight');
   searchSource.removeField('highlightAll');
   searchSource.removeField('aggs');

--- a/src/plugins/discover/public/application/apps/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/update_search_source.ts
@@ -54,10 +54,8 @@ export function updateSearchSource(
 
     // this is not the default index pattern, it determines that it's not of type rollup
     if (indexPatternsUtils.isDefault(indexPattern)) {
-      searchSource.setField(
-        'filter',
-        data.query.timefilter.timefilter.createRelativeFilter(indexPattern)
-      );
+      // Set the date range filter fields from timeFilter using the absolute format. Search sessions requires that it be converted from a relative range
+      searchSource.setField('filter', data.query.timefilter.timefilter.createFilter(indexPattern));
     }
 
     if (useNewFieldsApi) {

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -11,8 +11,10 @@ import { CoreStart } from 'src/core/public';
 import type { SearchSource } from 'src/plugins/data/common';
 import type { SavedSearch } from 'src/plugins/discover/public';
 import { coreMock } from '../../../../../src/core/public/mocks';
+import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
 import type { ILicense, LicensingPluginSetup } from '../../../licensing/public';
 import { ReportingAPIClient } from '../lib/reporting_api_client';
+import type { ReportingPublicPluginStartDendencies } from '../plugin';
 import type { ActionContext } from './get_csv_panel_action';
 import { ReportingCsvPanelAction } from './get_csv_panel_action';
 
@@ -25,8 +27,8 @@ describe('GetCsvReportPanelAction', () => {
   let context: ActionContext;
   let mockLicense$: (state?: LicenseResults) => Rx.Observable<ILicense>;
   let mockSearchSource: SearchSource;
-  let mockStartServicesPayload: [CoreStart, object, unknown];
-  let mockStartServices$: Rx.Subject<typeof mockStartServicesPayload>;
+  let mockStartServicesPayload: [CoreStart, ReportingPublicPluginStartDendencies, unknown];
+  let mockStartServices$: Rx.Observable<typeof mockStartServicesPayload>;
 
   beforeAll(() => {
     if (typeof window.URL.revokeObjectURL === 'undefined') {
@@ -48,14 +50,17 @@ describe('GetCsvReportPanelAction', () => {
       }) as unknown as LicensingPluginSetup['license$'];
     };
 
-    mockStartServices$ = new Rx.Subject<[CoreStart, object, unknown]>();
     mockStartServicesPayload = [
       {
+        ...core,
         application: { capabilities: { dashboard: { downloadCsv: true } } },
       } as unknown as CoreStart,
-      {},
+      {
+        data: dataPluginMock.createStartContract(),
+      } as ReportingPublicPluginStartDendencies,
       null,
     ];
+    mockStartServices$ = Rx.from(Promise.resolve(mockStartServicesPayload));
 
     mockSearchSource = {
       createCopy: () => mockSearchSource,
@@ -93,7 +98,7 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -130,7 +135,7 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -153,7 +158,7 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -169,7 +174,7 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -187,7 +192,7 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -204,14 +209,13 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
-
+    await mockStartServices$.pipe(first()).toPromise();
     await licenseMock$.pipe(first()).toPromise();
 
     expect(await plugin.isCompatible(context)).toEqual(false);
   });
 
-  it('sets a display and icon type', () => {
+  it('sets a display and icon type', async () => {
     const panel = new ReportingCsvPanelAction({
       core,
       apiClient,
@@ -220,7 +224,7 @@ describe('GetCsvReportPanelAction', () => {
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     expect(panel.getIconType()).toMatchInlineSnapshot(`"document"`);
     expect(panel.getDisplayName()).toMatchInlineSnapshot(`"Download CSV"`);
@@ -228,25 +232,28 @@ describe('GetCsvReportPanelAction', () => {
 
   describe('Application UI Capabilities', () => {
     it(`doesn't allow downloads when UI capability is not enabled`, async () => {
+      mockStartServicesPayload = [
+        { application: { capabilities: {} } } as unknown as CoreStart,
+        {
+          data: dataPluginMock.createStartContract(),
+        } as ReportingPublicPluginStartDendencies,
+        null,
+      ];
+      const startServices$ = Rx.from(Promise.resolve(mockStartServicesPayload));
       const plugin = new ReportingCsvPanelAction({
         core,
         apiClient,
         license$: mockLicense$(),
-        startServices$: mockStartServices$,
+        startServices$,
         usesUiCapabilities: true,
       });
 
-      mockStartServices$.next([
-        { application: { capabilities: {} } } as unknown as CoreStart,
-        {},
-        null,
-      ]);
+      await startServices$.pipe(first()).toPromise();
 
       expect(await plugin.isCompatible(context)).toEqual(false);
     });
 
     it(`allows downloads when license is valid and UI capability is enabled`, async () => {
-      mockStartServices$ = new Rx.Subject();
       const plugin = new ReportingCsvPanelAction({
         core,
         apiClient,
@@ -255,7 +262,7 @@ describe('GetCsvReportPanelAction', () => {
         usesUiCapabilities: true,
       });
 
-      mockStartServices$.next(mockStartServicesPayload);
+      await mockStartServices$.pipe(first()).toPromise();
 
       expect(await plugin.isCompatible(context)).toEqual(true);
     });

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.tsx
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.tsx
@@ -7,7 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 import * as Rx from 'rxjs';
-import type { CoreSetup, IUiSettingsClient, NotificationsSetup } from 'src/core/public';
+import { first } from 'rxjs/operators';
+import type { CoreSetup, NotificationsSetup } from 'src/core/public';
 import { CoreStart } from 'src/core/public';
 import type { ISearchEmbeddable, SavedSearch } from '../../../../../src/plugins/discover/public';
 import {
@@ -22,6 +23,7 @@ import type { LicensingPluginSetup } from '../../../licensing/public';
 import { CSV_REPORTING_ACTION } from '../../common/constants';
 import { checkLicense } from '../lib/license_check';
 import { ReportingAPIClient } from '../lib/reporting_api_client';
+import type { ReportingPublicPluginStartDendencies } from '../plugin';
 
 function isSavedSearchEmbeddable(
   embeddable: IEmbeddable | ISearchEmbeddable
@@ -36,7 +38,7 @@ export interface ActionContext {
 interface Params {
   apiClient: ReportingAPIClient;
   core: CoreSetup;
-  startServices$: Rx.Observable<[CoreStart, object, unknown]>;
+  startServices$: Rx.Observable<[CoreStart, ReportingPublicPluginStartDendencies, unknown]>;
   license$: LicensingPluginSetup['license$'];
   usesUiCapabilities: boolean;
 }
@@ -47,16 +49,16 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
   public readonly id = CSV_REPORTING_ACTION;
   private licenseHasDownloadCsv: boolean = false;
   private capabilityHasDownloadCsv: boolean = false;
-  private uiSettings: IUiSettingsClient;
   private notifications: NotificationsSetup;
   private apiClient: ReportingAPIClient;
+  private startServices$: Params['startServices$'];
 
   constructor({ core, startServices$, license$, usesUiCapabilities, apiClient }: Params) {
     this.isDownloading = false;
 
-    this.uiSettings = core.uiSettings;
     this.notifications = core.notifications;
     this.apiClient = apiClient;
+    this.startServices$ = startServices$;
 
     license$.subscribe((license) => {
       const results = license.check('reporting', 'basic');
@@ -65,7 +67,7 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
     });
 
     if (usesUiCapabilities) {
-      startServices$.subscribe(([{ application }]) => {
+      this.startServices$.subscribe(([{ application }]) => {
         this.capabilityHasDownloadCsv = application.capabilities.dashboard?.downloadCsv === true;
       });
     } else {
@@ -84,11 +86,12 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
   }
 
   public async getSearchSource(savedSearch: SavedSearch, embeddable: ISearchEmbeddable) {
+    const [{ uiSettings }, { data }] = await this.startServices$.pipe(first()).toPromise();
     const { getSharingData } = await loadSharingDataHelpers();
     return await getSharingData(
       savedSearch.searchSource,
-      savedSearch, // TODO: get unsaved state (using embeddale.searchScope): https://github.com/elastic/kibana/issues/43977
-      this.uiSettings
+      savedSearch, // TODO: get unsaved state (using embeddable.searchScope): https://github.com/elastic/kibana/issues/43977
+      { uiSettings, data }
     );
   }
 

--- a/x-pack/plugins/reporting/public/plugin.ts
+++ b/x-pack/plugins/reporting/public/plugin.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import * as Rx from 'rxjs';
 import { catchError, filter, map, mergeMap, takeUntil } from 'rxjs/operators';
+import type { DataPublicPluginStart } from 'src/plugins/data/public';
 import {
   CoreSetup,
   CoreStart,
@@ -77,6 +78,7 @@ export interface ReportingPublicPluginSetupDendencies {
 
 export interface ReportingPublicPluginStartDendencies {
   home: HomePublicPluginStart;
+  data: DataPublicPluginStart;
   management: ManagementStart;
   licensing: LicensingPluginStart;
   uiActions: UiActionsStart;
@@ -134,7 +136,10 @@ export class ReportingPublicPlugin
     return this.contract;
   }
 
-  public setup(core: CoreSetup, setupDeps: ReportingPublicPluginSetupDendencies) {
+  public setup(
+    core: CoreSetup<ReportingPublicPluginStartDendencies>,
+    setupDeps: ReportingPublicPluginSetupDendencies
+  ) {
     const { getStartServices, uiSettings } = core;
     const {
       home,

--- a/x-pack/test/functional/page_objects/search_sessions_management_page.ts
+++ b/x-pack/test/functional/page_objects/search_sessions_management_page.ts
@@ -38,6 +38,7 @@ export function SearchSessionsPageProvider({ getService, getPageObjects }: FtrPr
             mainUrl: $.findTestSubject('sessionManagementNameCol').text(),
             created: $.findTestSubject('sessionManagementCreatedCol').text(),
             expires: $.findTestSubject('sessionManagementExpiresCol').text(),
+            searchesCount: Number($.findTestSubject('sessionManagementNumSearchesCol').text()),
             app: $.findTestSubject('sessionManagementAppIcon').attr('data-test-app-id'),
             view: async () => {
               log.debug('management ui: view the session');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Reporting/Discover/Search Sessions] Only use relative time filter when generating share data (#112588)