### PR TITLE
[DOCS] Removes coming tag from 7.15.0 What's new

### DIFF
--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -1,8 +1,6 @@
 [[whats-new]]
 == What's new in {minor-version}
 
-coming::[7.15.0]
-
 Here are the highlights of what's new and improved in {minor-version}.
 For detailed information about this release,
 check out the <<release-notes, release notes>>.


### PR DESCRIPTION
## Summary

Removes the coming tag from the 7.15.0 What's new.

