### PR TITLE
[DOCS] Removes tag from 7.15.0 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -67,8 +67,6 @@ Review important information about the {kib} 7.x releases.
 [[release-notes-7.15.0]]
 == {kib} 7.15.0
 
-coming::[7.15.0]
-
 For information about the {kib} 7.15.0 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 7.15.0 release notes.