### PR TITLE
[7.14] [Reporting/Discover/Search Sessions] Only use relative time filter when generating share data (#112588)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
+++ b/src/plugins/discover/public/application/apps/main/components/top_nav/get_top_nav_links.ts
@@ -112,7 +112,7 @@ export const getTopNavLinks = ({
       const sharingData = await getSharingData(
         searchSource,
         state.appStateContainer.getState(),
-        services.uiSettings
+        services
       );
 
       services.share.toggleShareContextMenu({

--- a/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.test.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.test.ts
@@ -7,32 +7,37 @@
  */
 
 import { Capabilities, IUiSettingsClient } from 'kibana/public';
-import { IndexPattern } from 'src/plugins/data/public';
+import type { IndexPattern } from 'src/plugins/data/public';
+import type { DiscoverServices } from '../../../../build_services';
+import { dataPluginMock } from '../../../../../../data/public/mocks';
 import { createSearchSourceMock } from '../../../../../../data/common/search/search_source/mocks';
 import { DOC_HIDE_TIME_COLUMN_SETTING, SORT_DEFAULT_ORDER_SETTING } from '../../../../../common';
 import { indexPatternMock } from '../../../../__mocks__/index_pattern';
 import { getSharingData, showPublicUrlSwitch } from './get_sharing_data';
 
 describe('getSharingData', () => {
-  let mockConfig: IUiSettingsClient;
+  let services: DiscoverServices;
 
   beforeEach(() => {
-    mockConfig = ({
-      get: (key: string) => {
-        if (key === SORT_DEFAULT_ORDER_SETTING) {
-          return 'desc';
-        }
-        if (key === DOC_HIDE_TIME_COLUMN_SETTING) {
+    services = {
+      data: dataPluginMock.createStartContract(),
+      uiSettings: {
+        get: (key: string) => {
+          if (key === SORT_DEFAULT_ORDER_SETTING) {
+            return 'desc';
+          }
+          if (key === DOC_HIDE_TIME_COLUMN_SETTING) {
+            return false;
+          }
           return false;
-        }
-        return false;
+        },
       },
-    } as unknown) as IUiSettingsClient;
+    } as DiscoverServices;
   });
 
   test('returns valid data for sharing', async () => {
     const searchSourceMock = createSearchSourceMock({ index: indexPatternMock });
-    const result = await getSharingData(searchSourceMock, { columns: [] }, mockConfig);
+    const result = await getSharingData(searchSourceMock, { columns: [] }, services);
     expect(result).toMatchInlineSnapshot(`
       Object {
         "columns": Array [],
@@ -53,7 +58,7 @@ describe('getSharingData', () => {
     const result = await getSharingData(
       searchSourceMock,
       { columns: ['column_a', 'column_b'] },
-      mockConfig
+      services
     );
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -90,7 +95,7 @@ describe('getSharingData', () => {
           'cool-field-6',
         ],
       },
-      mockConfig
+      services
     );
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -116,7 +121,7 @@ describe('getSharingData', () => {
   });
 
   test('fields conditionally do not have prepended timeField', async () => {
-    mockConfig = ({
+    services.uiSettings = ({
       get: (key: string) => {
         if (key === DOC_HIDE_TIME_COLUMN_SETTING) {
           return true;
@@ -141,7 +146,7 @@ describe('getSharingData', () => {
           'cool-field-6',
         ],
       },
-      mockConfig
+      services
     );
     expect(result).toMatchInlineSnapshot(`
       Object {

--- a/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.ts
@@ -6,8 +6,10 @@
  * Side Public License, v 1.
  */
 
-import type { Capabilities, IUiSettingsClient } from 'kibana/public';
-import { ISearchSource } from '../../../../../../data/common';
+import type { Capabilities } from 'kibana/public';
+import type { IUiSettingsClient } from 'src/core/public';
+import type { DataPublicPluginStart } from 'src/plugins/data/public';
+import type { ISearchSource } from 'src/plugins/data/common';
 import { DOC_HIDE_TIME_COLUMN_SETTING, SORT_DEFAULT_ORDER_SETTING } from '../../../../../common';
 import type { SavedSearch, SortOrder } from '../../../../saved_searches/types';
 import { AppState } from '../services/discover_state';
@@ -19,8 +21,9 @@ import { getSortForSearchSource } from '../../../angular/doc_table';
 export async function getSharingData(
   currentSearchSource: ISearchSource,
   state: AppState | SavedSearch,
-  config: IUiSettingsClient
+  services: { uiSettings: IUiSettingsClient; data: DataPublicPluginStart }
 ) {
+  const { uiSettings: config, data } = services;
   const searchSource = currentSearchSource.createCopy();
   const index = searchSource.getField('index')!;
 
@@ -28,6 +31,8 @@ export async function getSharingData(
     'sort',
     getSortForSearchSource(state.sort as SortOrder[], index, config.get(SORT_DEFAULT_ORDER_SETTING))
   );
+  // When sharing externally we preserve relative time values
+  searchSource.setField('filter', data.query.timefilter.timefilter.createRelativeFilter(index));
   searchSource.removeField('highlight');
   searchSource.removeField('highlightAll');
   searchSource.removeField('aggs');

--- a/src/plugins/discover/public/application/apps/main/utils/update_search_source.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/update_search_source.ts
@@ -57,10 +57,8 @@ export function updateSearchSource(
 
     // this is not the default index pattern, it determines that it's not of type rollup
     if (indexPatternsUtils.isDefault(indexPattern)) {
-      searchSource.setField(
-        'filter',
-        data.query.timefilter.timefilter.createRelativeFilter(indexPattern)
-      );
+      // Set the date range filter fields from timeFilter using the absolute format. Search sessions requires that it be converted from a relative range
+      searchSource.setField('filter', data.query.timefilter.timefilter.createFilter(indexPattern));
     }
 
     if (useNewFieldsApi) {

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -130,7 +130,7 @@ describe('GetCsvReportPanelAction', () => {
     };
 
     const panel = new ReportingCsvPanelAction({
-      ore,
+      core,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -8,18 +8,27 @@
 import * as Rx from 'rxjs';
 import { first } from 'rxjs/operators';
 import { CoreStart } from 'src/core/public';
-import { LicensingPluginSetup } from '../../../licensing/public';
+import type { SearchSource } from 'src/plugins/data/common';
+import type { SavedSearch } from 'src/plugins/discover/public';
+import { coreMock } from '../../../../../src/core/public/mocks';
+import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
+import type { ILicense, LicensingPluginSetup } from '../../../licensing/public';
+import { ReportingAPIClient } from '../lib/reporting_api_client';
+import type { ReportingPublicPluginStartDendencies } from '../plugin';
+import type { ActionContext } from './get_csv_panel_action';
 import { ReportingCsvPanelAction } from './get_csv_panel_action';
 
 type LicenseResults = 'valid' | 'invalid' | 'unavailable' | 'expired';
 
+const core = coreMock.createSetup();
+let apiClient: ReportingAPIClient;
+
 describe('GetCsvReportPanelAction', () => {
-  let core: any;
-  let context: any;
-  let mockLicense$: any;
-  let mockSearchSource: any;
-  let mockStartServicesPayload: [CoreStart, object, unknown];
-  let mockStartServices$: Rx.Subject<typeof mockStartServicesPayload>;
+  let context: ActionContext;
+  let mockLicense$: (state?: LicenseResults) => Rx.Observable<ILicense>;
+  let mockSearchSource: SearchSource;
+  let mockStartServicesPayload: [CoreStart, ReportingPublicPluginStartDendencies, unknown];
+  let mockStartServices$: Rx.Observable<typeof mockStartServicesPayload>;
 
   beforeAll(() => {
     if (typeof window.URL.revokeObjectURL === 'undefined') {
@@ -32,45 +41,36 @@ describe('GetCsvReportPanelAction', () => {
   });
 
   beforeEach(() => {
+    apiClient = new ReportingAPIClient(core.http, core.uiSettings, '7.15.0');
+    jest.spyOn(apiClient, 'createImmediateReport');
+
     mockLicense$ = (state: LicenseResults = 'valid') => {
       return (Rx.of({
         check: jest.fn().mockImplementation(() => ({ state })),
       }) as unknown) as LicensingPluginSetup['license$'];
     };
 
-    mockStartServices$ = new Rx.Subject<[CoreStart, object, unknown]>();
     mockStartServicesPayload = [
       ({
+        ...core,
         application: { capabilities: { dashboard: { downloadCsv: true } } },
       } as unknown) as CoreStart,
-      {},
+      {
+        data: dataPluginMock.createStartContract(),
+      } as ReportingPublicPluginStartDendencies,
       null,
     ];
+    mockStartServices$ = Rx.from(Promise.resolve(mockStartServicesPayload));
 
-    core = {
-      http: {
-        post: jest.fn().mockImplementation(() => Promise.resolve(true)),
-      },
-      notifications: {
-        toasts: {
-          addSuccess: jest.fn(),
-          addDanger: jest.fn(),
-        },
-      },
-      uiSettings: {
-        get: () => 'Browser',
-      },
-    } as any;
-
-    mockSearchSource = {
+    mockSearchSource = ({
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
       getField: jest.fn(),
       getSerializedFields: jest.fn().mockImplementation(() => ({})),
-    };
+    } as unknown) as SearchSource;
 
-    context = {
+    context = ({
       embeddable: {
         type: 'search',
         getSavedSearch: () => {
@@ -86,73 +86,79 @@ describe('GetCsvReportPanelAction', () => {
           },
         }),
       },
-    } as any;
+    } as unknown) as ActionContext;
   });
 
   it('translates empty embeddable context into job params', async () => {
     const panel = new ReportingCsvPanelAction({
       core,
+      apiClient,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
-    expect(core.http.post).toHaveBeenCalledWith(
-      '/api/reporting/v1/generate/immediate/csv_searchsource',
-      {
-        body: '{"searchSource":{},"columns":[],"browserTimezone":"America/New_York"}',
-      }
-    );
+    expect(apiClient.createImmediateReport).toHaveBeenCalledWith({
+      browserTimezone: undefined,
+      columns: [],
+      objectType: 'downloadCsv',
+      searchSource: {},
+      title: undefined,
+      version: '7.15.0',
+    });
   });
 
   it('translates embeddable context into job params', async () => {
-    mockSearchSource = {
+    mockSearchSource = ({
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
       getField: jest.fn(),
       getSerializedFields: jest.fn().mockImplementation(() => ({ testData: 'testDataValue' })),
-    };
+    } as unknown) as SearchSource;
     context.embeddable.getSavedSearch = () => {
-      return {
+      return ({
         searchSource: mockSearchSource,
         columns: ['column_a', 'column_b'],
-      };
+      } as unknown) as SavedSearch;
     };
 
     const panel = new ReportingCsvPanelAction({
       core,
+      apiClient,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
-    expect(core.http.post).toHaveBeenCalledWith(
-      '/api/reporting/v1/generate/immediate/csv_searchsource',
-      {
-        body:
-          '{"searchSource":{"testData":"testDataValue"},"columns":["column_a","column_b"],"browserTimezone":"America/New_York"}',
-      }
-    );
+    expect(apiClient.createImmediateReport).toHaveBeenCalledWith({
+      browserTimezone: undefined,
+      columns: ['column_a', 'column_b'],
+      objectType: 'downloadCsv',
+      searchSource: { testData: 'testDataValue' },
+      title: undefined,
+      version: '7.15.0',
+    });
   });
 
   it('allows downloading for valid licenses', async () => {
     const panel = new ReportingCsvPanelAction({
       core,
+      apiClient,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -162,12 +168,13 @@ describe('GetCsvReportPanelAction', () => {
   it('shows a good old toastie when it successfully starts', async () => {
     const panel = new ReportingCsvPanelAction({
       core,
+      apiClient,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -176,20 +183,16 @@ describe('GetCsvReportPanelAction', () => {
   });
 
   it('shows a bad old toastie when it successfully fails', async () => {
-    const coreFails = {
-      ...core,
-      http: {
-        post: jest.fn().mockImplementation(() => Promise.reject('No more ram!')),
-      },
-    };
+    apiClient.createImmediateReport = jest.fn().mockRejectedValue('No more ram!');
     const panel = new ReportingCsvPanelAction({
-      core: coreFails,
+      core,
+      apiClient,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     await panel.execute(context);
 
@@ -200,27 +203,28 @@ describe('GetCsvReportPanelAction', () => {
     const licenseMock$ = mockLicense$('invalid');
     const plugin = new ReportingCsvPanelAction({
       core,
+      apiClient,
       license$: licenseMock$,
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
-
+    await mockStartServices$.pipe(first()).toPromise();
     await licenseMock$.pipe(first()).toPromise();
 
     expect(await plugin.isCompatible(context)).toEqual(false);
   });
 
-  it('sets a display and icon type', () => {
+  it('sets a display and icon type', async () => {
     const panel = new ReportingCsvPanelAction({
       core,
+      apiClient,
       license$: mockLicense$(),
       startServices$: mockStartServices$,
       usesUiCapabilities: true,
     });
 
-    mockStartServices$.next(mockStartServicesPayload);
+    await mockStartServices$.pipe(first()).toPromise();
 
     expect(panel.getIconType()).toMatchInlineSnapshot(`"document"`);
     expect(panel.getDisplayName()).toMatchInlineSnapshot(`"Download CSV"`);
@@ -228,32 +232,37 @@ describe('GetCsvReportPanelAction', () => {
 
   describe('Application UI Capabilities', () => {
     it(`doesn't allow downloads when UI capability is not enabled`, async () => {
+      mockStartServicesPayload = [
+        ({ application: { capabilities: {} } } as unknown) as CoreStart,
+        {
+          data: dataPluginMock.createStartContract(),
+        } as ReportingPublicPluginStartDendencies,
+        null,
+      ];
+      const startServices$ = Rx.from(Promise.resolve(mockStartServicesPayload));
       const plugin = new ReportingCsvPanelAction({
         core,
+        apiClient,
         license$: mockLicense$(),
-        startServices$: mockStartServices$,
+        startServices$,
         usesUiCapabilities: true,
       });
 
-      mockStartServices$.next([
-        ({ application: { capabilities: {} } } as unknown) as CoreStart,
-        {},
-        null,
-      ]);
+      await startServices$.pipe(first()).toPromise();
 
       expect(await plugin.isCompatible(context)).toEqual(false);
     });
 
     it(`allows downloads when license is valid and UI capability is enabled`, async () => {
-      mockStartServices$ = new Rx.Subject();
       const plugin = new ReportingCsvPanelAction({
         core,
+        apiClient,
         license$: mockLicense$(),
         startServices$: mockStartServices$,
         usesUiCapabilities: true,
       });
 
-      mockStartServices$.next(mockStartServicesPayload);
+      await mockStartServices$.pipe(first()).toPromise();
 
       expect(await plugin.isCompatible(context)).toEqual(true);
     });
@@ -261,6 +270,7 @@ describe('GetCsvReportPanelAction', () => {
     it(`allows download when license is valid and deprecated roles config is enabled`, async () => {
       const plugin = new ReportingCsvPanelAction({
         core,
+        apiClient,
         license$: mockLicense$(),
         startServices$: mockStartServices$,
         usesUiCapabilities: false,

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.tsx
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.tsx
@@ -6,9 +6,9 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import moment from 'moment-timezone';
 import * as Rx from 'rxjs';
-import type { CoreSetup } from 'src/core/public';
+import { first } from 'rxjs/operators';
+import type { CoreSetup, NotificationsSetup } from 'src/core/public';
 import { CoreStart } from 'src/core/public';
 import type { ISearchEmbeddable, SavedSearch } from '../../../../../src/plugins/discover/public';
 import {
@@ -20,9 +20,10 @@ import { ViewMode } from '../../../../../src/plugins/embeddable/public';
 import type { UiActionsActionDefinition as ActionDefinition } from '../../../../../src/plugins/ui_actions/public';
 import { IncompatibleActionError } from '../../../../../src/plugins/ui_actions/public';
 import type { LicensingPluginSetup } from '../../../licensing/public';
-import { API_GENERATE_IMMEDIATE, CSV_REPORTING_ACTION } from '../../common/constants';
-import type { JobParamsDownloadCSV } from '../../server/export_types/csv_searchsource_immediate/types';
+import { CSV_REPORTING_ACTION } from '../../common/constants';
 import { checkLicense } from '../lib/license_check';
+import { ReportingAPIClient } from '../lib/reporting_api_client';
+import type { ReportingPublicPluginStartDendencies } from '../plugin';
 
 function isSavedSearchEmbeddable(
   embeddable: IEmbeddable | ISearchEmbeddable
@@ -30,13 +31,14 @@ function isSavedSearchEmbeddable(
   return embeddable.type === SEARCH_EMBEDDABLE_TYPE;
 }
 
-interface ActionContext {
+export interface ActionContext {
   embeddable: ISearchEmbeddable;
 }
 
 interface Params {
+  apiClient: ReportingAPIClient;
   core: CoreSetup;
-  startServices$: Rx.Observable<[CoreStart, object, unknown]>;
+  startServices$: Rx.Observable<[CoreStart, ReportingPublicPluginStartDendencies, unknown]>;
   license$: LicensingPluginSetup['license$'];
   usesUiCapabilities: boolean;
 }
@@ -47,11 +49,16 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
   public readonly id = CSV_REPORTING_ACTION;
   private licenseHasDownloadCsv: boolean = false;
   private capabilityHasDownloadCsv: boolean = false;
-  private core: CoreSetup;
+  private notifications: NotificationsSetup;
+  private apiClient: ReportingAPIClient;
+  private startServices$: Params['startServices$'];
 
-  constructor({ core, startServices$, license$, usesUiCapabilities }: Params) {
+  constructor({ core, startServices$, license$, usesUiCapabilities, apiClient }: Params) {
     this.isDownloading = false;
-    this.core = core;
+
+    this.notifications = core.notifications;
+    this.apiClient = apiClient;
+    this.startServices$ = startServices$;
 
     license$.subscribe((license) => {
       const results = license.check('reporting', 'basic');
@@ -60,7 +67,7 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
     });
 
     if (usesUiCapabilities) {
-      startServices$.subscribe(([{ application }]) => {
+      this.startServices$.subscribe(([{ application }]) => {
         this.capabilityHasDownloadCsv = application.capabilities.dashboard?.downloadCsv === true;
       });
     } else {
@@ -79,11 +86,12 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
   }
 
   public async getSearchSource(savedSearch: SavedSearch, embeddable: ISearchEmbeddable) {
+    const [{ uiSettings }, { data }] = await this.startServices$.pipe(first()).toPromise();
     const { getSharingData } = await loadSharingDataHelpers();
     return await getSharingData(
       savedSearch.searchSource,
-      savedSearch, // TODO: get unsaved state (using embeddale.searchScope): https://github.com/elastic/kibana/issues/43977
-      this.core.uiSettings
+      savedSearch, // TODO: get unsaved state (using embeddable.searchScope): https://github.com/elastic/kibana/issues/43977
+      { uiSettings, data }
     );
   }
 
@@ -111,24 +119,16 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
     const savedSearch = embeddable.getSavedSearch();
     const { columns, searchSource } = await this.getSearchSource(savedSearch, embeddable);
 
-    // If the TZ is set to the default "Browser", it will not be useful for
-    // server-side export. We need to derive the timezone and pass it as a param
-    // to the export API.
-    // TODO: create a helper utility in Reporting. This is repeated in a few places.
-    const kibanaTimezone = this.core.uiSettings.get('dateFormat:tz');
-    const browserTimezone = kibanaTimezone === 'Browser' ? moment.tz.guess() : kibanaTimezone;
-    const immediateJobParams: JobParamsDownloadCSV = {
+    const immediateJobParams = this.apiClient.getDecoratedJobParams({
       searchSource,
       columns,
-      browserTimezone,
       title: savedSearch.title,
-    };
-
-    const body = JSON.stringify(immediateJobParams);
+      objectType: 'downloadCsv', // FIXME: added for typescript, but immediate download job does not need objectType
+    });
 
     this.isDownloading = true;
 
-    this.core.notifications.toasts.addSuccess({
+    this.notifications.toasts.addSuccess({
       title: i18n.translate('xpack.reporting.dashboard.csvDownloadStartedTitle', {
         defaultMessage: `CSV Download Started`,
       }),
@@ -138,9 +138,9 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
       'data-test-subj': 'csvDownloadStarted',
     });
 
-    await this.core.http
-      .post(`${API_GENERATE_IMMEDIATE}`, { body })
-      .then((rawResponse: string) => {
+    await this.apiClient
+      .createImmediateReport(immediateJobParams)
+      .then((rawResponse) => {
         this.isDownloading = false;
 
         const download = `${savedSearch.title}.csv`;
@@ -166,7 +166,7 @@ export class ReportingCsvPanelAction implements ActionDefinition<ActionContext> 
 
   private onGenerationFail(error: Error) {
     this.isDownloading = false;
-    this.core.notifications.toasts.addDanger({
+    this.notifications.toasts.addDanger({
       title: i18n.translate('xpack.reporting.dashboard.failedCsvDownloadTitle', {
         defaultMessage: `CSV download failed`,
       }),

--- a/x-pack/plugins/reporting/public/plugin.ts
+++ b/x-pack/plugins/reporting/public/plugin.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import * as Rx from 'rxjs';
 import { catchError, filter, map, mergeMap, takeUntil } from 'rxjs/operators';
+import type { DataPublicPluginStart } from 'src/plugins/data/public';
 import {
   CoreSetup,
   CoreStart,
@@ -70,6 +71,7 @@ export interface ReportingPublicPluginSetupDendencies {
 
 export interface ReportingPublicPluginStartDendencies {
   home: HomePublicPluginStart;
+  data: DataPublicPluginStart;
   management: ManagementStart;
   licensing: LicensingPluginStart;
   uiActions: UiActionsStart;
@@ -114,8 +116,11 @@ export class ReportingPublicPlugin
     return this.contract;
   }
 
-  public setup(core: CoreSetup, setupDeps: ReportingPublicPluginSetupDendencies) {
-    const { http, getStartServices, uiSettings } = core;
+  public setup(
+    core: CoreSetup<ReportingPublicPluginStartDendencies>,
+    setupDeps: ReportingPublicPluginSetupDendencies
+  ) {
+    const { getStartServices, http, uiSettings } = core;
     const {
       home,
       management,
@@ -175,7 +180,7 @@ export class ReportingPublicPlugin
 
     uiActions.addTriggerAction(
       CONTEXT_MENU_TRIGGER,
-      new ReportingCsvPanelAction({ core, startServices$, license$, usesUiCapabilities })
+      new ReportingCsvPanelAction({ core, apiClient, startServices$, license$, usesUiCapabilities })
     );
 
     const reportingStart = this.getContract(core);

--- a/x-pack/plugins/reporting/public/plugin.ts
+++ b/x-pack/plugins/reporting/public/plugin.ts
@@ -120,7 +120,7 @@ export class ReportingPublicPlugin
     core: CoreSetup<ReportingPublicPluginStartDendencies>,
     setupDeps: ReportingPublicPluginSetupDendencies
   ) {
-    const { getStartServices, http, uiSettings } = core;
+    const { getStartServices, uiSettings } = core;
     const {
       home,
       management,
@@ -132,7 +132,7 @@ export class ReportingPublicPlugin
     const startServices$ = Rx.from(getStartServices());
     const usesUiCapabilities = !this.config.roles.enabled;
 
-    const apiClient = new ReportingAPIClient(http);
+    const apiClient = new ReportingAPIClient(core.http);
 
     home.featureCatalogue.register({
       id: 'reporting',
@@ -180,7 +180,7 @@ export class ReportingPublicPlugin
 
     uiActions.addTriggerAction(
       CONTEXT_MENU_TRIGGER,
-      new ReportingCsvPanelAction({ core, apiClient, startServices$, license$, usesUiCapabilities })
+      new ReportingCsvPanelAction({ core, startServices$, license$, usesUiCapabilities })
     );
 
     const reportingStart = this.getContract(core);

--- a/x-pack/test/functional/page_objects/search_sessions_management_page.ts
+++ b/x-pack/test/functional/page_objects/search_sessions_management_page.ts
@@ -38,6 +38,7 @@ export function SearchSessionsPageProvider({ getService, getPageObjects }: FtrPr
             mainUrl: $.findTestSubject('sessionManagementNameCol').text(),
             created: $.findTestSubject('sessionManagementCreatedCol').text(),
             expires: $.findTestSubject('sessionManagementExpiresCol').text(),
+            searchesCount: Number($.findTestSubject('sessionManagementNumSearchesCol').text()),
             app: $.findTestSubject('sessionManagementAppIcon').attr('data-test-app-id'),
             view: async () => {
               log.debug('management ui: view the session');

--- a/x-pack/test/search_sessions_integration/tests/apps/discover/async_search.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/discover/async_search.ts
@@ -25,6 +25,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   ]);
   const searchSessions = getService('searchSessions');
   const retry = getService('retry');
+  const toasts = getService('toasts');
 
   describe('discover async search', () => {
     before(async () => {
@@ -104,12 +105,20 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       // load URL to restore a saved session
       await PageObjects.searchSessionsManagement.goTo();
-      const searchSessionList = await PageObjects.searchSessionsManagement.getList();
+      const searchSessionListBeforeRestore = await PageObjects.searchSessionsManagement.getList();
+      const searchesCountBeforeRestore = searchSessionListBeforeRestore[0].searchesCount;
       // navigate to Discover
-      await searchSessionList[0].view();
+      await searchSessionListBeforeRestore[0].view();
       await PageObjects.header.waitUntilLoadingHasFinished();
       await searchSessions.expectState('restored');
       expect(await PageObjects.discover.hasNoResults()).to.be(true);
+      expect(await toasts.getToastCount()).to.be(0); // no session restoration related warnings
+
+      await PageObjects.searchSessionsManagement.goTo();
+      const searchSessionListAfterRestore = await PageObjects.searchSessionsManagement.getList();
+      const searchesCountAfterRestore = searchSessionListAfterRestore[0].searchesCount;
+
+      expect(searchesCountBeforeRestore).to.be(searchesCountAfterRestore); // no new searches started during restore
     });
   });
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [Reporting/Discover/Search Sessions] Only use relative time filter when generating share data (#112588)