### PR TITLE
Prevent ResultSettingsLogic.actions.saveResultSettings from throwing exception after catching API error

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
@@ -321,26 +321,25 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
 
         actions.saving();
 
-        let response;
         try {
-          response = await http.put(url, {
+          const response = await http.put(url, {
             body: JSON.stringify({
               result_fields: values.reducedServerResultFields,
             }),
           });
+
+          actions.initializeResultFields(response.result_fields, values.schema);
+          flashSuccessToast(
+            i18n.translate(
+              'xpack.enterpriseSearch.appSearch.engine.resultSettings.saveSuccessMessage',
+              {
+                defaultMessage: 'Result settings were saved',
+              }
+            )
+          );
         } catch (e) {
           flashAPIErrors(e);
         }
-
-        actions.initializeResultFields(response.result_fields, values.schema);
-        flashSuccessToast(
-          i18n.translate(
-            'xpack.enterpriseSearch.appSearch.engine.resultSettings.saveSuccessMessage',
-            {
-              defaultMessage: 'Result settings were saved',
-            }
-          )
-        );
       }
     },
   }),


### PR DESCRIPTION
## Summary

In service of https://github.com/elastic/kibana/issues/112699 this fixes a codepath in `x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts` would throw an exception after catching an earlier API exception.  