### PR TITLE
[Cases] Switching title to a text field and adding visibleInManagement flags

### DIFF
--- a/x-pack/plugins/cases/server/saved_object_types/cases.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/cases.ts
@@ -117,7 +117,7 @@ export const createCaseSavedObjectType = (
         type: 'keyword',
       },
       title: {
-        type: 'keyword',
+        type: 'text',
       },
       status: {
         type: 'keyword',

--- a/x-pack/plugins/cases/server/saved_object_types/comments.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/comments.ts
@@ -112,5 +112,6 @@ export const createCaseCommentSavedObjectType = ({
   migrations: createCommentsMigrations(migrationDeps),
   management: {
     importableAndExportable: true,
+    visibleInManagement: false,
   },
 });

--- a/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
@@ -51,5 +51,6 @@ export const caseUserActionSavedObjectType: SavedObjectsType = {
   migrations: userActionsMigrations,
   management: {
     importableAndExportable: true,
+    visibleInManagement: false,
   },
 };


### PR DESCRIPTION
This PR fixes two issues:

Issue: https://github.com/elastic/kibana/issues/112659

Searching cases within the Saved Object Management Page was throwing an error because the `title` field was marked as a `keyword`. This has been moved to a `text` field. I tested and it seems like the search behavior in cases works even better than before. Prior to this change the search would have to match the title of a case exactly, now it can match a portion of the title.

![image](https://user-images.githubusercontent.com/56361221/134241221-087ebc1b-1293-4341-9487-fb0e098578da.png)



Issue: https://github.com/elastic/kibana/issues/110146

The comments and user actions saved objects were showing up in the Saved Object Management Page. These are now being hidden so a user should only see the case titles.

![image](https://user-images.githubusercontent.com/56361221/134241321-6b142fba-47e6-441b-a754-17bb323f7815.png)


![image](https://user-images.githubusercontent.com/56361221/134241283-d000bc84-a206-453b-8d13-69e993e77dfb.png)

