### PR TITLE
Suppress ignore_throttled deprecation warning in UI

### DIFF
--- a/src/plugins/data/public/search/fetch/handle_response.tsx
+++ b/src/plugins/data/public/search/fetch/handle_response.tsx
@@ -18,6 +18,15 @@ import { SearchRequest } from '..';
 export function handleResponse(request: SearchRequest, response: IKibanaSearchResponse) {
   const { rawResponse, warning } = response;
   if (warning) {
+    // suppress deprecation warning not actionable by the user
+    if (
+      warning.includes(
+        '[ignore_throttled] parameter is deprecated because frozen indices have been deprecated'
+      )
+    ) {
+      return response;
+    }
+
     getNotifications().toasts.addWarning({
       title: i18n.translate('data.search.searchSource.fetch.warningMessage', {
         defaultMessage: 'Warning: {warning}',


### PR DESCRIPTION
This parameter was deprecated in https://github.com/elastic/elasticsearch/pull/77479

Since the user is unable to do anything about this, we shouldn't give them a deprecation notice for it.

Due to this toast, it's failing the promotion of our ES snapshot and blocking the ML team downstream.