### PR TITLE
Fixes flakiness in timelion viz functional test

### DIFF
--- a/test/functional/apps/visualize/_timelion.ts
+++ b/test/functional/apps/visualize/_timelion.ts
@@ -280,6 +280,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
               '.es(index=logstash-*, timefield=@timestamp, split=',
               'timelionCodeEditor'
             );
+            // wait for split fields to load
+            await common.sleep(300);
             const suggestions = await timelion.getSuggestionItemsText();
 
             expect(suggestions.length).not.to.eql(0);

--- a/test/functional/apps/visualize/_timelion.ts
+++ b/test/functional/apps/visualize/_timelion.ts
@@ -277,17 +277,18 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           it('should show field suggestions for split argument when index pattern set', async () => {
             await monacoEditor.setCodeEditorValue('');
             await monacoEditor.typeCodeEditorValue(
-              '.es(index=logstash-*, timefield=@timestamp ,split=',
+              '.es(index=logstash-*, timefield=@timestamp, split=',
               'timelionCodeEditor'
             );
             const suggestions = await timelion.getSuggestionItemsText();
+
             expect(suggestions.length).not.to.eql(0);
             expect(suggestions[0].includes('@message.raw')).to.eql(true);
           });
 
           it('should show field suggestions for metric argument when index pattern set', async () => {
             await monacoEditor.typeCodeEditorValue(
-              '.es(index=logstash-*, timefield=@timestamp ,metric=avg:',
+              '.es(index=logstash-*, timefield=@timestamp, metric=avg:',
               'timelionCodeEditor'
             );
             const suggestions = await timelion.getSuggestionItemsText();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/112731

This test failed also locally (if you run it alone). The problem is that the syntax of timelion is quite sensitive, especially when it is tested on a functional test like this (the whole expression is added at once and we wait for the fields popover to be displayed)

I added a sleep to give some time to the suggestions to load and also have fixed the timelion expression syntax. I saw that `timefield=@timestamp ,split=` was flaky. Sometimes, the suggestions list were retrieved wrongly (instead of retrieving the suggestions it retrieved the word split). 

Flaky runner (50 times): https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1912/
Flaky runner (50 times): https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1915/