### PR TITLE
[Fleet] Fix possible unhandled promise in preconfiguration service

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -224,7 +224,7 @@ export async function ensurePreconfiguredPackagesAndPolicies(
       }
       // Add the is_managed flag after configuring package policies to avoid errors
       if (shouldAddIsManagedFlag) {
-        agentPolicyService.update(soClient, esClient, policy!.id, { is_managed: true });
+        await agentPolicyService.update(soClient, esClient, policy!.id, { is_managed: true });
       }
     }
   }


### PR DESCRIPTION
## Description 

Add a missing `await` in the preconfiguration service. The fix was done as part of this PR in `master` and `7.x` https://github.com/elastic/kibana/pull/111002 