### PR TITLE
[Fleet] Fix for agent logs dropdowns not showing

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.tsx
@@ -37,7 +37,7 @@ export const DatasetFilter: React.FunctionComponent<{
           field: DATASET_FIELD,
           query: '',
         });
-        setDatasetValues(values.sort());
+        if (values.length > 0) setDatasetValues(values.sort());
       } catch (e) {
         setDatasetValues([AGENT_DATASET]);
       }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useState, useEffect, useCallback } from 'react';
-import { EuiPopover, EuiFilterButton, EuiFilterSelectItem } from '@elastic/eui';
+import { EuiPopover, EuiFilterButton, EuiFilterSelectItem, EuiIcon, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { useStartServices } from '../../../../../hooks';
@@ -57,6 +57,29 @@ export const LogLevelFilter: React.FunctionComponent<{
     fetchValues();
   }, [data.autocomplete]);
 
+  const noLogsFound = (
+    <div className="euiFilterSelect__note">
+      <div className="euiFilterSelect__noteContent">
+        <EuiIcon type="minusInCircle" />
+        <EuiSpacer size="xs" />
+        <p>
+          {i18n.translate('xpack.fleet.agentLogs.logLevelEmpty', {
+            defaultMessage: 'No Logs Found',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+  const filterSelect = levelValues.map((level) => (
+    <EuiFilterSelectItem
+      checked={selectedLevels.includes(level) ? 'on' : undefined}
+      key={level}
+      onClick={() => onToggleLevel(level)}
+    >
+      {level}
+    </EuiFilterSelectItem>
+  ));
+
   return (
     <EuiPopover
       button={
@@ -78,15 +101,7 @@ export const LogLevelFilter: React.FunctionComponent<{
       closePopover={closePopover}
       panelPaddingSize="none"
     >
-      {levelValues.map((level) => (
-        <EuiFilterSelectItem
-          checked={selectedLevels.includes(level) ? 'on' : undefined}
-          key={level}
-          onClick={() => onToggleLevel(level)}
-        >
-          {level}
-        </EuiFilterSelectItem>
-      ))}
+      {levelValues.length === 0 ? noLogsFound : filterSelect}
     </EuiPopover>
   );
 });


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/111271
Fix for the dropdown in Agent logs not rendering properly. There are two different bugs: 

1. The dataset dropdown is supposed to always show at least a default option (`elastic_agent`), but when the query returns an empty array, the default value gets overriden and breaks the popover. So I'm checking that the `datasetValues` are only set when length > 0.
2. The logs dropdown works properly when logs are fetched, but if no logs are found the popover content receives an empty arrays and breaks. In this case I propose to display a string instead.

#### Reproduction steps
- Start your local with
`yarn start --no-base-path`
`yarn es snapshot -E xpack.security.authc.api_key.enabled=true -E http.host=0.0.0.0`
and run the fleet server docker image on another terminal
- Don't add integrations and especially make sure not to have the "elastic agent" integration.
- Check that in Fleet settings the URLs are misconfigured.
- Navigate to fleet > agents > (your agent) > logs. 

- Observe both `dataset` and the `logs` dropdowns rendering properly. `dataset` shows the default option `elastic_agent` and `logs` shows `No logs found`.

#### Before
![Screenshot 2021-09-22 at 16 10 39](https://user-images.githubusercontent.com/16084106/134361043-87f51b0c-94d3-4f3c-b3f4-fbbcf115b21f.png)
![Screenshot 2021-09-22 at 16 10 44](https://user-images.githubusercontent.com/16084106/134361012-68bd40d8-a332-4987-b7ad-f4b62fd1479a.png)

#### After
![Screenshot 2021-09-22 at 16 09 39](https://user-images.githubusercontent.com/16084106/134361225-9d97fcea-30c7-4235-b673-8bd64016d55c.png)

![Screenshot 2021-09-22 at 16 22 28](https://user-images.githubusercontent.com/16084106/134361886-99dcbddb-46df-46af-90c0-930b40842517.png)

### Checklist
Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
