### PR TITLE
Add a handler for a possible promise rejection

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/account_settings/account_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/account_settings/account_settings.test.tsx
@@ -27,6 +27,9 @@ describe('AccountSettings', () => {
   const mockCurrentUser = (user?: unknown) =>
     (getCurrentUser as jest.Mock).mockReturnValue(Promise.resolve(user));
 
+  const mockCurrentUserError = () =>
+    (getCurrentUser as jest.Mock).mockReturnValue(Promise.reject());
+
   beforeAll(() => {
     mockCurrentUser();
   });
@@ -39,6 +42,13 @@ describe('AccountSettings', () => {
 
   it('does not render if the current user does not exist', async () => {
     mockCurrentUser(null);
+    const wrapper = await shallow(<AccountSettings />);
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('does not render if the getCurrentUser promise returns error', async () => {
+    mockCurrentUserError();
     const wrapper = await shallow(<AccountSettings />);
 
     expect(wrapper.isEmptyRender()).toBe(true);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/account_settings/account_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/account_settings/account_settings.tsx
@@ -20,7 +20,12 @@ export const AccountSettings: React.FC = () => {
   const [currentUser, setCurrentUser] = useState<AuthenticatedUser | null>(null);
 
   useEffect(() => {
-    security.authc.getCurrentUser().then(setCurrentUser);
+    security.authc
+      .getCurrentUser()
+      .then(setCurrentUser)
+      .catch(() => {
+        setCurrentUser(null);
+      });
   }, [security.authc]);
 
   const PersonalInfo = useMemo(() => security.uiApi.components.getPersonalInfo, [security.uiApi]);


### PR DESCRIPTION
## Summary

This PR fixes the `UnhandledPromiseRejectionWarning` for the account_settings component. Previosly we were missing `catch` after the Promise call.

The issue was reported in https://github.com/elastic/kibana/issues/112699

| Before | After |
| ------------- | ------------- |
| <img width="1045" alt="Screen Shot 2021-09-22 at 11 59 05 AM" src="https://user-images.githubusercontent.com/11838280/134368632-dc7b093f-d72a-4edc-84b4-5258bd5cd900.png">  | <img width="912" alt="Screen Shot 2021-09-22 at 11 58 12 AM" src="https://user-images.githubusercontent.com/11838280/134368654-750fad8b-1952-494d-9343-456ec8aef189.png">  |