### PR TITLE
[7.x] [Mappings editor] Add multi-field support for ip type (#112477)

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.test.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.test.ts
@@ -10,7 +10,7 @@ jest.mock('../constants', () => {
   return { MAIN_DATA_TYPE_DEFINITION: {}, TYPE_DEFINITION };
 });
 
-import { stripUndefinedValues, getTypeLabelFromField } from './utils';
+import { stripUndefinedValues, getTypeLabelFromField, getFieldMeta } from './utils';
 
 describe('utils', () => {
   describe('stripUndefinedValues()', () => {
@@ -75,6 +75,19 @@ describe('utils', () => {
           type: 'hyperdrive',
         })
       ).toBe('Other: hyperdrive');
+    });
+  });
+
+  describe('getFieldMeta', () => {
+    test('returns "canHaveMultiFields:true" for IP data type', () => {
+      expect(getFieldMeta({ name: 'ip_field', type: 'ip' })).toEqual({
+        canHaveChildFields: false,
+        canHaveMultiFields: true,
+        childFieldsName: 'fields',
+        hasChildFields: false,
+        hasMultiFields: false,
+        isExpanded: false,
+      });
     });
   });
 });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.ts
@@ -40,7 +40,7 @@ import { TreeItem } from '../components/tree';
 export const getUniqueId = () => uuid.v4();
 
 export const getChildFieldsName = (dataType: DataType): ChildFieldName | undefined => {
-  if (dataType === 'text' || dataType === 'keyword') {
+  if (dataType === 'text' || dataType === 'keyword' || dataType === 'ip') {
     return 'fields';
   } else if (dataType === 'object' || dataType === 'nested') {
     return 'properties';


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Mappings editor] Add multi-field support for ip type (#112477)