### PR TITLE
[7.x] [maps] move registerLayerWizard and registerSource to MapsSetupApi (#112465)

### DIFF
--- a/x-pack/plugins/maps/public/api/index.ts
+++ b/x-pack/plugins/maps/public/api/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { MapsStartApi } from './start_api';
+export { MapsSetupApi } from './setup_api';
 export { createLayerDescriptors } from './create_layer_descriptors';
 export { registerLayerWizard, registerSource } from './register';
 export { suggestEMSTermJoinConfig } from './ems';

--- a/x-pack/plugins/maps/public/api/setup_api.ts
+++ b/x-pack/plugins/maps/public/api/setup_api.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SourceRegistryEntry } from '../classes/sources/source_registry';
+import type { LayerWizard } from '../classes/layers/layer_wizard_registry';
+
+export interface MapsSetupApi {
+  registerLayerWizard(layerWizard: LayerWizard): Promise<void>;
+  registerSource(entry: SourceRegistryEntry): Promise<void>;
+}

--- a/x-pack/plugins/maps/public/api/start_api.ts
+++ b/x-pack/plugins/maps/public/api/start_api.ts
@@ -6,8 +6,6 @@
  */
 
 import type { LayerDescriptor } from '../../common/descriptor_types';
-import type { SourceRegistryEntry } from '../classes/sources/source_registry';
-import type { LayerWizard } from '../classes/layers/layer_wizard_registry';
 import type { CreateLayerDescriptorParams } from '../classes/sources/es_search_source';
 import type { SampleValuesConfig, EMSTermJoinConfig } from '../ems_autosuggest';
 
@@ -22,7 +20,5 @@ export interface MapsStartApi {
       params: CreateLayerDescriptorParams
     ) => Promise<LayerDescriptor>;
   };
-  registerLayerWizard(layerWizard: LayerWizard): Promise<void>;
-  registerSource(entry: SourceRegistryEntry): Promise<void>;
   suggestEMSTermJoinConfig(config: SampleValuesConfig): Promise<EMSTermJoinConfig | null>;
 }

--- a/x-pack/plugins/maps/public/index.ts
+++ b/x-pack/plugins/maps/public/index.ts
@@ -18,11 +18,26 @@ export const plugin: PluginInitializer<MapsPluginSetup, MapsPluginStart> = (
 };
 
 export { MAP_SAVED_OBJECT_TYPE } from '../common/constants';
+export type { PreIndexedShape } from '../common/elasticsearch_util';
 
-export type { RenderTooltipContentParams } from './classes/tooltips/tooltip_property';
+export type {
+  ITooltipProperty,
+  RenderTooltipContentParams,
+} from './classes/tooltips/tooltip_property';
 
-export { MapsStartApi } from './api';
+export type { MapsSetupApi, MapsStartApi } from './api';
 
 export type { MapEmbeddable, MapEmbeddableInput, MapEmbeddableOutput } from './embeddable';
 
 export type { EMSTermJoinConfig, SampleValuesConfig } from './ems_autosuggest';
+
+export type { IVectorSource, GeoJsonWithMeta } from './classes/sources/vector_source/vector_source';
+export type { ImmutableSourceProperty, SourceEditorArgs } from './classes/sources/source';
+export type { Attribution } from '../common/descriptor_types';
+export type {
+  BoundsRequestMeta,
+  SourceTooltipConfig,
+} from './classes/sources/vector_source/vector_source';
+export type { IField } from './classes/fields/field';
+export type { LayerWizard, RenderWizardArguments } from './classes/layers/layer_wizard_registry';
+export type { DataRequest } from './classes/util/data_request';

--- a/x-pack/plugins/maps/public/plugin.ts
+++ b/x-pack/plugins/maps/public/plugin.ts
@@ -50,6 +50,7 @@ import {
   createLayerDescriptors,
   registerLayerWizard,
   registerSource,
+  MapsSetupApi,
   MapsStartApi,
   suggestEMSTermJoinConfig,
 } from './api';
@@ -128,7 +129,7 @@ export class MapsPlugin
     this._initializerContext = initializerContext;
   }
 
-  public setup(core: CoreSetup, plugins: MapsPluginSetupDependencies) {
+  public setup(core: CoreSetup, plugins: MapsPluginSetupDependencies): MapsSetupApi {
     registerLicensedFeatures(plugins.licensing);
 
     const config = this._initializerContext.config.get<MapsConfigType>();
@@ -178,6 +179,11 @@ export class MapsPlugin
         return renderApp(params, UsageTracker);
       },
     });
+
+    return {
+      registerLayerWizard,
+      registerSource,
+    };
   }
 
   public start(core: CoreStart, plugins: MapsPluginStartDependencies): MapsStartApi {
@@ -195,8 +201,6 @@ export class MapsPlugin
 
     return {
       createLayerDescriptors,
-      registerLayerWizard,
-      registerSource,
       suggestEMSTermJoinConfig,
     };
   }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [maps] move registerLayerWizard and registerSource to MapsSetupApi (#112465)