### PR TITLE
Failing test: X-Pack Case API Integration Tests.x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters·ts - cases security only enabled: trial Common get_reporters User: security solution only - should read the correct reporters

### DIFF
--- a/x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters.ts
+++ b/x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters.ts
@@ -28,14 +28,17 @@ import {
   superUserDefaultSpaceAuth,
   obsSecDefaultSpaceAuth,
 } from '../../../../utils';
+import { UserInfo } from '../../../../../common/lib/authentication/types';
+
+const sortReporters = (reporters: UserInfo[]) =>
+  reporters.sort((a, b) => a.username.localeCompare(b.username));
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const es = getService('es');
 
-  // Failing: See https://github.com/elastic/kibana/issues/106658
-  describe.skip('get_reporters', () => {
+  describe('get_reporters', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
     });
@@ -80,7 +83,10 @@ export default ({ getService }: FtrProviderContext): void => {
           },
         });
 
-        expect(reporters).to.eql(scenario.expectedReporters);
+        // sort reporters to prevent order failure
+        expect(sortReporters(reporters as unknown as UserInfo[])).to.eql(
+          sortReporters(scenario.expectedReporters)
+        );
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/106658

The test had a problem comparing the _reporters_ response and the expected array, as the order of the response items may change, since it is the expected behavior we can just sort both arrays before comparing.
