### PR TITLE
Unskip a functional test ( test_huge_fields.js) 

### DIFF
--- a/test/functional/apps/management/_test_huge_fields.js
+++ b/test/functional/apps/management/_test_huge_fields.js
@@ -14,7 +14,7 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['common', 'home', 'settings']);
 
   // FLAKY: https://github.com/elastic/kibana/issues/89031
-  describe.skip('test large number of fields', function () {
+  describe('test large number of fields', function () {
     this.tags(['skipCloud']);
 
     const EXPECTED_FIELD_COUNT = '10006';


### PR DESCRIPTION
Trying to skip this functional test . Has been consistently passing on my local . 

Fixes: https://github.com/elastic/kibana/issues/89031

Ref : https://github.com/elastic/kibana/pull/110310