### PR TITLE
[reporting] Remove async from ContentStream._final implementation

### DIFF
--- a/x-pack/plugins/reporting/server/lib/content_stream.ts
+++ b/x-pack/plugins/reporting/server/lib/content_stream.ts
@@ -288,13 +288,14 @@ export class ContentStream extends Duplex {
     }
   }
 
-  async _final(callback: Callback) {
-    try {
-      await this.flush();
-      callback();
-    } catch (error) {
-      callback(error);
-    }
+  // Starting in Node 16.5.0+
+  // this can either return a promise or
+  // use a callback, but not both
+  // see https://github.com/nodejs/node/issues/39535
+  _final(callback: Callback) {
+    this.flush()
+      .then(() => callback())
+      .catch((e) => callback(e));
   }
 
   getSeqNo(): number | undefined {


### PR DESCRIPTION
Starting in Node 16.5.0, Node will throw an error if a stream is
finished more than once.  Our _final implementation returns a promise
and executes the finish callback causing an error to throw.

Testing
- Reports should build as they did before
- Streams should finish after flushing - covered in content_stream.test.ts
- Tests should pass
```
nvm use v16.9.1
node scripts/jest x-pack/plugins/reporting/server/lib/
```

Part of https://github.com/elastic/kibana/issues/98650
