### PR TITLE
Revert "[Cases] Adding cases team owner to cases directories"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -381,9 +381,9 @@
 #CC# /x-pack/plugins/security_solution/ @elastic/security-solution
 
 # Security Solution sub teams
-/x-pack/plugins/cases @elastic/security-threat-hunting-cases
+/x-pack/plugins/cases @elastic/security-threat-hunting
 /x-pack/plugins/timelines @elastic/security-threat-hunting
-/x-pack/test/case_api_integration @elastic/security-threat-hunting-cases
+/x-pack/test/case_api_integration @elastic/security-threat-hunting
 /x-pack/plugins/lists @elastic/security-detections-response
 
 ## Security Solution sub teams - security-onboarding-and-lifecycle-mgt


### PR DESCRIPTION
Reverts elastic/kibana#112835

We were hoping that it would still allow the parent `security-threat-hunting` team to count for reviews but it doesn't seem to be working.

@cnasikas do you have any other ideas before we revert this?