### PR TITLE
[7.15] fix order problem and un-skip test (#112863)

### DIFF
--- a/x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters.ts
+++ b/x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters.ts
@@ -28,14 +28,17 @@ import {
   superUserDefaultSpaceAuth,
   obsSecDefaultSpaceAuth,
 } from '../../../../utils';
+import { UserInfo } from '../../../../../common/lib/authentication/types';
+
+const sortReporters = (reporters: UserInfo[]) =>
+  reporters.sort((a, b) => a.username.localeCompare(b.username));
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const es = getService('es');
 
-  // Failing: See https://github.com/elastic/kibana/issues/106658
-  describe.skip('get_reporters', () => {
+  describe('get_reporters', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
     });
@@ -80,7 +83,10 @@ export default ({ getService }: FtrProviderContext): void => {
           },
         });
 
-        expect(reporters).to.eql(scenario.expectedReporters);
+        // sort reporters to prevent order failure
+        expect(sortReporters(reporters as unknown as UserInfo[])).to.eql(
+          sortReporters(scenario.expectedReporters)
+        );
       }
     });
 

--- a/x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters.ts
+++ b/x-pack/test/case_api_integration/security_only/tests/common/cases/reporters/get_reporters.ts
@@ -84,7 +84,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         // sort reporters to prevent order failure
-        expect(sortReporters(reporters as unknown as UserInfo[])).to.eql(
+        expect(sortReporters((reporters as unknown) as UserInfo[])).to.eql(
           sortReporters(scenario.expectedReporters)
         );
       }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - fix order problem and un-skip test (#112863)