### PR TITLE
[Cases] Check cases configuration on functional testing

### DIFF
--- a/x-pack/test/case_api_integration/common/config.ts
+++ b/x-pack/test/case_api_integration/common/config.ts
@@ -93,6 +93,8 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         .isDirectory()
     );
 
+    const casesConfig = ['--xpack.cases.enabled'];
+
     return {
       testFiles: testFiles ? testFiles : [require.resolve('../tests/common')],
       servers,
@@ -115,6 +117,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         ...xPackApiIntegrationTestsConfig.get('kbnTestServer'),
         serverArgs: [
           ...xPackApiIntegrationTestsConfig.get('kbnTestServer.serverArgs'),
+          ...casesConfig,
           `--xpack.actions.allowedHosts=${JSON.stringify(['localhost', 'some.non.existent.com'])}`,
           `--xpack.actions.enabledActionTypes=${JSON.stringify(enabledActionTypes)}`,
           '--xpack.eventLog.logEntries=true',

--- a/x-pack/test/case_api_integration/common/config.ts
+++ b/x-pack/test/case_api_integration/common/config.ts
@@ -93,7 +93,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         .isDirectory()
     );
 
-    const casesConfig = ['--xpack.cases.enabled'];
+    const casesConfig = ['--xpack.cases.enabled=true'];
 
     return {
       testFiles: testFiles ? testFiles : [require.resolve('../tests/common')],


### PR DESCRIPTION
## Summary

PR #107637 fixed a bug where accidentally the `xpack.cases.enabled` changed. By passing in the configuration to our functional tests we can prevent that from happening again as the following error should be thrown 

```
[fatal][root] CriticalError: Unknown configuration key(s): "xpack.cases.enabled". Check for spelling errors and ensure that expected plugins are installed.
    at ensureValidConfiguration {
  code: 'InvalidConfig',
  processExitCode: 64,
  cause: undefined
}

 FATAL  Error: Unknown configuration key(s): "xpack.cases.enabled". Check for spelling errors and ensure that expected plugins are installed.
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
