### PR TITLE
[docker] Tag cloud images to kibana-ci

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -47,7 +47,7 @@ export async function runDockerGenerator(
 
   // General docker var config
   const license = 'Elastic License';
-  const imageTag = 'docker.elastic.co/kibana/kibana';
+  const imageTag = `docker.elastic.co/kibana${flags.cloud ? '-ci' : ''}/kibana`;
   const version = config.getBuildVersion();
   const artifactArchitecture = flags.architecture === 'aarch64' ? 'aarch64' : 'x86_64';
   const artifactPrefix = `kibana-${version}-linux`;


### PR DESCRIPTION
[skip-ci]

Cloud images should be part of the kibana-ci namespace.