### PR TITLE
[7.15] Add license querystring to EMS requests in Vega (#112765)

### DIFF
--- a/src/plugins/vis_type_vega/public/vega_view/vega_map_view/map_service_settings.ts
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_map_view/map_service_settings.ts
@@ -66,6 +66,11 @@ export class MapServiceSettings {
       tileApiUrl: this.config.emsTileApiUrl,
       landingPageUrl: this.config.emsLandingPageUrl,
     });
+
+    // Allow zooms > 10 for Vega Maps
+    // any kibana user, regardless of distribution, should get all zoom levels
+    // use `sspl` license to indicate this
+    this.emsClient.addQueryParams({ license: 'sspl' });
   }
 
   public async getTmsService(tmsTileLayer: string) {


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Add license querystring to EMS requests in Vega (#112765)