### PR TITLE
[Fleet] Rename misleading functions setupIngestManager and createAgentPolicyChangeAction

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -136,7 +136,7 @@ export const createAgentPolicyHandler: RequestHandler<
       });
     }
 
-    await agentPolicyService.createFleetPolicyChangeAction(soClient, agentPolicy.id);
+    await agentPolicyService.createFleetServerPolicy(soClient, agentPolicy.id);
 
     const body: CreateAgentPolicyResponse = {
       item: agentPolicy,

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.test.ts
@@ -11,17 +11,17 @@ import type { PostFleetSetupResponse } from '../../../common';
 import { RegistryError } from '../../errors';
 import { createAppContextStartContractMock, xpackMocks } from '../../mocks';
 import { appContextService } from '../../services/app_context';
-import { setupIngestManager } from '../../services/setup';
+import { setupFleet } from '../../services/setup';
 
 import { fleetSetupHandler } from './handlers';
 
 jest.mock('../../services/setup', () => {
   return {
-    setupIngestManager: jest.fn(),
+    setupFleet: jest.fn(),
   };
 });
 
-const mockSetupIngestManager = setupIngestManager as jest.MockedFunction<typeof setupIngestManager>;
+const mockSetupFleet = setupFleet as jest.MockedFunction<typeof setupFleet>;
 
 describe('FleetSetupHandler', () => {
   let context: ReturnType<typeof xpackMocks.createRequestHandlerContext>;
@@ -45,7 +45,7 @@ describe('FleetSetupHandler', () => {
   });
 
   it('POST /setup succeeds w/200 and body of resolved value', async () => {
-    mockSetupIngestManager.mockImplementation(() =>
+    mockSetupFleet.mockImplementation(() =>
       Promise.resolve({
         isInitialized: true,
         nonFatalErrors: [],
@@ -59,9 +59,7 @@ describe('FleetSetupHandler', () => {
   });
 
   it('POST /setup fails w/500 on custom error', async () => {
-    mockSetupIngestManager.mockImplementation(() =>
-      Promise.reject(new Error('SO method mocked to throw'))
-    );
+    mockSetupFleet.mockImplementation(() => Promise.reject(new Error('SO method mocked to throw')));
     await fleetSetupHandler(context, request, response);
 
     expect(response.customError).toHaveBeenCalledTimes(1);
@@ -74,7 +72,7 @@ describe('FleetSetupHandler', () => {
   });
 
   it('POST /setup fails w/502 on RegistryError', async () => {
-    mockSetupIngestManager.mockImplementation(() =>
+    mockSetupFleet.mockImplementation(() =>
       Promise.reject(new RegistryError('Registry method mocked to throw'))
     );
 

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -9,7 +9,7 @@ import type { RequestHandler } from 'src/core/server';
 
 import { appContextService } from '../../services';
 import type { GetFleetStatusResponse, PostFleetSetupResponse } from '../../../common';
-import { setupIngestManager } from '../../services/setup';
+import { setupFleet } from '../../services/setup';
 import { hasFleetServers } from '../../services/fleet_server';
 import { defaultIngestErrorHandler } from '../../errors';
 
@@ -46,7 +46,7 @@ export const fleetSetupHandler: RequestHandler = async (context, request, respon
   try {
     const soClient = context.core.savedObjects.client;
     const esClient = context.core.elasticsearch.client.asCurrentUser;
-    const setupStatus = await setupIngestManager(soClient, esClient);
+    const setupStatus = await setupFleet(soClient, esClient);
     const body: PostFleetSetupResponse = {
       ...setupStatus,
       nonFatalErrors: setupStatus.nonFatalErrors.map((e) => {

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -429,7 +429,7 @@ class AgentPolicyService {
       throw new Error('Copied agent policy not found');
     }
 
-    await this.createFleetPolicyChangeAction(soClient, newAgentPolicy.id);
+    await this.createFleetServerPolicy(soClient, newAgentPolicy.id);
 
     return updatedAgentPolicy;
   }
@@ -655,10 +655,11 @@ class AgentPolicyService {
     };
   }
 
-  public async createFleetPolicyChangeAction(
+  public async createFleetServerPolicy(
     soClient: SavedObjectsClientContract,
     agentPolicyId: string
   ) {
+    // Use internal ES client so we have permissions to write to .fleet* indices
     const esClient = appContextService.getInternalUserESClient();
     const defaultOutputId = await outputService.getDefaultOutputId(soClient);
 
@@ -666,14 +667,6 @@ class AgentPolicyService {
       return;
     }
 
-    await this.createFleetPolicyChangeFleetServer(soClient, esClient, agentPolicyId);
-  }
-
-  public async createFleetPolicyChangeFleetServer(
-    soClient: SavedObjectsClientContract,
-    esClient: ElasticsearchClient,
-    agentPolicyId: string
-  ) {
     const policy = await agentPolicyService.get(soClient, agentPolicyId);
     const fullPolicy = await agentPolicyService.getFullAgentPolicy(soClient, agentPolicyId);
     if (!policy || !fullPolicy || !fullPolicy.revision) {

--- a/x-pack/plugins/fleet/server/services/agent_policy_update.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_update.ts
@@ -43,11 +43,11 @@ export async function agentPolicyUpdateEventHandler(
       name: 'Default',
       agentPolicyId,
     });
-    await agentPolicyService.createFleetPolicyChangeAction(internalSoClient, agentPolicyId);
+    await agentPolicyService.createFleetServerPolicy(internalSoClient, agentPolicyId);
   }
 
   if (action === 'updated') {
-    await agentPolicyService.createFleetPolicyChangeAction(internalSoClient, agentPolicyId);
+    await agentPolicyService.createFleetServerPolicy(internalSoClient, agentPolicyId);
   }
 
   if (action === 'deleted') {

--- a/x-pack/plugins/fleet/server/services/agents/setup.ts
+++ b/x-pack/plugins/fleet/server/services/agents/setup.ts
@@ -11,12 +11,9 @@ import { SO_SEARCH_LIMIT } from '../../constants';
 import { agentPolicyService } from '../agent_policy';
 
 /**
- * During the migration from 7.9 to 7.10 we introduce a new agent action POLICY_CHANGE per policy
- * this function ensure that action exist for each policy
- *
- * @param soClient
+ * Ensure a .fleet-policy document exist for each agent policy so Fleet server can retrieve it
  */
-export async function ensureAgentActionPolicyChangeExists(
+export async function ensureFleetServerAgentPoliciesExists(
   soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient
 ) {
@@ -32,7 +29,7 @@ export async function ensureAgentActionPolicyChangeExists(
       ));
 
       if (!policyChangeActionExist) {
-        return agentPolicyService.createFleetPolicyChangeAction(soClient, agentPolicy.id);
+        return agentPolicyService.createFleetServerPolicy(soClient, agentPolicy.id);
       }
     })
   );

--- a/x-pack/plugins/fleet/server/services/epm/registry/requests.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/requests.test.ts
@@ -15,7 +15,7 @@ const { Response, FetchError } = jest.requireActual('node-fetch');
 const fetchMock = require('node-fetch') as jest.Mock;
 
 jest.setTimeout(120 * 1000);
-describe('setupIngestManager', () => {
+describe('Registry request', () => {
   beforeEach(async () => {});
 
   afterEach(async () => {

--- a/x-pack/plugins/fleet/server/services/fleet_server/saved_object_migrations.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_server/saved_object_migrations.ts
@@ -190,11 +190,7 @@ async function migrateAgentPolicies() {
 
       // @ts-expect-error value is number | TotalHits
       if (res.body.hits.total.value === 0) {
-        return agentPolicyService.createFleetPolicyChangeFleetServer(
-          soClient,
-          esClient,
-          agentPolicy.id
-        );
+        return agentPolicyService.createFleetServerPolicy(soClient, agentPolicy.id);
       }
     })
   );

--- a/x-pack/plugins/fleet/server/services/setup.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup.test.ts
@@ -8,7 +8,7 @@
 import { createAppContextStartContractMock, xpackMocks } from '../mocks';
 
 import { appContextService } from './app_context';
-import { setupIngestManager } from './setup';
+import { setupFleet } from './setup';
 
 const mockedMethodThrowsError = () =>
   jest.fn().mockImplementation(() => {
@@ -21,7 +21,7 @@ const mockedMethodThrowsCustom = () =>
     throw new CustomTestError('method mocked to throw');
   });
 
-describe('setupIngestManager', () => {
+describe('setupFleet', () => {
   let context: ReturnType<typeof xpackMocks.createRequestHandlerContext>;
 
   beforeEach(async () => {
@@ -44,7 +44,7 @@ describe('setupIngestManager', () => {
       soClient.update = mockedMethodThrowsError();
       const esClient = context.core.elasticsearch.client.asCurrentUser;
 
-      const setupPromise = setupIngestManager(soClient, esClient);
+      const setupPromise = setupFleet(soClient, esClient);
       await expect(setupPromise).rejects.toThrow('SO method mocked to throw');
       await expect(setupPromise).rejects.toThrow(Error);
     });
@@ -57,7 +57,7 @@ describe('setupIngestManager', () => {
       soClient.update = mockedMethodThrowsCustom();
       const esClient = context.core.elasticsearch.client.asCurrentUser;
 
-      const setupPromise = setupIngestManager(soClient, esClient);
+      const setupPromise = setupFleet(soClient, esClient);
       await expect(setupPromise).rejects.toThrow('method mocked to throw');
       await expect(setupPromise).rejects.toThrow(CustomTestError);
     });

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -25,7 +25,7 @@ import { outputService } from './output';
 import { generateEnrollmentAPIKey, hasEnrollementAPIKeysForPolicy } from './api_keys';
 import { settingsService } from '.';
 import { awaitIfPending } from './setup_utils';
-import { ensureAgentActionPolicyChangeExists } from './agents';
+import { ensureFleetServerAgentPoliciesExists } from './agents';
 import { awaitIfFleetServerSetupPending } from './fleet_server';
 import { ensureFleetFinalPipelineIsInstalled } from './epm/elasticsearch/ingest_pipeline/install';
 import { ensureDefaultComponentTemplate } from './epm/elasticsearch/template/install';
@@ -38,7 +38,7 @@ export interface SetupStatus {
   nonFatalErrors: Array<PreconfigurationError | DefaultPackagesInstallationError>;
 }
 
-export async function setupIngestManager(
+export async function setupFleet(
   soClient: SavedObjectsClientContract,
   esClient: ElasticsearchClient
 ): Promise<SetupStatus> {
@@ -101,7 +101,7 @@ async function createSetupSideEffects(
   await cleanPreconfiguredOutputs(soClient, outputsOrUndefined ?? []);
 
   await ensureDefaultEnrollmentAPIKeysExists(soClient, esClient);
-  await ensureAgentActionPolicyChangeExists(soClient, esClient);
+  await ensureFleetServerAgentPoliciesExists(soClient, esClient);
 
   return {
     isInitialized: true,


### PR DESCRIPTION
## Description 

While working on sharing knowledge on the Fleet setup I found we have these two functions that are misleading
* `setupIngestManager` I renamed `setupFleet` as IngestManager is a memory from the old plugin name
* `createAgentPolicyChangeAction` that I renamed `createFleetServerPolicy`, added some basic unit tests here