### PR TITLE
[DOCS] Fix broken link to proxy description

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -206,7 +206,7 @@ export class DocLinksService {
           nodeRoles: `${ELASTICSEARCH_DOCS}modules-node.html#node-roles`,
           releaseHighlights: `${ELASTICSEARCH_DOCS}release-highlights.html`,
           remoteClusters: `${ELASTICSEARCH_DOCS}remote-clusters.html`,
-          remoteClustersProxy: `${ELASTICSEARCH_DOCS}remote-clusters.html#proxy-mode`,
+          remoteClustersProxy: `${ELASTICSEARCH_DOCS}remote-clusters.html#proxy-mode-remote`,
           remoteClusersProxySettings: `${ELASTICSEARCH_DOCS}remote-clusters-settings.html#remote-cluster-proxy-settings`,
           scriptParameters: `${ELASTICSEARCH_DOCS}modules-scripting-using.html#prefer-params`,
           setupUpgrade: `${ELASTICSEARCH_DOCS}setup-upgrade.html`,


### PR DESCRIPTION
## Summary

Fixes a broken link in 7.15 that was updated via redirect. 

Build reference: https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/11158/

```
17:39:16 INFO:build_docs:  Kibana [7.15]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
17:39:16 INFO:build_docs:   - en/elasticsearch/reference/7.15/remote-clusters.html#proxy-mode
```

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
