### PR TITLE
[Alerting][Docs] Elasticsearch setting `search.allow_expensive_queries` should be set as true.

### DIFF
--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -20,8 +20,8 @@ If you are using an *on-premises* Elastic Stack deployment with <<using-kibana-w
 * You must enable Transport Layer Security (TLS) for communication <<configuring-tls-kib-es, between {es} and {kib}>>. {kib} alerting uses <<api-keys, API keys>> to secure background rule checks and actions, and API keys require {ref}/configuring-tls.html#tls-http[TLS on the HTTP interface]. A proxy will not suffice.
 * If you have enabled TLS and are still unable to access Alerting, ensure that you have not {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
 
-Allow expensive queries should be set to true `search.allow_expensive_queries`
-setting to `false` (defaults to `true`). Due to the frameworks need to retrive the actions references and telemetry scripts. 
+Allow expensive queries `search.allow_expensive_queries` should be set to the defaults value `true`.
+This requirenment comes from the Alerting frameworks need to retrive the actions references (using joining query) and telemetry scripts. According to the {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation] the scripts won't work if `search.allow_expensive_queries is `false`. 
 
 [float]
 [[alerting-setup-production]]

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -20,8 +20,8 @@ If you are using an *on-premises* Elastic Stack deployment with <<using-kibana-w
 * You must enable Transport Layer Security (TLS) for communication <<configuring-tls-kib-es, between {es} and {kib}>>. {kib} alerting uses <<api-keys, API keys>> to secure background rule checks and actions, and API keys require {ref}/configuring-tls.html#tls-http[TLS on the HTTP interface]. A proxy will not suffice.
 * If you have enabled TLS and are still unable to access Alerting, ensure that you have not {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
 
-Allow expensive queries `search.allow_expensive_queries` should be set to the defaults value `true`.
-This requirenment comes from the Alerting frameworks need to retrive the actions references (using joining query) and telemetry scripts. According to the {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation] the scripts won't work if `search.allow_expensive_queries is `false`. 
+Allow expensive queries `search.allow_expensive_queries` should be set to `true`. By default the value is `true`.
+This is the requirenment, which comes from the Alerting framework needs to retrive the actions references (using joining query) and building telemetry queries using `scripts`. According to the {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation] the scripts won't work if `search.allow_expensive_queries` is `false`. 
 
 [float]
 [[alerting-setup-production]]

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -20,6 +20,9 @@ If you are using an *on-premises* Elastic Stack deployment with <<using-kibana-w
 * You must enable Transport Layer Security (TLS) for communication <<configuring-tls-kib-es, between {es} and {kib}>>. {kib} alerting uses <<api-keys, API keys>> to secure background rule checks and actions, and API keys require {ref}/configuring-tls.html#tls-http[TLS on the HTTP interface]. A proxy will not suffice.
 * If you have enabled TLS and are still unable to access Alerting, ensure that you have not {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
 
+Allow expensive queries should be set to true `search.allow_expensive_queries`
+setting to `false` (defaults to `true`). Due to the frameworks need to retrive the actions references and telemetry scripts. 
+
 [float]
 [[alerting-setup-production]]
 === Production considerations and scaling guidance

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -20,8 +20,7 @@ If you are using an *on-premises* Elastic Stack deployment with <<using-kibana-w
 * You must enable Transport Layer Security (TLS) for communication <<configuring-tls-kib-es, between {es} and {kib}>>. {kib} alerting uses <<api-keys, API keys>> to secure background rule checks and actions, and API keys require {ref}/configuring-tls.html#tls-http[TLS on the HTTP interface]. A proxy will not suffice.
 * If you have enabled TLS and are still unable to access Alerting, ensure that you have not {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
 
-Allow expensive queries `search.allow_expensive_queries` should be set to `true`. By default the value is `true`.
-The Alerting framework uses queries that require this setting to be `true`. See the scripts {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation]. 
+The Alerting framework uses queries that require the `search.allow_expensive_queries` setting to be `true`. See the scripts {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation]. 
 
 [float]
 [[alerting-setup-production]]

--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[alerting-setup]]
-== Alerting Set up
+== Alerting set up
 ++++
 <titleabbrev>Set up</titleabbrev>
 ++++
@@ -21,7 +21,7 @@ If you are using an *on-premises* Elastic Stack deployment with <<using-kibana-w
 * If you have enabled TLS and are still unable to access Alerting, ensure that you have not {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
 
 Allow expensive queries `search.allow_expensive_queries` should be set to `true`. By default the value is `true`.
-This is the requirenment, which comes from the Alerting framework needs to retrive the actions references (using joining query) and building telemetry queries using `scripts`. According to the {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation] the scripts won't work if `search.allow_expensive_queries` is `false`. 
+The Alerting framework uses queries that require this setting to be `true`. See the scripts {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation]. 
 
 [float]
 [[alerting-setup-production]]


### PR DESCRIPTION
Resolves #111031

Based on the research [issue](https://github.com/elastic/kibana/issues/111031#issuecomment-924452940), extended existing Alerting Set Up documentation for the information about required setting: `search.allow_expensive_queries` to be `true` (as it is by default).

Link to test: https://kibana_113062.docs-preview.app.elstc.co/guide/en/kibana/master/alerting-setup.html
 
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
