### PR TITLE
[ML] Functional tests - re-enable tests after ES fix

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/anomaly_explorer.ts
@@ -63,8 +63,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const elasticChart = getService('elasticChart');
 
-  // Failing: See https://github.com/elastic/kibana/issues/112405
-  describe.skip('anomaly explorer', function () {
+  describe('anomaly explorer', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');

--- a/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/date_nanos_job.ts
@@ -114,8 +114,7 @@ export default function ({ getService }: FtrProviderContext) {
     },
   ];
 
-  // Failing: See https://github.com/elastic/kibana/issues/112194
-  describe.skip('job on data set with date_nanos time field', function () {
+  describe('job on data set with date_nanos time field', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/event_rate_nanos');

--- a/x-pack/test/functional/apps/ml/anomaly_detection/multi_metric_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/multi_metric_job.ts
@@ -71,8 +71,7 @@ export default function ({ getService }: FtrProviderContext) {
 
   const calendarId = `wizard-test-calendar_${Date.now()}`;
 
-  // Failing: See https://github.com/elastic/kibana/issues/112174
-  describe.skip('multi metric', function () {
+  describe('multi metric', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');

--- a/x-pack/test/functional/apps/ml/anomaly_detection/saved_search_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/saved_search_job.ts
@@ -265,8 +265,7 @@ export default function ({ getService }: FtrProviderContext) {
     },
   ];
 
-  // Failing: See https://github.com/elastic/kibana/issues/104174
-  describe.skip('saved search', function () {
+  describe('saved search', function () {
     this.tags(['mlqa']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');


### PR DESCRIPTION
## Summary

With the Elasticsearch fix https://github.com/elastic/elasticsearch/pull/77801 merged, we can now re-enable the test suites that have been skipped due to the corresponding sort optimization issue.

Closes #112405
Closes #112194
Closes #112174
Closes #104174