### PR TITLE
[ML] Functional tests - stabilize custom URLs tests

### DIFF
--- a/x-pack/test/functional/services/ml/job_table.ts
+++ b/x-pack/test/functional/services/ml/job_table.ts
@@ -634,9 +634,11 @@ export function MachineLearningJobTableProvider(
       }
 
       // Save custom URL
-      await testSubjects.click('mlJobAddCustomUrl');
-      const expectedIndex = existingCustomUrls.length;
-      await customUrls.assertCustomUrlLabel(expectedIndex, customUrl.label);
+      await retry.tryForTime(5000, async () => {
+        await testSubjects.click('mlJobAddCustomUrl');
+        const expectedIndex = existingCustomUrls.length;
+        await customUrls.assertCustomUrlLabel(expectedIndex, customUrl.label);
+      });
 
       // Save the job
       await this.saveEditJobFlyoutChanges();
@@ -654,9 +656,11 @@ export function MachineLearningJobTableProvider(
       await customUrls.setCustomUrlOtherTypeUrl(customUrl.url);
 
       // Save custom URL
-      await testSubjects.click('mlJobAddCustomUrl');
-      const expectedIndex = existingCustomUrls.length;
-      await customUrls.assertCustomUrlLabel(expectedIndex, customUrl.label);
+      await retry.tryForTime(5000, async () => {
+        await testSubjects.click('mlJobAddCustomUrl');
+        const expectedIndex = existingCustomUrls.length;
+        await customUrls.assertCustomUrlLabel(expectedIndex, customUrl.label);
+      });
 
       // Save the job
       await this.saveEditJobFlyoutChanges();


### PR DESCRIPTION
## Summary

This PR stabilizes the functional custom URLs tests by adding retries for the dashboard and other type URL save service methods, similar to what we already have in the discover type URL save service method.

Closes #106053 