### PR TITLE
[Upgrade Assistant] Add missing error handlers for deprecation logging route

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/routes/deprecation_logging.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/deprecation_logging.test.ts
@@ -8,6 +8,7 @@
 import { kibanaResponseFactory } from 'src/core/server';
 import { createMockRouter, MockRouter, routeHandlerContextMock } from './__mocks__/routes.mock';
 import { createRequestMock } from './__mocks__/request.mock';
+import { handleEsError } from '../shared_imports';
 
 jest.mock('../lib/es_version_precheck', () => ({
   versionCheckHandlerWrapper: (a: any) => a,
@@ -28,6 +29,7 @@ describe('deprecation logging API', () => {
     mockRouter = createMockRouter();
     routeDependencies = {
       router: mockRouter,
+      lib: { handleEsError },
     };
     registerDeprecationLoggingRoutes(routeDependencies);
   });

--- a/x-pack/plugins/upgrade_assistant/server/routes/deprecation_logging.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/deprecation_logging.ts
@@ -16,7 +16,10 @@ import { versionCheckHandlerWrapper } from '../lib/es_version_precheck';
 import { RouteDependencies } from '../types';
 import { DEPRECATION_LOGS_INDEX } from '../../common/constants';
 
-export function registerDeprecationLoggingRoutes({ router }: RouteDependencies) {
+export function registerDeprecationLoggingRoutes({
+  router,
+  lib: { handleEsError },
+}: RouteDependencies) {
   router.get(
     {
       path: `${API_BASE_PATH}/deprecation_logging`,
@@ -32,8 +35,12 @@ export function registerDeprecationLoggingRoutes({ router }: RouteDependencies) 
         request,
         response
       ) => {
-        const result = await getDeprecationLoggingStatus(client);
-        return response.ok({ body: result });
+        try {
+          const result = await getDeprecationLoggingStatus(client);
+          return response.ok({ body: result });
+        } catch (error) {
+          return handleEsError({ error, response });
+        }
       }
     )
   );
@@ -57,10 +64,14 @@ export function registerDeprecationLoggingRoutes({ router }: RouteDependencies) 
         request,
         response
       ) => {
-        const { isEnabled } = request.body as { isEnabled: boolean };
-        return response.ok({
-          body: await setDeprecationLogging(client, isEnabled),
-        });
+        try {
+          const { isEnabled } = request.body as { isEnabled: boolean };
+          return response.ok({
+            body: await setDeprecationLogging(client, isEnabled),
+          });
+        } catch (error) {
+          return handleEsError({ error, response });
+        }
       }
     )
   );
@@ -84,28 +95,32 @@ export function registerDeprecationLoggingRoutes({ router }: RouteDependencies) 
         request,
         response
       ) => {
-        const { body: indexExists } = await client.asCurrentUser.indices.exists({
-          index: DEPRECATION_LOGS_INDEX,
-        });
+        try {
+          const { body: indexExists } = await client.asCurrentUser.indices.exists({
+            index: DEPRECATION_LOGS_INDEX,
+          });
 
-        if (!indexExists) {
-          return response.ok({ body: { count: 0 } });
-        }
+          if (!indexExists) {
+            return response.ok({ body: { count: 0 } });
+          }
 
-        const { body } = await client.asCurrentUser.count({
-          index: DEPRECATION_LOGS_INDEX,
-          body: {
-            query: {
-              range: {
-                '@timestamp': {
-                  gte: request.query.from,
+          const { body } = await client.asCurrentUser.count({
+            index: DEPRECATION_LOGS_INDEX,
+            body: {
+              query: {
+                range: {
+                  '@timestamp': {
+                    gte: request.query.from,
+                  },
                 },
               },
             },
-          },
-        });
+          });
 
-        return response.ok({ body: { count: body.count } });
+          return response.ok({ body: { count: body.count } });
+        } catch (error) {
+          return handleEsError({ error, response });
+        }
       }
     )
   );


### PR DESCRIPTION
#### Summary 
I noticed that the deprecation logging routes didnt have a es error handler, so this PR fixes that.

<details>
<summary>Overview of changes</summary>

// Get count of deprecation logs
<img width="790" alt="Screenshot 2021-09-27 at 21 54 31" src="https://user-images.githubusercontent.com/1191206/134976418-50f3cc6c-28a3-412b-b353-0c9ba5adbbe9.png">


// Get deprecation logging status
<img width="809" alt="Screenshot 2021-09-27 at 21 56 04" src="https://user-images.githubusercontent.com/1191206/134976507-51ef8359-871d-4141-8cd9-05715cd75f67.png">

// Set deprecation logging status
<img width="816" alt="Screenshot 2021-09-27 at 21 57 04" src="https://user-images.githubusercontent.com/1191206/134976578-1ced653a-ce07-490d-a63b-99f46bb6568b.png">

</details>