### PR TITLE
[ML] Functional tests - stabilize and re-enable feature importance tests

### DIFF
--- a/x-pack/plugins/ml/public/application/components/data_grid/data_grid.tsx
+++ b/x-pack/plugins/ml/public/application/components/data_grid/data_grid.tsx
@@ -158,17 +158,21 @@ export const DataGrid: FC<Props> = memo(
               );
 
               return (
-                <DecisionPathPopover
-                  analysisType={analysisType}
-                  predictedValue={predictedValue}
-                  predictedProbability={predictedProbability}
-                  baseline={baseline}
-                  featureImportance={parsedFIArray}
-                  topClasses={topClasses}
-                  predictionFieldName={
-                    predictionFieldName ? predictionFieldName.replace('_prediction', '') : undefined
-                  }
-                />
+                <div data-test-subj="mlDFAFeatureImportancePopover">
+                  <DecisionPathPopover
+                    analysisType={analysisType}
+                    predictedValue={predictedValue}
+                    predictedProbability={predictedProbability}
+                    baseline={baseline}
+                    featureImportance={parsedFIArray}
+                    topClasses={topClasses}
+                    predictionFieldName={
+                      predictionFieldName
+                        ? predictionFieldName.replace('_prediction', '')
+                        : undefined
+                    }
+                  />
+                </div>
               );
             },
             featureInfluence: ({

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/feature_importance/decision_path_popover.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_exploration/components/feature_importance/decision_path_popover.tsx
@@ -58,7 +58,11 @@ export const DecisionPathPopover: FC<DecisionPathPopoverProps> = ({
   const docLink = docLinks.links.ml.featureImportance;
 
   if (featureImportance.length < 2) {
-    return <DecisionPathJSONViewer featureImportance={featureImportance} />;
+    return (
+      <div data-test-subj="mlDFADecisionPathJSONViewer">
+        <DecisionPathJSONViewer featureImportance={featureImportance} />
+      </div>
+    );
   }
 
   const tabs = [

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/feature_importance.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/feature_importance.ts
@@ -183,8 +183,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     for (const testData of testDataList) {
-      // FLAKY: https://github.com/elastic/kibana/issues/93188
-      describe.skip(`${testData.suiteTitle}`, function () {
+      describe(`${testData.suiteTitle}`, function () {
         before(async () => {
           await ml.navigation.navigateToMl();
           await ml.navigation.navigateToDataFrameAnalytics();
@@ -205,9 +204,8 @@ export default function ({ getService }: FtrProviderContext) {
         it('should display the feature importance decision path in the data grid', async () => {
           await ml.dataFrameAnalyticsResults.assertResultsTableExists();
           await ml.dataFrameAnalyticsResults.assertResultsTableNotEmpty();
-          await ml.dataFrameAnalyticsResults.openFeatureImportanceDecisionPathPopover();
-          await ml.dataFrameAnalyticsResults.assertFeatureImportanceDecisionPathElementsExists();
-          await ml.dataFrameAnalyticsResults.assertFeatureImportanceDecisionPathChartElementsExists();
+          await ml.dataFrameAnalyticsResults.openFeatureImportancePopover();
+          await ml.dataFrameAnalyticsResults.assertFeatureImportancePopoverContent();
         });
       });
     }

--- a/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
@@ -147,7 +147,24 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
       });
     },
 
-    async openFeatureImportanceDecisionPathPopover() {
+    async assertFeatureImportancePopoverContent() {
+      // we have two different types of content depending on the nuzmber of features returned
+      // by the analysis: decision path view with chart and JSON tabs or a plain JSON only view
+      if (await testSubjects.exists('mlDFADecisionPathJSONViewer', { timeout: 1000 })) {
+        const jsonContent = await testSubjects.getVisibleText('mlDFADecisionPathJSONViewer');
+        expect(jsonContent.length).greaterThan(
+          0,
+          `Feature importance JSON popover content should not be empty`
+        );
+      } else if (await testSubjects.exists('mlDFADecisionPathPopover', { timeout: 1000 })) {
+        await this.assertFeatureImportanceDecisionPathElementsExists();
+        await this.assertFeatureImportanceDecisionPathChartElementsExists();
+      } else {
+        throw new Error('Expected either decision path popover or JSON viewer to exist.');
+      }
+    },
+
+    async openFeatureImportancePopover() {
       this.assertResultsTableNotEmpty();
 
       const featureImportanceCell = await this.getFirstFeatureImportanceCell();
@@ -160,7 +177,7 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
 
       // open popover
       await interactionButton.click();
-      await testSubjects.existOrFail('mlDFADecisionPathPopover');
+      await testSubjects.existOrFail('mlDFAFeatureImportancePopover');
     },
 
     async getFirstFeatureImportanceCell(): Promise<WebElementWrapper> {

--- a/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
@@ -148,7 +148,7 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
     },
 
     async assertFeatureImportancePopoverContent() {
-      // we have two different types of content depending on the nuzmber of features returned
+      // we have two different types of content depending on the number of features returned
       // by the analysis: decision path view with chart and JSON tabs or a plain JSON only view
       if (await testSubjects.exists('mlDFADecisionPathJSONViewer', { timeout: 1000 })) {
         const jsonContent = await testSubjects.getVisibleText('mlDFADecisionPathJSONViewer');


### PR DESCRIPTION
## Summary

This PR re-enables and stabilizes the feature importance tests by making them independent from the number of features returned by the backend.

Closes #93188