### PR TITLE
[embeddable] Don’t include test samples into initial bundle

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -17,7 +17,7 @@ pageLoadAssetSize:
   devTools: 38637
   discover: 99999
   discoverEnhanced: 42730
-  embeddable: 312874
+  embeddable: 99999
   embeddableEnhanced: 41145
   enterpriseSearch: 35741
   esUiShared: 326654

--- a/src/plugins/embeddable/kibana.json
+++ b/src/plugins/embeddable/kibana.json
@@ -9,6 +9,6 @@
   },
   "description": "Adds embeddables service to Kibana",
   "requiredPlugins": ["inspector", "uiActions"],
-  "extraPublicDirs": ["public/lib/test_samples", "common"],
+  "extraPublicDirs": ["common"],
   "requiredBundles": ["savedObjects", "kibanaReact", "kibanaUtils"]
 }


### PR DESCRIPTION
## Summary

Close https://github.com/elastic/kibana/issues/95860

This brings embeddable just under 100Kb by not including test sample data into the initial bundle as those ared used only in unit test


There are [other](https://github.com/elastic/kibana/issues/95860#issuecomment-923809587) easy improvements in embeddable plugin, but I'd look at those separately 
