### PR TITLE
[APM] Use oldest exit span instead of newest

### DIFF
--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
@@ -111,7 +111,7 @@ export const getDestinationMap = ({
                   ] as const),
                   sort: [
                     {
-                      '@timestamp': 'desc' as const,
+                      '@timestamp': 'asc' as const,
                     },
                   ],
                 },


### PR DESCRIPTION
For discovering connections, select the oldest span instead of the newest. This increases the possiblity of the relevant transaction being indexed into Elasticsearch at query time. If this tranasaction isn't there, exit spans might not be appropriately resolved to the downstream service, as reported by @felixbarny and @LucaWintergerst.
