### PR TITLE
[FieldFormatters] Use default values for URL formatter

### DIFF
--- a/src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/url/url.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/url/url.tsx
@@ -148,6 +148,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
     const { formatParams, format } = this.props;
     const { error, samples, sampleConverterType } = this.state;
 
+    const type = formatParams.type ?? format.getParamDefaults().type
     return (
       <Fragment>
         <EuiFormRow
@@ -157,7 +158,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
         >
           <EuiSelect
             data-test-subj="urlEditorType"
-            value={formatParams.type}
+            value={type}
             options={(format.type as typeof UrlFormat).urlTypes.map((type: UrlType) => {
               return {
                 value: type.kind,
@@ -170,7 +171,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
           />
         </EuiFormRow>
 
-        {formatParams.type === 'a' ? (
+        {type === 'a' ? (
           <EuiFormRow
             label={
               <FormattedMessage
@@ -258,7 +259,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
           />
         </EuiFormRow>
 
-        {formatParams.type === 'img' && this.renderWidthHeightParameters()}
+        {type === 'img' && this.renderWidthHeightParameters()}
 
         <FormatEditorSamples samples={samples} sampleType={sampleConverterType} />
       </Fragment>

--- a/src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/url/url.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/field_format_editor/editors/url/url.tsx
@@ -148,7 +148,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
     const { formatParams, format } = this.props;
     const { error, samples, sampleConverterType } = this.state;
 
-    const type = formatParams.type ?? format.getParamDefaults().type
+    const urlType = formatParams.type ?? format.getParamDefaults().type;
     return (
       <Fragment>
         <EuiFormRow
@@ -158,7 +158,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
         >
           <EuiSelect
             data-test-subj="urlEditorType"
-            value={type}
+            value={urlType}
             options={(format.type as typeof UrlFormat).urlTypes.map((type: UrlType) => {
               return {
                 value: type.kind,
@@ -171,7 +171,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
           />
         </EuiFormRow>
 
-        {type === 'a' ? (
+        {urlType === 'a' ? (
           <EuiFormRow
             label={
               <FormattedMessage
@@ -259,7 +259,7 @@ export class UrlFormatEditor extends DefaultFormatEditor<
           />
         </EuiFormRow>
 
-        {type === 'img' && this.renderWidthHeightParameters()}
+        {urlType === 'img' && this.renderWidthHeightParameters()}
 
         <FormatEditorSamples samples={samples} sampleType={sampleConverterType} />
       </Fragment>


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/112238#issuecomment-928069338

The default behavior when creating a URL formatter is to have the type set to `link`, But the link specific field wasn't being shown until the the type select box had a transition to the link select from a different type. This was caused because the default for the type field is link, but the formatter props still have type as undefined. I addressed the issue by calling `format.getParamDefaults()` and coalescing it with the provided type prop.

Before this PR:
![open_in_new_tab_before](https://user-images.githubusercontent.com/5867784/134951368-ecd92a57-f004-43c0-8e54-62e61aee0e2b.png)

After this PR:
![open_in_new_tab_fixed](https://user-images.githubusercontent.com/5867784/134951385-b98a682d-459a-4d33-8d7c-088b298047fc.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

The unit tests passed without modification. However, they also passed before, despite the snapshot including the html for the "Open in new tab" toggle. So I may be running them incorrectly.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Release Notes

Fix url formatter editor "Open in new tab" is hidden by default
