### PR TITLE
[alerting] adds additional properties to the rule execution status

### DIFF
--- a/x-pack/plugins/alerting/common/alert.ts
+++ b/x-pack/plugins/alerting/common/alert.ts
@@ -34,7 +34,7 @@ export enum AlertExecutionStatusErrorReasons {
 
 export type AlertTypeExecutionStatus = Pick<
   AlertExecutionStatus,
-  'searchDuration' | 'indexDuration' | 'noData' | 'messages'
+  'searchDuration' | 'indexDuration' | 'messages' | 'experimental'
 >;
 
 export interface AlertExecutionStatus {
@@ -55,8 +55,13 @@ export interface AlertExecutionStatus {
   // set by the rule executor
   searchDuration?: null | number; // milliseconds
   indexDuration?: null | number; // milliseconds
-  noData?: boolean;
   messages?: string[];
+  experimental?: null | {
+    noData?: null | boolean;
+    ruleStatus?: null | string;
+    ruleStatusOrder?: null | number;
+    gapDuration?: null | number;
+  };
 }
 
 export type AlertActionParams = SavedObjectAttributes;

--- a/x-pack/plugins/alerting/common/alert.ts
+++ b/x-pack/plugins/alerting/common/alert.ts
@@ -35,6 +35,17 @@ export enum AlertExecutionStatusErrorReasons {
 export interface AlertExecutionStatus {
   status: AlertExecutionStatuses;
   lastExecutionDate: Date;
+  delay?: number; // aka "task drift"; milliseconds
+  duration?: number; // milliseconds
+  searchDuration?: null | number; // milliseconds
+  indexDuration?: null | number; // milliseconds
+  instances?: {
+    active: number;
+    new: number;
+    recovered: number;
+  };
+  noData?: boolean;
+  messages?: string[];
   error?: {
     reason: AlertExecutionStatusErrorReasons;
     message: string;

--- a/x-pack/plugins/alerting/common/alert.ts
+++ b/x-pack/plugins/alerting/common/alert.ts
@@ -32,24 +32,31 @@ export enum AlertExecutionStatusErrorReasons {
   License = 'license',
 }
 
+export type AlertTypeExecutionStatus = Pick<
+  AlertExecutionStatus,
+  'searchDuration' | 'indexDuration' | 'noData' | 'messages'
+>;
+
 export interface AlertExecutionStatus {
+  // set by the rule framework
   status: AlertExecutionStatuses;
   lastExecutionDate: Date;
+  error?: {
+    reason: AlertExecutionStatusErrorReasons;
+    message: string;
+  };
   delay?: number; // aka "task drift"; milliseconds
   duration?: number; // milliseconds
-  searchDuration?: null | number; // milliseconds
-  indexDuration?: null | number; // milliseconds
   instances?: {
     active: number;
     new: number;
     recovered: number;
   };
+  // set by the rule executor
+  searchDuration?: null | number; // milliseconds
+  indexDuration?: null | number; // milliseconds
   noData?: boolean;
   messages?: string[];
-  error?: {
-    reason: AlertExecutionStatusErrorReasons;
-    message: string;
-  };
 }
 
 export type AlertActionParams = SavedObjectAttributes;

--- a/x-pack/plugins/alerting/server/index.ts
+++ b/x-pack/plugins/alerting/server/index.ts
@@ -29,6 +29,7 @@ export type {
   AlertInstanceContext,
   AlertingApiRequestHandlerContext,
   RuleParamsAndRefs,
+  AlertTypeExecutionStatus,
 } from './types';
 export { DEFAULT_MAX_EPHEMERAL_ACTIONS_PER_ALERT } from './config';
 export { PluginSetupContract, PluginStartContract } from './plugin';

--- a/x-pack/plugins/alerting/server/lib/alert_execution_status.ts
+++ b/x-pack/plugins/alerting/server/lib/alert_execution_status.ts
@@ -6,7 +6,12 @@
  */
 
 import { Logger } from 'src/core/server';
-import { AlertTaskState, AlertExecutionStatus, RawAlertExecutionStatus } from '../types';
+import {
+  AlertTaskState,
+  AlertExecutionStatus,
+  AlertTypeExecutionStatus,
+  RawAlertExecutionStatus,
+} from '../types';
 import { getReasonFromError } from './error_with_reason';
 import { getEsErrorMessage } from './errors';
 import { AlertExecutionStatuses } from '../../common';
@@ -124,3 +129,16 @@ export const getAlertExecutionStatusPending = (lastExecutionDate: string) => ({
   lastExecutionDate,
   error: null,
 });
+
+export function normalizeAlertTypeExecutionStatus(
+  typeExecutionStatus: AlertTypeExecutionStatus = {}
+): AlertTypeExecutionStatus {
+  let { searchDuration, indexDuration, noData, messages } = typeExecutionStatus;
+
+  if (searchDuration === undefined) searchDuration = null;
+  if (indexDuration === undefined) indexDuration = null;
+  if (noData === undefined) noData = false;
+  if (messages == null) messages = [];
+
+  return { searchDuration, indexDuration, noData, messages };
+}

--- a/x-pack/plugins/alerting/server/lib/alert_execution_status.ts
+++ b/x-pack/plugins/alerting/server/lib/alert_execution_status.ts
@@ -11,34 +11,48 @@ import { getReasonFromError } from './error_with_reason';
 import { getEsErrorMessage } from './errors';
 import { AlertExecutionStatuses } from '../../common';
 
-export function executionStatusFromState(state: AlertTaskState): AlertExecutionStatus {
+export function setExecutionStatusFromState(
+  executionStatus: Partial<AlertExecutionStatus>,
+  state: AlertTaskState
+): void {
   const instanceIds = Object.keys(state.alertInstances ?? {});
-  return {
-    lastExecutionDate: new Date(),
-    status: instanceIds.length === 0 ? 'ok' : 'active',
-  };
+  executionStatus.status = instanceIds.length === 0 ? 'ok' : 'active';
 }
 
-export function executionStatusFromError(error: Error): AlertExecutionStatus {
-  return {
-    lastExecutionDate: new Date(),
-    status: 'error',
-    error: {
-      reason: getReasonFromError(error),
-      message: getEsErrorMessage(error),
-    },
+export function setExecutionStatusFromError(
+  executionStatus: Partial<AlertExecutionStatus>,
+  error: Error
+): void {
+  executionStatus.status = 'error';
+  executionStatus.error = {
+    reason: getReasonFromError(error),
+    message: getEsErrorMessage(error),
   };
 }
 
 export function alertExecutionStatusToRaw({
-  lastExecutionDate,
-  status,
+  lastExecutionDate = new Date(),
+  status = 'unknown',
   error,
-}: AlertExecutionStatus): RawAlertExecutionStatus {
+  delay,
+  duration,
+  searchDuration,
+  indexDuration,
+  instances,
+  noData,
+  messages,
+}: Partial<AlertExecutionStatus>): RawAlertExecutionStatus {
+  // explicitly using null (in case undefined) due to partial update concerns
   return {
     lastExecutionDate: lastExecutionDate.toISOString(),
     status,
-    // explicitly setting to null (in case undefined) due to partial update concerns
+    delay: delay ?? 0,
+    duration: duration ?? 0,
+    searchDuration: searchDuration ?? null,
+    indexDuration: indexDuration ?? null,
+    instances: instances ?? null,
+    noData: noData ?? false,
+    messages: messages ?? [],
     error: error ?? null,
   };
 }
@@ -61,11 +75,48 @@ export function alertExecutionStatusFromRaw(
   }
 
   const parsedDate = new Date(parsedDateMillis);
-  if (error) {
-    return { lastExecutionDate: parsedDate, status, error };
-  } else {
-    return { lastExecutionDate: parsedDate, status };
+
+  const { delay, duration, instances, searchDuration, indexDuration, noData, messages } =
+    rawAlertExecutionStatus;
+
+  const executionStatus: AlertExecutionStatus = {
+    status,
+    lastExecutionDate: parsedDate,
+  };
+
+  if (delay !== undefined) {
+    executionStatus.delay = delay;
   }
+
+  if (duration !== undefined) {
+    executionStatus.duration = duration;
+  }
+
+  if (searchDuration != null) {
+    executionStatus.searchDuration = searchDuration;
+  }
+
+  if (indexDuration != null) {
+    executionStatus.indexDuration = indexDuration;
+  }
+
+  if (instances != null) {
+    executionStatus.instances = instances;
+  }
+
+  if (noData != null) {
+    executionStatus.noData = noData;
+  }
+
+  if (messages != null) {
+    executionStatus.messages = messages;
+  }
+
+  if (error) {
+    executionStatus.error = error;
+  }
+
+  return executionStatus;
 }
 
 export const getAlertExecutionStatusPending = (lastExecutionDate: string) => ({

--- a/x-pack/plugins/alerting/server/lib/index.ts
+++ b/x-pack/plugins/alerting/server/lib/index.ts
@@ -19,8 +19,8 @@ export {
   ElasticsearchError,
 } from './errors';
 export {
-  executionStatusFromState,
-  executionStatusFromError,
+  setExecutionStatusFromState,
+  setExecutionStatusFromError,
   alertExecutionStatusToRaw,
   alertExecutionStatusFromRaw,
 } from './alert_execution_status';

--- a/x-pack/plugins/alerting/server/saved_objects/mappings.json
+++ b/x-pack/plugins/alerting/server/saved_objects/mappings.json
@@ -122,8 +122,15 @@
           },
           "searchDuration": { "type": "long" },
           "indexDuration": { "type": "long" },
-          "noData": { "type": "boolean" },
-          "messages": { "type": "text" }
+          "messages": { "type": "text" },
+          "experimental": { 
+            "properties": {
+              "noData": { "type": "boolean" },
+              "ruleStatus": { "type": "keyword" },
+              "ruleStatusOrder": { "type": "long" },
+              "gapDuration": { "type": "long" }
+            }
+          }
         }
       }
     }

--- a/x-pack/plugins/alerting/server/saved_objects/mappings.json
+++ b/x-pack/plugins/alerting/server/saved_objects/mappings.json
@@ -110,7 +110,20 @@
                 "type": "keyword"
               }
             }
-          }
+          },
+          "delay": { "type": "long" },
+          "duration": { "type": "long" },
+          "instances": { 
+            "properties": {
+              "active": { "type": "long" },
+              "new": { "type": "long" },
+              "recovered": { "type": "long" }
+            }
+          },
+          "searchDuration": { "type": "long" },
+          "indexDuration": { "type": "long" },
+          "noData": { "type": "boolean" },
+          "messages": { "type": "text" }
         }
       }
     }

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -278,7 +278,7 @@ export class TaskRunner<
         const status = normalizeAlertTypeExecutionStatus(executorStatus);
         executionStatus.searchDuration = status.searchDuration;
         executionStatus.indexDuration = status.indexDuration;
-        executionStatus.noData = status.noData;
+        executionStatus.experimental = status.experimental;
         executionStatus.messages = status.messages;
       }
 

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -177,12 +177,23 @@ export interface AlertMeta extends SavedObjectAttributes {
   versionApiKeyLastmodified?: string;
 }
 
-// note that the `error` property is "null-able", as we're doing a partial
+// properties are "null-able", so they can be as we're doing a partial
 // update on the alert when we update this data, but need to ensure we
-// delete any previous error if the current status has no error
+// delete any previous value if the next execution doesn't supply them
 export interface RawAlertExecutionStatus extends SavedObjectAttributes {
   status: AlertExecutionStatuses;
   lastExecutionDate: string;
+  delay?: number; // aka "task drift"; milliseconds
+  duration?: number; // milliseconds
+  searchDuration?: null | number; // milliseconds
+  indexDuration?: null | number; // milliseconds
+  noData?: null | boolean;
+  messages?: string[];
+  instances?: null | {
+    active: number;
+    new: number;
+    recovered: number;
+  };
   error: null | {
     reason: AlertExecutionStatusErrorReasons;
     message: string;

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -198,8 +198,13 @@ export interface RawAlertExecutionStatus extends SavedObjectAttributes {
   };
   searchDuration?: null | number; // milliseconds
   indexDuration?: null | number; // milliseconds
-  noData?: null | boolean;
   messages?: string[];
+  experimental?: null | {
+    noData?: null | boolean;
+    ruleStatus?: null | string;
+    ruleStatusOrder?: null | number;
+    gapDuration?: null | number;
+  };
 }
 
 export type PartialAlert<Params extends AlertTypeParams = never> = Pick<Alert<Params>, 'id'> &

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -33,6 +33,7 @@ import {
   WithoutReservedActionGroups,
   ActionVariable,
   SanitizedRuleConfig,
+  AlertTypeExecutionStatus,
 } from '../common';
 import { LicenseType } from '../../licensing/server';
 
@@ -75,6 +76,7 @@ export interface AlertServices<
   alertInstanceFactory: (
     id: string
   ) => PublicAlertInstance<InstanceState, InstanceContext, ActionGroupIds>;
+  setExecutorStatus(executorStatus: AlertTypeExecutionStatus): void;
 }
 
 export interface AlertExecutorOptions<
@@ -183,21 +185,21 @@ export interface AlertMeta extends SavedObjectAttributes {
 export interface RawAlertExecutionStatus extends SavedObjectAttributes {
   status: AlertExecutionStatuses;
   lastExecutionDate: string;
+  error: null | {
+    reason: AlertExecutionStatusErrorReasons;
+    message: string;
+  };
   delay?: number; // aka "task drift"; milliseconds
   duration?: number; // milliseconds
-  searchDuration?: null | number; // milliseconds
-  indexDuration?: null | number; // milliseconds
-  noData?: null | boolean;
-  messages?: string[];
   instances?: null | {
     active: number;
     new: number;
     recovered: number;
   };
-  error: null | {
-    reason: AlertExecutionStatusErrorReasons;
-    message: string;
-  };
+  searchDuration?: null | number; // milliseconds
+  indexDuration?: null | number; // milliseconds
+  noData?: null | boolean;
+  messages?: string[];
 }
 
 export type PartialAlert<Params extends AlertTypeParams = never> = Pick<Alert<Params>, 'id'> &

--- a/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts
+++ b/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts
@@ -164,15 +164,18 @@ export function getAlertType(
       timeWindowUnit: params.timeWindowUnit,
       interval: undefined,
     };
+    const dataAccessor = await data;
     // console.log(`index_threshold: query: ${JSON.stringify(queryParams, null, 4)}`);
-    const result = await (
-      await data
-    ).timeSeriesQuery({
+    const timeStart = Date.now();
+    const result = await dataAccessor.timeSeriesQuery({
       logger,
       esClient,
       query: queryParams,
     });
+    const timeElapsed = Date.now() - timeStart;
     logger.debug(`alert ${ID}:${alertId} "${name}" query result: ${JSON.stringify(result)}`);
+
+    services.setExecutorStatus({ searchDuration: timeElapsed });
 
     const groupResults = result.results || [];
     // console.log(`index_threshold: response: ${JSON.stringify(groupResults, null, 4)}`);

--- a/x-pack/plugins/stack_alerts/server/types.ts
+++ b/x-pack/plugins/stack_alerts/server/types.ts
@@ -13,6 +13,7 @@ export {
   AlertType,
   RuleParamsAndRefs,
   AlertExecutorOptions,
+  AlertTypeExecutionStatus,
 } from '../../alerting/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '../../features/server';
 

--- a/x-pack/plugins/triggers_actions_ui/server/data/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/index.ts
@@ -11,6 +11,7 @@ import { registerRoutes } from './routes';
 
 export {
   TimeSeriesQuery,
+  TimeSeriesResult,
   CoreQueryParams,
   CoreQueryParamsSchemaProperties,
   validateCoreQueryBody,

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { TimeSeriesQuery } from './time_series_query';
+export { TimeSeriesQuery, TimeSeriesResult } from './time_series_query';
 export {
   CoreQueryParams,
   CoreQueryParamsSchemaProperties,

--- a/x-pack/plugins/triggers_actions_ui/server/index.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/index.ts
@@ -12,6 +12,7 @@ import { TriggersActionsPlugin } from './plugin';
 export { PluginStartContract } from './plugin';
 export {
   TimeSeriesQuery,
+  TimeSeriesResult,
   CoreQueryParams,
   CoreQueryParamsSchemaProperties,
   validateCoreQueryBody,


### PR DESCRIPTION
## Summary

Adds additional properties to the rule execution status stored in the alerting rule saved object.

Currently a POC for issue https://github.com/elastic/kibana/issues/112193

Additional properties added here TBD - current candidates can be seen in the `saved_objects/mappings.json` file

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
