### PR TITLE
[Fleet] Fix some vars from preconfiguration not being added to package policies

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1092,7 +1092,7 @@ function deepMergeVars(original: any, override: any): any {
 
   for (const { name, ...overrideVal } of overrideVars) {
     const originalVar = original.vars[name];
-    result.vars[name] = { ...overrideVal, ...originalVar };
+    result.vars[name] = { ...originalVar, ...overrideVal };
   }
 
   return result;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/fleet-server/issues/742.

This PR fixes an issue where some variables defined in `xpack.fleet.agentPolicies` were not having their values correctly applied to the final package policies. This is seen on 7.15 Cloud deployments where the Fleet Server policies is missing values for `max_connections` and `custom`, even though they are specified in the preconfiguration setup.

This is due to a mistake in the ordering of objects that are merged in the helper function `deepMergeVars`. The override value should get merged last as, well, it is meant to override ;)

## Testing

With Postman or cURL, send the below request to set up some preconfigured policy (I am using the exact Cloud setup in this case) **prior** to this PR. Observe the policy in Fleet UI, notice the empty fields:

![image](https://user-images.githubusercontent.com/1965714/135001693-b8da916d-c2eb-4e70-b227-e2d0ca5f0532.png)

After applying this PR, run the request again **after incrementing the `id`**. The new policy should have the fields correctly filled out:

![image](https://user-images.githubusercontent.com/1965714/135001810-6a99dd12-6941-488a-a4b9-ccd80eb1c54e.png)

```
PUT /api/fleet/setup/preconfiguration
{
  "agentPolicies": [
    {
      "id": "some-test-1",
      "name": "Some test 1",
      "description": "Default agent policy for agents hosted on Elastic Cloud",
      "is_default": false,
      "is_managed": true,
      "is_default_fleet_server": false,
      "namespace": "default",
      "monitoring_enabled": [],
      "unenroll_timeout": 600,
      "package_policies": [
        {
          "name": "Fleet Server",
          "package": {
            "name": "fleet_server"
          },
          "inputs": [
            {
              "type": "fleet-server",
              "keep_enabled": true,
              "vars": [
                {
                  "name": "host",
                  "value": "0.0.0.0",
                  "frozen": true
                },
                {
                  "name": "port",
                  "value": 8220,
                  "frozen": true
                },
                {
                  "name": "max_connections",
                  "value": 200
                },
                {
                  "name": "custom",
                  "value": "cache:\n  num_counters: 2000        # Limit the size of the hash table to rougly 10x expected number of elements\n  max_cost: 2097152         # Limit the total size of data allowed in the cache, 2 MiB in bytes.\nserver.limits:\n   policy_throttle: 200ms  # Roll out a new policy every 200ms; roughly 5 per second.\n   checkin_limit:\n     interval: 50ms        # Check in no faster than 20 per second.\n     burst: 25             # Allow burst up to 25, then fall back to interval rate.\n     max: 100              # No more than 100 long polls allowed. THIS EFFECTIVELY LIMITS MAX ENDPOINTS.\n   artifact_limit:\n     interval: 100ms       # Roll out 10 artifacts per second\n     burst: 10             # Small burst prevents outbound buffer explosion.\n     max: 10               # Only 10 transactions at a time max.  This should generally not be a relavent limitation as the transactions are cached.\n   ack_limit:\n     interval: 10ms        # Allow ACK only 100 per second.  ACK payload is unbounded in RAM so need to limit.\n     burst: 20             # Allow burst up to 20, then fall back to interrval rate.\n     max: 20               # Cannot have too many processing at once due to unbounded payload size.\n   enroll_limit:\n     interval: 100ms       # Enroll is both CPU and RAM intensive.  Limit to 10 per second.\n     burst: 5              # Allow intial burst, but limit to max.\n     max: 10               # Max limit.\nserver.runtime:\n  gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent\n"
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```