### PR TITLE
[Reporting] Download/install the browser in the setup phase

### DIFF
--- a/src/dev/build/tasks/install_chromium.js
+++ b/src/dev/build/tasks/install_chromium.js
@@ -6,8 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { first } from 'rxjs/operators';
-
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { installBrowser } from '../../../../x-pack/plugins/reporting/server/browsers/install';
 
@@ -18,13 +16,12 @@ export const InstallChromium = {
     for (const platform of config.getNodePlatforms()) {
       log.info(`Installing Chromium for ${platform.getName()}-${platform.getArchitecture()}`);
 
-      const { binaryPath$ } = installBrowser(
+      await installBrowser(
         log,
         build.resolvePathForPlatform(platform, 'x-pack/plugins/reporting/chromium'),
         platform.getName(),
         platform.getArchitecture()
       );
-      await binaryPath$.pipe(first()).toPromise();
     }
   },
 };

--- a/x-pack/plugins/reporting/server/browsers/chromium/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/index.ts
@@ -9,13 +9,17 @@ import { i18n } from '@kbn/i18n';
 import { BrowserDownload } from '../';
 import { ReportingCore } from '../../../server';
 import { LevelLogger } from '../../lib';
+import { ReportingConfigType } from '../../config';
 import { HeadlessChromiumDriverFactory } from './driver_factory';
 import { ChromiumArchivePaths } from './paths';
 
 export const chromium: BrowserDownload = {
   paths: new ChromiumArchivePaths(),
-  createDriverFactory: (core: ReportingCore, binaryPath: string, logger: LevelLogger) =>
-    new HeadlessChromiumDriverFactory(core, binaryPath, logger),
+  createDriverFactory: (
+    core: ReportingCore,
+    captureConfig: ReportingConfigType['capture'],
+    logger: LevelLogger
+  ) => new HeadlessChromiumDriverFactory(core, captureConfig, logger),
 };
 
 export const getChromiumDisconnectedError = () =>

--- a/x-pack/plugins/reporting/server/browsers/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/index.ts
@@ -5,30 +5,21 @@
  * 2.0.
  */
 
-import { first } from 'rxjs/operators';
 import { ReportingCore } from '../';
+import { ReportingConfigType } from '../config';
 import { LevelLogger } from '../lib';
-import { chromium, ChromiumArchivePaths } from './chromium';
+import { ChromiumArchivePaths } from './chromium';
 import { HeadlessChromiumDriverFactory } from './chromium/driver_factory';
-import { installBrowser } from './install';
 
 export { chromium } from './chromium';
 export { HeadlessChromiumDriver } from './chromium/driver';
 export { HeadlessChromiumDriverFactory } from './chromium/driver_factory';
 
-type CreateDriverFactory = (
-  core: ReportingCore,
-  binaryPath: string,
-  logger: LevelLogger
-) => HeadlessChromiumDriverFactory;
-
 export interface BrowserDownload {
-  createDriverFactory: CreateDriverFactory;
+  createDriverFactory: (
+    core: ReportingCore,
+    captureConfig: ReportingConfigType['capture'],
+    logger: LevelLogger
+  ) => HeadlessChromiumDriverFactory;
   paths: ChromiumArchivePaths;
 }
-
-export const initializeBrowserDriverFactory = async (core: ReportingCore, logger: LevelLogger) => {
-  const { binaryPath$ } = installBrowser(logger);
-  const binaryPath = await binaryPath$.pipe(first()).toPromise();
-  return chromium.createDriverFactory(core, binaryPath, logger);
-};

--- a/x-pack/plugins/reporting/server/export_types/common/generate_png.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/generate_png.ts
@@ -15,10 +15,10 @@ import { LayoutParams, PreserveLayout } from '../../lib/layouts';
 import { getScreenshots$, ScreenshotResults } from '../../lib/screenshots';
 import { ConditionalHeaders } from '../common';
 
-export async function generatePngObservableFactory(reporting: ReportingCore) {
+export function generatePngObservableFactory(reporting: ReportingCore) {
   const config = reporting.getConfig();
   const captureConfig = config.get('capture');
-  const { browserDriverFactory } = await reporting.getPluginStartDeps();
+  const browserDriverFactory = reporting.getBrowserDriverFactory();
 
   return function generatePngObservable(
     logger: LevelLogger,

--- a/x-pack/plugins/reporting/server/export_types/png/execute_job/index.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/png/execute_job/index.test.ts
@@ -69,10 +69,10 @@ afterEach(() => (generatePngObservableFactory as jest.Mock).mockReset());
 
 test(`passes browserTimezone to generatePng`, async () => {
   const encryptedHeaders = await encryptHeaders({});
-  const generatePngObservable = (await generatePngObservableFactory(mockReporting)) as jest.Mock;
+  const generatePngObservable = generatePngObservableFactory(mockReporting) as jest.Mock;
   generatePngObservable.mockReturnValue(Rx.of({ buffer: Buffer.from('') }));
 
-  const runTask = await runTaskFnFactory(mockReporting, getMockLogger());
+  const runTask = runTaskFnFactory(mockReporting, getMockLogger());
   const browserTimezone = 'UTC';
   await runTask(
     'pngJobId',
@@ -117,10 +117,10 @@ test(`passes browserTimezone to generatePng`, async () => {
 });
 
 test(`returns content_type of application/png`, async () => {
-  const runTask = await runTaskFnFactory(mockReporting, getMockLogger());
+  const runTask = runTaskFnFactory(mockReporting, getMockLogger());
   const encryptedHeaders = await encryptHeaders({});
 
-  const generatePngObservable = await generatePngObservableFactory(mockReporting);
+  const generatePngObservable = generatePngObservableFactory(mockReporting);
   (generatePngObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from('foo') }));
 
   const { content_type: contentType } = await runTask(
@@ -134,10 +134,10 @@ test(`returns content_type of application/png`, async () => {
 
 test(`returns content of generatePng`, async () => {
   const testContent = 'raw string from get_screenhots';
-  const generatePngObservable = await generatePngObservableFactory(mockReporting);
+  const generatePngObservable = generatePngObservableFactory(mockReporting);
   (generatePngObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from(testContent) }));
 
-  const runTask = await runTaskFnFactory(mockReporting, getMockLogger());
+  const runTask = runTaskFnFactory(mockReporting, getMockLogger());
   const encryptedHeaders = await encryptHeaders({});
   await runTask(
     'pngJobId',

--- a/x-pack/plugins/reporting/server/export_types/png/execute_job/index.ts
+++ b/x-pack/plugins/reporting/server/export_types/png/execute_job/index.ts
@@ -30,7 +30,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPNG>> =
       const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
       let apmGeneratePng: { end: () => void } | null | undefined;
 
-      const generatePngObservable = await generatePngObservableFactory(reporting);
+      const generatePngObservable = generatePngObservableFactory(reporting);
       const jobLogger = parentLogger.clone([PNG_JOB_TYPE, 'execute', jobId]);
       const process$: Rx.Observable<TaskRunResult> = Rx.of(1).pipe(
         mergeMap(() => decryptJobHeaders(encryptionKey, job.headers, jobLogger)),

--- a/x-pack/plugins/reporting/server/export_types/png_v2/execute_job.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/png_v2/execute_job.test.ts
@@ -70,10 +70,10 @@ afterEach(() => (generatePngObservableFactory as jest.Mock).mockReset());
 
 test(`passes browserTimezone to generatePng`, async () => {
   const encryptedHeaders = await encryptHeaders({});
-  const generatePngObservable = (await generatePngObservableFactory(mockReporting)) as jest.Mock;
+  const generatePngObservable = generatePngObservableFactory(mockReporting) as jest.Mock;
   generatePngObservable.mockReturnValue(Rx.of({ buffer: Buffer.from('') }));
 
-  const runTask = await runTaskFnFactory(mockReporting, getMockLogger());
+  const runTask = runTaskFnFactory(mockReporting, getMockLogger());
   const browserTimezone = 'UTC';
   await runTask(
     'pngJobId',
@@ -128,10 +128,10 @@ test(`passes browserTimezone to generatePng`, async () => {
 });
 
 test(`returns content_type of application/png`, async () => {
-  const runTask = await runTaskFnFactory(mockReporting, getMockLogger());
+  const runTask = runTaskFnFactory(mockReporting, getMockLogger());
   const encryptedHeaders = await encryptHeaders({});
 
-  const generatePngObservable = await generatePngObservableFactory(mockReporting);
+  const generatePngObservable = generatePngObservableFactory(mockReporting);
   (generatePngObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from('foo') }));
 
   const { content_type: contentType } = await runTask(
@@ -148,12 +148,12 @@ test(`returns content_type of application/png`, async () => {
 
 test(`returns content of generatePng getBuffer base64 encoded`, async () => {
   const testContent = 'raw string from get_screenhots';
-  const generatePngObservable = await generatePngObservableFactory(mockReporting);
+  const generatePngObservable = generatePngObservableFactory(mockReporting);
   (generatePngObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from(testContent) }));
 
-  const runTask = await runTaskFnFactory(mockReporting, getMockLogger());
+  const runTask = runTaskFnFactory(mockReporting, getMockLogger());
   const encryptedHeaders = await encryptHeaders({});
-  await runTask(
+  runTask(
     'pngJobId',
     getBasePayload({
       locatorParams: [{ version: 'test', id: 'test' }] as LocatorParams[],

--- a/x-pack/plugins/reporting/server/export_types/png_v2/execute_job.ts
+++ b/x-pack/plugins/reporting/server/export_types/png_v2/execute_job.ts
@@ -31,7 +31,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPNGV2>> =
       const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
       let apmGeneratePng: { end: () => void } | null | undefined;
 
-      const generatePngObservable = await generatePngObservableFactory(reporting);
+      const generatePngObservable = generatePngObservableFactory(reporting);
       const jobLogger = parentLogger.clone([PNG_JOB_TYPE_V2, 'execute', jobId]);
       const process$: Rx.Observable<TaskRunResult> = Rx.of(1).pipe(
         mergeMap(() => decryptJobHeaders(encryptionKey, job.headers, jobLogger)),

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf/execute_job/index.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf/execute_job/index.test.ts
@@ -64,7 +64,7 @@ afterEach(() => (generatePdfObservableFactory as jest.Mock).mockReset());
 
 test(`passes browserTimezone to generatePdf`, async () => {
   const encryptedHeaders = await encryptHeaders({});
-  const generatePdfObservable = (await generatePdfObservableFactory(mockReporting)) as jest.Mock;
+  const generatePdfObservable = generatePdfObservableFactory(mockReporting) as jest.Mock;
   generatePdfObservable.mockReturnValue(Rx.of({ buffer: Buffer.from('') }));
 
   const runTask = runTaskFnFactory(mockReporting, getMockLogger());
@@ -90,7 +90,7 @@ test(`returns content_type of application/pdf`, async () => {
   const runTask = runTaskFnFactory(mockReporting, logger);
   const encryptedHeaders = await encryptHeaders({});
 
-  const generatePdfObservable = await generatePdfObservableFactory(mockReporting);
+  const generatePdfObservable = generatePdfObservableFactory(mockReporting);
   (generatePdfObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from('') }));
 
   const { content_type: contentType } = await runTask(
@@ -104,7 +104,7 @@ test(`returns content_type of application/pdf`, async () => {
 
 test(`returns content of generatePdf getBuffer base64 encoded`, async () => {
   const testContent = 'test content';
-  const generatePdfObservable = await generatePdfObservableFactory(mockReporting);
+  const generatePdfObservable = generatePdfObservableFactory(mockReporting);
   (generatePdfObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from(testContent) }));
 
   const runTask = runTaskFnFactory(mockReporting, getMockLogger());

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf/lib/generate_pdf.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf/lib/generate_pdf.ts
@@ -26,10 +26,10 @@ const getTimeRange = (urlScreenshots: ScreenshotResults[]) => {
   return null;
 };
 
-export async function generatePdfObservableFactory(reporting: ReportingCore) {
+export function generatePdfObservableFactory(reporting: ReportingCore) {
   const config = reporting.getConfig();
   const captureConfig = config.get('capture');
-  const { browserDriverFactory } = await reporting.getPluginStartDeps();
+  const browserDriverFactory = reporting.getBrowserDriverFactory();
 
   return function generatePdfObservable(
     logger: LevelLogger,

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.test.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.test.ts
@@ -69,7 +69,7 @@ afterEach(() => (generatePdfObservableFactory as jest.Mock).mockReset());
 
 test(`passes browserTimezone to generatePdf`, async () => {
   const encryptedHeaders = await encryptHeaders({});
-  const generatePdfObservable = (await generatePdfObservableFactory(mockReporting)) as jest.Mock;
+  const generatePdfObservable = generatePdfObservableFactory(mockReporting) as jest.Mock;
   generatePdfObservable.mockReturnValue(Rx.of(Buffer.from('')));
 
   const runTask = runTaskFnFactory(mockReporting, getMockLogger());
@@ -96,7 +96,7 @@ test(`returns content_type of application/pdf`, async () => {
   const runTask = runTaskFnFactory(mockReporting, logger);
   const encryptedHeaders = await encryptHeaders({});
 
-  const generatePdfObservable = await generatePdfObservableFactory(mockReporting);
+  const generatePdfObservable = generatePdfObservableFactory(mockReporting);
   (generatePdfObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from('') }));
 
   const { content_type: contentType } = await runTask(
@@ -110,7 +110,7 @@ test(`returns content_type of application/pdf`, async () => {
 
 test(`returns content of generatePdf getBuffer base64 encoded`, async () => {
   const testContent = 'test content';
-  const generatePdfObservable = await generatePdfObservableFactory(mockReporting);
+  const generatePdfObservable = generatePdfObservableFactory(mockReporting);
   (generatePdfObservable as jest.Mock).mockReturnValue(Rx.of({ buffer: Buffer.from(testContent) }));
 
   const runTask = runTaskFnFactory(mockReporting, getMockLogger());

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/execute_job.ts
@@ -32,7 +32,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDFV2>> =
       const apmGetAssets = apmTrans?.startSpan('get_assets', 'setup');
       let apmGeneratePdf: { end: () => void } | null | undefined;
 
-      const generatePdfObservable = await generatePdfObservableFactory(reporting);
+      const generatePdfObservable = generatePdfObservableFactory(reporting);
 
       const process$: Rx.Observable<TaskRunResult> = Rx.of(1).pipe(
         mergeMap(() => decryptJobHeaders(encryptionKey, job.headers, jobLogger)),
@@ -57,7 +57,7 @@ export const runTaskFnFactory: RunTaskFnFactory<RunTaskFn<TaskPayloadPDFV2>> =
             logo
           );
         }),
-        tap(({ buffer, warnings }) => {
+        tap(({ buffer }) => {
           apmGeneratePdf?.end();
 
           if (buffer) {

--- a/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
+++ b/x-pack/plugins/reporting/server/export_types/printable_pdf_v2/lib/generate_pdf.ts
@@ -29,10 +29,10 @@ const getTimeRange = (urlScreenshots: ScreenshotResults[]) => {
   return null;
 };
 
-export async function generatePdfObservableFactory(reporting: ReportingCore) {
+export function generatePdfObservableFactory(reporting: ReportingCore) {
   const config = reporting.getConfig();
   const captureConfig = config.get('capture');
-  const { browserDriverFactory } = await reporting.getPluginStartDeps();
+  const browserDriverFactory = reporting.getBrowserDriverFactory();
 
   return function generatePdfObservable(
     logger: LevelLogger,

--- a/x-pack/plugins/reporting/server/plugin.test.ts
+++ b/x-pack/plugins/reporting/server/plugin.test.ts
@@ -5,15 +5,13 @@
  * 2.0.
  */
 
-jest.mock('./browsers/install', () => ({
-  installBrowser: jest.fn().mockImplementation(() => ({
-    binaryPath$: {
-      pipe: jest.fn().mockImplementation(() => ({
-        toPromise: () => Promise.resolve(),
-      })),
-    },
-  })),
-}));
+jest.mock('./browsers/install', () =>
+  Promise.resolve({
+    installBrowser: jest.fn().mockImplementation(() => ({
+      binaryPath: 'super/cool/amazing/path',
+    })),
+  })
+);
 
 import { coreMock } from 'src/core/server/mocks';
 import { featuresPluginMock } from '../../features/server/mocks';

--- a/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
+++ b/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
@@ -24,8 +24,8 @@ export const registerDiagnoseScreenshot = (reporting: ReportingCore, logger: Log
       path: `${API_DIAGNOSE_URL}/screenshot`,
       validate: {},
     },
-    authorizedUserPreRouting(reporting, async (_user, _context, req, res) => {
-      const generatePngObservable = await generatePngObservableFactory(reporting);
+    authorizedUserPreRouting(reporting, (_user, _context, req, res) => {
+      const generatePngObservable = generatePngObservableFactory(reporting);
       const config = reporting.getConfig();
       const decryptedHeaders = req.headers as Record<string, string>;
       const [basePath, protocol, hostname, port] = [

--- a/x-pack/plugins/reporting/server/test_helpers/create_mock_browserdriverfactory.ts
+++ b/x-pack/plugins/reporting/server/test_helpers/create_mock_browserdriverfactory.ts
@@ -120,8 +120,7 @@ export const createMockBrowserDriverFactory = async (
     maxAttempts: 1,
   };
 
-  const binaryPath = '/usr/local/share/common/secure/super_awesome_binary';
-  const mockBrowserDriverFactory = chromium.createDriverFactory(core, binaryPath, logger);
+  const mockBrowserDriverFactory = chromium.createDriverFactory(core, captureConfig, logger);
   const mockPage = { setViewport: () => {} } as unknown as Page;
   const mockBrowserDriver = new HeadlessChromiumDriver(core, mockPage, {
     inspect: true,

--- a/x-pack/plugins/reporting/server/test_helpers/create_mock_reportingplugin.ts
+++ b/x-pack/plugins/reporting/server/test_helpers/create_mock_reportingplugin.ts
@@ -12,25 +12,17 @@ jest.mock('../browsers');
 import _ from 'lodash';
 import * as Rx from 'rxjs';
 import { coreMock, elasticsearchServiceMock } from 'src/core/server/mocks';
-import { FieldFormatsRegistry } from 'src/plugins/field_formats/common';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { dataPluginMock } from 'src/plugins/data/server/mocks';
+import { FieldFormatsRegistry } from 'src/plugins/field_formats/common';
 import { ReportingConfig, ReportingCore } from '../';
 import { featuresPluginMock } from '../../../features/server/mocks';
-import {
-  chromium,
-  HeadlessChromiumDriverFactory,
-  initializeBrowserDriverFactory,
-} from '../browsers';
+import { chromium } from '../browsers';
 import { ReportingConfigType } from '../config';
 import { ReportingInternalSetup, ReportingInternalStart } from '../core';
 import { ReportingStore } from '../lib';
 import { setFieldFormats } from '../services';
 import { createMockLevelLogger } from './create_mock_levellogger';
-
-(
-  initializeBrowserDriverFactory as jest.Mock<Promise<HeadlessChromiumDriverFactory>>
-).mockImplementation(() => Promise.resolve({} as HeadlessChromiumDriverFactory));
 
 (chromium as any).createDriverFactory.mockImplementation(() => ({}));
 


### PR DESCRIPTION
## Summary

Problem: Something that would have made working on https://github.com/elastic/kibana/pull/112905 better, is if the browser drivers were initialized in the `setup` phase of the Reporting plugin, rather than the `start`. That would allowed dev to work through this without the need to have Elasticsearch connected.
 
This PR makes Reporting register its browser driver factory register in the plugin `setup` method, which means not waiting for Elasticsearch to start before checking the existence of the browser and validating the checksum.