### PR TITLE
[Alerting] Fixed Jest test suites with unhandled promise rejections

### DIFF
--- a/x-pack/plugins/stack_alerts/server/feature.test.ts
+++ b/x-pack/plugins/stack_alerts/server/feature.test.ts
@@ -12,13 +12,20 @@ import { featuresPluginMock } from '../../features/server/mocks';
 import { BUILT_IN_ALERTS_FEATURE } from './feature';
 
 describe('Stack Alerts Feature Privileges', () => {
-  test('feature privilege should contain all built-in rule types', async () => {
+  test('feature privilege should contain all built-in rule types', () => {
     const context = coreMock.createPluginInitializerContext();
     const plugin = new AlertingBuiltinsPlugin(context);
     const coreSetup = coreMock.createSetup();
+    coreSetup.getStartServices = jest.fn().mockResolvedValue([
+      {
+        application: {},
+      },
+      { triggersActionsUi: {} },
+    ]);
+
     const alertingSetup = alertsMock.createSetup();
     const featuresSetup = featuresPluginMock.createSetup();
-    await plugin.setup(coreSetup, { alerting: alertingSetup, features: featuresSetup });
+    plugin.setup(coreSetup, { alerting: alertingSetup, features: featuresSetup });
 
     const typesInFeaturePrivilege = BUILT_IN_ALERTS_FEATURE.alerting ?? [];
     const typesInFeaturePrivilegeAll =

--- a/x-pack/plugins/stack_alerts/server/plugin.test.ts
+++ b/x-pack/plugins/stack_alerts/server/plugin.test.ts
@@ -21,12 +21,18 @@ describe('AlertingBuiltins Plugin', () => {
       context = coreMock.createPluginInitializerContext();
       plugin = new AlertingBuiltinsPlugin(context);
       coreSetup = coreMock.createSetup();
+      coreSetup.getStartServices = jest.fn().mockResolvedValue([
+        {
+          application: {},
+        },
+        { triggersActionsUi: {} },
+      ]);
     });
 
-    it('should register built-in alert types', async () => {
+    it('should register built-in alert types', () => {
       const alertingSetup = alertsMock.createSetup();
       const featuresSetup = featuresPluginMock.createSetup();
-      await plugin.setup(coreSetup, { alerting: alertingSetup, features: featuresSetup });
+      plugin.setup(coreSetup, { alerting: alertingSetup, features: featuresSetup });
 
       expect(alertingSetup.registerType).toHaveBeenCalledTimes(3);
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import * as React from 'react';
-import { mountWithIntl } from '@kbn/test/jest';
+import { mountWithIntl, nextTick } from '@kbn/test/jest';
+import { act } from 'react-dom/test-utils';
 import ConnectorAddModal from './connector_add_modal';
 import { actionTypeRegistryMock } from '../../action_type_registry.mock';
 import { ActionType, ConnectorValidationResult, GenericValidationResult } from '../../../types';
@@ -14,17 +15,17 @@ import { useKibana } from '../../../common/lib/kibana';
 import { coreMock } from '../../../../../../../src/core/public/mocks';
 
 jest.mock('../../../common/lib/kibana');
-const mocks = coreMock.createSetup();
 const actionTypeRegistry = actionTypeRegistryMock.create();
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 describe('connector_add_modal', () => {
   beforeAll(async () => {
+    const mockes = coreMock.createSetup();
     const [
       {
         application: { capabilities },
       },
-    ] = await mocks.getStartServices();
+    ] = await mockes.getStartServices();
     useKibanaMock().services.application.capabilities = {
       ...capabilities,
       actions: {
@@ -34,13 +35,14 @@ describe('connector_add_modal', () => {
       },
     };
   });
-  it('renders connector modal form if addModalVisible is true', () => {
+
+  it('renders connector modal form if addModalVisible is true', async () => {
     const actionTypeModel = actionTypeRegistryMock.createMockActionTypeModel({
       id: 'my-action-type',
       iconClass: 'test',
       selectMessage: 'test',
       validateConnector: (): Promise<ConnectorValidationResult<unknown, unknown>> => {
-        return Promise.resolve({});
+        return Promise.resolve({ config: { errors: {} }, secrets: { errors: {} } });
       },
       validateParams: (): Promise<GenericValidationResult<unknown>> => {
         const validationResult = { errors: {} };
@@ -48,7 +50,7 @@ describe('connector_add_modal', () => {
       },
       actionConnectorFields: null,
     });
-    actionTypeRegistry.get.mockReturnValueOnce(actionTypeModel);
+    actionTypeRegistry.get.mockReturnValue(actionTypeModel);
     actionTypeRegistry.has.mockReturnValue(true);
 
     const actionType: ActionType = {
@@ -67,6 +69,11 @@ describe('connector_add_modal', () => {
         actionTypeRegistry={actionTypeRegistry}
       />
     );
+
+    await act(async () => {
+      await nextTick();
+      wrapper.update();
+    });
     expect(wrapper.exists('.euiModalHeader')).toBeTruthy();
     expect(wrapper.exists('[data-test-subj="saveActionButtonModal"]')).toBeTruthy();
   });

--- a/x-pack/plugins/triggers_actions_ui/server/data/lib/time_series_query.test.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/data/lib/time_series_query.test.ts
@@ -10,12 +10,7 @@
 import type { estypes } from '@elastic/elasticsearch';
 import { loggingSystemMock } from '../../../../../../src/core/server/mocks';
 import { Logger } from '../../../../../../src/core/server';
-import {
-  TimeSeriesQueryParameters,
-  TimeSeriesQuery,
-  timeSeriesQuery,
-  getResultFromEs,
-} from './time_series_query';
+import { TimeSeriesQuery, timeSeriesQuery, getResultFromEs } from './time_series_query';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { elasticsearchClientMock } from '../../../../../../src/core/server/elasticsearch/client/mocks';
 


### PR DESCRIPTION
## Summary
Current PR fixed `UnhandledPromiseRejectionWarning: ...` which caused in the next Alerting jest tests:
`x-pack/plugins/stack_alerts/server/feature.test.ts`
`x-pack/plugins/stack_alerts/server/plugin.test.ts`
`x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/connector_add_modal.test.tsx`
`x-pack/plugins/triggers_actions_ui/server/data/lib/time_series_query.test.ts`

To test it just run each suite using command:
```
node scripts/jest <suite>
```

Resolves #112703