### PR TITLE
Fixes error with percentiles on index with many docs

### DIFF
--- a/src/plugins/data/common/search/aggs/metrics/percentiles.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles.test.ts
@@ -10,6 +10,7 @@ import { IPercentileAggConfig, getPercentilesMetricAgg } from './percentiles';
 import { AggConfigs, IAggConfigs } from '../agg_configs';
 import { mockAggTypesRegistry } from '../test_helpers';
 import { METRIC_TYPES } from './metric_agg_types';
+import { IResponseAggConfig } from './lib/get_response_agg_config_class';
 
 describe('AggTypesMetricsPercentilesProvider class', () => {
   let aggConfigs: IAggConfigs;
@@ -91,5 +92,55 @@ describe('AggTypesMetricsPercentilesProvider class', () => {
         "type": "expression",
       }
     `);
+  });
+
+  it('returns NaN if bucket has zero documents', () => {
+    const agg = {
+      id: '1.5',
+      key: 5,
+      parentId: '1',
+    } as IResponseAggConfig;
+    const percentileValue: any = getPercentilesMetricAgg().getValue(agg, {
+      doc_count: 0,
+    });
+
+    expect(percentileValue).toBe(NaN);
+  });
+
+  it('computes the value correctly', () => {
+    const agg = {
+      id: '1.5',
+      key: 5,
+      parentId: '1',
+    } as IResponseAggConfig;
+    const percentileValue: any = getPercentilesMetricAgg().getValue(agg, {
+      doc_count: 0,
+      1: {
+        values: [
+          {
+            key: 1,
+            value: 0,
+          },
+          {
+            key: 5,
+            value: 306.5442142237532,
+          },
+          {
+            key: 75,
+            value: 8014.248827201506,
+          },
+          {
+            key: 95,
+            value: 10118.560640759324,
+          },
+          {
+            key: 99,
+            value: 18028.720727798096,
+          },
+        ],
+      },
+    });
+
+    expect(percentileValue).toBe(306.5442142237532);
   });
 });

--- a/src/plugins/data/common/search/aggs/metrics/percentiles_get_value.ts
+++ b/src/plugins/data/common/search/aggs/metrics/percentiles_get_value.ts
@@ -13,7 +13,7 @@ export const getPercentileValue = <TAggConfig extends IResponseAggConfig>(
   agg: TAggConfig,
   bucket: any
 ) => {
-  const { values } = bucket[agg.parentId];
+  const { values } = bucket[agg.parentId] ?? {};
 
   const percentile: any = find(values, ({ key }) => key === agg.key);
 

--- a/test/functional/apps/visualize/_metric_chart.ts
+++ b/test/functional/apps/visualize/_metric_chart.ts
@@ -17,8 +17,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const inspector = getService('inspector');
   const PageObjects = getPageObjects(['visualize', 'visEditor', 'visChart', 'timePicker']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/106121
-  describe.skip('metric chart', function () {
+  describe('metric chart', function () {
     before(async function () {
       await PageObjects.visualize.initTests();
       log.debug('navigateToApp visualize');


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/kibana/issues/106121
closes https://github.com/elastic/kibana/issues/113215

This fixes the error described on the issue. Specifically, we found out that when we are using percentiles agg on visualizations based on an index with many documents, the request returns zero data. As a result, the destructure fails and the error appears.

By providing a fallback, seems to solve the problem.

Runner 100 times https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1949/
Runner 100 times https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/1950/