### PR TITLE
[ML] Functional tests - adjust custom URL timeout

### DIFF
--- a/x-pack/test/functional/services/ml/custom_urls.ts
+++ b/x-pack/test/functional/services/ml/custom_urls.ts
@@ -103,7 +103,7 @@ export function MachineLearningCustomUrlsProvider({
     },
 
     async assertCustomUrlLabel(index: number, expectedLabel: string) {
-      await testSubjects.existOrFail(`mlJobEditCustomUrlLabelInput_${index}`);
+      await testSubjects.existOrFail(`mlJobEditCustomUrlLabelInput_${index}`, { timeout: 1000 });
       const actualLabel = await testSubjects.getAttribute(
         `mlJobEditCustomUrlLabelInput_${index}`,
         'value'


### PR DESCRIPTION
## Summary

This PR adjusts the timeout for checking the custom URL label.

Some time ago the default timeout for the `existOrFail` method changed from 2.5 seconds to 120 seconds. As a result, a timeout in this assertion did not trigger the surrounding 5 second retry anymore. With this PR, the inner timeout is set to 1 second, so the retry is triggered as expected. This is a follow-up fix on #113096.

Closes #106053
