### PR TITLE
[Reporting] Improve _read code in ContentStream

### DIFF
--- a/x-pack/plugins/reporting/server/lib/content_stream.ts
+++ b/x-pack/plugins/reporting/server/lib/content_stream.ts
@@ -179,28 +179,27 @@ export class ContentStream extends Duplex {
     return this.jobSize != null && this.bytesRead >= this.jobSize;
   }
 
-  async _read() {
-    try {
-      const content = this.chunksRead ? await this.readChunk() : await this.readHead();
-      if (!content) {
-        this.logger.debug(`Chunk is empty.`);
-        this.push(null);
-        return;
-      }
+  _read() {
+    (this.chunksRead ? this.readChunk() : this.readHead())
+      .then((content) => {
+        if (!content) {
+          this.logger.debug(`Chunk is empty.`);
+          this.push(null);
+          return;
+        }
 
-      const buffer = this.decode(content);
+        const buffer = this.decode(content);
 
-      this.push(buffer);
-      this.chunksRead++;
-      this.bytesRead += buffer.byteLength;
+        this.push(buffer);
+        this.chunksRead++;
+        this.bytesRead += buffer.byteLength;
 
-      if (this.isRead()) {
-        this.logger.debug(`Read ${this.bytesRead} of ${this.jobSize} bytes.`);
-        this.push(null);
-      }
-    } catch (error) {
-      this.destroy(error);
-    }
+        if (this.isRead()) {
+          this.logger.debug(`Read ${this.bytesRead} of ${this.jobSize} bytes.`);
+          this.push(null);
+        }
+      })
+      .catch((err) => this.destroy(err));
   }
 
   private async removeChunks() {


### PR DESCRIPTION
This PR is a follow up to #112950, in which I forgot to also refactor the `_read` function. Similar to that PR, this PR cleans up the streaming code to not imply that the overridden `_read` function is `async` as this could have unintended consequences.