### PR TITLE
[7.x] [AppServices] Fix unhandled promise rejections in search tests (#112849)

### DIFF
--- a/src/plugins/data/common/search/search_source/search_source.test.ts
+++ b/src/plugins/data/common/search/search_source/search_source.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { GetConfigFn } from '../../types';
 import { IndexPattern } from '../..';
 import { SearchSource, SearchSourceDependencies, SortDirection } from './';
@@ -26,25 +26,25 @@ const getComputedFields = () => ({
 const mockSource = { excludes: ['foo-*'] };
 const mockSource2 = { excludes: ['bar-*'] };
 
-const indexPattern = {
+const indexPattern = ({
   title: 'foo',
   fields: [{ name: 'foo-bar' }, { name: 'field1' }, { name: 'field2' }, { name: '_id' }],
   getComputedFields,
   getSourceFiltering: () => mockSource,
-} as unknown as IndexPattern;
+} as unknown) as IndexPattern;
 
-const indexPattern2 = {
+const indexPattern2 = ({
   title: 'foo',
   getComputedFields,
   getSourceFiltering: () => mockSource2,
-} as unknown as IndexPattern;
+} as unknown) as IndexPattern;
 
 const fields3 = [{ name: 'foo-bar' }, { name: 'field1' }, { name: 'field2' }];
-const indexPattern3 = {
+const indexPattern3 = ({
   title: 'foo',
   fields: {
     getByName: (name: string) => {
-      return fields3.find((field) => field.name === name);
+      return fields3.find(field => field.name === name);
     },
     filter: () => {
       return fields3;
@@ -52,7 +52,7 @@ const indexPattern3 = {
   },
   getComputedFields,
   getSourceFiltering: () => mockSource,
-} as unknown as IndexPattern;
+} as unknown) as IndexPattern;
 
 const runtimeFieldDef = {
   type: 'keyword',
@@ -69,7 +69,7 @@ describe('SearchSource', () => {
   beforeEach(() => {
     const getConfigMock = jest
       .fn()
-      .mockImplementation((param) => param === 'metaFields' && ['_type', '_source', '_id'])
+      .mockImplementation(param => param === 'metaFields' && ['_type', '_source', '_id'])
       .mockName('getConfig');
 
     mockSearchMethod = jest
@@ -140,7 +140,7 @@ describe('SearchSource', () => {
     describe('computed fields handling', () => {
       test('still provides computed fields when no fields are specified', async () => {
         const runtimeFields = { runtime_field: runtimeFieldDef };
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['hello'],
@@ -148,7 +148,7 @@ describe('SearchSource', () => {
             docvalueFields: ['@timestamp'],
             runtimeFields,
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
 
         const request = searchSource.getSearchRequestBody();
         expect(request.stored_fields).toEqual(['hello']);
@@ -158,14 +158,14 @@ describe('SearchSource', () => {
       });
 
       test('never includes docvalue_fields', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['@timestamp'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['@timestamp']);
         searchSource.setField('fieldsFromSource', ['foo']);
 
@@ -174,14 +174,14 @@ describe('SearchSource', () => {
       });
 
       test('overrides computed docvalue fields with ones that are provided', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['hello'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('docvalue_fields', ['world']);
 
@@ -191,14 +191,14 @@ describe('SearchSource', () => {
       });
 
       test('allows explicitly provided docvalue fields to override fields API when fetching fieldsFromSource', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: [{ field: 'a', format: 'date_time' }],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('docvalue_fields', [{ field: 'b', format: 'date_time' }]);
         searchSource.setField('fields', ['c']);
@@ -213,10 +213,10 @@ describe('SearchSource', () => {
 
       test('allows you to override computed fields if you provide a format', async () => {
         const indexPatternFields = indexPattern.fields;
-        indexPatternFields.getByType = (type) => {
+        indexPatternFields.getByType = type => {
           return [];
         };
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           fields: indexPatternFields,
           getComputedFields: () => ({
@@ -224,7 +224,7 @@ describe('SearchSource', () => {
             scriptFields: {},
             docvalueFields: [{ field: 'hello', format: 'date_time' }],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', [{ field: 'hello', format: 'strict_date_time' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -233,14 +233,14 @@ describe('SearchSource', () => {
       });
 
       test('injects a date format for computed docvalue fields if none is provided', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: [{ field: 'hello', format: 'date_time' }],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['hello']);
 
         const request = searchSource.getSearchRequestBody();
@@ -249,7 +249,7 @@ describe('SearchSource', () => {
       });
 
       test('injects a date format for computed docvalue fields while merging other properties', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           fields: {
             getByType: () => {
@@ -261,7 +261,7 @@ describe('SearchSource', () => {
             scriptFields: {},
             docvalueFields: [{ field: 'hello', format: 'date_time', a: 'test', b: 'test' }],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', [{ field: 'hello', a: 'a', c: 'c' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -272,14 +272,14 @@ describe('SearchSource', () => {
       });
 
       test('merges provided script fields with computed fields', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('script_fields', { world: {} });
 
@@ -292,14 +292,14 @@ describe('SearchSource', () => {
       });
 
       test(`requests any fields that aren't script_fields from stored_fields`, async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['hello', 'a', { field: 'c' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -308,14 +308,14 @@ describe('SearchSource', () => {
       });
 
       test('ignores objects without a `field` property when setting stored_fields', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['hello', 'a', { foo: 'c' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -324,14 +324,14 @@ describe('SearchSource', () => {
       });
 
       test(`requests any fields that aren't script_fields from stored_fields with fieldsFromSource`, async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fieldsFromSource', ['hello', 'a']);
 
         const request = searchSource.getSearchRequestBody();
@@ -427,14 +427,14 @@ describe('SearchSource', () => {
 
     describe('source filters handling', () => {
       test('excludes docvalue fields based on source filtering', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['@timestamp', 'exclude-me'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         // @ts-expect-error Typings for excludes filters need to be fixed.
         searchSource.setField('source', { excludes: ['exclude-*'] });
 
@@ -443,28 +443,28 @@ describe('SearchSource', () => {
       });
 
       test('defaults to source filters from index pattern', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['@timestamp', 'foo-bar', 'foo-baz'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
 
         const request = searchSource.getSearchRequestBody();
         expect(request.fields).toEqual(['@timestamp']);
       });
 
       test('filters script fields to only include specified fields', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['hello']);
 
         const request = searchSource.getSearchRequestBody();
@@ -472,14 +472,14 @@ describe('SearchSource', () => {
       });
 
       test('request all fields except the ones specified with source filters', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', [
           'hello',
           'foo-bar',
@@ -493,14 +493,14 @@ describe('SearchSource', () => {
       });
 
       test('request all fields from index pattern except the ones specified with source filters', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -508,14 +508,14 @@ describe('SearchSource', () => {
       });
 
       test('request all fields from index pattern except the ones specified with source filters with unmapped_fields option', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -523,14 +523,14 @@ describe('SearchSource', () => {
       });
 
       test('excludes metafields from the request', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -545,14 +545,14 @@ describe('SearchSource', () => {
       });
 
       test('returns all scripted fields when one fields entry is *', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: [],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['timestamp', '*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -562,14 +562,14 @@ describe('SearchSource', () => {
 
     describe('handling for when specific fields are provided', () => {
       test('fieldsFromSource will request any fields outside of script_fields from _source & stored fields', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: ['@timestamp'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fieldsFromSource', [
           'hello',
           'world',
@@ -586,14 +586,14 @@ describe('SearchSource', () => {
       });
 
       test('filters request when a specific list of fields is provided', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['*'],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: ['@timestamp', 'date'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['hello', '@timestamp', 'foo-a', 'bar']);
 
         const request = searchSource.getSearchRequestBody();
@@ -604,7 +604,7 @@ describe('SearchSource', () => {
 
       test('filters request when a specific list of fields is provided with fieldsFromSource', async () => {
         const runtimeFields = { runtime_field: runtimeFieldDef, runtime_field_b: runtimeFieldDef };
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['*'],
@@ -612,7 +612,7 @@ describe('SearchSource', () => {
             docvalueFields: ['@timestamp', 'date'],
             runtimeFields,
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fieldsFromSource', [
           'hello',
           '@timestamp',
@@ -632,14 +632,14 @@ describe('SearchSource', () => {
       });
 
       test('filters request when a specific list of fields is provided with fieldsFromSource or fields', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['*'],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: ['@timestamp', 'date', 'time'],
           }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['hello', '@timestamp', 'foo-a', 'bar']);
         searchSource.setField('fieldsFromSource', ['foo-b', 'date', 'baz']);
 
@@ -655,7 +655,7 @@ describe('SearchSource', () => {
 
     describe('handling date fields', () => {
       test('adds date format to any date field', async () => {
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
@@ -666,7 +666,7 @@ describe('SearchSource', () => {
             getByType: () => [{ name: '@timestamp', esTypes: ['date_nanos'] }],
           },
           getSourceFiltering: () => ({ excludes: [] }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -679,13 +679,13 @@ describe('SearchSource', () => {
       test('adds date format to any date field except the one excluded by source filters', async () => {
         const indexPatternFields = indexPattern.fields;
         // @ts-ignore
-        indexPatternFields.getByType = (type) => {
+        indexPatternFields.getByType = type => {
           return [
             { name: '@timestamp', esTypes: ['date_nanos'] },
             { name: 'custom_date', esTypes: ['date'] },
           ];
         };
-        searchSource.setField('index', {
+        searchSource.setField('index', ({
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
@@ -694,7 +694,7 @@ describe('SearchSource', () => {
           }),
           fields: indexPatternFields,
           getSourceFiltering: () => ({ excludes: ['custom_date'] }),
-        } as unknown as IndexPattern);
+        } as unknown) as IndexPattern);
         searchSource.setField('fields', ['*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -867,7 +867,7 @@ describe('SearchSource', () => {
       searchSource.setField('docvalue_fields', ['prop1']);
       searchSource.setField('source', ['geometry']);
       searchSource.setField('fieldsFromSource', ['geometry', 'prop1']);
-      searchSource.setField('index', {
+      searchSource.setField('index', ({
         ...indexPattern,
         getSourceFiltering: () => ({ excludes: [] }),
         getComputedFields: () => ({
@@ -875,7 +875,7 @@ describe('SearchSource', () => {
           scriptFields: {},
           docvalueFields: [],
         }),
-      } as unknown as IndexPattern);
+      } as unknown) as IndexPattern);
       const request = searchSource.getSearchRequestBody();
       expect(request.stored_fields).toEqual(['geometry', 'prop1']);
       expect(request.docvalue_fields).toEqual(['prop1']);
@@ -1067,7 +1067,7 @@ describe('SearchSource', () => {
         const complete = jest.fn();
         const res$ = searchSource.fetch$(options);
         res$.subscribe({ next, error, complete });
-        await res$.toPromise().catch((e) => {});
+        await res$.toPromise().catch(e => {});
 
         expect(next).toBeCalledTimes(1);
         expect(error).toBeCalledTimes(1);
@@ -1082,12 +1082,12 @@ describe('SearchSource', () => {
     describe('inspector', () => {
       let requestResponder: RequestResponder;
       beforeEach(() => {
-        requestResponder = {
+        requestResponder = ({
           stats: jest.fn(),
           ok: jest.fn(),
           error: jest.fn(),
           json: jest.fn(),
-        } as unknown as RequestResponder;
+        } as unknown) as RequestResponder;
       });
 
       test('calls inspector if provided', async () => {
@@ -1153,7 +1153,7 @@ describe('SearchSource', () => {
           },
         };
 
-        searchSourceDependencies.search = jest.fn().mockReturnValue(of(Promise.reject('aaaaa')));
+        searchSourceDependencies.search = jest.fn().mockReturnValue(throwError('aaaaa'));
 
         searchSource = new SearchSource({}, searchSourceDependencies);
         searchSource.setField('index', indexPattern);
@@ -1223,7 +1223,7 @@ describe('SearchSource', () => {
 
         searchSourceDependencies.search = jest.fn().mockImplementation(() =>
           of(1).pipe(
-            switchMap((r) => {
+            switchMap(r => {
               throw r;
             })
           )
@@ -1234,7 +1234,7 @@ describe('SearchSource', () => {
         searchSource.setField('aggs', ac);
         const fetch$ = searchSource.fetch$({});
         fetch$.subscribe(fetchSub);
-        await fetch$.toPromise().catch((e) => {});
+        await fetch$.toPromise().catch(e => {});
 
         expect(fetchSub.next).toHaveBeenCalledTimes(0);
         expect(fetchSub.complete).toHaveBeenCalledTimes(0);

--- a/src/plugins/data/common/search/search_source/search_source.test.ts
+++ b/src/plugins/data/common/search/search_source/search_source.test.ts
@@ -26,25 +26,25 @@ const getComputedFields = () => ({
 const mockSource = { excludes: ['foo-*'] };
 const mockSource2 = { excludes: ['bar-*'] };
 
-const indexPattern = ({
+const indexPattern = {
   title: 'foo',
   fields: [{ name: 'foo-bar' }, { name: 'field1' }, { name: 'field2' }, { name: '_id' }],
   getComputedFields,
   getSourceFiltering: () => mockSource,
-} as unknown) as IndexPattern;
+} as unknown as IndexPattern;
 
-const indexPattern2 = ({
+const indexPattern2 = {
   title: 'foo',
   getComputedFields,
   getSourceFiltering: () => mockSource2,
-} as unknown) as IndexPattern;
+} as unknown as IndexPattern;
 
 const fields3 = [{ name: 'foo-bar' }, { name: 'field1' }, { name: 'field2' }];
-const indexPattern3 = ({
+const indexPattern3 = {
   title: 'foo',
   fields: {
     getByName: (name: string) => {
-      return fields3.find(field => field.name === name);
+      return fields3.find((field) => field.name === name);
     },
     filter: () => {
       return fields3;
@@ -52,7 +52,7 @@ const indexPattern3 = ({
   },
   getComputedFields,
   getSourceFiltering: () => mockSource,
-} as unknown) as IndexPattern;
+} as unknown as IndexPattern;
 
 const runtimeFieldDef = {
   type: 'keyword',
@@ -69,7 +69,7 @@ describe('SearchSource', () => {
   beforeEach(() => {
     const getConfigMock = jest
       .fn()
-      .mockImplementation(param => param === 'metaFields' && ['_type', '_source', '_id'])
+      .mockImplementation((param) => param === 'metaFields' && ['_type', '_source', '_id'])
       .mockName('getConfig');
 
     mockSearchMethod = jest
@@ -140,7 +140,7 @@ describe('SearchSource', () => {
     describe('computed fields handling', () => {
       test('still provides computed fields when no fields are specified', async () => {
         const runtimeFields = { runtime_field: runtimeFieldDef };
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['hello'],
@@ -148,7 +148,7 @@ describe('SearchSource', () => {
             docvalueFields: ['@timestamp'],
             runtimeFields,
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
 
         const request = searchSource.getSearchRequestBody();
         expect(request.stored_fields).toEqual(['hello']);
@@ -158,14 +158,14 @@ describe('SearchSource', () => {
       });
 
       test('never includes docvalue_fields', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['@timestamp'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['@timestamp']);
         searchSource.setField('fieldsFromSource', ['foo']);
 
@@ -174,14 +174,14 @@ describe('SearchSource', () => {
       });
 
       test('overrides computed docvalue fields with ones that are provided', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['hello'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('docvalue_fields', ['world']);
 
@@ -191,14 +191,14 @@ describe('SearchSource', () => {
       });
 
       test('allows explicitly provided docvalue fields to override fields API when fetching fieldsFromSource', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: [{ field: 'a', format: 'date_time' }],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('docvalue_fields', [{ field: 'b', format: 'date_time' }]);
         searchSource.setField('fields', ['c']);
@@ -213,10 +213,10 @@ describe('SearchSource', () => {
 
       test('allows you to override computed fields if you provide a format', async () => {
         const indexPatternFields = indexPattern.fields;
-        indexPatternFields.getByType = type => {
+        indexPatternFields.getByType = (type) => {
           return [];
         };
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           fields: indexPatternFields,
           getComputedFields: () => ({
@@ -224,7 +224,7 @@ describe('SearchSource', () => {
             scriptFields: {},
             docvalueFields: [{ field: 'hello', format: 'date_time' }],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', [{ field: 'hello', format: 'strict_date_time' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -233,14 +233,14 @@ describe('SearchSource', () => {
       });
 
       test('injects a date format for computed docvalue fields if none is provided', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: [{ field: 'hello', format: 'date_time' }],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['hello']);
 
         const request = searchSource.getSearchRequestBody();
@@ -249,7 +249,7 @@ describe('SearchSource', () => {
       });
 
       test('injects a date format for computed docvalue fields while merging other properties', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           fields: {
             getByType: () => {
@@ -261,7 +261,7 @@ describe('SearchSource', () => {
             scriptFields: {},
             docvalueFields: [{ field: 'hello', format: 'date_time', a: 'test', b: 'test' }],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', [{ field: 'hello', a: 'a', c: 'c' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -272,14 +272,14 @@ describe('SearchSource', () => {
       });
 
       test('merges provided script fields with computed fields', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         // @ts-expect-error TS won't like using this field name, but technically it's possible.
         searchSource.setField('script_fields', { world: {} });
 
@@ -292,14 +292,14 @@ describe('SearchSource', () => {
       });
 
       test(`requests any fields that aren't script_fields from stored_fields`, async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['hello', 'a', { field: 'c' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -308,14 +308,14 @@ describe('SearchSource', () => {
       });
 
       test('ignores objects without a `field` property when setting stored_fields', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['hello', 'a', { foo: 'c' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -324,14 +324,14 @@ describe('SearchSource', () => {
       });
 
       test(`requests any fields that aren't script_fields from stored_fields with fieldsFromSource`, async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {} },
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fieldsFromSource', ['hello', 'a']);
 
         const request = searchSource.getSearchRequestBody();
@@ -427,14 +427,14 @@ describe('SearchSource', () => {
 
     describe('source filters handling', () => {
       test('excludes docvalue fields based on source filtering', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['@timestamp', 'exclude-me'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         // @ts-expect-error Typings for excludes filters need to be fixed.
         searchSource.setField('source', { excludes: ['exclude-*'] });
 
@@ -443,28 +443,28 @@ describe('SearchSource', () => {
       });
 
       test('defaults to source filters from index pattern', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: {},
             docvalueFields: ['@timestamp', 'foo-bar', 'foo-baz'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
 
         const request = searchSource.getSearchRequestBody();
         expect(request.fields).toEqual(['@timestamp']);
       });
 
       test('filters script fields to only include specified fields', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['hello']);
 
         const request = searchSource.getSearchRequestBody();
@@ -472,14 +472,14 @@ describe('SearchSource', () => {
       });
 
       test('request all fields except the ones specified with source filters', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', [
           'hello',
           'foo-bar',
@@ -493,14 +493,14 @@ describe('SearchSource', () => {
       });
 
       test('request all fields from index pattern except the ones specified with source filters', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -508,14 +508,14 @@ describe('SearchSource', () => {
       });
 
       test('request all fields from index pattern except the ones specified with source filters with unmapped_fields option', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -523,14 +523,14 @@ describe('SearchSource', () => {
       });
 
       test('excludes metafields from the request', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: [],
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
 
         const request = searchSource.getSearchRequestBody();
@@ -545,14 +545,14 @@ describe('SearchSource', () => {
       });
 
       test('returns all scripted fields when one fields entry is *', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: [],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['timestamp', '*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -562,14 +562,14 @@ describe('SearchSource', () => {
 
     describe('handling for when specific fields are provided', () => {
       test('fieldsFromSource will request any fields outside of script_fields from _source & stored fields', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: ['@timestamp'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fieldsFromSource', [
           'hello',
           'world',
@@ -586,14 +586,14 @@ describe('SearchSource', () => {
       });
 
       test('filters request when a specific list of fields is provided', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['*'],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: ['@timestamp', 'date'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['hello', '@timestamp', 'foo-a', 'bar']);
 
         const request = searchSource.getSearchRequestBody();
@@ -604,7 +604,7 @@ describe('SearchSource', () => {
 
       test('filters request when a specific list of fields is provided with fieldsFromSource', async () => {
         const runtimeFields = { runtime_field: runtimeFieldDef, runtime_field_b: runtimeFieldDef };
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['*'],
@@ -612,7 +612,7 @@ describe('SearchSource', () => {
             docvalueFields: ['@timestamp', 'date'],
             runtimeFields,
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fieldsFromSource', [
           'hello',
           '@timestamp',
@@ -632,14 +632,14 @@ describe('SearchSource', () => {
       });
 
       test('filters request when a specific list of fields is provided with fieldsFromSource or fields', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: ['*'],
             scriptFields: { hello: {}, world: {} },
             docvalueFields: ['@timestamp', 'date', 'time'],
           }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['hello', '@timestamp', 'foo-a', 'bar']);
         searchSource.setField('fieldsFromSource', ['foo-b', 'date', 'baz']);
 
@@ -655,7 +655,7 @@ describe('SearchSource', () => {
 
     describe('handling date fields', () => {
       test('adds date format to any date field', async () => {
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
@@ -666,7 +666,7 @@ describe('SearchSource', () => {
             getByType: () => [{ name: '@timestamp', esTypes: ['date_nanos'] }],
           },
           getSourceFiltering: () => ({ excludes: [] }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -679,13 +679,13 @@ describe('SearchSource', () => {
       test('adds date format to any date field except the one excluded by source filters', async () => {
         const indexPatternFields = indexPattern.fields;
         // @ts-ignore
-        indexPatternFields.getByType = type => {
+        indexPatternFields.getByType = (type) => {
           return [
             { name: '@timestamp', esTypes: ['date_nanos'] },
             { name: 'custom_date', esTypes: ['date'] },
           ];
         };
-        searchSource.setField('index', ({
+        searchSource.setField('index', {
           ...indexPattern,
           getComputedFields: () => ({
             storedFields: [],
@@ -694,7 +694,7 @@ describe('SearchSource', () => {
           }),
           fields: indexPatternFields,
           getSourceFiltering: () => ({ excludes: ['custom_date'] }),
-        } as unknown) as IndexPattern);
+        } as unknown as IndexPattern);
         searchSource.setField('fields', ['*']);
 
         const request = searchSource.getSearchRequestBody();
@@ -867,7 +867,7 @@ describe('SearchSource', () => {
       searchSource.setField('docvalue_fields', ['prop1']);
       searchSource.setField('source', ['geometry']);
       searchSource.setField('fieldsFromSource', ['geometry', 'prop1']);
-      searchSource.setField('index', ({
+      searchSource.setField('index', {
         ...indexPattern,
         getSourceFiltering: () => ({ excludes: [] }),
         getComputedFields: () => ({
@@ -875,7 +875,7 @@ describe('SearchSource', () => {
           scriptFields: {},
           docvalueFields: [],
         }),
-      } as unknown) as IndexPattern);
+      } as unknown as IndexPattern);
       const request = searchSource.getSearchRequestBody();
       expect(request.stored_fields).toEqual(['geometry', 'prop1']);
       expect(request.docvalue_fields).toEqual(['prop1']);
@@ -1067,7 +1067,7 @@ describe('SearchSource', () => {
         const complete = jest.fn();
         const res$ = searchSource.fetch$(options);
         res$.subscribe({ next, error, complete });
-        await res$.toPromise().catch(e => {});
+        await res$.toPromise().catch((e) => {});
 
         expect(next).toBeCalledTimes(1);
         expect(error).toBeCalledTimes(1);
@@ -1082,12 +1082,12 @@ describe('SearchSource', () => {
     describe('inspector', () => {
       let requestResponder: RequestResponder;
       beforeEach(() => {
-        requestResponder = ({
+        requestResponder = {
           stats: jest.fn(),
           ok: jest.fn(),
           error: jest.fn(),
           json: jest.fn(),
-        } as unknown) as RequestResponder;
+        } as unknown as RequestResponder;
       });
 
       test('calls inspector if provided', async () => {
@@ -1223,7 +1223,7 @@ describe('SearchSource', () => {
 
         searchSourceDependencies.search = jest.fn().mockImplementation(() =>
           of(1).pipe(
-            switchMap(r => {
+            switchMap((r) => {
               throw r;
             })
           )
@@ -1234,7 +1234,7 @@ describe('SearchSource', () => {
         searchSource.setField('aggs', ac);
         const fetch$ = searchSource.fetch$({});
         fetch$.subscribe(fetchSub);
-        await fetch$.toPromise().catch(e => {});
+        await fetch$.toPromise().catch((e) => {});
 
         expect(fetchSub.next).toHaveBeenCalledTimes(0);
         expect(fetchSub.complete).toHaveBeenCalledTimes(0);

--- a/src/plugins/data/server/search/search_service.test.ts
+++ b/src/plugins/data/server/search/search_service.test.ts
@@ -38,10 +38,8 @@ describe('Search service', () => {
   let mockCoreStart: MockedKeys<CoreStart>;
 
   beforeEach(() => {
-    const mockLogger: any = {
-      debug: () => {},
-    };
     const context = coreMock.createPluginInitializerContext({});
+    const mockLogger = context.logger.get();
     context.config.create = jest.fn().mockImplementation(() => {
       return of({
         search: {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [AppServices] Fix unhandled promise rejections in search tests (#112849)