### PR TITLE
[Lens] Fix formula fullscreen in threshold layers

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -680,7 +680,7 @@ export function DimensionEditor(props: DimensionEditorProps) {
   const hasFormula =
     !isFullscreen && operationSupportMatrix.operationWithoutField.has(formulaOperationName);
 
-  const hasTabs = hasFormula || supportStaticValue;
+  const hasTabs = !isFullscreen && (hasFormula || supportStaticValue);
 
   return (
     <div id={columnId}>

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -2263,7 +2263,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
     ).toBeTruthy();
   });
 
-  it('should now show the static_value tab when not supported', () => {
+  it('should not show the static_value tab when not supported', () => {
     const stateWithFormulaColumn: IndexPatternPrivateState = getStateWithColumns({
       col1: {
         label: 'Formula',
@@ -2336,5 +2336,29 @@ describe('IndexPatternDimensionEditorPanel', () => {
     expect(
       wrapper.find('[data-test-subj="lens-dimensionTabs-static_value"]').first().prop('isSelected')
     ).toBeTruthy();
+  });
+
+  it('should not show any tab when formula is in full screen mode', () => {
+    const stateWithFormulaColumn: IndexPatternPrivateState = getStateWithColumns({
+      col1: {
+        label: 'Formula',
+        dataType: 'number',
+        isBucketed: false,
+        operationType: 'formula',
+        references: ['ref1'],
+        params: {},
+      },
+    });
+
+    wrapper = mount(
+      <IndexPatternDimensionEditorComponent
+        {...defaultProps}
+        state={stateWithFormulaColumn}
+        supportStaticValue
+        isFullscreen
+      />
+    );
+
+    expect(wrapper.find('[data-test-subj="lens-dimensionTabs"]').exists()).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #113178 

The tabs check didn't consider the fullscreen flag. This PR addresses the problem and adds a unit test to check regressions.


<img width="1112" alt="Screenshot 2021-09-28 at 16 00 48" src="https://user-images.githubusercontent.com/924948/135102713-cc4161ea-0c28-47c7-bd82-40dede5417a9.png">

<img width="1406" alt="Screenshot 2021-09-28 at 16 00 57" src="https://user-images.githubusercontent.com/924948/135102740-9fa443b3-c76e-47ff-9c16-47460f53b88e.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
