### PR TITLE
[Uptime] Fix waterfall chart top axis

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor/synthetics/step_detail/waterfall/waterfall_chart_wrapper.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/synthetics/step_detail/waterfall/waterfall_chart_wrapper.tsx
@@ -125,16 +125,16 @@ export const WaterfallChartWrapper: React.FC<Props> = ({ data, total }) => {
       <WaterfallChart
         tickFormat={useCallback((d: number) => `${Number(d).toFixed(0)} ms`, [])}
         domain={domain}
-        barStyleAccessor={useCallback((datum) => {
-          if (!datum.datum.config.isHighlighted) {
+        barStyleAccessor={useCallback(({ datum }) => {
+          if (!datum.config?.isHighlighted) {
             return {
               rect: {
-                fill: datum.datum.config.colour,
+                fill: datum.config?.colour,
                 opacity: '0.1',
               },
             };
           }
-          return datum.datum.config.colour;
+          return datum.config.colour;
         }, [])}
         renderSidebarItem={renderSidebarItem}
         renderLegendItem={renderLegendItem}


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/113283

Waterfall chart fixed axis is broken, seems like config is not being passed to barStyleAccessor in case of fixed chart axis dummy bar. 

After:

![image](https://user-images.githubusercontent.com/3505601/135114331-fbd00967-067e-4443-ac19-d766e5defc10.png)

Before:
![image](https://user-images.githubusercontent.com/3505601/135114396-6e009103-4133-4789-b5f0-af0f01c1012b.png)
