### PR TITLE
[7.x] [Index management] Treat indices beginning with a period as regular indices (#112990)

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/__jest__/__snapshots__/extend_index_management.test.tsx.snap
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/__snapshots__/extend_index_management.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`extend index management ilm summary extension should return extension w
       "documents": "2",
       "documents_deleted": "0",
       "health": "yellow",
+      "hidden": false,
       "ilm": Object {
         "action": "rollover",
         "action_time_millis": 1544187775891,
@@ -650,6 +651,7 @@ exports[`extend index management ilm summary extension should return extension w
       "documents": "2",
       "documents_deleted": "0",
       "health": "yellow",
+      "hidden": false,
       "ilm": Object {
         "action": "complete",
         "action_time_millis": 1544187775867,

--- a/x-pack/plugins/index_lifecycle_management/__jest__/extend_index_management.test.tsx
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/extend_index_management.test.tsx
@@ -49,6 +49,7 @@ const indexWithoutLifecyclePolicy: Index = {
   primary_size: '3.4kb',
   aliases: 'none',
   isFrozen: false,
+  hidden: false,
   ilm: {
     index: 'testy1',
     managed: false,
@@ -68,6 +69,7 @@ const indexWithLifecyclePolicy: Index = {
   primary_size: '6.5kb',
   aliases: 'none',
   isFrozen: false,
+  hidden: false,
   ilm: {
     index: 'testy3',
     managed: true,
@@ -95,6 +97,7 @@ const indexWithLifecycleError = {
   primary_size: '6.5kb',
   aliases: 'none',
   isFrozen: false,
+  hidden: false,
   ilm: {
     index: 'testy3',
     managed: true,

--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/constants.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/constants.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export const BRANCH = '7.x';
+export const MAJOR_VERSION = '7.16.0';

--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/index.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/index.ts
@@ -9,8 +9,11 @@ import './mocks';
 
 export { nextTick, getRandomString, findTestSubject, TestBed } from '@kbn/test/jest';
 
-export { setupEnvironment, WithAppDependencies, services } from './setup_environment';
+export {
+  setupEnvironment,
+  WithAppDependencies,
+  services,
+  kibanaVersion,
+} from './setup_environment';
 
 export { TestSubjects } from './test_subjects';
-
-export { BRANCH } from './constants';

--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/setup_environment.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import axios from 'axios';
 import axiosXhrAdapter from 'axios/lib/adapters/xhr';
 import { merge } from 'lodash';
+import { SemVer } from 'semver';
 
 import {
   notificationServiceMock,
@@ -31,9 +32,12 @@ import {
 } from '../../../public/application/components';
 import { componentTemplatesMockDependencies } from '../../../public/application/components/component_templates/__jest__';
 import { init as initHttpRequests } from './http_requests';
+import { MAJOR_VERSION } from './constants';
 
 const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
 const { GlobalFlyoutProvider } = GlobalFlyout;
+
+export const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 export const services = {
   extensionsService: new ExtensionsService(),

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_template_wizard/template_edit.test.tsx
@@ -10,7 +10,7 @@ import { act } from 'react-dom/test-utils';
 
 import '../../../test/global_mocks';
 import * as fixtures from '../../../test/fixtures';
-import { setupEnvironment, BRANCH } from '../helpers';
+import { setupEnvironment, kibanaVersion } from '../helpers';
 
 import { TEMPLATE_NAME, SETTINGS, ALIASES, MAPPINGS as DEFAULT_MAPPING } from './constants';
 import { setup } from './template_edit.helpers';
@@ -321,7 +321,7 @@ describe('<TemplateEdit />', () => {
     });
   });
 
-  if (BRANCH === '7.x') {
+  if (kibanaVersion.major < 8) {
     describe('legacy index templates', () => {
       const legacyTemplateToEdit = fixtures.getTemplate({
         name: 'legacy_index_template',

--- a/x-pack/plugins/index_management/__jest__/components/__snapshots__/index_table.test.js.snap
+++ b/x-pack/plugins/index_management/__jest__/components/__snapshots__/index_table.test.js.snap
@@ -20,7 +20,7 @@ exports[`index table force merge button works from context menu 2`] = `"forcing 
 
 exports[`index table force merge button works from context menu 3`] = `"open"`;
 
-exports[`index table open index button works from context menu 1`] = `"opening..."`;
+exports[`index table open index button works from context menu 1`] = `"open"`;
 
 exports[`index table open index button works from context menu 2`] = `"open"`;
 
@@ -64,33 +64,44 @@ Array [
 ]
 `;
 
-exports[`index table should show system indices only when the switch is turned on 1`] = `
+exports[`index table should show hidden indices only when the switch is turned on 1`] = `
 Array [
-  "1",
-  "2",
-  "3",
-  "4",
-  "5",
-  "…",
-  "11",
+  "testy0",
+  "testy1",
+  "testy2",
+  "testy3",
+  "testy4",
+  "testy5",
+  "testy6",
+  "testy7",
+  "testy8",
+  "testy9",
 ]
 `;
 
-exports[`index table should show system indices only when the switch is turned on 2`] = `
+exports[`index table should show hidden indices only when the switch is turned on 2`] = `
 Array [
-  "1",
-  "2",
-  "3",
-  "4",
-  "5",
-  "…",
-  "21",
+  "testy0",
+  ".admin0",
+  "testy1",
+  ".admin1",
+  "testy2",
+  ".admin2",
+  "testy3",
+  ".admin3",
+  "testy4",
+  ".admin4",
 ]
 `;
 
 exports[`index table should show the right context menu options when more than one closed index is selected 1`] = `
 Array [
-  "Open indices",
+  "Close indices",
+  "Force merge indices",
+  "Refresh indices",
+  "Clear indices cache",
+  "Flush indices",
+  "Freeze indices",
   "Delete indices",
 ]
 `;
@@ -111,8 +122,14 @@ exports[`index table should show the right context menu options when one index i
 Array [
   "Show index settings",
   "Show index mapping",
+  "Show index stats",
   "Edit index settings",
-  "Open index",
+  "Close index",
+  "Force merge index",
+  "Refresh index",
+  "Clear index cache",
+  "Flush index",
+  "Freeze index",
   "Delete index",
 ]
 `;
@@ -135,7 +152,12 @@ Array [
 
 exports[`index table should show the right context menu options when one open and one closed index is selected 1`] = `
 Array [
-  "Open indices",
+  "Close indices",
+  "Force merge indices",
+  "Refresh indices",
+  "Clear indices cache",
+  "Flush indices",
+  "Freeze indices",
   "Delete indices",
 ]
 `;

--- a/x-pack/plugins/index_management/common/types/indices.ts
+++ b/x-pack/plugins/index_management/common/types/indices.ts
@@ -58,9 +58,10 @@ export interface Index {
   uuid: string;
   primary: string;
   replica: string;
-  documents: any;
+  documents?: string;
   size: any;
   isFrozen: boolean;
+  hidden: boolean;
   aliases: string | string[];
   data_stream?: string;
   [key: string]: any;

--- a/x-pack/plugins/index_management/public/application/lib/indices.ts
+++ b/x-pack/plugins/index_management/public/application/lib/indices.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import SemVer from 'semver/classes/semver';
+import { Index } from '../../../common';
+
+const version = '7.16.0';
+const kibanaVersion = new SemVer(version);
+
+export const isHiddenIndex = (index: Index): boolean => {
+  if (kibanaVersion.major < 8) {
+    // In 7.x we consider hidden index all indices whose name start with a dot
+    return (index.name ?? '').startsWith('.') || index.hidden === true;
+  }
+  return index.hidden === true;
+};
+
+export const isSystemIndex = (index: Index): boolean => {
+  if (kibanaVersion.major < 8) {
+    return (index.name ?? '').startsWith('.');
+  }
+  // From 8.0 we won't surface system indices in Index management
+  return false;
+};

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.container.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.container.js
@@ -34,6 +34,7 @@ import {
 const mapStateToProps = (state, ownProps) => {
   const indexStatusByName = {};
   const { indexNames } = ownProps;
+  const allIndices = state.indices.byId;
 
   indexNames.forEach((indexName) => {
     indexStatusByName[indexName] = getIndexStatusByIndexName(state, indexName);
@@ -42,8 +43,8 @@ const mapStateToProps = (state, ownProps) => {
   return {
     indexStatusByName,
     indices: getIndicesByName(state, indexNames),
-    isSystemIndexByName: getIsSystemIndexByName(indexNames),
-    hasSystemIndex: hasSystemIndex(indexNames),
+    isSystemIndexByName: getIsSystemIndexByName(indexNames, allIndices),
+    hasSystemIndex: hasSystemIndex(indexNames, allIndices),
   };
 };
 

--- a/x-pack/plugins/index_management/public/application/store/selectors/index.js
+++ b/x-pack/plugins/index_management/public/application/store/selectors/index.js
@@ -10,6 +10,7 @@ import { Pager, EuiSearchBar } from '@elastic/eui';
 import { createSelector } from 'reselect';
 import * as qs from 'query-string';
 import { indexStatusLabels } from '../../lib/index_status_labels';
+import { isHiddenIndex, isSystemIndex } from '../../lib/indices';
 import { sortTable } from '../../services';
 import { extensionsService } from './extension_service';
 
@@ -39,14 +40,14 @@ export const getIndexStatusByIndexName = (state, indexName) => {
   const { status } = indices[indexName] || {};
   return status;
 };
-export const getIsSystemIndexByName = (indexNames) => {
+export const getIsSystemIndexByName = (indexNames, allIndices) => {
   return indexNames.reduce((obj, indexName) => {
-    obj[indexName] = indexName.startsWith('.');
+    obj[indexName] = isSystemIndex(allIndices[indexName]);
     return obj;
   }, {});
 };
-export const hasSystemIndex = (indexNames) => {
-  return Boolean(indexNames.find((indexName) => indexName.startsWith('.')));
+export const hasSystemIndex = (indexNames, allIndices) => {
+  return indexNames.some((indexName) => isSystemIndex(allIndices[indexName]));
 };
 
 const defaultFilterFields = ['name'];
@@ -90,9 +91,7 @@ export const getFilteredIndices = createSelector(
     const includeHidden = includeHiddenParam === 'true';
     const filteredIndices = includeHidden
       ? indexArray
-      : indexArray.filter((index) => {
-          return !(index.name + '').startsWith('.') && !index.hidden;
-        });
+      : indexArray.filter((index) => !isHiddenIndex(index));
     const filter = tableState.filter || EuiSearchBar.Query.MATCH_ALL;
     return EuiSearchBar.Query.execute(filter, filteredIndices, {
       defaultFields: defaultFilterFields,

--- a/x-pack/plugins/index_management/public/application/store/selectors/indices_filter.test.ts
+++ b/x-pack/plugins/index_management/public/application/store/selectors/indices_filter.test.ts
@@ -4,12 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import SemVer from 'semver/classes/semver';
 import { ExtensionsService } from '../../../services';
 import { getFilteredIndices } from '.';
 // @ts-ignore
 import { defaultTableState } from '../reducers/table_state';
 import { setExtensionsService } from './extension_service';
+
+const version = '7.16.0';
+const kibanaVersion = new SemVer(version);
 
 describe('getFilteredIndices selector', () => {
   let extensionService: ExtensionsService;
@@ -33,10 +36,14 @@ describe('getFilteredIndices selector', () => {
   };
 
   it('filters out hidden indices', () => {
-    expect(getFilteredIndices(state, { location: { search: '' } })).toEqual([
-      { name: 'index2', hidden: false },
-      { name: 'index3' },
-    ]);
+    let expected = [{ name: 'index2', hidden: false }, { name: 'index3' }, { name: '.index4' }];
+
+    if (kibanaVersion.major < 8) {
+      // In 7.x index name starting with a dot are considered hidden indices
+      expected = [{ name: 'index2', hidden: false }, { name: 'index3' }];
+    }
+
+    expect(getFilteredIndices(state, { location: { search: '' } })).toEqual(expected);
   });
 
   it('includes hidden indices', () => {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Index management] Treat indices beginning with a period as regular indices (#112990)