### PR TITLE
[Alerting] Fixed docs to replace a copy/paste for Elastic Maps Server in action settings docs

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -107,7 +107,7 @@ Overrides the general `xpack.actions.rejectUnauthorized` configuration
 for requests made for this hostname/port.
 
 [[action-config-custom-host-verification-mode]] `xpack.actions.customHostSettings[n].ssl.verificationMode` {ess-icon}::
-Controls the verification of the server certificate that {hosted-ems} receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`.
+Controls the verification of the server certificate that {kib} receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`.
 Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. <<elasticsearch-ssl-verificationMode,Equivalent {kib} setting>>. Overrides the general `xpack.actions.ssl.verificationMode` configuration
 for requests made for this hostname/port.
 


### PR DESCRIPTION
## Summary

Resolves #112064

Fixed copy/paste word in `/docs/settings/alert-action-settings.asciidoc` for `xpack.actions.customHostSettings[n].ssl.verificationMode` by replacing `{hosted-ems}` with `{kib}`