### PR TITLE
Fix APM E2E

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/header_filters.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/header_filters.spec.ts
@@ -16,43 +16,43 @@ const serviceOverviewHref = url.format({
 
 const apisToIntercept = [
   {
-    endpoint: '/api/apm/services/opbeans-node/transactions/charts/latency',
+    endpoint: '/api/apm/services/opbeans-node/transactions/charts/latency?*',
     name: 'latencyChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/throughput',
+    endpoint: '/api/apm/services/opbeans-node/throughput?*',
     name: 'throughputChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/transactions/charts/error_rate',
+    endpoint: '/api/apm/services/opbeans-node/transactions/charts/error_rate?*',
     name: 'errorRateChartRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/transactions/groups/detailed_statistics',
+      '/api/apm/services/opbeans-node/transactions/groups/detailed_statistics?*',
     name: 'transactionGroupsDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/service_overview_instances/detailed_statistics',
+      '/api/apm/services/opbeans-node/service_overview_instances/detailed_statistics?*',
     name: 'instancesDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/service_overview_instances/main_statistics',
+      '/api/apm/services/opbeans-node/service_overview_instances/main_statistics?*',
     name: 'instancesMainStatisticsRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/error_groups/main_statistics',
+    endpoint: '/api/apm/services/opbeans-node/error_groups/main_statistics?*',
     name: 'errorGroupsMainStatisticsRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/transaction/charts/breakdown',
+    endpoint: '/api/apm/services/opbeans-node/transaction/charts/breakdown?*',
     name: 'transactonBreakdownRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/transactions/groups/main_statistics',
+      '/api/apm/services/opbeans-node/transactions/groups/main_statistics?*',
     name: 'transactionsGroupsMainStatisticsRequest',
   },
 ];

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
@@ -18,26 +18,22 @@ const serviceOverviewHref = url.format({
 const apisToIntercept = [
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/main_statistics',
+      '/api/apm/services/opbeans-java/service_overview_instances/main_statistics?*',
     name: 'instancesMainRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics',
+      '/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics?*',
     name: 'instancesDetailsRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/details/31651f3c624b81c55dd4633df0b5b9f9ab06b151121b0404ae796632cd1f87ad',
-    name: 'instanceDetailsRequest',
-  },
-  {
-    endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/details/31651f3c624b81c55dd4633df0b5b9f9ab06b151121b0404ae796632cd1f87ad',
+      '/api/apm/services/opbeans-java/service_overview_instances/details/31651f3c624b81c55dd4633df0b5b9f9ab06b151121b0404ae796632cd1f87ad?*',
     name: 'instanceDetailsRequest',
   },
 ];
 
+const x = 1;
 describe('Instances table', () => {
   beforeEach(() => {
     cy.loginAsReadOnlyUser();

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
@@ -33,7 +33,6 @@ const apisToIntercept = [
   },
 ];
 
-const x = 1;
 describe('Instances table', () => {
   beforeEach(() => {
     cy.loginAsReadOnlyUser();

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
@@ -59,7 +59,7 @@ describe('Service Overview', () => {
   });
 
   it('hides dependency tab when RUM service', () => {
-    cy.intercept('GET', '/api/apm/services/opbeans-rum/agent').as(
+    cy.intercept('GET', '/api/apm/services/opbeans-rum/agent?*').as(
       'agentRequest'
     );
     cy.visit(

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/time_comparison.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/time_comparison.spec.ts
@@ -18,29 +18,30 @@ const serviceOverviewHref = url.format({
 
 const apisToIntercept = [
   {
-    endpoint: '/api/apm/services/opbeans-java/transactions/charts/latency',
+    endpoint: '/api/apm/services/opbeans-java/transactions/charts/latency?*',
     name: 'latencyChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-java/throughput',
+    endpoint: '/api/apm/services/opbeans-java/throughput?*',
     name: 'throughputChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-java/transactions/charts/error_rate',
+    endpoint: '/api/apm/services/opbeans-java/transactions/charts/error_rate?*',
     name: 'errorRateChartRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/transactions/groups/detailed_statistics',
+      '/api/apm/services/opbeans-java/transactions/groups/detailed_statistics?*',
     name: 'transactionGroupsDetailedRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-java/error_groups/detailed_statistics',
+    endpoint:
+      '/api/apm/services/opbeans-java/error_groups/detailed_statistics?*',
     name: 'errorGroupsDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics',
+      '/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics?*',
     name: 'instancesDetailedRequest',
   },
 ];


### PR DESCRIPTION
Add `?*` to the end of request aliases in instances table tests.

#104301 upgraded Cypress to a newer version that required this, but the APM E2E tests were not run because there were no changes to any files in APM.
