### PR TITLE
Documents es/so/server deprecated settings removal in breaking changes

### DIFF
--- a/docs/migration/migrate_8_0.asciidoc
+++ b/docs/migration/migrate_8_0.asciidoc
@@ -342,13 +342,13 @@ Configuration management tools and automation will need to be updated to use the
 === `elasticsearch.preserveHost` is no longer valid
 *Details:* The deprecated `elasticsearch.preserveHost` setting in the `kibana.yml` file has been removed.
 
-*Impact:* Configure {kibana-ref}/settings.html#elasticsearch-requestHeadersWhitelist[`elasticsearch.requestHeadersWhitelist`] to whitelist client-side headers or {kibana-ref}/settings.html#elasticsearch-customHeaders[`elasticsearch.customHeaders`] for custom headers.
+*Impact:* Configure {kibana-ref}/settings.html#elasticsearch-requestHeadersWhitelist[`elasticsearch.requestHeadersWhitelist`] to whitelist client-side headers.
 
 [float]
 === `elasticsearch.startupTimeout` is no longer valid
 *Details:* The deprecated `elasticsearch.startupTimeout` setting in the `kibana.yml` file has been removed.
 
-*Impact:* Kibana will keep on trying to connect to Elasticsearch until it manages to connect. Use {kibana-ref}/settings.html#elasticsearch-sniffOnStart[`elasticsearch.sniffOnStart`] to attempt to find other Elasticsearch nodes on startup. 
+*Impact:* Kibana will keep on trying to connect to Elasticsearch until it manages to connect.
 
 [float]
 === `savedObjects.indexCheckTimeout` is no longer valid

--- a/docs/migration/migrate_8_0.asciidoc
+++ b/docs/migration/migrate_8_0.asciidoc
@@ -342,7 +342,7 @@ Configuration management tools and automation will need to be updated to use the
 === `elasticsearch.preserveHost` is no longer valid
 *Details:* The deprecated `elasticsearch.preserveHost` setting in the `kibana.yml` file has been removed.
 
-*Impact:* Configure {kibana-ref}/settings.html#elasticsearch-requestHeadersWhitelist[`elasticsearch.requestHeadersWhitelist`] to whitelist client-side headers or {kibana-ref}/settings.html#elasticsearch-customHeaders[`elasticsearch-customHeaders`] for custom headers.
+*Impact:* Configure {kibana-ref}/settings.html#elasticsearch-requestHeadersWhitelist[`elasticsearch.requestHeadersWhitelist`] to whitelist client-side headers or {kibana-ref}/settings.html#elasticsearch-customHeaders[`elasticsearch.customHeaders`] for custom headers.
 
 [float]
 === `elasticsearch.startupTimeout` is no longer valid

--- a/docs/migration/migrate_8_0.asciidoc
+++ b/docs/migration/migrate_8_0.asciidoc
@@ -338,4 +338,24 @@ The output directory after extracting an archive no longer includes the target p
 *Impact:*
 Configuration management tools and automation will need to be updated to use the new directory.
 
+[float]
+=== `elasticsearch.preserveHost` is no longer valid
+*Details:* The deprecated `elasticsearch.preserveHost` setting in the `kibana.yml` file has been removed.
+
+*Impact:* Configure {kibana-ref}/settings.html#elasticsearch-requestHeadersWhitelist[`elasticsearch.requestHeadersWhitelist`] to whitelist client-side headers or {kibana-ref}/settings.html#elasticsearch-customHeaders[`elasticsearch-customHeaders`] for custom headers.
+
+[float]
+=== `elasticsearch.startupTimeout` is no longer valid
+*Details:* The deprecated `elasticsearch.startupTimeout` setting in the `kibana.yml` file has been removed.
+
+*Impact:* Kibana will keep on trying to connect to Elasticsearch until it manages to connect. Use {kibana-ref}/settings.html#elasticsearch-sniffOnStart[`elasticsearch.sniffOnStart`] to attempt to find other Elasticsearch nodes on startup. 
+
+[float]
+=== `savedObjects.indexCheckTimeout` is no longer valid
+*Details:* The deprecated `savedObjects.indexCheckTimeout` setting in the `kibana.yml` file has been removed.
+
+[float]
+=== `server.xsrf.token` is no longer valid
+*Details:* The deprecated `server.xsrf.token` setting in the `kibana.yml` file has been removed.
+
 // end::notable-breaking-changes[]


### PR DESCRIPTION
Adds docs for https://github.com/elastic/kibana/pull/113173.
Related to https://github.com/elastic/kibana/issues/103915

## Screen shots (docs)

In breaking changes in 8.0:


![Screen Shot 2021-09-28 at 15 26 40](https://user-images.githubusercontent.com/11909450/135174312-a0997b99-4278-450a-932b-3900c9c5ca4d.png)

**To reviewers:**
I tried to find alternative settings for each of these but hit a dead-end for `savedObjects.indexCheckTimeout` and `server.xsrf.token` during the platform migration.

The semi-alternative setting for `elasticsearch.preserveHost` comes from https://github.com/elastic/kibana/issues/17237#issuecomment-374200960

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials