### PR TITLE
[build/docker] Fix beats architecture

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -52,8 +52,9 @@ export async function runDockerGenerator(
   const artifactArchitecture = flags.architecture === 'aarch64' ? 'aarch64' : 'x86_64';
   const artifactPrefix = `kibana-${version}-linux`;
   const artifactTarball = `${artifactPrefix}-${artifactArchitecture}.tar.gz`;
-  const metricbeatTarball = `metricbeat-${version}-linux-${artifactArchitecture}.tar.gz`;
-  const filebeatTarball = `filebeat-${version}-linux-${artifactArchitecture}.tar.gz`;
+  const beatsArchitecture = flags.architecture === 'aarch64' ? 'arm64' : 'x86_64';
+  const metricbeatTarball = `metricbeat-${version}-linux-${beatsArchitecture}.tar.gz`;
+  const filebeatTarball = `filebeat-${version}-linux-${beatsArchitecture}.tar.gz`;
   const artifactsDir = config.resolveFromTarget('.');
   const beatsDir = config.resolveFromRepo('.beats');
   const dockerBuildDate = flags.dockerBuildDate || new Date().toISOString();


### PR DESCRIPTION
Beats ARM artifacts use arm64 as the identifier.  This fixes the
architecture passed to docker.
