### PR TITLE
Add support for single manual steps to Upgrade Assistant

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/kibana_deprecations_service.mock.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/helpers/kibana_deprecations_service.mock.ts
@@ -10,7 +10,8 @@ import type { DeprecationsServiceStart, DomainDeprecationDetails } from 'kibana/
 const kibanaDeprecations: DomainDeprecationDetails[] = [
   {
     correctiveActions: {
-      manualSteps: ['Step 1', 'Step 2', 'Step 3'],
+      // Only has one manual step.
+      manualSteps: ['Step 1'],
       api: {
         method: 'POST',
         path: '/test',
@@ -24,6 +25,7 @@ const kibanaDeprecations: DomainDeprecationDetails[] = [
   },
   {
     correctiveActions: {
+      // Has multiple manual steps.
       manualSteps: ['Step 1', 'Step 2', 'Step 3'],
     },
     domainId: 'test_domain_2',

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecation_details_flyout.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecation_details_flyout.test.ts
@@ -40,22 +40,26 @@ describe('Kibana deprecation details flyout', () => {
   });
 
   describe('Deprecation with manual steps', () => {
-    test('renders flyout with manual steps only', async () => {
+    test('renders flyout with single manual step as a standalone paragraph', async () => {
+      const { find, exists, actions } = testBed;
+      const manualDeprecation = mockedKibanaDeprecations[1];
+
+      await actions.table.clickDeprecationAt(0);
+
+      expect(exists('kibanaDeprecationDetails')).toBe(true);
+      expect(find('kibanaDeprecationDetails.flyoutTitle').text()).toBe(manualDeprecation.title);
+      expect(find('manualStep').length).toBe(1);
+    });
+
+    test('renders flyout with multiple manual steps as a list', async () => {
       const { find, exists, actions } = testBed;
       const manualDeprecation = mockedKibanaDeprecations[1];
 
       await actions.table.clickDeprecationAt(1);
 
       expect(exists('kibanaDeprecationDetails')).toBe(true);
-      expect(exists('kibanaDeprecationDetails.warningDeprecationBadge')).toBe(true);
       expect(find('kibanaDeprecationDetails.flyoutTitle').text()).toBe(manualDeprecation.title);
-      expect(find('manualStepsList').find('li').length).toEqual(
-        manualDeprecation.correctiveActions.manualSteps.length
-      );
-
-      // Quick resolve callout and button should not display
-      expect(exists('quickResolveCallout')).toBe(false);
-      expect(exists('resolveButton')).toBe(false);
+      expect(find('manualStepsListItem').length).toBe(3);
     });
   });
 
@@ -70,9 +74,6 @@ describe('Kibana deprecation details flyout', () => {
       expect(exists('kibanaDeprecationDetails.criticalDeprecationBadge')).toBe(true);
       expect(find('kibanaDeprecationDetails.flyoutTitle').text()).toBe(
         quickResolveDeprecation.title
-      );
-      expect(find('manualStepsList').find('li').length).toEqual(
-        quickResolveDeprecation.correctiveActions.manualSteps.length
       );
 
       // Quick resolve callout and button should display

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/deprecation_details_flyout.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/deprecation_details_flyout.tsx
@@ -203,16 +203,26 @@ export const DeprecationDetailsFlyout = ({
               <h3>{i18nTexts.manualFixTitle}</h3>
             </EuiTitle>
 
-            <EuiSpacer />
+            <EuiSpacer size="s" />
 
             <EuiText>
-              <ol data-test-subj="manualStepsList">
-                {correctiveActions.manualSteps.map((step, stepIndex) => (
-                  <li key={`step-${stepIndex}`} className="upgResolveStep eui-textBreakWord">
-                    {step}
-                  </li>
-                ))}
-              </ol>
+              {correctiveActions.manualSteps.length === 1 ? (
+                <p data-test-subj="manualStep" className="eui-textBreakWord">
+                  {correctiveActions.manualSteps[0]}
+                </p>
+              ) : (
+                <ol data-test-subj="manualStepsList">
+                  {correctiveActions.manualSteps.map((step, stepIndex) => (
+                    <li
+                      data-test-subj="manualStepsListItem"
+                      key={`step-${stepIndex}`}
+                      className="upgResolveStep eui-textBreakWord"
+                    >
+                      {step}
+                    </li>
+                  ))}
+                </ol>
+              )}
             </EuiText>
           </div>
         )}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/112622

If there's a single manual step, we now render it as a paragraph instead of as a list with one item.

![image](https://user-images.githubusercontent.com/1238659/135180131-fca00901-df3b-442b-9982-ab6a172c47b7.png)
