### PR TITLE
[data views] add display name for `index-pattern` saved objects

### DIFF
--- a/src/plugins/data/server/saved_objects/index_patterns.ts
+++ b/src/plugins/data/server/saved_objects/index_patterns.ts
@@ -8,13 +8,14 @@
 
 import type { SavedObjectsType } from 'kibana/server';
 import { indexPatternSavedObjectTypeMigrations } from './index_pattern_migrations';
-import { INDEX_PATTERN_SAVED_OBJECT_TYPE } from '../../common';
+import { DATA_VIEW_SAVED_OBJECT_TYPE } from '../../common';
 
 export const indexPatternSavedObjectType: SavedObjectsType = {
-  name: INDEX_PATTERN_SAVED_OBJECT_TYPE,
+  name: DATA_VIEW_SAVED_OBJECT_TYPE,
   hidden: false,
   namespaceType: 'single',
   management: {
+    displayName: 'Data view',
     icon: 'indexPatternApp',
     defaultSearchField: 'title',
     importableAndExportable: true,


### PR DESCRIPTION
## Summary

This is allows saved object management to display 'Data views' for `index-pattern` saved objects since we're unable to change the saved object type.