### PR TITLE
[7.x only] Remove `plugins.scanDirs` value from default config

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -138,7 +138,9 @@ function applyConfigOverrides(rawConfig, opts, extraCliOptions) {
     }
   }
 
-  set('plugins.scanDirs', _.compact([].concat(get('plugins.scanDirs'), opts.pluginDir)));
+  if (opts.pluginDir.length) {
+    set('plugins.scanDirs', _.compact([].concat(get('plugins.scanDirs'), opts.pluginDir)));
+  }
   set('plugins.paths', _.compact([].concat(get('plugins.paths'), opts.pluginPath)));
 
   merge(extraCliOptions);
@@ -171,10 +173,10 @@ export default function (program) {
     )
     .option(
       '--plugin-dir <path>',
-      'A path to scan for plugins, this can be specified multiple ' +
+      'Deprecated, A path to scan for plugins, this can be specified multiple ' +
         'times to specify multiple directories',
       pluginDirCollector,
-      [fromRoot('plugins')]
+      []
     )
     .option(
       '--plugin-path <path>',


### PR DESCRIPTION
## Summary

Targets `7.x` only. Changes on `master` are handled by https://github.com/elastic/kibana/pull/113367

Fix https://github.com/elastic/kibana/issues/113345

Only sets `plugin.scanDirs` from the cli script when required, to avoid showing a deprecation warning on vanilla installs.