### PR TITLE
[Lens] Fix infinite loop when loading rejected data view

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -336,7 +336,18 @@ describe('Lens App', () => {
         {}
       );
     });
-
+    it('handles rejected index pattern', async () => {
+      const customServices = makeDefaultServices(sessionIdSubject, 'sessionId-1');
+      customServices.data.indexPatterns.get = jest
+        .fn()
+        .mockImplementation((id) => Promise.reject({ reason: 'Could not locate that data view' }));
+      const customProps = makeDefaultProps();
+      const { services } = await mountWith({ props: customProps, services: customServices });
+      expect(services.navigation.ui.TopNavMenu).toHaveBeenCalledWith(
+        expect.objectContaining({ indexPatterns: [] }),
+        {}
+      );
+    });
     describe('save buttons', () => {
       interface SaveProps {
         newCopyOnSave: boolean;

--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -337,7 +337,7 @@ describe('Lens App', () => {
       );
     });
     it('handles rejected index pattern', async () => {
-      const customServices = makeDefaultServices(sessionIdSubject, 'sessionId-1');
+      const customServices = makeDefaultServices(sessionIdSubject);
       customServices.data.indexPatterns.get = jest
         .fn()
         .mockImplementation((id) => Promise.reject({ reason: 'Could not locate that data view' }));

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -169,6 +169,7 @@ export const LensTopNavMenu = ({
   );
 
   const [indexPatterns, setIndexPatterns] = useState<IndexPattern[]>([]);
+  const [rejectedIndexPatterns, setRejectedIndexPatterns] = useState<string[]>([]);
 
   const {
     isSaveable,
@@ -200,17 +201,31 @@ export const LensTopNavMenu = ({
       datasourceStates,
     });
     const hasIndexPatternsChanged =
-      indexPatterns.length !== indexPatternIds.length ||
-      indexPatternIds.some((id) => !indexPatterns.find((indexPattern) => indexPattern.id === id));
+      indexPatterns.length + rejectedIndexPatterns.length !== indexPatternIds.length ||
+      indexPatternIds.some(
+        (id) =>
+          ![...indexPatterns.map((ip) => ip.id), ...rejectedIndexPatterns].find(
+            (loadedId) => loadedId === id
+          )
+      );
+
     // Update the cached index patterns if the user made a change to any of them
     if (hasIndexPatternsChanged) {
       getIndexPatternsObjects(indexPatternIds, data.indexPatterns).then(
-        ({ indexPatterns: indexPatternObjects }) => {
+        ({ indexPatterns: indexPatternObjects, rejectedIds }) => {
           setIndexPatterns(indexPatternObjects);
+          setRejectedIndexPatterns(rejectedIds);
         }
       );
     }
-  }, [datasourceStates, activeDatasourceId, data.indexPatterns, datasourceMap, indexPatterns]);
+  }, [
+    datasourceStates,
+    activeDatasourceId,
+    rejectedIndexPatterns,
+    datasourceMap,
+    indexPatterns,
+    data.indexPatterns,
+  ]);
 
   const { TopNavMenu } = navigation.ui;
   const { from, to } = data.query.timefilter.timefilter.getTime();


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/113377

This is the issue with `useEffect` that uses `getIndexPatternObjects`. we compare the length of loaded index patterns to the expected ids from the document. When the expected index pattern gets rejected and not properly loaded, the length is always different, so we end up in infinite loop.