### PR TITLE
[Security Solution][Threat Hunting] Fixes failing timeline test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/timelines/creation.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timelines/creation.spec.ts
@@ -12,8 +12,10 @@ import {
   NOTES_TEXT,
   PIN_EVENT,
   SERVER_SIDE_EVENT_COUNT,
+  TIMELINE_DESCRIPTION,
   TIMELINE_FILTER,
   TIMELINE_FLYOUT_WRAPPER,
+  TIMELINE_QUERY,
   TIMELINE_PANEL,
   TIMELINE_TAB_CONTENT_EQL,
   TIMELINE_TAB_CONTENT_GRAPHS_NOTES,
@@ -124,19 +126,11 @@ describe('Create a timeline from a template', () => {
       cy.intercept('/api/timeline').as('timeline');
 
       clickingOnCreateTimelineFormTemplateBtn();
-      cy.wait('@timeline', { timeout: 100000 }).then(({ request }) => {
-        if (request.body && request.body.timeline) {
-          expect(request.body.timeline).to.haveOwnProperty(
-            'description',
-            getTimeline().description
-          );
-          expect(request.body.timeline.kqlQuery.filterQuery.kuery).to.haveOwnProperty(
-            'expression',
-            getTimeline().query
-          );
-          cy.get(TIMELINE_FLYOUT_WRAPPER).should('have.css', 'visibility', 'visible');
-        }
-      });
+      cy.wait('@timeline', { timeout: 100000 });
+
+      cy.get(TIMELINE_FLYOUT_WRAPPER).should('have.css', 'visibility', 'visible');
+      cy.get(TIMELINE_DESCRIPTION).should('have.text', getTimeline().description);
+      cy.get(TIMELINE_QUERY).should('have.text', getTimeline().query);
     });
   });
 });


### PR DESCRIPTION
## Summary

In this PR we are fixing a failing Cypress test. 

After the Cypress upgrade to the latest version, the `Create a timeline from a template` test started to fail. I don't know exactly the reason but looks like related to the way the assertions were done on the API response.

We need to take into consideration that Cypress should be used purely for testing the UI in those situations where it is impossible to check the same behavior with Jest or the API framework. The API in Cypress should be only used to prepare test data, to prepare the initial status of the test, or to wait for certain events before continuing with the assertions on the UI.

I refactored the test and now the assertions are done using the UI. 