### PR TITLE
[7.x] [embeddable] Don’t include test samples into initial bundle (#113126)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -18,7 +18,7 @@ pageLoadAssetSize:
   devTools: 38781
   discover: 99999
   discoverEnhanced: 42730
-  embeddable: 242753
+  embeddable: 99999
   embeddableEnhanced: 41145
   enterpriseSearch: 35741
   features: 21723


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [embeddable] Don’t include test samples into initial bundle (#113126)