### PR TITLE
Partial revert "[DOCS] Adds #112562 known issue to 7.14.2 release notes"

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -817,8 +817,6 @@ Uptime::
 [[release-notes-7.13.2]]
 == {kib} 7.13.2
 
-coming::[7.13.2]
-
 The 7.13.2 release includes the following bug fixes.
 
 [float]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -66,12 +66,6 @@ Review important information about the {kib} 7.14.x releases.
 Review the following information about the 7.14.2 release.
 
 [float]
-[[known-issue-v7.14.2]]
-=== Known issue
-
-{kib} is unable to restore *Discover* search sessions with a relative time range. When you restore the *Discover* search session, then run a new search, {kib} displays a `Your search session is still running` message. For more information, refer to {kibana-issue}101430[#101430].
-
-[float]
 [[breaking-changes-v7.14.2]]
 === Breaking changes
 Breaking changes can prevent your application from optimal operation and performance. Before you upgrade to 7.14.2, review the <<breaking-changes-7.14.0,7.14.0 breaking changes>>.
@@ -822,6 +816,8 @@ Uptime::
 ////////////////////////
 [[release-notes-7.13.2]]
 == {kib} 7.13.2
+
+coming::[7.13.2]
 
 The 7.13.2 release includes the following bug fixes.
 


### PR DESCRIPTION
Reverts elastic/kibana#112744

This is a known issue for 7.15.0, erroneously reported for 7.14.2, we should update the public docs to reflect this.

See https://github.com/elastic/kibana/pull/113442