### PR TITLE
[Enterprise Search] Exclude cypress folders from Jest test coverage

### DIFF
--- a/x-pack/plugins/enterprise_search/jest.config.js
+++ b/x-pack/plugins/enterprise_search/jest.config.js
@@ -18,4 +18,8 @@ module.exports = {
     '!<rootDir>/x-pack/plugins/enterprise_search/public/applications/test_helpers/**/*.{ts,tsx}',
   ],
   coverageDirectory: '<rootDir>/target/kibana-coverage/jest/x-pack/plugins/enterprise_search',
+  modulePathIgnorePatterns: [
+    '<rootDir>/x-pack/plugins/enterprise_search/public/applications/app_search/cypress',
+    '<rootDir>/x-pack/plugins/enterprise_search/public/applications/workplace_search/cypress',
+  ],
 };


### PR DESCRIPTION
## Summary

This PR removes the Cypress test helpers from the Jest coverage reports.