### PR TITLE
[7.15] [APM] Use oldest exit span instead of newest (#113133)

### DIFF
--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
@@ -111,7 +111,7 @@ export const getDestinationMap = ({
                   ] as const),
                   sort: [
                     {
-                      '@timestamp': 'desc' as const,
+                      '@timestamp': 'asc' as const,
                     },
                   ],
                 },


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [APM] Use oldest exit span instead of newest (#113133)