### PR TITLE
[7.x] [Mappings editor] Remove boost parameter from field types (#113142)

### DIFF
--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
@@ -504,18 +504,21 @@ export const useField = <T, FormType = FormData, I = T>(
       const { resetValue = true, defaultValue: updatedDefaultValue } = resetOptions;
 
       setPristine(true);
-      setIsModified(false);
-      setValidating(false);
-      setIsChangingValue(false);
-      setIsValidated(false);
-      setStateErrors([]);
 
-      if (resetValue) {
-        hasBeenReset.current = true;
-        const newValue = deserializeValue(updatedDefaultValue ?? defaultValue);
-        // updateStateIfMounted('value', newValue);
-        setValue(newValue);
-        return newValue;
+      if (isMounted.current) {
+        setIsModified(false);
+        setValidating(false);
+        setIsChangingValue(false);
+        setIsValidated(false);
+        setStateErrors([]);
+
+        if (resetValue) {
+          hasBeenReset.current = true;
+          const newValue = deserializeValue(updatedDefaultValue ?? defaultValue);
+          // updateStateIfMounted('value', newValue);
+          setValue(newValue);
+          return newValue;
+        }
       }
     },
     [deserializeValue, defaultValue, setValue, setStateErrors]

--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/constants.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/constants.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export const MAJOR_VERSION = '7.16.0';

--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/setup_environment.tsx
@@ -14,9 +14,12 @@ import { SemVer } from 'semver';
 import {
   notificationServiceMock,
   docLinksServiceMock,
+  uiSettingsServiceMock,
 } from '../../../../../../src/core/public/mocks';
 import { GlobalFlyout } from '../../../../../../src/plugins/es_ui_shared/public';
+import { createKibanaReactContext } from '../../../../../../src/plugins/kibana_react/public';
 
+import { MAJOR_VERSION } from '../../../common';
 import { AppContextProvider } from '../../../public/application/app_context';
 import { httpService } from '../../../public/application/services/http';
 import { breadcrumbService } from '../../../public/application/services/breadcrumbs';
@@ -32,12 +35,9 @@ import {
 } from '../../../public/application/components';
 import { componentTemplatesMockDependencies } from '../../../public/application/components/component_templates/__jest__';
 import { init as initHttpRequests } from './http_requests';
-import { MAJOR_VERSION } from './constants';
 
 const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });
 const { GlobalFlyoutProvider } = GlobalFlyout;
-
-export const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 export const services = {
   extensionsService: new ExtensionsService(),
@@ -53,6 +53,15 @@ const appDependencies = {
   core: { getUrlForApp: () => {} },
   plugins: {},
 } as any;
+
+export const kibanaVersion = new SemVer(MAJOR_VERSION);
+
+const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
+  uiSettings: uiSettingsServiceMock.createSetupContract(),
+  kibanaVersion: {
+    get: () => kibanaVersion,
+  },
+});
 
 export const setupEnvironment = () => {
   // Mock initialization of services
@@ -75,14 +84,16 @@ export const WithAppDependencies =
   (props: any) => {
     const mergedDependencies = merge({}, appDependencies, overridingDependencies);
     return (
-      <AppContextProvider value={mergedDependencies}>
-        <MappingsEditorProvider>
-          <ComponentTemplatesProvider value={componentTemplatesMockDependencies}>
-            <GlobalFlyoutProvider>
-              <Comp {...props} />
-            </GlobalFlyoutProvider>
-          </ComponentTemplatesProvider>
-        </MappingsEditorProvider>
-      </AppContextProvider>
+      <KibanaReactContextProvider>
+        <AppContextProvider value={mergedDependencies}>
+          <MappingsEditorProvider>
+            <ComponentTemplatesProvider value={componentTemplatesMockDependencies}>
+              <GlobalFlyoutProvider>
+                <Comp {...props} />
+              </GlobalFlyoutProvider>
+            </ComponentTemplatesProvider>
+          </MappingsEditorProvider>
+        </AppContextProvider>
+      </KibanaReactContextProvider>
     );
   };

--- a/x-pack/plugins/index_management/common/constants/index.ts
+++ b/x-pack/plugins/index_management/common/constants/index.ts
@@ -53,3 +53,5 @@ export {
   UIM_TEMPLATE_CLONE,
   UIM_TEMPLATE_SIMULATE,
 } from './ui_metric';
+
+export { MAJOR_VERSION } from './plugin';

--- a/x-pack/plugins/index_management/common/constants/plugin.ts
+++ b/x-pack/plugins/index_management/common/constants/plugin.ts
@@ -17,3 +17,9 @@ export const PLUGIN = {
       defaultMessage: 'Index Management',
     }),
 };
+
+// Ideally we want to access the Kibana major version from core
+// "PluginInitializerContext.env.packageInfo.version". In some cases it is not possible
+// to dynamically inject that version without a huge refactor on the code base.
+// We will then keep this single constant to declare on which major branch we are.
+export const MAJOR_VERSION = '8.0.0';

--- a/x-pack/plugins/index_management/common/constants/plugin.ts
+++ b/x-pack/plugins/index_management/common/constants/plugin.ts
@@ -22,4 +22,4 @@ export const PLUGIN = {
 // "PluginInitializerContext.env.packageInfo.version". In some cases it is not possible
 // to dynamically inject that version without a huge refactor on the code base.
 // We will then keep this single constant to declare on which major branch we are.
-export const MAJOR_VERSION = '8.0.0';
+export const MAJOR_VERSION = '7.16.0';

--- a/x-pack/plugins/index_management/common/index.ts
+++ b/x-pack/plugins/index_management/common/index.ts
@@ -8,7 +8,7 @@
 // TODO: https://github.com/elastic/kibana/issues/110892
 /* eslint-disable @kbn/eslint/no_export_all */
 
-export { API_BASE_PATH, BASE_PATH } from './constants';
+export { API_BASE_PATH, BASE_PATH, MAJOR_VERSION } from './constants';
 
 export { getTemplateParameter } from './lib';
 

--- a/x-pack/plugins/index_management/public/application/app_context.tsx
+++ b/x-pack/plugins/index_management/public/application/app_context.tsx
@@ -7,6 +7,7 @@
 
 import React, { createContext, useContext } from 'react';
 import { ScopedHistory } from 'kibana/public';
+import { SemVer } from 'semver';
 import { ManagementAppMountParams } from 'src/plugins/management/public';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
 
@@ -37,6 +38,7 @@ export interface AppDependencies {
   uiSettings: CoreSetup['uiSettings'];
   url: SharePluginStart['url'];
   docLinks: CoreStart['docLinks'];
+  kibanaVersion: SemVer;
 }
 
 export const AppContextProvider = ({

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/datatypes/scaled_float_datatype.test.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/datatypes/scaled_float_datatype.test.tsx
@@ -7,7 +7,7 @@
 
 import { act } from 'react-dom/test-utils';
 
-import { componentHelpers, MappingsEditorTestBed } from '../helpers';
+import { componentHelpers, MappingsEditorTestBed, kibanaVersion } from '../helpers';
 
 const { setup, getMappingsEditorDataFactory } = componentHelpers.mappingsEditor;
 
@@ -91,6 +91,13 @@ describe('Mappings editor: scaled float datatype', () => {
     });
     await updateFieldAndCloseFlyout();
     expect(exists('mappingsEditorFieldEdit')).toBe(false);
+
+    if (kibanaVersion.major < 7) {
+      expect(exists('boostParameterToggle')).toBe(true);
+    } else {
+      // Since 8.x the boost parameter is deprecated
+      expect(exists('boostParameterToggle')).toBe(false);
+    }
 
     // It should have the default parameters values added, plus the scaling factor
     updatedMappings.properties.myField = {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/datatypes/text_datatype.test.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/datatypes/text_datatype.test.tsx
@@ -7,7 +7,7 @@
 
 import { act } from 'react-dom/test-utils';
 
-import { componentHelpers, MappingsEditorTestBed } from '../helpers';
+import { componentHelpers, MappingsEditorTestBed, kibanaVersion } from '../helpers';
 import { getFieldConfig } from '../../../lib';
 
 const { setup, getMappingsEditorDataFactory } = componentHelpers.mappingsEditor;
@@ -64,6 +64,7 @@ describe('Mappings editor: text datatype', () => {
 
     const {
       component,
+      exists,
       actions: { startEditField, getToggleValue, updateFieldAndCloseFlyout },
     } = testBed;
 
@@ -73,6 +74,13 @@ describe('Mappings editor: text datatype', () => {
     // It should have searchable ("index" param) active by default
     const indexFieldConfig = getFieldConfig('index');
     expect(getToggleValue('indexParameter.formRowToggle')).toBe(indexFieldConfig.defaultValue);
+
+    if (kibanaVersion.major < 7) {
+      expect(exists('boostParameterToggle')).toBe(true);
+    } else {
+      // Since 8.x the boost parameter is deprecated
+      expect(exists('boostParameterToggle')).toBe(false);
+    }
 
     // Save the field and close the flyout
     await updateFieldAndCloseFlyout();

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/helpers/index.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/helpers/index.ts
@@ -13,6 +13,7 @@ import {
 } from './mappings_editor.helpers';
 
 export { nextTick, getRandomString, findTestSubject, TestBed } from '@kbn/test/jest';
+export { kibanaVersion } from './setup_environment';
 
 export const componentHelpers = {
   mappingsEditor: { setup: mappingsEditorSetup, getMappingsEditorDataFactory },

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/helpers/mappings_editor.helpers.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/helpers/mappings_editor.helpers.tsx
@@ -123,12 +123,10 @@ const createActions = (testBed: TestBed<TestSubjects>) => {
 
     component.update();
 
-    if (subType !== undefined) {
+    if (subType !== undefined && type === 'other') {
       await act(async () => {
-        if (type === 'other') {
-          // subType is a text input
-          form.setInputValue('createFieldForm.fieldSubType', subType);
-        }
+        // subType is a text input
+        form.setInputValue('createFieldForm.fieldSubType', subType);
       });
     }
 

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/helpers/setup_environment.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/helpers/setup_environment.tsx
@@ -6,6 +6,8 @@
  */
 
 import React from 'react';
+import { SemVer } from 'semver';
+
 /* eslint-disable-next-line @kbn/eslint/no-restricted-paths */
 import '../../../../../../../../../../src/plugins/es_ui_shared/public/components/code_editor/jest_mock';
 import { GlobalFlyout } from '../../../../../../../../../../src/plugins/es_ui_shared/public';
@@ -13,8 +15,11 @@ import {
   docLinksServiceMock,
   uiSettingsServiceMock,
 } from '../../../../../../../../../../src/core/public/mocks';
+import { MAJOR_VERSION } from '../../../../../../../common';
 import { MappingsEditorProvider } from '../../../mappings_editor_context';
 import { createKibanaReactContext } from '../../../shared_imports';
+
+export const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 jest.mock('@elastic/eui', () => {
   const original = jest.requireActual('@elastic/eui');
@@ -72,6 +77,9 @@ const { GlobalFlyoutProvider } = GlobalFlyout;
 
 const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
   uiSettings: uiSettingsServiceMock.createSetupContract(),
+  kibanaVersion: {
+    get: () => kibanaVersion,
+  },
 });
 
 const defaultProps = {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/boost_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/boost_parameter.tsx
@@ -33,6 +33,7 @@ export const BoostParameter = ({ defaultToggleValue }: Props) => (
       href: documentationService.getBoostLink(),
     }}
     defaultToggleValue={defaultToggleValue}
+    data-test-subj="boostParameter"
   >
     {/* Boost level */}
     <UseField

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
@@ -19,6 +19,7 @@ import {
   EuiSpacer,
   EuiCallOut,
 } from '@elastic/eui';
+import { SemVer } from 'semver';
 
 import { documentationService } from '../../../../../../services/documentation';
 import { Form, FormHook, FormDataProvider } from '../../../../shared_imports';
@@ -43,6 +44,7 @@ export interface Props {
   allFields: NormalizedFields['byId'];
   exitEdit(): void;
   updateField: UpdateFieldFunc;
+  kibanaVersion: SemVer;
 }
 
 // The default FormWrapper is the <EuiForm />, which wrapps the form with
@@ -50,161 +52,164 @@ export interface Props {
 // the height calculaction and does not render the footer position correctly.
 const FormWrapper: React.FC = ({ children }) => <>{children}</>;
 
-export const EditField = React.memo(({ form, field, allFields, exitEdit, updateField }: Props) => {
-  const submitForm = async () => {
-    const { isValid, data } = await form.submit();
+export const EditField = React.memo(
+  ({ form, field, allFields, exitEdit, updateField, kibanaVersion }: Props) => {
+    const submitForm = async () => {
+      const { isValid, data } = await form.submit();
 
-    if (isValid) {
-      updateField({ ...field, source: data });
-    }
-  };
+      if (isValid) {
+        updateField({ ...field, source: data });
+      }
+    };
 
-  const { isMultiField } = field;
+    const { isMultiField } = field;
 
-  return (
-    <Form form={form} FormWrapper={FormWrapper}>
-      <EuiFlyoutHeader>
-        <EuiFlexGroup gutterSize="xs">
-          <EuiFlexItem>
-            {/* We need an extra div to get out of flex grow */}
-            <div>
-              {/* Title */}
-              <EuiTitle size="m">
-                <h2 data-test-subj="flyoutTitle">
-                  {isMultiField
-                    ? i18n.translate('xpack.idxMgmt.mappingsEditor.editMultiFieldTitle', {
-                        defaultMessage: "Edit multi-field '{fieldName}'",
+    return (
+      <Form form={form} FormWrapper={FormWrapper}>
+        <EuiFlyoutHeader>
+          <EuiFlexGroup gutterSize="xs">
+            <EuiFlexItem>
+              {/* We need an extra div to get out of flex grow */}
+              <div>
+                {/* Title */}
+                <EuiTitle size="m">
+                  <h2 data-test-subj="flyoutTitle">
+                    {isMultiField
+                      ? i18n.translate('xpack.idxMgmt.mappingsEditor.editMultiFieldTitle', {
+                          defaultMessage: "Edit multi-field '{fieldName}'",
+                          values: {
+                            fieldName: limitStringLength(field.source.name),
+                          },
+                        })
+                      : i18n.translate('xpack.idxMgmt.mappingsEditor.editFieldTitle', {
+                          defaultMessage: "Edit field '{fieldName}'",
+                          values: {
+                            fieldName: limitStringLength(field.source.name),
+                          },
+                        })}
+                  </h2>
+                </EuiTitle>
+              </div>
+            </EuiFlexItem>
+
+            {/* Documentation link */}
+            <FormDataProvider pathsToWatch={['type', 'subType']}>
+              {({ type, subType }) => {
+                const linkDocumentation =
+                  documentationService.getTypeDocLink(subType?.[0]?.value) ||
+                  documentationService.getTypeDocLink(type?.[0]?.value);
+
+                if (!linkDocumentation) {
+                  return null;
+                }
+
+                const typeDefinition = TYPE_DEFINITION[type[0].value as MainType];
+                const subTypeDefinition = TYPE_DEFINITION[subType?.[0].value as SubType];
+
+                return (
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty
+                      size="s"
+                      flush="right"
+                      href={linkDocumentation}
+                      target="_blank"
+                      iconType="help"
+                      data-test-subj="documentationLink"
+                    >
+                      {i18n.translate('xpack.idxMgmt.mappingsEditor.editField.typeDocumentation', {
+                        defaultMessage: '{type} documentation',
                         values: {
-                          fieldName: limitStringLength(field.source.name),
-                        },
-                      })
-                    : i18n.translate('xpack.idxMgmt.mappingsEditor.editFieldTitle', {
-                        defaultMessage: "Edit field '{fieldName}'",
-                        values: {
-                          fieldName: limitStringLength(field.source.name),
+                          type: subTypeDefinition ? subTypeDefinition.label : typeDefinition.label,
                         },
                       })}
-                </h2>
-              </EuiTitle>
-            </div>
-          </EuiFlexItem>
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                );
+              }}
+            </FormDataProvider>
+          </EuiFlexGroup>
 
-          {/* Documentation link */}
+          {/* Field path */}
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false} data-test-subj="fieldPath">
+              <CodeBlock padding="small">{field.path.join(' > ')}</CodeBlock>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutHeader>
+
+        <EuiFlyoutBody>
+          <EditFieldHeaderForm
+            defaultValue={field.source}
+            isRootLevelField={field.parentId === undefined}
+            isMultiField={isMultiField}
+          />
+
           <FormDataProvider pathsToWatch={['type', 'subType']}>
             {({ type, subType }) => {
-              const linkDocumentation =
-                documentationService.getTypeDocLink(subType?.[0]?.value) ||
-                documentationService.getTypeDocLink(type?.[0]?.value);
+              const ParametersForm = getParametersFormForType(type?.[0].value, subType?.[0].value);
 
-              if (!linkDocumentation) {
+              if (!ParametersForm) {
                 return null;
               }
 
-              const typeDefinition = TYPE_DEFINITION[type[0].value as MainType];
-              const subTypeDefinition = TYPE_DEFINITION[subType?.[0].value as SubType];
-
               return (
-                <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty
-                    size="s"
-                    flush="right"
-                    href={linkDocumentation}
-                    target="_blank"
-                    iconType="help"
-                    data-test-subj="documentationLink"
-                  >
-                    {i18n.translate('xpack.idxMgmt.mappingsEditor.editField.typeDocumentation', {
-                      defaultMessage: '{type} documentation',
-                      values: {
-                        type: subTypeDefinition ? subTypeDefinition.label : typeDefinition.label,
-                      },
-                    })}
-                  </EuiButtonEmpty>
-                </EuiFlexItem>
+                <ParametersForm
+                  // As the component "ParametersForm" does not change when switching type, and all the props
+                  // also remain the same (===), adding a key give us *a new instance* each time we change the type or subType.
+                  // This will trigger an unmount of all the previous form fields and then mount the new ones.
+                  key={subType ?? type}
+                  field={field}
+                  allFields={allFields}
+                  isMultiField={isMultiField}
+                  kibanaVersion={kibanaVersion}
+                />
               );
             }}
           </FormDataProvider>
-        </EuiFlexGroup>
+        </EuiFlyoutBody>
 
-        {/* Field path */}
-        <EuiFlexGroup>
-          <EuiFlexItem grow={false} data-test-subj="fieldPath">
-            <CodeBlock padding="small">{field.path.join(' > ')}</CodeBlock>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlyoutHeader>
-
-      <EuiFlyoutBody>
-        <EditFieldHeaderForm
-          defaultValue={field.source}
-          isRootLevelField={field.parentId === undefined}
-          isMultiField={isMultiField}
-        />
-
-        <FormDataProvider pathsToWatch={['type', 'subType']}>
-          {({ type, subType }) => {
-            const ParametersForm = getParametersFormForType(type?.[0].value, subType?.[0].value);
-
-            if (!ParametersForm) {
-              return null;
-            }
-
-            return (
-              <ParametersForm
-                // As the component "ParametersForm" does not change when switching type, and all the props
-                // also remain the same (===), adding a key give us *a new instance* each time we change the type or subType.
-                // This will trigger an unmount of all the previous form fields and then mount the new ones.
-                key={subType ?? type}
-                field={field}
-                allFields={allFields}
-                isMultiField={isMultiField}
+        <EuiFlyoutFooter>
+          {form.isSubmitted && !form.isValid && (
+            <>
+              <EuiCallOut
+                title={i18n.translate(
+                  'xpack.idxMgmt.mappingsEditor.editFieldFlyout.validationErrorTitle',
+                  {
+                    defaultMessage: 'Fix errors in form before continuing.',
+                  }
+                )}
+                color="danger"
+                iconType="cross"
+                data-test-subj="formError"
               />
-            );
-          }}
-        </FormDataProvider>
-      </EuiFlyoutBody>
+              <EuiSpacer size="m" />
+            </>
+          )}
 
-      <EuiFlyoutFooter>
-        {form.isSubmitted && !form.isValid && (
-          <>
-            <EuiCallOut
-              title={i18n.translate(
-                'xpack.idxMgmt.mappingsEditor.editFieldFlyout.validationErrorTitle',
-                {
-                  defaultMessage: 'Fix errors in form before continuing.',
-                }
-              )}
-              color="danger"
-              iconType="cross"
-              data-test-subj="formError"
-            />
-            <EuiSpacer size="m" />
-          </>
-        )}
-
-        <EuiFlexGroup justifyContent="flexEnd">
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={exitEdit}>
-              {i18n.translate('xpack.idxMgmt.mappingsEditor.editFieldCancelButtonLabel', {
-                defaultMessage: 'Cancel',
-              })}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              onClick={submitForm}
-              type="submit"
-              disabled={form.isSubmitted && !form.isValid}
-              data-test-subj="editFieldUpdateButton"
-            >
-              {i18n.translate('xpack.idxMgmt.mappingsEditor.editFieldUpdateButtonLabel', {
-                defaultMessage: 'Update',
-              })}
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlyoutFooter>
-    </Form>
-  );
-});
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty onClick={exitEdit}>
+                {i18n.translate('xpack.idxMgmt.mappingsEditor.editFieldCancelButtonLabel', {
+                  defaultMessage: 'Cancel',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                onClick={submitForm}
+                type="submit"
+                disabled={form.isSubmitted && !form.isValid}
+                data-test-subj="editFieldUpdateButton"
+              >
+                {i18n.translate('xpack.idxMgmt.mappingsEditor.editFieldUpdateButtonLabel', {
+                  defaultMessage: 'Update',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </Form>
+    );
+  }
+);

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_container.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_container.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useMemo } from 'react';
 
+import { useKibana } from '../../../../../../index';
 import { useForm } from '../../../../shared_imports';
 import { useDispatch, useMappingsState } from '../../../../mappings_state_context';
 import { Field } from '../../../../types';
@@ -30,6 +31,9 @@ export const EditFieldContainer = React.memo(({ exitEdit }: Props) => {
   const { fields, documentFields } = useMappingsState();
   const dispatch = useDispatch();
   const { updateField, modal } = useUpdateField();
+  const {
+    services: { kibanaVersion },
+  } = useKibana();
 
   const { status, fieldToEdit } = documentFields;
   const isEditing = status === 'editingField';
@@ -73,6 +77,7 @@ export const EditFieldContainer = React.memo(({ exitEdit }: Props) => {
         allFields={fields.byId}
         exitEdit={exitEdit}
         updateField={updateField}
+        kibanaVersion={kibanaVersion.get()}
       />
       {renderModal()}
     </>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/boolean_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/boolean_type.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { SemVer } from 'semver';
 
 import { i18n } from '@kbn/i18n';
 
@@ -57,9 +58,10 @@ const nullValueOptions = [
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const BooleanType = ({ field }: Props) => {
+export const BooleanType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -96,7 +98,10 @@ export const BooleanType = ({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/date_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/date_type.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-
+import { SemVer } from 'semver';
 import { i18n } from '@kbn/i18n';
 
 import { NormalizedField, Field as FieldType } from '../../../../types';
@@ -43,9 +43,10 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const DateType = ({ field }: Props) => {
+export const DateType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -79,7 +80,10 @@ export const DateType = ({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/flattened_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/flattened_type.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { SemVer } from 'semver';
 
 import { NormalizedField, Field as FieldType } from '../../../../types';
 import { UseField, Field } from '../../../../shared_imports';
@@ -27,6 +28,7 @@ import { BasicParametersSection, EditFieldFormRow, AdvancedParametersSection } f
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
 const getDefaultToggleValue = (param: string, field: FieldType) => {
@@ -45,7 +47,7 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
   }
 };
 
-export const FlattenedType = React.memo(({ field }: Props) => {
+export const FlattenedType = React.memo(({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -89,7 +91,10 @@ export const FlattenedType = React.memo(({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/index.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/index.ts
@@ -6,6 +6,8 @@
  */
 
 import { ComponentType } from 'react';
+import { SemVer } from 'semver';
+
 import { MainType, SubType, DataType, NormalizedField, NormalizedFields } from '../../../../types';
 
 import { AliasType } from './alias_type';
@@ -75,6 +77,7 @@ export const getParametersFormForType = (
       field: NormalizedField;
       allFields: NormalizedFields['byId'];
       isMultiField: boolean;
+      kibanaVersion: SemVer;
     }>
   | undefined =>
   subType === undefined

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/ip_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/ip_type.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { SemVer } from 'semver';
 
 import { NormalizedField, Field as FieldType } from '../../../../types';
 import { getFieldConfig } from '../../../../lib';
@@ -36,9 +37,10 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const IpType = ({ field }: Props) => {
+export const IpType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -54,7 +56,10 @@ export const IpType = ({ field }: Props) => {
 
         <StoreParameter />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/keyword_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/keyword_type.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-
+import { SemVer } from 'semver';
 import { i18n } from '@kbn/i18n';
 
 import { documentationService } from '../../../../../../services/documentation';
@@ -48,9 +48,10 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const KeywordType = ({ field }: Props) => {
+export const KeywordType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -104,7 +105,10 @@ export const KeywordType = ({ field }: Props) => {
 
         <StoreParameter />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/numeric_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/numeric_type.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { SemVer } from 'semver';
 
 import { NormalizedField, Field as FieldType, ComboBoxOption } from '../../../../types';
 import { getFieldConfig } from '../../../../lib';
@@ -43,9 +44,10 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const NumericType = ({ field }: Props) => {
+export const NumericType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -102,7 +104,10 @@ export const NumericType = ({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/range_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/range_type.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { SemVer } from 'semver';
 
 import {
   NormalizedField,
@@ -32,9 +33,10 @@ const getDefaultToggleValue = (param: ParameterName, field: FieldType) => {
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const RangeType = ({ field }: Props) => {
+export const RangeType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -67,7 +69,10 @@ export const RangeType = ({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/text_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/text_type.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { EuiSpacer, EuiDualRange, EuiFormRow, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { SemVer } from 'semver';
 
 import { documentationService } from '../../../../../../services/documentation';
 import { NormalizedField, Field as FieldType } from '../../../../types';
@@ -36,6 +37,7 @@ import { BasicParametersSection, EditFieldFormRow, AdvancedParametersSection } f
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
 const getDefaultToggleValue = (param: string, field: FieldType) => {
@@ -73,7 +75,7 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
   }
 };
 
-export const TextType = React.memo(({ field }: Props) => {
+export const TextType = React.memo(({ field, kibanaVersion }: Props) => {
   const onIndexPrefixesChanage =
     (minField: FieldHook, maxField: FieldHook) =>
     ([min, max]: any) => {
@@ -246,7 +248,10 @@ export const TextType = React.memo(({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/token_count_type.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/field_types/token_count_type.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-
+import { SemVer } from 'semver';
 import { i18n } from '@kbn/i18n';
 
 import { documentationService } from '../../../../../../services/documentation';
@@ -43,9 +43,10 @@ const getDefaultToggleValue = (param: string, field: FieldType) => {
 
 interface Props {
   field: NormalizedField;
+  kibanaVersion: SemVer;
 }
 
-export const TokenCountType = ({ field }: Props) => {
+export const TokenCountType = ({ field, kibanaVersion }: Props) => {
   return (
     <>
       <BasicParametersSection>
@@ -113,7 +114,10 @@ export const TokenCountType = ({ field }: Props) => {
 
         <MetaParameter defaultToggleValue={getDefaultToggleValue('meta', field.source)} />
 
-        <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        {/* The "boost" parameter is deprecated since 8.x */}
+        {kibanaVersion.major < 8 && (
+          <BoostParameter defaultToggleValue={getDefaultToggleValue('boost', field.source)} />
+        )}
       </AdvancedParametersSection>
     </>
   );

--- a/x-pack/plugins/index_management/public/application/index.tsx
+++ b/x-pack/plugins/index_management/public/application/index.tsx
@@ -8,11 +8,16 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render, unmountComponentAtNode } from 'react-dom';
+import { SemVer } from 'semver';
 
-import { CoreStart } from '../../../../../src/core/public';
+import { CoreStart, CoreSetup } from '../../../../../src/core/public';
 
 import { API_BASE_PATH } from '../../common';
-import { createKibanaReactContext, GlobalFlyout } from '../shared_imports';
+import {
+  createKibanaReactContext,
+  GlobalFlyout,
+  useKibana as useKibanaReactPlugin,
+} from '../shared_imports';
 
 import { AppContextProvider, AppDependencies } from './app_context';
 import { App } from './app';
@@ -31,12 +36,16 @@ export const renderApp = (
 
   const { i18n, docLinks, notifications, application } = core;
   const { Context: I18nContext } = i18n;
-  const { services, history, setBreadcrumbs, uiSettings } = dependencies;
+  const { services, history, setBreadcrumbs, uiSettings, kibanaVersion } = dependencies;
 
   // uiSettings is required by the CodeEditor component used to edit runtime field Painless scripts.
-  const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
-    uiSettings,
-  });
+  const { Provider: KibanaReactContextProvider } =
+    createKibanaReactContext<KibanaReactContextServices>({
+      uiSettings,
+      kibanaVersion: {
+        get: () => kibanaVersion,
+      },
+    });
 
   const componentTemplateProviderValues = {
     httpClient: services.httpService.httpClient,
@@ -72,4 +81,16 @@ export const renderApp = (
   };
 };
 
-export { AppDependencies };
+interface KibanaReactContextServices {
+  uiSettings: CoreSetup['uiSettings'];
+  kibanaVersion: {
+    get: () => SemVer;
+  };
+}
+
+// We override useKibana() from the react plugin to return a typed version for this app
+const useKibana = () => {
+  return useKibanaReactPlugin<KibanaReactContextServices>();
+};
+
+export { AppDependencies, useKibana };

--- a/x-pack/plugins/index_management/public/application/lib/indices.ts
+++ b/x-pack/plugins/index_management/public/application/lib/indices.ts
@@ -4,11 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import SemVer from 'semver/classes/semver';
+import { SemVer } from 'semver';
+
+import { MAJOR_VERSION } from '../../../common';
 import { Index } from '../../../common';
 
-const version = '7.16.0';
-const kibanaVersion = new SemVer(version);
+const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 export const isHiddenIndex = (index: Index): boolean => {
   if (kibanaVersion.major < 8) {

--- a/x-pack/plugins/index_management/public/application/mount_management_section.ts
+++ b/x-pack/plugins/index_management/public/application/mount_management_section.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { SemVer } from 'semver';
 import { CoreSetup } from 'src/core/public';
 import { ManagementAppMountParams } from 'src/plugins/management/public/';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
@@ -50,7 +51,8 @@ export async function mountManagementSection(
   usageCollection: UsageCollectionSetup,
   params: ManagementAppMountParams,
   extensionsService: ExtensionsService,
-  isFleetEnabled: boolean
+  isFleetEnabled: boolean,
+  kibanaVersion: SemVer
 ) {
   const { element, setBreadcrumbs, history } = params;
   const [core, startDependencies] = await coreSetup.getStartServices();
@@ -88,6 +90,7 @@ export async function mountManagementSection(
     uiSettings,
     url,
     docLinks,
+    kibanaVersion,
   };
 
   const unmountAppCallback = renderApp(element, { core, dependencies: appDependencies });

--- a/x-pack/plugins/index_management/public/application/store/selectors/indices_filter.test.ts
+++ b/x-pack/plugins/index_management/public/application/store/selectors/indices_filter.test.ts
@@ -4,15 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import SemVer from 'semver/classes/semver';
+import { SemVer } from 'semver';
+
+import { MAJOR_VERSION } from '../../../../common';
 import { ExtensionsService } from '../../../services';
 import { getFilteredIndices } from '.';
 // @ts-ignore
 import { defaultTableState } from '../reducers/table_state';
 import { setExtensionsService } from './extension_service';
 
-const version = '7.16.0';
-const kibanaVersion = new SemVer(version);
+const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 describe('getFilteredIndices selector', () => {
   let extensionService: ExtensionsService;

--- a/x-pack/plugins/index_management/public/index.ts
+++ b/x-pack/plugins/index_management/public/index.ts
@@ -6,11 +6,12 @@
  */
 
 import './index.scss';
+import { PluginInitializerContext } from 'src/core/public';
 import { IndexMgmtUIPlugin } from './plugin';
 
 /** @public */
-export const plugin = () => {
-  return new IndexMgmtUIPlugin();
+export const plugin = (ctx: PluginInitializerContext) => {
+  return new IndexMgmtUIPlugin(ctx);
 };
 
 export { IndexManagementPluginSetup } from './types';

--- a/x-pack/plugins/index_management/public/plugin.ts
+++ b/x-pack/plugins/index_management/public/plugin.ts
@@ -6,8 +6,9 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { SemVer } from 'semver';
 
-import { CoreSetup } from '../../../../src/core/public';
+import { CoreSetup, PluginInitializerContext } from '../../../../src/core/public';
 import { setExtensionsService } from './application/store/selectors/extension_service';
 
 import { ExtensionsService } from './services';
@@ -20,7 +21,7 @@ import { PLUGIN } from '../common/constants/plugin';
 export class IndexMgmtUIPlugin {
   private extensionsService = new ExtensionsService();
 
-  constructor() {
+  constructor(private ctx: PluginInitializerContext) {
     // Temporary hack to provide the service instances in module files in order to avoid a big refactor
     // For the selectors we should expose them through app dependencies and read them from there on each container component.
     setExtensionsService(this.extensionsService);
@@ -31,6 +32,7 @@ export class IndexMgmtUIPlugin {
     plugins: SetupDependencies
   ): IndexManagementPluginSetup {
     const { fleet, usageCollection, management } = plugins;
+    const kibanaVersion = new SemVer(this.ctx.env.packageInfo.version);
 
     management.sections.section.data.registerApp({
       id: PLUGIN.id,
@@ -43,7 +45,8 @@ export class IndexMgmtUIPlugin {
           usageCollection,
           params,
           this.extensionsService,
-          Boolean(fleet)
+          Boolean(fleet),
+          kibanaVersion
         );
       },
     });

--- a/x-pack/plugins/index_management/public/shared_imports.ts
+++ b/x-pack/plugins/index_management/public/shared_imports.ts
@@ -56,4 +56,5 @@ export { isJSON } from '../../../../src/plugins/es_ui_shared/static/validators/s
 export {
   createKibanaReactContext,
   reactRouterNavigate,
+  useKibana,
 } from '../../../../src/plugins/kibana_react/public';


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Mappings editor] Remove boost parameter from field types (#113142)