### PR TITLE
[7.15] Revert [Vega] Fix: Scrollbars are appearing in default Vega configurations (#113110)

### DIFF
--- a/src/plugins/vis_type_vega/public/components/vega_vis.scss
+++ b/src/plugins/vis_type_vega/public/components/vega_vis.scss
@@ -18,7 +18,7 @@
   z-index: 0;
   flex: 1 1 100%;
 
-  //display determined by js
+  display: block;
   max-width: 100%;
   max-height: 100%;
   width: 100%;

--- a/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_base_view.js
@@ -83,10 +83,9 @@ export class VegaBaseView {
         return;
       }
 
-      const containerDisplay = this._parser.useResize ? 'flex' : 'block';
       this._$container = $('<div class="vgaVis__view">')
         // Force a height here because css is not loaded in mocha test
-        .css({ height: '100%', display: containerDisplay })
+        .css('height', '100%')
         .appendTo(this._$parentEl);
       this._$controls = $(
         `<div class="vgaVis__controls vgaVis__controls--${this._parser.controlsDir}">`


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Revert [Vega] Fix: Scrollbars are appearing in default Vega configurations (#113110)