### PR TITLE
[7.x] [Actions] Better enqueue test (#112434)

### DIFF
--- a/x-pack/test/alerting_api_integration/common/fixtures/plugins/alerts/server/action_types.ts
+++ b/x-pack/test/alerting_api_integration/common/fixtures/plugins/alerts/server/action_types.ts
@@ -213,6 +213,7 @@ function getNoAttemptsRateLimitedActionType() {
       });
       return {
         status: 'error',
+        message: 'intentional failure from action',
         retry: new Date(params.retryAt),
         actionId: '',
       };

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/enqueue.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/enqueue.ts
@@ -23,8 +23,7 @@ export default function ({ getService }: FtrProviderContext) {
   const retry = getService('retry');
   const esTestIndexTool = new ESTestIndexTool(es, retry);
 
-  // Failing: See https://github.com/elastic/kibana/issues/111812
-  describe.skip('enqueue', () => {
+  describe('enqueue', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     before(async () => {
@@ -170,21 +169,17 @@ export default function ({ getService }: FtrProviderContext) {
                       'task.taskType': 'actions:test.no-attempts-rate-limit',
                     },
                   },
-                  {
-                    term: {
-                      'task.status': 'running',
-                    },
-                  },
                 ],
               },
             },
           },
         });
-        expect((runningSearchResult.body.hits.total as estypes.SearchTotalHits).value).to.eql(1);
+        const total = (runningSearchResult.body.hits.total as estypes.SearchTotalHits).value;
+        expect(total).to.eql(1);
       });
 
       await retry.try(async () => {
-        const searchResult = await es.search({
+        const runningSearchResult = await es.search({
           index: '.kibana_task_manager',
           body: {
             query: {
@@ -200,7 +195,8 @@ export default function ({ getService }: FtrProviderContext) {
             },
           },
         });
-        expect((searchResult.body.hits.total as estypes.SearchTotalHits).value).to.eql(0);
+        const total = (runningSearchResult.body.hits.total as estypes.SearchTotalHits).value;
+        expect(total).to.eql(0);
       });
     });
   });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Actions] Better enqueue test (#112434)