### PR TITLE
[Stack Monitoring] fix missing nested property when storing in local storage

### DIFF
--- a/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_table.ts
@@ -112,7 +112,7 @@ export function useTable(storageKey: string) {
     setSorting(cleanSortingData({ sort }));
     setLocalStorageData(storage, {
       page,
-      sort,
+      sort: { sort },
     });
   };
 


### PR DESCRIPTION
Introduced in https://github.com/elastic/kibana/pull/113284, setting the storage is missing a property and so it will break in either Angular mode or React when trying to access.