### PR TITLE
[7.15] [eslint] forbid trailing slashes in package imports (#113455)

### DIFF
--- a/packages/elastic-eslint-config-kibana/.eslintrc.js
+++ b/packages/elastic-eslint-config-kibana/.eslintrc.js
@@ -92,5 +92,6 @@ module.exports = {
     ],
 
     '@kbn/eslint/no_async_promise_body': 'error',
+    '@kbn/eslint/no_trailing_import_slash': 'error',
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -13,5 +13,6 @@ module.exports = {
     'no-restricted-paths': require('./rules/no_restricted_paths'),
     module_migration: require('./rules/module_migration'),
     no_async_promise_body: require('./rules/no_async_promise_body'),
+    no_trailing_import_slash: require('./rules/no_trailing_import_slash'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/no_trailing_import_slash.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_trailing_import_slash.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+/** @typedef {import("@typescript-eslint/typescript-estree").TSESTree.ImportDeclaration} ImportDeclaration */
+
+const ERROR_MSG =
+  'Using a trailing slash in package import statements causes issues with webpack and is inconsistent with the rest of the respository.';
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    fixable: 'code',
+    schema: [],
+  },
+  create: (context) => ({
+    ImportDeclaration(_) {
+      const node = /** @type {ImportDeclaration} */ (_);
+      const req = node.source.value;
+
+      if (!req.startsWith('.') && req.endsWith('/')) {
+        context.report({
+          message: ERROR_MSG,
+          loc: node.source.loc,
+          fix(fixer) {
+            return fixer.replaceText(node.source, `'${req.slice(0, -1)}'`);
+          },
+        });
+      }
+    },
+  }),
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/no_trailing_import_slash.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_trailing_import_slash.test.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./no_trailing_import_slash');
+const dedent = require('dedent');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('@kbn/eslint/no_trailing_import_slash', rule, {
+  valid: [
+    {
+      code: dedent`
+        import foo from 'bar';
+      `,
+    },
+    {
+      code: dedent`
+        import foo from './bar';
+      `,
+    },
+    {
+      code: dedent`
+        import foo from './bar/';
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: dedent`
+        import foo from 'bar/';
+      `,
+      errors: [
+        {
+          line: 1,
+          message:
+            'Using a trailing slash in package import statements causes issues with webpack and is inconsistent with the rest of the respository.',
+        },
+      ],
+      output: dedent`
+        import foo from 'bar';
+      `,
+    },
+    {
+      code: dedent`
+        import foo from 'bar/box/';
+      `,
+      errors: [
+        {
+          line: 1,
+          message:
+            'Using a trailing slash in package import statements causes issues with webpack and is inconsistent with the rest of the respository.',
+        },
+      ],
+      output: dedent`
+        import foo from 'bar/box';
+      `,
+    },
+  ],
+});

--- a/src/plugins/discover/public/application/apps/main/components/doc_table/components/pager/tool_bar_pagination.tsx
+++ b/src/plugins/discover/public/application/apps/main/components/doc_table/components/pager/tool_bar_pagination.tsx
@@ -17,7 +17,7 @@ import {
   EuiPopover,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { i18n } from '@kbn/i18n/';
+import { i18n } from '@kbn/i18n';
 
 interface ToolBarPaginationProps {
   pageSize: number;

--- a/x-pack/plugins/index_management/public/application/mount_management_section.ts
+++ b/x-pack/plugins/index_management/public/application/mount_management_section.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { CoreSetup } from 'src/core/public';
-import { ManagementAppMountParams } from 'src/plugins/management/public/';
+import { ManagementAppMountParams } from 'src/plugins/management/public';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/public';
 
 import { UIM_APP_NAME } from '../../common/constants';

--- a/x-pack/plugins/reporting/server/config/create_config.ts
+++ b/x-pack/plugins/reporting/server/config/create_config.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n/';
+import { i18n } from '@kbn/i18n';
 import crypto from 'crypto';
 import { upperFirst } from 'lodash';
 import { Observable } from 'rxjs';


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [eslint] forbid trailing slashes in package imports (#113455)