### PR TITLE
[APM] Disabling apm e2e test

### DIFF
--- a/vars/tasks.groovy
+++ b/vars/tasks.groovy
@@ -146,13 +146,14 @@ def functionalXpack(Map params = [:]) {
       }
     }
 
-    whenChanged([
-      'x-pack/plugins/apm/',
-    ]) {
-      if (githubPr.isPr()) {
-        task(kibanaPipeline.functionalTestProcess('xpack-APMCypress', './test/scripts/jenkins_apm_cypress.sh'))
-      }
-    }
+    //temporarily disable apm e2e test since it's breaking due to a version upgrade.
+    // whenChanged([
+    //   'x-pack/plugins/apm/',
+    // ]) {
+    //   if (githubPr.isPr()) {
+    //     task(kibanaPipeline.functionalTestProcess('xpack-APMCypress', './test/scripts/jenkins_apm_cypress.sh'))
+    //   }
+    // }
 
     whenChanged([
       'x-pack/plugins/uptime/',


### PR DESCRIPTION
The APM e2e tests started to fail after a version update of cypress. In the meantime that it is fixed I'm disabling so it won't block PRs to be merged.