### PR TITLE
Add responseInterceptors feature to ES UI Shared request module.

### DIFF
--- a/src/plugins/es_ui_shared/public/index.ts
+++ b/src/plugins/es_ui_shared/public/index.ts
@@ -30,6 +30,7 @@ export {
   UseRequestResponse,
   sendRequest,
   useRequest,
+  ResponseInterceptor,
 } from './request';
 
 export { indices } from './indices';

--- a/src/plugins/es_ui_shared/public/request/index.ts
+++ b/src/plugins/es_ui_shared/public/request/index.ts
@@ -6,5 +6,10 @@
  * Side Public License, v 1.
  */
 
-export { SendRequestConfig, SendRequestResponse, sendRequest } from './send_request';
+export {
+  SendRequestConfig,
+  SendRequestResponse,
+  sendRequest,
+  ResponseInterceptor,
+} from './send_request';
 export { UseRequestConfig, UseRequestResponse, useRequest } from './use_request';

--- a/src/plugins/es_ui_shared/public/request/index.ts
+++ b/src/plugins/es_ui_shared/public/request/index.ts
@@ -10,6 +10,6 @@ export {
   SendRequestConfig,
   SendRequestResponse,
   sendRequest,
-  ResponseInterceptor,
+  ResponseHandler,
 } from './send_request';
 export { UseRequestConfig, UseRequestResponse, useRequest } from './use_request';

--- a/src/plugins/es_ui_shared/public/request/send_request.test.helpers.ts
+++ b/src/plugins/es_ui_shared/public/request/send_request.test.helpers.ts
@@ -19,7 +19,9 @@ export interface SendRequestHelpers {
   getSendRequestSpy: () => sinon.SinonStub;
   sendSuccessRequest: () => Promise<SendRequestResponse>;
   getSuccessResponse: () => SendRequestResponse;
-  sendErrorRequest: () => Promise<SendRequestResponse>;
+  sendErrorRequest: (
+    errorInterceptors?: SendRequestConfig['errorInterceptors']
+  ) => Promise<SendRequestResponse>;
   getErrorResponse: () => SendRequestResponse;
 }
 
@@ -62,7 +64,8 @@ export const createSendRequestHelpers = (): SendRequestHelpers => {
       })
     )
     .rejects(errorResponse);
-  const sendErrorRequest = () => sendRequest({ ...errorRequest });
+  const sendErrorRequest = (errorInterceptors?: SendRequestConfig['errorInterceptors']) =>
+    sendRequest({ ...errorRequest, errorInterceptors });
   const getErrorResponse = () => ({
     data: null,
     error: errorResponse.response.data,

--- a/src/plugins/es_ui_shared/public/request/send_request.test.helpers.ts
+++ b/src/plugins/es_ui_shared/public/request/send_request.test.helpers.ts
@@ -18,11 +18,11 @@ import {
 export interface SendRequestHelpers {
   getSendRequestSpy: () => sinon.SinonStub;
   sendSuccessRequest: (
-    responseInterceptors?: SendRequestConfig['responseInterceptors']
+    responseHandlers?: SendRequestConfig['responseHandlers']
   ) => Promise<SendRequestResponse>;
   getSuccessResponse: () => SendRequestResponse;
   sendErrorRequest: (
-    responseInterceptors?: SendRequestConfig['responseInterceptors']
+    responseHandlers?: SendRequestConfig['responseHandlers']
   ) => Promise<SendRequestResponse>;
   getErrorResponse: () => SendRequestResponse;
 }
@@ -53,8 +53,8 @@ export const createSendRequestHelpers = (): SendRequestHelpers => {
       })
     )
     .resolves(successResponse);
-  const sendSuccessRequest = (responseInterceptors?: SendRequestConfig['responseInterceptors']) =>
-    sendRequest({ ...successRequest, responseInterceptors });
+  const sendSuccessRequest = (responseHandlers?: SendRequestConfig['responseHandlers']) =>
+    sendRequest({ ...successRequest, responseHandlers });
   const getSuccessResponse = () => ({ data: successResponse.data, error: null });
 
   // Set up failed request helpers.
@@ -67,8 +67,8 @@ export const createSendRequestHelpers = (): SendRequestHelpers => {
       })
     )
     .rejects(errorResponse);
-  const sendErrorRequest = (responseInterceptors?: SendRequestConfig['responseInterceptors']) =>
-    sendRequest({ ...errorRequest, responseInterceptors });
+  const sendErrorRequest = (responseHandlers?: SendRequestConfig['responseHandlers']) =>
+    sendRequest({ ...errorRequest, responseHandlers });
   const getErrorResponse = () => ({
     data: null,
     error: errorResponse.response.data,

--- a/src/plugins/es_ui_shared/public/request/send_request.test.helpers.ts
+++ b/src/plugins/es_ui_shared/public/request/send_request.test.helpers.ts
@@ -17,10 +17,12 @@ import {
 
 export interface SendRequestHelpers {
   getSendRequestSpy: () => sinon.SinonStub;
-  sendSuccessRequest: () => Promise<SendRequestResponse>;
+  sendSuccessRequest: (
+    responseInterceptors?: SendRequestConfig['responseInterceptors']
+  ) => Promise<SendRequestResponse>;
   getSuccessResponse: () => SendRequestResponse;
   sendErrorRequest: (
-    errorInterceptors?: SendRequestConfig['errorInterceptors']
+    responseInterceptors?: SendRequestConfig['responseInterceptors']
   ) => Promise<SendRequestResponse>;
   getErrorResponse: () => SendRequestResponse;
 }
@@ -51,7 +53,8 @@ export const createSendRequestHelpers = (): SendRequestHelpers => {
       })
     )
     .resolves(successResponse);
-  const sendSuccessRequest = () => sendRequest({ ...successRequest });
+  const sendSuccessRequest = (responseInterceptors?: SendRequestConfig['responseInterceptors']) =>
+    sendRequest({ ...successRequest, responseInterceptors });
   const getSuccessResponse = () => ({ data: successResponse.data, error: null });
 
   // Set up failed request helpers.
@@ -64,8 +67,8 @@ export const createSendRequestHelpers = (): SendRequestHelpers => {
       })
     )
     .rejects(errorResponse);
-  const sendErrorRequest = (errorInterceptors?: SendRequestConfig['errorInterceptors']) =>
-    sendRequest({ ...errorRequest, errorInterceptors });
+  const sendErrorRequest = (responseInterceptors?: SendRequestConfig['responseInterceptors']) =>
+    sendRequest({ ...errorRequest, responseInterceptors });
   const getErrorResponse = () => ({
     data: null,
     error: errorResponse.response.data,

--- a/src/plugins/es_ui_shared/public/request/send_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/send_request.test.ts
@@ -33,4 +33,20 @@ describe('sendRequest function', () => {
     sinon.assert.calledOnce(getSendRequestSpy());
     expect(error).toEqual(getErrorResponse());
   });
+
+  it('applies errorInterceptors to errors', async () => {
+    const { sendErrorRequest, getSendRequestSpy } = helpers;
+    const errorInterceptors = [
+      (error: any) => ['Error is:', error.statusText],
+      (interceptedError: string[]) => interceptedError.join(' '),
+    ];
+
+    // For some reason sinon isn't throwing an error on rejection, as an awaited Promise normally would.
+    const error = await sendErrorRequest(errorInterceptors);
+    sinon.assert.calledOnce(getSendRequestSpy());
+    expect(error).toEqual({
+      data: null,
+      error: 'Error is: Error message',
+    });
+  });
 });

--- a/src/plugins/es_ui_shared/public/request/send_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/send_request.test.ts
@@ -29,24 +29,29 @@ describe('sendRequest function', () => {
     const { sendErrorRequest, getSendRequestSpy, getErrorResponse } = helpers;
 
     // For some reason sinon isn't throwing an error on rejection, as an awaited Promise normally would.
-    const error = await sendErrorRequest();
+    const errorResponse = await sendErrorRequest();
     sinon.assert.calledOnce(getSendRequestSpy());
-    expect(error).toEqual(getErrorResponse());
+    expect(errorResponse).toEqual(getErrorResponse());
   });
 
-  it('applies errorInterceptors to errors', async () => {
-    const { sendErrorRequest, getSendRequestSpy } = helpers;
-    const errorInterceptors = [
-      (error: any) => ['Error is:', error.statusText],
-      (interceptedError: string[]) => interceptedError.join(' '),
-    ];
+  it('calls responseInterceptors with successful responses', async () => {
+    const { sendSuccessRequest, getSuccessResponse } = helpers;
+    const successInterceptorSpy = sinon.spy();
+    const successInterceptors = [successInterceptorSpy];
+
+    await sendSuccessRequest(successInterceptors);
+    sinon.assert.calledOnce(successInterceptorSpy);
+    sinon.assert.calledWith(successInterceptorSpy, getSuccessResponse());
+  });
+
+  it('calls responseInterceptors with errors', async () => {
+    const { sendErrorRequest, getErrorResponse } = helpers;
+    const errorInterceptorSpy = sinon.spy();
+    const errorInterceptors = [errorInterceptorSpy];
 
     // For some reason sinon isn't throwing an error on rejection, as an awaited Promise normally would.
-    const error = await sendErrorRequest(errorInterceptors);
-    sinon.assert.calledOnce(getSendRequestSpy());
-    expect(error).toEqual({
-      data: null,
-      error: 'Error is: Error message',
-    });
+    await sendErrorRequest(errorInterceptors);
+    sinon.assert.calledOnce(errorInterceptorSpy);
+    sinon.assert.calledWith(errorInterceptorSpy, getErrorResponse());
   });
 });

--- a/src/plugins/es_ui_shared/public/request/send_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/send_request.test.ts
@@ -34,24 +34,24 @@ describe('sendRequest function', () => {
     expect(errorResponse).toEqual(getErrorResponse());
   });
 
-  it('calls responseInterceptors with successful responses', async () => {
+  it('calls responseHandlers with successful responses', async () => {
     const { sendSuccessRequest, getSuccessResponse } = helpers;
-    const successInterceptorSpy = sinon.spy();
-    const successInterceptors = [successInterceptorSpy];
+    const successHandlerSpy = sinon.spy();
+    const successHandlers = [successHandlerSpy];
 
-    await sendSuccessRequest(successInterceptors);
-    sinon.assert.calledOnce(successInterceptorSpy);
-    sinon.assert.calledWith(successInterceptorSpy, getSuccessResponse());
+    await sendSuccessRequest(successHandlers);
+    sinon.assert.calledOnce(successHandlerSpy);
+    sinon.assert.calledWith(successHandlerSpy, getSuccessResponse());
   });
 
-  it('calls responseInterceptors with errors', async () => {
+  it('calls responseHandlers with errors', async () => {
     const { sendErrorRequest, getErrorResponse } = helpers;
-    const errorInterceptorSpy = sinon.spy();
-    const errorInterceptors = [errorInterceptorSpy];
+    const errorHandlerSpy = sinon.spy();
+    const errorHandlers = [errorHandlerSpy];
 
     // For some reason sinon isn't throwing an error on rejection, as an awaited Promise normally would.
-    await sendErrorRequest(errorInterceptors);
-    sinon.assert.calledOnce(errorInterceptorSpy);
-    sinon.assert.calledWith(errorInterceptorSpy, getErrorResponse());
+    await sendErrorRequest(errorHandlers);
+    sinon.assert.calledOnce(errorHandlerSpy);
+    sinon.assert.calledWith(errorHandlerSpy, getErrorResponse());
   });
 });

--- a/src/plugins/es_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.test.ts
@@ -117,18 +117,6 @@ describe('useRequest hook', () => {
         expect(hookResult.error).toBe(getErrorResponse().error);
       });
 
-      it('applies errorInterceptors to errors', async () => {
-        const { setupErrorRequest, completeRequest, hookResult } = helpers;
-        const errorInterceptors = [
-          (error: any) => ['Error is:', error.statusText],
-          (interceptedError: string[]) => interceptedError.join(' '),
-        ];
-
-        setupErrorRequest({ errorInterceptors });
-        await completeRequest();
-        expect(hookResult.error).toBe('Error is: Error message');
-      });
-
       it('surfaces body-shaped errors from requests', async () => {
         const { setupErrorWithBodyRequest, completeRequest, hookResult, getErrorWithBodyResponse } =
           helpers;

--- a/src/plugins/es_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.test.ts
@@ -117,6 +117,18 @@ describe('useRequest hook', () => {
         expect(hookResult.error).toBe(getErrorResponse().error);
       });
 
+      it('applies errorInterceptors to errors', async () => {
+        const { setupErrorRequest, completeRequest, hookResult } = helpers;
+        const errorInterceptors = [
+          (error: any) => ['Error is:', error.statusText],
+          (interceptedError: string[]) => interceptedError.join(' '),
+        ];
+
+        setupErrorRequest({ errorInterceptors });
+        await completeRequest();
+        expect(hookResult.error).toBe('Error is: Error message');
+      });
+
       it('surfaces body-shaped errors from requests', async () => {
         const { setupErrorWithBodyRequest, completeRequest, hookResult, getErrorWithBodyResponse } =
           helpers;

--- a/src/plugins/es_ui_shared/public/request/use_request.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.ts
@@ -35,7 +35,7 @@ export const useRequest = <D = any, E = Error>(
     pollIntervalMs,
     initialData,
     deserializer,
-    errorInterceptors,
+    responseInterceptors,
   }: UseRequestConfig
 ): UseRequestResponse<D, E> => {
   const isMounted = useRef(false);
@@ -89,7 +89,7 @@ export const useRequest = <D = any, E = Error>(
       // Any requests that are sent in the background (without user interaction) should be flagged as "system requests". This should not be
       // confused with any terminology in Elasticsearch. This is a Kibana-specific construct that allows the server to differentiate between
       // user-initiated and requests "system"-initiated requests, for purposes like security features.
-      const requestPayload = { ...requestBody, asSystemRequest, errorInterceptors };
+      const requestPayload = { ...requestBody, asSystemRequest, responseInterceptors };
       const response = await sendRequest<D, E>(httpClient, requestPayload);
       const { data: serializedResponseData, error: responseError } = response;
 
@@ -115,7 +115,7 @@ export const useRequest = <D = any, E = Error>(
       // Setting isLoading to false also acts as a signal for scheduling the next poll request.
       setIsLoading(false);
     },
-    [requestBody, httpClient, deserializer, clearPollInterval, errorInterceptors]
+    [requestBody, httpClient, deserializer, clearPollInterval, responseInterceptors]
   );
 
   const scheduleRequest = useCallback(() => {

--- a/src/plugins/es_ui_shared/public/request/use_request.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.ts
@@ -35,7 +35,7 @@ export const useRequest = <D = any, E = Error>(
     pollIntervalMs,
     initialData,
     deserializer,
-    responseInterceptors,
+    responseHandlers,
   }: UseRequestConfig
 ): UseRequestResponse<D, E> => {
   const isMounted = useRef(false);
@@ -89,7 +89,7 @@ export const useRequest = <D = any, E = Error>(
       // Any requests that are sent in the background (without user interaction) should be flagged as "system requests". This should not be
       // confused with any terminology in Elasticsearch. This is a Kibana-specific construct that allows the server to differentiate between
       // user-initiated and requests "system"-initiated requests, for purposes like security features.
-      const requestPayload = { ...requestBody, asSystemRequest, responseInterceptors };
+      const requestPayload = { ...requestBody, asSystemRequest, responseHandlers };
       const response = await sendRequest<D, E>(httpClient, requestPayload);
       const { data: serializedResponseData, error: responseError } = response;
 
@@ -115,7 +115,7 @@ export const useRequest = <D = any, E = Error>(
       // Setting isLoading to false also acts as a signal for scheduling the next poll request.
       setIsLoading(false);
     },
-    [requestBody, httpClient, deserializer, clearPollInterval, responseInterceptors]
+    [requestBody, httpClient, deserializer, clearPollInterval, responseHandlers]
   );
 
   const scheduleRequest = useCallback(() => {

--- a/src/plugins/es_ui_shared/public/request/use_request.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.ts
@@ -27,7 +27,16 @@ export interface UseRequestResponse<D = any, E = Error> {
 
 export const useRequest = <D = any, E = Error>(
   httpClient: HttpSetup,
-  { path, method, query, body, pollIntervalMs, initialData, deserializer }: UseRequestConfig
+  {
+    path,
+    method,
+    query,
+    body,
+    pollIntervalMs,
+    initialData,
+    deserializer,
+    errorInterceptors,
+  }: UseRequestConfig
 ): UseRequestResponse<D, E> => {
   const isMounted = useRef(false);
 
@@ -80,7 +89,7 @@ export const useRequest = <D = any, E = Error>(
       // Any requests that are sent in the background (without user interaction) should be flagged as "system requests". This should not be
       // confused with any terminology in Elasticsearch. This is a Kibana-specific construct that allows the server to differentiate between
       // user-initiated and requests "system"-initiated requests, for purposes like security features.
-      const requestPayload = { ...requestBody, asSystemRequest };
+      const requestPayload = { ...requestBody, asSystemRequest, errorInterceptors };
       const response = await sendRequest<D, E>(httpClient, requestPayload);
       const { data: serializedResponseData, error: responseError } = response;
 
@@ -106,7 +115,7 @@ export const useRequest = <D = any, E = Error>(
       // Setting isLoading to false also acts as a signal for scheduling the next poll request.
       setIsLoading(false);
     },
-    [requestBody, httpClient, deserializer, clearPollInterval]
+    [requestBody, httpClient, deserializer, clearPollInterval, errorInterceptors]
   );
 
   const scheduleRequest = useCallback(() => {


### PR DESCRIPTION
This will enable consuming plugins to intercept errors and successful responses that apply to the entire app, and execute side effects such as updating the UI accordingly.

For example, https://github.com/elastic/kibana/pull/112907 requires Upgrade Assistant to block off the UI if a `426` error is returned from any API route. This change will enable the `api.ts` file to define error interceptors to handle this type of error and update the UI accordingly.

Note that this branch's history captures the evolution of this solution:
* 9947d657aa5607e81b7e108beccf02e88c9ce8df I approached the solution with an emphasis on intercepting errors only, and allowing the interceptor function to mutate the response. This introduced complexity which didn't seem useful.
* c44b2c988582ff6dbfe52f4f9eb29bc19ccb83b1 I remove this complexity by focusing interceptors on executing side effects, without changing the response. I also provide successful responses to the interceptor in case this information has global meaning for the app.

**For reviewers:** Does this approach make sense? Does it introduce any drawbacks, or anything confusing to the interface of the `request` module?