### PR TITLE
[buildkite] Fix unbound variable in post_build script

### DIFF
--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -9,7 +9,7 @@ export BUILD_SUCCESSFUL
 
 node "$(dirname "${0}")/ci_stats_complete.js"
 
-if [[ "$GITHUB_PR_NUMBER" ]]; then
+if [[ "${GITHUB_PR_NUMBER:-}" ]]; then
   DOCS_CHANGES_URL="https://kibana_$GITHUB_PR_NUMBER}.docs-preview.app.elstc.co/diff"
   DOCS_CHANGES=$(curl --connect-timeout 10 -m 10 -sf "$DOCS_CHANGES_URL" || echo '')
 


### PR DESCRIPTION
Fixes:

```
./.buildkite/scripts/lifecycle/post_build.sh: line 12: GITHUB_PR_NUMBER: unbound variable
```