### PR TITLE
[7.15] Partial revert "[DOCS] Adds #112562 known issue to 7.14.2 release notes" (#113441)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -505,6 +505,12 @@ Reporting::
 Review the following information about the 7.14.2 release.
 
 [float]
+[[known-issue-v7.14.2]]
+=== Known issue
+
+{kib} is unable to restore *Discover* search sessions with a relative time range. When you restore the *Discover* search session, then run a new search, {kib} displays a `Your search session is still running` message. For more information, refer to {kibana-issue}101430[#101430].
+
+[float]
 [[breaking-changes-v7.14.2]]
 === Breaking changes
 Breaking changes can prevent your application from optimal operation and performance. Before you upgrade to 7.14.2, review the <<breaking-changes-7.14.0,7.14.0 breaking changes>>.

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -505,12 +505,6 @@ Reporting::
 Review the following information about the 7.14.2 release.
 
 [float]
-[[known-issue-v7.14.2]]
-=== Known issue
-
-{kib} is unable to restore *Discover* search sessions with a relative time range. When you restore the *Discover* search session, then run a new search, {kib} displays a `Your search session is still running` message. For more information, refer to {kibana-issue}101430[#101430].
-
-[float]
 [[breaking-changes-v7.14.2]]
 === Breaking changes
 Breaking changes can prevent your application from optimal operation and performance. Before you upgrade to 7.14.2, review the <<breaking-changes-7.14.0,7.14.0 breaking changes>>.


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Partial revert "[DOCS] Adds #112562 known issue to 7.14.2 release notes" (#113441)