### PR TITLE
[Fleet] Set code editor height to solve an overlap in default policy settings

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_var_field.tsx
@@ -17,11 +17,16 @@ import {
   EuiFieldPassword,
   EuiCodeBlock,
 } from '@elastic/eui';
+import styled from 'styled-components';
 
 import type { RegistryVarsEntry } from '../../../../types';
 import { CodeEditor } from '../../../../../../../../../../src/plugins/kibana_react/public';
 
 import { MultiTextInput } from './multi_text_input';
+
+const FixedHeightDiv = styled.div`
+  height: 300px;
+`;
 
 export const PackagePolicyInputVarField: React.FunctionComponent<{
   varDef: RegistryVarsEntry;
@@ -55,31 +60,34 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
             <pre>{value}</pre>
           </EuiCodeBlock>
         ) : (
-          <CodeEditor
-            languageId="yaml"
-            width="100%"
-            height="300px"
-            value={value}
-            onChange={onChange}
-            options={{
-              minimap: {
-                enabled: false,
-              },
-              ariaLabel: i18n.translate('xpack.fleet.packagePolicyField.yamlCodeEditor', {
-                defaultMessage: 'YAML Code Editor',
-              }),
-              scrollBeyondLastLine: false,
-              wordWrap: 'off',
-              wrappingIndent: 'indent',
-              tabSize: 2,
-              // To avoid left margin
-              lineNumbers: 'off',
-              lineNumbersMinChars: 0,
-              glyphMargin: false,
-              folding: false,
-              lineDecorationsWidth: 0,
-            }}
-          />
+          <FixedHeightDiv>
+            <CodeEditor
+              languageId="yaml"
+              width="100%"
+              height="300px"
+              value={value}
+              onChange={onChange}
+              options={{
+                minimap: {
+                  enabled: false,
+                },
+                ariaLabel: i18n.translate('xpack.fleet.packagePolicyField.yamlCodeEditor', {
+                  defaultMessage: 'YAML Code Editor',
+                }),
+                scrollBeyondLastLine: false,
+                wordWrap: 'off',
+                wrappingIndent: 'indent',
+                tabSize: 2,
+                // To avoid left margin
+                lineNumbers: 'off',
+                lineNumbersMinChars: 0,
+                glyphMargin: false,
+                folding: false,
+                lineDecorationsWidth: 0,
+                overviewRulerBorder: false,
+              }}
+            />
+          </FixedHeightDiv>
         );
       case 'bool':
         return (


### PR DESCRIPTION
## Summary

Fix for https://github.com/elastic/kibana/issues/112054

Setting the code editor height in the "Default Policy" settings to 100% to avoid an overlap of the field content.
Also adding `overviewRulerBorder: false` to the code editor to hide the right ruler overlapping with the code.
Documentation available [here](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html#overviewrulerborder)

### Before
![before_settings](https://user-images.githubusercontent.com/16084106/135867269-69cda546-a9a9-4769-a9c4-dddcefa9c88d.png)

### After

![Screenshot 2021-10-04 at 16 14 27](https://user-images.githubusercontent.com/16084106/135867371-5a6f0256-7097-46bc-bb10-55928cb4ff7a.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
