### PR TITLE
[Security Solution][Platform] - Replace ts-ignore in favor of ts-expect

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/trusted_app_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/trusted_app_generator.ts
@@ -67,8 +67,8 @@ export class TrustedAppGenerator extends BaseDataGenerator<TrustedApp> {
       ...(scopeType === 'policy' ? { policies: this.randomArray(5, () => this.randomUUID()) } : {}),
     }) as EffectScope;
 
-    // TODO: remove ts-ignore. TS types are conditional when it comes to the combination of OS and ENTRIES
-    // @ts-ignore
+    // TS types are conditional when it comes to the combination of OS and ENTRIES
+    // @ts-expect-error TS2322
     return merge(
       {
         description: `Generator says we trust ${name}`,

--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/setup_fleet_for_endpoint.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/setup_fleet_for_endpoint.ts
@@ -31,7 +31,7 @@ export const setupFleetForEndpoint = async (
   kbnClient: KbnClient
 ): Promise<SetupFleetForEndpointResponse> => {
   // We try to use the kbnClient **private** logger, bug if unable to access it, then just use console
-  // @ts-ignore
+  // @ts-expect-error TS2341
   const log = kbnClient.log ? kbnClient.log : console;
 
   // Setup Fleet

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.test.tsx
@@ -266,7 +266,8 @@ describe('useSecuritySolutionNavigation', () => {
       { wrapper: TestProviders }
     );
 
-    // @ts-ignore possibly undefined, but if undefined we want this test to fail
+    // possibly undefined, but if undefined we want this test to fail
+    // @ts-expect-error TS2532
     expect(result.current.items[2].items[2].id).toEqual(SecurityPageName.ueba);
   });
 

--- a/x-pack/plugins/security_solution/public/common/mock/endpoint/http_handler_mock_factory.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/endpoint/http_handler_mock_factory.ts
@@ -161,7 +161,7 @@ export const httpHandlerMockFactory = <R extends ResponseProvidersInterface = {}
     const responseProvider: MockedApi<R>['responseProvider'] = mocks.reduce(
       (providers, routeMock) => {
         // FIXME: find a way to remove the ignore below. May need to limit the calling signature of `RouteMock['handler']`
-        // @ts-ignore
+        // @ts-expect-error TS2322
         const routeResponseCallbackMock: SingleResponseProvider<R[keyof R]> = jest.fn(
           routeMock.handler
         );
@@ -210,7 +210,7 @@ export const httpHandlerMockFactory = <R extends ResponseProvidersInterface = {}
                 // Ignore below is needed because the http service methods are defined via an overloaded interface.
                 // If the first argument is NOT fetch with options, then we know that its a string and `args` has
                 // a potential for being of `.length` 2.
-                // @ts-ignore
+                // @ts-expect-error TS2493
                 ...(args[1] || {}),
                 path: args[0],
               };
@@ -303,7 +303,7 @@ export const composeHttpHandlerMocks = <
       },
       // Ignore here because we populate this object with the entries provided
       // via the input argument `handlerMocks`
-      // @ts-ignore
+      // @ts-expect-error TS2322
       responseProvider: {},
     };
 

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.tsx
@@ -107,9 +107,11 @@ export const ValueListsModalComponent: React.FC<ValueListsModalProps> = ({
   useEffect(() => {
     if (!isEmpty(deleteError)) {
       const references: string[] =
-        // @ts-ignore-next-line deleteError response unknown message.error.references
+        // deleteError response unknown message.error.references
+        // @ts-expect-error TS2571
         deleteError?.body?.message?.error?.references?.map(
-          // @ts-ignore-next-line response not typed
+          // response not typed
+          // @ts-expect-error TS7006
           (ref) => ref?.exception_list.name
         ) ?? [];
       const uniqueExceptionListReferences = Array.from(new Set(references));
@@ -118,7 +120,8 @@ export const ValueListsModalComponent: React.FC<ValueListsModalProps> = ({
         contentText: i18n.referenceErrorMessage(uniqueExceptionListReferences.length),
         exceptionListReferences: uniqueExceptionListReferences,
         isLoading: false,
-        // @ts-ignore-next-line deleteError response unknown
+        // deleteError response unknown
+        // @ts-expect-error TS2571
         valueListId: deleteError?.body?.message?.error?.value_list_id,
       });
     }

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
@@ -256,7 +256,7 @@ describe('endpoint list middleware', () => {
       dispatch({
         type: 'endpointDetailsActivityLogChanged',
         // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-        // @ts-ignore
+        // @ts-expect-error TS2345
         payload: createLoadingResourceState({ previousState: createUninitialisedResourceState() }),
       });
     };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
@@ -284,7 +284,7 @@ const handleIsolateEndpointHost = async (
   dispatch({
     type: 'endpointIsolationRequestStateChange',
     // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-    // @ts-ignore
+    // @ts-expect-error TS2345
     payload: createLoadingResourceState(getCurrentIsolationRequestState(state)),
   });
 
@@ -320,7 +320,7 @@ async function getEndpointPackageInfo(
   dispatch({
     type: 'endpointPackageInfoStateChanged',
     // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-    // @ts-ignore
+    // @ts-expect-error TS2345
     payload: createLoadingResourceState<PackageListItem>(endpointPackageInfo(state)),
   });
 

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/actions_menu.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/actions_menu.test.tsx
@@ -44,11 +44,11 @@ describe('When using the Endpoint Details Actions Menu', () => {
   const setEndpointMetadataResponse = (isolation: boolean = false) => {
     const endpointHost = httpMocks.responseProvider.metadataDetails();
     // Safe to mutate this mocked data
-    // @ts-ignore
+    // @ts-expect-error TS2540
     endpointHost.metadata.Endpoint.state.isolation = isolation;
-    // @ts-ignore
+    // @ts-expect-error TS2540
     endpointHost.metadata.host.os.name = 'Windows';
-    // @ts-ignore
+    // @ts-expect-error TS2540
     endpointHost.metadata.agent.version = '7.14.0';
     httpMocks.responseProvider.metadataDetails.mockReturnValue(endpointHost);
   };

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/store/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/store/selectors.test.ts
@@ -61,7 +61,7 @@ describe('event filters selectors', () => {
     previousStateWhileLoading = previousState;
 
     // will be fixed when AsyncResourceState is refactored (#830)
-    // @ts-ignore
+    // @ts-expect-error TS2345
     initialState.listPage.data = createLoadingResourceState(previousState);
   };
 
@@ -204,8 +204,8 @@ describe('event filters selectors', () => {
       expect(getListPageDoesDataExist(initialState)).toBe(false);
 
       // Set DataExists to Loading
-      // ts-ignore will be fixed when AsyncResourceState is refactored (#830)
-      // @ts-ignore
+      // will be fixed when AsyncResourceState is refactored (#830)
+      // @ts-expect-error TS2345
       initialState.listPage.dataExist = createLoadingResourceState(initialState.listPage.dataExist);
       expect(getListPageDoesDataExist(initialState)).toBe(false);
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware/policy_trusted_apps_middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware/policy_trusted_apps_middleware.ts
@@ -114,7 +114,7 @@ const checkIfThereAreAssignableTrustedApps = async (
   store.dispatch({
     type: 'policyArtifactsAssignableListExistDataChanged',
     // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-    // @ts-ignore
+    // @ts-expect-error TS2345
     payload: createLoadingResourceState({ previousState: createUninitialisedResourceState() }),
   });
   try {
@@ -132,7 +132,7 @@ const checkIfThereAreAssignableTrustedApps = async (
     store.dispatch({
       type: 'policyArtifactsAssignableListExistDataChanged',
       // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-      // @ts-ignore
+      // @ts-expect-error TS2741
       payload: createFailedResourceState(err.body ?? err),
     });
   }
@@ -181,7 +181,7 @@ const searchTrustedApps = async (
   store.dispatch({
     type: 'policyArtifactsAssignableListPageDataChanged',
     // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-    // @ts-ignore
+    // @ts-expect-error TS2345
     payload: createLoadingResourceState({ previousState: createUninitialisedResourceState() }),
   });
 
@@ -213,7 +213,7 @@ const searchTrustedApps = async (
     store.dispatch({
       type: 'policyArtifactsAssignableListPageDataChanged',
       // Ignore will be fixed with when AsyncResourceState is refactored (#830)
-      // @ts-ignore
+      // @ts-expect-error TS2322
       payload: createFailedResourceState(err.body ?? err),
     });
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/components/fleet_event_filters_card.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/components/fleet_event_filters_card.test.tsx
@@ -66,10 +66,10 @@ describe('Fleet event filters card', () => {
         <ThemeProvider theme={mockTheme}>{children}</ThemeProvider>
       </I18nProvider>
     );
-    // @ts-ignore
+    // @ts-expect-error TS2739
     const component = reactTestingLibrary.render(<FleetEventFiltersCard />, { wrapper: Wrapper });
     try {
-      // @ts-ignore
+      // @ts-expect-error TS2769
       await reactTestingLibrary.act(() => promise);
     } catch (err) {
       return component;

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/components/fleet_trusted_apps_card.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_package_custom_extension/components/fleet_trusted_apps_card.test.tsx
@@ -66,12 +66,12 @@ describe('Fleet trusted apps card', () => {
         <ThemeProvider theme={mockTheme}>{children}</ThemeProvider>
       </I18nProvider>
     );
-    // @ts-ignore
+    // @ts-expect-error TS2739
     const component = reactTestingLibrary.render(<FleetTrustedAppsCardWrapper />, {
       wrapper: Wrapper,
     });
     try {
-      // @ts-ignore
+      // @ts-expect-error TS2769
       await reactTestingLibrary.act(() => promise);
     } catch (err) {
       return component;

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/with_security_context.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/with_security_context.tsx
@@ -57,7 +57,8 @@ export const withSecurityContext = <P extends {}>({
         }),
         {
           management: undefined,
-          // @ts-ignore ignore this error as we just need the enableExperimental and it's temporary
+          // ignore this error as we just need the enableExperimental and it's temporary
+          // @ts-expect-error TS2739
           app: {
             enableExperimental: ExperimentalFeaturesService.get(),
           },

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/trusted_apps_page.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/trusted_apps_page.test.tsx
@@ -89,7 +89,7 @@ describe('When on the Trusted Apps Page', () => {
 
     http.get.mockImplementation(async (...args) => {
       const path = args[0] as unknown as string;
-      // @ts-ignore
+      // @ts-expect-error TS2352
       const httpOptions = args[1] as HttpFetchOptions;
 
       if (path === TRUSTED_APPS_LIST_API) {
@@ -591,7 +591,7 @@ describe('When on the Trusted Apps Page', () => {
           // we can control when the API call response is returned, which will allow us
           // to test the UI behaviours while the API call is in flight
           coreStart.http.post.mockImplementation(
-            // @ts-ignore
+            // @ts-expect-error TS2345
             async (_, options: HttpFetchOptions) => {
               return new Promise((resolve, reject) => {
                 httpPostBody = options.body as string;
@@ -794,7 +794,7 @@ describe('When on the Trusted Apps Page', () => {
 
     beforeEach(() => {
       const priorMockImplementation = coreStart.http.get.getMockImplementation();
-      // @ts-ignore
+      // @ts-expect-error TS7006
       coreStart.http.get.mockImplementation((path, options) => {
         if (path === TRUSTED_APPS_LIST_API) {
           const { page, per_page: perPage } = options.query as { page: number; per_page: number };
@@ -958,7 +958,7 @@ describe('When on the Trusted Apps Page', () => {
     beforeEach(async () => {
       // Ensure implementation is defined before render to avoid undefined responses from hidden api calls
       const priorMockImplementation = coreStart.http.get.getMockImplementation();
-      // @ts-ignore
+      // @ts-expect-error TS7006
       coreStart.http.get.mockImplementation((path, options) => {
         if (path === PACKAGE_POLICY_API_ROUTES.LIST_PATTERN) {
           const policy = generator.generatePolicyPackagePolicy();

--- a/x-pack/plugins/security_solution/public/overview/components/link_panel/link_panel.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/link_panel/link_panel.tsx
@@ -20,7 +20,7 @@ import { InspectButtonContainer } from '../../../common/components/inspect';
 import { HeaderSection } from '../../../common/components/header_section';
 import { LinkPanelListItem } from './types';
 
-// @ts-ignore-next-line
+// @ts-expect-error TS2769
 const StyledTable = styled(EuiBasicTable)`
   [data-test-subj='panel-link'],
   [data-test-subj='panel-no-link'] {

--- a/x-pack/plugins/security_solution/public/ueba/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/ueba/store/reducer.ts
@@ -111,7 +111,7 @@ export const uebaReducer = reducerWithInitialState(initialUebaState)
         ...state[uebaType].queries,
         [tableType]: {
           // TODO: Steph/ueba fix active page/limit on ueba tables. is broken because multiple UebaTableType.userRules tables
-          // @ts-ignore
+          // @ts-expect-error TS7053
           ...state[uebaType].queries[tableType],
           activePage,
         },
@@ -126,7 +126,7 @@ export const uebaReducer = reducerWithInitialState(initialUebaState)
         ...state[uebaType].queries,
         [tableType]: {
           // TODO: Steph/ueba fix active page/limit on ueba tables. is broken because multiple UebaTableType.userRules tables
-          // @ts-ignore
+          // @ts-expect-error TS7053
           ...state[uebaType].queries[tableType],
           limit,
         },

--- a/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/trusted_apps/index.ts
@@ -41,7 +41,7 @@ export const cli = async () => {
 node ${basename(process.argv[1])} [options]
 
 Options:${Object.keys(cliDefaults.default).reduce((out, option) => {
-      // @ts-ignore
+      // @ts-expect-error TS7053
       return `${out}\n  --${option}=${cliDefaults.default[option]}`;
     }, '')}
 `);

--- a/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/migrate_artifacts_to_fleet.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/artifacts/migrate_artifacts_to_fleet.test.ts
@@ -68,7 +68,7 @@ describe('When migrating artifacts to fleet', () => {
         }),
         _index: '.fleet-artifacts-7',
         _id: `endpoint:endpoint-exceptionlist-macos-v1-${
-          // @ts-ignore
+          // @ts-expect-error TS2339
           props?.body?.decodedSha256 ?? 'UNKNOWN?'
         }`,
         _version: 1,

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -85,8 +85,8 @@ const errorHandler = <E extends Error>(
     return res.badRequest({ body: error });
   }
 
-  // legacy check for Boom errors. `ts-ignore` is for the errors around non-standard error properties
-  // @ts-ignore
+  // legacy check for Boom errors. for the errors around non-standard error properties
+  // @ts-expect-error TS2339
   const boomStatusCode = error.isBoom && error?.output?.statusCode;
   if (boomStatusCode) {
     return res.customError({

--- a/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/trusted_apps/mocks.ts
@@ -66,7 +66,7 @@ export const getPutTrustedAppByPolicyMock = function (): ExceptionListItemSchema
 export const getPackagePoliciesResponse = function (): PackagePolicy[] {
   return [
     // Next line is ts-ignored as this is the response when the policy doesn't exists but the type is complaining about it.
-    // @ts-ignore
+    // @ts-expect-error TS2740
     { id: '9da95be9-9bee-4761-a8c4-28d6d9bd8c71', version: undefined },
     {
       id: 'e5cbb9cf-98aa-4303-a04b-6a1165915079',

--- a/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.ts
@@ -485,7 +485,7 @@ export class ManifestManager {
               try {
                 await this.packagePolicyService.update(
                   this.savedObjectsClient,
-                  // @ts-ignore
+                  // @ts-expect-error TS2345
                   undefined,
                   id,
                   newPackagePolicy


### PR DESCRIPTION
## Summary

Fixes #113705

this PR replaces `ts-ignore` with `ts-expect-error`

| The difference is that // @ts-ignore will do nothing if the following line is error-free.

see [TS docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#ts-ignore-or-ts-expect-error) for more details

i've included the TS error number after each occurrence of `ts-expect-error`
for now it just gives some relevant context from the author, but later on TS will expect that specific error.
see: https://github.com/microsoft/TypeScript/issues/45937, https://github.com/microsoft/TypeScript/pull/45938

