### PR TITLE
[7.x] [console] Deprecate "proxyFilter" and "proxyConfig" on 8.x (#113555)

### DIFF
--- a/src/plugins/console/common/constants/index.ts
+++ b/src/plugins/console/common/constants/index.ts
@@ -6,11 +6,4 @@
  * Side Public License, v 1.
  */
 
-import { PluginInitializerContext } from 'kibana/server';
-
-import { ConsoleServerPlugin } from './plugin';
-
-export { ConsoleSetup, ConsoleStart } from './types';
-export { config } from './config';
-
-export const plugin = (ctx: PluginInitializerContext) => new ConsoleServerPlugin(ctx);
+export { MAJOR_VERSION } from './plugin';

--- a/src/plugins/console/common/constants/plugin.ts
+++ b/src/plugins/console/common/constants/plugin.ts
@@ -6,11 +6,4 @@
  * Side Public License, v 1.
  */
 
-import { PluginInitializerContext } from 'kibana/server';
-
-import { ConsoleServerPlugin } from './plugin';
-
-export { ConsoleSetup, ConsoleStart } from './types';
-export { config } from './config';
-
-export const plugin = (ctx: PluginInitializerContext) => new ConsoleServerPlugin(ctx);
+export const MAJOR_VERSION = '8.0.0';

--- a/src/plugins/console/common/constants/plugin.ts
+++ b/src/plugins/console/common/constants/plugin.ts
@@ -6,4 +6,4 @@
  * Side Public License, v 1.
  */
 
-export const MAJOR_VERSION = '8.0.0';
+export const MAJOR_VERSION = '7.16.0';

--- a/src/plugins/console/kibana.json
+++ b/src/plugins/console/kibana.json
@@ -1,12 +1,14 @@
 {
   "id": "console",
-  "version": "kibana",
+  "version": "8.0.0",
+  "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
   "owner": {
     "name": "Stack Management",
     "githubTeam": "kibana-stack-management"
   },
+  "configPath": ["console"],
   "requiredPlugins": ["devTools", "share"],
   "optionalPlugins": ["usageCollection", "home"],
   "requiredBundles": ["esUiShared", "kibanaReact", "kibanaUtils", "home"]

--- a/src/plugins/console/server/config.ts
+++ b/src/plugins/console/server/config.ts
@@ -6,37 +6,70 @@
  * Side Public License, v 1.
  */
 
+import { SemVer } from 'semver';
 import { schema, TypeOf } from '@kbn/config-schema';
+import { PluginConfigDescriptor } from 'kibana/server';
 
-export type ConfigType = TypeOf<typeof config>;
+import { MAJOR_VERSION } from '../common/constants';
 
-export const config = schema.object(
-  {
-    enabled: schema.boolean({ defaultValue: true }),
-    proxyFilter: schema.arrayOf(schema.string(), { defaultValue: ['.*'] }),
-    ssl: schema.object({ verify: schema.boolean({ defaultValue: false }) }, {}),
-    proxyConfig: schema.arrayOf(
-      schema.object({
-        match: schema.object({
-          protocol: schema.string({ defaultValue: '*' }),
-          host: schema.string({ defaultValue: '*' }),
-          port: schema.string({ defaultValue: '*' }),
-          path: schema.string({ defaultValue: '*' }),
-        }),
+const kibanaVersion = new SemVer(MAJOR_VERSION);
 
-        timeout: schema.number(),
-        ssl: schema.object(
-          {
-            verify: schema.boolean(),
-            ca: schema.arrayOf(schema.string()),
-            cert: schema.string(),
-            key: schema.string(),
-          },
-          { defaultValue: undefined }
-        ),
+const baseSettings = {
+  enabled: schema.boolean({ defaultValue: true }),
+  ssl: schema.object({ verify: schema.boolean({ defaultValue: false }) }, {}),
+};
+
+// Settings only available in 7.x
+const deprecatedSettings = {
+  proxyFilter: schema.arrayOf(schema.string(), { defaultValue: ['.*'] }),
+  proxyConfig: schema.arrayOf(
+    schema.object({
+      match: schema.object({
+        protocol: schema.string({ defaultValue: '*' }),
+        host: schema.string({ defaultValue: '*' }),
+        port: schema.string({ defaultValue: '*' }),
+        path: schema.string({ defaultValue: '*' }),
       }),
-      { defaultValue: [] }
-    ),
+
+      timeout: schema.number(),
+      ssl: schema.object(
+        {
+          verify: schema.boolean(),
+          ca: schema.arrayOf(schema.string()),
+          cert: schema.string(),
+          key: schema.string(),
+        },
+        { defaultValue: undefined }
+      ),
+    }),
+    { defaultValue: [] }
+  ),
+};
+
+const configSchema = schema.object(
+  {
+    ...baseSettings,
   },
   { defaultValue: undefined }
 );
+
+const configSchema7x = schema.object(
+  {
+    ...baseSettings,
+    ...deprecatedSettings,
+  },
+  { defaultValue: undefined }
+);
+
+export type ConfigType = TypeOf<typeof configSchema>;
+export type ConfigType7x = TypeOf<typeof configSchema7x>;
+
+export const config: PluginConfigDescriptor<ConfigType | ConfigType7x> = {
+  schema: kibanaVersion.major < 8 ? configSchema7x : configSchema,
+  deprecations: ({ deprecate, unused }) => [
+    deprecate('enabled', '8.0.0'),
+    deprecate('proxyFilter', '8.0.0'),
+    deprecate('proxyConfig', '8.0.0'),
+    unused('ssl'),
+  ],
+};

--- a/src/plugins/console/server/plugin.ts
+++ b/src/plugins/console/server/plugin.ts
@@ -7,10 +7,11 @@
  */
 
 import { CoreSetup, Logger, Plugin, PluginInitializerContext } from 'kibana/server';
+import { SemVer } from 'semver';
 
 import { ProxyConfigCollection } from './lib';
 import { SpecDefinitionsService, EsLegacyConfigService } from './services';
-import { ConfigType } from './config';
+import { ConfigType, ConfigType7x } from './config';
 
 import { registerRoutes } from './routes';
 
@@ -23,7 +24,7 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
 
   esLegacyConfigService = new EsLegacyConfigService();
 
-  constructor(private readonly ctx: PluginInitializerContext<ConfigType>) {
+  constructor(private readonly ctx: PluginInitializerContext<ConfigType | ConfigType7x>) {
     this.log = this.ctx.logger.get();
   }
 
@@ -34,10 +35,17 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
         save: true,
       },
     }));
-
+    const kibanaVersion = new SemVer(this.ctx.env.packageInfo.version);
     const config = this.ctx.config.get();
     const globalConfig = this.ctx.config.legacy.get();
-    const proxyPathFilters = config.proxyFilter.map((str: string) => new RegExp(str));
+
+    let pathFilters: RegExp[] | undefined;
+    let proxyConfigCollection: ProxyConfigCollection | undefined;
+    if (kibanaVersion.major < 8) {
+      // "pathFilters" and "proxyConfig" are only used in 7.x
+      pathFilters = (config as ConfigType7x).proxyFilter.map((str: string) => new RegExp(str));
+      proxyConfigCollection = new ProxyConfigCollection((config as ConfigType7x).proxyConfig);
+    }
 
     this.esLegacyConfigService.setup(elasticsearch.legacy.config$);
 
@@ -51,7 +59,6 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
         specDefinitionService: this.specDefinitionsService,
       },
       proxy: {
-        proxyConfigCollection: new ProxyConfigCollection(config.proxyConfig),
         readLegacyESConfig: async (): Promise<ESConfigForProxy> => {
           const legacyConfig = await this.esLegacyConfigService.readConfig();
           return {
@@ -59,8 +66,11 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
             ...legacyConfig,
           };
         },
-        pathFilters: proxyPathFilters,
+        // Deprecated settings (only used in 7.x):
+        proxyConfigCollection,
+        pathFilters,
       },
+      kibanaVersion,
     });
 
     return {

--- a/src/plugins/console/server/routes/api/console/proxy/params.test.ts
+++ b/src/plugins/console/server/routes/api/console/proxy/params.test.ts
@@ -5,13 +5,16 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import { SemVer } from 'semver';
 
 import { kibanaResponseFactory } from '../../../../../../../core/server';
-import { getProxyRouteHandlerDeps } from './mocks';
-import { createResponseStub } from './stubs';
+import { getProxyRouteHandlerDeps } from './mocks'; // import need to come first
+import { createResponseStub } from './stubs'; // import needs to come first
+import { MAJOR_VERSION } from '../../../../../common/constants';
 import * as requestModule from '../../../../lib/proxy_request';
-
 import { createHandler } from './create_handler';
+
+const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 describe('Console Proxy Route', () => {
   let handler: ReturnType<typeof createHandler>;
@@ -21,58 +24,71 @@ describe('Console Proxy Route', () => {
   });
 
   describe('params', () => {
-    describe('pathFilters', () => {
-      describe('no matches', () => {
-        it('rejects with 403', async () => {
-          handler = createHandler(
-            getProxyRouteHandlerDeps({ proxy: { pathFilters: [/^\/foo\//, /^\/bar\//] } })
-          );
+    if (kibanaVersion.major < 8) {
+      describe('pathFilters', () => {
+        describe('no matches', () => {
+          it('rejects with 403', async () => {
+            handler = createHandler(
+              getProxyRouteHandlerDeps({
+                proxy: { pathFilters: [/^\/foo\//, /^\/bar\//] },
+              })
+            );
 
-          const { status } = await handler(
-            {} as any,
-            { query: { method: 'POST', path: '/baz/id' } } as any,
-            kibanaResponseFactory
-          );
+            const { status } = await handler(
+              {} as any,
+              { query: { method: 'POST', path: '/baz/id' } } as any,
+              kibanaResponseFactory
+            );
 
-          expect(status).toBe(403);
+            expect(status).toBe(403);
+          });
+        });
+
+        describe('one match', () => {
+          it('allows the request', async () => {
+            handler = createHandler(
+              getProxyRouteHandlerDeps({
+                proxy: { pathFilters: [/^\/foo\//, /^\/bar\//] },
+              })
+            );
+
+            (requestModule.proxyRequest as jest.Mock).mockResolvedValue(createResponseStub('foo'));
+
+            const { status } = await handler(
+              {} as any,
+              { headers: {}, query: { method: 'POST', path: '/foo/id' } } as any,
+              kibanaResponseFactory
+            );
+
+            expect(status).toBe(200);
+            expect((requestModule.proxyRequest as jest.Mock).mock.calls.length).toBe(1);
+          });
+        });
+
+        describe('all match', () => {
+          it('allows the request', async () => {
+            handler = createHandler(
+              getProxyRouteHandlerDeps({ proxy: { pathFilters: [/^\/foo\//] } })
+            );
+
+            (requestModule.proxyRequest as jest.Mock).mockResolvedValue(createResponseStub('foo'));
+
+            const { status } = await handler(
+              {} as any,
+              { headers: {}, query: { method: 'GET', path: '/foo/id' } } as any,
+              kibanaResponseFactory
+            );
+
+            expect(status).toBe(200);
+            expect((requestModule.proxyRequest as jest.Mock).mock.calls.length).toBe(1);
+          });
         });
       });
-      describe('one match', () => {
-        it('allows the request', async () => {
-          handler = createHandler(
-            getProxyRouteHandlerDeps({ proxy: { pathFilters: [/^\/foo\//, /^\/bar\//] } })
-          );
-
-          (requestModule.proxyRequest as jest.Mock).mockResolvedValue(createResponseStub('foo'));
-
-          const { status } = await handler(
-            {} as any,
-            { headers: {}, query: { method: 'POST', path: '/foo/id' } } as any,
-            kibanaResponseFactory
-          );
-
-          expect(status).toBe(200);
-          expect((requestModule.proxyRequest as jest.Mock).mock.calls.length).toBe(1);
-        });
+    } else {
+      // jest requires to have at least one test in the file
+      test('dummy required test', () => {
+        expect(true).toBe(true);
       });
-      describe('all match', () => {
-        it('allows the request', async () => {
-          handler = createHandler(
-            getProxyRouteHandlerDeps({ proxy: { pathFilters: [/^\/foo\//] } })
-          );
-
-          (requestModule.proxyRequest as jest.Mock).mockResolvedValue(createResponseStub('foo'));
-
-          const { status } = await handler(
-            {} as any,
-            { headers: {}, query: { method: 'GET', path: '/foo/id' } } as any,
-            kibanaResponseFactory
-          );
-
-          expect(status).toBe(200);
-          expect((requestModule.proxyRequest as jest.Mock).mock.calls.length).toBe(1);
-        });
-      });
-    });
+    }
   });
 });

--- a/src/plugins/console/server/routes/index.ts
+++ b/src/plugins/console/server/routes/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { IRouter, Logger } from 'kibana/server';
+import { SemVer } from 'semver';
 
 import { EsLegacyConfigService, SpecDefinitionsService } from '../services';
 import { ESConfigForProxy } from '../types';
@@ -18,8 +19,8 @@ import { registerSpecDefinitionsRoute } from './api/console/spec_definitions';
 
 export interface ProxyDependencies {
   readLegacyESConfig: () => Promise<ESConfigForProxy>;
-  pathFilters: RegExp[];
-  proxyConfigCollection: ProxyConfigCollection;
+  pathFilters?: RegExp[]; // Only present in 7.x
+  proxyConfigCollection?: ProxyConfigCollection; // Only present in 7.x
 }
 
 export interface RouteDependencies {
@@ -30,6 +31,7 @@ export interface RouteDependencies {
     esLegacyConfigService: EsLegacyConfigService;
     specDefinitionService: SpecDefinitionsService;
   };
+  kibanaVersion: SemVer;
 }
 
 export const registerRoutes = (dependencies: RouteDependencies) => {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [console] Deprecate "proxyFilter" and "proxyConfig" on 8.x (#113555)