### PR TITLE
[Observability] Add tooltips to alert table row action buttons

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -36,6 +36,7 @@ import {
   EuiFlexItem,
   EuiContextMenuPanel,
   EuiPopover,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
@@ -248,40 +249,63 @@ function ObservabilityActions({
     ];
   }, [afterCaseSelection, casePermissions, timelines, event, statusActionItems, alertPermissions]);
 
+  const viewDetailsTextLabel = i18n.translate(
+    'xpack.observability.alertsTable.viewDetailsTextLabel',
+    {
+      defaultMessage: 'View details',
+    }
+  );
+  const viewInAppTextLabel = i18n.translate('xpack.observability.alertsTable.viewInAppTextLabel', {
+    defaultMessage: 'View in app',
+  });
+  const moreActionsTextLabel = i18n.translate(
+    'xpack.observability.alertsTable.moreActionsTextLabel',
+    {
+      defaultMessage: 'More actions',
+    }
+  );
+
   return (
     <>
       <EuiFlexGroup gutterSize="none" responsive={false}>
         <EuiFlexItem>
-          <EuiButtonIcon
-            size="s"
-            iconType="expand"
-            color="text"
-            onClick={() => setFlyoutAlert(alert)}
-            data-test-subj="openFlyoutButton"
-          />
+          <EuiToolTip content={viewDetailsTextLabel}>
+            <EuiButtonIcon
+              size="s"
+              iconType="expand"
+              color="text"
+              onClick={() => setFlyoutAlert(alert)}
+              data-test-subj="openFlyoutButton"
+              aria-label={viewDetailsTextLabel}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiButtonIcon
-            size="s"
-            href={prepend(alert.link ?? '')}
-            iconType="eye"
-            color="text"
-            aria-label="View alert in app"
-          />
+          <EuiToolTip content={viewInAppTextLabel}>
+            <EuiButtonIcon
+              size="s"
+              href={prepend(alert.link ?? '')}
+              iconType="eye"
+              color="text"
+              aria-label={viewInAppTextLabel}
+            />
+          </EuiToolTip>
         </EuiFlexItem>
         {actionsMenuItems.length > 0 && (
           <EuiFlexItem>
             <EuiPopover
               button={
-                <EuiButtonIcon
-                  display="empty"
-                  size="s"
-                  color="text"
-                  iconType="boxesHorizontal"
-                  aria-label="More"
-                  onClick={() => toggleActionsPopover(eventId)}
-                  data-test-subj="alerts-table-row-action-more"
-                />
+                <EuiToolTip content={moreActionsTextLabel}>
+                  <EuiButtonIcon
+                    display="empty"
+                    size="s"
+                    color="text"
+                    iconType="boxesHorizontal"
+                    aria-label={moreActionsTextLabel}
+                    onClick={() => toggleActionsPopover(eventId)}
+                    data-test-subj="alerts-table-row-action-more"
+                  />
+                </EuiToolTip>
               }
               isOpen={openActionsPopoverId === eventId}
               closePopover={closeActionsPopover}


### PR DESCRIPTION
## Summary

Closes #109383 

This PR adds tooltips to the icon buttons found in the Actions column of the alerts table. It also adds and updates the aria-labels for those icon buttons.

<img width="307" alt="Screenshot 2021-10-05 at 12 40 37" src="https://user-images.githubusercontent.com/2564140/136008271-59398bae-4aa4-4478-ae50-2f9c28d666ad.png">
<img width="303" alt="Screenshot 2021-10-05 at 12 40 45" src="https://user-images.githubusercontent.com/2564140/136008275-48246c7a-ded2-47f0-8877-59c502d7825d.png">
<img width="303" alt="Screenshot 2021-10-05 at 12 40 52" src="https://user-images.githubusercontent.com/2564140/136008277-3b8e557f-dea5-4ff1-8a56-38283aab1ec9.png">

