### PR TITLE
Dev docs: updates DevPrinciples URL

### DIFF
--- a/dev_docs/contributing/standards.mdx
+++ b/dev_docs/contributing/standards.mdx
@@ -9,7 +9,7 @@ tags: ['contributor', 'dev', 'github', 'getting started', 'onboarding', 'kibana'
 
 ## Developer principles
 
-We expect all developers to read and abide by our overarching <DocLink id="kibDeveloperPrinciples" />.
+We expect all developers to read and abide by our overarching <DocLink id="kibDevPrinciples" />.
 
 ## Style guide
 


### PR DESCRIPTION
## Summary

Fixes typo in link, expects `kibDevPrinciples` not `kibDeveloperPrinciples`.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
