### PR TITLE
[App Search] Wired up Suggestion detail data

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_result_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_result_panel.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { setMockValues } from '../../../../../__mocks__/kea_logic';
+
 import React from 'react';
 
 import { shallow } from 'enzyme';
@@ -14,6 +16,13 @@ import { Result } from '../../../result';
 import { CurationResultPanel } from './curation_result_panel';
 
 describe('CurationResultPanel', () => {
+  const values = {
+    isMetaEngine: true,
+    engine: {
+      schema: {},
+    },
+  };
+
   const results = [
     {
       id: { raw: 'foo' },
@@ -25,6 +34,10 @@ describe('CurationResultPanel', () => {
     },
   ];
 
+  beforeAll(() => {
+    setMockValues(values);
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -33,12 +46,22 @@ describe('CurationResultPanel', () => {
     const wrapper = shallow(<CurationResultPanel variant="current" results={results} />);
     expect(wrapper.find('[data-test-subj="suggestedText"]').exists()).toBe(false);
     expect(wrapper.find(Result).length).toBe(2);
+    expect(wrapper.find(Result).at(0).props()).toEqual({
+      result: results[0],
+      isMetaEngine: true,
+      schemaForTypeHighlights: values.engine.schema,
+    });
   });
 
   it('renders a no results message when there are no results', () => {
     const wrapper = shallow(<CurationResultPanel variant="current" results={[]} />);
     expect(wrapper.find('[data-test-subj="noResults"]').exists()).toBe(true);
     expect(wrapper.find(Result).length).toBe(0);
+  });
+
+  it('renders the correct count', () => {
+    const wrapper = shallow(<CurationResultPanel variant="current" results={results} />);
+    expect(wrapper.find('[data-test-subj="curationCount"]').prop('children')).toBe(2);
   });
 
   it('shows text about automation when variant is "suggested"', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_result_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_result_panel.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 
+import { useValues } from 'kea';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,6 +18,8 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
+import { EngineLogic } from '../../../engine';
 
 import { Result } from '../../../result';
 import { Result as ResultType } from '../../../result/types';
@@ -27,14 +31,14 @@ interface Props {
 }
 
 export const CurationResultPanel: React.FC<Props> = ({ variant, results }) => {
-  // TODO wire up
-  const count = 3;
+  const { isMetaEngine, engine } = useValues(EngineLogic);
+  const count = results.length;
 
   return (
     <>
       <EuiFlexGroup className="curationResultPanel__header" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiNotificationBadge>{count}</EuiNotificationBadge>
+          <EuiNotificationBadge data-test-subj="curationCount">{count}</EuiNotificationBadge>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiTitle size="xxxs">
@@ -70,7 +74,11 @@ export const CurationResultPanel: React.FC<Props> = ({ variant, results }) => {
         {results.length > 0 ? (
           results.map((result) => (
             <EuiFlexItem grow={false} key={result.id.raw}>
-              <Result result={result} isMetaEngine={false} />
+              <Result
+                result={result}
+                isMetaEngine={isMetaEngine}
+                schemaForTypeHighlights={engine.schema}
+              />
             </EuiFlexItem>
           ))
         ) : (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { setMockActions, setMockValues } from '../../../../../__mocks__/kea_logic';
+import '../../../../../__mocks__/shallow_useeffect.mock';
 import { mockUseParams } from '../../../../../__mocks__/react_router';
 import '../../../../__mocks__/engine_logic.mock';
 
@@ -14,12 +16,59 @@ import { shallow } from 'enzyme';
 
 import { AppSearchPageTemplate } from '../../../layout';
 
+import { CurationResultPanel } from './curation_result_panel';
 import { CurationSuggestion } from './curation_suggestion';
 
 describe('CurationSuggestion', () => {
+  const values = {
+    suggestion: {
+      query: 'foo',
+      updated_at: '2021-07-08T14:35:50Z',
+      promoted: ['1', '2', '3'],
+    },
+    suggestedPromotedDocuments: [
+      {
+        id: {
+          raw: '1',
+        },
+        _meta: {
+          id: '1',
+          engine: 'some-engine',
+        },
+      },
+      {
+        id: {
+          raw: '2',
+        },
+        _meta: {
+          id: '2',
+          engine: 'some-engine',
+        },
+      },
+      {
+        id: {
+          raw: '3',
+        },
+        _meta: {
+          id: '3',
+          engine: 'some-engine',
+        },
+      },
+    ],
+  };
+
+  const actions = {
+    loadSuggestion: jest.fn(),
+  };
+
+  beforeAll(() => {
+    setMockValues(values);
+    setMockActions(actions);
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseParams.mockReturnValue({ query: 'some%20query' });
+    mockUseParams.mockReturnValue({ query: 'foo' });
   });
 
   it('renders', () => {
@@ -28,19 +77,21 @@ describe('CurationSuggestion', () => {
     expect(wrapper.is(AppSearchPageTemplate)).toBe(true);
   });
 
-  it('displays the decoded query in the title', () => {
-    const wrapper = shallow(<CurationSuggestion />);
-
-    expect(wrapper.prop('pageHeader').pageTitle).toEqual('some query');
+  it('loads data on initialization', () => {
+    shallow(<CurationSuggestion />);
+    expect(actions.loadSuggestion).toHaveBeenCalled();
   });
 
-  // TODO This will need to come from somewhere else when wired up
-  it('displays an empty query if "" is encoded in as the qery', () => {
-    mockUseParams.mockReturnValue({ query: '%22%22' });
+  it('shows suggested promoted documents', () => {
+    const wrapper = shallow(<CurationSuggestion />);
+    const suggestedResultsPanel = wrapper.find(CurationResultPanel).at(1);
+    expect(suggestedResultsPanel.prop('results')).toEqual(values.suggestedPromotedDocuments);
+  });
 
+  it('displays the query in the title', () => {
     const wrapper = shallow(<CurationSuggestion />);
 
-    expect(wrapper.prop('pageHeader').pageTitle).toEqual('""');
+    expect(wrapper.prop('pageHeader').pageTitle).toEqual('foo');
   });
 
   it('displays has a button to display organic results', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.test.tsx
@@ -16,6 +16,8 @@ import { shallow } from 'enzyme';
 
 import { AppSearchPageTemplate } from '../../../layout';
 
+import { Result } from '../../../result';
+
 import { CurationResultPanel } from './curation_result_panel';
 import { CurationSuggestion } from './curation_suggestion';
 
@@ -55,6 +57,10 @@ describe('CurationSuggestion', () => {
         },
       },
     ],
+    isMetaEngine: true,
+    engine: {
+      schema: {},
+    },
   };
 
   const actions = {
@@ -102,5 +108,25 @@ describe('CurationSuggestion', () => {
     expect(wrapper.find('[data-test-subj="organicResults"]').exists()).toBe(true);
     wrapper.find('[data-test-subj="showOrganicResults"]').simulate('click');
     expect(wrapper.find('[data-test-subj="organicResults"]').exists()).toBe(false);
+  });
+
+  it('displays proposed organic results', () => {
+    const wrapper = shallow(<CurationSuggestion />);
+    wrapper.find('[data-test-subj="showOrganicResults"]').simulate('click');
+    expect(wrapper.find('[data-test-subj="proposedOrganicResults"]').find(Result).length).toBe(4);
+    expect(wrapper.find(Result).at(0).prop('isMetaEngine')).toEqual(true);
+    expect(wrapper.find(Result).at(0).prop('schemaForTypeHighlights')).toEqual(
+      values.engine.schema
+    );
+  });
+
+  it('displays current organic results', () => {
+    const wrapper = shallow(<CurationSuggestion />);
+    wrapper.find('[data-test-subj="showOrganicResults"]').simulate('click');
+    expect(wrapper.find('[data-test-subj="currentOrganicResults"]').find(Result).length).toBe(4);
+    expect(wrapper.find(Result).at(0).prop('isMetaEngine')).toEqual(true);
+    expect(wrapper.find(Result).at(0).prop('schemaForTypeHighlights')).toEqual(
+      values.engine.schema
+    );
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+
+import { useActions, useValues } from 'kea';
 
 import {
   EuiButtonEmpty,
@@ -27,26 +29,36 @@ import { getCurationsBreadcrumbs } from '../../utils';
 import { CurationActionBar } from './curation_action_bar';
 import { CurationResultPanel } from './curation_result_panel';
 
+import { CurationSuggestionLogic } from './curation_suggestion_logic';
 import { DATA } from './temp_data';
 
 export const CurationSuggestion: React.FC = () => {
   const { query } = useDecodedParams();
+  const curationSuggestionLogic = CurationSuggestionLogic({ query });
+  const { loadSuggestion } = useActions(curationSuggestionLogic);
+  const { suggestion, suggestedPromotedDocuments, dataLoading } =
+    useValues(curationSuggestionLogic);
   const [showOrganicResults, setShowOrganicResults] = useState(false);
   const currentOrganicResults = [...DATA].splice(5, 4);
   const proposedOrganicResults = [...DATA].splice(2, 4);
 
-  const queryTitle = query === '""' ? query : `${query}`;
+  const suggestionQuery = suggestion?.query || '';
+
+  useEffect(() => {
+    loadSuggestion();
+  }, []);
 
   return (
     <AppSearchPageTemplate
+      isLoading={dataLoading}
       pageChrome={getCurationsBreadcrumbs([
         i18n.translate(
           'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.breadcrumbLabel',
-          { defaultMessage: 'Suggested: {query}', values: { query } }
+          { defaultMessage: 'Suggested: {query}', values: { query: suggestionQuery } }
         ),
       ])}
       pageHeader={{
-        pageTitle: queryTitle,
+        pageTitle: suggestionQuery,
       }}
     >
       <CurationActionBar
@@ -67,7 +79,7 @@ export const CurationSuggestion: React.FC = () => {
             <h2>Suggested</h2>
           </EuiTitle>
           <EuiSpacer size="s" />
-          <CurationResultPanel variant="suggested" results={[...DATA].splice(3, 2)} />
+          <CurationResultPanel variant="suggested" results={suggestedPromotedDocuments} />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
@@ -107,11 +107,11 @@ export const CurationSuggestion: React.FC = () => {
         >
           {showOrganicResults
             ? i18n.translate(
-                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.collapseButtonLable',
+                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.collapseButtonLabel',
                 { defaultMessage: 'Collapse organic search results' }
               )
             : i18n.translate(
-                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.expandButtonLable',
+                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.expandButtonLabel',
                 { defaultMessage: 'Expand organic search results' }
               )}
         </EuiButtonEmpty>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
@@ -71,14 +71,24 @@ export const CurationSuggestion: React.FC = () => {
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiTitle size="xxs">
-            <h2>Current</h2>
+            <h2>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.currentTitle',
+                { defaultMessage: 'Current' }
+              )}
+            </h2>
           </EuiTitle>
           <EuiSpacer size="s" />
           <CurationResultPanel variant="current" results={[...DATA].splice(0, 3)} />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiTitle size="xxs">
-            <h2>Suggested</h2>
+            <h2>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.suggestionTitle',
+                { defaultMessage: 'Suggested' }
+              )}
+            </h2>
           </EuiTitle>
           <EuiSpacer size="s" />
           <CurationResultPanel variant="suggested" results={suggestedPromotedDocuments} />
@@ -95,7 +105,15 @@ export const CurationSuggestion: React.FC = () => {
           onClick={() => setShowOrganicResults(!showOrganicResults)}
           data-test-subj="showOrganicResults"
         >
-          {showOrganicResults ? 'Collapse' : 'Expand'} organic search results
+          {showOrganicResults
+            ? i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.collapseButtonLable',
+                { defaultMessage: 'Collapse organic search results' }
+              )
+            : i18n.translate(
+                'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.expandButtonLable',
+                { defaultMessage: 'Expand organic search results' }
+              )}
         </EuiButtonEmpty>
         {showOrganicResults && (
           <>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
@@ -21,6 +21,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { useDecodedParams } from '../../../../utils/encode_path_params';
+import { EngineLogic } from '../../../engine';
 import { AppSearchPageTemplate } from '../../../layout';
 import { Result } from '../../../result';
 import { Result as ResultType } from '../../../result/types';
@@ -36,6 +37,7 @@ export const CurationSuggestion: React.FC = () => {
   const { query } = useDecodedParams();
   const curationSuggestionLogic = CurationSuggestionLogic({ query });
   const { loadSuggestion } = useActions(curationSuggestionLogic);
+  const { engine, isMetaEngine } = useValues(EngineLogic);
   const { suggestion, suggestedPromotedDocuments, dataLoading } =
     useValues(curationSuggestionLogic);
   const [showOrganicResults, setShowOrganicResults] = useState(false);
@@ -102,10 +104,18 @@ export const CurationSuggestion: React.FC = () => {
               <EuiFlexGroup gutterSize="m">
                 <EuiFlexItem>
                   {currentOrganicResults.length > 0 && (
-                    <EuiFlexGroup direction="column" gutterSize="s">
+                    <EuiFlexGroup
+                      direction="column"
+                      gutterSize="s"
+                      data-test-subj="currentOrganicResults"
+                    >
                       {currentOrganicResults.map((result: ResultType) => (
                         <EuiFlexItem grow={false} key={result.id.raw}>
-                          <Result result={result} isMetaEngine={false} />
+                          <Result
+                            result={result}
+                            isMetaEngine={isMetaEngine}
+                            schemaForTypeHighlights={engine.schema}
+                          />
                         </EuiFlexItem>
                       ))}
                     </EuiFlexGroup>
@@ -113,10 +123,18 @@ export const CurationSuggestion: React.FC = () => {
                 </EuiFlexItem>
                 <EuiFlexItem>
                   {proposedOrganicResults.length > 0 && (
-                    <EuiFlexGroup direction="column" gutterSize="s">
+                    <EuiFlexGroup
+                      direction="column"
+                      gutterSize="s"
+                      data-test-subj="proposedOrganicResults"
+                    >
                       {proposedOrganicResults.map((result: ResultType) => (
                         <EuiFlexItem grow={false} key={result.id.raw}>
-                          <Result result={result} isMetaEngine={false} />
+                          <Result
+                            result={result}
+                            isMetaEngine={isMetaEngine}
+                            schemaForTypeHighlights={engine.schema}
+                          />
                         </EuiFlexItem>
                       ))}
                     </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  LogicMounter,
+  mockFlashMessageHelpers,
+  mockHttpValues,
+} from '../../../../../__mocks__/kea_logic';
+
+import '../../../../__mocks__/engine_logic.mock';
+
+import { nextTick } from '@kbn/test/jest';
+
+import { CurationSuggestionLogic } from './curation_suggestion_logic';
+
+const DEFAULT_VALUES = {
+  dataLoading: true,
+  suggestion: null,
+  suggestedPromotedDocuments: [],
+};
+
+const suggestion = {
+  query: 'foo',
+  updated_at: '2021-07-08T14:35:50Z',
+  promoted: ['1', '2', '3'],
+};
+
+const suggestedPromotedDocuments = [
+  {
+    id: {
+      raw: '1',
+    },
+    _meta: {
+      id: '1',
+      engine: 'some-engine',
+    },
+  },
+  {
+    id: {
+      raw: '2',
+    },
+    _meta: {
+      id: '2',
+      engine: 'some-engine',
+    },
+  },
+  {
+    id: {
+      raw: '3',
+    },
+    _meta: {
+      id: '3',
+      engine: 'some-engine',
+    },
+  },
+];
+
+const MOCK_RESPONSE = {
+  meta: {
+    page: {
+      current: 1,
+      size: 10,
+      total_results: 1,
+      total_pages: 1,
+    },
+  },
+  results: [suggestion],
+};
+
+const MOCK_DOCUMENTS_RESPONSE = {
+  results: [
+    {
+      id: {
+        raw: '2',
+      },
+      _meta: {
+        id: '2',
+        engine: 'some-engine',
+      },
+    },
+    {
+      id: {
+        raw: '1',
+      },
+      _meta: {
+        id: '1',
+        engine: 'some-engine',
+      },
+    },
+  ],
+};
+
+describe('CurationSuggestionLogic', () => {
+  const { mount } = new LogicMounter(CurationSuggestionLogic);
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+  const mountLogic = (props: object = {}) => {
+    mount(props, { query: 'foo-query' });
+  };
+
+  const { http } = mockHttpValues;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has expected default values', () => {
+    mountLogic();
+    expect(CurationSuggestionLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    describe('onSuggestionLoaded', () => {
+      it('should save the loaded suggestion and promoted documents associated with that suggestion and set dataLoading to false', () => {
+        mountLogic();
+        CurationSuggestionLogic.actions.onSuggestionLoaded({
+          suggestion,
+          suggestedPromotedDocuments,
+        });
+        expect(CurationSuggestionLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          suggestion,
+          suggestedPromotedDocuments,
+          dataLoading: false,
+        });
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('loadSuggestion', () => {
+      it('should set dataLoading state', () => {
+        mountLogic({ dataLoading: false });
+
+        CurationSuggestionLogic.actions.loadSuggestion();
+
+        expect(CurationSuggestionLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: true,
+        });
+      });
+
+      it('should make an API call and trigger onSuggestionLoaded', async () => {
+        http.post.mockReturnValueOnce(Promise.resolve(MOCK_RESPONSE));
+        http.post.mockReturnValueOnce(Promise.resolve(MOCK_DOCUMENTS_RESPONSE));
+        mountLogic();
+        jest.spyOn(CurationSuggestionLogic.actions, 'onSuggestionLoaded');
+
+        CurationSuggestionLogic.actions.loadSuggestion();
+        await nextTick();
+
+        expect(http.post).toHaveBeenCalledWith(
+          '/internal/app_search/engines/some-engine/search_relevance_suggestions/foo-query',
+          {
+            body: JSON.stringify({
+              page: {
+                current: 1,
+                size: 1,
+              },
+              filters: {
+                status: ['pending'],
+                type: 'curation',
+              },
+            }),
+          }
+        );
+
+        expect(http.post).toHaveBeenCalledWith('/internal/app_search/engines/some-engine/search', {
+          query: { query: '' },
+          body: JSON.stringify({
+            page: {
+              size: 100,
+            },
+            filters: {
+              // The results of the first API call are used to make the second http call for document details
+              id: MOCK_RESPONSE.results[0].promoted,
+            },
+          }),
+        });
+
+        expect(CurationSuggestionLogic.actions.onSuggestionLoaded).toHaveBeenCalledWith({
+          suggestion: {
+            query: 'foo',
+            updated_at: '2021-07-08T14:35:50Z',
+            promoted: ['1', '2', '3'],
+          },
+          // Note that these were re-ordered to match the 'promoted' list above, and since document
+          // 3 was not found it is not included in this list
+          suggestedPromotedDocuments: [
+            {
+              id: {
+                raw: '1',
+              },
+              _meta: {
+                id: '1',
+                engine: 'some-engine',
+              },
+            },
+            {
+              id: {
+                raw: '2',
+              },
+              _meta: {
+                id: '2',
+                engine: 'some-engine',
+              },
+            },
+          ],
+        });
+      });
+
+      it('handles errors', async () => {
+        http.post.mockReturnValueOnce(Promise.reject('error'));
+        mount();
+
+        CurationSuggestionLogic.actions.loadSuggestion();
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { flashAPIErrors } from '../../../../../shared/flash_messages';
+import { HttpLogic } from '../../../../../shared/http';
+import { EngineLogic } from '../../../engine';
+import { Result } from '../../../result/types';
+import { CurationSuggestion } from '../../types';
+
+interface CurationSuggestionValues {
+  dataLoading: boolean;
+  suggestion: CurationSuggestion | null;
+  suggestedPromotedDocuments: Result[];
+}
+
+interface CurationSuggestionActions {
+  loadSuggestion(): void;
+  onSuggestionLoaded({
+    suggestion,
+    suggestedPromotedDocuments,
+  }: {
+    suggestion: CurationSuggestion;
+    suggestedPromotedDocuments: Result[];
+  }): {
+    suggestion: CurationSuggestion;
+    suggestedPromotedDocuments: Result[];
+  };
+}
+
+interface CurationSuggestionProps {
+  query: CurationSuggestion['query'];
+}
+
+export const CurationSuggestionLogic = kea<
+  MakeLogicType<CurationSuggestionValues, CurationSuggestionActions, CurationSuggestionProps>
+>({
+  path: ['enterprise_search', 'app_search', 'curations', 'suggestion_logic'],
+  actions: () => ({
+    loadSuggestion: true,
+    onSuggestionLoaded: ({ suggestion, suggestedPromotedDocuments }) => ({
+      suggestion,
+      suggestedPromotedDocuments,
+    }),
+  }),
+  reducers: () => ({
+    dataLoading: [
+      true,
+      {
+        loadSuggestion: () => true,
+        onSuggestionLoaded: () => false,
+      },
+    ],
+    suggestion: [
+      null,
+      {
+        onSuggestionLoaded: (_, { suggestion }) => suggestion,
+      },
+    ],
+    suggestedPromotedDocuments: [
+      [],
+      {
+        onSuggestionLoaded: (_, { suggestedPromotedDocuments }) => suggestedPromotedDocuments,
+      },
+    ],
+  }),
+  listeners: ({ actions, props }) => ({
+    loadSuggestion: async () => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const response = await http.post(
+          `/internal/app_search/engines/${engineName}/search_relevance_suggestions/${props.query}`,
+          {
+            body: JSON.stringify({
+              page: {
+                current: 1,
+                size: 1,
+              },
+              filters: {
+                status: ['pending'],
+                type: 'curation',
+              },
+            }),
+          }
+        );
+
+        const suggestion = response.results[0];
+
+        const searchResponse = await http.post(
+          `/internal/app_search/engines/${engineName}/search`,
+          {
+            query: { query: '' },
+            body: JSON.stringify({
+              page: {
+                size: 100,
+              },
+              filters: {
+                id: suggestion.promoted,
+              },
+            }),
+          }
+        );
+
+        // Filter out docs that were not found and maintain promoted order
+        const promotedIds: string[] = suggestion.promoted;
+        const documentDetails = searchResponse.results;
+        const suggestedPromotedDocuments = promotedIds.reduce((acc: Result[], id: string) => {
+          const found = documentDetails.find(
+            (documentDetail: Result) => documentDetail.id.raw === id
+          );
+          if (!found) return acc;
+          return [...acc, found];
+        }, []);
+
+        actions.onSuggestionLoaded({
+          suggestion: suggestion as CurationSuggestion,
+          suggestedPromotedDocuments,
+        });
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_relevance_suggestions.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_relevance_suggestions.test.ts
@@ -86,4 +86,28 @@ describe('search relevance insights routes', () => {
       });
     });
   });
+
+  describe('POST /internal/app_search/engines/{name}/search_relevance_suggestions/{query}', () => {
+    const mockRouter = new MockRouter({
+      method: 'post',
+      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/{query}',
+    });
+
+    beforeEach(() => {
+      registerSearchRelevanceSuggestionsRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      mockRouter.callRoute({
+        params: { engineName: 'some-engine', query: 'foo' },
+      });
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/:query',
+      });
+    });
+  });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_relevance_suggestions.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_relevance_suggestions.ts
@@ -66,4 +66,29 @@ export function registerSearchRelevanceSuggestionsRoutes({
       path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/settings',
     })
   );
+
+  router.post(
+    {
+      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/{query}',
+      validate: {
+        params: schema.object({
+          engineName: schema.string(),
+          query: schema.string(),
+        }),
+        body: schema.object({
+          page: schema.object({
+            current: schema.number(),
+            size: schema.number(),
+          }),
+          filters: schema.object({
+            status: schema.arrayOf(schema.string()),
+            type: schema.string(),
+          }),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/:query',
+    })
+  );
 }


### PR DESCRIPTION
## Summary

This PR wires up the Suggested section of the Curation Suggestion Detail view.

Note that ONLY the section in red is wired up, the remaining panels on the screen are still static.

![export](https://user-images.githubusercontent.com/1427475/135884852-109995c9-2791-41fd-a02a-731f05e3a8b2.png)

To test with suggestions, use the following API endpoint:

```
curl --location --request POST 'localhost:3002/api/as/v0/engines/national-parks-demo/create_search_relevance_suggestions' \
--header 'Authorization: Basic xxxxx' \
--header 'Content-Type: application/json' \
--data-raw '{
      "query" : "test2",
      "type": "curation",
      "status": "pending",
      "promoted": ["park_grand-teton", "park_hot-springs"],
      "operation": "create"
}'
```


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
