### PR TITLE
[Fleet] Fix integration category redirect after loading categories

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/index.tsx
@@ -343,7 +343,7 @@ const AvailablePackages: React.FC = memo(() => {
     isLoadingCategories,
   ]);
 
-  if (!categoryExists(selectedCategory, categories)) {
+  if (!isLoadingCategories && !categoryExists(selectedCategory, categories)) {
     history.replace(pagePathGetters.integrations_all({ category: '', searchTerm: searchParam })[1]);
     return null;
   }


### PR DESCRIPTION
## Summary

Resolve #112871

Fix a bug when navigating directly to the url `/app/integrations/browse/aws` (or other category in Kibana) the user was redirected to `/browse`.

That PR fix that by waiting we load the categories before doing the redirect.



