### PR TITLE
[Observability] [Exploratory View] Fix calendar cut off, change title, and close accordions on apply changes

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/components/date_range_picker.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/components/date_range_picker.tsx
@@ -91,6 +91,7 @@ export function DateRangePicker({ seriesId, series }: { seriesId: number; series
           })}
           dateFormat={dateFormat.replace('ss.SSS', 'ss')}
           showTimeSelect
+          popoverPlacement="left"
         />
       }
       endDateControl={
@@ -105,6 +106,7 @@ export function DateRangePicker({ seriesId, series }: { seriesId: number; series
           })}
           dateFormat={dateFormat.replace('ss.SSS', 'ss')}
           showTimeSelect
+          popoverPlacement="left"
         />
       }
     />

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.test.tsx
@@ -51,9 +51,7 @@ describe('ExploratoryView', () => {
     expect(await screen.findByText(/No series found. Please add a series./i)).toBeInTheDocument();
     expect(await screen.findByText(/Hide chart/i)).toBeInTheDocument();
     expect(await screen.findByText(/Refresh/i)).toBeInTheDocument();
-    expect(
-      await screen.findByRole('heading', { name: /Performance Distribution/i })
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /Explore data/i })).toBeInTheDocument();
   });
 
   it('renders lens component when there is series', async () => {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/header/header.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/header.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiBetaBadge, EuiButton, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { TypedLensByValueInput } from '../../../../../../lens/public';
-import { DataViewLabels } from '../configurations/constants';
 import { useSeriesStorage } from '../hooks/use_series_storage';
 import { LastUpdated } from './last_updated';
 import { combineTimeRanges } from '../lens_embeddable';

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/header/header.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/header/header.tsx
@@ -35,10 +35,9 @@ export function ExploratoryViewHeader({ seriesId, lensAttributes, lastUpdated }:
         <EuiFlexItem>
           <EuiText>
             <h2>
-              {DataViewLabels[reportType] ??
-                i18n.translate('xpack.observability.expView.heading.label', {
-                  defaultMessage: 'Analyze data',
-                })}{' '}
+              {i18n.translate('xpack.observability.expView.heading.label', {
+                defaultMessage: 'Explore data',
+              })}{' '}
               <EuiBetaBadge
                 style={{
                   verticalAlign: `middle`,

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
@@ -25,7 +25,7 @@ export interface SeriesContextValue {
   firstSeries?: SeriesUrl;
   lastRefresh: number;
   setLastRefresh: (val: number) => void;
-  applyChanges: () => void;
+  applyChanges: (onApply?: () => void) => void;
   allSeries: AllSeries;
   setSeries: (seriesIndex: number, newValue: SeriesUrl) => void;
   getSeries: (seriesIndex: number) => SeriesUrl | undefined;
@@ -103,12 +103,18 @@ export function UrlStorageContextProvider({
     [allSeries]
   );
 
-  const applyChanges = useCallback(() => {
-    const allShortSeries = allSeries.map((series) => convertToShortUrl(series));
+  const applyChanges = useCallback(
+    (onApply?: () => void) => {
+      const allShortSeries = allSeries.map((series) => convertToShortUrl(series));
 
-    (storage as IKbnUrlStateStorage).set(allSeriesKey, allShortSeries);
-    setLastRefresh(Date.now());
-  }, [allSeries, storage]);
+      (storage as IKbnUrlStateStorage).set(allSeriesKey, allShortSeries);
+      setLastRefresh(Date.now());
+      if (onApply) {
+        onApply();
+      }
+    },
+    [allSeries, storage]
+  );
 
   const value = {
     applyChanges,

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import { i18n } from '@kbn/i18n';
 import { EuiFlexItem, EuiFlexGroup, EuiPanel, EuiAccordion, EuiSpacer } from '@elastic/eui';
 import { BuilderItem } from '../types';
 import { SeriesActions } from './columns/series_actions';
@@ -26,6 +27,10 @@ const StyledAccordion = styled(EuiAccordion)`
   .euiAccordion__optionalAction {
     flex-grow: 1;
     flex-shrink: 1;
+  }
+
+  .euiAccordion__childWrapper {
+    overflow: visible;
   }
 `;
 
@@ -47,6 +52,7 @@ export function Series({ item, isExpanded, toggleExpanded }: Props) {
       <StyledAccordion
         id={`exploratoryViewSeriesAccordion${id}`}
         forceState={isExpanded ? 'open' : 'closed'}
+        aria-label={ACCORDION_LABEL}
         onToggle={toggleExpanded}
         arrowDisplay={!seriesProps.series.dataType ? 'none' : undefined}
         extraAction={
@@ -91,3 +97,10 @@ export function Series({ item, isExpanded, toggleExpanded }: Props) {
     </EuiPanel>
   );
 }
+
+export const ACCORDION_LABEL = i18n.translate(
+  'xpack.observability.expView.seriesBuilder.accordion.label',
+  {
+    defaultMessage: 'Toggle series information',
+  }
+);

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -146,7 +146,7 @@ export const SeriesEditor = React.memo(function () {
             </EuiFlexItem>
           )}
           <EuiFlexItem>
-            <ViewActions />
+            <ViewActions onApply={() => setItemIdToExpandedRowMap({})} />
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/views/view_actions.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/views/view_actions.tsx
@@ -11,7 +11,11 @@ import { i18n } from '@kbn/i18n';
 import { isEqual } from 'lodash';
 import { allSeriesKey, convertAllShortSeries, useSeriesStorage } from '../hooks/use_series_storage';
 
-export function ViewActions() {
+interface Props {
+  onApply?: () => void;
+}
+
+export function ViewActions({ onApply }: Props) {
   const { allSeries, storage, applyChanges } = useSeriesStorage();
 
   const noChanges = isEqual(allSeries, convertAllShortSeries(storage.get(allSeriesKey) ?? []));
@@ -19,7 +23,7 @@ export function ViewActions() {
   return (
     <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiButton onClick={() => applyChanges()} isDisabled={noChanges} fill size="s">
+        <EuiButton onClick={() => applyChanges(onApply)} isDisabled={noChanges} fill size="s">
           {i18n.translate('xpack.observability.expView.seriesBuilder.apply', {
             defaultMessage: 'Apply changes',
           })}


### PR DESCRIPTION
## Summary

Fixes elastic/uptime#369 collapse series accordions on apply
Fixes elastic/uptime#370 change title to match figma
<img width="542" alt="Screen Shot 2021-10-04 at 1 46 08 PM" src="https://user-images.githubusercontent.com/11356435/135900273-c2813b41-72e3-4f82-aa34-eb43faf00029.png">
Fixes #113711 fix cut off calendar for series 2+
<img width="1762" alt="Screen Shot 2021-10-04 at 1 46 00 PM" src="https://user-images.githubusercontent.com/11356435/135900275-a21054f5-4ebd-4e9a-9970-670250d118c4.png">


### Testing calendar cut off

- The issue only exists on second and subsequent series. Create two or more series, open the accordion for series 2 or up, and click the date range picker. Ensure the calendar is not cut off at any point

### Testing close accordions on apply changes

Make any change to any series configuration, then click 'Apply changes'. Ensure that the accordion closes on its own.
