### PR TITLE
Fix long agent policy name accessibility in add/edit integration

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
+import styled from 'styled-components';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -22,6 +23,14 @@ import { WithHeaderLayout } from '../../../../layouts';
 import type { AgentPolicy, PackageInfo, RegistryPolicyTemplate } from '../../../../types';
 import { PackageIcon } from '../../../../components';
 import type { EditPackagePolicyFrom } from '../types';
+
+const AgentPolicyName = styled(EuiDescriptionListDescription)`
+  margin-left: auto;
+  max-width: 250px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`;
 
 export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
   from: EditPackagePolicyFrom;
@@ -209,9 +218,9 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
               defaultMessage="Agent policy"
             />
           </EuiDescriptionListTitle>
-          <EuiDescriptionListDescription className="eui-textBreakWord">
+          <AgentPolicyName className="eui-textBreakWord" title={agentPolicy?.name || '-'}>
             {agentPolicy?.name || '-'}
-          </EuiDescriptionListDescription>
+          </AgentPolicyName>
         </EuiDescriptionList>
       ) : undefined;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/113820 where long agent policy name pushes page title to the very left when on add/edit integrations page

![image](https://user-images.githubusercontent.com/16872649/135904450-c10d8bcb-8ad9-4246-b867-9d7a4a60f22d.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
