### PR TITLE
[7.15] [test/page_objects] validate selected dates for timepicker (#113597)

### DIFF
--- a/test/functional/apps/discover/_discover_histogram.ts
+++ b/test/functional/apps/discover/_discover_histogram.ts
@@ -52,21 +52,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     }
 
     it('should visualize monthly data with different day intervals', async () => {
-      const fromTime = 'Nov 01, 2017 @ 00:00:00.000';
+      const fromTime = 'Nov 1, 2017 @ 00:00:00.000';
       const toTime = 'Mar 21, 2018 @ 00:00:00.000';
       await prepareTest(fromTime, toTime, 'Month');
       const chartCanvasExist = await elasticChart.canvasExists();
       expect(chartCanvasExist).to.be(true);
     });
     it('should visualize weekly data with within DST changes', async () => {
-      const fromTime = 'Mar 01, 2018 @ 00:00:00.000';
-      const toTime = 'May 01, 2018 @ 00:00:00.000';
+      const fromTime = 'Mar 1, 2018 @ 00:00:00.000';
+      const toTime = 'May 1, 2018 @ 00:00:00.000';
       await prepareTest(fromTime, toTime, 'Week');
       const chartCanvasExist = await elasticChart.canvasExists();
       expect(chartCanvasExist).to.be(true);
     });
     it('should visualize monthly data with different years scaled to 30 days', async () => {
-      const fromTime = 'Jan 01, 2010 @ 00:00:00.000';
+      const fromTime = 'Jan 1, 2010 @ 00:00:00.000';
       const toTime = 'Mar 21, 2019 @ 00:00:00.000';
       await prepareTest(fromTime, toTime, 'Day');
       const chartCanvasExist = await elasticChart.canvasExists();
@@ -75,7 +75,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(chartIntervalIconTip).to.be(true);
     });
     it('should allow hide/show histogram, persisted in url state', async () => {
-      const fromTime = 'Jan 01, 2010 @ 00:00:00.000';
+      const fromTime = 'Jan 1, 2010 @ 00:00:00.000';
       const toTime = 'Mar 21, 2019 @ 00:00:00.000';
       await prepareTest(fromTime, toTime);
       let canvasExists = await elasticChart.canvasExists();
@@ -93,7 +93,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(canvasExists).to.be(true);
     });
     it('should allow hiding the histogram, persisted in saved search', async () => {
-      const fromTime = 'Jan 01, 2010 @ 00:00:00.000';
+      const fromTime = 'Jan 1, 2010 @ 00:00:00.000';
       const toTime = 'Mar 21, 2019 @ 00:00:00.000';
       const savedSearch = 'persisted hidden histogram';
       await prepareTest(fromTime, toTime);

--- a/test/functional/page_objects/time_picker.ts
+++ b/test/functional/page_objects/time_picker.ts
@@ -116,23 +116,38 @@ export class TimePickerPageObject extends FtrService {
   public async setAbsoluteRange(fromTime: string, toTime: string) {
     this.log.debug(`Setting absolute range to ${fromTime} to ${toTime}`);
     await this.showStartEndTimes();
+    let panel!: WebElementWrapper;
 
     // set to time
-    await this.testSubjects.click('superDatePickerendDatePopoverButton');
-    let panel = await this.getTimePickerPanel();
-    await this.testSubjects.click('superDatePickerAbsoluteTab');
-    await this.testSubjects.click('superDatePickerAbsoluteDateInput');
-    await this.inputValue('superDatePickerAbsoluteDateInput', toTime);
-    await this.browser.pressKeys(this.browser.keys.ESCAPE); // close popover because sometimes browser can't find start input
+    await this.retry.waitFor(`endDate is set to ${toTime}`, async () => {
+      await this.testSubjects.click('superDatePickerendDatePopoverButton');
+      panel = await this.getTimePickerPanel();
+      await this.testSubjects.click('superDatePickerAbsoluteTab');
+      await this.testSubjects.click('superDatePickerAbsoluteDateInput');
+      await this.inputValue('superDatePickerAbsoluteDateInput', toTime);
+      await this.browser.pressKeys(this.browser.keys.ESCAPE); // close popover because sometimes browser can't find start input
+      const actualToTime = await this.testSubjects.getVisibleText(
+        'superDatePickerendDatePopoverButton'
+      );
+      this.log.debug(`Validating 'endDate' - expected: '${toTime}, actual: ${actualToTime}'`);
+      return toTime === actualToTime;
+    });
 
     // set from time
-    await this.testSubjects.click('superDatePickerstartDatePopoverButton');
-    await this.waitPanelIsGone(panel);
-    panel = await this.getTimePickerPanel();
-    await this.testSubjects.click('superDatePickerAbsoluteTab');
-    await this.testSubjects.click('superDatePickerAbsoluteDateInput');
-    await this.inputValue('superDatePickerAbsoluteDateInput', fromTime);
-    await this.browser.pressKeys(this.browser.keys.ESCAPE);
+    await this.retry.waitFor(`endDate is set to ${fromTime}`, async () => {
+      await this.testSubjects.click('superDatePickerstartDatePopoverButton');
+      await this.waitPanelIsGone(panel);
+      panel = await this.getTimePickerPanel();
+      await this.testSubjects.click('superDatePickerAbsoluteTab');
+      await this.testSubjects.click('superDatePickerAbsoluteDateInput');
+      await this.inputValue('superDatePickerAbsoluteDateInput', fromTime);
+      await this.browser.pressKeys(this.browser.keys.ESCAPE);
+      const actualFromTime = await this.testSubjects.getVisibleText(
+        'superDatePickerstartDatePopoverButton'
+      );
+      this.log.debug(`Validating 'startDate' - expected: '${fromTime}, actual: ${actualFromTime}'`);
+      return fromTime === actualFromTime;
+    });
 
     await this.retry.waitFor('Timepicker popover to close', async () => {
       return !(await this.testSubjects.exists('superDatePickerAbsoluteDateInput'));

--- a/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
+++ b/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
@@ -28,8 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await PageObjects.timePicker.setDefaultAbsoluteRange();
   }
 
-  // FLAKY https://github.com/elastic/kibana/issues/113067
-  describe.skip('spaces', () => {
+  describe('spaces', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
     });

--- a/x-pack/test/functional/apps/lens/persistent_context.ts
+++ b/x-pack/test/functional/apps/lens/persistent_context.ts
@@ -31,7 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');
       await PageObjects.lens.goToTimeRange(
-        'Sep 06, 2015 @ 06:31:44.000',
+        'Sep 6, 2015 @ 06:31:44.000',
         'Sep 18, 2025 @ 06:31:44.000'
       );
       await filterBar.addFilter('ip', 'is', '97.220.3.248');
@@ -45,7 +45,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should remember time range and pinned filters from discover', async () => {
       await PageObjects.lens.goToTimeRange(
-        'Sep 07, 2015 @ 06:31:44.000',
+        'Sep 7, 2015 @ 06:31:44.000',
         'Sep 19, 2025 @ 06:31:44.000'
       );
       await filterBar.toggleFilterEnabled('ip');


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [test/page_objects] validate selected dates for timepicker (#113597)