### PR TITLE
[buildkite] Speed up OSS misc tests by removing TS refs and bumping instance

### DIFF
--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -98,7 +98,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/oss_misc.sh
     label: 'OSS Misc Functional Tests'
     agents:
-      queue: ci-group-4d
+      queue: ci-group-6
     depends_on: build
     timeout_in_minutes: 120
     retry:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -96,7 +96,7 @@ steps:
   - command: .buildkite/scripts/steps/functional/oss_misc.sh
     label: 'OSS Misc Functional Tests'
     agents:
-      queue: ci-group-4d
+      queue: ci-group-6
     depends_on: build
     timeout_in_minutes: 120
     retry:

--- a/.buildkite/scripts/steps/functional/oss_misc.sh
+++ b/.buildkite/scripts/steps/functional/oss_misc.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-# Required, at least for kbn_sample_panel_action
-export BUILD_TS_REFS_DISABLE=false
-
 source .buildkite/scripts/steps/functional/common.sh
 
 # Required, at least for plugin_functional tests


### PR DESCRIPTION
[skip-ci]

TS refs were required for OSS Misc in a previous iteration, but are no longer required, so they should not run during that step.

Also, bump the machine size to help the plugin build process execute faster.

This brings OSS Misc from 1h15m -> 34m