### PR TITLE
[Fleet] Remove enterprise license requirement for custom registry URL

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { appContextService, licenseService } from '../../';
+import { appContextService } from '../../';
 
 // from https://github.com/elastic/package-registry#docker (maybe from OpenAPI one day)
 // the unused variables cause a TS warning about unused values
@@ -32,16 +32,9 @@ const getDefaultRegistryUrl = (): string => {
 
 export const getRegistryUrl = (): string => {
   const customUrl = appContextService.getConfig()?.registryUrl;
-  const isEnterprise = licenseService.isEnterprise();
-
-  if (customUrl && isEnterprise) {
-    return customUrl;
-  }
 
   if (customUrl) {
-    appContextService
-      .getLogger()
-      .warn('Enterprise license is required to use a custom registry url.');
+    return customUrl;
   }
 
   return getDefaultRegistryUrl();

--- a/x-pack/plugins/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_server/index.ts
@@ -50,22 +50,25 @@ export async function startFleetServerSetup() {
     _onResolve = resolve;
   });
   const logger = appContextService.getLogger();
+
+  // Check for security
   if (!appContextService.hasSecurity()) {
     // Fleet will not work if security is not enabled
     logger?.warn('Fleet requires the security plugin to be enabled.');
     return;
   }
 
+  // Log information about custom registry URL
+  const customUrl = appContextService.getConfig()?.registryUrl;
+  if (customUrl) {
+    logger.info(
+      `Custom registry url is an experimental feature and is unsupported. Using custom registry at ${customUrl}`
+    );
+  }
+
   try {
     // We need licence to be initialized before using the SO service.
     await licenseService.getLicenseInformation$()?.pipe(first())?.toPromise();
-
-    const customUrl = appContextService.getConfig()?.registryUrl;
-    const isEnterprise = licenseService.isEnterprise();
-    if (customUrl && isEnterprise) {
-      logger.info('Custom registry url is an experimental feature and is unsupported.');
-    }
-
     await runFleetServerMigration();
     _isFleetServerSetup = true;
   } catch (err) {


### PR DESCRIPTION
## Summary

Resolves #113780. This PR removes the enterprise license check for using a custom registry URL (aka setting `xpack.fleet.registryUrl`). I also appended the custom URL to our existing logging as might be helpful for debugging purposes:

![image](https://user-images.githubusercontent.com/1965714/135928980-c3e06068-515c-4e87-86d5-2c0e0723a60f.png)
