### PR TITLE
[ci] Add branch to failed test reporter github comments

### DIFF
--- a/packages/kbn-test/src/failed_tests_reporter/report_failure.test.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/report_failure.test.ts
@@ -26,7 +26,8 @@ describe('createFailureIssue()', () => {
         time: '2018-01-01T01:00:00Z',
         likelyIrrelevant: false,
       },
-      api
+      api,
+      'main'
     );
 
     expect(api.createIssue).toMatchInlineSnapshot(`
@@ -40,7 +41,7 @@ describe('createFailureIssue()', () => {
       this is the failure text
       \`\`\`
 
-      First failure: [CI Build](https://build-url)
+      First failure: [CI Build - main](https://build-url)
 
       <!-- kibanaCiData = {\\"failed-test\\":{\\"test.class\\":\\"some.classname\\",\\"test.name\\":\\"test name\\",\\"test.failCount\\":1}} -->",
             Array [
@@ -74,7 +75,8 @@ describe('updateFailureIssue()', () => {
           <!-- kibanaCiData = {"failed-test":{"test.failCount":10}} -->"
         `,
       },
-      api
+      api,
+      'main'
     );
 
     expect(api.editIssueBodyAndEnsureOpen).toMatchInlineSnapshot(`
@@ -100,7 +102,7 @@ describe('updateFailureIssue()', () => {
         "calls": Array [
           Array [
             1234,
-            "New failure: [CI Build](https://build-url)",
+            "New failure: [CI Build - main](https://build-url)",
           ],
         ],
         "results": Array [

--- a/packages/kbn-test/src/failed_tests_reporter/report_failure.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/report_failure.ts
@@ -10,7 +10,12 @@ import { TestFailure } from './get_failures';
 import { GithubIssueMini, GithubApi } from './github_api';
 import { getIssueMetadata, updateIssueMetadata } from './issue_metadata';
 
-export async function createFailureIssue(buildUrl: string, failure: TestFailure, api: GithubApi) {
+export async function createFailureIssue(
+  buildUrl: string,
+  failure: TestFailure,
+  api: GithubApi,
+  branch: string
+) {
   const title = `Failing test: ${failure.classname} - ${failure.name}`;
 
   const body = updateIssueMetadata(
@@ -21,7 +26,7 @@ export async function createFailureIssue(buildUrl: string, failure: TestFailure,
       failure.failure,
       '```',
       '',
-      `First failure: [CI Build](${buildUrl})`,
+      `First failure: [CI Build - ${branch}](${buildUrl})`,
     ].join('\n'),
     {
       'test.class': failure.classname,
@@ -33,7 +38,12 @@ export async function createFailureIssue(buildUrl: string, failure: TestFailure,
   return await api.createIssue(title, body, ['failed-test']);
 }
 
-export async function updateFailureIssue(buildUrl: string, issue: GithubIssueMini, api: GithubApi) {
+export async function updateFailureIssue(
+  buildUrl: string,
+  issue: GithubIssueMini,
+  api: GithubApi,
+  branch: string
+) {
   // Increment failCount
   const newCount = getIssueMetadata(issue.body, 'test.failCount', 0) + 1;
   const newBody = updateIssueMetadata(issue.body, {
@@ -41,7 +51,7 @@ export async function updateFailureIssue(buildUrl: string, issue: GithubIssueMin
   });
 
   await api.editIssueBodyAndEnsureOpen(issue.number, newBody);
-  await api.addIssueComment(issue.number, `New failure: [CI Build](${buildUrl})`);
+  await api.addIssueComment(issue.number, `New failure: [CI Build - ${branch}](${buildUrl})`);
 
   return newCount;
 }

--- a/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
@@ -139,7 +139,12 @@ export function runFailedTestsReporterCli() {
           }
 
           if (existingIssue) {
-            const newFailureCount = await updateFailureIssue(buildUrl, existingIssue, githubApi);
+            const newFailureCount = await updateFailureIssue(
+              buildUrl,
+              existingIssue,
+              githubApi,
+              branch
+            );
             const url = existingIssue.html_url;
             pushMessage(`Test has failed ${newFailureCount - 1} times on tracked branches: ${url}`);
             if (updateGithub) {
@@ -148,7 +153,7 @@ export function runFailedTestsReporterCli() {
             continue;
           }
 
-          const newIssue = await createFailureIssue(buildUrl, failure, githubApi);
+          const newIssue = await createFailureIssue(buildUrl, failure, githubApi, branch);
           pushMessage('Test has not failed recently on tracked branches');
           if (updateGithub) {
             pushMessage(`Created new issue: ${newIssue.html_url}`);

--- a/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
+++ b/packages/kbn-test/src/failed_tests_reporter/run_failed_tests_reporter_cli.ts
@@ -37,8 +37,8 @@ export function runFailedTestsReporterCli() {
         );
       }
 
+      let branch: string = '';
       if (updateGithub) {
-        let branch: string = '';
         let isPr = false;
 
         if (process.env.BUILDKITE === 'true') {


### PR DESCRIPTION
[skip-ci]

Buildkite builds don't have branch in the URL, so let's put it in the comment so that it's easy to see which branch the failure was for.