### PR TITLE
[7.x] [Alerting][Docs] Elasticsearch setting `search.allow_expensive_queries` should be set as true. (#113062)

### DIFF
--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[alerting-setup]]
-== Alerting Set up
+== Alerting set up
 ++++
 <titleabbrev>Set up</titleabbrev>
 ++++
@@ -19,6 +19,8 @@ If you are using an *on-premises* Elastic Stack deployment with <<using-kibana-w
 
 * You must enable Transport Layer Security (TLS) for communication {ref}/security-basic-setup-https.html#encrypt-kibana-elasticsearch[between {es} and {kib}]. {kib} alerting uses <<api-keys, API keys>> to secure background rule checks and actions, and API keys require {ref}/configuring-tls.html#tls-http[TLS on the HTTP interface]. A proxy will not suffice.
 * If you have enabled TLS and are still unable to access Alerting, ensure that you have not {ref}/security-settings.html#api-key-service-settings[explicitly disabled API keys].
+
+The Alerting framework uses queries that require the `search.allow_expensive_queries` setting to be `true`. See the scripts {ref}/query-dsl-script-query.html#_allow_expensive_queries_4[documentation]. 
 
 [float]
 [[alerting-setup-production]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Alerting][Docs] Elasticsearch setting `search.allow_expensive_queries` should be set as true. (#113062)