### PR TITLE
[Dashboard] Adding timelion panel without asking for the index pattern

### DIFF
--- a/src/plugins/dashboard/public/application/top_nav/editor_menu.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/editor_menu.tsx
@@ -27,7 +27,7 @@ interface Props {
   /** Dashboard container */
   dashboardContainer: DashboardContainer;
   /** Handler for creating new visualization of a specified type */
-  createNewVisType: (visType: BaseVisType | VisTypeAlias) => () => void;
+  createNewVisType: (visType: BaseVisType | VisTypeAlias | undefined) => () => void;
 }
 
 interface FactoryGroup {
@@ -128,7 +128,9 @@ export const EditorMenu = ({ dashboardContainer, createNewVisType }: Props) => {
       name: titleInWizard || title,
       icon: icon as string,
       onClick:
-        group === VisGroups.AGGBASED ? createNewAggsBasedVis(visType) : createNewVisType(visType),
+        group === VisGroups.AGGBASED && visType.options.showIndexSelection
+          ? createNewAggsBasedVis(visType)
+          : createNewVisType(visType),
       'data-test-subj': `visType-${name}`,
       toolTipContent: description,
     };

--- a/src/plugins/dashboard/public/application/top_nav/editor_menu.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/editor_menu.tsx
@@ -27,7 +27,7 @@ interface Props {
   /** Dashboard container */
   dashboardContainer: DashboardContainer;
   /** Handler for creating new visualization of a specified type */
-  createNewVisType: (visType: BaseVisType | VisTypeAlias | undefined) => () => void;
+  createNewVisType: (visType: BaseVisType | VisTypeAlias) => () => void;
 }
 
 interface FactoryGroup {
@@ -128,6 +128,7 @@ export const EditorMenu = ({ dashboardContainer, createNewVisType }: Props) => {
       name: titleInWizard || title,
       icon: icon as string,
       onClick:
+        // not all the agg-based visualizations need to be created via the wizard
         group === VisGroups.AGGBASED && visType.options.showIndexSelection
           ? createNewAggsBasedVis(visType)
           : createNewVisType(visType),

--- a/test/functional/apps/dashboard/create_and_add_embeddables.ts
+++ b/test/functional/apps/dashboard/create_and_add_embeddables.ts
@@ -68,6 +68,24 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.dashboard.waitForRenderComplete();
       });
 
+      it('adds a new timelion visualization', async () => {
+        // adding this case, as the timelion agg-based viz doesn't need the `clickNewSearch()` step
+        const originalPanelCount = await PageObjects.dashboard.getPanelCount();
+        await dashboardAddPanel.clickEditorMenuButton();
+        await dashboardAddPanel.clickAggBasedVisualizations();
+        await PageObjects.visualize.clickTimelion();
+        await PageObjects.visualize.saveVisualizationExpectSuccess(
+          'timelion visualization from add new link',
+          { redirectToOrigin: true }
+        );
+
+        await retry.try(async () => {
+          const panelCount = await PageObjects.dashboard.getPanelCount();
+          expect(panelCount).to.eql(originalPanelCount + 1);
+        });
+        await PageObjects.dashboard.waitForRenderComplete();
+      });
+
       it('adds a markdown visualization via the quick button', async () => {
         const originalPanelCount = await PageObjects.dashboard.getPanelCount();
         await dashboardAddPanel.clickMarkdownQuickButton();


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/113895

In 7.13 a new UI for adding panels was introduced in the dashboard app. We didn't notice that the timelion agg-based viz initialized the `Select source` wizard step. This is not needed as timelion doesn't work with index patterns, so it is confusing for the users. Moreover, if we create a timelion vi z from the visualize listing page, it works as expected.

The fix is simple. Every `visType` has the `showIndexSelection` property which is set to false for timelion and is used in the wizard. It should also be respected by the dashboard app. This PR fixes it and also adds a functional test just to ensure that we won't break it again!

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios