### PR TITLE
[Fleet] fix policies version overlap

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -217,7 +217,7 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
         }),
         render(_version, { agentPolicy, packagePolicy }) {
           return (
-            <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexGroup gutterSize="s" alignItems="center" wrap={true}>
               <EuiFlexItem grow={false}>
                 <EuiText size="s" className="eui-textNoWrap">
                   <FormattedMessage


### PR DESCRIPTION
## Summary

Fix for overlap in Integrations -> Policies table, Version column

https://github.com/elastic/kibana/issues/113261#issuecomment-930522823

![image](https://user-images.githubusercontent.com/90178898/136006217-eb216b25-d9af-4395-8cb4-e51453bfd2ae.png)
