### PR TITLE
Allow elastic/fleet-server to call appropriate Fleet APIs

### DIFF
--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -23,7 +23,17 @@ import type { FleetAppContext } from '../plugin';
 // Export all mocks from artifacts
 export * from '../services/artifacts/mocks';
 
-export const createAppContextStartContractMock = (): FleetAppContext => {
+export interface MockedFleetAppContext extends FleetAppContext {
+  elasticsearch: ReturnType<typeof elasticsearchServiceMock.createStart>;
+  data: ReturnType<typeof dataPluginMock.createStartContract>;
+  encryptedSavedObjectsStart?: ReturnType<typeof encryptedSavedObjectsMock.createStart>;
+  savedObjects: ReturnType<typeof savedObjectsServiceMock.createStartContract>;
+  securitySetup?: ReturnType<typeof securityMock.createSetup>;
+  securityStart?: ReturnType<typeof securityMock.createStart>;
+  logger: ReturnType<ReturnType<typeof loggingSystemMock.create>['get']>;
+}
+
+export const createAppContextStartContractMock = (): MockedFleetAppContext => {
   const config = {
     agents: { enabled: true, elasticsearch: {} },
     enabled: true,

--- a/x-pack/plugins/fleet/server/routes/agent_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { IRouter } from 'src/core/server';
-
 import { PLUGIN_ID, AGENT_POLICY_API_ROUTES } from '../../constants';
 import {
   GetAgentPoliciesRequestSchema,
@@ -17,6 +15,7 @@ import {
   DeleteAgentPolicyRequestSchema,
   GetFullAgentPolicyRequestSchema,
 } from '../../types';
+import type { FleetRouter } from '../../types/request_context';
 
 import {
   getAgentPoliciesHandler,
@@ -29,19 +28,21 @@ import {
   downloadFullAgentPolicy,
 } from './handlers';
 
-export const registerRoutes = (router: IRouter) => {
-  // List
-  router.get(
+export const registerRoutes = (routers: { superuser: FleetRouter; fleetSetup: FleetRouter }) => {
+  // List - Fleet Server needs access to run setup
+  routers.fleetSetup.get(
     {
       path: AGENT_POLICY_API_ROUTES.LIST_PATTERN,
       validate: GetAgentPoliciesRequestSchema,
-      options: { tags: [`access:${PLUGIN_ID}-read`] },
+      // Disable this tag and the automatic RBAC support until elastic/fleet-server access is removed in 8.0
+      // Required to allow elastic/fleet-server to access this API.
+      // options: { tags: [`access:${PLUGIN_ID}-read`] },
     },
     getAgentPoliciesHandler
   );
 
   // Get one
-  router.get(
+  routers.superuser.get(
     {
       path: AGENT_POLICY_API_ROUTES.INFO_PATTERN,
       validate: GetOneAgentPolicyRequestSchema,
@@ -51,7 +52,7 @@ export const registerRoutes = (router: IRouter) => {
   );
 
   // Create
-  router.post(
+  routers.superuser.post(
     {
       path: AGENT_POLICY_API_ROUTES.CREATE_PATTERN,
       validate: CreateAgentPolicyRequestSchema,
@@ -61,7 +62,7 @@ export const registerRoutes = (router: IRouter) => {
   );
 
   // Update
-  router.put(
+  routers.superuser.put(
     {
       path: AGENT_POLICY_API_ROUTES.UPDATE_PATTERN,
       validate: UpdateAgentPolicyRequestSchema,
@@ -71,7 +72,7 @@ export const registerRoutes = (router: IRouter) => {
   );
 
   // Copy
-  router.post(
+  routers.superuser.post(
     {
       path: AGENT_POLICY_API_ROUTES.COPY_PATTERN,
       validate: CopyAgentPolicyRequestSchema,
@@ -81,7 +82,7 @@ export const registerRoutes = (router: IRouter) => {
   );
 
   // Delete
-  router.post(
+  routers.superuser.post(
     {
       path: AGENT_POLICY_API_ROUTES.DELETE_PATTERN,
       validate: DeleteAgentPolicyRequestSchema,
@@ -91,7 +92,7 @@ export const registerRoutes = (router: IRouter) => {
   );
 
   // Get one full agent policy
-  router.get(
+  routers.superuser.get(
     {
       path: AGENT_POLICY_API_ROUTES.FULL_INFO_PATTERN,
       validate: GetFullAgentPolicyRequestSchema,
@@ -101,7 +102,7 @@ export const registerRoutes = (router: IRouter) => {
   );
 
   // Download one full agent policy
-  router.get(
+  routers.superuser.get(
     {
       path: AGENT_POLICY_API_ROUTES.FULL_INFO_DOWNLOAD_PATTERN,
       validate: GetFullAgentPolicyRequestSchema,

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.ts
@@ -27,7 +27,8 @@ export const getEnrollmentApiKeysHandler: RequestHandler<
   undefined,
   TypeOf<typeof GetEnrollmentAPIKeysRequestSchema.query>
 > = async (context, request, response) => {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  // Use kibana_system and depend on authz checks on HTTP layer to prevent abuse
+  const esClient = context.core.elasticsearch.client.asInternalUser;
 
   try {
     const { items, total, page, perPage } = await APIKeyService.listEnrollmentApiKeys(esClient, {
@@ -87,7 +88,8 @@ export const deleteEnrollmentApiKeyHandler: RequestHandler<
 export const getOneEnrollmentApiKeyHandler: RequestHandler<
   TypeOf<typeof GetOneEnrollmentAPIKeyRequestSchema.params>
 > = async (context, request, response) => {
-  const esClient = context.core.elasticsearch.client.asCurrentUser;
+  // Use kibana_system and depend on authz checks on HTTP layer to prevent abuse
+  const esClient = context.core.elasticsearch.client.asInternalUser;
   try {
     const apiKey = await APIKeyService.getEnrollmentAPIKey(esClient, request.params.keyId);
     const body: GetOneEnrollmentAPIKeyResponse = { item: apiKey };

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { IRouter } from 'src/core/server';
-
 import { PLUGIN_ID, ENROLLMENT_API_KEY_ROUTES } from '../../constants';
 import {
   GetEnrollmentAPIKeysRequestSchema,
@@ -14,6 +12,7 @@ import {
   DeleteEnrollmentAPIKeyRequestSchema,
   PostEnrollmentAPIKeyRequestSchema,
 } from '../../types';
+import type { FleetRouter } from '../../types/request_context';
 
 import {
   getEnrollmentApiKeysHandler,
@@ -22,17 +21,19 @@ import {
   postEnrollmentApiKeyHandler,
 } from './handler';
 
-export const registerRoutes = (router: IRouter) => {
-  router.get(
+export const registerRoutes = (routers: { superuser: FleetRouter; fleetSetup: FleetRouter }) => {
+  routers.fleetSetup.get(
     {
       path: ENROLLMENT_API_KEY_ROUTES.INFO_PATTERN,
       validate: GetOneEnrollmentAPIKeyRequestSchema,
-      options: { tags: [`access:${PLUGIN_ID}-read`] },
+      // Disable this tag and the automatic RBAC support until elastic/fleet-server access is removed in 8.0
+      // Required to allow elastic/fleet-server to access this API.
+      // options: { tags: [`access:${PLUGIN_ID}-read`] },
     },
     getOneEnrollmentApiKeyHandler
   );
 
-  router.delete(
+  routers.superuser.delete(
     {
       path: ENROLLMENT_API_KEY_ROUTES.DELETE_PATTERN,
       validate: DeleteEnrollmentAPIKeyRequestSchema,
@@ -41,16 +42,18 @@ export const registerRoutes = (router: IRouter) => {
     deleteEnrollmentApiKeyHandler
   );
 
-  router.get(
+  routers.fleetSetup.get(
     {
       path: ENROLLMENT_API_KEY_ROUTES.LIST_PATTERN,
       validate: GetEnrollmentAPIKeysRequestSchema,
-      options: { tags: [`access:${PLUGIN_ID}-read`] },
+      // Disable this tag and the automatic RBAC support until elastic/fleet-server access is removed in 8.0
+      // Required to allow elastic/fleet-server to access this API.
+      // options: { tags: [`access:${PLUGIN_ID}-read`] },
     },
     getEnrollmentApiKeysHandler
   );
 
-  router.post(
+  routers.superuser.post(
     {
       path: ENROLLMENT_API_KEY_ROUTES.CREATE_PATTERN,
       validate: PostEnrollmentAPIKeyRequestSchema,

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type { IRouter } from 'src/core/server';
-
 import { PLUGIN_ID, EPM_API_ROUTES } from '../../constants';
-import type { FleetRequestHandlerContext } from '../../types';
 import {
   GetCategoriesRequestSchema,
   GetPackagesRequestSchema,
@@ -21,7 +18,7 @@ import {
   GetStatsRequestSchema,
   UpdatePackageRequestSchema,
 } from '../../types';
-import { enforceSuperUser } from '../security';
+import type { FleetRouter } from '../../types/request_context';
 
 import {
   getCategoriesHandler,
@@ -39,8 +36,8 @@ import {
 
 const MAX_FILE_SIZE_BYTES = 104857600; // 100MB
 
-export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
-  router.get(
+export const registerRoutes = (routers: { rbac: FleetRouter; superuser: FleetRouter }) => {
+  routers.rbac.get(
     {
       path: EPM_API_ROUTES.CATEGORIES_PATTERN,
       validate: GetCategoriesRequestSchema,
@@ -49,7 +46,7 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
     getCategoriesHandler
   );
 
-  router.get(
+  routers.rbac.get(
     {
       path: EPM_API_ROUTES.LIST_PATTERN,
       validate: GetPackagesRequestSchema,
@@ -58,7 +55,7 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
     getListHandler
   );
 
-  router.get(
+  routers.rbac.get(
     {
       path: EPM_API_ROUTES.LIMITED_LIST_PATTERN,
       validate: false,
@@ -67,7 +64,7 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
     getLimitedListHandler
   );
 
-  router.get(
+  routers.rbac.get(
     {
       path: EPM_API_ROUTES.STATS_PATTERN,
       validate: GetStatsRequestSchema,
@@ -76,7 +73,7 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
     getStatsHandler
   );
 
-  router.get(
+  routers.rbac.get(
     {
       path: EPM_API_ROUTES.FILEPATH_PATTERN,
       validate: GetFileRequestSchema,
@@ -85,7 +82,7 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
     getFileHandler
   );
 
-  router.get(
+  routers.rbac.get(
     {
       path: EPM_API_ROUTES.INFO_PATTERN,
       validate: GetInfoRequestSchema,
@@ -94,34 +91,34 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
     getInfoHandler
   );
 
-  router.put(
+  routers.superuser.put(
     {
       path: EPM_API_ROUTES.INFO_PATTERN,
       validate: UpdatePackageRequestSchema,
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
-    enforceSuperUser(updatePackageHandler)
+    updatePackageHandler
   );
 
-  router.post(
+  routers.superuser.post(
     {
       path: EPM_API_ROUTES.INSTALL_FROM_REGISTRY_PATTERN,
       validate: InstallPackageFromRegistryRequestSchema,
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
-    enforceSuperUser(installPackageFromRegistryHandler)
+    installPackageFromRegistryHandler
   );
 
-  router.post(
+  routers.superuser.post(
     {
       path: EPM_API_ROUTES.BULK_INSTALL_PATTERN,
       validate: BulkUpgradePackagesFromRegistryRequestSchema,
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
-    enforceSuperUser(bulkInstallPackagesFromRegistryHandler)
+    bulkInstallPackagesFromRegistryHandler
   );
 
-  router.post(
+  routers.superuser.post(
     {
       path: EPM_API_ROUTES.INSTALL_BY_UPLOAD_PATTERN,
       validate: InstallPackageByUploadRequestSchema,
@@ -134,15 +131,15 @@ export const registerRoutes = (router: IRouter<FleetRequestHandlerContext>) => {
         },
       },
     },
-    enforceSuperUser(installPackageByUploadHandler)
+    installPackageByUploadHandler
   );
 
-  router.delete(
+  routers.superuser.delete(
     {
       path: EPM_API_ROUTES.DELETE_PATTERN,
       validate: DeletePackageRequestSchema,
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
-    enforceSuperUser(deletePackageHandler)
+    deletePackageHandler
   );
 };

--- a/x-pack/plugins/fleet/server/routes/security.test.ts
+++ b/x-pack/plugins/fleet/server/routes/security.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter, RequestHandler, RouteConfig } from '../../../../../src/core/server';
+import { coreMock } from '../../../../../src/core/server/mocks';
+import type { AuthenticatedUser } from '../../../security/server';
+import type { CheckPrivilegesDynamically } from '../../../security/server/authorization/check_privileges_dynamically';
+import { createAppContextStartContractMock } from '../mocks';
+import { appContextService } from '../services';
+
+import type { RouterWrapper } from './security';
+import { RouterWrappers } from './security';
+
+describe('RouterWrappers', () => {
+  const runTest = async ({
+    wrapper,
+    security: {
+      roles = [],
+      pluginEnabled = true,
+      licenseEnabled = true,
+      checkPrivilegesDynamically,
+    } = {},
+  }: {
+    wrapper: RouterWrapper;
+    security?: {
+      roles?: string[];
+      pluginEnabled?: boolean;
+      licenseEnabled?: boolean;
+      checkPrivilegesDynamically?: CheckPrivilegesDynamically;
+    };
+  }) => {
+    const fakeRouter = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<IRouter>;
+    const fakeHandler: RequestHandler = jest.fn((ctx, req, res) => res.ok());
+
+    const mockContext = createAppContextStartContractMock();
+    // @ts-expect-error type doesn't properly respect deeply mocked keys
+    mockContext.securityStart?.authz.actions.api.get.mockImplementation((priv) => `api:${priv}`);
+
+    if (!pluginEnabled) {
+      mockContext.securitySetup = undefined;
+      mockContext.securityStart = undefined;
+    } else {
+      mockContext.securityStart?.authc.getCurrentUser.mockReturnValue({
+        username: 'foo',
+        roles,
+      } as unknown as AuthenticatedUser);
+
+      mockContext.securitySetup?.license.isEnabled.mockReturnValue(licenseEnabled);
+      if (licenseEnabled) {
+        mockContext.securityStart?.authz.mode.useRbacForRequest.mockReturnValue(true);
+      }
+
+      if (checkPrivilegesDynamically) {
+        mockContext.securityStart?.authz.checkPrivilegesDynamicallyWithRequest.mockReturnValue(
+          checkPrivilegesDynamically
+        );
+      }
+    }
+
+    appContextService.start(mockContext);
+
+    const wrappedRouter = wrapper(fakeRouter);
+    wrappedRouter.get({} as RouteConfig<any, any, any, any>, fakeHandler);
+    const wrappedHandler = fakeRouter.get.mock.calls[0][1];
+    const resFactory = { forbidden: jest.fn(() => 'forbidden'), ok: jest.fn(() => 'ok') };
+    const res = await wrappedHandler(
+      { core: coreMock.createRequestHandlerContext() },
+      {} as any,
+      resFactory as any
+    );
+
+    return res as unknown as 'forbidden' | 'ok';
+  };
+
+  describe('require.superuser', () => {
+    it('allow users with the superuser role', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.superuser,
+          security: { roles: ['superuser'] },
+        })
+      ).toEqual('ok');
+    });
+
+    it('does not allow users without the superuser role', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.superuser,
+          security: { roles: ['foo'] },
+        })
+      ).toEqual('forbidden');
+    });
+
+    it('does not allow security plugin to be disabled', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.superuser,
+          security: { pluginEnabled: false },
+        })
+      ).toEqual('forbidden');
+    });
+
+    it('does not allow security license to be disabled', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.superuser,
+          security: { licenseEnabled: false },
+        })
+      ).toEqual('forbidden');
+    });
+  });
+
+  describe('require.fleetSetupPrivilege', () => {
+    const mockCheckPrivileges: jest.Mock<
+      ReturnType<CheckPrivilegesDynamically>,
+      Parameters<CheckPrivilegesDynamically>
+    > = jest.fn().mockResolvedValue({ hasAllRequested: true });
+
+    it('executes custom authz check', async () => {
+      await runTest({
+        wrapper: RouterWrappers.require.fleetSetupPrivilege,
+        security: { checkPrivilegesDynamically: mockCheckPrivileges },
+      });
+      expect(mockCheckPrivileges).toHaveBeenCalledWith(
+        { kibana: ['api:fleet-setup'] },
+        {
+          requireLoginAction: false,
+        }
+      );
+    });
+
+    it('allow users with required privileges', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.fleetSetupPrivilege,
+          security: { checkPrivilegesDynamically: mockCheckPrivileges },
+        })
+      ).toEqual('ok');
+    });
+
+    it('does not allow users without required privileges', async () => {
+      mockCheckPrivileges.mockResolvedValueOnce({ hasAllRequested: false } as any);
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.fleetSetupPrivilege,
+          security: { checkPrivilegesDynamically: mockCheckPrivileges },
+        })
+      ).toEqual('forbidden');
+    });
+
+    it('does not allow security plugin to be disabled', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.fleetSetupPrivilege,
+          security: { pluginEnabled: false },
+        })
+      ).toEqual('forbidden');
+    });
+
+    it('does not allow security license to be disabled', async () => {
+      expect(
+        await runTest({
+          wrapper: RouterWrappers.require.fleetSetupPrivilege,
+          security: { licenseEnabled: false },
+        })
+      ).toEqual('forbidden');
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/routes/security.ts
+++ b/x-pack/plugins/fleet/server/routes/security.ts
@@ -5,56 +5,137 @@
  * 2.0.
  */
 
-import type { IRouter, RequestHandler, RequestHandlerContext } from 'src/core/server';
+import type {
+  IRouter,
+  KibanaRequest,
+  RequestHandler,
+  RequestHandlerContext,
+} from 'src/core/server';
 
 import { appContextService } from '../services';
 
-export function enforceSuperUser<T1, T2, T3, TContext extends RequestHandlerContext>(
+const SUPERUSER_AUTHZ_MESSAGE =
+  'Access to Fleet API requires the superuser role and for stack security features to be enabled.';
+
+function checkSecurityEnabled() {
+  return appContextService.hasSecurity() && appContextService.getSecurityLicense().isEnabled();
+}
+
+function checkSuperuser(req: KibanaRequest) {
+  if (!checkSecurityEnabled()) {
+    return false;
+  }
+
+  const security = appContextService.getSecurity();
+  const user = security.authc.getCurrentUser(req);
+  if (!user) {
+    return false;
+  }
+
+  const userRoles = user.roles || [];
+  if (!userRoles.includes('superuser')) {
+    return false;
+  }
+
+  return true;
+}
+
+function enforceSuperuser<T1, T2, T3, TContext extends RequestHandlerContext>(
   handler: RequestHandler<T1, T2, T3, TContext>
 ): RequestHandler<T1, T2, T3, TContext> {
   return function enforceSuperHandler(context, req, res) {
-    if (!appContextService.hasSecurity() || !appContextService.getSecurityLicense().isEnabled()) {
+    const isSuperuser = checkSuperuser(req);
+    if (!isSuperuser) {
       return res.forbidden({
         body: {
-          message: `Access to this API requires that security is enabled`,
+          message: SUPERUSER_AUTHZ_MESSAGE,
         },
       });
     }
 
-    const security = appContextService.getSecurity();
-    const user = security.authc.getCurrentUser(req);
-    if (!user) {
-      return res.forbidden({
-        body: {
-          message:
-            'Access to Fleet API require the superuser role, and for stack security features to be enabled.',
-        },
-      });
-    }
-
-    const userRoles = user.roles || [];
-    if (!userRoles.includes('superuser')) {
-      return res.forbidden({
-        body: {
-          message: 'Access to Fleet API require the superuser role.',
-        },
-      });
-    }
     return handler(context, req, res);
   };
 }
 
-export function makeRouterEnforcingSuperuser<TContext extends RequestHandlerContext>(
+function makeRouterEnforcingSuperuser<TContext extends RequestHandlerContext>(
   router: IRouter<TContext>
 ): IRouter<TContext> {
   return {
-    get: (options, handler) => router.get(options, enforceSuperUser(handler)),
-    delete: (options, handler) => router.delete(options, enforceSuperUser(handler)),
-    post: (options, handler) => router.post(options, enforceSuperUser(handler)),
-    put: (options, handler) => router.put(options, enforceSuperUser(handler)),
-    patch: (options, handler) => router.patch(options, enforceSuperUser(handler)),
+    get: (options, handler) => router.get(options, enforceSuperuser(handler)),
+    delete: (options, handler) => router.delete(options, enforceSuperuser(handler)),
+    post: (options, handler) => router.post(options, enforceSuperuser(handler)),
+    put: (options, handler) => router.put(options, enforceSuperuser(handler)),
+    patch: (options, handler) => router.patch(options, enforceSuperuser(handler)),
     handleLegacyErrors: (handler) => router.handleLegacyErrors(handler),
     getRoutes: () => router.getRoutes(),
     routerPath: router.routerPath,
   };
 }
+
+async function checkFleetSetupPrivilege(req: KibanaRequest) {
+  if (!checkSecurityEnabled()) {
+    return false;
+  }
+
+  const security = appContextService.getSecurity();
+
+  if (security.authz.mode.useRbacForRequest(req)) {
+    const checkPrivileges = security.authz.checkPrivilegesDynamicallyWithRequest(req);
+    const { hasAllRequested } = await checkPrivileges(
+      { kibana: [security.authz.actions.api.get('fleet-setup')] },
+      { requireLoginAction: false } // exclude login access requirement
+    );
+
+    return !!hasAllRequested;
+  }
+
+  return true;
+}
+
+function enforceFleetSetupPrivilege<P, Q, B, TContext extends RequestHandlerContext>(
+  handler: RequestHandler<P, Q, B, TContext>
+): RequestHandler<P, Q, B, TContext> {
+  return async (context, req, res) => {
+    const hasFleetSetupPrivilege = await checkFleetSetupPrivilege(req);
+    if (!hasFleetSetupPrivilege) {
+      return res.forbidden({ body: { message: SUPERUSER_AUTHZ_MESSAGE } });
+    }
+
+    return handler(context, req, res);
+  };
+}
+
+function makeRouterEnforcingFleetSetupPrivilege<TContext extends RequestHandlerContext>(
+  router: IRouter<TContext>
+): IRouter<TContext> {
+  return {
+    get: (options, handler) => router.get(options, enforceFleetSetupPrivilege(handler)),
+    delete: (options, handler) => router.delete(options, enforceFleetSetupPrivilege(handler)),
+    post: (options, handler) => router.post(options, enforceFleetSetupPrivilege(handler)),
+    put: (options, handler) => router.put(options, enforceFleetSetupPrivilege(handler)),
+    patch: (options, handler) => router.patch(options, enforceFleetSetupPrivilege(handler)),
+    handleLegacyErrors: (handler) => router.handleLegacyErrors(handler),
+    getRoutes: () => router.getRoutes(),
+    routerPath: router.routerPath,
+  };
+}
+
+type RouterWrapper = <T extends RequestHandlerContext>(route: IRouter<T>) => IRouter<T>;
+
+interface RouterWrappersSetup {
+  require: {
+    superuser: RouterWrapper;
+    fleetSetupPrivilege: RouterWrapper;
+  };
+}
+
+export const RouterWrappers: RouterWrappersSetup = {
+  require: {
+    superuser: (router) => {
+      return makeRouterEnforcingSuperuser(router);
+    },
+    fleetSetupPrivilege: (router) => {
+      return makeRouterEnforcingFleetSetupPrivilege(router);
+    },
+  },
+};

--- a/x-pack/plugins/fleet/server/routes/security.ts
+++ b/x-pack/plugins/fleet/server/routes/security.ts
@@ -120,7 +120,7 @@ function makeRouterEnforcingFleetSetupPrivilege<TContext extends RequestHandlerC
   };
 }
 
-type RouterWrapper = <T extends RequestHandlerContext>(route: IRouter<T>) => IRouter<T>;
+export type RouterWrapper = <T extends RequestHandlerContext>(route: IRouter<T>) => IRouter<T>;
 
 interface RouterWrappersSetup {
   require: {

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { RequestHandler } from 'src/core/server';
-
 import { appContextService } from '../../services';
 import type { GetFleetStatusResponse, PostFleetSetupResponse } from '../../../common';
 import { setupFleet } from '../../services/setup';
@@ -14,12 +12,14 @@ import { hasFleetServers } from '../../services/fleet_server';
 import { defaultIngestErrorHandler } from '../../errors';
 import type { FleetRequestHandler } from '../../types';
 
-export const getFleetStatusHandler: RequestHandler = async (context, request, response) => {
+export const getFleetStatusHandler: FleetRequestHandler = async (context, request, response) => {
   try {
     const isApiKeysEnabled = await appContextService
       .getSecurity()
       .authc.apiKeys.areAPIKeysEnabled();
-    const isFleetServerSetup = await hasFleetServers(appContextService.getInternalUserESClient());
+    const isFleetServerSetup = await hasFleetServers(
+      context.core.elasticsearch.client.asInternalUser
+    );
 
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
     if (!isApiKeysEnabled) {

--- a/x-pack/plugins/fleet/server/routes/setup/index.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/index.ts
@@ -5,55 +5,48 @@
  * 2.0.
  */
 
-import type { IRouter } from 'src/core/server';
-
 import { PLUGIN_ID, AGENTS_SETUP_API_ROUTES, SETUP_API_ROUTE } from '../../constants';
 import type { FleetConfigType } from '../../../common';
 
-import type { FleetRequestHandlerContext } from '../../types/request_context';
+import type { FleetRouter } from '../../types/request_context';
 
 import { getFleetStatusHandler, fleetSetupHandler } from './handlers';
 
-export const registerFleetSetupRoute = (router: IRouter<FleetRequestHandlerContext>) => {
+export const registerFleetSetupRoute = (router: FleetRouter) => {
   router.post(
     {
       path: SETUP_API_ROUTE,
       validate: false,
-      // if this route is set to `-all`, a read-only user get a 404 for this route
-      // and will see `Unable to initialize Ingest Manager` in the UI
-      options: { tags: [`access:${PLUGIN_ID}-read`] },
     },
     fleetSetupHandler
   );
 };
 
 // That route is used by agent to setup Fleet
-export const registerCreateFleetSetupRoute = (router: IRouter<FleetRequestHandlerContext>) => {
+export const registerCreateFleetSetupRoute = (router: FleetRouter) => {
   router.post(
     {
       path: AGENTS_SETUP_API_ROUTES.CREATE_PATTERN,
       validate: false,
-      options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
     fleetSetupHandler
   );
 };
 
-export const registerGetFleetStatusRoute = (router: IRouter<FleetRequestHandlerContext>) => {
+export const registerGetFleetStatusRoute = (router: FleetRouter) => {
   router.get(
     {
       path: AGENTS_SETUP_API_ROUTES.INFO_PATTERN,
       validate: false,
+      // Disable this tag and the automatic RBAC support until elastic/fleet-server access is removed in 8.0
+      // Required to allow elastic/fleet-server to access this API.
       options: { tags: [`access:${PLUGIN_ID}-read`] },
     },
     getFleetStatusHandler
   );
 };
 
-export const registerRoutes = (
-  router: IRouter<FleetRequestHandlerContext>,
-  config: FleetConfigType
-) => {
+export const registerRoutes = (router: FleetRouter, config: FleetConfigType) => {
   // Ingest manager setup
   registerFleetSetupRoute(router);
 

--- a/x-pack/plugins/fleet/server/types/request_context.ts
+++ b/x-pack/plugins/fleet/server/types/request_context.ts
@@ -11,6 +11,7 @@ import type {
   RequestHandlerContext,
   RouteMethod,
   SavedObjectsClientContract,
+  IRouter,
 } from '../../../../../src/core/server';
 
 /** @internal */
@@ -37,3 +38,9 @@ export type FleetRequestHandler<
   Method extends RouteMethod = any,
   ResponseFactory extends KibanaResponseFactory = KibanaResponseFactory
 > = RequestHandler<P, Q, B, FleetRequestHandlerContext, Method, ResponseFactory>;
+
+/**
+ * Convenience type for routers in Fleet that includes the FleetRequestHandlerContext type
+ * @internal
+ */
+export type FleetRouter = IRouter<FleetRequestHandlerContext>;

--- a/x-pack/plugins/security/server/authorization/check_privileges.test.ts
+++ b/x-pack/plugins/security/server/authorization/check_privileges.test.ts
@@ -878,6 +878,42 @@ describe('#atSpace', () => {
       `);
     });
   });
+
+  test('omits login privilege when requireLoginAction: false', async () => {
+    const { mockClusterClient, mockScopedClusterClient } = createMockClusterClient({
+      has_all_requested: true,
+      username: 'foo-username',
+      index: {},
+      application: {
+        [application]: {
+          'space:space_1': {
+            [mockActions.version]: true,
+          },
+        },
+      },
+    });
+    const checkPrivilegesWithRequest = checkPrivilegesWithRequestFactory(
+      mockActions,
+      () => Promise.resolve(mockClusterClient),
+      application
+    );
+    const request = httpServerMock.createKibanaRequest();
+    const checkPrivileges = checkPrivilegesWithRequest(request);
+    await checkPrivileges.atSpace('space_1', {}, { requireLoginAction: false });
+
+    expect(mockScopedClusterClient.asCurrentUser.security.hasPrivileges).toHaveBeenCalledWith({
+      body: {
+        index: [],
+        application: [
+          {
+            application,
+            resources: [`space:space_1`],
+            privileges: [mockActions.version],
+          },
+        ],
+      },
+    });
+  });
 });
 
 describe('#atSpaces', () => {
@@ -2083,6 +2119,42 @@ describe('#atSpaces', () => {
       `);
     });
   });
+
+  test('omits login privilege when requireLoginAction: false', async () => {
+    const { mockClusterClient, mockScopedClusterClient } = createMockClusterClient({
+      has_all_requested: true,
+      username: 'foo-username',
+      index: {},
+      application: {
+        [application]: {
+          'space:space_1': {
+            [mockActions.version]: true,
+          },
+        },
+      },
+    });
+    const checkPrivilegesWithRequest = checkPrivilegesWithRequestFactory(
+      mockActions,
+      () => Promise.resolve(mockClusterClient),
+      application
+    );
+    const request = httpServerMock.createKibanaRequest();
+    const checkPrivileges = checkPrivilegesWithRequest(request);
+    await checkPrivileges.atSpaces(['space_1'], {}, { requireLoginAction: false });
+
+    expect(mockScopedClusterClient.asCurrentUser.security.hasPrivileges).toHaveBeenCalledWith({
+      body: {
+        index: [],
+        application: [
+          {
+            application,
+            resources: [`space:space_1`],
+            privileges: [mockActions.version],
+          },
+        ],
+      },
+    });
+  });
 });
 
 describe('#globally', () => {
@@ -2935,6 +3007,42 @@ describe('#globally', () => {
           "username": "foo-username",
         }
       `);
+    });
+  });
+
+  test('omits login privilege when requireLoginAction: false', async () => {
+    const { mockClusterClient, mockScopedClusterClient } = createMockClusterClient({
+      has_all_requested: true,
+      username: 'foo-username',
+      index: {},
+      application: {
+        [application]: {
+          [GLOBAL_RESOURCE]: {
+            [mockActions.version]: true,
+          },
+        },
+      },
+    });
+    const checkPrivilegesWithRequest = checkPrivilegesWithRequestFactory(
+      mockActions,
+      () => Promise.resolve(mockClusterClient),
+      application
+    );
+    const request = httpServerMock.createKibanaRequest();
+    const checkPrivileges = checkPrivilegesWithRequest(request);
+    await checkPrivileges.globally({}, { requireLoginAction: false });
+
+    expect(mockScopedClusterClient.asCurrentUser.security.hasPrivileges).toHaveBeenCalledWith({
+      body: {
+        index: [],
+        application: [
+          {
+            application,
+            resources: [GLOBAL_RESOURCE],
+            privileges: [mockActions.version],
+          },
+        ],
+      },
     });
   });
 });

--- a/x-pack/plugins/security/server/authorization/check_privileges_dynamically.test.ts
+++ b/x-pack/plugins/security/server/authorization/check_privileges_dynamically.test.ts
@@ -8,6 +8,7 @@
 import { httpServerMock } from 'src/core/server/mocks';
 
 import { checkPrivilegesDynamicallyWithRequestFactory } from './check_privileges_dynamically';
+import type { CheckPrivilegesOptions } from './types';
 
 test(`checkPrivileges.atSpace when spaces is enabled`, async () => {
   const expectedResult = Symbol();
@@ -25,13 +26,18 @@ test(`checkPrivileges.atSpace when spaces is enabled`, async () => {
       namespaceToSpaceId: jest.fn(),
     })
   )(request);
-  const result = await checkPrivilegesDynamically({ kibana: privilegeOrPrivileges });
+  const options: CheckPrivilegesOptions = { requireLoginAction: true };
+  const result = await checkPrivilegesDynamically({ kibana: privilegeOrPrivileges }, options);
 
   expect(result).toBe(expectedResult);
   expect(mockCheckPrivilegesWithRequest).toHaveBeenCalledWith(request);
-  expect(mockCheckPrivileges.atSpace).toHaveBeenCalledWith(spaceId, {
-    kibana: privilegeOrPrivileges,
-  });
+  expect(mockCheckPrivileges.atSpace).toHaveBeenCalledWith(
+    spaceId,
+    {
+      kibana: privilegeOrPrivileges,
+    },
+    options
+  );
 });
 
 test(`checkPrivileges.globally when spaces is disabled`, async () => {
@@ -46,9 +52,13 @@ test(`checkPrivileges.globally when spaces is disabled`, async () => {
     mockCheckPrivilegesWithRequest,
     () => undefined
   )(request);
-  const result = await checkPrivilegesDynamically({ kibana: privilegeOrPrivileges });
+  const options: CheckPrivilegesOptions = { requireLoginAction: true };
+  const result = await checkPrivilegesDynamically({ kibana: privilegeOrPrivileges }, options);
 
   expect(result).toBe(expectedResult);
   expect(mockCheckPrivilegesWithRequest).toHaveBeenCalledWith(request);
-  expect(mockCheckPrivileges.globally).toHaveBeenCalledWith({ kibana: privilegeOrPrivileges });
+  expect(mockCheckPrivileges.globally).toHaveBeenCalledWith(
+    { kibana: privilegeOrPrivileges },
+    options
+  );
 });

--- a/x-pack/plugins/security/server/authorization/check_privileges_dynamically.ts
+++ b/x-pack/plugins/security/server/authorization/check_privileges_dynamically.ts
@@ -9,13 +9,15 @@ import type { KibanaRequest } from 'src/core/server';
 
 import type { SpacesService } from '../plugin';
 import type {
+  CheckPrivilegesOptions,
   CheckPrivilegesPayload,
   CheckPrivilegesResponse,
   CheckPrivilegesWithRequest,
 } from './types';
 
 export type CheckPrivilegesDynamically = (
-  privileges: CheckPrivilegesPayload
+  privileges: CheckPrivilegesPayload,
+  options?: CheckPrivilegesOptions
 ) => Promise<CheckPrivilegesResponse>;
 
 export type CheckPrivilegesDynamicallyWithRequest = (
@@ -28,11 +30,15 @@ export function checkPrivilegesDynamicallyWithRequestFactory(
 ): CheckPrivilegesDynamicallyWithRequest {
   return function checkPrivilegesDynamicallyWithRequest(request: KibanaRequest) {
     const checkPrivileges = checkPrivilegesWithRequest(request);
-    return async function checkPrivilegesDynamically(privileges: CheckPrivilegesPayload) {
+
+    return async function checkPrivilegesDynamically(
+      privileges: CheckPrivilegesPayload,
+      options?: CheckPrivilegesOptions
+    ) {
       const spacesService = getSpacesService();
       return spacesService
-        ? await checkPrivileges.atSpace(spacesService.getSpaceId(request), privileges)
-        : await checkPrivileges.globally(privileges);
+        ? await checkPrivileges.atSpace(spacesService.getSpaceId(request), privileges, options)
+        : await checkPrivileges.globally(privileges, options);
     };
   };
 }

--- a/x-pack/plugins/security/server/authorization/types.ts
+++ b/x-pack/plugins/security/server/authorization/types.ts
@@ -29,6 +29,18 @@ export interface HasPrivilegesResponse {
   };
 }
 
+/**
+ * Options to influce the privilege checks.
+ */
+export interface CheckPrivilegesOptions {
+  /**
+   * Whether or not the `login` action should be required (default: true).
+   * Setting this to false is not advised except for special circumstances, when you do not require
+   * the request to belong to a user capable of logging into Kibana.
+   */
+  requireLoginAction?: boolean;
+}
+
 export interface CheckPrivilegesResponse {
   hasAllRequested: boolean;
   username: string;
@@ -59,12 +71,20 @@ export interface CheckPrivilegesResponse {
 export type CheckPrivilegesWithRequest = (request: KibanaRequest) => CheckPrivileges;
 
 export interface CheckPrivileges {
-  atSpace(spaceId: string, privileges: CheckPrivilegesPayload): Promise<CheckPrivilegesResponse>;
+  atSpace(
+    spaceId: string,
+    privileges: CheckPrivilegesPayload,
+    options?: CheckPrivilegesOptions
+  ): Promise<CheckPrivilegesResponse>;
   atSpaces(
     spaceIds: string[],
-    privileges: CheckPrivilegesPayload
+    privileges: CheckPrivilegesPayload,
+    options?: CheckPrivilegesOptions
   ): Promise<CheckPrivilegesResponse>;
-  globally(privileges: CheckPrivilegesPayload): Promise<CheckPrivilegesResponse>;
+  globally(
+    privileges: CheckPrivilegesPayload,
+    options?: CheckPrivilegesOptions
+  ): Promise<CheckPrivilegesResponse>;
 }
 
 export interface CheckPrivilegesPayload {

--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -73,7 +73,7 @@ export default function ({ getService }: FtrProviderContext) {
               'packs_read',
             ],
           },
-          reserved: ['ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
+          reserved: ['fleet-setup', 'ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
         };
 
         await supertest

--- a/x-pack/test/api_integration/apis/security/privileges_basic.ts
+++ b/x-pack/test/api_integration/apis/security/privileges_basic.ts
@@ -45,7 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
           global: ['all', 'read'],
           space: ['all', 'read'],
-          reserved: ['ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
+          reserved: ['fleet-setup', 'ml_user', 'ml_admin', 'ml_apm_user', 'monitoring'],
         };
 
         await supertest

--- a/x-pack/test/fleet_api_integration/apis/agents/services.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/services.ts
@@ -32,12 +32,28 @@ export function getEsClientForAPIKey({ getService }: FtrProviderContext, esApiKe
   });
 }
 
-export function setupFleetAndAgents({ getService }: FtrProviderContext) {
+export function setupFleetAndAgents(providerContext: FtrProviderContext) {
   before(async () => {
-    await getService('supertest').post(`/api/fleet/setup`).set('kbn-xsrf', 'xxx').send();
-    await getService('supertest')
+    // Use elastic/fleet-server service account to execute setup to verify privilege configuration
+    const es = providerContext.getService('es');
+    const {
+      body: { token },
+      // @ts-expect-error SecurityCreateServiceTokenRequest should not require `name`
+    } = await es.security.createServiceToken({
+      namespace: 'elastic',
+      service: 'fleet-server',
+    });
+    const supetestWithoutAuth = getSupertestWithoutAuth(providerContext);
+
+    await supetestWithoutAuth
+      .post(`/api/fleet/setup`)
+      .set('kbn-xsrf', 'xxx')
+      .set('Authentication', `Bearer ${token.value}`)
+      .send();
+    await supetestWithoutAuth
       .post(`/api/fleet/agents/setup`)
       .set('kbn-xsrf', 'xxx')
+      .set('Authentication', `Bearer ${token.value}`)
       .send({ forceRecreate: true });
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/agents/services.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/services.ts
@@ -48,12 +48,14 @@ export function setupFleetAndAgents(providerContext: FtrProviderContext) {
     await supetestWithoutAuth
       .post(`/api/fleet/setup`)
       .set('kbn-xsrf', 'xxx')
-      .set('Authentication', `Bearer ${token.value}`)
-      .send();
+      .set('Authorization', `Bearer ${token.value}`)
+      .send()
+      .expect(200);
     await supetestWithoutAuth
       .post(`/api/fleet/agents/setup`)
       .set('kbn-xsrf', 'xxx')
-      .set('Authentication', `Bearer ${token.value}`)
-      .send({ forceRecreate: true });
+      .set('Authorization', `Bearer ${token.value}`)
+      .send({ forceRecreate: true })
+      .expect(200);
   });
 }


### PR DESCRIPTION
## Summary

Fixes #112647

First commit is ready for review from @elastic/kibana-security 

Allows the `elastic/fleet-server` user to call the required Fleet APIs to trigger the full setup process. This will be removed as part of #111858. 

**Fleet reviewers: you may skip the first commit if you'd like. It's a required change in the security plugin that has already been approved.**

### How to test this

The appropriate support for this available across all components now and this is the last piece. You can now test this end-to-end by:
1. Starting the latest Elasticsearch 8.0 snapshot
2. Start Kibana (with this branch or with a snapshot once merged)
3. Creating a service account token for elastic/fleet-server
	```http
	POST http://localhost:9200/_security/service/elastic/fleet-server/credential/token
	Authorization: Basic elastic:changeme
	```
4. Start Fleet Server using the service account token value:
	```sh
	docker run \
		-e KIBANA_HOST=http://<YOUR PRIVATE IP>:5601 \
		-e KIBANA_FLEET_SERVICE_TOKEN=<service token value from step 3> \
		-e ELASTICSEARCH_HOST=http://<YOUR PRIVATE IP>:9200 \
		-e KIBANA_FLEET_SETUP=1 \
		-e FLEET_SERVER_ENABLE=1 \
		-e FLEET_SERVER_INSECURE_HTTP=1 \
		-p 8220:8220 \
		docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
	```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
