### PR TITLE
[Stack Monitoring] update setup mode data when required

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
@@ -12,7 +12,11 @@ import { useTitle } from '../hooks/use_title';
 import { MonitoringToolbar } from '../../components/shared/toolbar';
 import { MonitoringTimeContainer } from '../hooks/use_monitoring_time';
 import { PageLoading } from '../../components';
-import { getSetupModeState, isSetupModeFeatureEnabled } from '../setup_mode/setup_mode';
+import {
+  getSetupModeState,
+  isSetupModeFeatureEnabled,
+  updateSetupModeData,
+} from '../setup_mode/setup_mode';
 import { SetupModeFeature } from '../../../common/enums';
 
 export interface TabMenuItem {
@@ -54,7 +58,12 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({
   }, [getPageData, currentTimerange]);
 
   const onRefresh = () => {
-    getPageData?.().catch((err) => {
+    const requests = [getPageData?.()];
+    if (isSetupModeFeatureEnabled(SetupModeFeature.MetricbeatMigration)) {
+      requests.push(updateSetupModeData());
+    }
+
+    Promise.allSettled(requests).then((results) => {
       // TODO: handle errors
     });
   };


### PR DESCRIPTION
## Summary

Context here https://github.com/elastic/kibana/issues/113873

### Testing
- verified `api/monitoring/v1/setup/collection/cluster/:id` was polled in setup mode
- created a legacy-monitored kibana instance, opened the setup mode panel and followed instructions. Ensured metricbeat data was detected and the ui was updated accordingly

<img width="1573" alt="Screenshot 2021-10-05 at 15 23 09" src="https://user-images.githubusercontent.com/5239883/136031994-61d280a0-d48c-4869-8e32-c65f1618c68f.png">


