### PR TITLE
fix(NA): @kbn/monaco types exports

### DIFF
--- a/packages/kbn-monaco/src/esql/index.ts
+++ b/packages/kbn-monaco/src/esql/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { LangModule as LangModuleType } from '../types';
+import { LangModuleType } from '../types';
 import { ID } from './constants';
 import { lexerRules } from './lexer_rules';
 

--- a/packages/kbn-monaco/src/helpers.ts
+++ b/packages/kbn-monaco/src/helpers.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import { monaco } from './monaco_imports';
-import { LangModule as LangModuleType } from './types';
+import { LangModuleType } from './types';
 
 function registerLanguage(language: LangModuleType) {
   const { ID, lexerRules, languageConfiguration } = language;

--- a/packages/kbn-monaco/src/index.ts
+++ b/packages/kbn-monaco/src/index.ts
@@ -11,14 +11,11 @@ import './register_globals';
 
 export { monaco } from './monaco_imports';
 export { XJsonLang } from './xjson';
-export { PainlessLang, PainlessContext, PainlessAutocompleteField } from './painless';
+export * from './painless';
 /* eslint-disable-next-line @kbn/eslint/module_migration */
 import * as BarePluginApi from 'monaco-editor/esm/vs/editor/editor.api';
 
 import { registerLanguage } from './helpers';
-import {
-  LangModule as LangModuleType,
-  CompleteLangModule as CompleteLangModuleType,
-} from './types';
 
-export { BarePluginApi, registerLanguage, LangModuleType, CompleteLangModuleType };
+export { BarePluginApi, registerLanguage };
+export * from './types';

--- a/packages/kbn-monaco/src/painless/index.ts
+++ b/packages/kbn-monaco/src/painless/index.ts
@@ -9,7 +9,7 @@
 import { ID } from './constants';
 import { lexerRules, languageConfiguration } from './lexer_rules';
 import { getSuggestionProvider, getSyntaxErrors } from './language';
-import { CompleteLangModule as CompleteLangModuleType } from '../types';
+import { CompleteLangModuleType } from '../types';
 
 export const PainlessLang: CompleteLangModuleType = {
   ID,
@@ -19,4 +19,4 @@ export const PainlessLang: CompleteLangModuleType = {
   getSyntaxErrors,
 };
 
-export { PainlessContext, PainlessAutocompleteField } from './types';
+export * from './types';

--- a/packages/kbn-monaco/src/types.ts
+++ b/packages/kbn-monaco/src/types.ts
@@ -7,7 +7,7 @@
  */
 import { monaco } from './monaco_imports';
 
-export interface LangModule {
+export interface LangModuleType {
   ID: string;
   lexerRules: monaco.languages.IMonarchLanguage;
   languageConfiguration?: monaco.languages.LanguageConfiguration;
@@ -15,7 +15,7 @@ export interface LangModule {
   getSyntaxErrors?: Function;
 }
 
-export interface CompleteLangModule extends LangModule {
+export interface CompleteLangModuleType extends LangModuleType {
   languageConfiguration: monaco.languages.LanguageConfiguration;
   getSuggestionProvider: Function;
   getSyntaxErrors: Function;

--- a/packages/kbn-monaco/src/xjson/index.ts
+++ b/packages/kbn-monaco/src/xjson/index.ts
@@ -12,6 +12,6 @@
 import './language';
 import { ID } from './constants';
 import { lexerRules, languageConfiguration } from './lexer_rules';
-import { LangModule as LangModuleType } from '../types';
+import { LangModuleType } from '../types';
 
 export const XJsonLang: LangModuleType = { ID, lexerRules, languageConfiguration };


### PR DESCRIPTION
This PR fixes the types export layout for `@kbn/monaco`. Currently and since we broke `kbn-ui-shared-deps` and moved into building the package with babel we were getting the following warnings during the build:

```
info [bazel] WARNING in /private/var/tmp/_bazel_/e81b6a886b074390725115607d34098d/sandbox/darwin-sandbox/138/execroot/kibana/node_modules/@kbn/monaco/target_web/index.js 18:0-83
 info [bazel] "export 'CompleteLangModule' (reexported as 'CompleteLangModuleType') was not found in './types'
 info [bazel]
 info [bazel] WARNING in /private/var/tmp/_bazel_/e81b6a886b074390725115607d34098d/sandbox/darwin-sandbox/138/execroot/kibana/node_modules/@kbn/monaco/target_web/index.js 18:0-83
 info [bazel] "export 'LangModule' (reexported as 'LangModuleType') was not found in './types'
 info [bazel]
 info [bazel] WARNING in /private/var/tmp/_bazel_/e81b6a886b074390725115607d34098d/sandbox/darwin-sandbox/138/execroot/kibana/node_modules/@kbn/monaco/target_web/painless/index.js 18:0-69
 info [bazel] "export 'PainlessAutocompleteField' was not found in './types'
 info [bazel]
 info [bazel] WARNING in /private/var/tmp/_bazel_/e81b6a886b074390725115607d34098d/sandbox/darwin-sandbox/138/execroot/kibana/node_modules/@kbn/monaco/target_web/painless/index.js 18:0-69
 info [bazel] "export 'PainlessContext' was not found in './types'
```

The current PR fixes the problem by removing the named exports from parts that will be removed by babel when transpiling the typescript files into `js`.