### PR TITLE
Add test to useRequest hook to verify ability to cancel poll.

### DIFF
--- a/src/plugins/es_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.test.ts
@@ -308,6 +308,24 @@ describe('useRequest hook', () => {
       expect(getSendRequestSpy().callCount).toBe(2);
     });
 
+    it(`changing pollIntervalMs to undefined cancels the poll`, async () => {
+      const { setupErrorRequest, setErrorResponse, completeRequest, getSendRequestSpy } = helpers;
+      // Send initial request.
+      setupErrorRequest({ pollIntervalMs: REQUEST_TIME });
+
+      // Setting the poll to undefined will cancel subsequent requests.
+      setErrorResponse({ pollIntervalMs: undefined });
+
+      // Complete initial request.
+      await completeRequest();
+
+      // If there were another scheduled poll request, this would complete it.
+      await completeRequest();
+
+      // But because we canceled the poll, we only see 1 request instead of 2.
+      expect(getSendRequestSpy().callCount).toBe(1);
+    });
+
     it('when the path changes after a request is scheduled, the scheduled request is sent with that path', async () => {
       const {
         setupSuccessRequest,


### PR DESCRIPTION
I noticed that this test case had been overlooked. It asserts that the correct way to cancel a polling `useRequest` is to set `pollIntervalMs` to `undefined`.