### PR TITLE
Removed unused transaction breakdown aggregation

### DIFF
--- a/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -24,7 +24,7 @@ import { getMetricsDateHistogramParams } from '../../helpers/metrics';
 import { MAX_KPIS } from './constants';
 import { getVizColorForIndex } from '../../../../common/viz_colors';
 
-export async function getTransactionBreakdown({
+export async function getSpanBreakdown({
   environment,
   kuery,
   setup,
@@ -49,11 +49,6 @@ export async function getTransactionBreakdown({
     sum_all_self_times: {
       sum: {
         field: SPAN_SELF_TIME_SUM,
-      },
-    },
-    total_transaction_breakdown_count: {
-      sum: {
-        field: TRANSACTION_BREAKDOWN_COUNT,
       },
     },
     types: {

--- a/x-pack/plugins/apm/server/routes/transactions.ts
+++ b/x-pack/plugins/apm/server/routes/transactions.ts
@@ -15,7 +15,7 @@ import { getSearchAggregatedTransactions } from '../lib/helpers/aggregated_trans
 import { setupRequest } from '../lib/helpers/setup_request';
 import { getServiceTransactionGroups } from '../lib/services/get_service_transaction_groups';
 import { getServiceTransactionGroupDetailedStatisticsPeriods } from '../lib/services/get_service_transaction_group_detailed_statistics';
-import { getTransactionBreakdown } from '../lib/transactions/breakdown';
+import { getSpanBreakdown } from '../lib/transactions/breakdown';
 import { getTransactionTraceSamples } from '../lib/transactions/trace_samples';
 import { getAnomalySeries } from '../lib/transactions/get_anomaly_data';
 import { getLatencyPeriods } from '../lib/transactions/get_latency_charts';
@@ -306,7 +306,7 @@ const transactionChartsBreakdownRoute = createApmServerRoute({
     const { environment, kuery, transactionName, transactionType, start, end } =
       params.query;
 
-    return getTransactionBreakdown({
+    return getSpanBreakdown({
       environment,
       kuery,
       serviceName,


### PR DESCRIPTION
fix #113901
Removed unused transaction breakdown aggregation

Renamed the function getTransactionBreakdown to getSpanBreakdown