### PR TITLE
[Security Solution] Uncomment missing feature privileges callout message

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/translations.tsx
@@ -56,7 +56,7 @@ export const missingPrivilegesCallOutBody = ({
 }: MissingPrivileges) => (
   <FormattedMessage
     id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail"
-    defaultMessage="{essence} {indexPrivileges} Related documentation: {docs}"
+    defaultMessage="{essence} {indexPrivileges} {featurePrivileges} Related documentation: {docs}"
     values={{
       essence: (
         <p>
@@ -77,30 +77,23 @@ export const missingPrivilegesCallOutBody = ({
               {indexPrivileges.map(([index, missingPrivileges]) => (
                 <li key={index}>{missingIndexPrivileges(index, missingPrivileges)}</li>
               ))}
-              {
-                // TODO: Uncomment once RBAC for alerts is reenabled
-                /* {featurePrivileges.map(([feature, missingPrivileges]) => (
-                <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
-              ))} */
-              }
             </ul>
           </>
         ) : null,
-      // TODO: Uncomment once RBAC for alerts is reenabled
-      // featurePrivileges:
-      //   featurePrivileges.length > 0 ? (
-      //     <>
-      //       <FormattedMessage
-      //         id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.featurePrivilegesTitle"
-      //         defaultMessage="Missing Kibana feature privileges:"
-      //       />
-      //       <ul>
-      //         {featurePrivileges.map(([feature, missingPrivileges]) => (
-      //           <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
-      //         ))}
-      //       </ul>
-      //     </>
-      //   ) : null,
+      featurePrivileges:
+        featurePrivileges.length > 0 ? (
+          <>
+            <FormattedMessage
+              id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.featurePrivilegesTitle"
+              defaultMessage="Missing Kibana feature privileges:"
+            />
+            <ul>
+              {featurePrivileges.map(([feature, missingPrivileges]) => (
+                <li key={feature}>{missingFeaturePrivileges(feature, missingPrivileges)}</li>
+              ))}
+            </ul>
+          </>
+        ) : null,
       docs: (
         <ul>
           <li>
@@ -159,15 +152,14 @@ const missingIndexPrivileges = (index: string, privileges: string[]) => (
   />
 );
 
-// TODO: Uncomment once RBAC for alerts is reenabled
-// const missingFeaturePrivileges = (feature: string, privileges: string[]) => (
-//   <FormattedMessage
-//     id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingFeaturePrivileges"
-//     defaultMessage="Missing {privileges} privileges for the {index} feature. {explanation}"
-//     values={{
-//       privileges: <CommaSeparatedValues values={privileges} />,
-//       index: <EuiCode>{feature}</EuiCode>,
-//       explanation: getPrivilegesExplanation(privileges, feature),
-//     }}
-//   />
-// );
+const missingFeaturePrivileges = (feature: string, privileges: string[]) => (
+  <FormattedMessage
+    id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingFeaturePrivileges"
+    defaultMessage="Missing {privileges} privileges for the {index} feature. {explanation}"
+    values={{
+      privileges: <CommaSeparatedValues values={privileges} />,
+      index: <EuiCode>{feature}</EuiCode>,
+      explanation: getPrivilegesExplanation(privileges, feature),
+    }}
+  />
+);


### PR DESCRIPTION
## Summary

Brought back the missing privileges callout message commented out in [this PR](https://github.com/elastic/kibana/pull/110472/files#diff-3137c70466ee9b05a428679ac9fd3e10152e8115554749126bc9d7aba61ded58R89). So users can see again what Kibana feature privileges they're missing.

**Before:**
![Screenshot 2021-10-05 at 17 47 04](https://user-images.githubusercontent.com/1938181/136057352-7e9e2dbb-80d7-4eaa-bb68-49f635391f38.png)

**After:**
![Screenshot 2021-10-05 at 17 16 37](https://user-images.githubusercontent.com/1938181/136056797-368f592a-dd41-444e-8ecd-b5bcb168ae59.png)
