### PR TITLE
[vscode] Set typescript.tsserver.maxTsServerMemory

### DIFF
--- a/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
+++ b/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
@@ -8,7 +8,7 @@
 
 export interface ManagedConfigKey {
   key: string;
-  value: string | Record<string, any> | boolean;
+  value: string | Record<string, any> | boolean | number;
 }
 
 /**
@@ -45,5 +45,9 @@ export const MANAGED_CONFIG_KEYS: ManagedConfigKey[] = [
   {
     key: 'typescript.enablePromptUseWorkspaceTsdk',
     value: true,
+  },
+  {
+    key: 'typescript.tsserver.maxTsServerMemory',
+    value: 4096,
   },
 ];

--- a/packages/kbn-dev-utils/src/vscode_config/update_vscode_config.ts
+++ b/packages/kbn-dev-utils/src/vscode_config/update_vscode_config.ts
@@ -69,13 +69,13 @@ const createObjectPropOfManagedValues = (key: string, value: Record<string, any>
 const addManagedProp = (
   ast: t.ObjectExpression,
   key: string,
-  value: string | Record<string, any> | boolean
+  value: string | Record<string, any> | boolean | number
 ) => {
-  ast.properties.push(
-    typeof value === 'string' || typeof value === 'boolean'
-      ? createManagedProp(key, value)
-      : createObjectPropOfManagedValues(key, value)
-  );
+  if (['number', 'string', 'bolean'].includes(typeof value)) {
+    ast.properties.push(createManagedProp(key, value));
+  } else {
+    ast.properties.push(createObjectPropOfManagedValues(key, value as Record<string, any>));
+  }
 };
 
 /**
@@ -89,7 +89,7 @@ const addManagedProp = (
 const replaceManagedProp = (
   ast: t.ObjectExpression,
   existing: BasicObjectProp,
-  value: string | Record<string, any> | boolean
+  value: string | Record<string, any> | boolean | number
 ) => {
   remove(ast.properties, existing);
   addManagedProp(ast, existing.key.value, value);

--- a/packages/kbn-dev-utils/src/vscode_config/update_vscode_config.ts
+++ b/packages/kbn-dev-utils/src/vscode_config/update_vscode_config.ts
@@ -71,7 +71,7 @@ const addManagedProp = (
   key: string,
   value: string | Record<string, any> | boolean | number
 ) => {
-  if (['number', 'string', 'bolean'].includes(typeof value)) {
+  if (['number', 'string', 'boolean'].includes(typeof value)) {
     ast.properties.push(createManagedProp(key, value));
   } else {
     ast.properties.push(createObjectPropOfManagedValues(key, value as Record<string, any>));


### PR DESCRIPTION
Sets `typescript.tsserver.maxTsServerMemory` to 4GB in attempt to keep Typescript from crashing.

You can see this from looking for `TSServer exited. Signal: SIGABRT` in the Typescript output within VSCode.

cc @smith @matschaffer 