### PR TITLE
[Canvas] Hide dashed border on embeddable panel

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.scss
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.scss
@@ -1,6 +1,7 @@
 .canvasEmbeddable {
   .embPanel {
     border: none;
+    border-style: none !important;
     background: none;
 
     .embPanel__title {


### PR DESCRIPTION
## Summary

Closes #113984.

This hides the dashed border surrounding embeddables in Canvas. Canvas already has it's own dashed border around selected elements, so we can just hide the one provided by the embeddable panel.

Before:
<img width="1444" alt="Screen Shot 2021-10-05 at 11 10 15 AM" src="https://user-images.githubusercontent.com/1697105/136079310-e4b5154a-156d-461a-a73e-f6085826977f.png">


After:
<img width="1442" alt="Screen Shot 2021-10-05 at 11 11 25 AM" src="https://user-images.githubusercontent.com/1697105/136079328-436c5ffa-6e9b-431d-9a3d-94b4fbd92708.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
