### PR TITLE
[Observability] [Exploratory View] Only show y axis label for a single series

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.test.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.test.ts
@@ -246,6 +246,24 @@ describe('Lens Attribute', () => {
     });
   });
 
+  it('should hide y axis when there are multiple series', function () {
+    const lensAttrWithMultiSeries = new LensAttributes([layerConfig, layerConfig]).getJSON() as any;
+    expect(lensAttrWithMultiSeries.state.visualization.axisTitlesVisibilitySettings).toEqual({
+      x: true,
+      yLeft: false,
+      yRight: false,
+    });
+  });
+
+  it('should show y axis when there is a single series', function () {
+    const lensAttrWithMultiSeries = new LensAttributes([layerConfig]).getJSON() as any;
+    expect(lensAttrWithMultiSeries.state.visualization.axisTitlesVisibilitySettings).toEqual({
+      x: true,
+      yLeft: true,
+      yRight: true,
+    });
+  });
+
   it('should return first layer', function () {
     expect(lnsAttr.getLayers()).toEqual({
       layer0: {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/lens_attributes.ts
@@ -98,6 +98,7 @@ export class LensAttributes {
   layers: Record<string, PersistedIndexPatternLayer>;
   visualization: XYState;
   layerConfigs: LayerConfig[];
+  isMultiSeries: boolean;
 
   constructor(layerConfigs: LayerConfig[]) {
     this.layers = {};
@@ -114,6 +115,7 @@ export class LensAttributes {
     });
 
     this.layerConfigs = layerConfigs;
+    this.isMultiSeries = layerConfigs.length > 1;
     this.layers = this.getLayers();
     this.visualization = this.getXyState();
   }
@@ -612,7 +614,11 @@ export class LensAttributes {
       valueLabels: 'hide',
       fittingFunction: 'Linear',
       curveType: 'CURVE_MONOTONE_X' as XYCurveType,
-      axisTitlesVisibilitySettings: { x: true, yLeft: true, yRight: true },
+      axisTitlesVisibilitySettings: {
+        x: true,
+        yLeft: !this.isMultiSeries,
+        yRight: !this.isMultiSeries,
+      },
       tickLabelsVisibilitySettings: { x: true, yLeft: true, yRight: true },
       gridlinesVisibilitySettings: { x: true, yLeft: true, yRight: true },
       preferredSeriesType: 'line',


### PR DESCRIPTION
## Summary
Fixes #113433

Removes y axis labels for more than one series
<img width="1735" alt="Screen Shot 2021-10-05 at 2 42 32 PM" src="https://user-images.githubusercontent.com/11356435/136083918-aedf5917-fe01-44f7-8afb-995ca1b0fb16.png">


### Testing
Navigate to exploratory view
Add a second series
Observe the y axis labels disappear
