### PR TITLE
[TSVB] Update copy for string indices setting popover

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/components/lib/index_pattern_select/switch_mode_popover.tsx
+++ b/src/plugins/vis_types/timeseries/public/application/components/lib/index_pattern_select/switch_mode_popover.tsx
@@ -57,7 +57,7 @@ export const SwitchModePopover = ({ onModeChange, useKibanaIndices }: PopoverPro
     allowStringIndicesLabel = (
       <FormattedMessage
         id="visTypeTimeseries.indexPatternSelect.switchModePopover.enableAllowStringIndices"
-        defaultMessage="To search by Elasticsearch indices enable {allowStringIndices} setting."
+        defaultMessage="To query Elasticsearch indices, you must enable the {allowStringIndices} setting."
         values={{
           allowStringIndices: canEditAdvancedSettings ? (
             <EuiLink color="accent" onClick={handleAllowStringIndicesLinkClick}>


### PR DESCRIPTION
## Summary

The TSVB data view popover includes additional copy if the **Allow string indices in TSVB** Kibana setting is disabled (the default). This updates the copy to better align with changes in https://github.com/elastic/kibana/pull/110253.

<img width="621" alt="Screen Shot 2021-10-05 at 2 48 35 PM" src="https://user-images.githubusercontent.com/40268737/136084865-3aec0218-2a63-4853-a2a0-a535894e32fb.PNG">

### Testing instructions

1. In terminal, run `yarn es snapshot --license=trial`.
2. In a new terminal session, run `yarn start`.
3. Open Kibana, click **Try sample data**, and add the sample web logs data.
4. In the main menu, click **Dashboard**.
5. From the **All types** drop-down, select **TSVB**.
6. Click **Panel Options**. Click the gear icon in the **Data view** drop-down.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)


