### PR TITLE
[7.15] [Fleet] Fix Step 1 in policy editor not loading when agent policy already contains a limited integration (#113883)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/hooks/use_breadcrumbs.tsx
@@ -64,24 +64,6 @@ const breadcrumbGetters: {
     },
     { text: policyName },
   ],
-  add_integration_from_policy: ({ policyName, policyId }) => [
-    BASE_BREADCRUMB,
-    {
-      href: pagePathGetters.policies()[1],
-      text: i18n.translate('xpack.fleet.breadcrumbs.policiesPageTitle', {
-        defaultMessage: 'Agent policies',
-      }),
-    },
-    {
-      href: pagePathGetters.policy_details({ policyId })[1],
-      text: policyName,
-    },
-    {
-      text: i18n.translate('xpack.fleet.breadcrumbs.addPackagePolicyPageTitle', {
-        defaultMessage: 'Add integration',
-      }),
-    },
-  ],
   add_integration_to_policy: ({ pkgTitle, pkgkey, integration }) => [
     INTEGRATIONS_BASE_BREADCRUMB,
     {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -48,7 +48,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
     'data-test-subj': dataTestSubj,
     tabs = [],
   }) => {
-    const isAdd = useMemo(() => ['policy', 'package'].includes(from), [from]);
+    const isAdd = useMemo(() => ['package'].includes(from), [from]);
     const isEdit = useMemo(() => ['edit', 'package-edit'].includes(from), [from]);
     const isUpgrade = useMemo(
       () =>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -81,10 +81,9 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
 
   const { search } = useLocation();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
-  const queryParamsPolicyId = useMemo(
-    () => queryParams.get('policyId') ?? undefined,
-    [queryParams]
-  );
+  const queryParamsPolicyId = useMemo(() => queryParams.get('policyId') ?? undefined, [
+    queryParams,
+  ]);
 
   /**
    * Please note: policyId can come from one of two sources. The URL param (in the URL path) or

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -81,9 +81,10 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
 
   const { search } = useLocation();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
-  const queryParamsPolicyId = useMemo(() => queryParams.get('policyId') ?? undefined, [
-    queryParams,
-  ]);
+  const queryParamsPolicyId = useMemo(
+    () => queryParams.get('policyId') ?? undefined,
+    [queryParams]
+  );
 
   /**
    * Please note: policyId can come from one of two sources. The URL param (in the URL path) or
@@ -233,8 +234,8 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
     }
     return from === 'policy' && agentPolicyId
       ? getHref('policy_details', {
-        policyId: agentPolicyId,
-      })
+          policyId: agentPolicyId,
+        })
       : getHref('integration_details_overview', { pkgkey: params.pkgkey });
   }, [routeState, from, agentPolicyId, getHref, params.pkgkey]);
 
@@ -306,16 +307,16 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
         }),
         text: fromPolicyWithoutAgentsAssigned
           ? i18n.translate(
-            'xpack.fleet.createPackagePolicy.policyContextAddAgentNextNotificationMessage',
-            {
-              defaultMessage: `The policy has been updated. Add an agent to the '{agentPolicyName}' policy to deploy this policy.`,
-              values: {
-                agentPolicyName: agentPolicy!.name,
-              },
-            }
-          )
+              'xpack.fleet.createPackagePolicy.policyContextAddAgentNextNotificationMessage',
+              {
+                defaultMessage: `The policy has been updated. Add an agent to the '{agentPolicyName}' policy to deploy this policy.`,
+                values: {
+                  agentPolicyName: agentPolicy!.name,
+                },
+              }
+            )
           : fromPackageWithoutAgentsAssigned
-            ? toMountPoint(
+          ? toMountPoint(
               // To render the link below we need to mount this JSX in the success toast
               <FormattedMessage
                 id="xpack.fleet.createPackagePolicy.integrationsContextaddAgentNextNotificationMessage"
@@ -337,14 +338,14 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
                 }}
               />
             )
-            : hasAgentsAssigned
-              ? i18n.translate('xpack.fleet.createPackagePolicy.addedNotificationMessage', {
-                defaultMessage: `Fleet will deploy updates to all agents that use the '{agentPolicyName}' policy.`,
-                values: {
-                  agentPolicyName: agentPolicy!.name,
-                },
-              })
-              : undefined,
+          : hasAgentsAssigned
+          ? i18n.translate('xpack.fleet.createPackagePolicy.addedNotificationMessage', {
+              defaultMessage: `Fleet will deploy updates to all agents that use the '{agentPolicyName}' policy.`,
+              values: {
+                agentPolicyName: agentPolicy!.name,
+              },
+            })
+          : undefined,
         'data-test-subj': 'packagePolicyCreateSuccessToast',
       });
     } else {
@@ -374,8 +375,8 @@ export const CreatePackagePolicyPage: React.FunctionComponent = () => {
     () =>
       (params as AddToPolicyParams).integration
         ? packageInfo?.policy_templates?.find(
-          (policyTemplate) => policyTemplate.name === (params as AddToPolicyParams).integration
-        )
+            (policyTemplate) => policyTemplate.name === (params as AddToPolicyParams).integration
+          )
         : undefined,
     [packageInfo?.policy_templates, params]
   );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_define_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_define_package_policy.tsx
@@ -47,7 +47,7 @@ const FormGroupResponsiveFields = styled(EuiDescribedFormGroup)`
 `;
 
 export const StepDefinePackagePolicy: React.FunctionComponent<{
-  agentPolicy: AgentPolicy;
+  agentPolicy?: AgentPolicy;
   packageInfo: PackageInfo;
   packagePolicy: NewPackagePolicy;
   integrationToEnable?: string;
@@ -92,15 +92,17 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
       if (currentPkgKey !== pkgKey) {
         // Existing package policies on the agent policy using the package name, retrieve highest number appended to package policy name
         const pkgPoliciesNamePattern = new RegExp(`${packageInfo.name}-(\\d+)`);
-        const pkgPoliciesWithMatchingNames = (agentPolicy.package_policies as PackagePolicy[])
-          .filter((ds) => Boolean(ds.name.match(pkgPoliciesNamePattern)))
-          .map((ds) => parseInt(ds.name.match(pkgPoliciesNamePattern)![1], 10))
-          .sort((a, b) => a - b);
+        const pkgPoliciesWithMatchingNames = agentPolicy
+          ? (agentPolicy.package_policies as PackagePolicy[])
+              .filter((ds) => Boolean(ds.name.match(pkgPoliciesNamePattern)))
+              .map((ds) => parseInt(ds.name.match(pkgPoliciesNamePattern)![1], 10))
+              .sort((a, b) => a - b)
+          : [];
 
         updatePackagePolicy(
           packageToPackagePolicy(
             packageInfo,
-            agentPolicy.id,
+            agentPolicy?.id || '',
             packagePolicy.output_id,
             packagePolicy.namespace,
             `${packageInfo.name}-${
@@ -115,7 +117,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
       }
 
       // If agent policy has changed, update package policy's agent policy ID and namespace
-      if (packagePolicy.policy_id !== agentPolicy.id) {
+      if (agentPolicy && packagePolicy.policy_id !== agentPolicy.id) {
         updatePackagePolicy({
           policy_id: agentPolicy.id,
           namespace: agentPolicy.namespace,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_agent_policy.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -26,7 +26,6 @@ import { Error } from '../../../components';
 import type { AgentPolicy, PackageInfo, GetAgentPoliciesResponseItem } from '../../../types';
 import { isPackageLimited, doesAgentPolicyAlreadyIncludePackage } from '../../../services';
 import {
-  useGetPackageInfoByKey,
   useGetAgentPolicies,
   sendGetOneAgentPolicy,
   useCapabilities,
@@ -41,19 +40,17 @@ const AgentPolicyFormRow = styled(EuiFormRow)`
 `;
 
 export const StepSelectAgentPolicy: React.FunctionComponent<{
-  pkgkey: string;
-  updatePackageInfo: (packageInfo: PackageInfo | undefined) => void;
+  packageInfo?: PackageInfo;
   defaultAgentPolicyId?: string;
   agentPolicy: AgentPolicy | undefined;
   updateAgentPolicy: (agentPolicy: AgentPolicy | undefined) => void;
-  setIsLoadingSecondStep: (isLoading: boolean) => void;
+  setHasAgentPolicyError: (hasError: boolean) => void;
 }> = ({
-  pkgkey,
-  updatePackageInfo,
+  packageInfo,
   agentPolicy,
   updateAgentPolicy,
-  setIsLoadingSecondStep,
   defaultAgentPolicyId,
+  setHasAgentPolicyError,
 }) => {
   const { isReady: isFleetReady } = useFleetStatus();
 
@@ -68,14 +65,6 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
   const [isCreateAgentPolicyFlyoutOpen, setIsCreateAgentPolicyFlyoutOpen] = useState<boolean>(
     false
   );
-
-  // Fetch package info
-  const {
-    data: packageInfoData,
-    error: packageInfoError,
-    isLoading: isPackageInfoLoading,
-  } = useGetPackageInfoByKey(pkgkey);
-  const isLimitedPackage = (packageInfoData && isPackageLimited(packageInfoData.response)) || false;
 
   // Fetch agent policies info
   const {
@@ -102,18 +91,19 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
     }, {});
   }, [agentPolicies]);
 
-  // Update parent package state
-  useEffect(() => {
-    if (packageInfoData && packageInfoData.response) {
-      updatePackageInfo(packageInfoData.response);
-    }
-  }, [packageInfoData, updatePackageInfo]);
+  const doesAgentPolicyHaveLimitedPackage = useCallback(
+    (policy: AgentPolicy, pkgInfo: PackageInfo) => {
+      return policy
+        ? isPackageLimited(pkgInfo) && doesAgentPolicyAlreadyIncludePackage(policy, pkgInfo.name)
+        : false;
+    },
+    []
+  );
 
   // Update parent selected agent policy state
   useEffect(() => {
     const fetchAgentPolicyInfo = async () => {
       if (selectedPolicyId) {
-        setIsLoadingSecondStep(true);
         const { data, error } = await sendGetOneAgentPolicy(selectedPolicyId);
         if (error) {
           setSelectedAgentPolicyError(error);
@@ -126,39 +116,36 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
         setSelectedAgentPolicyError(undefined);
         updateAgentPolicy(undefined);
       }
-      setIsLoadingSecondStep(false);
     };
     if (!agentPolicy || selectedPolicyId !== agentPolicy.id) {
       fetchAgentPolicyInfo();
     }
-  }, [selectedPolicyId, agentPolicy, updateAgentPolicy, setIsLoadingSecondStep]);
+  }, [selectedPolicyId, agentPolicy, updateAgentPolicy]);
 
   const agentPolicyOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(
     () =>
-      packageInfoData
+      packageInfo
         ? agentPolicies.map((agentConf) => {
-            const alreadyHasLimitedPackage =
-              (isLimitedPackage &&
-                doesAgentPolicyAlreadyIncludePackage(agentConf, packageInfoData.response.name)) ||
-              false;
             return {
               label: agentConf.name,
               value: agentConf.id,
-              disabled: alreadyHasLimitedPackage,
+              disabled: doesAgentPolicyHaveLimitedPackage(agentConf, packageInfo),
               'data-test-subj': 'agentPolicyItem',
             };
           })
         : [],
-    [agentPolicies, isLimitedPackage, packageInfoData]
+    [agentPolicies, doesAgentPolicyHaveLimitedPackage, packageInfo]
   );
 
-  const selectedAgentPolicyOption = agentPolicyOptions.find(
-    (option) => option.value === selectedPolicyId
+  const selectedAgentPolicyOption = useMemo(
+    () => agentPolicyOptions.find((option) => option.value === selectedPolicyId),
+    [agentPolicyOptions, selectedPolicyId]
   );
 
   // Try to select default agent policy
   useEffect(() => {
     if (!selectedPolicyId && agentPolicies.length && agentPolicyOptions.length) {
+      const firstEnabledOption = agentPolicyOptions.find((option) => !option.disabled);
       const defaultAgentPolicy = agentPolicies.find((policy) => policy.is_default);
       if (defaultAgentPolicy) {
         const defaultAgentPolicyOption = agentPolicyOptions.find(
@@ -166,25 +153,33 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
         );
         if (defaultAgentPolicyOption && !defaultAgentPolicyOption.disabled) {
           setSelectedPolicyId(defaultAgentPolicy.id);
+        } else {
+          if (firstEnabledOption) {
+            setSelectedPolicyId(firstEnabledOption.value);
+          }
         }
+      } else if (firstEnabledOption) {
+        setSelectedPolicyId(firstEnabledOption.value);
       }
     }
   }, [agentPolicies, agentPolicyOptions, selectedPolicyId]);
 
-  // Display package error if there is one
-  if (packageInfoError) {
-    return (
-      <Error
-        title={
-          <FormattedMessage
-            id="xpack.fleet.createPackagePolicy.StepSelectPolicy.errorLoadingPackageTitle"
-            defaultMessage="Error loading package information"
-          />
-        }
-        error={packageInfoError}
-      />
-    );
-  }
+  // Bubble up any issues with agent policy selection
+  useEffect(() => {
+    if (
+      selectedPolicyId &&
+      !selectedAgentPolicyError &&
+      selectedAgentPolicyOption &&
+      !selectedAgentPolicyOption.disabled
+    ) {
+      setHasAgentPolicyError(false);
+    } else setHasAgentPolicyError(true);
+  }, [
+    selectedAgentPolicyError,
+    selectedAgentPolicyOption,
+    selectedPolicyId,
+    setHasAgentPolicyError,
+  ]);
 
   // Display agent policies list error if there is one
   if (agentPoliciesError) {
@@ -277,6 +272,27 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                   />
                 ) : null
               }
+              isInvalid={Boolean(
+                !selectedPolicyId ||
+                  !packageInfo ||
+                  doesAgentPolicyHaveLimitedPackage(
+                    agentPoliciesById[selectedPolicyId],
+                    packageInfo
+                  )
+              )}
+              error={
+                !selectedPolicyId ? (
+                  <FormattedMessage
+                    id="xpack.fleet.createPackagePolicy.StepSelectPolicy.noPolicySelectedError"
+                    defaultMessage="An agent policy is required."
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.fleet.createPackagePolicy.StepSelectPolicy.cannotAddLimitedIntegrationError"
+                    defaultMessage="This integration can only be added once per agent policy."
+                  />
+                )
+              }
             >
               <EuiComboBox
                 placeholder={i18n.translate(
@@ -288,7 +304,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 singleSelection={{ asPlainText: true }}
                 isClearable={false}
                 fullWidth={true}
-                isLoading={isAgentPoliciesLoading || isPackageInfoLoading}
+                isLoading={isAgentPoliciesLoading || !packageInfo}
                 options={agentPolicyOptions}
                 selectedOptions={selectedAgentPolicyOption ? [selectedAgentPolicyOption] : []}
                 onChange={(options) => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/index.tsx
@@ -15,7 +15,6 @@ import { DefaultLayout } from '../../layouts';
 
 import { AgentPolicyListPage } from './list_page';
 import { AgentPolicyDetailsPage } from './details_page';
-import { CreatePackagePolicyPage } from './create_package_policy_page';
 import { EditPackagePolicyPage } from './edit_package_policy_page';
 import { UpgradePackagePolicyPage } from './upgrade_package_policy_page';
 
@@ -31,9 +30,6 @@ export const AgentPolicyApp: React.FunctionComponent = () => {
         </Route>
         <Route path={FLEET_ROUTING_PATHS.upgrade_package_policy}>
           <UpgradePackagePolicyPage />
-        </Route>
-        <Route path={FLEET_ROUTING_PATHS.add_integration_from_policy}>
-          <CreatePackagePolicyPage />
         </Route>
         <Route path={FLEET_ROUTING_PATHS.policy_details}>
           <AgentPolicyDetailsPage />

--- a/x-pack/plugins/fleet/public/constants/page_paths.ts
+++ b/x-pack/plugins/fleet/public/constants/page_paths.ts
@@ -26,7 +26,6 @@ export type DynamicPage =
   | 'integration_details_custom'
   | 'integration_policy_edit'
   | 'policy_details'
-  | 'add_integration_from_policy'
   | 'add_integration_to_policy'
   | 'edit_integration'
   | 'upgrade_package_policy'
@@ -56,8 +55,6 @@ export const FLEET_ROUTING_PATHS = {
   policy_details_settings: '/policies/:policyId/settings',
   edit_integration: '/policies/:policyId/edit-integration/:packagePolicyId',
   upgrade_package_policy: '/policies/:policyId/upgrade-package-policy/:packagePolicyId',
-  // TODO: Review uses and remove if it is no longer used or linked to in any UX flows
-  add_integration_from_policy: '/policies/:policyId/add-integration',
   enrollment_tokens: '/enrollment-tokens',
   data_streams: '/data-streams',
 
@@ -118,11 +115,6 @@ export const pagePathGetters: {
   policy_details: ({ policyId, tabId }) => [
     FLEET_BASE_PATH,
     `/policies/${policyId}${tabId ? `/${tabId}` : ''}`,
-  ],
-  // TODO: This might need to be removed because we do not have a way to pick an integration in line anymore
-  add_integration_from_policy: ({ policyId }) => [
-    FLEET_BASE_PATH,
-    `/policies/${policyId}/add-integration`,
   ],
   add_integration_to_policy: ({ pkgkey, integration, agentPolicyId }) => [
     FLEET_BASE_PATH,


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [Fleet] Fix Step 1 in policy editor not loading when agent policy already contains a limited integration (#113883)