### PR TITLE
docs: remove link to APM Server

### DIFF
--- a/docs/apm/troubleshooting.asciidoc
+++ b/docs/apm/troubleshooting.asciidoc
@@ -72,8 +72,6 @@ then the index template will not be set up automatically. Instead, you'll need t
 
 *Using a custom index names*
 This problem can also occur if you've customized the index name that you write APM data to.
-The default index name that APM writes events to can be found
-{apm-server-ref}/elasticsearch-output.html#index-option-es[here].
 If you change the default, you must also configure the `setup.template.name` and `setup.template.pattern` options.
 See {apm-server-ref}/configuration-template.html[Load the Elasticsearch index template].
 If the Elasticsearch index template has already been successfully loaded to the index,


### PR DESCRIPTION
Temporarily removes a link that is blocking https://github.com/elastic/apm-server/pull/6287.