### PR TITLE
[proposal] Multi-card treatment for Replacements

### DIFF
--- a/src/plugins/custom_integrations/common/index.ts
+++ b/src/plugins/custom_integrations/common/index.ts
@@ -14,8 +14,40 @@ export interface IntegrationCategoryCount {
   id: IntegrationCategory;
 }
 
-export const INTEGRATION_CATEGORY_DISPLAY = {
-  // Known EPR
+export const category = [
+  'aws',
+  'azure',
+  'cloud',
+  'config_management',
+  'containers',
+  'crm',
+  'custom',
+  'datastore',
+  'elastic_stack',
+  'google_cloud',
+  'kubernetes',
+  'languages',
+  'language_client',
+  'message_queue',
+  'monitoring',
+  'network',
+  'notification',
+  'os_system',
+  'productivity',
+  'security',
+  'sample_data',
+  'support',
+  'ticketing',
+  'version_control',
+  'web',
+  'upload_file',
+  'updates_available',
+] as const;
+
+export type IntegrationCategory = typeof category[number];
+
+// TODO: consider i18n
+export const INTEGRATION_CATEGORY_DISPLAY: { [K in IntegrationCategory]: string } = {
   aws: 'AWS',
   azure: 'Azure',
   cloud: 'Cloud',
@@ -49,8 +81,16 @@ export const INTEGRATION_CATEGORY_DISPLAY = {
   updates_available: 'Updates available',
 };
 
-export type IntegrationCategory = keyof typeof INTEGRATION_CATEGORY_DISPLAY;
+export const shipper = ['beats', 'tutorial', 'sample_data'] as const;
 
+export type Shipper = typeof shipper[number];
+
+// TODO: consider i18n
+export const SHIPPER_DISPLAY: { [K in Shipper]: string } = {
+  beats: 'Beats',
+  tutorial: 'Tutorials',
+  sample_data: 'Sample data',
+};
 export interface CustomIntegrationIcon {
   src: string;
   type: 'eui' | 'svg';
@@ -65,7 +105,7 @@ export interface CustomIntegration {
   isBeta: boolean;
   icons: CustomIntegrationIcon[];
   categories: IntegrationCategory[];
-  shipper: string;
+  shipper: Shipper;
   eprOverlap?: string; // name of the equivalent Elastic Agent integration in EPR. e.g. a beat module can correspond to an EPR-package, or an APM-tutorial. When completed, Integrations-UX can preferentially show the EPR-package, rather than the custom-integration
 }
 

--- a/src/plugins/custom_integrations/public/components/replacement_card/replacement_card.component.tsx
+++ b/src/plugins/custom_integrations/public/components/replacement_card/replacement_card.component.tsx
@@ -23,38 +23,73 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { CustomIntegration } from '../../../common';
+import { FC } from 'react';
+import { CustomIntegration, Shipper, SHIPPER_DISPLAY } from '../../../common';
 import { usePlatformService } from '../../services';
 
 export interface Props {
   replacements: Array<Pick<CustomIntegration, 'id' | 'uiInternalPath' | 'title'>>;
+  shipper: Shipper;
 }
 
 // TODO - clintandrewhall: should use doc-links service
 const URL_COMPARISON = 'https://ela.st/beats-agent-comparison';
 
 const idGenerator = htmlIdGenerator('replacementCard');
-const alsoAvailable = i18n.translate('customIntegrations.components.replacementAccordionLabel', {
-  defaultMessage: 'Also available in Beats',
-});
 
-const link = (
-  <EuiLink
-    href={URL_COMPARISON}
-    data-test-subj="customIntegrationsBeatsAgentComparisonLink"
-    external
-  >
+const getAlsoAvailable = (shipper: Shipper) =>
+  i18n.translate('customIntegrations.components.replacementAccordionLabel', {
+    defaultMessage: 'Also available in {shipper}',
+    values: {
+      shipper: SHIPPER_DISPLAY[shipper],
+    },
+  });
+
+const messages: { [key in Shipper]: FC } = {
+  beats: () => {
+    const link = (
+      <EuiLink
+        href={URL_COMPARISON}
+        data-test-subj="customIntegrationsBeatsAgentComparisonLink"
+        external
+      >
+        <FormattedMessage
+          id="customIntegrations.components.replacementAccordion.comparisonPageLinkLabel"
+          defaultMessage="comparison page"
+        />
+      </EuiLink>
+    );
+
+    return (
+      <FormattedMessage
+        id="customIntegrations.components.replacementAccordion.beatsDescription"
+        defaultMessage="Elastic Agent Integrations are recommended, but you can also use {beats}. For more
+      details, check out our {link}."
+        values={{
+          beats: SHIPPER_DISPLAY.beats,
+          link,
+        }}
+      />
+    );
+  },
+  sample_data: () => (
     <FormattedMessage
-      id="customIntegrations.components.replacementAccordion.comparisonPageLinkLabel"
-      defaultMessage="comparison page"
+      id="customIntegrations.components.replacementAccordion.sampleDataDescription"
+      defaultMessage="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
     />
-  </EuiLink>
-);
+  ),
+  tutorial: () => (
+    <FormattedMessage
+      id="customIntegrations.components.replacementAccordion.sampleDataDescription"
+      defaultMessage="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+    />
+  ),
+};
 
 /**
  * A pure component, an accordion panel which can display information about replacements for a given EPR module.
  */
-export const ReplacementCard = ({ replacements }: Props) => {
+export const ReplacementCard = ({ replacements, shipper }: Props) => {
   const { euiTheme } = useEuiTheme();
   const { getAbsolutePath } = usePlatformService();
 
@@ -77,9 +112,14 @@ export const ReplacementCard = ({ replacements }: Props) => {
     </EuiFlexItem>
   ));
 
+  const Message = messages[shipper];
+
   return (
     <div
       css={css`
+        & + & {
+          margin-top: ${euiTheme.size.s};
+        }
         & .euiAccordion__button {
           color: ${euiTheme.colors.link};
         }
@@ -88,19 +128,12 @@ export const ReplacementCard = ({ replacements }: Props) => {
         }
       `}
     >
-      <EuiAccordion id={idGenerator()} buttonContent={alsoAvailable} paddingSize="none">
+      <EuiAccordion id={idGenerator()} buttonContent={getAlsoAvailable(shipper)} paddingSize="none">
         <EuiPanel color="subdued" hasShadow={false} paddingSize="m">
           <EuiFlexGroup direction="column" gutterSize="m">
             <EuiFlexItem>
               <EuiText size="s">
-                <FormattedMessage
-                  id="customIntegrations.components.replacementAccordion.recommendationDescription"
-                  defaultMessage="Elastic Agent Integrations are recommended, but you can also use Beats. For more
-      details, check out our {link}."
-                  values={{
-                    link,
-                  }}
-                />
+                <Message />
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem>

--- a/src/plugins/custom_integrations/public/components/replacement_card/replacement_card.stories.tsx
+++ b/src/plugins/custom_integrations/public/components/replacement_card/replacement_card.stories.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 
+import { Shipper, shipper } from '../../../common';
 import { ReplacementCard as ConnectedComponent } from './replacement_card';
 import { ReplacementCard as PureComponent } from './replacement_card.component';
 
@@ -34,23 +35,31 @@ export default {
 
 interface Args {
   eprPackageName: string;
+  shipper: Shipper;
 }
 
 const args: Args = {
   eprPackageName: 'nginx',
+  shipper: 'beats',
 };
 
 const argTypes = {
   eprPackageName: {
     control: {
       type: 'radio',
-      options: ['nginx', 'okta', 'aws', 'apache'],
+      options: ['nginx', 'okta', 'aws', 'apm'],
+    },
+  },
+  shipper: {
+    control: {
+      type: 'radio',
+      options: shipper,
     },
   },
 };
 
-export function ReplacementCard({ eprPackageName }: Args) {
-  return <ConnectedComponent {...{ eprPackageName }} />;
+export function ReplacementCard(storyArgs: Args) {
+  return <ConnectedComponent {...storyArgs} />;
 }
 
 ReplacementCard.args = args;
@@ -63,6 +72,35 @@ export function Component() {
         { id: 'foo', title: 'Foo', uiInternalPath: '#' },
         { id: 'bar', title: 'Bar', uiInternalPath: '#' },
       ]}
+      shipper="beats"
     />
+  );
+}
+
+export function MultiCardTreatment() {
+  return (
+    <>
+      <PureComponent
+        shipper="beats"
+        replacements={[
+          { id: 'foo', title: 'Foo', uiInternalPath: '#' },
+          { id: 'bar', title: 'Bar', uiInternalPath: '#' },
+        ]}
+      />
+      <PureComponent
+        shipper="tutorial"
+        replacements={[
+          { id: 'foo', title: 'Foo', uiInternalPath: '#' },
+          { id: 'bar', title: 'Bar', uiInternalPath: '#' },
+        ]}
+      />
+      <PureComponent
+        shipper="sample_data"
+        replacements={[
+          { id: 'foo', title: 'Foo', uiInternalPath: '#' },
+          { id: 'bar', title: 'Bar', uiInternalPath: '#' },
+        ]}
+      />
+    </>
   );
 }

--- a/src/plugins/custom_integrations/public/components/replacement_card/replacement_card.tsx
+++ b/src/plugins/custom_integrations/public/components/replacement_card/replacement_card.tsx
@@ -8,21 +8,23 @@
 
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
+import type { Shipper } from '../../../common';
 import { useFindService } from '../../services';
 
 import { ReplacementCard as Component } from './replacement_card.component';
 
 export interface Props {
   eprPackageName: string;
+  shipper: Shipper;
 }
 
 /**
  * A data-connected component which can query about Beats-based replacement options for a given EPR module.
  */
-export const ReplacementCard = ({ eprPackageName }: Props) => {
+export const ReplacementCard = ({ eprPackageName, shipper }: Props) => {
   const { findReplacementIntegrations } = useFindService();
   const integrations = useAsync(async () => {
-    return await findReplacementIntegrations({ shipper: 'beats', eprPackageName });
+    return await findReplacementIntegrations({ eprPackageName, shipper });
   }, [eprPackageName]);
 
   const { loading, value: replacements } = integrations;
@@ -31,5 +33,5 @@ export const ReplacementCard = ({ eprPackageName }: Props) => {
     return null;
   }
 
-  return <Component {...{ replacements }} />;
+  return <Component {...{ replacements, shipper }} />;
 };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
@@ -211,7 +211,9 @@ export const Details: React.FC<Props> = memo(({ packageInfo }) => {
           <EuiDescriptionList type="column" compressed listItems={listItems} />
         </EuiFlexItem>
         <Replacements>
-          <ReplacementCard eprPackageName={packageInfo.name} />
+          <ReplacementCard eprPackageName={packageInfo.name} shipper="beats" />
+          <ReplacementCard eprPackageName={packageInfo.name} shipper="tutorial" />
+          <ReplacementCard eprPackageName={packageInfo.name} shipper="sample_data" />
         </Replacements>
       </EuiFlexGroup>
     </>


### PR DESCRIPTION
## Summary

> Draft PR for gathering feedback from relative product, design and engineering stakeholders.  The code is nearly production ready, but also needs copy.  It will either be abandoned or iterated upon and submitted for review.
>
> This is one idea of two.  Feedback and pulls welcome!

### The Problem

We've created a "replacement" accordion in Fleet for when an Integration has available Beats to consider.  From the standpoint of `custom_integrations`, Beats is just one "shipper" that can have a matching alternative.

### This PR

This is a proposal where we can include more than one accordion on an Integration page:

<img width="739" alt="Screen Shot 2021-10-05 at 7 55 36 PM" src="https://user-images.githubusercontent.com/297604/136124321-6022b77a-0f42-4307-9b34-e0c5a7e3a6c6.png">
<img width="719" alt="Screen Shot 2021-10-05 at 7 55 49 PM" src="https://user-images.githubusercontent.com/297604/136124322-6c8e6e64-2f32-46ef-8ec9-bd902d469a7d.png">

I'd add a wrapping component to take the results and output the accordions, rather than enumerate them.

### To Test

Once CI completes the Storybook build, go to "Storybook Preview" -> "custom_integrations" -> "Replacement Card" -> "Multi Card Treatment"