### PR TITLE
[DOCS/7.14] Remove release note for relative time fix on Discover

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -97,7 +97,6 @@ Dashboard::
 * Read App State from URL on Soft Refresh {kibana-pull}109354[#109354]
 Discover::
 * Fixes opening the same saved search {kibana-pull}111127[#111127]
-* Fixes export that does not contain relative time filter {kibana-pull}110459[#110459]
 * Fixes cleaning error state in 7.14 {kibana-pull}110036[#110036]
 * Fixes performance regression in sidebar {kibana-pull}109999[#109999]
 Elastic Security::


### PR DESCRIPTION
## Summary

Since https://github.com/elastic/kibana/pull/110459 missed 7.14.2 we should remove this associated release note from the 7.14.2 fixes and add it to 7.14.3 release notes instead (if there will be one).

Partial revert of https://github.com/elastic/kibana/pull/112310.