### PR TITLE
[6.8] Bump prismjs from 1.24.0 to 1.25.0 (#113388)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "**/istanbul-instrumenter-loader/schema-utils": "1.0.0",
     "**/load-grunt-config/js-yaml": "^3.13.1",
     "**/minimist": "^1.2.5",
+    "**/refractor/prismjs": "~1.25.0",
     "**/request": "^2.88.2",
     "**/sass-graph/yargs/yargs-parser": "5.0.0-security.0",
     "**/terser-webpack-plugin/serialize-javascript": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17005,10 +17005,10 @@ pretty-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.21.0, prismjs@~1.24.0:
-  version "1.24.1"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
-  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
+prismjs@^1.21.0, prismjs@~1.24.0, prismjs@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
+  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
 
 private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Bump prismjs from 1.24.0 to 1.25.0 (#113388)