### PR TITLE
[Metrics UI] Fix metric threshold alert reason message for gte/lte comparator

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/common/messages.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/common/messages.ts
@@ -62,9 +62,13 @@ const comparatorToI18n = (comparator: Comparator, threshold: number[], currentVa
       return ltText;
     case Comparator.GT_OR_EQ:
     case Comparator.LT_OR_EQ: {
-      if (threshold[0] === currentValue) return eqText;
-      else if (threshold[0] < currentValue) return ltText;
-      return gtText;
+      if (threshold[0] === currentValue) {
+        return eqText;
+      } else if (threshold[0] > currentValue) {
+        return ltText;
+      } else {
+        return gtText;
+      }
     }
   }
 };

--- a/x-pack/plugins/infra/server/lib/alerting/common/messages.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/common/messages.ts
@@ -62,9 +62,9 @@ const comparatorToI18n = (comparator: Comparator, threshold: number[], currentVa
       return ltText;
     case Comparator.GT_OR_EQ:
     case Comparator.LT_OR_EQ: {
-      if (threshold[0] === currentValue) {
+      if (currentValue === threshold[0]) {
         return eqText;
-      } else if (threshold[0] > currentValue) {
+      } else if (currentValue < threshold[0]) {
         return ltText;
       } else {
         return gtText;


### PR DESCRIPTION
## :memo: Summary

This fixes one of the conditions used for determining the correct message for a given comparator. The less/greater than comparison was inverted in the "less/greater or equal" case.

closes #88585

## :art: Previews

*Before*
![image](https://user-images.githubusercontent.com/973741/136189079-67410cf0-ab71-45ab-9bc9-debcaa11af1a.png)

*After*
![image](https://user-images.githubusercontent.com/973741/136189117-e4d69dde-c888-414a-a4cd-fd3188a43251.png)