### PR TITLE
[Search] Reuse `uiSettings` within `bsearch` request

### DIFF
--- a/src/plugins/data/server/search/routes/bsearch.ts
+++ b/src/plugins/data/server/search/routes/bsearch.ts
@@ -25,13 +25,13 @@ export function registerBsearchRoute(
     { request: IKibanaSearchRequest; options?: ISearchOptionsSerializable },
     IKibanaSearchResponse
   >('/internal/bsearch', (request) => {
+    const search = getScoped(request);
     return {
       /**
        * @param requestOptions
        * @throws `KibanaServerError`
        */
       onBatchItem: async ({ request: requestData, options }) => {
-        const search = getScoped(request);
         const { executionContext, ...restOptions } = options || {};
 
         return executionContextService.withContext(executionContext, () =>

--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -89,6 +89,7 @@ import { getKibanaContext } from './expressions/kibana_context';
 import { enhancedEsSearchStrategyProvider } from './strategies/ese_search';
 import { eqlSearchStrategyProvider } from './strategies/eql_search';
 import { NoSearchIdInSessionError } from './errors/no_search_id_in_session';
+import { CachedUiSettingsClient } from './services';
 
 type StrategyMap = Record<string, ISearchStrategy<any, any>>;
 
@@ -453,7 +454,9 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
         searchSessionsClient,
         savedObjectsClient,
         esClient: elasticsearch.client.asScoped(request),
-        uiSettingsClient: uiSettings.asScopedToClient(savedObjectsClient),
+        uiSettingsClient: new CachedUiSettingsClient(
+          uiSettings.asScopedToClient(savedObjectsClient)
+        ),
         request,
       };
       return {

--- a/src/plugins/data/server/search/services/cached_ui_settings_client.test.ts
+++ b/src/plugins/data/server/search/services/cached_ui_settings_client.test.ts
@@ -10,7 +10,7 @@ import { coreMock, httpServerMock } from '../../../../../core/server/mocks';
 
 import { CachedUiSettingsClient } from './cached_ui_settings_client';
 
-test('fetching uiSettings once', async () => {
+test('fetching uiSettings once for the same key', async () => {
   const request = httpServerMock.createKibanaRequest();
   const soClient = coreMock.createStart().savedObjects.getScopedClient(request);
   const uiSettings = coreMock.createStart().uiSettings.asScopedToClient(soClient);
@@ -30,4 +30,30 @@ test('fetching uiSettings once', async () => {
 
   expect(await res1).toBe(value);
   expect(await res2).toBe(value);
+});
+
+test('fetching uiSettings once for different keys', async () => {
+  const request = httpServerMock.createKibanaRequest();
+  const soClient = coreMock.createStart().savedObjects.getScopedClient(request);
+  const uiSettings = coreMock.createStart().uiSettings.asScopedToClient(soClient);
+
+  const key1 = 'key1';
+  const value1 = 'value1';
+
+  const key2 = 'key2';
+  const value2 = 'value2';
+
+  const spy = jest
+    .spyOn(uiSettings, 'getAll')
+    .mockImplementation(() => Promise.resolve({ [key1]: value1, [key2]: value2 }));
+
+  const cachedUiSettings = new CachedUiSettingsClient(uiSettings);
+
+  const res1 = cachedUiSettings.get(key1);
+  const res2 = cachedUiSettings.get(key2);
+
+  expect(spy).toHaveBeenCalledTimes(1); // check that internally uiSettings.getAll() called only once
+
+  expect(await res1).toBe(value1);
+  expect(await res2).toBe(value2);
 });

--- a/src/plugins/data/server/search/services/cached_ui_settings_client.test.ts
+++ b/src/plugins/data/server/search/services/cached_ui_settings_client.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { coreMock, httpServerMock } from '../../../../../core/server/mocks';
+
+import { CachedUiSettingsClient } from './cached_ui_settings_client';
+
+test('fetching uiSettings once', async () => {
+  const request = httpServerMock.createKibanaRequest();
+  const soClient = coreMock.createStart().savedObjects.getScopedClient(request);
+  const uiSettings = coreMock.createStart().uiSettings.asScopedToClient(soClient);
+
+  const key = 'key';
+  const value = 'value';
+  const spy = jest
+    .spyOn(uiSettings, 'getAll')
+    .mockImplementation(() => Promise.resolve({ [key]: value }));
+
+  const cachedUiSettings = new CachedUiSettingsClient(uiSettings);
+
+  const res1 = cachedUiSettings.get(key);
+  const res2 = cachedUiSettings.get(key);
+
+  expect(spy).toHaveBeenCalledTimes(1); // check that internally uiSettings.getAll() called only once
+
+  expect(await res1).toBe(value);
+  expect(await res2).toBe(value);
+});

--- a/src/plugins/data/server/search/services/cached_ui_settings_client.ts
+++ b/src/plugins/data/server/search/services/cached_ui_settings_client.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { IUiSettingsClient } from 'kibana/server';
+
+/**
+ * {@link IUiSettingsClient} wrapper to ensure uiSettings requested only once within a single KibanaRequest,
+ * {@link IUiSettingsClient} has its own cache, but it doesn't cache pending promises, so this produces two requests:
+ *
+ * const promise1 = uiSettings.get(1); // fetches config
+ * const promise2 = uiSettings.get(2); // fetches config
+ *
+ * And {@link CachedUiSettingsClient} solves it, so this produced a single request:
+ *
+ * const promise1 = cachedUiSettingsClient.get(1); // fetches config
+ * const promise2 = cachedUiSettingsClient.get(2); // reuses existing promise
+ *
+ * @internal
+ */
+export class CachedUiSettingsClient implements Pick<IUiSettingsClient, 'get'> {
+  private cache: Promise<Record<string, unknown>> | undefined;
+
+  constructor(private readonly client: IUiSettingsClient) {}
+
+  async get<T = any>(key: string): Promise<T> {
+    if (!this.cache) {
+      // caching getAll() instead of just get(key) because internally uiSettings calls `getAll()` anyways
+      // this way we reuse cache in case settings for different keys were requested
+      this.cache = this.client.getAll();
+    }
+
+    return this.cache
+      .then((cache) => cache[key] as T)
+      .catch((e) => {
+        this.cache = undefined;
+        throw e;
+      });
+  }
+}

--- a/src/plugins/data/server/search/services/index.ts
+++ b/src/plugins/data/server/search/services/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { CachedUiSettingsClient } from './cached_ui_settings_client';

--- a/src/plugins/data/server/search/strategies/es_search/request_utils.ts
+++ b/src/plugins/data/server/search/strategies/es_search/request_utils.ts
@@ -17,7 +17,7 @@ export function getShardTimeout(config: SharedGlobalConfig): Pick<Search, 'timeo
 }
 
 export async function getDefaultSearchParams(
-  uiSettingsClient: IUiSettingsClient
+  uiSettingsClient: Pick<IUiSettingsClient, 'get'>
 ): Promise<
   Pick<Search, 'max_concurrent_shard_requests' | 'ignore_unavailable' | 'track_total_hits'>
 > {

--- a/src/plugins/data/server/search/strategies/ese_search/request_utils.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/request_utils.ts
@@ -20,7 +20,7 @@ import { SearchSessionsConfigSchema } from '../../../../config';
  * @internal
  */
 export async function getIgnoreThrottled(
-  uiSettingsClient: IUiSettingsClient
+  uiSettingsClient: Pick<IUiSettingsClient, 'get'>
 ): Promise<Pick<Search, 'ignore_throttled'>> {
   const includeFrozen = await uiSettingsClient.get(UI_SETTINGS.SEARCH_INCLUDE_FROZEN);
   return includeFrozen ? { ignore_throttled: false } : {};
@@ -30,7 +30,7 @@ export async function getIgnoreThrottled(
  @internal
  */
 export async function getDefaultAsyncSubmitParams(
-  uiSettingsClient: IUiSettingsClient,
+  uiSettingsClient: Pick<IUiSettingsClient, 'get'>,
   searchSessionsConfig: SearchSessionsConfigSchema | null,
   options: ISearchOptions
 ): Promise<

--- a/src/plugins/data/server/search/types.ts
+++ b/src/plugins/data/server/search/types.ts
@@ -35,7 +35,7 @@ export interface SearchEnhancements {
 export interface SearchStrategyDependencies {
   savedObjectsClient: SavedObjectsClientContract;
   esClient: IScopedClusterClient;
-  uiSettingsClient: IUiSettingsClient;
+  uiSettingsClient: Pick<IUiSettingsClient, 'get'>;
   searchSessionsClient: IScopedSearchSessionsClient;
   request: KibanaRequest;
 }


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/108062

Now we reuse a scoped search service when processing multiple search requests within a single `bsearch` request

### Before

Each search request requested uiSettings separatly: 

![Screen Shot 2021-10-06 at 13 21 17](https://user-images.githubusercontent.com/7784120/136196297-68f6a080-0415-4562-ba26-ddabdb65cdbb.png)


### After

A single uiSettings request 

![Screen Shot 2021-10-06 at 12 55 20](https://user-images.githubusercontent.com/7784120/136196340-28182407-ed02-43ed-84c1-53d2e0254592.png)

