### PR TITLE
[Fleet] Improve default settings for Fleet component templates

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.test.ts
@@ -46,19 +46,11 @@ describe('buildDefaultSettings', () => {
           "lifecycle": Object {
             "name": "logs",
           },
-          "mapping": Object {
-            "total_fields": Object {
-              "limit": "10000",
-            },
-          },
-          "number_of_routing_shards": "30",
-          "number_of_shards": "1",
           "query": Object {
             "default_field": Array [
               "field1Keyword",
             ],
           },
-          "refresh_interval": "5s",
         },
       }
     `);

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/default_settings.ts
@@ -67,17 +67,6 @@ export function buildDefaultSettings({
       },
       // What should be our default for the compression?
       codec: 'best_compression',
-      mapping: {
-        total_fields: {
-          limit: '10000',
-        },
-      },
-      // This is the default from Beats? So far seems to be a good value
-      refresh_interval: '5s',
-      // Default in the stack now, still good to have it in
-      number_of_shards: '1',
-      // We are setting 30 because it can be devided by several numbers. Useful when shrinking.
-      number_of_routing_shards: '30',
 
       // All the default fields which should be queried have to be added here.
       // So far we add all keyword and text fields here if there are any, otherwise

--- a/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
@@ -121,14 +121,7 @@ export default function (providerContext: FtrProviderContext) {
               lifecycle: {
                 name: 'overridden by user',
               },
-              mapping: {
-                total_fields: {
-                  limit: '10000',
-                },
-              },
-              number_of_routing_shards: 30,
               number_of_shards: '3',
-              refresh_interval: '5s',
             },
           },
           mappings: {

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -220,17 +220,9 @@ export default function (providerContext: FtrProviderContext) {
         index: {
           lifecycle: { name: 'reference2' },
           codec: 'best_compression',
-          mapping: {
-            total_fields: {
-              limit: '10000',
-            },
-          },
-          number_of_routing_shards: '30',
-          number_of_shards: '1',
           query: {
             default_field: ['logs_test_name', 'new_field_name'],
           },
-          refresh_interval: '5s',
         },
       });
       const resUserSettings = await es.transport.request({


### PR DESCRIPTION
## Summary

Resolves #104620

Improve default settings for Fleet component templates based https://github.com/elastic/kibana/issues/104620#issuecomment-884113688. We removed several fields in favor of allowing Elasticsearch's defaults to remain in place:

- Remove `mapping.total_fields.limit`
- Remove `refresh_interval`
- Remove `number_of_shards`
- Remove `number_of_routing_shards`

New default settings example after fresh Fleet setup:

```
GET _component_template/metrics-system.cpu@settings

{
  "component_templates" : [
    {
      "name" : "metrics-system.cpu@settings",
      "component_template" : {
        "template" : {
          "settings" : {
            "index" : {
              "lifecycle" : {
                "name" : "metrics"
              },
              "codec" : "best_compression",
              "query" : {
                "default_field" : [
                  "cloud.account.id",
                  "cloud.availability_zone",
                  "cloud.instance.id",
                  "cloud.instance.name",
                  "cloud.machine.type",
                  "cloud.provider",
                  "cloud.region",
                  "cloud.project.id",
                  "cloud.image.id",
                  "container.id",
                  "container.image.name",
                  "container.name",
                  "host.architecture",
                  "host.domain",
                  "host.hostname",
                  "host.id",
                  "host.mac",
                  "host.name",
                  "host.os.family",
                  "host.os.kernel",
                  "host.os.name",
                  "host.os.platform",
                  "host.os.version",
                  "host.type",
                  "host.os.build",
                  "host.os.codename",
                  "host.architecture",
                  "host.domain",
                  "host.geo.city_name",
                  "host.geo.continent_code",
                  "host.geo.continent_name",
                  "host.geo.country_iso_code",
                  "host.geo.country_name",
                  "host.geo.name",
                  "host.geo.postal_code",
                  "host.geo.region_iso_code",
                  "host.geo.region_name",
                  "host.geo.timezone",
                  "host.hostname",
                  "host.id",
                  "host.mac",
                  "host.name",
                  "host.os.family",
                  "host.os.full",
                  "host.os.kernel",
                  "host.os.name",
                  "host.os.platform",
                  "host.os.type",
                  "host.os.version",
                  "host.type",
                  "host.user.domain",
                  "host.user.email",
                  "host.user.full_name",
                  "host.user.group.domain",
                  "host.user.group.id",
                  "host.user.group.name",
                  "host.user.hash",
                  "host.user.id",
                  "host.user.name",
                  "host.user.roles",
                  "host.architecture",
                  "host.mac",
                  "host.name",
                  "host.os.family",
                  "host.os.full",
                  "host.os.kernel",
                  "host.os.name",
                  "host.os.platform",
                  "host.os.version",
                  "host.type"
                ]
              }
            }
          }
        },
        "_meta" : {
          "package" : {
            "name" : "system"
          }
        }
      }
    }
  ]
}

```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
