### PR TITLE
[App Search] Split Curation Detail views into tabs

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.test.tsx
@@ -14,9 +14,9 @@ import React from 'react';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
-import { EuiBadge } from '@elastic/eui';
+import { EuiBadge, EuiTab } from '@elastic/eui';
 
-import { getPageHeaderActions, getPageTitle } from '../../../../test_helpers';
+import { getPageHeaderActions, getPageHeaderTabs, getPageTitle } from '../../../../test_helpers';
 
 jest.mock('./curation_logic', () => ({ CurationLogic: jest.fn() }));
 
@@ -58,6 +58,15 @@ describe('AutomatedCuration', () => {
     expect(wrapper.is(AppSearchPageTemplate));
     expect(wrapper.find(PromotedDocuments)).toHaveLength(1);
     expect(wrapper.find(OrganicDocuments)).toHaveLength(1);
+  });
+
+  it('includes a single static tab', () => {
+    const wrapper = shallow(<AutomatedCuration />);
+    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
+
+    expect(tabs).toHaveLength(1);
+    expect(tabs.at(0).prop('onClick')).toBeUndefined();
+    expect(tabs.at(0).prop('isSelected')).toBe(true);
   });
 
   it('initializes CurationLogic with a curationId prop from URL param', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.test.tsx
@@ -60,13 +60,18 @@ describe('AutomatedCuration', () => {
     expect(wrapper.find(OrganicDocuments)).toHaveLength(1);
   });
 
-  it('includes a single static tab', () => {
+  it('includes a static tab group', () => {
     const wrapper = shallow(<AutomatedCuration />);
     const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
 
-    expect(tabs).toHaveLength(1);
+    expect(tabs).toHaveLength(2);
+
     expect(tabs.at(0).prop('onClick')).toBeUndefined();
     expect(tabs.at(0).prop('isSelected')).toBe(true);
+
+    expect(tabs.at(1).prop('onClick')).toBeUndefined();
+    expect(tabs.at(1).prop('isSelected')).toBe(false);
+    expect(tabs.at(1).prop('disabled')).toBe(true);
   });
 
   it('initializes CurationLogic with a curationId prop from URL param', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.tsx
@@ -12,6 +12,8 @@ import { useValues, useActions } from 'kea';
 
 import { EuiSpacer, EuiButton, EuiBadge } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
+
 import { AppSearchPageTemplate } from '../../layout';
 import { AutomatedIcon } from '../components/automated_icon';
 import {
@@ -29,6 +31,19 @@ export const AutomatedCuration: React.FC = () => {
   const logic = CurationLogic({ curationId });
   const { convertToManual } = useActions(logic);
   const { activeQuery, dataLoading, queries } = useValues(logic);
+
+  // This single static tab is meant to visually mirror the dynamic set of tags
+  // in the ManualCuration component. This page however does not include
+  // hidden documents, so we only need one tab.
+  const pageTabs = [
+    {
+      label: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.engine.curations.promotedDocuments.title',
+        { defaultMessage: 'Promoted documents' }
+      ),
+      isSelected: true,
+    },
+  ];
 
   return (
     <AppSearchPageTemplate
@@ -54,6 +69,7 @@ export const AutomatedCuration: React.FC = () => {
             {COVERT_TO_MANUAL_BUTTON_LABEL}
           </EuiButton>,
         ],
+        tabs: pageTabs,
       }}
       isLoading={dataLoading}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.tsx
@@ -12,8 +12,6 @@ import { useValues, useActions } from 'kea';
 
 import { EuiSpacer, EuiButton, EuiBadge } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
-
 import { AppSearchPageTemplate } from '../../layout';
 import { AutomatedIcon } from '../components/automated_icon';
 import {
@@ -21,8 +19,10 @@ import {
   COVERT_TO_MANUAL_BUTTON_LABEL,
   CONVERT_TO_MANUAL_CONFIRMATION,
 } from '../constants';
+
 import { getCurationsBreadcrumbs } from '../utils';
 
+import { PROMOTED_DOCUMENTS_TITLE } from './constants';
 import { CurationLogic } from './curation_logic';
 import { PromotedDocuments, OrganicDocuments } from './documents';
 
@@ -37,10 +37,7 @@ export const AutomatedCuration: React.FC = () => {
   // hidden documents, so we only need one tab.
   const pageTabs = [
     {
-      label: i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.curations.promotedDocuments.title',
-        { defaultMessage: 'Promoted documents' }
-      ),
+      label: PROMOTED_DOCUMENTS_TITLE,
       isSelected: true,
     },
   ];

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/automated_curation.tsx
@@ -22,7 +22,7 @@ import {
 
 import { getCurationsBreadcrumbs } from '../utils';
 
-import { PROMOTED_DOCUMENTS_TITLE } from './constants';
+import { HIDDEN_DOCUMENTS_TITLE, PROMOTED_DOCUMENTS_TITLE } from './constants';
 import { CurationLogic } from './curation_logic';
 import { PromotedDocuments, OrganicDocuments } from './documents';
 
@@ -32,13 +32,16 @@ export const AutomatedCuration: React.FC = () => {
   const { convertToManual } = useActions(logic);
   const { activeQuery, dataLoading, queries } = useValues(logic);
 
-  // This single static tab is meant to visually mirror the dynamic set of tags
-  // in the ManualCuration component. This page however does not include
-  // hidden documents, so we only need one tab.
+  // This tab group is meant to visually mirror the dynamic group of tags in the ManualCuration component
   const pageTabs = [
     {
       label: PROMOTED_DOCUMENTS_TITLE,
       isSelected: true,
+    },
+    {
+      label: HIDDEN_DOCUMENTS_TITLE,
+      isSelected: false,
+      disabled: true,
     },
   ];
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/constants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const PROMOTED_DOCUMENTS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.curations.promotedDocuments.title',
+  { defaultMessage: 'Promoted documents' }
+);
+
+export const HIDDEN_DOCUMENTS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.curations.hiddenDocuments.title',
+  { defaultMessage: 'Hidden documents' }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
@@ -56,6 +56,7 @@ describe('CurationLogic', () => {
     hiddenIds: [],
     hiddenDocumentsLoading: false,
     isAutomated: false,
+    selectedPageTab: 'promoted',
   };
 
   beforeEach(() => {
@@ -261,6 +262,21 @@ describe('CurationLogic', () => {
           promotedDocumentsLoading: true,
           hiddenIds: [],
           hiddenDocumentsLoading: true,
+        });
+      });
+    });
+
+    describe('onSelectPageTab', () => {
+      it('should set the selected page tab', () => {
+        mount({
+          selectedPageTab: 'promoted',
+        });
+
+        CurationLogic.actions.onSelectPageTab('hidden');
+
+        expect(CurationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          selectedPageTab: 'hidden',
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -16,6 +16,8 @@ import { EngineLogic, generateEnginePath } from '../../engine';
 import { Curation } from '../types';
 import { addDocument, removeDocument } from '../utils';
 
+type CurationPageTabs = 'promoted' | 'hidden';
+
 interface CurationValues {
   dataLoading: boolean;
   curation: Curation;
@@ -28,6 +30,7 @@ interface CurationValues {
   hiddenIds: string[];
   hiddenDocumentsLoading: boolean;
   isAutomated: boolean;
+  selectedPageTab: CurationPageTabs;
 }
 
 interface CurationActions {
@@ -46,6 +49,7 @@ interface CurationActions {
   removeHiddenId(id: string): { id: string };
   clearHiddenIds(): void;
   resetCuration(): void;
+  onSelectPageTab(pageTab: CurationPageTabs): { pageTab: CurationPageTabs };
 }
 
 interface CurationProps {
@@ -70,6 +74,7 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
     removeHiddenId: (id) => ({ id }),
     clearHiddenIds: true,
     resetCuration: true,
+    onSelectPageTab: (pageTab) => ({ pageTab }),
   }),
   reducers: () => ({
     dataLoading: [
@@ -162,6 +167,12 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
         clearHiddenIds: () => true,
         onCurationLoad: () => false,
         onCurationError: () => false,
+      },
+    ],
+    selectedPageTab: [
+      'promoted',
+      {
+        onSelectPageTab: (_, { pageTab }) => pageTab,
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/documents/hidden_documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/documents/hidden_documents.tsx
@@ -15,6 +15,7 @@ import { i18n } from '@kbn/i18n';
 import { DataPanel } from '../../../data_panel';
 
 import { SHOW_DOCUMENT_ACTION } from '../../constants';
+import { HIDDEN_DOCUMENTS_TITLE } from '../constants';
 import { CurationLogic } from '../curation_logic';
 import { AddResultButton, CurationResult, convertToResultFormat } from '../results';
 
@@ -29,14 +30,7 @@ export const HiddenDocuments: React.FC = () => {
     <DataPanel
       filled
       iconType="eyeClosed"
-      title={
-        <h2>
-          {i18n.translate(
-            'xpack.enterpriseSearch.appSearch.engine.curations.hiddenDocuments.title',
-            { defaultMessage: 'Hidden documents' }
-          )}
-        </h2>
-      }
+      title={<h2>{HIDDEN_DOCUMENTS_TITLE}</h2>}
       subtitle={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.curations.hiddenDocuments.description',
         { defaultMessage: 'Hidden documents will not appear in organic results.' }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/documents/promoted_documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/documents/promoted_documents.tsx
@@ -26,6 +26,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { DataPanel } from '../../../data_panel';
 
 import { DEMOTE_DOCUMENT_ACTION } from '../../constants';
+import { PROMOTED_DOCUMENTS_TITLE } from '../constants';
 import { CurationLogic } from '../curation_logic';
 import { AddResultButton, CurationResult, convertToResultFormat } from '../results';
 
@@ -46,14 +47,7 @@ export const PromotedDocuments: React.FC = () => {
     <DataPanel
       filled
       iconType="starFilled"
-      title={
-        <h2>
-          {i18n.translate(
-            'xpack.enterpriseSearch.appSearch.engine.curations.promotedDocuments.title',
-            { defaultMessage: 'Promoted documents' }
-          )}
-        </h2>
-      }
+      title={<h2>{PROMOTED_DOCUMENTS_TITLE}</h2>}
       subtitle={
         isAutomated ? (
           <FormattedMessage

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/manual_curation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/manual_curation.test.tsx
@@ -14,11 +14,14 @@ import React from 'react';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
-import { getPageTitle, getPageHeaderActions } from '../../../../test_helpers';
+import { EuiTab } from '@elastic/eui';
+
+import { getPageTitle, getPageHeaderActions, getPageHeaderTabs } from '../../../../test_helpers';
 
 jest.mock('./curation_logic', () => ({ CurationLogic: jest.fn() }));
 import { CurationLogic } from './curation_logic';
 
+import { PromotedDocuments, HiddenDocuments } from './documents';
 import { ManualCuration } from './manual_curation';
 import { AddResultFlyout } from './results';
 import { SuggestedDocumentsCallout } from './suggested_documents_callout';
@@ -28,9 +31,11 @@ describe('ManualCuration', () => {
     dataLoading: false,
     queries: ['query A', 'query B'],
     isFlyoutOpen: false,
+    selectedPageTab: 'promoted',
   };
   const actions = {
     resetCuration: jest.fn(),
+    onSelectPageTab: jest.fn(),
   };
 
   beforeEach(() => {
@@ -39,7 +44,7 @@ describe('ManualCuration', () => {
     setMockActions(actions);
   });
 
-  it('renders', () => {
+  it('renders a view for managing a curation', () => {
     const wrapper = shallow(<ManualCuration />);
 
     expect(getPageTitle(wrapper)).toEqual('Manage curation');
@@ -51,10 +56,42 @@ describe('ManualCuration', () => {
     ]);
   });
 
-  it('contains a suggested documents callout', () => {
+  it('includes set of tabs in the page header', () => {
+    const wrapper = shallow(<ManualCuration />);
+
+    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
+
+    tabs.at(0).simulate('click');
+    expect(actions.onSelectPageTab).toHaveBeenNthCalledWith(1, 'promoted');
+
+    tabs.at(1).simulate('click');
+    expect(actions.onSelectPageTab).toHaveBeenNthCalledWith(2, 'hidden');
+  });
+
+  it('contains a suggested documents callout when the selectedPageTab is ', () => {
     const wrapper = shallow(<ManualCuration />);
 
     expect(wrapper.find(SuggestedDocumentsCallout)).toHaveLength(1);
+  });
+
+  it('renders promoted documents when that tab is selected', () => {
+    setMockValues({ ...values, selectedPageTab: 'promoted' });
+    const wrapper = shallow(<ManualCuration />);
+    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
+
+    expect(tabs.at(0).prop('isSelected')).toEqual(true);
+
+    expect(wrapper.find(PromotedDocuments)).toHaveLength(1);
+  });
+
+  it('renders hidden documents when that tab is selected', () => {
+    setMockValues({ ...values, selectedPageTab: 'hidden' });
+    const wrapper = shallow(<ManualCuration />);
+    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
+
+    expect(tabs.at(1).prop('isSelected')).toEqual(true);
+
+    expect(wrapper.find(HiddenDocuments)).toHaveLength(1);
   });
 
   it('renders the add result flyout when open', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/manual_curation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/manual_curation.tsx
@@ -12,13 +12,12 @@ import { useValues, useActions } from 'kea';
 
 import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
-
 import { RESTORE_DEFAULTS_BUTTON_LABEL } from '../../../constants';
 import { AppSearchPageTemplate } from '../../layout';
 import { MANAGE_CURATION_TITLE, RESTORE_CONFIRMATION } from '../constants';
 import { getCurationsBreadcrumbs } from '../utils';
 
+import { PROMOTED_DOCUMENTS_TITLE, HIDDEN_DOCUMENTS_TITLE } from './constants';
 import { CurationLogic } from './curation_logic';
 import { PromotedDocuments, OrganicDocuments, HiddenDocuments } from './documents';
 import { ActiveQuerySelect, ManageQueriesModal } from './queries';
@@ -33,18 +32,12 @@ export const ManualCuration: React.FC = () => {
 
   const pageTabs = [
     {
-      label: i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.curations.promotedDocuments.title',
-        { defaultMessage: 'Promoted documents' }
-      ),
+      label: PROMOTED_DOCUMENTS_TITLE,
       isSelected: selectedPageTab === 'promoted',
       onClick: () => onSelectPageTab('promoted'),
     },
     {
-      label: i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.curations.hiddenDocuments.title',
-        { defaultMessage: 'Hidden documents' }
-      ),
+      label: HIDDEN_DOCUMENTS_TITLE,
       isSelected: selectedPageTab === 'hidden',
       onClick: () => onSelectPageTab('hidden'),
     },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/manual_curation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/manual_curation.tsx
@@ -12,6 +12,8 @@ import { useValues, useActions } from 'kea';
 
 import { EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
+
 import { RESTORE_DEFAULTS_BUTTON_LABEL } from '../../../constants';
 import { AppSearchPageTemplate } from '../../layout';
 import { MANAGE_CURATION_TITLE, RESTORE_CONFIRMATION } from '../constants';
@@ -25,9 +27,28 @@ import { SuggestedDocumentsCallout } from './suggested_documents_callout';
 
 export const ManualCuration: React.FC = () => {
   const { curationId } = useParams() as { curationId: string };
-  const { resetCuration } = useActions(CurationLogic({ curationId }));
-  const { dataLoading, queries } = useValues(CurationLogic({ curationId }));
+  const { onSelectPageTab, resetCuration } = useActions(CurationLogic({ curationId }));
+  const { dataLoading, queries, selectedPageTab } = useValues(CurationLogic({ curationId }));
   const { isFlyoutOpen } = useValues(AddResultLogic);
+
+  const pageTabs = [
+    {
+      label: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.engine.curations.promotedDocuments.title',
+        { defaultMessage: 'Promoted documents' }
+      ),
+      isSelected: selectedPageTab === 'promoted',
+      onClick: () => onSelectPageTab('promoted'),
+    },
+    {
+      label: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.engine.curations.hiddenDocuments.title',
+        { defaultMessage: 'Hidden documents' }
+      ),
+      isSelected: selectedPageTab === 'hidden',
+      onClick: () => onSelectPageTab('hidden'),
+    },
+  ];
 
   return (
     <AppSearchPageTemplate
@@ -44,6 +65,7 @@ export const ManualCuration: React.FC = () => {
             {RESTORE_DEFAULTS_BUTTON_LABEL}
           </EuiButton>,
         ],
+        tabs: pageTabs,
       }}
       isLoading={dataLoading}
     >
@@ -57,12 +79,10 @@ export const ManualCuration: React.FC = () => {
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xl" />
-
-      <PromotedDocuments />
+      {selectedPageTab === 'promoted' && <PromotedDocuments />}
+      {selectedPageTab === 'hidden' && <HiddenDocuments />}
       <EuiSpacer />
       <OrganicDocuments />
-      <EuiSpacer />
-      <HiddenDocuments />
 
       {isFlyoutOpen && <AddResultFlyout />}
     </AppSearchPageTemplate>


### PR DESCRIPTION
## Summary

Splits the Manual Curation Detail page into two separate views for promoted and hidden documents, controlled by a group of tabs.  The Automated Curation Detail page now has a similar group of tabs, but since there are no hidden documents for automated curations the group that tab is disabled and the promoted tab is always selected.

### Screenshots

<img width="800" alt="Screen Shot 2021-10-06 at 9 28 12 AM" src="https://user-images.githubusercontent.com/2479295/136215145-25d835e3-60b9-4c54-835b-b9b4fde31c2b.png">


<img width="800" alt="Screen Shot 2021-10-06 at 9 28 19 AM" src="https://user-images.githubusercontent.com/2479295/136215157-87ce7018-636d-4d11-a53c-b31376c0b4de.png">

<img width="1680" alt="Screen Shot 2021-10-06 at 10 32 12 AM" src="https://user-images.githubusercontent.com/2479295/136224400-b52fbdf5-25c8-4eee-ac6f-c45144ffd56a.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
