### PR TITLE
[7.x] [Alerting] Track deprecated configs (#113015)

### DIFF
--- a/x-pack/plugins/actions/server/index.ts
+++ b/x-pack/plugins/actions/server/index.ts
@@ -64,7 +64,8 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
       if (
         customHostSettings.find(
           (customHostSchema: CustomHostSettings) =>
-            !!customHostSchema.ssl && !!customHostSchema.ssl.rejectUnauthorized
+            customHostSchema.hasOwnProperty('ssl') &&
+            customHostSchema.ssl?.hasOwnProperty('rejectUnauthorized')
         )
       ) {
         addDeprecation({
@@ -82,11 +83,18 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
             ],
           },
         });
+        return {
+          unset: [
+            {
+              path: `xpack.actions.customHostSettings.ssl.rejectUnauthorized`,
+            },
+          ],
+        };
       }
     },
     (settings, fromPath, addDeprecation) => {
       const actions = get(settings, fromPath);
-      if (!!actions?.rejectUnauthorized) {
+      if (actions?.hasOwnProperty('rejectUnauthorized')) {
         addDeprecation({
           message:
             `"xpack.actions.rejectUnauthorized" is deprecated. Use "xpack.actions.verificationMode" instead, ` +
@@ -101,11 +109,18 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
             ],
           },
         });
+        return {
+          unset: [
+            {
+              path: `xpack.actions.rejectUnauthorized`,
+            },
+          ],
+        };
       }
     },
     (settings, fromPath, addDeprecation) => {
       const actions = get(settings, fromPath);
-      if (!!actions?.proxyRejectUnauthorizedCertificates) {
+      if (actions?.hasOwnProperty('proxyRejectUnauthorizedCertificates')) {
         addDeprecation({
           message:
             `"xpack.actions.proxyRejectUnauthorizedCertificates" is deprecated. Use "xpack.actions.proxyVerificationMode" instead, ` +
@@ -120,6 +135,13 @@ export const config: PluginConfigDescriptor<ActionsConfig> = {
             ],
           },
         });
+        return {
+          unset: [
+            {
+              path: `xpack.actions.proxyRejectUnauthorizedCertificates`,
+            },
+          ],
+        };
       }
     },
     (settings, fromPath, addDeprecation) => {

--- a/x-pack/plugins/task_manager/server/index.ts
+++ b/x-pack/plugins/task_manager/server/index.ts
@@ -41,6 +41,9 @@ export type {
 
 export const config: PluginConfigDescriptor<TaskManagerConfig> = {
   schema: configSchema,
+  exposeToUsage: {
+    max_workers: true,
+  },
   deprecations: () => [
     (settings, fromPath, addDeprecation) => {
       const taskManager = get(settings, fromPath);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Alerting] Track deprecated configs (#113015)