### PR TITLE
[config] Remove leading spaces from logging configuration

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -88,28 +88,28 @@
 #pid.file: /run/kibana/kibana.pid
 
 # Set the value of this setting to off to suppress all logging output, or to debug to log everything.
-# logging.root.level: debug
+#logging.root.level: debug
 
 # Enables you to specify a file where Kibana stores log output.
-# logging.appenders.default:
-#   type: file
-#   fileName: /var/logs/kibana.log
+#logging.appenders.default:
+#  type: file
+#  fileName: /var/logs/kibana.log
 
 
 # Logs queries sent to Elasticsearch.
-# logging.loggers:
-#   - name: elasticsearch.queries
-#     level: debug
+#logging.loggers:
+#  - name: elasticsearch.queries
+#    level: debug
 
 # Logs http responses.
-# logging.loggers:
-#   - name: http.server.response
-#     level: debug
+#logging.loggers:
+#  - name: http.server.response
+#    level: debug
 
 # Logs system usage information.
-# logging.loggers:
-#   - name: metrics.ops
-#     level: debug
+#logging.loggers:
+#  - name: metrics.ops
+#    level: debug
 
 # Set the interval in milliseconds to sample system and process performance
 # metrics. Minimum is 100ms. Defaults to 5000.

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -95,7 +95,6 @@
 #  type: file
 #  fileName: /var/logs/kibana.log
 
-
 # Logs queries sent to Elasticsearch.
 #logging.loggers:
 #  - name: elasticsearch.queries


### PR DESCRIPTION
This is a consistency check with other areas of the stack and other
configurations in kibana.yml.

Part of https://github.com/elastic/kibana/issues/8268

[skip-ci]
