### PR TITLE
[Discover] Fix columns selection state after resetting state

### DIFF
--- a/src/plugins/discover/public/application/apps/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/apps/main/services/discover_state.ts
@@ -232,7 +232,10 @@ export function getState({
       initialAppState = appStateContainer.getState();
     },
     resetAppState: () => {
-      const defaultState = getStateDefaults ? getStateDefaults() : {};
+      const defaultState = handleSourceColumnState(
+        getStateDefaults ? getStateDefaults() : {},
+        uiSettings
+      );
       setState(appStateContainerModified, defaultState);
     },
     getPreviousAppState: () => previousAppState,


### PR DESCRIPTION
## Summary

Fixes #113693

This PR takes into account `useNewFieldsApi` flag, when resetting state.



