### PR TITLE
[QA][fix failing test] Refactor to ui settings for timepicker

### DIFF
--- a/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
+++ b/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
@@ -22,11 +22,20 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   describe('spaces', () => {
     const basePath = `/s/${space}`;
 
-    const time = (range: { from: string; to: string }) => (space: string) => async () =>
-      await kibanaServer.uiSettings.replace({ 'timepicker:timeDefaults': JSON.stringify(range) }, { space });
-    const september2015 = time({ from: '2015-09-19T06:31:44.000Z', to: '2015-09-23T18:31:44.000Z' })(space);
+    const time = (range: { from: string; to: string }) => async () =>
+      await kibanaServer.uiSettings.replace(
+        { 'timepicker:timeDefaults': JSON.stringify(range) },
+        { space }
+      );
+    const september2015 = time({
+      from: '2015-09-19T06:31:44.000Z',
+      to: '2015-09-23T18:31:44.000Z',
+    });
 
-    before(async () => await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional'));
+    before(
+      async () =>
+        await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional')
+    );
 
     describe('space with no features disabled', async () => {
       before(async () => {
@@ -61,7 +70,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows save button', async () => {
         await PageObjects.common.navigateToApp('discover', { basePath });
-        await testSubjects.existOrFail('discoverSaveButton', { timeout: config.get('timeouts.waitFor') });
+        await testSubjects.existOrFail('discoverSaveButton', {
+          timeout: config.get('timeouts.waitFor'),
+        });
       });
 
       it('shows "visualize" field button', async () => {
@@ -137,7 +148,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const noIdxPtrns = 'custom_space_no_index_patterns';
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
-        await spacesService.create({ id: noIdxPtrns, name: noIdxPtrns, disabledFeatures: ['indexPatterns'] });
+        await spacesService.create({
+          id: noIdxPtrns,
+          name: noIdxPtrns,
+          disabledFeatures: ['indexPatterns'],
+        });
       });
 
       after(async () => await spacesService.delete(noIdxPtrns));

--- a/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
+++ b/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
@@ -12,80 +12,60 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const config = getService('config');
   const spacesService = getService('spaces');
-  const PageObjects = getPageObjects([
-    'common',
-    'error',
-    'discover',
-    'timePicker',
-    'security',
-    'spaceSelector',
-  ]);
+  const PageObjects = getPageObjects(['common', 'error', 'discover']);
   const testSubjects = getService('testSubjects');
   const appsMenu = getService('appsMenu');
   const kibanaServer = getService('kibanaServer');
 
-  async function setDiscoverTimeRange() {
-    await PageObjects.timePicker.setDefaultAbsoluteRange();
-  }
+  const space = 'custom_space';
 
-  // Failing: See https://github.com/elastic/kibana/issues/113067
-  describe.skip('spaces', () => {
-    before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
-    });
+  describe('spaces', () => {
+    const basePath = `/s/${space}`;
 
-    // FLAKY: https://github.com/elastic/kibana/issues/60559
-    describe.skip('space with no features disabled', () => {
+    const time = (range: { from: string; to: string }) => (space: string) => async () =>
+      await kibanaServer.uiSettings.replace({ 'timepicker:timeDefaults': JSON.stringify(range) }, { space });
+    const september2015 = time({ from: '2015-09-19T06:31:44.000Z', to: '2015-09-23T18:31:44.000Z' })(space);
+
+    before(async () => await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional'));
+
+    describe('space with no features disabled', async () => {
       before(async () => {
-        // we need to load the following in every situation as deleting
-        // a space deletes all of the associated saved objects
         await kibanaServer.importExport.load(
           'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/spaces'
         );
         await kibanaServer.importExport.load(
           'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/custom_space',
-          { space: 'custom_space' }
+          { space }
         );
-        await spacesService.create({
-          id: 'custom_space',
-          name: 'custom_space',
-          disabledFeatures: [],
-        });
+        await spacesService.create({ id: space, name: space, disabledFeatures: [] });
+        await september2015();
       });
 
       after(async () => {
-        await spacesService.delete('custom_space');
         await kibanaServer.importExport.unload(
           'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/custom_space',
-          { space: 'custom_space' }
+          { space }
         );
         await kibanaServer.importExport.unload(
           'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/spaces'
         );
+        await kibanaServer.uiSettings.unset('timepicker:timeDefaults', { space });
+        await spacesService.delete(space);
       });
 
       it('shows discover navlink', async () => {
-        await PageObjects.common.navigateToApp('home', {
-          basePath: '/s/custom_space',
-        });
+        await PageObjects.common.navigateToApp('home', { basePath });
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
         expect(navLinks).to.contain('Discover');
       });
 
       it('shows save button', async () => {
-        await PageObjects.common.navigateToApp('discover', {
-          basePath: '/s/custom_space',
-        });
-        await testSubjects.existOrFail('discoverSaveButton', {
-          timeout: config.get('timeouts.waitFor'),
-        });
+        await PageObjects.common.navigateToApp('discover', { basePath });
+        await testSubjects.existOrFail('discoverSaveButton', { timeout: config.get('timeouts.waitFor') });
       });
 
       it('shows "visualize" field button', async () => {
-        await PageObjects.common.navigateToApp('discover', {
-          basePath: '/s/custom_space',
-        });
-        await setDiscoverTimeRange();
+        await PageObjects.common.navigateToApp('discover', { basePath });
         await PageObjects.discover.clickFieldListItem('bytes');
         await PageObjects.discover.expectFieldListItemVisualize('bytes');
       });
@@ -99,30 +79,28 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/spaces'
         );
         await spacesService.create({
-          id: 'custom_space',
-          name: 'custom_space',
+          id: space,
+          name: space,
           disabledFeatures: ['discover'],
         });
       });
 
       after(async () => {
-        await spacesService.delete('custom_space');
+        await spacesService.delete(space);
         await kibanaServer.importExport.unload(
           'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/spaces'
         );
       });
 
       it(`doesn't show discover navlink`, async () => {
-        await PageObjects.common.navigateToApp('home', {
-          basePath: '/s/custom_space',
-        });
+        await PageObjects.common.navigateToApp('home', { basePath });
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
         expect(navLinks).not.to.contain('Discover');
       });
 
       it(`shows 404`, async () => {
         await PageObjects.common.navigateToUrl('discover', '', {
-          basePath: '/s/custom_space',
+          basePath,
           shouldLoginIfPrompted: false,
           ensureCurrentUrl: false,
           useActualUrl: true,
@@ -136,23 +114,17 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         // we need to load the following in every situation as deleting
         // a space deletes all of the associated saved objects
         await esArchiver.load('x-pack/test/functional/es_archives/spaces/disabled_features');
-        await spacesService.create({
-          id: 'custom_space',
-          name: 'custom_space',
-          disabledFeatures: ['visualize'],
-        });
+        await spacesService.create({ id: space, name: space, disabledFeatures: ['visualize'] });
+        await september2015();
       });
 
       after(async () => {
-        await spacesService.delete('custom_space');
+        await spacesService.delete(space);
         await esArchiver.unload('x-pack/test/functional/es_archives/spaces/disabled_features');
       });
 
       it('Does not show the "visualize" field button', async () => {
-        await PageObjects.common.navigateToApp('discover', {
-          basePath: '/s/custom_space',
-        });
-        await setDiscoverTimeRange();
+        await PageObjects.common.navigateToApp('discover', { basePath });
         await PageObjects.discover.clickFieldListItem('bytes');
         await PageObjects.discover.expectMissingFieldListItemVisualize('bytes');
       });
@@ -162,21 +134,17 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // unskipped because of flakiness in cloud, caused be ingest management tests
       // should be unskipped when https://github.com/elastic/kibana/issues/74353 was resolved
       this.tags(['skipCloud']);
+      const noIdxPtrns = 'custom_space_no_index_patterns';
       before(async () => {
-        await spacesService.create({
-          id: 'custom_space_no_index_patterns',
-          name: 'custom_space_no_index_patterns',
-          disabledFeatures: ['indexPatterns'],
-        });
+        await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+        await spacesService.create({ id: noIdxPtrns, name: noIdxPtrns, disabledFeatures: ['indexPatterns'] });
       });
 
-      after(async () => {
-        await spacesService.delete('custom_space_no_index_patterns');
-      });
+      after(async () => await spacesService.delete(noIdxPtrns));
 
       it('Navigates to Kibana home rather than index pattern management when no index patterns exist', async () => {
         await PageObjects.common.navigateToUrl('discover', '', {
-          basePath: '/s/custom_space_no_index_patterns',
+          basePath: `/s/${noIdxPtrns}`,
           ensureCurrentUrl: false,
           shouldUseHashForSubUrl: false,
         });


### PR DESCRIPTION
[skip-ci]

Use `kibanaServer.uiSettings.replace()`
instead of `PageObjects.timePicker.setDefaultAbsoluteRange()`

Resolves https://github.com/elastic/kibana/issues/60559

Helps with: https://github.com/elastic/kibana/issues/113998