### PR TITLE
[App Search] Wired up action buttons for suggestion detail view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_logic.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_logic.test.tsx
@@ -45,6 +45,7 @@ const MOCK_RESPONSE: SuggestionsAPIResponse = {
       updated_at: '2021-07-08T14:35:50Z',
       promoted: ['1', '2'],
       status: 'applied',
+      operation: 'create',
     },
   ],
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
@@ -14,6 +14,7 @@ export interface CurationSuggestion {
   promoted: string[];
   status: 'pending' | 'applied' | 'automated' | 'rejected' | 'disabled';
   curation_id?: string;
+  operation: 'create' | 'update' | 'delete';
   override_curation_id?: string;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_action_bar.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_action_bar.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { setMockActions } from '../../../../../__mocks__/kea_logic';
+
 import React from 'react';
 
 import { shallow } from 'enzyme';
@@ -12,18 +14,22 @@ import { shallow } from 'enzyme';
 import { CurationActionBar } from './curation_action_bar';
 
 describe('CurationActionBar', () => {
-  const handleAcceptClick = jest.fn();
-  const handleRejectClick = jest.fn();
+  const actions = {
+    acceptSuggestion: jest.fn(),
+    rejectSuggestion: jest.fn(),
+  };
+
+  beforeAll(() => {
+    setMockActions(actions);
+  });
 
   it('renders', () => {
-    const wrapper = shallow(
-      <CurationActionBar onAcceptClick={handleAcceptClick} onRejectClick={handleRejectClick} />
-    );
+    const wrapper = shallow(<CurationActionBar />);
 
     wrapper.find('[data-test-subj="rejectButton"]').simulate('click');
-    expect(handleRejectClick).toHaveBeenCalled();
+    expect(actions.rejectSuggestion).toHaveBeenCalled();
 
     wrapper.find('[data-test-subj="acceptButton"]').simulate('click');
-    expect(handleAcceptClick).toHaveBeenCalled();
+    expect(actions.acceptSuggestion).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_action_bar.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_action_bar.tsx
@@ -7,17 +7,17 @@
 
 import React from 'react';
 
+import { useActions } from 'kea';
+
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { CurationActionsPopover } from './curation_actions_popover';
+import { CurationSuggestionLogic } from './curation_suggestion_logic';
 
-interface Props {
-  onAcceptClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  onRejectClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-}
+export const CurationActionBar: React.FC = () => {
+  const { acceptSuggestion, rejectSuggestion } = useActions(CurationSuggestionLogic);
 
-export const CurationActionBar: React.FC<Props> = ({ onAcceptClick, onRejectClick }) => {
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
@@ -41,7 +41,7 @@ export const CurationActionBar: React.FC<Props> = ({ onAcceptClick, onRejectClic
                     color="danger"
                     iconType="crossInACircleFilled"
                     data-test-subj="rejectButton"
-                    onClick={onRejectClick}
+                    onClick={rejectSuggestion}
                   >
                     {i18n.translate(
                       'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.rejectButtonLabel',
@@ -55,7 +55,7 @@ export const CurationActionBar: React.FC<Props> = ({ onAcceptClick, onRejectClic
                     color="success"
                     iconType="checkInCircleFilled"
                     data-test-subj="acceptButton"
-                    onClick={onAcceptClick}
+                    onClick={acceptSuggestion}
                   >
                     {i18n.translate(
                       'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.acceptButtonLabel',
@@ -64,12 +64,7 @@ export const CurationActionBar: React.FC<Props> = ({ onAcceptClick, onRejectClic
                   </EuiButton>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <CurationActionsPopover
-                    onAccept={() => {}}
-                    onAutomate={() => {}}
-                    onReject={() => {}}
-                    onTurnOff={() => {}}
-                  />
+                  <CurationActionsPopover />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_actions_popover.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_actions_popover.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { setMockActions } from '../../../../../__mocks__/kea_logic';
+
 import React from 'react';
 
 import { shallow } from 'enzyme';
@@ -12,48 +14,40 @@ import { shallow } from 'enzyme';
 import { CurationActionsPopover } from './curation_actions_popover';
 
 describe('CurationActionsPopover', () => {
-  const handleAccept = jest.fn();
-  const handleAutomate = jest.fn();
-  const handleReject = jest.fn();
-  const handleTurnOff = jest.fn();
+  const actions = {
+    acceptSuggestion: jest.fn(),
+    acceptAndAutomateSuggestion: jest.fn(),
+    rejectSuggestion: jest.fn(),
+    rejectAndDisableSuggestion: jest.fn(),
+  };
+
+  beforeAll(() => {
+    setMockActions(actions);
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders', () => {
-    const wrapper = shallow(
-      <CurationActionsPopover
-        onAccept={handleAccept}
-        onAutomate={handleAutomate}
-        onReject={handleReject}
-        onTurnOff={handleTurnOff}
-      />
-    );
+    const wrapper = shallow(<CurationActionsPopover />);
     expect(wrapper.isEmptyRender()).toBe(false);
 
     wrapper.find('[data-test-subj="acceptButton"]').simulate('click');
-    expect(handleAccept).toHaveBeenCalled();
+    expect(actions.acceptSuggestion).toHaveBeenCalled();
 
     wrapper.find('[data-test-subj="automateButton"]').simulate('click');
-    expect(handleAutomate).toHaveBeenCalled();
+    expect(actions.acceptAndAutomateSuggestion).toHaveBeenCalled();
 
     wrapper.find('[data-test-subj="rejectButton"]').simulate('click');
-    expect(handleReject).toHaveBeenCalled();
+    expect(actions.rejectSuggestion).toHaveBeenCalled();
 
     wrapper.find('[data-test-subj="turnoffButton"]').simulate('click');
-    expect(handleTurnOff).toHaveBeenCalled();
+    expect(actions.rejectAndDisableSuggestion).toHaveBeenCalled();
   });
 
   it('can open and close', () => {
-    const wrapper = shallow(
-      <CurationActionsPopover
-        onAccept={handleAccept}
-        onAutomate={handleAutomate}
-        onReject={handleReject}
-        onTurnOff={handleTurnOff}
-      />
-    );
+    const wrapper = shallow(<CurationActionsPopover />);
 
     expect(wrapper.prop('isOpen')).toBe(false);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_actions_popover.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_actions_popover.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState } from 'react';
 
+import { useActions } from 'kea';
+
 import {
   EuiButtonIcon,
   EuiListGroup,
@@ -16,20 +18,16 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-interface Props {
-  onAccept: () => void;
-  onAutomate: () => void;
-  onReject: () => void;
-  onTurnOff: () => void;
-}
+import { CurationSuggestionLogic } from './curation_suggestion_logic';
 
-export const CurationActionsPopover: React.FC<Props> = ({
-  onAccept,
-  onAutomate,
-  onReject,
-  onTurnOff,
-}) => {
+export const CurationActionsPopover: React.FC = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const {
+    acceptSuggestion,
+    acceptAndAutomateSuggestion,
+    rejectSuggestion,
+    rejectAndDisableSuggestion,
+  } = useActions(CurationSuggestionLogic);
 
   const onButtonClick = () => setIsPopoverOpen(!isPopoverOpen);
   const closePopover = () => setIsPopoverOpen(false);
@@ -63,7 +61,7 @@ export const CurationActionsPopover: React.FC<Props> = ({
             'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.actionsAcceptButtonLabel',
             { defaultMessage: 'Accept this suggestion' }
           )}
-          onClick={onAccept}
+          onClick={acceptSuggestion}
           data-test-subj="acceptButton"
         />
         <EuiListGroupItem
@@ -73,7 +71,7 @@ export const CurationActionsPopover: React.FC<Props> = ({
             'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.actionsAutomateButtonLabel',
             { defaultMessage: 'Automate - always accept new suggestions for this query' }
           )}
-          onClick={onAutomate}
+          onClick={acceptAndAutomateSuggestion}
           data-test-subj="automateButton"
         />
         <EuiListGroupItem
@@ -83,7 +81,7 @@ export const CurationActionsPopover: React.FC<Props> = ({
             'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.actionsRejectButtonLabel',
             { defaultMessage: 'Reject this suggestion' }
           )}
-          onClick={onReject}
+          onClick={rejectSuggestion}
           data-test-subj="rejectButton"
         />
         <EuiListGroupItem
@@ -93,7 +91,7 @@ export const CurationActionsPopover: React.FC<Props> = ({
             'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.actionsTurnOffButtonLabel',
             { defaultMessage: 'Reject and turn off suggestions for this query' }
           )}
-          onClick={onTurnOff}
+          onClick={rejectAndDisableSuggestion}
           data-test-subj="turnoffButton"
         />
       </EuiListGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
@@ -65,10 +65,7 @@ export const CurationSuggestion: React.FC = () => {
         pageTitle: suggestionQuery,
       }}
     >
-      <CurationActionBar
-        onAcceptClick={() => alert('Accepted')}
-        onRejectClick={() => alert('Rejected')}
-      />
+      <CurationActionBar />
       <EuiSpacer size="m" />
       <EuiFlexGroup>
         <EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
@@ -248,6 +248,7 @@ describe('CurationSuggestionLogic', () => {
             updated_at: '2021-07-08T14:35:50Z',
             promoted: ['1', '2', '3'],
             status: 'pending',
+            operation: 'create',
           },
           // Note that these were re-ordered to match the 'promoted' list above, and since document
           // 3 was not found it is not included in this list

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
@@ -9,6 +9,7 @@ import {
   LogicMounter,
   mockFlashMessageHelpers,
   mockHttpValues,
+  mockKibanaValues,
 } from '../../../../../__mocks__/kea_logic';
 
 import { set } from 'lodash/fp';
@@ -32,7 +33,7 @@ const suggestion: CurationSuggestion = {
   query: 'foo',
   updated_at: '2021-07-08T14:35:50Z',
   promoted: ['1', '2', '3'],
-  status: 'applied',
+  status: 'pending',
 };
 
 const curation = {
@@ -116,11 +117,49 @@ const MOCK_DOCUMENTS_RESPONSE = {
 describe('CurationSuggestionLogic', () => {
   const { mount } = new LogicMounter(CurationSuggestionLogic);
   const { flashAPIErrors } = mockFlashMessageHelpers;
+  const { navigateToUrl } = mockKibanaValues;
+
   const mountLogic = (props: object = {}) => {
     mount(props, { query: 'foo-query' });
   };
 
   const { http } = mockHttpValues;
+
+  const itHandlesInlineErrors = (callback: () => void) => {
+    it('handles inline errors', async () => {
+      http.put.mockReturnValueOnce(
+        Promise.resolve({
+          results: [
+            {
+              error: 'error',
+            },
+          ],
+        })
+      );
+      mountLogic({
+        suggestion,
+      });
+
+      callback();
+      await nextTick();
+
+      expect(flashAPIErrors).toHaveBeenCalledWith('error');
+    });
+  };
+
+  const itHandlesErrors = (httpMethod: any, callback: () => void) => {
+    it('handles errors', async () => {
+      httpMethod.mockReturnValueOnce(Promise.reject('error'));
+      mountLogic({
+        suggestion,
+      });
+
+      callback();
+      await nextTick();
+
+      expect(flashAPIErrors).toHaveBeenCalledWith('error');
+    });
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -207,7 +246,7 @@ describe('CurationSuggestionLogic', () => {
             query: 'foo',
             updated_at: '2021-07-08T14:35:50Z',
             promoted: ['1', '2', '3'],
-            status: 'applied',
+            status: 'pending',
           },
           // Note that these were re-ordered to match the 'promoted' list above, and since document
           // 3 was not found it is not included in this list
@@ -243,9 +282,7 @@ describe('CurationSuggestionLogic', () => {
         );
         http.post.mockReturnValueOnce(Promise.resolve(MOCK_DOCUMENTS_RESPONSE));
         http.get.mockReturnValueOnce(Promise.resolve(curation));
-        mountLogic({
-          suggestion: set('curation_id', 'cur-6155e69c7a2f2e4f756303fd', suggestion),
-        });
+        mountLogic();
         jest.spyOn(CurationSuggestionLogic.actions, 'onSuggestionLoaded');
 
         CurationSuggestionLogic.actions.loadSuggestion();
@@ -255,7 +292,6 @@ describe('CurationSuggestionLogic', () => {
           '/internal/app_search/engines/some-engine/curations/cur-6155e69c7a2f2e4f756303fd',
           { query: { skip_record_analytics: 'true' } }
         );
-        await nextTick();
 
         expect(CurationSuggestionLogic.actions.onSuggestionLoaded).toHaveBeenCalledWith({
           suggestion: expect.any(Object),
@@ -264,14 +300,192 @@ describe('CurationSuggestionLogic', () => {
         });
       });
 
-      it('handles errors', async () => {
-        http.post.mockReturnValueOnce(Promise.reject('error'));
-        mount();
-
+      itHandlesErrors(http.post, () => {
         CurationSuggestionLogic.actions.loadSuggestion();
+      });
+    });
+
+    describe('acceptSuggestion', () => {
+      it('will make an http call to apply the suggestion, and then navigate to that detail page', async () => {
+        http.put.mockReturnValueOnce(
+          Promise.resolve({
+            results: [
+              {
+                ...suggestion,
+                status: 'accepted',
+                curation_id: 'cur-6155e69c7a2f2e4f756303fd',
+              },
+            ],
+          })
+        );
+        mountLogic({
+          suggestion,
+        });
+
+        CurationSuggestionLogic.actions.acceptSuggestion();
         await nextTick();
 
-        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+        expect(http.put).toHaveBeenCalledWith(
+          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          {
+            body: JSON.stringify([
+              {
+                query: 'foo',
+                type: 'curation',
+                status: 'applied',
+              },
+            ]),
+          }
+        );
+
+        expect(navigateToUrl).toHaveBeenCalledWith(
+          '/engines/some-engine/curations/cur-6155e69c7a2f2e4f756303fd'
+        );
+      });
+
+      itHandlesErrors(http.put, () => {
+        CurationSuggestionLogic.actions.acceptSuggestion();
+      });
+
+      itHandlesInlineErrors(() => {
+        CurationSuggestionLogic.actions.acceptSuggestion();
+      });
+    });
+
+    describe('acceptAndAutomateSuggestion', () => {
+      it('will make an http call to apply the suggestion, and then navigate to that detail page', async () => {
+        http.put.mockReturnValueOnce(
+          Promise.resolve({
+            results: [
+              {
+                ...suggestion,
+                status: 'accepted',
+                curation_id: 'cur-6155e69c7a2f2e4f756303fd',
+              },
+            ],
+          })
+        );
+        mountLogic({
+          suggestion,
+        });
+
+        CurationSuggestionLogic.actions.acceptAndAutomateSuggestion();
+        await nextTick();
+
+        expect(http.put).toHaveBeenCalledWith(
+          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          {
+            body: JSON.stringify([
+              {
+                query: 'foo',
+                type: 'curation',
+                status: 'automated',
+              },
+            ]),
+          }
+        );
+
+        expect(navigateToUrl).toHaveBeenCalledWith(
+          '/engines/some-engine/curations/cur-6155e69c7a2f2e4f756303fd'
+        );
+      });
+
+      itHandlesErrors(http.put, () => {
+        CurationSuggestionLogic.actions.acceptAndAutomateSuggestion();
+      });
+
+      itHandlesInlineErrors(() => {
+        CurationSuggestionLogic.actions.acceptAndAutomateSuggestion();
+      });
+    });
+
+    describe('rejectSuggestion', () => {
+      it('will make an http call to apply the suggestion, and then navigate back the curations page', async () => {
+        http.put.mockReturnValueOnce(
+          Promise.resolve({
+            results: [
+              {
+                ...suggestion,
+                status: 'rejected',
+                curation_id: 'cur-6155e69c7a2f2e4f756303fd',
+              },
+            ],
+          })
+        );
+        mountLogic({
+          suggestion,
+        });
+
+        CurationSuggestionLogic.actions.rejectSuggestion();
+        await nextTick();
+
+        expect(http.put).toHaveBeenCalledWith(
+          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          {
+            body: JSON.stringify([
+              {
+                query: 'foo',
+                type: 'curation',
+                status: 'rejected',
+              },
+            ]),
+          }
+        );
+
+        expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/curations');
+      });
+
+      itHandlesErrors(http.put, () => {
+        CurationSuggestionLogic.actions.rejectSuggestion();
+      });
+
+      itHandlesInlineErrors(() => {
+        CurationSuggestionLogic.actions.rejectSuggestion();
+      });
+    });
+
+    describe('rejectAndDisableSuggestion', () => {
+      it('will make an http call to apply the suggestion, and then navigate back the curations page', async () => {
+        http.put.mockReturnValueOnce(
+          Promise.resolve({
+            results: [
+              {
+                ...suggestion,
+                status: 'disabled',
+                curation_id: 'cur-6155e69c7a2f2e4f756303fd',
+              },
+            ],
+          })
+        );
+        mountLogic({
+          suggestion,
+        });
+
+        CurationSuggestionLogic.actions.rejectAndDisableSuggestion();
+        await nextTick();
+
+        expect(http.put).toHaveBeenCalledWith(
+          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          {
+            body: JSON.stringify([
+              {
+                query: 'foo',
+                type: 'curation',
+                status: 'disabled',
+              },
+            ]),
+          }
+        );
+
+        expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/curations');
+      });
+
+      itHandlesErrors(http.put, () => {
+        CurationSuggestionLogic.actions.rejectAndDisableSuggestion();
+      });
+
+      itHandlesInlineErrors(() => {
+        CurationSuggestionLogic.actions.rejectAndDisableSuggestion();
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
@@ -34,6 +34,7 @@ const suggestion: CurationSuggestion = {
   updated_at: '2021-07-08T14:35:50Z',
   promoted: ['1', '2', '3'],
   status: 'pending',
+  operation: 'create',
 };
 
 const curation = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
@@ -179,7 +179,7 @@ export const CurationSuggestionLogic = kea<
 
         setQueuedSuccessMessage(
           i18n.translate(
-            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAutomatedMessage',
             {
               defaultMessage:
                 'Suggestion was succefully applied and all future suggestions for the query "{query}" will be automatically applied.',
@@ -206,7 +206,7 @@ export const CurationSuggestionLogic = kea<
 
         setQueuedSuccessMessage(
           i18n.translate(
-            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyRejectedMessage',
             {
               defaultMessage: 'Suggestion was succefully rejected.',
               values: { query: suggestion!.query },
@@ -228,7 +228,7 @@ export const CurationSuggestionLogic = kea<
 
         setQueuedSuccessMessage(
           i18n.translate(
-            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyDisabledMessage',
             {
               defaultMessage:
                 'Suggestion was succefully rejected and you will no longer receive suggestions for the query "{query}".',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
@@ -10,7 +10,11 @@ import { HttpSetup } from 'kibana/public';
 
 import { i18n } from '@kbn/i18n';
 
-import { flashAPIErrors, setQueuedErrorMessage } from '../../../../../shared/flash_messages';
+import {
+  flashAPIErrors,
+  setQueuedErrorMessage,
+  setQueuedSuccessMessage,
+} from '../../../../../shared/flash_messages';
 import { HttpLogic } from '../../../../../shared/http';
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { ENGINE_CURATIONS_PATH, ENGINE_CURATION_PATH } from '../../../../routes';
@@ -145,7 +149,12 @@ export const CurationSuggestionLogic = kea<
           'applied'
         );
 
-        // Show flash success here?
+        setQueuedSuccessMessage(
+          i18n.translate(
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            { defaultMessage: 'Suggestion was succefully applied.' }
+          )
+        );
         KibanaLogic.values.navigateToUrl(
           generateEnginePath(ENGINE_CURATION_PATH, {
             curationId: updatedSuggestion.curation_id,
@@ -168,7 +177,16 @@ export const CurationSuggestionLogic = kea<
           'automated'
         );
 
-        // Show flash success here?
+        setQueuedSuccessMessage(
+          i18n.translate(
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            {
+              defaultMessage:
+                'Suggestion was succefully applied and all future suggestions for the query "{query}" will be automatically applied.',
+              values: { query: suggestion!.query },
+            }
+          )
+        );
         KibanaLogic.values.navigateToUrl(
           generateEnginePath(ENGINE_CURATION_PATH, {
             curationId: updatedSuggestion.curation_id,
@@ -186,7 +204,15 @@ export const CurationSuggestionLogic = kea<
       try {
         await updateSuggestion(http, engineName, suggestion!.query, 'rejected');
 
-        // Show flash success here?
+        setQueuedSuccessMessage(
+          i18n.translate(
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            {
+              defaultMessage: 'Suggestion was succefully rejected.',
+              values: { query: suggestion!.query },
+            }
+          )
+        );
         KibanaLogic.values.navigateToUrl(generateEnginePath(ENGINE_CURATIONS_PATH));
       } catch (e) {
         flashAPIErrors(e);
@@ -200,7 +226,16 @@ export const CurationSuggestionLogic = kea<
       try {
         await updateSuggestion(http, engineName, suggestion!.query, 'disabled');
 
-        // Show flash success here?
+        setQueuedSuccessMessage(
+          i18n.translate(
+            'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyAppliedMessage',
+            {
+              defaultMessage:
+                'Suggestion was succefully rejected and you will no longer receive suggestions for the query "{query}".',
+              values: { query: suggestion!.query },
+            }
+          )
+        );
         KibanaLogic.values.navigateToUrl(generateEnginePath(ENGINE_CURATIONS_PATH));
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
@@ -209,7 +209,6 @@ export const CurationSuggestionLogic = kea<
             'xpack.enterpriseSearch.appSearch.engine.curations.suggestedCuration.successfullyRejectedMessage',
             {
               defaultMessage: 'Suggestion was succefully rejected.',
-              values: { query: suggestion!.query },
             }
           )
         );


### PR DESCRIPTION
## Summary

This PR wires up the action buttons on the suggestion detail view.

![latest](https://user-images.githubusercontent.com/1427475/136275140-ae11c620-aab7-4d17-8316-1ea8ffefa46d.gif)


When a user accepts a suggestion:
<img width="1707" alt="accepted2" src="https://user-images.githubusercontent.com/1427475/136275439-aa731799-fe78-4340-93df-bbfe9998ee0d.png">

When a user accepts and automates a suggestion:
<img width="1701" alt="accept" src="https://user-images.githubusercontent.com/1427475/136275282-2b4d2a17-7275-4ad6-8f94-6de62b6a2cce.png">

When a user rejects a suggestion:
<img width="1707" alt="reject" src="https://user-images.githubusercontent.com/1427475/136275574-8570749c-166a-40ec-9d3b-2c1af54cbcfe.png">

When a user rejects and disables a suggestion:
<img width="1700" alt="rejected2" src="https://user-images.githubusercontent.com/1427475/136275709-2b09e6b5-5f6f-4b40-882b-c0b43033bdae.png">

When a user attempts to use the back button to a suggestion detail page:
<img width="1705" alt="backbutton" src="https://user-images.githubusercontent.com/1427475/136275807-940a0bff-7a2f-4583-a6ce-82279247e565.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
