### PR TITLE
Replaces x-pack/test/functional/es_archives/logstash_functional with test/functional/fixtures/es_archiver/logstash_functional in test files

### DIFF
--- a/x-pack/test/accessibility/apps/dashboard_edit_panel.ts
+++ b/x-pack/test/accessibility/apps/dashboard_edit_panel.ts
@@ -23,7 +23,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('Dashboard Edit Panel', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/dashboard/drilldowns');
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await PageObjects.common.navigateToApp('dashboard');
       await dashboard.loadSavedDashboard(drilldowns.DASHBOARD_WITH_PIE_CHART_NAME);

--- a/x-pack/test/accessibility/apps/reporting.ts
+++ b/x-pack/test/accessibility/apps/reporting.ts
@@ -34,7 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
 
       await createReportingUser();
       await reporting.loginReportingUser();
@@ -42,7 +42,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
 
       await deleteReportingUser();
     });

--- a/x-pack/test/accessibility/apps/roles.ts
+++ b/x-pack/test/accessibility/apps/roles.ts
@@ -19,7 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('Kibana roles page a11y tests', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.update({
         defaultIndex: 'logstash-*',
       });
@@ -27,7 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     it('a11y test for Roles main page', async () => {

--- a/x-pack/test/api_integration/apis/file_upload/index_exists.ts
+++ b/x-pack/test/api_integration/apis/file_upload/index_exists.ts
@@ -14,11 +14,11 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('POST /internal/file_upload/index_exists', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     it('should return true when index exists', async () => {

--- a/x-pack/test/api_integration/apis/lens/existing_fields.ts
+++ b/x-pack/test/api_integration/apis/lens/existing_fields.ts
@@ -161,11 +161,11 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('existing_fields apis', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/visualize/default');
     });
     after(async () => {
-      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
+      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/visualize/default');
     });
 

--- a/x-pack/test/api_integration/apis/lens/existing_fields.ts
+++ b/x-pack/test/api_integration/apis/lens/existing_fields.ts
@@ -162,11 +162,11 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('existing_fields apis', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/visualize/default');
     });
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/visualize/default');
     });
 

--- a/x-pack/test/api_integration/apis/lens/existing_fields.ts
+++ b/x-pack/test/api_integration/apis/lens/existing_fields.ts
@@ -62,7 +62,6 @@ const fieldsWithData = [
   'xss',
   'xss.raw',
   'runtime_number',
-
   'relatedContent.article:modified_time',
   'relatedContent.article:published_time',
   'relatedContent.article:section',

--- a/x-pack/test/api_integration/apis/lens/field_stats.ts
+++ b/x-pack/test/api_integration/apis/lens/field_stats.ts
@@ -21,10 +21,10 @@ export default ({ getService }: FtrProviderContext) => {
 
   describe('index stats apis', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     describe('field distribution', () => {

--- a/x-pack/test/api_integration/apis/maps/index.js
+++ b/x-pack/test/api_integration/apis/maps/index.js
@@ -10,12 +10,12 @@ export default function ({ loadTestFile, getService }) {
 
   describe('Maps endpoints', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/maps/data');
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/maps/data');
     });
 

--- a/x-pack/test/examples/embedded_lens/index.ts
+++ b/x-pack/test/examples/embedded_lens/index.ts
@@ -14,7 +14,7 @@ export default function ({ getService, loadTestFile }: PluginFunctionalProviderC
 
   describe('embedded Lens examples', function () {
     before(async () => {
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/lens/basic'); // need at least one index pattern
       await kibanaServer.uiSettings.update({
         defaultIndex: 'logstash-*',

--- a/x-pack/test/examples/search_examples/index.ts
+++ b/x-pack/test/examples/search_examples/index.ts
@@ -15,7 +15,7 @@ export default function ({ getService, loadTestFile }: PluginFunctionalProviderC
     this.tags('ciGroup13');
     before(async () => {
       await esArchiver.emptyKibanaIndex();
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic'); // need at least one index pattern
     });
 

--- a/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_spaces.ts
+++ b/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_spaces.ts
@@ -18,7 +18,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('spaces feature controls', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     describe('space with no features disabled', () => {

--- a/x-pack/test/functional/apps/canvas/feature_controls/canvas_spaces.ts
+++ b/x-pack/test/functional/apps/canvas/feature_controls/canvas_spaces.ts
@@ -22,7 +22,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     this.tags(['skipFirefox']);
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/canvas/index.js
+++ b/x-pack/test/functional/apps/canvas/index.js
@@ -13,7 +13,7 @@ export default function canvasApp({ loadTestFile, getService }) {
     before(async () => {
       // init data
       await security.testUser.setRoles(['test_logstash_reader', 'global_canvas_all']);
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/dashboard/dashboard_lens_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/dashboard_lens_by_value.ts
@@ -18,7 +18,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('dashboard lens by value', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.preserveCrossAppState();

--- a/x-pack/test/functional/apps/dashboard/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/dashboard_maps_by_value.ts
@@ -76,7 +76,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('dashboard maps by value', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
     });
 

--- a/x-pack/test/functional/apps/dashboard/dashboard_tagging.ts
+++ b/x-pack/test/functional/apps/dashboard/dashboard_tagging.ts
@@ -66,7 +66,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     };
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.preserveCrossAppState();

--- a/x-pack/test/functional/apps/dashboard/drilldowns/index.ts
+++ b/x-pack/test/functional/apps/dashboard/drilldowns/index.ts
@@ -15,7 +15,7 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
     this.tags(['skipFirefox']);
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/dashboard/drilldowns');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
     });

--- a/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_security.ts
@@ -36,7 +36,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
 
       // ensure we're logged out so we can login as the appropriate users
       await PageObjects.security.forceLogout();

--- a/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_spaces.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_spaces.ts
@@ -22,7 +22,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('spaces', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     describe('space with no features disabled', () => {

--- a/x-pack/test/functional/apps/dashboard/feature_controls/time_to_visualize_security.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/time_to_visualize_security.ts
@@ -34,7 +34,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
 
       // ensure we're logged out so we can login as the appropriate users
       await PageObjects.security.forceLogout();

--- a/x-pack/test/functional/apps/dashboard/feature_controls/time_to_visualize_security.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/time_to_visualize_security.ts
@@ -34,7 +34,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
 
       // ensure we're logged out so we can login as the appropriate users
       await PageObjects.security.forceLogout();

--- a/x-pack/test/functional/apps/dashboard/migration_smoke_tests/tsvb_migration_smoke_test.ts
+++ b/x-pack/test/functional/apps/dashboard/migration_smoke_tests/tsvb_migration_smoke_test.ts
@@ -20,7 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('Export import saved objects between versions', () => {
     describe('From 7.12.1', () => {
       before(async () => {
-        await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+        await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
         await kibanaServer.uiSettings.replace({});
         await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickKibanaSavedObjects();
@@ -78,14 +78,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
-        await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+        await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
         await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       });
     });
 
     describe('from 7.13.3', () => {
       before(async () => {
-        await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+        await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
         await kibanaServer.uiSettings.replace({});
         await PageObjects.settings.navigateTo();
         await PageObjects.settings.clickKibanaSavedObjects();
@@ -124,7 +124,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
-        await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+        await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
         await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       });
     });

--- a/x-pack/test/functional/apps/dashboard/sync_colors.ts
+++ b/x-pack/test/functional/apps/dashboard/sync_colors.ts
@@ -36,12 +36,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   // FLAKY: https://github.com/elastic/kibana/issues/97403
   describe.skip('sync colors', function () {
     before(async function () {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
     });
 
     after(async function () {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/lens/basic');
     });
 

--- a/x-pack/test/functional/apps/discover/async_scripted_fields.js
+++ b/x-pack/test/functional/apps/discover/async_scripted_fields.js
@@ -26,7 +26,7 @@ export default function ({ getService, getPageObjects }) {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/kibana_scripted_fields_on_logstash'
       );
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await security.testUser.setRoles(['test_logstash_reader', 'global_discover_read']);
       // changing the timepicker default here saves us from having to set it in Discover (~8s)
       await kibanaServer.uiSettings.update({
@@ -38,7 +38,7 @@ export default function ({ getService, getPageObjects }) {
     after(async function afterAll() {
       await kibanaServer.uiSettings.replace({});
       await kibanaServer.uiSettings.update({});
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
       await security.testUser.restoreDefaults();
     });

--- a/x-pack/test/functional/apps/discover/async_scripted_fields.js
+++ b/x-pack/test/functional/apps/discover/async_scripted_fields.js
@@ -122,7 +122,7 @@ export default function ({ getService, getPageObjects }) {
       await queryBar.setQuery('php* OR *jpg OR *css*');
       await testSubjects.click('querySubmitButton');
       await retry.tryForTime(30000, async function () {
-        expect(await PageObjects.discover.getHitCount()).to.be('13,301');
+        expect(await PageObjects.discover.getHitCount()).to.be('13,300');
       });
     });
   });

--- a/x-pack/test/functional/apps/discover/error_handling.ts
+++ b/x-pack/test/functional/apps/discover/error_handling.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('errors', function describeIndexTests() {
     before(async function () {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/invalid_scripted_field');
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();
       await PageObjects.common.navigateToApp('discover');

--- a/x-pack/test/functional/apps/discover/feature_controls/discover_security.ts
+++ b/x-pack/test/functional/apps/discover/feature_controls/discover_security.ts
@@ -36,7 +36,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/security'
       );
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
 
       // ensure we're logged out so we can login as the appropriate users
       await PageObjects.security.forceLogout();

--- a/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
+++ b/x-pack/test/functional/apps/discover/feature_controls/discover_spaces.ts
@@ -31,7 +31,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   // Failing: See https://github.com/elastic/kibana/issues/113067
   describe.skip('spaces', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     // FLAKY: https://github.com/elastic/kibana/issues/60559

--- a/x-pack/test/functional/apps/discover/value_suggestions.ts
+++ b/x-pack/test/functional/apps/discover/value_suggestions.ts
@@ -27,7 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('value suggestions', function describeIndexTests() {
     before(async function () {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/dashboard/drilldowns');
     });
 

--- a/x-pack/test/functional/apps/discover/visualize_field.ts
+++ b/x-pack/test/functional/apps/discover/visualize_field.ts
@@ -30,7 +30,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('discover field visualize button', () => {
     beforeEach(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
       await PageObjects.common.navigateToApp('discover');
       await setDiscoverTimeRange();

--- a/x-pack/test/functional/apps/home/feature_controls/home_security.ts
+++ b/x-pack/test/functional/apps/home/feature_controls/home_security.ts
@@ -19,7 +19,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await esArchiver.load(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
 
       // ensure we're logged out so we can login as the appropriate users
       await PageObjects.security.forceLogout();

--- a/x-pack/test/functional/apps/index_patterns/feature_controls/index_patterns_security.ts
+++ b/x-pack/test/functional/apps/index_patterns/feature_controls/index_patterns_security.ts
@@ -20,7 +20,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   describe('security', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/index_patterns/feature_controls/index_patterns_spaces.ts
+++ b/x-pack/test/functional/apps/index_patterns/feature_controls/index_patterns_spaces.ts
@@ -18,7 +18,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('spaces', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     describe('space with no features disabled', () => {

--- a/x-pack/test/functional/apps/lens/lens_tagging.ts
+++ b/x-pack/test/functional/apps/lens/lens_tagging.ts
@@ -30,7 +30,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('lens tagging', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
       await PageObjects.common.navigateToApp('dashboard');
       await PageObjects.dashboard.preserveCrossAppState();

--- a/x-pack/test/functional/apps/maps/index.js
+++ b/x-pack/test/functional/apps/maps/index.js
@@ -16,7 +16,7 @@ export default function ({ loadTestFile, getService }) {
     this.tags(['skipFirefox']);
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/maps.json'
       );

--- a/x-pack/test/functional/apps/saved_objects_management/import_saved_objects_between_versions.ts
+++ b/x-pack/test/functional/apps/saved_objects_management/import_saved_objects_between_versions.ts
@@ -22,7 +22,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('Export import saved objects between versions', function () {
     before(async function () {
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/getting_started/shakespeare');
       await kibanaServer.uiSettings.replace({});
       await PageObjects.settings.navigateTo();
@@ -30,7 +30,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/getting_started/shakespeare');
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
     });

--- a/x-pack/test/functional/apps/security/secure_roles_perm.js
+++ b/x-pack/test/functional/apps/security/secure_roles_perm.js
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }) {
     before(async () => {
       await browser.setWindowSize(1600, 1000);
       log.debug('users');
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/security/discover'

--- a/x-pack/test/functional/apps/visualize/feature_controls/visualize_security.ts
+++ b/x-pack/test/functional/apps/visualize/feature_controls/visualize_security.ts
@@ -31,7 +31,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   describe('visualize feature controls security', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/visualize/default');
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       // ensure we're logged out so we can login as the appropriate users
       await PageObjects.security.forceLogout();
     });

--- a/x-pack/test/functional/apps/visualize/feature_controls/visualize_spaces.ts
+++ b/x-pack/test/functional/apps/visualize/feature_controls/visualize_spaces.ts
@@ -19,7 +19,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('visualize', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     describe('space with no features disabled', () => {

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -233,7 +233,7 @@ export class SecurityPageObject extends FtrService {
   async initTests() {
     this.log.debug('SecurityPage:initTests');
     await this.esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');
-    await this.esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+    await this.esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     await this.browser.setWindowSize(1600, 1000);
   }
 

--- a/x-pack/test/functional_vis_wizard/apps/visualization_wizard.ts
+++ b/x-pack/test/functional_vis_wizard/apps/visualization_wizard.ts
@@ -14,12 +14,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('lens and maps disabled', function () {
     before(async function () {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/visualize/default');
     });
 
     after(async function () {
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/visualize/default');
     });
 

--- a/x-pack/test/reporting_api_integration/reporting_and_security/download_csv_dashboard.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/download_csv_dashboard.ts
@@ -196,11 +196,11 @@ export default function ({ getService }: FtrProviderContext) {
       before(async () => {
         // load test data that contains a saved search and documents
         await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
-        await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+        await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
       });
       after(async () => {
         await esArchiver.unload('x-pack/test/functional/es_archives/reporting/logs');
-        await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+        await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       });
 
       it('With filters and timebased data, default to UTC', async () => {

--- a/x-pack/test/reporting_api_integration/reporting_and_security/generate_csv_discover_deprecated.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/generate_csv_discover_deprecated.ts
@@ -33,12 +33,12 @@ export default function ({ getService }: FtrProviderContext) {
   describe('Generation from Legacy Job Params', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
       await reportingAPI.deleteAllReports();
     });
 

--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -23,12 +23,12 @@ export default function ({ getService }: FtrProviderContext) {
   describe('ILM policy migration APIs', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     afterEach(async () => {

--- a/x-pack/test/reporting_api_integration/reporting_without_security/job_apis_csv.ts
+++ b/x-pack/test/reporting_api_integration/reporting_without_security/job_apis_csv.ts
@@ -50,12 +50,12 @@ export default function ({ getService }: FtrProviderContext) {
   describe('Job Listing APIs', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     afterEach(async () => {

--- a/x-pack/test/reporting_api_integration/reporting_without_security/job_apis_csv_deprecated.ts
+++ b/x-pack/test/reporting_api_integration/reporting_without_security/job_apis_csv_deprecated.ts
@@ -34,12 +34,12 @@ export default function ({ getService }: FtrProviderContext) {
   describe('Job Listing APIs: Deprecated CSV Export', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/reporting/logs');
-      await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     afterEach(async () => {

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/index.ts
@@ -17,7 +17,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     this.tags('ciGroup3');
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/dashboard/async_search');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await kibanaServer.uiSettings.replace({ 'search:timeout': 10000 });

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/session_sharing/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/session_sharing/index.ts
@@ -16,7 +16,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     this.tags('ciGroup3');
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await PageObjects.common.navigateToApp('dashboard');
     });

--- a/x-pack/test/search_sessions_integration/tests/apps/discover/async_search.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/discover/async_search.ts
@@ -30,7 +30,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('discover async search', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/discover/default'
       );

--- a/x-pack/test/search_sessions_integration/tests/apps/discover/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/discover/index.ts
@@ -17,7 +17,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
     this.tags('ciGroup3');
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await PageObjects.common.navigateToApp('discover');
     });

--- a/x-pack/test/search_sessions_integration/tests/apps/lens/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/lens/index.ts
@@ -15,7 +15,7 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
     this.tags('ciGroup3');
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
     });
 

--- a/x-pack/test/search_sessions_integration/tests/apps/lens/search_sessions.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/lens/search_sessions.ts
@@ -16,7 +16,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('lens search sessions', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/lens/basic');
     });
     after(async () => {

--- a/x-pack/test/search_sessions_integration/tests/apps/management/search_sessions/index.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/management/search_sessions/index.ts
@@ -15,7 +15,7 @@ export default function ({ loadTestFile, getService }: FtrProviderContext) {
     this.tags('ciGroup3');
 
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/dashboard/async_search');
       await kibanaServer.uiSettings.replace({ defaultIndex: 'logstash-*' });
       await kibanaServer.uiSettings.replace({ 'search:timeout': 10000 });

--- a/x-pack/test/visual_regression/tests/canvas/index.js
+++ b/x-pack/test/visual_regression/tests/canvas/index.js
@@ -15,7 +15,7 @@ export default function ({ loadTestFile, getService }) {
 
   describe('canvas app visual regression', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/canvas/default');
 
       await browser.setWindowSize(SCREEN_WIDTH, 1000);

--- a/x-pack/test/visual_regression/tests/maps/index.js
+++ b/x-pack/test/visual_regression/tests/maps/index.js
@@ -14,7 +14,7 @@ export default function ({ loadTestFile, getService }) {
 
   describe('maps app visual regression', function () {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/maps.json'
       );


### PR DESCRIPTION
We have two logstash functional data folders - one under test/functional/fixtures/es_archiver/logstash_functiona and another under x-pack/test/functional/es_archives/logstash_functional ( this data has mapping conflicts). This PR is replacing the latter with the former. 