### PR TITLE
[failed-test-reporter/es-config] add new sub-fields in mapping

### DIFF
--- a/packages/kbn-test/src/failed_tests_reporter/es_config
+++ b/packages/kbn-test/src/failed_tests_reporter/es_config
@@ -78,17 +78,32 @@ PUT _component_template/test-failures-mappings
           "properties": {
             "classname": {
               "type": "keyword",
-              "ignore_above": 256
+              "ignore_above": 256,
+              "fields": {
+                "text": {
+                  "type": "text"
+                }
+              }
             },
             "failure": {
               "type": "keyword",
-              "ignore_above": 256
+              "ignore_above": 256,
+              "fields": {
+                "text": {
+                  "type": "text"
+                }
+              }
             },
             "likelyIrrelevant": {
               "type": "boolean"
             },
             "name": {
-              "type": "keyword"
+              "type": "keyword",
+              "fields": {
+                "text": {
+                  "type": "text"
+                }
+              }
             },
             "system-out": {
               "type": "match_only_text"


### PR DESCRIPTION
Added `.text` subfields to failure fields and updating the `es_config` file to reflect the change.