### PR TITLE
Logstash view cleanup fixes

### DIFF
--- a/x-pack/plugins/monitoring/public/application/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/index.tsx
@@ -231,32 +231,10 @@ const MonitoringApp: React.FC<{
                     fetchAllClusters={false}
                   />
 
-                  {/* APM Views */}
-                  <RouteInit
-                    path="/apm/instances/:instance"
-                    component={ApmInstancePage}
-                    codePaths={[CODE_PATH_APM]}
-                    fetchAllClusters={false}
-                  />
-
-                  {/* Logstash Routes */}
-                  <RouteInit
-                    path="/logstash/nodes"
-                    component={LogStashNodesPage}
-                    codePaths={[CODE_PATH_LOGSTASH]}
-                    fetchAllClusters={false}
-                  />
-
                   <RouteInit
                     path="/logstash/node/:uuid/advanced"
                     component={LogStashNodeAdvancedPage}
                     codePaths={[CODE_PATH_LOGSTASH]}
-                    fetchAllClusters={false}
-                  />
-                  <RouteInit
-                    path="/apm/instances"
-                    component={ApmInstancesPage}
-                    codePaths={[CODE_PATH_APM]}
                     fetchAllClusters={false}
                   />
 
@@ -294,6 +272,22 @@ const MonitoringApp: React.FC<{
                     codePaths={[CODE_PATH_LOGSTASH]}
                     fetchAllClusters={false}
                   />
+
+                  {/* APM Views */}
+                  <RouteInit
+                    path="/apm/instances/:instance"
+                    component={ApmInstancePage}
+                    codePaths={[CODE_PATH_APM]}
+                    fetchAllClusters={false}
+                  />
+
+                  <RouteInit
+                    path="/apm/instances"
+                    component={ApmInstancesPage}
+                    codePaths={[CODE_PATH_APM]}
+                    fetchAllClusters={false}
+                  />
+
                   <RouteInit
                     path="/apm"
                     component={ApmOverviewPage}

--- a/x-pack/plugins/monitoring/public/application/pages/logstash/logstash_template.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/logstash/logstash_template.tsx
@@ -55,21 +55,21 @@ export const LogstashTemplate: React.FC<LogstashTemplateProps> = ({
         label: i18n.translate('xpack.monitoring.logstashNavigation.instance.overviewLinkText', {
           defaultMessage: 'Overview',
         }),
-        route: `/logstash/node/${instance.nodeSummary?.uuid}`, // IDK if this is right
+        route: `/logstash/node/${instance.nodeSummary?.uuid}`,
       });
       tabs.push({
         id: 'pipeline',
         label: i18n.translate('xpack.monitoring.logstashNavigation.instance.pipelinesLinkText', {
           defaultMessage: 'Pipelines',
         }),
-        route: `/logstash/node/${instance.nodeSummary?.uuid}/pipelines`, // IDK if this is right
+        route: `/logstash/node/${instance.nodeSummary?.uuid}/pipelines`,
       });
       tabs.push({
         id: 'advanced',
         label: i18n.translate('xpack.monitoring.logstashNavigation.instance.advancedLinkText', {
           defaultMessage: 'Advanced',
         }),
-        route: `/logstash/node/${instance.nodeSummary?.uuid}/advanced`, // IDK if this is right
+        route: `/logstash/node/${instance.nodeSummary?.uuid}/advanced`,
       });
     }
   }


### PR DESCRIPTION
## Summary

A few code fixes for #113256

Originally from https://github.com/phillipb/kibana/pull/1


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
