### PR TITLE
[Charts] Unskips the jest active cursor test suite

### DIFF
--- a/src/plugins/charts/public/services/active_cursor/use_active_cursor.test.ts
+++ b/src/plugins/charts/public/services/active_cursor/use_active_cursor.test.ts
@@ -15,8 +15,7 @@ import type { ActiveCursorSyncOption, ActiveCursorPayload } from './types';
 import type { Chart, PointerEvent } from '@elastic/charts';
 import type { Datatable } from '../../../../expressions/public';
 
-// FLAKY: https://github.com/elastic/kibana/issues/110038
-describe.skip('useActiveCursor', () => {
+describe('useActiveCursor', () => {
   let cursor: ActiveCursorPayload['cursor'];
   let dispatchExternalPointerEvent: jest.Mock;
 
@@ -77,7 +76,7 @@ describe.skip('useActiveCursor', () => {
   test('should debounce events', async () => {
     await act(
       {
-        debounce: 5,
+        debounce: 50,
         datatables: [
           {
             columns: [


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/110038

As described here https://github.com/elastic/kibana/issues/110038#issuecomment-937619356
I am unskipping this test and icreasr the debounce to 50ms (than 5ms that it was before).