### PR TITLE
Ensure deprecation documentationUrl's point to correct doc branch

### DIFF
--- a/x-pack/plugins/security/server/config_deprecations.ts
+++ b/x-pack/plugins/security/server/config_deprecations.ts
@@ -24,7 +24,7 @@ export const securityConfigDeprecationProvider: ConfigDeprecationProvider = ({
   unused('authorization.legacyFallback.enabled'),
   unused('authc.saml.maxRedirectURLSize'),
   // Deprecation warning for the legacy audit logger.
-  (settings, fromPath, addDeprecation) => {
+  (settings, fromPath, addDeprecation, { branch }) => {
     const auditLoggingEnabled = settings?.xpack?.security?.audit?.enabled ?? false;
     const legacyAuditLoggerEnabled = !settings?.xpack?.security?.audit?.appender;
     if (auditLoggingEnabled && legacyAuditLoggerEnabled) {
@@ -36,8 +36,7 @@ export const securityConfigDeprecationProvider: ConfigDeprecationProvider = ({
           defaultMessage:
             'The legacy audit logger is deprecated in favor of the new ECS-compliant audit logger.',
         }),
-        documentationUrl:
-          'https://www.elastic.co/guide/en/kibana/current/security-settings-kb.html#audit-logging-settings',
+        documentationUrl: `https://www.elastic.co/guide/en/kibana/${branch}/security-settings-kb.html#audit-logging-settings`,
         correctiveActions: {
           manualSteps: [
             i18n.translate('xpack.security.deprecations.auditLogger.manualStepOneMessage', {


### PR DESCRIPTION
This was made possible via PR #113600.

This PR does not do anything about the `documenationUrl` usage in the following files as they do not currently have access to `ConfigDeprecationContext`:

- [src/plugins/data_views/server/deprecations/scripted_fields.ts](https://github.com/elastic/kibana/blob/master/src/plugins/data_views/server/deprecations/scripted_fields.ts)
- [x-pack/plugins/apm/server/deprecations/index.ts](https://github.com/elastic/kibana/blob/master/x-pack/plugins/apm/server/deprecations/index.ts)
- [x-pack/plugins/maps/server/index.ts](https://github.com/elastic/kibana/blob/master/x-pack/plugins/maps/server/index.ts)
- [x-pack/plugins/reporting/server/deprecations/reporting_role.ts](https://github.com/elastic/kibana/blob/master/x-pack/plugins/reporting/server/deprecations/reporting_role.ts)

This PR will not be backported to the `7.x` branch. In regards to deprecation messages there's too many differences between `master` and `7.x` to warrant a single PR to `master` that's then backported to `7.x`. I've made another PR specifically for `7.x`: #114263.