### PR TITLE
[Stack Monitoring] sync timepicker with url

### DIFF
--- a/x-pack/plugins/monitoring/public/application/hooks/use_monitoring_time.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_monitoring_time.ts
@@ -54,7 +54,7 @@ export const useMonitoringTime = () => {
   );
 
   useEffect(() => {
-    const sub = Legacy.shims.timefilter.getTimeUpdate$().subscribe(function () {
+    const sub = Legacy.shims.timefilter.getTimeUpdate$().subscribe(function onTimeUpdate() {
       const updatedTime = Legacy.shims.timefilter.getTime();
       setTimeRange({ ...currentTimerange, ...updatedTime });
       state.time = { ...updatedTime };

--- a/x-pack/plugins/monitoring/public/application/hooks/use_monitoring_time.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_monitoring_time.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { useCallback, useState, useContext } from 'react';
+import { useCallback, useState, useContext, useEffect } from 'react';
 import createContainer from 'constate';
 import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 import { Legacy } from '../../legacy_shims';
@@ -52,6 +52,17 @@ export const useMonitoringTime = () => {
     },
     [currentTimerange, setTimeRange, state]
   );
+
+  useEffect(() => {
+    const sub = Legacy.shims.timefilter.getTimeUpdate$().subscribe(function () {
+      const updatedTime = Legacy.shims.timefilter.getTime();
+      setTimeRange({ ...currentTimerange, ...updatedTime });
+      state.time = { ...updatedTime };
+      state.save?.();
+    });
+
+    return () => sub.unsubscribe();
+  }, []);
 
   return {
     currentTimerange,

--- a/x-pack/plugins/monitoring/public/application/hooks/use_monitoring_time.ts
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_monitoring_time.ts
@@ -62,6 +62,7 @@ export const useMonitoringTime = () => {
     });
 
     return () => sub.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {

--- a/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
+++ b/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
@@ -40,12 +40,6 @@ export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle,
         return;
       }
       handleTimeChange(selectedTime.start, selectedTime.end);
-      state.time = {
-        from: selectedTime.start,
-        to: selectedTime.end,
-      };
-      Legacy.shims.timefilter.setTime(state.time);
-      state.save?.();
     },
     [handleTimeChange, state]
   );

--- a/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
+++ b/x-pack/plugins/monitoring/public/components/shared/toolbar.tsx
@@ -41,7 +41,7 @@ export const MonitoringToolbar: React.FC<MonitoringToolbarProps> = ({ pageTitle,
       }
       handleTimeChange(selectedTime.start, selectedTime.end);
     },
-    [handleTimeChange, state]
+    [handleTimeChange]
   );
 
   const onRefreshChange = useCallback(


### PR DESCRIPTION
## Summary

Context here https://github.com/elastic/kibana/issues/112063

Propagate url changes to the time range down to the appropriate hook.

### Testing
- verified timepicker and graph were updated when manually changing the timerange query in url
- verified it also updated when zooming out from the graph action button