### PR TITLE
[ts] support building refs for one project

### DIFF
--- a/src/dev/typescript/build_ts_refs.ts
+++ b/src/dev/typescript/build_ts_refs.ts
@@ -11,17 +11,20 @@ import Path from 'path';
 import { ToolingLog, REPO_ROOT, ProcRunner } from '@kbn/dev-utils';
 
 import { ROOT_REFS_CONFIG_PATH } from './root_refs_config';
+import { Project } from './project';
 
 export async function buildAllTsRefs({
   log,
   procRunner,
   verbose,
+  project,
 }: {
   log: ToolingLog;
   procRunner: ProcRunner;
   verbose?: boolean;
+  project?: Project;
 }): Promise<{ failed: boolean }> {
-  const relative = Path.relative(REPO_ROOT, ROOT_REFS_CONFIG_PATH);
+  const relative = Path.relative(REPO_ROOT, project ? project.tsConfigPath : ROOT_REFS_CONFIG_PATH);
   log.info(`Building TypeScript projects refs for ${relative}...`);
 
   try {

--- a/src/dev/typescript/build_ts_refs.ts
+++ b/src/dev/typescript/build_ts_refs.ts
@@ -13,7 +13,7 @@ import { ToolingLog, REPO_ROOT, ProcRunner } from '@kbn/dev-utils';
 import { ROOT_REFS_CONFIG_PATH } from './root_refs_config';
 import { Project } from './project';
 
-export async function buildAllTsRefs({
+export async function buildTsRefs({
   log,
   procRunner,
   verbose,

--- a/src/dev/typescript/build_ts_refs_cli.ts
+++ b/src/dev/typescript/build_ts_refs_cli.ts
@@ -12,7 +12,7 @@ import { run, REPO_ROOT, createFlagError } from '@kbn/dev-utils';
 import del from 'del';
 
 import { RefOutputCache } from './ref_output_cache';
-import { buildAllTsRefs } from './build_ts_refs';
+import { buildTsRefs } from './build_ts_refs';
 import { updateRootRefsConfig, ROOT_REFS_CONFIG_PATH } from './root_refs_config';
 import { Project } from './project';
 import { PROJECT_CACHE } from './projects';
@@ -97,7 +97,7 @@ export async function runBuildRefsCli() {
       }
 
       try {
-        await buildAllTsRefs({
+        await buildTsRefs({
           log,
           procRunner,
           verbose: !!flags.verbose,

--- a/src/dev/typescript/build_ts_refs_cli.ts
+++ b/src/dev/typescript/build_ts_refs_cli.ts
@@ -8,7 +8,7 @@
 
 import Path from 'path';
 
-import { run, REPO_ROOT } from '@kbn/dev-utils';
+import { run, REPO_ROOT, createFlagError } from '@kbn/dev-utils';
 import del from 'del';
 
 import { RefOutputCache } from './ref_output_cache';
@@ -41,24 +41,34 @@ export async function runBuildRefsCli() {
         return;
       }
 
+      const projectFilter = flags.project;
+      if (projectFilter && typeof projectFilter !== 'string') {
+        throw createFlagError('expected --project to be a string');
+      }
+
       // if the tsconfig.refs.json file is not self-managed then make sure it has
       // a reference to every composite project in the repo
       await updateRootRefsConfig(log);
 
-      // load all the projects referenced from the root refs config deeply, so we know all
-      // the ts projects we are going to be cleaning or populating with caches
-      const projects = Project.load(
-        ROOT_REFS_CONFIG_PATH,
+      const rootProject = Project.load(
+        projectFilter ? projectFilter : ROOT_REFS_CONFIG_PATH,
         {},
         {
           skipConfigValidation: true,
         }
-      ).getProjectsDeep(PROJECT_CACHE);
+      );
+      // load all the projects referenced from the root project deeply, so we know all
+      // the ts projects we are going to be cleaning or populating with caches
+      const projects = rootProject.getProjectsDeep(PROJECT_CACHE);
 
       const cacheEnabled = process.env.BUILD_TS_REFS_CACHE_ENABLE !== 'false' && !!flags.cache;
       const doCapture = process.env.BUILD_TS_REFS_CACHE_CAPTURE === 'true';
       const doClean = !!flags.clean || doCapture;
       const doInitCache = cacheEnabled && !doCapture;
+
+      if (doCapture && projectFilter) {
+        throw createFlagError('--project can not be combined with cache capture');
+      }
 
       statsMeta.set('buildTsRefsEnabled', enabled);
       statsMeta.set('buildTsRefsCacheEnabled', cacheEnabled);
@@ -87,7 +97,12 @@ export async function runBuildRefsCli() {
       }
 
       try {
-        await buildAllTsRefs({ log, procRunner, verbose: !!flags.verbose });
+        await buildAllTsRefs({
+          log,
+          procRunner,
+          verbose: !!flags.verbose,
+          project: rootProject,
+        });
         log.success('ts refs build successfully');
       } catch (error) {
         const typeFailure = isTypeFailure(error);
@@ -110,13 +125,15 @@ export async function runBuildRefsCli() {
       }
     },
     {
-      description: 'Build TypeScript projects',
+      description: 'Build TypeScript project references',
       flags: {
         boolean: ['clean', 'force', 'cache', 'ignore-type-failures'],
+        string: ['project'],
         default: {
           cache: true,
         },
         help: `
+          --project          Only build the TS Refs for a specific project
           --force            Run the build even if the BUILD_TS_REFS_DISABLE is set to "true"
           --clean            Delete outDirs for each ts project before building
           --no-cache         Disable fetching/extracting outDir caches based on the mergeBase with upstream

--- a/src/dev/typescript/run_type_check_cli.ts
+++ b/src/dev/typescript/run_type_check_cli.ts
@@ -26,11 +26,6 @@ export async function runTypeCheckCli() {
       // a reference to every composite project in the repo
       await updateRootRefsConfig(log);
 
-      const { failed } = await buildAllTsRefs({ log, procRunner, verbose: !!flags.verbose });
-      if (failed) {
-        throw createFailError('Unable to build TS project refs');
-      }
-
       const projectFilter =
         flags.project && typeof flags.project === 'string'
           ? Path.resolve(flags.project)
@@ -39,6 +34,16 @@ export async function runTypeCheckCli() {
       const projects = PROJECTS.filter((p) => {
         return !p.disableTypeCheck && (!projectFilter || p.tsConfigPath === projectFilter);
       });
+
+      const { failed } = await buildAllTsRefs({
+        log,
+        procRunner,
+        verbose: !!flags.verbose,
+        project: projects.length === 1 ? projects[0] : undefined,
+      });
+      if (failed) {
+        throw createFailError('Unable to build TS project refs');
+      }
 
       if (!projects.length) {
         if (projectFilter) {

--- a/src/dev/typescript/run_type_check_cli.ts
+++ b/src/dev/typescript/run_type_check_cli.ts
@@ -16,7 +16,7 @@ import { run, createFailError } from '@kbn/dev-utils';
 import { lastValueFrom } from '@kbn/std';
 
 import { PROJECTS } from './projects';
-import { buildAllTsRefs } from './build_ts_refs';
+import { buildTsRefs } from './build_ts_refs';
 import { updateRootRefsConfig } from './root_refs_config';
 
 export async function runTypeCheckCli() {
@@ -35,7 +35,7 @@ export async function runTypeCheckCli() {
         return !p.disableTypeCheck && (!projectFilter || p.tsConfigPath === projectFilter);
       });
 
-      const { failed } = await buildAllTsRefs({
+      const { failed } = await buildTsRefs({
         log,
         procRunner,
         verbose: !!flags.verbose,


### PR DESCRIPTION
Adds support for building TS Refs for a specific project by passing `--project` to `node scripts/build_ts_refs`. Additionally, when passing `--project` to `node scripts/type_check` only the refs for that project are built.

[skip ci]