### PR TITLE
[DOCS] Adds 6.8.20 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -126,7 +126,7 @@ Breaking changes can prevent your application from optimal operation and perform
 [[bug-fixes-and-enhancements-6.8.20]]
 === Bug fixes and enhancements
 
-There are no user-facing changes in the 6.8.20 release.
+* Routine dependency upgrades {kibana-pull}113388[#113388]
 
 [[release-notes-6.8.19]]
 == {kib} 6.8.19

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -14,6 +14,7 @@
 
 Review important information about the {kib} 6.x.x releases.
 
+* <<release-notes-6.8.20>>
 * <<release-notes-6.8.19>>
 * <<release-notes-6.8.18>>
 * <<release-notes-6.8.17>>
@@ -107,6 +108,25 @@ Review important information about the {kib} 6.x.x releases.
 //[float]
 //=== Known issues
 ////
+
+[[release-notes-6.8.20]]
+== {kib} 6.8.20
+
+coming::[6.8.20]
+
+For information about the {kib} 6.8.20 release, review the following information.
+
+[float]
+[[breaking-changes-6.8.20]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and performance. Before you upgrade, review the <<breaking-changes,Breaking changes>>, then mitigate the impact to your application.
+
+[float]
+[[bug-fixes-and-enhancements-6.8.20]]
+=== Bug fixes and enhancements
+
+There are no user-facing changes in the 6.8.20 release.
 
 [[release-notes-6.8.19]]
 == {kib} 6.8.19


### PR DESCRIPTION
## Summary

Adds the [release notes for the 6.8.20 release](https://kibana_114349.docs-preview.app.elstc.co/guide/en/kibana/6.8/release-notes-6.8.20.html).
