### PR TITLE
[ci-stats-reporter] ensure HTTP adapter is used

### DIFF
--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -13,6 +13,8 @@ import Path from 'path';
 import crypto from 'crypto';
 import execa from 'execa';
 import Axios from 'axios';
+// @ts-expect-error not "public", but necessary to prevent Jest shimming from breaking things
+import httpAdapter from 'axios/lib/adapters/http';
 
 import { ToolingLog } from '../tooling_log';
 import { parseConfig, Config } from './ci_stats_config';
@@ -225,6 +227,7 @@ export class CiStatsReporter {
           baseURL: BASE_URL,
           headers,
           data: body,
+          adapter: httpAdapter,
         });
 
         return true;

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -8965,6 +8965,8 @@ var _execa = _interopRequireDefault(__webpack_require__(134));
 
 var _axios = _interopRequireDefault(__webpack_require__(177));
 
+var _http = _interopRequireDefault(__webpack_require__(199));
+
 var _ci_stats_config = __webpack_require__(218);
 
 /*
@@ -8974,6 +8976,7 @@ var _ci_stats_config = __webpack_require__(218);
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+// @ts-expect-error not "public", but necessary to prevent Jest shimming from breaking things
 const BASE_URL = 'https://ci-stats.kibana.dev';
 
 class CiStatsReporter {
@@ -9173,7 +9176,8 @@ class CiStatsReporter {
           url: path,
           baseURL: BASE_URL,
           headers,
-          data: body
+          data: body,
+          adapter: _http.default
         });
         return true;
       } catch (error) {


### PR DESCRIPTION
In a few tests we're seeing the `CiStatsReporter` trigger errors because Jest is tearing down JSDOM preventing the XHR adapter (which Axios uses by default when it detects JSDOM) from working. To prevent this behavior we can pass a specific adapter to Axios.

Issues: https://github.com/elastic/kibana/issues/113695 and https://github.com/elastic/kibana/issues/113682