### PR TITLE
[build] Fix os package kibana.yml

### DIFF
--- a/src/dev/build/tasks/os_packages/create_os_package_kibana_yml.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_kibana_yml.ts
@@ -23,7 +23,7 @@ export async function createOSPackageKibanaYML(config: Config, build: Build) {
   [
     [/#pid.file:.*/g, 'pid.file: /run/kibana/kibana.pid'],
     [
-      /#logging.dest:.*/g,
+      /#\s?logging.appenders.default:.*kibana\.log\n/gs,
       dump({
         logging: {
           appenders: {

--- a/src/dev/build/tasks/os_packages/create_os_package_kibana_yml.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_kibana_yml.ts
@@ -23,7 +23,7 @@ export async function createOSPackageKibanaYML(config: Config, build: Build) {
   [
     [/#pid.file:.*/g, 'pid.file: /run/kibana/kibana.pid'],
     [
-      /#\s?logging.appenders.default:.*kibana\.log\n/gs,
+      /#logging.appenders.default:.*kibana\.log\n/gs,
       dump({
         logging: {
           appenders: {


### PR DESCRIPTION
With the removal of legacy logging settings, kibana.yml generation isn't
able to match on the old logging.dest setting.  This updates the regex
to match the new settings.
