### PR TITLE
[Visualize] Wizard rename Index pattern to Data view

### DIFF
--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -71,9 +71,9 @@ export class SearchSelection extends React.Component<SearchSelectionProps> {
                 type: 'index-pattern',
                 getIconForSavedObject: () => 'indexPatternApp',
                 name: i18n.translate(
-                  'visualizations.newVisWizard.searchSelection.savedObjectType.indexPattern',
+                  'visualizations.newVisWizard.searchSelection.savedObjectType.dataView',
                   {
-                    defaultMessage: 'Index pattern',
+                    defaultMessage: 'Data view',
                   }
                 ),
               },

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -5870,7 +5870,6 @@
     "visualizations.newVisWizard.newVisTypeTitle": "新規 {visTypeName}",
     "visualizations.newVisWizard.readDocumentationLink": "ドキュメンテーションを表示",
     "visualizations.newVisWizard.searchSelection.notFoundLabel": "一致インデックスまたは保存した検索が見つかりません。",
-    "visualizations.newVisWizard.searchSelection.savedObjectType.indexPattern": "インデックスパターン",
     "visualizations.newVisWizard.searchSelection.savedObjectType.search": "保存検索",
     "visualizations.newVisWizard.title": "新規ビジュアライゼーション",
     "visualizations.newVisWizard.toolsGroupTitle": "ツール",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -5917,7 +5917,6 @@
     "visualizations.newVisWizard.readDocumentationLink": "阅读文档",
     "visualizations.newVisWizard.resultsFound": "{resultCount, plural, other {类型}}已找到",
     "visualizations.newVisWizard.searchSelection.notFoundLabel": "未找到匹配的索引或已保存搜索。",
-    "visualizations.newVisWizard.searchSelection.savedObjectType.indexPattern": "索引模式",
     "visualizations.newVisWizard.searchSelection.savedObjectType.search": "已保存搜索",
     "visualizations.newVisWizard.title": "新建可视化",
     "visualizations.newVisWizard.toolsGroupTitle": "工具",


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/105199

## Summary

Renamed `index patterns` to `data views` in Visualize Wizard UI.

![image](https://user-images.githubusercontent.com/17003240/135221910-dd24c791-21a4-4ec3-a605-2f3bc807dc2a.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
