### PR TITLE
[Vega] Improve error message in case of invalid $schema URL

### DIFF
--- a/src/plugins/vis_types/vega/public/data_model/vega_parser.test.js
+++ b/src/plugins/vis_types/vega/public/data_model/vega_parser.test.js
@@ -81,6 +81,20 @@ describe(`VegaParser.parseAsync`, () => {
       })
     )
   );
+
+  test(`should return a specific error in case of $schema URL not valid`, async () => {
+    const vp = new VegaParser({
+      $schema: 'https://vega.github.io/schema/vega-lite/v4.jsonanythingtobreakthis',
+      mark: 'circle',
+      encoding: { row: { field: 'a' } },
+    });
+
+    await vp.parseAsync();
+
+    expect(vp.error).toBe(
+      'The URL for the JSON "$schema" is incorrect. Correct the URL, then click Update.'
+    );
+  });
 });
 
 describe(`VegaParser._setDefaultValue`, () => {

--- a/src/plugins/vis_types/vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_types/vega/public/data_model/vega_parser.ts
@@ -578,7 +578,10 @@ The URL is an identifier only. Kibana and your browser will never access this UR
       return { isVegaLite, libVersion };
     } catch (e) {
       throw Error(
-        'The URL for the JSON "$schema" is incorrect. Correct the URL, then click Update.'
+        i18n.translate('visTypeVega.vegaParser.notValidSchemaForInputSpec', {
+          defaultMessage:
+            'The URL for the JSON "$schema" is incorrect. Correct the URL, then click Update.',
+        })
       );
     }
   }

--- a/src/plugins/vis_types/vega/public/data_model/vega_parser.ts
+++ b/src/plugins/vis_types/vega/public/data_model/vega_parser.ts
@@ -553,25 +553,34 @@ The URL is an identifier only. Kibana and your browser will never access this UR
    * @private
    */
   private parseSchema(spec: VegaSpec) {
-    const schema = schemaParser(spec.$schema);
-    const isVegaLite = schema.library === 'vega-lite';
-    const libVersion = isVegaLite ? vegaLiteVersion : vegaVersion;
+    try {
+      const schema = schemaParser(spec.$schema);
+      const isVegaLite = schema.library === 'vega-lite';
+      const libVersion = isVegaLite ? vegaLiteVersion : vegaVersion;
 
-    if (versionCompare(schema.version, libVersion) > 0) {
-      this._onWarning(
-        i18n.translate('visTypeVega.vegaParser.notValidLibraryVersionForInputSpecWarningMessage', {
-          defaultMessage:
-            'The input spec uses {schemaLibrary} {schemaVersion}, but current version of {schemaLibrary} is {libraryVersion}.',
-          values: {
-            schemaLibrary: schema.library,
-            schemaVersion: schema.version,
-            libraryVersion: libVersion,
-          },
-        })
+      if (versionCompare(schema.version, libVersion) > 0) {
+        this._onWarning(
+          i18n.translate(
+            'visTypeVega.vegaParser.notValidLibraryVersionForInputSpecWarningMessage',
+            {
+              defaultMessage:
+                'The input spec uses {schemaLibrary} {schemaVersion}, but current version of {schemaLibrary} is {libraryVersion}.',
+              values: {
+                schemaLibrary: schema.library,
+                schemaVersion: schema.version,
+                libraryVersion: libVersion,
+              },
+            }
+          )
+        );
+      }
+
+      return { isVegaLite, libVersion };
+    } catch (e) {
+      throw Error(
+        'The URL for the JSON "$schema" is incorrect. Correct the URL, then click Update.'
       );
     }
-
-    return { isVegaLite, libVersion };
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #113899 

This PR wraps the schema parser and provides a better error for the invalid case.

<img width="1243" alt="Screenshot 2021-10-11 at 12 15 47" src="https://user-images.githubusercontent.com/924948/136775845-c87f739a-2d0b-4a29-949e-aa1d695c3939.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
