### PR TITLE
[Enterprise Search] Fix typo

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/crawler_status_indicator.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawler_status_indicator/crawler_status_indicator.test.tsx
@@ -37,7 +37,7 @@ describe('CrawlerStatusIndicator', () => {
   describe('when status is not a valid status', () => {
     it('is disabled', () => {
       // this tests a codepath that should be impossible to reach, status should always be a CrawlerStatus
-      // but we use a switch statement and need to test the default case for this to recieve 100% coverage
+      // but we use a switch statement and need to test the default case for this to receive 100% coverage
       setMockValues({
         ...MOCK_VALUES,
         mostRecentCrawlRequestStatus: null,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
@@ -14,7 +14,7 @@ import { IFlashMessage } from './types';
 
 /**
  * The API errors we are handling can come from one of two ways:
- *  - When our http calls recieve a response containing an error code, such as a 404 or 500
+ *  - When our http calls receive a response containing an error code, such as a 404 or 500
  *  - Our own JS while handling a successful response
  *
  * In the first case, if it is a purposeful error (like a 404) we will receive an


### PR DESCRIPTION
Fixing a small typo (`recieve` -> `receive`) I noticed in comments.