### PR TITLE
[7.x] Relocate internal APM API endpoints to /internal  (#114196)

### DIFF
--- a/x-pack/plugins/apm/dev_docs/local_setup.md
+++ b/x-pack/plugins/apm/dev_docs/local_setup.md
@@ -46,4 +46,4 @@ This will create:
 All APM api endpoints accept `_inspect=true` as a query param that will output all Elasticsearch queries performed in that request. It will be available in the browser response and on localhost it is also available in the Kibana Node.js process output.
 
 Example:
-`/api/apm/services/my_service?_inspect=true`
+`/internal/apm/services/my_service?_inspect=true`

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/no_data_screen.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/power_user/no_data_screen.ts
@@ -6,7 +6,7 @@
  */
 /* eslint-disable @typescript-eslint/naming-convention */
 
-const apmIndicesSaveURL = '/api/apm/settings/apm-indices/save';
+const apmIndicesSaveURL = '/internal/apm/settings/apm-indices/save';
 
 describe('No data screen', () => {
   describe('bypass no data screen on settings pages', () => {

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/home.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/home.spec.ts
@@ -17,11 +17,11 @@ const serviceInventoryHref = url.format({
 
 const apisToIntercept = [
   {
-    endpoint: '/api/apm/service?*',
+    endpoint: '/internal/apm/service?*',
     name: 'servicesMainStatistics',
   },
   {
-    endpoint: '/api/apm/services/detailed_statistics?*',
+    endpoint: '/internal/apm/services/detailed_statistics?*',
     name: 'servicesDetailedStatistics',
   },
 ];

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/header_filters.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/header_filters.spec.ts
@@ -16,43 +16,47 @@ const serviceOverviewHref = url.format({
 
 const apisToIntercept = [
   {
-    endpoint: '/api/apm/services/opbeans-node/transactions/charts/latency?*',
+    endpoint:
+      '/internal/apm/services/opbeans-node/transactions/charts/latency?*',
     name: 'latencyChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/throughput?*',
+    endpoint: '/internal/apm/services/opbeans-node/throughput?*',
     name: 'throughputChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/transactions/charts/error_rate?*',
+    endpoint:
+      '/internal/apm/services/opbeans-node/transactions/charts/error_rate?*',
     name: 'errorRateChartRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/transactions/groups/detailed_statistics?*',
+      '/internal/apm/services/opbeans-node/transactions/groups/detailed_statistics?*',
     name: 'transactionGroupsDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/service_overview_instances/detailed_statistics?*',
+      '/internal/apm/services/opbeans-node/service_overview_instances/detailed_statistics?*',
     name: 'instancesDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/service_overview_instances/main_statistics?*',
+      '/internal/apm/services/opbeans-node/service_overview_instances/main_statistics?*',
     name: 'instancesMainStatisticsRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/error_groups/main_statistics?*',
+    endpoint:
+      '/internal/apm/services/opbeans-node/error_groups/main_statistics?*',
     name: 'errorGroupsMainStatisticsRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-node/transaction/charts/breakdown?*',
+    endpoint:
+      '/internal/apm/services/opbeans-node/transaction/charts/breakdown?*',
     name: 'transactonBreakdownRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-node/transactions/groups/main_statistics?*',
+      '/internal/apm/services/opbeans-node/transactions/groups/main_statistics?*',
     name: 'transactionsGroupsMainStatisticsRequest',
   },
 ];

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/instances_table.spec.ts
@@ -18,17 +18,17 @@ const serviceOverviewHref = url.format({
 const apisToIntercept = [
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/main_statistics?*',
+      '/internal/apm/services/opbeans-java/service_overview_instances/main_statistics?*',
     name: 'instancesMainRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics?*',
+      '/internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics?*',
     name: 'instancesDetailsRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/details/31651f3c624b81c55dd4633df0b5b9f9ab06b151121b0404ae796632cd1f87ad?*',
+      '/internal/apm/services/opbeans-java/service_overview_instances/details/31651f3c624b81c55dd4633df0b5b9f9ab06b151121b0404ae796632cd1f87ad?*',
     name: 'instanceDetailsRequest',
   },
 ];

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
@@ -59,7 +59,7 @@ describe('Service Overview', () => {
   });
 
   it('hides dependency tab when RUM service', () => {
-    cy.intercept('GET', '/api/apm/services/opbeans-rum/agent?*').as(
+    cy.intercept('GET', '/internal/apm/services/opbeans-rum/agent?*').as(
       'agentRequest'
     );
     cy.visit(

--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/time_comparison.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/time_comparison.spec.ts
@@ -18,30 +18,32 @@ const serviceOverviewHref = url.format({
 
 const apisToIntercept = [
   {
-    endpoint: '/api/apm/services/opbeans-java/transactions/charts/latency?*',
+    endpoint:
+      '/internal/apm/services/opbeans-java/transactions/charts/latency?*',
     name: 'latencyChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-java/throughput?*',
+    endpoint: '/internal/apm/services/opbeans-java/throughput?*',
     name: 'throughputChartRequest',
   },
   {
-    endpoint: '/api/apm/services/opbeans-java/transactions/charts/error_rate?*',
+    endpoint:
+      '/internal/apm/services/opbeans-java/transactions/charts/error_rate?*',
     name: 'errorRateChartRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/transactions/groups/detailed_statistics?*',
+      '/internal/apm/services/opbeans-java/transactions/groups/detailed_statistics?*',
     name: 'transactionGroupsDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/error_groups/detailed_statistics?*',
+      '/internal/apm/services/opbeans-java/error_groups/detailed_statistics?*',
     name: 'errorGroupsDetailedRequest',
   },
   {
     endpoint:
-      '/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics?*',
+      '/internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics?*',
     name: 'instancesDetailedRequest',
   },
 ];

--- a/x-pack/plugins/apm/public/components/alerting/error_count_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/error_count_alert_trigger/index.tsx
@@ -61,7 +61,8 @@ export function ErrorCountAlertTrigger(props: Props) {
       });
       if (interval && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_count',
+          endpoint:
+            'GET /internal/apm/alerts/chart_preview/transaction_error_count',
           params: {
             query: {
               environment: params.environment,

--- a/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.tsx
@@ -99,7 +99,8 @@ export function TransactionDurationAlertTrigger(props: Props) {
       });
       if (interval && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/alerts/chart_preview/transaction_duration',
+          endpoint:
+            'GET /internal/apm/alerts/chart_preview/transaction_duration',
           params: {
             query: {
               aggregationType: params.aggregationType,

--- a/x-pack/plugins/apm/public/components/alerting/transaction_error_rate_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_error_rate_alert_trigger/index.tsx
@@ -68,7 +68,8 @@ export function TransactionErrorRateAlertTrigger(props: Props) {
       });
       if (interval && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_rate',
+          endpoint:
+            'GET /internal/apm/alerts/chart_preview/transaction_error_rate',
           params: {
             query: {
               environment: params.environment,

--- a/x-pack/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
@@ -76,7 +76,7 @@ async function saveApmIndices({
   apmIndices: Record<string, string>;
 }) {
   await callApmApi({
-    endpoint: 'POST /api/apm/settings/apm-indices/save',
+    endpoint: 'POST /internal/apm/settings/apm-indices/save',
     signal: null,
     params: {
       body: apmIndices,
@@ -86,7 +86,8 @@ async function saveApmIndices({
   clearCache();
 }
 
-type ApiResponse = APIReturnType<`GET /api/apm/settings/apm-index-settings`>;
+type ApiResponse =
+  APIReturnType<`GET /internal/apm/settings/apm-index-settings`>;
 
 // avoid infinite loop by initializing the state outside the component
 const INITIAL_STATE: ApiResponse = { apmIndexSettings: [] };
@@ -103,7 +104,7 @@ export function ApmIndices() {
     (_callApmApi) => {
       if (canSave) {
         return _callApmApi({
-          endpoint: `GET /api/apm/settings/apm-index-settings`,
+          endpoint: `GET /internal/apm/settings/apm-index-settings`,
         });
       }
     },

--- a/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/add_environments.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/add_environments.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 type ApiResponse =
-  APIReturnType<'GET /api/apm/settings/anomaly-detection/environments'>;
+  APIReturnType<'GET /internal/apm/settings/anomaly-detection/environments'>;
 const INITIAL_DATA: ApiResponse = { environments: [] };
 
 export function AddEnvironments({
@@ -50,7 +50,7 @@ export function AddEnvironments({
   const { data = INITIAL_DATA, status } = useFetcher(
     (callApmApi) =>
       callApmApi({
-        endpoint: `GET /api/apm/settings/anomaly-detection/environments`,
+        endpoint: `GET /internal/apm/settings/anomaly-detection/environments`,
       }),
     [],
     { preservePreviousData: false }

--- a/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/create_jobs.ts
+++ b/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/create_jobs.ts
@@ -28,7 +28,7 @@ export async function createJobs({
 }) {
   try {
     await callApmApi({
-      endpoint: 'POST /api/apm/settings/anomaly-detection/jobs',
+      endpoint: 'POST /internal/apm/settings/anomaly-detection/jobs',
       signal: null,
       params: {
         body: { environments },

--- a/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/index.tsx
@@ -17,7 +17,7 @@ import { useLicenseContext } from '../../../../context/license/use_license_conte
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 
 export type AnomalyDetectionApiResponse =
-  APIReturnType<'GET /api/apm/settings/anomaly-detection/jobs'>;
+  APIReturnType<'GET /internal/apm/settings/anomaly-detection/jobs'>;
 
 const DEFAULT_VALUE: AnomalyDetectionApiResponse = {
   jobs: [],
@@ -40,7 +40,7 @@ export function AnomalyDetection() {
     (callApmApi) => {
       if (canGetJobs) {
         return callApmApi({
-          endpoint: `GET /api/apm/settings/anomaly-detection/jobs`,
+          endpoint: `GET /internal/apm/settings/anomaly-detection/jobs`,
         });
       }
     },

--- a/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/create_edit_custom_link_flyout/DeleteButton.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/create_edit_custom_link_flyout/DeleteButton.tsx
@@ -49,7 +49,7 @@ async function deleteConfig(
 ) {
   try {
     await callApmApi({
-      endpoint: 'DELETE /api/apm/settings/custom_links/{id}',
+      endpoint: 'DELETE /internal/apm/settings/custom_links/{id}',
       signal: null,
       params: {
         path: { id: customLinkId },

--- a/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/create_edit_custom_link_flyout/link_preview.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/create_edit_custom_link_flyout/link_preview.tsx
@@ -34,7 +34,7 @@ const fetchTransaction = debounce(
   async (filters: Filter[], callback: (transaction: Transaction) => void) => {
     const transaction = await callApmApi({
       signal: null,
-      endpoint: 'GET /api/apm/settings/custom_links/transaction',
+      endpoint: 'GET /internal/apm/settings/custom_links/transaction',
       params: { query: convertFiltersToQuery(filters) },
     });
     callback(transaction);

--- a/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/create_edit_custom_link_flyout/saveCustomLink.ts
+++ b/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/create_edit_custom_link_flyout/saveCustomLink.ts
@@ -35,7 +35,7 @@ export async function saveCustomLink({
 
     if (id) {
       await callApmApi({
-        endpoint: 'PUT /api/apm/settings/custom_links/{id}',
+        endpoint: 'PUT /internal/apm/settings/custom_links/{id}',
         signal: null,
         params: {
           path: { id },
@@ -44,7 +44,7 @@ export async function saveCustomLink({
       });
     } else {
       await callApmApi({
-        endpoint: 'POST /api/apm/settings/custom_links',
+        endpoint: 'POST /internal/apm/settings/custom_links',
         signal: null,
         params: {
           body: customLink,

--- a/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/customize_ui/custom_link/index.tsx
@@ -38,7 +38,7 @@ export function CustomLinkOverview() {
     async (callApmApi) => {
       if (hasValidLicense) {
         return callApmApi({
-          endpoint: 'GET /api/apm/settings/custom_links',
+          endpoint: 'GET /internal/apm/settings/custom_links',
         });
       }
     },

--- a/x-pack/plugins/apm/public/components/app/Settings/schema/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/schema/index.tsx
@@ -20,7 +20,7 @@ import {
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 
 type FleetMigrationCheckResponse =
-  APIReturnType<'GET /api/apm/fleet/migration_check'>;
+  APIReturnType<'GET /internal/apm/fleet/migration_check'>;
 
 const APM_DATA_STREAMS_MIGRATION_STATUS_LS = {
   value: '',
@@ -46,7 +46,8 @@ export function Schema() {
     data = {} as FleetMigrationCheckResponse,
     status,
   } = useFetcher(
-    (callApi) => callApi({ endpoint: 'GET /api/apm/fleet/migration_check' }),
+    (callApi) =>
+      callApi({ endpoint: 'GET /internal/apm/fleet/migration_check' }),
     [],
     { preservePreviousData: false }
   );
@@ -118,7 +119,7 @@ async function getUnsupportedApmServerConfigs(
 ) {
   try {
     const { unsupported } = await callApmApi({
-      endpoint: 'GET /api/apm/fleet/apm_server_schema/unsupported',
+      endpoint: 'GET /internal/apm/fleet/apm_server_schema/unsupported',
       signal: null,
     });
     return unsupported;
@@ -142,7 +143,7 @@ async function createCloudApmPackagePolicy(
   updateLocalStorage(FETCH_STATUS.LOADING);
   try {
     const { cloudApmPackagePolicy } = await callApmApi({
-      endpoint: 'POST /api/apm/fleet/cloud_apm_package_policy',
+      endpoint: 'POST /internal/apm/fleet/cloud_apm_package_policy',
       signal: null,
     });
     updateLocalStorage(FETCH_STATUS.SUCCESS);

--- a/x-pack/plugins/apm/public/components/app/TraceLink/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceLink/index.tsx
@@ -29,7 +29,7 @@ export function TraceLink() {
     (callApmApi) => {
       if (traceId) {
         return callApmApi({
-          endpoint: 'GET /api/apm/traces/{traceId}/root_transaction',
+          endpoint: 'GET /internal/apm/traces/{traceId}/root_transaction',
           params: {
             path: {
               traceId,

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_detail_dependencies_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_detail_dependencies_table.tsx
@@ -44,7 +44,7 @@ export function BackendDetailDependenciesTable() {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/upstream_services',
+        endpoint: 'GET /internal/apm/backends/{backendName}/upstream_services',
         params: {
           path: {
             backendName,

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_error_rate_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_error_rate_chart.tsx
@@ -44,7 +44,7 @@ export function BackendFailedTransactionRateChart({
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/charts/error_rate',
+        endpoint: 'GET /internal/apm/backends/{backendName}/charts/error_rate',
         params: {
           path: {
             backendName,

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_latency_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_latency_chart.tsx
@@ -40,7 +40,7 @@ export function BackendLatencyChart({ height }: { height: number }) {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/charts/latency',
+        endpoint: 'GET /internal/apm/backends/{backendName}/charts/latency',
         params: {
           path: {
             backendName,

--- a/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_detail_overview/backend_throughput_chart.tsx
@@ -36,7 +36,7 @@ export function BackendThroughputChart({ height }: { height: number }) {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/charts/throughput',
+        endpoint: 'GET /internal/apm/backends/{backendName}/charts/throughput',
         params: {
           path: {
             backendName,

--- a/x-pack/plugins/apm/public/components/app/backend_inventory/backend_inventory_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/backend_inventory/backend_inventory_dependencies_table/index.tsx
@@ -45,7 +45,7 @@ export function BackendInventoryDependenciesTable() {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/top_backends',
+        endpoint: 'GET /internal/apm/backends/top_backends',
         params: {
           query: { start, end, environment, numBuckets: 20, offset, kuery },
         },

--- a/x-pack/plugins/apm/public/components/app/error_group_details/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/Distribution/index.tsx
@@ -35,7 +35,7 @@ const ALERT_RULE_TYPE_ID: typeof ALERT_RULE_TYPE_ID_TYPED =
   ALERT_RULE_TYPE_ID_NON_TYPED;
 
 type ErrorDistributionAPIResponse =
-  APIReturnType<'GET /api/apm/services/{serviceName}/errors/distribution'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/errors/distribution'>;
 
 interface FormattedBucket {
   x0: number;

--- a/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/detail_view/index.tsx
@@ -54,7 +54,7 @@ const TransactionLinkName = euiStyled.div`
 `;
 
 interface Props {
-  errorGroup: APIReturnType<'GET /api/apm/services/{serviceName}/errors/{groupId}'>;
+  errorGroup: APIReturnType<'GET /internal/apm/services/{serviceName}/errors/{groupId}'>;
   urlParams: ApmUrlParams;
   kuery: string;
 }

--- a/x-pack/plugins/apm/public/components/app/error_group_details/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/index.tsx
@@ -127,7 +127,7 @@ export function ErrorGroupDetails() {
     (callApmApi) => {
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/errors/{groupId}',
+          endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}',
           params: {
             path: {
               serviceName,

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/List/index.tsx
@@ -48,7 +48,7 @@ const Culprit = euiStyled.div`
 `;
 
 type ErrorGroupItem =
-  APIReturnType<'GET /api/apm/services/{serviceName}/errors'>['errorGroups'][0];
+  APIReturnType<'GET /internal/apm/services/{serviceName}/errors'>['errorGroups'][0];
 
 interface Props {
   items: ErrorGroupItem[];

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -44,7 +44,7 @@ export function ErrorGroupOverview() {
 
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/errors',
+          endpoint: 'GET /internal/apm/services/{serviceName}/errors',
           params: {
             path: {
               serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_dependencies/service_dependencies_breakdown_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_dependencies/service_dependencies_breakdown_chart.tsx
@@ -29,7 +29,8 @@ export function ServiceDependenciesBreakdownChart({
   const { data, status } = useFetcher(
     (callApmApi) => {
       return callApmApi({
-        endpoint: 'GET /api/apm/services/{serviceName}/dependencies/breakdown',
+        endpoint:
+          'GET /internal/apm/services/{serviceName}/dependencies/breakdown',
         params: {
           path: {
             serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/index.tsx
@@ -64,7 +64,7 @@ function useServicesFetcher() {
     (callApmApi) => {
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services',
+          endpoint: 'GET /internal/apm/services',
           params: {
             query: {
               environment,
@@ -90,7 +90,7 @@ function useServicesFetcher() {
     (callApmApi) => {
       if (start && end && mainStatisticsData.items.length) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/detailed_statistics',
+          endpoint: 'GET /internal/apm/services/detailed_statistics',
           params: {
             query: {
               environment,

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/__fixtures__/service_api_mock_data.ts
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/__fixtures__/service_api_mock_data.ts
@@ -7,7 +7,7 @@
 
 import { APIReturnType } from '../../../../../services/rest/createCallApmApi';
 
-type ServiceListAPIResponse = APIReturnType<'GET /api/apm/services'>;
+type ServiceListAPIResponse = APIReturnType<'GET /internal/apm/services'>;
 
 export const items: ServiceListAPIResponse['items'] = [
   {

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -43,10 +43,10 @@ import { ServiceLink } from '../../../shared/service_link';
 import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { HealthBadge } from './HealthBadge';
 
-type ServiceListAPIResponse = APIReturnType<'GET /api/apm/services'>;
+type ServiceListAPIResponse = APIReturnType<'GET /internal/apm/services'>;
 type Items = ServiceListAPIResponse['items'];
 type ServicesDetailedStatisticsAPIResponse =
-  APIReturnType<'GET /api/apm/services/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/detailed_statistics'>;
 
 type ServiceListItem = ValuesType<Items>;
 

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/service_list.test.tsx
@@ -33,7 +33,7 @@ describe('ServiceList', () => {
 
     const callApmApiSpy = getCallApmApiSpy().mockImplementation(
       ({ endpoint }) => {
-        if (endpoint === 'GET /api/apm/fallback_to_transactions') {
+        if (endpoint === 'GET /internal/apm/fallback_to_transactions') {
           return Promise.resolve({ fallbackToTransactions: false });
         }
         return Promise.reject(`Response for ${endpoint} is not defined`);

--- a/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_logs/index.tsx
@@ -35,7 +35,7 @@ export function ServiceLogs() {
     (callApmApi) => {
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/infrastructure',
+          endpoint: 'GET /internal/apm/services/{serviceName}/infrastructure',
           params: {
             path: { serviceName },
             query: {
@@ -92,7 +92,7 @@ export function ServiceLogs() {
 }
 
 export const getInfrastructureKQLFilter = (
-  data?: APIReturnType<'GET /api/apm/services/{serviceName}/infrastructure'>
+  data?: APIReturnType<'GET /internal/apm/services/{serviceName}/infrastructure'>
 ) => {
   const containerIds = data?.serviceInfrastructure?.containerIds ?? [];
   const hostNames = data?.serviceInfrastructure?.hostNames ?? [];

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/backend_contents.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/backend_contents.tsx
@@ -38,7 +38,7 @@ export function BackendContents({
     (callApmApi) => {
       if (backendName) {
         return callApmApi({
-          endpoint: 'GET /api/apm/service-map/backend/{backendName}',
+          endpoint: 'GET /internal/apm/service-map/backend/{backendName}',
           params: {
             path: { backendName },
             query: {

--- a/x-pack/plugins/apm/public/components/app/service_map/Popover/service_contents.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/Popover/service_contents.tsx
@@ -47,7 +47,7 @@ export function ServiceContents({
     (callApmApi) => {
       if (serviceName && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/service-map/service/{serviceName}',
+          endpoint: 'GET /internal/apm/service-map/service/{serviceName}',
           params: {
             path: { serviceName },
             query: { environment, start, end },

--- a/x-pack/plugins/apm/public/components/app/service_map/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_map/index.tsx
@@ -124,7 +124,7 @@ export function ServiceMap({
 
       return callApmApi({
         isCachable: false,
-        endpoint: 'GET /api/apm/service-map',
+        endpoint: 'GET /internal/apm/service-map',
         params: {
           query: {
             start,

--- a/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_metrics/index.tsx
@@ -85,7 +85,7 @@ export function ServiceNodeMetrics() {
       if (start && end) {
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
+            'GET /internal/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
           params: {
             path: { serviceName, serviceNodeName },
             query: {

--- a/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_node_overview/index.tsx
@@ -48,7 +48,7 @@ function ServiceNodeOverview() {
         return undefined;
       }
       return callApmApi({
-        endpoint: 'GET /api/apm/services/{serviceName}/serviceNodes',
+        endpoint: 'GET /internal/apm/services/{serviceName}/serviceNodes',
         params: {
           path: {
             serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview.test.tsx
@@ -99,21 +99,21 @@ describe('ServiceOverview', () => {
 
     /* eslint-disable @typescript-eslint/naming-convention */
     const calls = {
-      'GET /api/apm/services/{serviceName}/error_groups/main_statistics': {
+      'GET /internal/apm/services/{serviceName}/error_groups/main_statistics': {
         error_groups: [] as any[],
       },
-      'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics':
+      'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics':
         {
           transactionGroups: [] as any[],
           totalTransactionGroups: 0,
           isAggregationAccurate: true,
         },
-      'GET /api/apm/services/{serviceName}/dependencies': {
+      'GET /internal/apm/services/{serviceName}/dependencies': {
         serviceDependencies: [],
       },
-      'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics':
+      'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics':
         [],
-      'GET /api/apm/services/{serviceName}/transactions/charts/latency': {
+      'GET /internal/apm/services/{serviceName}/transactions/charts/latency': {
         currentPeriod: {
           overallAvgDuration: null,
           latencyTimeseries: [],
@@ -123,26 +123,27 @@ describe('ServiceOverview', () => {
           latencyTimeseries: [],
         },
       },
-      'GET /api/apm/services/{serviceName}/throughput': {
+      'GET /internal/apm/services/{serviceName}/throughput': {
         currentPeriod: [],
         previousPeriod: [],
       },
-      'GET /api/apm/services/{serviceName}/transactions/charts/error_rate': {
-        currentPeriod: {
-          transactionErrorRate: [],
-          noHits: true,
-          average: null,
+      'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate':
+        {
+          currentPeriod: {
+            transactionErrorRate: [],
+            noHits: true,
+            average: null,
+          },
+          previousPeriod: {
+            transactionErrorRate: [],
+            noHits: true,
+            average: null,
+          },
         },
-        previousPeriod: {
-          transactionErrorRate: [],
-          noHits: true,
-          average: null,
-        },
-      },
       'GET /api/apm/services/{serviceName}/annotation/search': {
         annotations: [],
       },
-      'GET /api/apm/fallback_to_transactions': {
+      'GET /internal/apm/fallback_to_transactions': {
         fallbackToTransactions: false,
       },
     };

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
@@ -59,7 +59,7 @@ export function ServiceOverviewDependenciesTable({
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/services/{serviceName}/dependencies',
+        endpoint: 'GET /internal/apm/services/{serviceName}/dependencies',
         params: {
           path: { serviceName },
           query: { start, end, environment, numBuckets: 20, offset },

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/get_columns.tsx
@@ -16,9 +16,9 @@ import { TimestampTooltip } from '../../../shared/TimestampTooltip';
 import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 
 type ErrorGroupMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/error_groups/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/error_groups/main_statistics'>;
 type ErrorGroupDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/error_groups/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/error_groups/detailed_statistics'>;
 
 export function getColumns({
   serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
@@ -30,9 +30,9 @@ interface Props {
   serviceName: string;
 }
 type ErrorGroupMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/error_groups/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/error_groups/main_statistics'>;
 type ErrorGroupDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/error_groups/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/error_groups/detailed_statistics'>;
 
 type SortDirection = 'asc' | 'desc';
 type SortField = 'name' | 'lastSeen' | 'occurrences';
@@ -97,7 +97,7 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
       }
       return callApmApi({
         endpoint:
-          'GET /api/apm/services/{serviceName}/error_groups/main_statistics',
+          'GET /internal/apm/services/{serviceName}/error_groups/main_statistics',
         params: {
           path: { serviceName },
           query: {
@@ -150,7 +150,7 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
       if (requestId && items.length && start && end && transactionType) {
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/error_groups/detailed_statistics',
+            'GET /internal/apm/services/{serviceName}/error_groups/detailed_statistics',
           params: {
             path: { serviceName },
             query: {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_chart_and_table.tsx
@@ -28,9 +28,9 @@ interface ServiceOverviewInstancesChartAndTableProps {
 }
 
 type ApiResponseMainStats =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type ApiResponseDetailedStats =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
 
 const INITIAL_STATE_MAIN_STATS = {
   currentPeriodItems: [] as ApiResponseMainStats['currentPeriod'],
@@ -100,7 +100,7 @@ export function ServiceOverviewInstancesChartAndTable({
 
       return callApmApi({
         endpoint:
-          'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics',
+          'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics',
         params: {
           path: {
             serviceName,
@@ -181,7 +181,7 @@ export function ServiceOverviewInstancesChartAndTable({
 
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
+            'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
           params: {
             path: {
               serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/get_columns.tsx
@@ -33,11 +33,11 @@ import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { InstanceActionsMenu } from './instance_actions_menu';
 
 type ServiceInstanceMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type MainStatsServiceInstanceItem =
   ServiceInstanceMainStatistics['currentPeriod'][0];
 type ServiceInstanceDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
 
 export function getColumns({
   serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
@@ -29,11 +29,11 @@ import { useApmParams } from '../../../../hooks/use_apm_params';
 import { useBreakpoints } from '../../../../hooks/use_breakpoints';
 
 type ServiceInstanceMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type MainStatsServiceInstanceItem =
   ServiceInstanceMainStatistics['currentPeriod'][0];
 type ServiceInstanceDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
 
 export interface TableOptions {
   pageIndex: number;

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_actions_menu/menu_sections.ts
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_actions_menu/menu_sections.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../shared/transaction_action_menu/sections_helper';
 
 type InstaceDetails =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
 
 function getInfraMetricsQuery(timestamp?: string) {
   if (!timestamp) {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_details.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/instance_details.test.tsx
@@ -16,7 +16,7 @@ import { InstanceDetails } from './intance_details';
 import * as useInstanceDetailsFetcher from './use_instance_details_fetcher';
 
 type ServiceInstanceDetails =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
 
 describe('InstanceDetails', () => {
   it('renders loading spinner when data is being fetched', () => {

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/intance_details.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/intance_details.tsx
@@ -34,7 +34,7 @@ import { getCloudIcon, getContainerIcon } from '../../../shared/service_icons';
 import { useInstanceDetailsFetcher } from './use_instance_details_fetcher';
 
 type ServiceInstanceDetails =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
 
 interface Props {
   serviceName: string;

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/use_instance_details_fetcher.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/use_instance_details_fetcher.tsx
@@ -28,7 +28,7 @@ export function useInstanceDetailsFetcher({
       }
       return callApmApi({
         endpoint:
-          'GET /api/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
+          'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
         params: {
           path: {
             serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
@@ -69,7 +69,7 @@ export function ServiceOverviewThroughputChart({
     (callApmApi) => {
       if (serviceName && transactionType && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/throughput',
+          endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
           params: {
             path: {
               serviceName,

--- a/x-pack/plugins/apm/public/components/app/service_profiling/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_profiling/index.tsx
@@ -19,7 +19,7 @@ import { ServiceProfilingFlamegraph } from './service_profiling_flamegraph';
 import { ServiceProfilingTimeline } from './service_profiling_timeline';
 
 type ApiResponse =
-  APIReturnType<'GET /api/apm/services/{serviceName}/profiling/timeline'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/profiling/timeline'>;
 const DEFAULT_DATA: ApiResponse = { profilingTimeline: [] };
 
 export function ServiceProfiling() {
@@ -38,7 +38,7 @@ export function ServiceProfiling() {
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/services/{serviceName}/profiling/timeline',
+        endpoint: 'GET /internal/apm/services/{serviceName}/profiling/timeline',
         params: {
           path: { serviceName },
           query: {

--- a/x-pack/plugins/apm/public/components/app/service_profiling/service_profiling_flamegraph.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_profiling/service_profiling_flamegraph.tsx
@@ -147,7 +147,8 @@ export function ServiceProfilingFlamegraph({
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/services/{serviceName}/profiling/statistics',
+        endpoint:
+          'GET /internal/apm/services/{serviceName}/profiling/statistics',
         params: {
           path: {
             serviceName,

--- a/x-pack/plugins/apm/public/components/app/trace_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/trace_overview/index.tsx
@@ -16,7 +16,7 @@ import { useFallbackToTransactionsFetcher } from '../../../hooks/use_fallback_to
 import { AggregatedTransactionsBadge } from '../../shared/aggregated_transactions_badge';
 import { useTimeRange } from '../../../hooks/use_time_range';
 
-type TracesAPIResponse = APIReturnType<'GET /api/apm/traces'>;
+type TracesAPIResponse = APIReturnType<'GET /internal/apm/traces'>;
 const DEFAULT_RESPONSE: TracesAPIResponse = {
   items: [],
 };
@@ -35,7 +35,7 @@ export function TraceOverview() {
     (callApmApi) => {
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/traces',
+          endpoint: 'GET /internal/apm/traces',
           params: {
             query: {
               environment,

--- a/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
+++ b/x-pack/plugins/apm/public/components/app/trace_overview/trace_list.tsx
@@ -20,7 +20,7 @@ import { ImpactBar } from '../../shared/ImpactBar';
 import { TransactionDetailLink } from '../../shared/Links/apm/transaction_detail_link';
 import { ITableColumn, ManagedTable } from '../../shared/managed_table';
 
-type TraceGroup = APIReturnType<'GET /api/apm/traces'>['items'][0];
+type TraceGroup = APIReturnType<'GET /internal/apm/traces'>['items'][0];
 
 const StyledTransactionLink = euiStyled(TransactionDetailLink)`
   font-size: ${({ theme }) => theme.eui.euiFontSizeS};

--- a/x-pack/plugins/apm/public/components/app/transaction_details/use_waterfall_fetcher.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/use_waterfall_fetcher.ts
@@ -36,7 +36,7 @@ export function useWaterfallFetcher() {
     (callApmApi) => {
       if (traceId && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/traces/{traceId}',
+          endpoint: 'GET /internal/apm/traces/{traceId}',
           params: {
             path: { traceId },
             query: {

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -12,7 +12,7 @@ import { APMError } from '../../../../../../../../typings/es_schemas/ui/apm_erro
 import { Span } from '../../../../../../../../typings/es_schemas/ui/span';
 import { Transaction } from '../../../../../../../../typings/es_schemas/ui/transaction';
 
-type TraceAPIResponse = APIReturnType<'GET /api/apm/traces/{traceId}'>;
+type TraceAPIResponse = APIReturnType<'GET /internal/apm/traces/{traceId}'>;
 
 interface IWaterfallGroup {
   [key: string]: IWaterfallSpanOrTransaction[];

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfallContainer.stories.data.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfallContainer.stories.data.ts
@@ -16,7 +16,7 @@ export const location = {
   hash: '',
 } as Location;
 
-type TraceAPIResponse = APIReturnType<'GET /api/apm/traces/{traceId}'>;
+type TraceAPIResponse = APIReturnType<'GET /internal/apm/traces/{traceId}'>;
 
 export const urlParams = {
   start: '2020-03-22T15:16:38.742Z',

--- a/x-pack/plugins/apm/public/components/app/transaction_link/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_link/index.tsx
@@ -28,7 +28,7 @@ export function TransactionLink() {
     (callApmApi) => {
       if (transactionId) {
         return callApmApi({
-          endpoint: 'GET /api/apm/transactions/{transactionId}',
+          endpoint: 'GET /internal/apm/transactions/{transactionId}',
           params: {
             path: {
               transactionId,

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_main_template.tsx
@@ -49,7 +49,7 @@ export function ApmMainTemplate({
     services.observability.navigation.PageTemplate;
 
   const { data } = useFetcher((callApmApi) => {
-    return callApmApi({ endpoint: 'GET /api/apm/has_data' });
+    return callApmApi({ endpoint: 'GET /internal/apm/has_data' });
   }, []);
 
   const noDataConfig = getNoDataConfig({

--- a/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/anomaly_detection_setup_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/apm_header_action_menu/anomaly_detection_setup_link.tsx
@@ -27,7 +27,7 @@ import { APIReturnType } from '../../../services/rest/createCallApmApi';
 import { getAPMHref } from '../Links/apm/APMLink';
 
 export type AnomalyDetectionApiResponse =
-  APIReturnType<'GET /api/apm/settings/anomaly-detection/jobs'>;
+  APIReturnType<'GET /internal/apm/settings/anomaly-detection/jobs'>;
 
 const DEFAULT_DATA = { jobs: [], hasLegacyJobs: false };
 

--- a/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.test.tsx
@@ -30,7 +30,7 @@ import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { getAlertAnnotations } from './get_alert_annotations';
 
 type Alert = ValuesType<
-  APIReturnType<'GET /api/apm/services/{serviceName}/alerts'>['alerts']
+  APIReturnType<'GET /internal/apm/services/{serviceName}/alerts'>['alerts']
 >;
 
 const euiColorDanger = 'red';

--- a/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.tsx
@@ -46,7 +46,7 @@ const ALERT_RULE_TYPE_ID: typeof ALERT_RULE_TYPE_ID_TYPED =
 const ALERT_RULE_NAME: typeof ALERT_RULE_NAME_TYPED = ALERT_RULE_NAME_NON_TYPED;
 
 type Alert = ValuesType<
-  APIReturnType<'GET /api/apm/services/{serviceName}/alerts'>['alerts']
+  APIReturnType<'GET /internal/apm/services/{serviceName}/alerts'>['alerts']
 >;
 
 function getAlertColor({

--- a/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/custom_tooltip.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/custom_tooltip.stories.tsx
@@ -12,7 +12,7 @@ import { getDurationFormatter } from '../../../../../common/utils/formatters';
 import { CustomTooltip } from './custom_tooltip';
 
 type ServiceInstanceMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type MainStatsServiceInstanceItem =
   ServiceInstanceMainStatistics['currentPeriod'][0];
 

--- a/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/custom_tooltip.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/custom_tooltip.tsx
@@ -18,7 +18,7 @@ import {
 import { useTheme } from '../../../../hooks/use_theme';
 
 type ServiceInstanceMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 type MainStatsServiceInstanceItem =
   ServiceInstanceMainStatistics['currentPeriod'][0];
 

--- a/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/instances_latency_distribution_chart/index.tsx
@@ -37,7 +37,7 @@ import { getResponseTimeTickFormatter } from '../transaction_charts/helper';
 import { CustomTooltip } from './custom_tooltip';
 
 type ApiResponseMainStats =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics'>;
 
 export interface InstancesLatencyDistributionChartProps {
   height: number;

--- a/x-pack/plugins/apm/public/components/shared/charts/latency_chart/latency_chart.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/latency_chart/latency_chart.stories.tsx
@@ -42,8 +42,8 @@ import {
 import { LatencyChart } from './';
 
 interface Args {
-  alertsResponse: APIReturnType<'GET /api/apm/services/{serviceName}/alerts'>;
-  latencyChartResponse: APIReturnType<'GET /api/apm/services/{serviceName}/transactions/charts/latency'>;
+  alertsResponse: APIReturnType<'GET /internal/apm/services/{serviceName}/alerts'>;
+  latencyChartResponse: APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/charts/latency'>;
 }
 
 export default {
@@ -70,7 +70,7 @@ export default {
             basePath: { prepend: () => {} },
             get: (endpoint: string) => {
               switch (endpoint) {
-                case `/api/apm/services/${serviceName}/transactions/charts/latency`:
+                case `/internal/apm/services/${serviceName}/transactions/charts/latency`:
                   return latencyChartResponse;
                 default:
                   return {};

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/use_transaction_breakdown.ts
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/use_transaction_breakdown.ts
@@ -39,7 +39,7 @@ export function useTransactionBreakdown({
       if (serviceName && start && end && transactionType) {
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/transaction/charts/breakdown',
+            'GET /internal/apm/services/{serviceName}/transaction/charts/breakdown',
           params: {
             path: { serviceName },
             query: {

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 type ErrorRate =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/charts/error_rate'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate'>;
 
 const INITIAL_STATE: ErrorRate = {
   currentPeriod: {
@@ -82,7 +82,7 @@ export function TransactionErrorRateChart({
       if (transactionType && serviceName && start && end) {
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/transactions/charts/error_rate',
+            'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate',
           params: {
             path: {
               serviceName,

--- a/x-pack/plugins/apm/public/components/shared/service_icons/cloud_details.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/cloud_details.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
 
 type ServiceDetailsReturnType =
-  APIReturnType<'GET /api/apm/services/{serviceName}/metadata/details'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/metadata/details'>;
 
 interface Props {
   cloud: ServiceDetailsReturnType['cloud'];

--- a/x-pack/plugins/apm/public/components/shared/service_icons/container_details.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/container_details.tsx
@@ -13,7 +13,7 @@ import { asInteger } from '../../../../common/utils/formatters';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
 
 type ServiceDetailsReturnType =
-  APIReturnType<'GET /api/apm/services/{serviceName}/metadata/details'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/metadata/details'>;
 
 interface Props {
   container: ServiceDetailsReturnType['container'];

--- a/x-pack/plugins/apm/public/components/shared/service_icons/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/index.test.tsx
@@ -186,7 +186,7 @@ describe('ServiceIcons', () => {
       };
     it('Shows loading spinner while fetching data', () => {
       const apisMockData = {
-        'GET /api/apm/services/{serviceName}/metadata/icons': {
+        'GET /internal/apm/services/{serviceName}/metadata/icons': {
           data: {
             agentName: 'java',
             containerType: 'Kubernetes',
@@ -195,7 +195,7 @@ describe('ServiceIcons', () => {
           status: fetcherHook.FETCH_STATUS.SUCCESS,
           refetch: jest.fn(),
         },
-        'GET /api/apm/services/{serviceName}/metadata/details': {
+        'GET /internal/apm/services/{serviceName}/metadata/details': {
           data: undefined,
           status: fetcherHook.FETCH_STATUS.LOADING,
           refetch: jest.fn(),
@@ -228,7 +228,7 @@ describe('ServiceIcons', () => {
 
     it('shows service content', () => {
       const apisMockData = {
-        'GET /api/apm/services/{serviceName}/metadata/icons': {
+        'GET /internal/apm/services/{serviceName}/metadata/icons': {
           data: {
             agentName: 'java',
             containerType: 'Kubernetes',
@@ -237,7 +237,7 @@ describe('ServiceIcons', () => {
           status: fetcherHook.FETCH_STATUS.SUCCESS,
           refetch: jest.fn(),
         },
-        'GET /api/apm/services/{serviceName}/metadata/details': {
+        'GET /internal/apm/services/{serviceName}/metadata/details': {
           data: { service: { versions: ['v1.0.0'] } },
           status: fetcherHook.FETCH_STATUS.SUCCESS,
           refetch: jest.fn(),

--- a/x-pack/plugins/apm/public/components/shared/service_icons/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/index.tsx
@@ -71,7 +71,7 @@ export function ServiceIcons({ start, end, serviceName }: Props) {
     (callApmApi) => {
       if (serviceName && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/metadata/icons',
+          endpoint: 'GET /internal/apm/services/{serviceName}/metadata/icons',
           params: {
             path: { serviceName },
             query: { start, end },
@@ -87,7 +87,7 @@ export function ServiceIcons({ start, end, serviceName }: Props) {
       if (selectedIconPopover && serviceName && start && end) {
         return callApmApi({
           isCachable: true,
-          endpoint: 'GET /api/apm/services/{serviceName}/metadata/details',
+          endpoint: 'GET /internal/apm/services/{serviceName}/metadata/details',
           params: {
             path: { serviceName },
             query: { start, end },

--- a/x-pack/plugins/apm/public/components/shared/service_icons/service_details.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/service_details.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
 
 type ServiceDetailsReturnType =
-  APIReturnType<'GET /api/apm/services/{serviceName}/metadata/details'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/metadata/details'>;
 
 interface Props {
   service: ServiceDetailsReturnType['service'];

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/custom_link_menu_section/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/custom_link_menu_section/index.tsx
@@ -61,7 +61,7 @@ export function CustomLinkMenuSection({
     (callApmApi) =>
       callApmApi({
         isCachable: false,
-        endpoint: 'GET /api/apm/settings/custom_links',
+        endpoint: 'GET /internal/apm/settings/custom_links',
         params: { query: convertFiltersToQuery(filters) },
       }),
     [filters]

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -28,13 +28,13 @@ import { TruncateWithTooltip } from '../truncate_with_tooltip';
 import { getLatencyColumnLabel } from './get_latency_column_label';
 
 type TransactionGroupMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics'>;
 
 type ServiceTransactionGroupItem = ValuesType<
   TransactionGroupMainStatistics['transactionGroups']
 >;
 type TransactionGroupDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/detailed_statistics'>;
 
 export function getColumns({
   serviceName,

--- a/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transactions_table/index.tsx
@@ -30,7 +30,7 @@ import { ElasticDocsLink } from '../Links/ElasticDocsLink';
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
 
 type ApiResponse =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics'>;
 
 interface InitialState {
   requestId: string;
@@ -116,7 +116,7 @@ export function TransactionsTable({
       }
       return callApmApi({
         endpoint:
-          'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics',
+          'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics',
         params: {
           path: { serviceName },
           query: {
@@ -189,7 +189,7 @@ export function TransactionsTable({
       ) {
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/transactions/groups/detailed_statistics',
+            'GET /internal/apm/services/{serviceName}/transactions/groups/detailed_statistics',
           params: {
             path: { serviceName },
             query: {

--- a/x-pack/plugins/apm/public/context/anomaly_detection_jobs/anomaly_detection_jobs_context.tsx
+++ b/x-pack/plugins/apm/public/context/anomaly_detection_jobs/anomaly_detection_jobs_context.tsx
@@ -10,7 +10,7 @@ import { FETCH_STATUS, useFetcher } from '../../hooks/use_fetcher';
 import { APIReturnType } from '../../services/rest/createCallApmApi';
 
 export interface AnomalyDetectionJobsContextValue {
-  anomalyDetectionJobsData?: APIReturnType<'GET /api/apm/settings/anomaly-detection/jobs'>;
+  anomalyDetectionJobsData?: APIReturnType<'GET /internal/apm/settings/anomaly-detection/jobs'>;
   anomalyDetectionJobsStatus: FETCH_STATUS;
   anomalyDetectionJobsRefetch: () => void;
 }
@@ -30,7 +30,7 @@ export function AnomalyDetectionJobsContextProvider({
   const { data, status } = useFetcher(
     (callApmApi) =>
       callApmApi({
-        endpoint: `GET /api/apm/settings/anomaly-detection/jobs`,
+        endpoint: `GET /internal/apm/settings/anomaly-detection/jobs`,
       }),
     [fetchId], // eslint-disable-line react-hooks/exhaustive-deps
     { showToastOnError: false }

--- a/x-pack/plugins/apm/public/context/apm_backend/apm_backend_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_backend/apm_backend_context.tsx
@@ -15,7 +15,7 @@ export const ApmBackendContext = createContext<
   | {
       backendName: string;
       metadata: {
-        data?: APIReturnType<'GET /api/apm/backends/{backendName}/metadata'>;
+        data?: APIReturnType<'GET /internal/apm/backends/{backendName}/metadata'>;
         status?: FETCH_STATUS;
       };
     }
@@ -41,7 +41,7 @@ export function ApmBackendContextProvider({
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/backends/{backendName}/metadata',
+        endpoint: 'GET /internal/apm/backends/{backendName}/metadata',
         params: {
           path: {
             backendName,

--- a/x-pack/plugins/apm/public/context/apm_service/apm_service_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/apm_service_context.tsx
@@ -20,7 +20,7 @@ import { useApmParams } from '../../hooks/use_apm_params';
 import { useTimeRange } from '../../hooks/use_time_range';
 
 export type APMServiceAlert = ValuesType<
-  APIReturnType<'GET /api/apm/services/{serviceName}/alerts'>['alerts']
+  APIReturnType<'GET /internal/apm/services/{serviceName}/alerts'>['alerts']
 >;
 
 export const APMServiceContext = createContext<{

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_agent_fetcher.ts
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_agent_fetcher.ts
@@ -29,7 +29,7 @@ export function useServiceAgentFetcher({
     (callApmApi) => {
       if (serviceName) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/agent',
+          endpoint: 'GET /internal/apm/services/{serviceName}/agent',
           params: {
             path: { serviceName },
             query: { start, end },

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_alerts_fetcher.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_alerts_fetcher.tsx
@@ -41,7 +41,7 @@ export function useServiceAlertsFetcher({
       }
 
       return callApmApi({
-        endpoint: 'GET /api/apm/services/{serviceName}/alerts',
+        endpoint: 'GET /internal/apm/services/{serviceName}/alerts',
         params: {
           path: {
             serviceName,

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_transaction_types_fetcher.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_transaction_types_fetcher.tsx
@@ -22,7 +22,8 @@ export function useServiceTransactionTypesFetcher({
     (callApmApi) => {
       if (serviceName && start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/transaction_types',
+          endpoint:
+            'GET /internal/apm/services/{serviceName}/transaction_types',
           params: {
             path: { serviceName },
             query: { start, end },

--- a/x-pack/plugins/apm/public/hooks/use_dynamic_index_pattern.ts
+++ b/x-pack/plugins/apm/public/hooks/use_dynamic_index_pattern.ts
@@ -10,7 +10,7 @@ import { useFetcher } from './use_fetcher';
 export function useDynamicIndexPatternFetcher() {
   const { data, status } = useFetcher((callApmApi) => {
     return callApmApi({
-      endpoint: 'GET /api/apm/index_pattern/dynamic',
+      endpoint: 'GET /internal/apm/index_pattern/dynamic',
       isCachable: true,
     });
   }, []);

--- a/x-pack/plugins/apm/public/hooks/use_environments_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_environments_fetcher.tsx
@@ -38,7 +38,7 @@ export function useEnvironmentsFetcher({
     (callApmApi) => {
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/environments',
+          endpoint: 'GET /internal/apm/environments',
           params: {
             query: {
               start,

--- a/x-pack/plugins/apm/public/hooks/use_error_group_distribution_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_error_group_distribution_fetcher.tsx
@@ -30,7 +30,8 @@ export function useErrorGroupDistributionFetcher({
     (callApmApi) => {
       if (start && end) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/errors/distribution',
+          endpoint:
+            'GET /internal/apm/services/{serviceName}/errors/distribution',
           params: {
             path: { serviceName },
             query: {

--- a/x-pack/plugins/apm/public/hooks/use_fallback_to_transactions_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_fallback_to_transactions_fetcher.tsx
@@ -19,7 +19,7 @@ export function useFallbackToTransactionsFetcher({ kuery }: { kuery: string }) {
   const { data = { fallbackToTransactions: false } } = useFetcher(
     (callApmApi) => {
       return callApmApi({
-        endpoint: 'GET /api/apm/fallback_to_transactions',
+        endpoint: 'GET /internal/apm/fallback_to_transactions',
         params: {
           query: { kuery, start, end },
         },

--- a/x-pack/plugins/apm/public/hooks/use_service_metric_charts_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_service_metric_charts_fetcher.ts
@@ -40,7 +40,7 @@ export function useServiceMetricChartsFetcher({
     (callApmApi) => {
       if (serviceName && start && end && agentName) {
         return callApmApi({
-          endpoint: 'GET /api/apm/services/{serviceName}/metrics/charts',
+          endpoint: 'GET /internal/apm/services/{serviceName}/metrics/charts',
           params: {
             path: { serviceName },
             query: {

--- a/x-pack/plugins/apm/public/hooks/use_transaction_latency_chart_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_latency_chart_fetcher.ts
@@ -57,7 +57,7 @@ export function useTransactionLatencyChartsFetcher({
       ) {
         return callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/transactions/charts/latency',
+            'GET /internal/apm/services/{serviceName}/transactions/charts/latency',
           params: {
             path: { serviceName },
             query: {

--- a/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
@@ -51,7 +51,7 @@ export function useTransactionTraceSamplesFetcher({
       if (serviceName && start && end && transactionType && transactionName) {
         const response = await callApmApi({
           endpoint:
-            'GET /api/apm/services/{serviceName}/transactions/traces/samples',
+            'GET /internal/apm/services/{serviceName}/transactions/traces/samples',
           params: {
             path: {
               serviceName,

--- a/x-pack/plugins/apm/public/selectors/latency_chart_selectors.ts
+++ b/x-pack/plugins/apm/public/selectors/latency_chart_selectors.ts
@@ -14,7 +14,7 @@ import { APMChartSpec, Coordinate } from '../../typings/timeseries';
 import { APIReturnType } from '../services/rest/createCallApmApi';
 
 export type LatencyChartsResponse =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/charts/latency'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/charts/latency'>;
 
 export interface LatencyChartData {
   currentPeriod?: APMChartSpec<Coordinate>;

--- a/x-pack/plugins/apm/public/services/callApi.test.ts
+++ b/x-pack/plugins/apm/public/services/callApi.test.ts
@@ -41,11 +41,14 @@ describe('callApi', () => {
     });
 
     it('should add debug param for APM endpoints', async () => {
-      await callApi(core, { pathname: `/api/apm/status/server` });
+      await callApi(core, { pathname: `/internal/apm/status/server` });
 
-      expect(core.http.get).toHaveBeenCalledWith('/api/apm/status/server', {
-        query: { _inspect: true },
-      });
+      expect(core.http.get).toHaveBeenCalledWith(
+        '/internal/apm/status/server',
+        {
+          query: { _inspect: true },
+        }
+      );
     });
 
     it('should not add debug param for non-APM endpoints', async () => {

--- a/x-pack/plugins/apm/public/services/callApmApi.test.ts
+++ b/x-pack/plugins/apm/public/services/callApmApi.test.ts
@@ -24,7 +24,7 @@ describe('callApmApi', () => {
 
   it('should format the pathname with the given path params', async () => {
     await callApmApi({
-      endpoint: 'GET /api/apm/{param1}/to/{param2}',
+      endpoint: 'GET /internal/apm/{param1}/to/{param2}',
       params: {
         path: {
           param1: 'foo',
@@ -36,14 +36,14 @@ describe('callApmApi', () => {
     expect(callApi).toHaveBeenCalledWith(
       {},
       expect.objectContaining({
-        pathname: '/api/apm/foo/to/bar',
+        pathname: '/internal/apm/foo/to/bar',
       })
     );
   });
 
   it('should add the query parameters to the options object', async () => {
     await callApmApi({
-      endpoint: 'GET /api/apm',
+      endpoint: 'GET /internal/apm',
       params: {
         query: {
           foo: 'bar',
@@ -55,7 +55,7 @@ describe('callApmApi', () => {
     expect(callApi).toHaveBeenCalledWith(
       {},
       expect.objectContaining({
-        pathname: '/api/apm',
+        pathname: '/internal/apm',
         query: {
           foo: 'bar',
           bar: 'foo',
@@ -66,7 +66,7 @@ describe('callApmApi', () => {
 
   it('should stringify the body and add it to the options object', async () => {
     await callApmApi({
-      endpoint: 'POST /api/apm',
+      endpoint: 'POST /internal/apm',
       params: {
         body: {
           foo: 'bar',
@@ -78,7 +78,7 @@ describe('callApmApi', () => {
     expect(callApi).toHaveBeenCalledWith(
       {},
       expect.objectContaining({
-        pathname: '/api/apm',
+        pathname: '/internal/apm',
         method: 'post',
         body: {
           foo: 'bar',

--- a/x-pack/plugins/apm/public/services/rest/apm_observability_overview_fetchers.ts
+++ b/x-pack/plugins/apm/public/services/rest/apm_observability_overview_fetchers.ts
@@ -17,7 +17,7 @@ export const fetchObservabilityOverviewPageData = async ({
   bucketSize,
 }: FetchDataParams): Promise<ApmFetchDataResponse> => {
   const data = await callApmApi({
-    endpoint: 'GET /api/apm/observability_overview',
+    endpoint: 'GET /internal/apm/observability_overview',
     signal: null,
     params: {
       query: {
@@ -52,7 +52,7 @@ export const fetchObservabilityOverviewPageData = async ({
 
 export async function getHasData() {
   return await callApmApi({
-    endpoint: 'GET /api/apm/observability_overview/has_data',
+    endpoint: 'GET /internal/apm/observability_overview/has_data',
     signal: null,
   });
 }

--- a/x-pack/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/plugins/apm/public/services/rest/callApi.ts
@@ -18,7 +18,7 @@ function fetchOptionsWithDebug(
 ) {
   const debugEnabled =
     inspectableEsQueriesEnabled &&
-    startsWith(fetchOptions.pathname, '/api/apm');
+    startsWith(fetchOptions.pathname, '/internal/apm');
 
   const { body, ...rest } = fetchOptions;
 

--- a/x-pack/plugins/apm/public/services/rest/index_pattern.ts
+++ b/x-pack/plugins/apm/public/services/rest/index_pattern.ts
@@ -9,7 +9,7 @@ import { callApmApi } from './createCallApmApi';
 
 export const createStaticIndexPattern = async () => {
   return await callApmApi({
-    endpoint: 'POST /api/apm/index_pattern/static',
+    endpoint: 'POST /internal/apm/index_pattern/static',
     signal: null,
   });
 };

--- a/x-pack/plugins/apm/public/tutorial/config_agent/config_agent.stories.tsx
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/config_agent.stories.tsx
@@ -12,7 +12,7 @@ import { POLICY_ELASTIC_AGENT_ON_CLOUD } from '../../../common/fleet';
 import TutorialConfigAgent from './';
 import { APIReturnType } from '../../services/rest/createCallApmApi';
 
-export type APIResponseType = APIReturnType<'GET /api/apm/fleet/agents'>;
+export type APIResponseType = APIReturnType<'GET /internal/apm/fleet/agents'>;
 
 interface Args {
   apmAgent: string;

--- a/x-pack/plugins/apm/public/tutorial/config_agent/get_policy_options.test.ts
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/get_policy_options.test.ts
@@ -7,7 +7,7 @@
 import { getPolicyOptions } from './get_policy_options';
 import { APIReturnType } from '../../services/rest/createCallApmApi';
 
-type APIResponseType = APIReturnType<'GET /api/apm/fleet/agents'>;
+type APIResponseType = APIReturnType<'GET /internal/apm/fleet/agents'>;
 
 const policyElasticAgentOnCloudAgent = {
   id: 'policy-elastic-agent-on-cloud',

--- a/x-pack/plugins/apm/public/tutorial/config_agent/index.tsx
+++ b/x-pack/plugins/apm/public/tutorial/config_agent/index.tsx
@@ -21,7 +21,7 @@ import { CopyCommands } from './copy_commands';
 import { getPolicyOptions, PolicyOption } from './get_policy_options';
 import { PolicySelector } from './policy_selector';
 
-export type APIResponseType = APIReturnType<'GET /api/apm/fleet/agents'>;
+export type APIResponseType = APIReturnType<'GET /internal/apm/fleet/agents'>;
 
 const CentralizedContainer = styled.div`
   display: flex;
@@ -90,7 +90,7 @@ function TutorialConfigAgent({
     async function fetchData() {
       setIsLoading(true);
       try {
-        const response = await http.get('/api/apm/fleet/agents');
+        const response = await http.get('/internal/apm/fleet/agents');
         if (response) {
           setData(response as APIResponseType);
         }

--- a/x-pack/plugins/apm/public/tutorial/tutorial_apm_fleet_check.ts
+++ b/x-pack/plugins/apm/public/tutorial/tutorial_apm_fleet_check.ts
@@ -9,7 +9,7 @@ import { callApmApi } from '../services/rest/createCallApmApi';
 export async function hasFleetApmIntegrations() {
   try {
     const { hasData = false } = await callApmApi({
-      endpoint: 'GET /api/apm/fleet/has_data',
+      endpoint: 'GET /internal/apm/fleet/has_data',
       signal: null,
     });
     return hasData;

--- a/x-pack/plugins/apm/public/tutorial/tutorial_fleet_instructions/index.tsx
+++ b/x-pack/plugins/apm/public/tutorial/tutorial_fleet_instructions/index.tsx
@@ -29,7 +29,7 @@ const CentralizedContainer = styled.div`
   align-items: center;
 `;
 
-type APIResponseType = APIReturnType<'GET /api/apm/fleet/has_data'>;
+type APIResponseType = APIReturnType<'GET /internal/apm/fleet/has_data'>;
 
 function TutorialFleetInstructions({ http, basePath, isDarkTheme }: Props) {
   const [data, setData] = useState<APIResponseType | undefined>();
@@ -39,7 +39,7 @@ function TutorialFleetInstructions({ http, basePath, isDarkTheme }: Props) {
     async function fetchData() {
       setIsLoading(true);
       try {
-        const response = await http.get('/api/apm/fleet/has_data');
+        const response = await http.get('/internal/apm/fleet/has_data');
         setData(response as APIResponseType);
       } catch (e) {
         setIsLoading(false);

--- a/x-pack/plugins/apm/server/routes/alerts/chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/chart_preview.ts
@@ -34,7 +34,7 @@ const alertParamsRt = t.intersection([
 export type AlertParams = t.TypeOf<typeof alertParamsRt>;
 
 const transactionErrorRateChartPreview = createApmServerRoute({
-  endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_rate',
+  endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_error_rate',
   params: t.type({ query: alertParamsRt }),
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
@@ -52,7 +52,7 @@ const transactionErrorRateChartPreview = createApmServerRoute({
 });
 
 const transactionErrorCountChartPreview = createApmServerRoute({
-  endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_count',
+  endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_error_count',
   params: t.type({ query: alertParamsRt }),
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
@@ -71,7 +71,7 @@ const transactionErrorCountChartPreview = createApmServerRoute({
 });
 
 const transactionDurationChartPreview = createApmServerRoute({
-  endpoint: 'GET /api/apm/alerts/chart_preview/transaction_duration',
+  endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_duration',
   params: t.type({ query: alertParamsRt }),
   options: { tags: ['access:apm'] },
   handler: async (resources) => {

--- a/x-pack/plugins/apm/server/routes/backends.ts
+++ b/x-pack/plugins/apm/server/routes/backends.ts
@@ -19,7 +19,7 @@ import { getThroughputChartsForBackend } from '../lib/backends/get_throughput_ch
 import { getErrorRateChartsForBackend } from '../lib/backends/get_error_rate_charts_for_backend';
 
 const topBackendsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/backends/top_backends',
+  endpoint: 'GET /internal/apm/backends/top_backends',
   params: t.intersection([
     t.type({
       query: t.intersection([
@@ -65,7 +65,7 @@ const topBackendsRoute = createApmServerRoute({
 });
 
 const upstreamServicesForBackendRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/backends/{backendName}/upstream_services',
+  endpoint: 'GET /internal/apm/backends/{backendName}/upstream_services',
   params: t.intersection([
     t.type({
       path: t.type({
@@ -121,7 +121,7 @@ const upstreamServicesForBackendRoute = createApmServerRoute({
 });
 
 const backendMetadataRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/backends/{backendName}/metadata',
+  endpoint: 'GET /internal/apm/backends/{backendName}/metadata',
   params: t.type({
     path: t.type({
       backendName: t.string,
@@ -150,7 +150,7 @@ const backendMetadataRoute = createApmServerRoute({
 });
 
 const backendLatencyChartsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/backends/{backendName}/charts/latency',
+  endpoint: 'GET /internal/apm/backends/{backendName}/charts/latency',
   params: t.type({
     path: t.type({
       backendName: t.string,
@@ -193,7 +193,7 @@ const backendLatencyChartsRoute = createApmServerRoute({
 });
 
 const backendThroughputChartsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/backends/{backendName}/charts/throughput',
+  endpoint: 'GET /internal/apm/backends/{backendName}/charts/throughput',
   params: t.type({
     path: t.type({
       backendName: t.string,
@@ -236,7 +236,7 @@ const backendThroughputChartsRoute = createApmServerRoute({
 });
 
 const backendFailedTransactionRateChartsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/backends/{backendName}/charts/error_rate',
+  endpoint: 'GET /internal/apm/backends/{backendName}/charts/error_rate',
   params: t.type({
     path: t.type({
       backendName: t.string,

--- a/x-pack/plugins/apm/server/routes/environments.ts
+++ b/x-pack/plugins/apm/server/routes/environments.ts
@@ -15,7 +15,7 @@ import { createApmServerRoute } from './create_apm_server_route';
 import { createApmServerRouteRepository } from './create_apm_server_route_repository';
 
 const environmentsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/environments',
+  endpoint: 'GET /internal/apm/environments',
   params: t.type({
     query: t.intersection([
       t.partial({

--- a/x-pack/plugins/apm/server/routes/errors.ts
+++ b/x-pack/plugins/apm/server/routes/errors.ts
@@ -15,7 +15,7 @@ import { environmentRt, kueryRt, rangeRt } from './default_api_types';
 import { createApmServerRouteRepository } from './create_apm_server_route_repository';
 
 const errorsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/errors',
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -54,7 +54,7 @@ const errorsRoute = createApmServerRoute({
 });
 
 const errorGroupsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/errors/{groupId}',
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -82,7 +82,7 @@ const errorGroupsRoute = createApmServerRoute({
 });
 
 const errorDistributionRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/errors/distribution',
+  endpoint: 'GET /internal/apm/services/{serviceName}/errors/distribution',
   params: t.type({
     path: t.type({
       serviceName: t.string,

--- a/x-pack/plugins/apm/server/routes/fallback_to_transactions.ts
+++ b/x-pack/plugins/apm/server/routes/fallback_to_transactions.ts
@@ -13,7 +13,7 @@ import { createApmServerRouteRepository } from './create_apm_server_route_reposi
 import { kueryRt, rangeRt } from './default_api_types';
 
 const fallbackToTransactionsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/fallback_to_transactions',
+  endpoint: 'GET /internal/apm/fallback_to_transactions',
   params: t.partial({
     query: t.intersection([kueryRt, t.partial(rangeRt.props)]),
   }),

--- a/x-pack/plugins/apm/server/routes/fleet.ts
+++ b/x-pack/plugins/apm/server/routes/fleet.ts
@@ -28,7 +28,7 @@ import { createApmServerRoute } from './create_apm_server_route';
 import { createApmServerRouteRepository } from './create_apm_server_route_repository';
 
 const hasFleetDataRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/fleet/has_data',
+  endpoint: 'GET /internal/apm/fleet/has_data',
   options: { tags: [] },
   handler: async ({ core, plugins }) => {
     const fleetPluginStart = await plugins.fleet?.start();
@@ -44,7 +44,7 @@ const hasFleetDataRoute = createApmServerRoute({
 });
 
 const fleetAgentsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/fleet/agents',
+  endpoint: 'GET /internal/apm/fleet/agents',
   options: { tags: [] },
   handler: async ({ core, plugins }) => {
     const cloudSetup = plugins.cloud?.setup;
@@ -92,7 +92,7 @@ const fleetAgentsRoute = createApmServerRoute({
 });
 
 const saveApmServerSchemaRoute = createApmServerRoute({
-  endpoint: 'POST /api/apm/fleet/apm_server_schema',
+  endpoint: 'POST /internal/apm/fleet/apm_server_schema',
   options: { tags: ['access:apm', 'access:apm_write'] },
   params: t.type({
     body: t.type({
@@ -113,7 +113,7 @@ const saveApmServerSchemaRoute = createApmServerRoute({
 });
 
 const getUnsupportedApmServerSchemaRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/fleet/apm_server_schema/unsupported',
+  endpoint: 'GET /internal/apm/fleet/apm_server_schema/unsupported',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const { context } = resources;
@@ -125,7 +125,7 @@ const getUnsupportedApmServerSchemaRoute = createApmServerRoute({
 });
 
 const getMigrationCheckRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/fleet/migration_check',
+  endpoint: 'GET /internal/apm/fleet/migration_check',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const { plugins, context, config, request } = resources;
@@ -154,7 +154,7 @@ const getMigrationCheckRoute = createApmServerRoute({
 });
 
 const createCloudApmPackagePolicyRoute = createApmServerRoute({
-  endpoint: 'POST /api/apm/fleet/cloud_apm_package_policy',
+  endpoint: 'POST /internal/apm/fleet/cloud_apm_package_policy',
   options: { tags: ['access:apm', 'access:apm_write'] },
   handler: async (resources) => {
     const { plugins, context, config, request, logger } = resources;

--- a/x-pack/plugins/apm/server/routes/historical_data/index.ts
+++ b/x-pack/plugins/apm/server/routes/historical_data/index.ts
@@ -11,7 +11,7 @@ import { createApmServerRouteRepository } from '../create_apm_server_route_repos
 import { hasHistoricalAgentData } from './has_historical_agent_data';
 
 const hasDataRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/has_data',
+  endpoint: 'GET /internal/apm/has_data',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const setup = await setupRequest(resources);

--- a/x-pack/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/index_pattern.ts
@@ -12,7 +12,7 @@ import { getDynamicIndexPattern } from '../lib/index_pattern/get_dynamic_index_p
 import { createApmServerRoute } from './create_apm_server_route';
 
 const staticIndexPatternRoute = createApmServerRoute({
-  endpoint: 'POST /api/apm/index_pattern/static',
+  endpoint: 'POST /internal/apm/index_pattern/static',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const {
@@ -43,7 +43,7 @@ const staticIndexPatternRoute = createApmServerRoute({
 });
 
 const dynamicIndexPatternRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/index_pattern/dynamic',
+  endpoint: 'GET /internal/apm/index_pattern/dynamic',
   options: { tags: ['access:apm'] },
   handler: async ({ context, config, logger }) => {
     const dynamicIndexPattern = await getDynamicIndexPattern({

--- a/x-pack/plugins/apm/server/routes/metrics.ts
+++ b/x-pack/plugins/apm/server/routes/metrics.ts
@@ -13,7 +13,7 @@ import { createApmServerRouteRepository } from './create_apm_server_route_reposi
 import { environmentRt, kueryRt, rangeRt } from './default_api_types';
 
 const metricsChartsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/metrics/charts',
+  endpoint: 'GET /internal/apm/services/{serviceName}/metrics/charts',
   params: t.type({
     path: t.type({
       serviceName: t.string,

--- a/x-pack/plugins/apm/server/routes/observability_overview.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview.ts
@@ -17,7 +17,7 @@ import { createApmServerRouteRepository } from './create_apm_server_route_reposi
 import { createApmServerRoute } from './create_apm_server_route';
 
 const observabilityOverviewHasDataRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/observability_overview/has_data',
+  endpoint: 'GET /internal/apm/observability_overview/has_data',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const setup = await setupRequest(resources);
@@ -26,7 +26,7 @@ const observabilityOverviewHasDataRoute = createApmServerRoute({
 });
 
 const observabilityOverviewRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/observability_overview',
+  endpoint: 'GET /internal/apm/observability_overview',
   params: t.type({
     query: t.intersection([rangeRt, t.type({ bucketSize: t.string })]),
   }),

--- a/x-pack/plugins/apm/server/routes/service_map.ts
+++ b/x-pack/plugins/apm/server/routes/service_map.ts
@@ -20,7 +20,7 @@ import { createApmServerRouteRepository } from './create_apm_server_route_reposi
 import { environmentRt, rangeRt } from './default_api_types';
 
 const serviceMapRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/service-map',
+  endpoint: 'GET /internal/apm/service-map',
   params: t.type({
     query: t.intersection([
       t.partial({
@@ -70,7 +70,7 @@ const serviceMapRoute = createApmServerRoute({
 });
 
 const serviceMapServiceNodeRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/service-map/service/{serviceName}',
+  endpoint: 'GET /internal/apm/service-map/service/{serviceName}',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -114,7 +114,7 @@ const serviceMapServiceNodeRoute = createApmServerRoute({
 });
 
 const serviceMapBackendNodeRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/service-map/backend/{backendName}',
+  endpoint: 'GET /internal/apm/service-map/backend/{backendName}',
   params: t.type({
     path: t.type({
       backendName: t.string,

--- a/x-pack/plugins/apm/server/routes/service_nodes.ts
+++ b/x-pack/plugins/apm/server/routes/service_nodes.ts
@@ -14,7 +14,7 @@ import { rangeRt, kueryRt } from './default_api_types';
 import { environmentRt } from '../../common/environment_rt';
 
 const serviceNodesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/serviceNodes',
+  endpoint: 'GET /internal/apm/services/{serviceName}/serviceNodes',
   params: t.type({
     path: t.type({
       serviceName: t.string,

--- a/x-pack/plugins/apm/server/routes/services.ts
+++ b/x-pack/plugins/apm/server/routes/services.ts
@@ -48,7 +48,7 @@ import { getServiceDependenciesBreakdown } from '../lib/services/get_service_dep
 import { getBucketSizeForAggregatedTransactions } from '../lib/helpers/get_bucket_size_for_aggregated_transactions';
 
 const servicesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services',
+  endpoint: 'GET /internal/apm/services',
   params: t.type({
     query: t.intersection([environmentRt, kueryRt, rangeRt]),
   }),
@@ -75,7 +75,7 @@ const servicesRoute = createApmServerRoute({
 });
 
 const servicesDetailedStatisticsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/detailed_statistics',
+  endpoint: 'GET /internal/apm/services/detailed_statistics',
   params: t.type({
     query: t.intersection([
       environmentRt,
@@ -116,7 +116,7 @@ const servicesDetailedStatisticsRoute = createApmServerRoute({
 });
 
 const serviceMetadataDetailsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/metadata/details',
+  endpoint: 'GET /internal/apm/services/{serviceName}/metadata/details',
   params: t.type({
     path: t.type({ serviceName: t.string }),
     query: rangeRt,
@@ -147,7 +147,7 @@ const serviceMetadataDetailsRoute = createApmServerRoute({
 });
 
 const serviceMetadataIconsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/metadata/icons',
+  endpoint: 'GET /internal/apm/services/{serviceName}/metadata/icons',
   params: t.type({
     path: t.type({ serviceName: t.string }),
     query: rangeRt,
@@ -178,7 +178,7 @@ const serviceMetadataIconsRoute = createApmServerRoute({
 });
 
 const serviceAgentRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/agent',
+  endpoint: 'GET /internal/apm/services/{serviceName}/agent',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -211,7 +211,7 @@ const serviceAgentRoute = createApmServerRoute({
 });
 
 const serviceTransactionTypesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/transaction_types',
+  endpoint: 'GET /internal/apm/services/{serviceName}/transaction_types',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -243,7 +243,7 @@ const serviceTransactionTypesRoute = createApmServerRoute({
 
 const serviceNodeMetadataRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
+    'GET /internal/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -383,7 +383,8 @@ const serviceAnnotationsCreateRoute = createApmServerRoute({
 });
 
 const serviceErrorGroupsMainStatisticsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/error_groups/main_statistics',
+  endpoint:
+    'GET /internal/apm/services/{serviceName}/error_groups/main_statistics',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -420,7 +421,7 @@ const serviceErrorGroupsMainStatisticsRoute = createApmServerRoute({
 
 const serviceErrorGroupsDetailedStatisticsRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/error_groups/detailed_statistics',
+    'GET /internal/apm/services/{serviceName}/error_groups/detailed_statistics',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -474,7 +475,7 @@ const serviceErrorGroupsDetailedStatisticsRoute = createApmServerRoute({
 });
 
 const serviceThroughputRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/throughput',
+  endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -556,7 +557,7 @@ const serviceThroughputRoute = createApmServerRoute({
 
 const serviceInstancesMainStatisticsRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics',
+    'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -630,7 +631,7 @@ const serviceInstancesMainStatisticsRoute = createApmServerRoute({
 
 const serviceInstancesDetailedStatisticsRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
+    'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -693,7 +694,7 @@ const serviceInstancesDetailedStatisticsRoute = createApmServerRoute({
 
 export const serviceInstancesMetadataDetails = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
+    'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -718,7 +719,7 @@ export const serviceInstancesMetadataDetails = createApmServerRoute({
 });
 
 export const serviceDependenciesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/dependencies',
+  endpoint: 'GET /internal/apm/services/{serviceName}/dependencies',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -773,7 +774,7 @@ export const serviceDependenciesRoute = createApmServerRoute({
 });
 
 export const serviceDependenciesBreakdownRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/dependencies/breakdown',
+  endpoint: 'GET /internal/apm/services/{serviceName}/dependencies/breakdown',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -805,7 +806,7 @@ export const serviceDependenciesBreakdownRoute = createApmServerRoute({
 });
 
 const serviceProfilingTimelineRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/profiling/timeline',
+  endpoint: 'GET /internal/apm/services/{serviceName}/profiling/timeline',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -837,7 +838,7 @@ const serviceProfilingTimelineRoute = createApmServerRoute({
 });
 
 const serviceProfilingStatisticsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/profiling/statistics',
+  endpoint: 'GET /internal/apm/services/{serviceName}/profiling/statistics',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -886,7 +887,7 @@ const serviceProfilingStatisticsRoute = createApmServerRoute({
 });
 
 const serviceAlertsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/alerts',
+  endpoint: 'GET /internal/apm/services/{serviceName}/alerts',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -922,7 +923,7 @@ const serviceAlertsRoute = createApmServerRoute({
 });
 
 const serviceInfrastructureRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/infrastructure',
+  endpoint: 'GET /internal/apm/services/{serviceName}/infrastructure',
   params: t.type({
     path: t.type({
       serviceName: t.string,

--- a/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
+++ b/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
@@ -23,7 +23,7 @@ import { createApmServerRouteRepository } from '../create_apm_server_route_repos
 
 // get ML anomaly detection jobs for each environment
 const anomalyDetectionJobsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/settings/anomaly-detection/jobs',
+  endpoint: 'GET /internal/apm/settings/anomaly-detection/jobs',
   options: {
     tags: ['access:apm', 'access:ml:canGetJobs'],
   },
@@ -51,7 +51,7 @@ const anomalyDetectionJobsRoute = createApmServerRoute({
 
 // create new ML anomaly detection jobs for each given environment
 const createAnomalyDetectionJobsRoute = createApmServerRoute({
-  endpoint: 'POST /api/apm/settings/anomaly-detection/jobs',
+  endpoint: 'POST /internal/apm/settings/anomaly-detection/jobs',
   options: {
     tags: ['access:apm', 'access:apm_write', 'access:ml:canCreateJob'],
   },
@@ -83,7 +83,7 @@ const createAnomalyDetectionJobsRoute = createApmServerRoute({
 
 // get all available environments to create anomaly detection jobs for
 const anomalyDetectionEnvironmentsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/settings/anomaly-detection/environments',
+  endpoint: 'GET /internal/apm/settings/anomaly-detection/environments',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const setup = await setupRequest(resources);

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
@@ -16,7 +16,7 @@ import { saveApmIndices } from '../../lib/settings/apm_indices/save_apm_indices'
 
 // get list of apm indices and values
 const apmIndexSettingsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/settings/apm-index-settings',
+  endpoint: 'GET /internal/apm/settings/apm-index-settings',
   options: { tags: ['access:apm'] },
   handler: async ({ config, context }) => {
     const apmIndexSettings = await getApmIndexSettings({ config, context });
@@ -26,7 +26,7 @@ const apmIndexSettingsRoute = createApmServerRoute({
 
 // get apm indices configuration object
 const apmIndicesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/settings/apm-indices',
+  endpoint: 'GET /internal/apm/settings/apm-indices',
   options: { tags: ['access:apm'] },
   handler: async (resources) => {
     const { context, config } = resources;
@@ -39,7 +39,7 @@ const apmIndicesRoute = createApmServerRoute({
 
 // save ui indices
 const saveApmIndicesRoute = createApmServerRoute({
-  endpoint: 'POST /api/apm/settings/apm-indices/save',
+  endpoint: 'POST /internal/apm/settings/apm-indices/save',
   options: {
     tags: ['access:apm', 'access:apm_write'],
   },

--- a/x-pack/plugins/apm/server/routes/settings/custom_link.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link.ts
@@ -25,7 +25,7 @@ import { createApmServerRoute } from '../create_apm_server_route';
 import { createApmServerRouteRepository } from '../create_apm_server_route_repository';
 
 const customLinkTransactionRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/settings/custom_links/transaction',
+  endpoint: 'GET /internal/apm/settings/custom_links/transaction',
   options: { tags: ['access:apm'] },
   params: t.partial({
     query: filterOptionsRt,
@@ -41,7 +41,7 @@ const customLinkTransactionRoute = createApmServerRoute({
 });
 
 const listCustomLinksRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/settings/custom_links',
+  endpoint: 'GET /internal/apm/settings/custom_links',
   options: { tags: ['access:apm'] },
   params: t.partial({
     query: filterOptionsRt,
@@ -63,7 +63,7 @@ const listCustomLinksRoute = createApmServerRoute({
 });
 
 const createCustomLinkRoute = createApmServerRoute({
-  endpoint: 'POST /api/apm/settings/custom_links',
+  endpoint: 'POST /internal/apm/settings/custom_links',
   params: t.type({
     body: payloadRt,
   }),
@@ -86,7 +86,7 @@ const createCustomLinkRoute = createApmServerRoute({
 });
 
 const updateCustomLinkRoute = createApmServerRoute({
-  endpoint: 'PUT /api/apm/settings/custom_links/{id}',
+  endpoint: 'PUT /internal/apm/settings/custom_links/{id}',
   params: t.type({
     path: t.type({
       id: t.string,
@@ -116,7 +116,7 @@ const updateCustomLinkRoute = createApmServerRoute({
 });
 
 const deleteCustomLinkRoute = createApmServerRoute({
-  endpoint: 'DELETE /api/apm/settings/custom_links/{id}',
+  endpoint: 'DELETE /internal/apm/settings/custom_links/{id}',
   params: t.type({
     path: t.type({
       id: t.string,

--- a/x-pack/plugins/apm/server/routes/traces.ts
+++ b/x-pack/plugins/apm/server/routes/traces.ts
@@ -17,7 +17,7 @@ import { createApmServerRouteRepository } from './create_apm_server_route_reposi
 import { getTransaction } from '../lib/transactions/get_transaction';
 
 const tracesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/traces',
+  endpoint: 'GET /internal/apm/traces',
   params: t.type({
     query: t.intersection([environmentRt, kueryRt, rangeRt]),
   }),
@@ -41,7 +41,7 @@ const tracesRoute = createApmServerRoute({
 });
 
 const tracesByIdRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/traces/{traceId}',
+  endpoint: 'GET /internal/apm/traces/{traceId}',
   params: t.type({
     path: t.type({
       traceId: t.string,
@@ -60,7 +60,7 @@ const tracesByIdRoute = createApmServerRoute({
 });
 
 const rootTransactionByTraceIdRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/traces/{traceId}/root_transaction',
+  endpoint: 'GET /internal/apm/traces/{traceId}/root_transaction',
   params: t.type({
     path: t.type({
       traceId: t.string,
@@ -76,7 +76,7 @@ const rootTransactionByTraceIdRoute = createApmServerRoute({
 });
 
 const transactionByIdRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/transactions/{transactionId}',
+  endpoint: 'GET /internal/apm/transactions/{transactionId}',
   params: t.type({
     path: t.type({
       transactionId: t.string,

--- a/x-pack/plugins/apm/server/routes/transactions.ts
+++ b/x-pack/plugins/apm/server/routes/transactions.ts
@@ -31,7 +31,7 @@ import {
 
 const transactionGroupsMainStatisticsRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics',
+    'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics',
   params: t.type({
     path: t.type({ serviceName: t.string }),
     query: t.intersection([
@@ -85,7 +85,7 @@ const transactionGroupsMainStatisticsRoute = createApmServerRoute({
 
 const transactionGroupsDetailedStatisticsRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/transactions/groups/detailed_statistics',
+    'GET /internal/apm/services/{serviceName}/transactions/groups/detailed_statistics',
   params: t.type({
     path: t.type({ serviceName: t.string }),
     query: t.intersection([
@@ -150,7 +150,8 @@ const transactionGroupsDetailedStatisticsRoute = createApmServerRoute({
 });
 
 const transactionLatencyChartsRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/transactions/charts/latency',
+  endpoint:
+    'GET /internal/apm/services/{serviceName}/transactions/charts/latency',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -227,7 +228,8 @@ const transactionLatencyChartsRoute = createApmServerRoute({
 });
 
 const transactionTraceSamplesRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/transactions/traces/samples',
+  endpoint:
+    'GET /internal/apm/services/{serviceName}/transactions/traces/samples',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -284,7 +286,8 @@ const transactionTraceSamplesRoute = createApmServerRoute({
 });
 
 const transactionChartsBreakdownRoute = createApmServerRoute({
-  endpoint: 'GET /api/apm/services/{serviceName}/transaction/charts/breakdown',
+  endpoint:
+    'GET /internal/apm/services/{serviceName}/transaction/charts/breakdown',
   params: t.type({
     path: t.type({
       serviceName: t.string,
@@ -321,7 +324,7 @@ const transactionChartsBreakdownRoute = createApmServerRoute({
 
 const transactionChartsErrorRateRoute = createApmServerRoute({
   endpoint:
-    'GET /api/apm/services/{serviceName}/transactions/charts/error_rate',
+    'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate',
   params: t.type({
     path: t.type({
       serviceName: t.string,

--- a/x-pack/plugins/rule_registry/server/scripts/get_alerts_index.sh
+++ b/x-pack/plugins/rule_registry/server/scripts/get_alerts_index.sh
@@ -20,4 +20,4 @@ curl -v -k \
  -u $USER:changeme \
  -X GET "${KIBANA_URL}${SPACE_URL}/internal/rac/alerts/index" | jq .
 
-# -X GET "${KIBANA_URL}${SPACE_URL}/api/apm/settings/apm-alerts-as-data-indices" | jq .
+# -X GET "${KIBANA_URL}${SPACE_URL}/internal/apm/settings/apm-alerts-as-data-indices" | jq .

--- a/x-pack/test/apm_api_integration/tests/alerts/chart_preview.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/chart_preview.ts
@@ -33,7 +33,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     it('transaction_error_rate (without data)', async () => {
       const options = getOptions();
       const response = await apmApiClient.readUser({
-        endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_rate',
+        endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_error_rate',
         ...options,
       });
 
@@ -46,7 +46,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       options.params.query.transactionType = undefined;
 
       const response = await apmApiClient.readUser({
-        endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_count',
+        endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_error_count',
         ...options,
       });
 
@@ -58,7 +58,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       const options = getOptions();
 
       const response = await apmApiClient.readUser({
-        endpoint: 'GET /api/apm/alerts/chart_preview/transaction_duration',
+        endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_duration',
         ...options,
       });
 
@@ -71,7 +71,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     it('transaction_error_rate (with data)', async () => {
       const options = getOptions();
       const response = await apmApiClient.readUser({
-        endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_rate',
+        endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_error_rate',
         ...options,
       });
 
@@ -88,7 +88,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       options.params.query.transactionType = undefined;
 
       const response = await apmApiClient.readUser({
-        endpoint: 'GET /api/apm/alerts/chart_preview/transaction_error_count',
+        endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_error_count',
         ...options,
       });
 
@@ -104,7 +104,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       const options = getOptions();
       const response = await apmApiClient.readUser({
         ...options,
-        endpoint: 'GET /api/apm/alerts/chart_preview/transaction_duration',
+        endpoint: 'GET /internal/apm/alerts/chart_preview/transaction_duration',
       });
 
       expect(response.status).to.be(200);

--- a/x-pack/test/apm_api_integration/tests/feature_controls.ts
+++ b/x-pack/test/apm_api_integration/tests/feature_controls.ts
@@ -44,87 +44,89 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     {
       // this doubles as a smoke test for the _inspect query parameter
       req: {
-        url: `/api/apm/services/foo/errors?start=${start}&end=${end}&_inspect=true&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services/foo/errors?start=${start}&end=${end}&_inspect=true&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/errors/bar?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services/foo/errors/bar?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/errors/distribution?start=${start}&end=${end}&groupId=bar&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services/foo/errors/distribution?start=${start}&end=${end}&groupId=bar&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/errors/distribution?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services/foo/errors/distribution?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/metrics/charts?start=${start}&end=${end}&agentName=cool-agent&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services/foo/metrics/charts?start=${start}&end=${end}&agentName=cool-agent&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/agent?start=${start}&end=${end}`,
+        url: `/internal/apm/services/foo/agent?start=${start}&end=${end}`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
-      req: { url: `/api/apm/services/foo/transaction_types?start=${start}&end=${end}` },
-      expectForbidden: expect403,
-      expectResponse: expect200,
-    },
-    {
-      req: { url: `/api/apm/traces?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=` },
+      req: { url: `/internal/apm/services/foo/transaction_types?start=${start}&end=${end}` },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/traces/foo?start=${start}&end=${end}`,
-      },
-      expectForbidden: expect403,
-      expectResponse: expect200,
-    },
-    {
-      req: {
-        url: `/api/apm/services/foo/transactions/charts/latency?environment=testing&start=${start}&end=${end}&transactionType=bar&latencyAggregationType=avg&kuery=`,
+        url: `/internal/apm/traces?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/transactions/charts/latency?environment=testing&start=${start}&end=${end}&transactionType=bar&latencyAggregationType=avg&transactionName=baz&kuery=`,
+        url: `/internal/apm/traces/foo?start=${start}&end=${end}`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/transactions/traces/samples?start=${start}&end=${end}&transactionType=bar&transactionName=baz&environment=ENVIRONMENT_ALL&kuery=`,
+        url: `/internal/apm/services/foo/transactions/charts/latency?environment=testing&start=${start}&end=${end}&transactionType=bar&latencyAggregationType=avg&kuery=`,
+      },
+      expectForbidden: expect403,
+      expectResponse: expect200,
+    },
+    {
+      req: {
+        url: `/internal/apm/services/foo/transactions/charts/latency?environment=testing&start=${start}&end=${end}&transactionType=bar&latencyAggregationType=avg&transactionName=baz&kuery=`,
+      },
+      expectForbidden: expect403,
+      expectResponse: expect200,
+    },
+    {
+      req: {
+        url: `/internal/apm/services/foo/transactions/traces/samples?start=${start}&end=${end}&transactionType=bar&transactionName=baz&environment=ENVIRONMENT_ALL&kuery=`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
@@ -147,21 +149,21 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     },
     {
       req: {
-        url: `/api/apm/settings/custom_links/transaction`,
+        url: `/internal/apm/settings/custom_links/transaction`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/metadata/details?start=${start}&end=${end}`,
+        url: `/internal/apm/services/foo/metadata/details?start=${start}&end=${end}`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,
     },
     {
       req: {
-        url: `/api/apm/services/foo/metadata/icons?start=${start}&end=${end}`,
+        url: `/internal/apm/services/foo/metadata/icons?start=${start}&end=${end}`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,

--- a/x-pack/test/apm_api_integration/tests/historical_data/has_data.ts
+++ b/x-pack/test/apm_api_integration/tests/historical_data/has_data.ts
@@ -18,7 +18,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     { config: 'basic', archives: [] },
     () => {
       it('handles the empty state', async () => {
-        const response = await supertest.get(`/api/apm/has_data`);
+        const response = await supertest.get(`/internal/apm/has_data`);
 
         expect(response.status).to.be(200);
         expect(response.body.hasData).to.be(false);
@@ -31,7 +31,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     { config: 'basic', archives: [archiveName] },
     () => {
       it('returns hasData: true', async () => {
-        const response = await supertest.get(`/api/apm/has_data`);
+        const response = await supertest.get(`/internal/apm/has_data`);
 
         expect(response.status).to.be(200);
         expect(response.body.hasData).to.be(true);

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -146,7 +146,7 @@ export default function apmApiIntegrationTests(providerContext: FtrProviderConte
     describe('traces/top_traces', function () {
       loadTestFile(require.resolve('./traces/top_traces'));
     });
-    describe('/api/apm/traces/{traceId}', function () {
+    describe('/internal/apm/traces/{traceId}', function () {
       loadTestFile(require.resolve('./traces/trace_by_id'));
     });
 

--- a/x-pack/test/apm_api_integration/tests/inspect/inspect.ts
+++ b/x-pack/test/apm_api_integration/tests/inspect/inspect.ts
@@ -21,7 +21,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
     describe('when omitting `_inspect` query param', () => {
       it('returns response without `_inspect`', async () => {
         const { status, body } = await apmApiClient.readUser({
-          endpoint: 'GET /api/apm/environments',
+          endpoint: 'GET /internal/apm/environments',
           params: {
             query: {
               start: metadata.start,
@@ -39,7 +39,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
       describe('elasticsearch calls made with end-user auth are returned', () => {
         it('for environments', async () => {
           const { status, body } = await apmApiClient.readUser({
-            endpoint: 'GET /api/apm/environments',
+            endpoint: 'GET /internal/apm/environments',
             params: {
               query: {
                 start: metadata.start,
@@ -67,7 +67,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
       describe('elasticsearch calls made with internal user are not return', () => {
         it('for custom links', async () => {
           const { status, body } = await apmApiClient.readUser({
-            endpoint: 'GET /api/apm/settings/custom_links',
+            endpoint: 'GET /internal/apm/settings/custom_links',
             params: {
               query: {
                 'service.name': 'opbeans-node',

--- a/x-pack/test/apm_api_integration/tests/metrics_charts/metrics_charts.ts
+++ b/x-pack/test/apm_api_integration/tests/metrics_charts/metrics_charts.ts
@@ -33,7 +33,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           let chartsResponse: ChartResponse;
           before(async () => {
             chartsResponse = await supertest.get(
-              `/api/apm/services/opbeans-node/metrics/charts?start=${start}&end=${end}&agentName=${agentName}&kuery=&environment=ENVIRONMENT_ALL`
+              `/internal/apm/services/opbeans-node/metrics/charts?start=${start}&end=${end}&agentName=${agentName}&kuery=&environment=ENVIRONMENT_ALL`
             );
           });
           it('contains CPU usage and System memory usage chart data', async () => {
@@ -121,7 +121,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           let chartsResponse: ChartResponse;
           before(async () => {
             chartsResponse = await supertest.get(
-              `/api/apm/services/opbeans-java/metrics/charts?start=${start}&end=${end}&agentName=${agentName}&environment=ENVIRONMENT_ALL&kuery=`
+              `/internal/apm/services/opbeans-java/metrics/charts?start=${start}&end=${end}&agentName=${agentName}&environment=ENVIRONMENT_ALL&kuery=`
             );
           });
 
@@ -410,7 +410,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           const end = encodeURIComponent('2020-09-08T15:05:00.000Z');
 
           const chartsResponse: ChartResponse = await supertest.get(
-            `/api/apm/services/opbeans-java/metrics/charts?start=${start}&end=${end}&agentName=${agentName}&environment=ENVIRONMENT_ALL&kuery=`
+            `/internal/apm/services/opbeans-java/metrics/charts?start=${start}&end=${end}&agentName=${agentName}&environment=ENVIRONMENT_ALL&kuery=`
           );
 
           const systemMemoryUsageChart = chartsResponse.body.charts.find(

--- a/x-pack/test/apm_api_integration/tests/observability_overview/has_data.ts
+++ b/x-pack/test/apm_api_integration/tests/observability_overview/has_data.ts
@@ -19,7 +19,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('returns false when there is no data', async () => {
         const response = await apmApiClient.readUser({
-          endpoint: 'GET /api/apm/observability_overview/has_data',
+          endpoint: 'GET /internal/apm/observability_overview/has_data',
         });
         expect(response.status).to.be(200);
         expect(response.body.hasData).to.eql(false);
@@ -33,7 +33,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('returns false when there is only onboarding data', async () => {
         const response = await apmApiClient.readUser({
-          endpoint: 'GET /api/apm/observability_overview/has_data',
+          endpoint: 'GET /internal/apm/observability_overview/has_data',
         });
         expect(response.status).to.be(200);
         expect(response.body.hasData).to.eql(false);
@@ -47,7 +47,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('returns true when there is at least one document on transaction, error or metrics indices', async () => {
         const response = await apmApiClient.readUser({
-          endpoint: 'GET /api/apm/observability_overview/has_data',
+          endpoint: 'GET /internal/apm/observability_overview/has_data',
         });
         expect(response.status).to.be(200);
         expect(response.body.hasData).to.eql(true);

--- a/x-pack/test/apm_api_integration/tests/observability_overview/observability_overview.ts
+++ b/x-pack/test/apm_api_integration/tests/observability_overview/observability_overview.ts
@@ -28,7 +28,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       describe('when data is not loaded', () => {
         it('handles the empty state', async () => {
           const response = await supertest.get(
-            `/api/apm/observability_overview?start=${start}&end=${end}&bucketSize=${bucketSize}`
+            `/internal/apm/observability_overview?start=${start}&end=${end}&bucketSize=${bucketSize}`
           );
           expect(response.status).to.be(200);
 
@@ -45,7 +45,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('returns the service count and transaction coordinates', async () => {
         const response = await supertest.get(
-          `/api/apm/observability_overview?start=${start}&end=${end}&bucketSize=${bucketSize}`
+          `/internal/apm/observability_overview?start=${start}&end=${end}&bucketSize=${bucketSize}`
         );
         expect(response.status).to.be(200);
 

--- a/x-pack/test/apm_api_integration/tests/service_maps/__snapshots__/service_maps.snap
+++ b/x-pack/test/apm_api_integration/tests/service_maps/__snapshots__/service_maps.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`APM API tests trial apm_8.0.0 Service Map with data /api/apm/service-map returns the correct data 3`] = `
+exports[`APM API tests trial apm_8.0.0 Service Map with data /internal/apm/service-map returns the correct data 3`] = `
 Array [
   Object {
     "data": Object {
@@ -1376,7 +1376,7 @@ Array [
 ]
 `;
 
-exports[`APM API tests trial apm_8.0.0 Service Map with data /api/apm/service-map with ML data with the default apm user returns the correct anomaly stats 3`] = `
+exports[`APM API tests trial apm_8.0.0 Service Map with data /internal/apm/service-map with ML data with the default apm user returns the correct anomaly stats 3`] = `
 Object {
   "elements": Array [
     Object {

--- a/x-pack/test/apm_api_integration/tests/service_maps/service_maps.ts
+++ b/x-pack/test/apm_api_integration/tests/service_maps/service_maps.ts
@@ -28,7 +28,7 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
   registry.when('Service map with a basic license', { config: 'basic', archives: [] }, () => {
     it('is only be available to users with Platinum license (or higher)', async () => {
       const response = await supertest.get(
-        `/api/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
+        `/internal/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
       );
 
       expect(response.status).to.be(403);
@@ -40,10 +40,10 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
   });
 
   registry.when('Service map without data', { config: 'trial', archives: [] }, () => {
-    describe('/api/apm/service-map', () => {
+    describe('/internal/apm/service-map', () => {
       it('returns an empty list', async () => {
         const response = await supertest.get(
-          `/api/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
+          `/internal/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
         );
 
         expect(response.status).to.be(200);
@@ -51,14 +51,14 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
       });
     });
 
-    describe('/api/apm/service-map/service/{serviceName}', () => {
+    describe('/internal/apm/service-map/service/{serviceName}', () => {
       it('returns an object with nulls', async () => {
         const q = querystring.stringify({
           start: metadata.start,
           end: metadata.end,
           environment: 'ENVIRONMENT_ALL',
         });
-        const response = await supertest.get(`/api/apm/service-map/service/opbeans-node?${q}`);
+        const response = await supertest.get(`/internal/apm/service-map/service/opbeans-node?${q}`);
 
         expect(response.status).to.be(200);
 
@@ -76,14 +76,14 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
       });
     });
 
-    describe('/api/apm/service-map/backend/{backendName}', () => {
+    describe('/internal/apm/service-map/backend/{backendName}', () => {
       it('returns an object with nulls', async () => {
         const q = querystring.stringify({
           start: metadata.start,
           end: metadata.end,
           environment: 'ENVIRONMENT_ALL',
         });
-        const response = await supertest.get(`/api/apm/service-map/backend/postgres?${q}`);
+        const response = await supertest.get(`/internal/apm/service-map/backend/postgres?${q}`);
 
         expect(response.status).to.be(200);
 
@@ -101,12 +101,12 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
   });
 
   registry.when('Service Map with data', { config: 'trial', archives: ['apm_8.0.0'] }, () => {
-    describe('/api/apm/service-map', () => {
+    describe('/internal/apm/service-map', () => {
       let response: PromiseReturnType<typeof supertest.get>;
 
       before(async () => {
         response = await supertest.get(
-          `/api/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
+          `/internal/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
         );
       });
 
@@ -159,7 +159,7 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
         describe('with the default apm user', () => {
           before(async () => {
             response = await supertest.get(
-              `/api/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
+              `/internal/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
             );
           });
 
@@ -246,7 +246,7 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
         describe('with a user that does not have access to ML', () => {
           before(async () => {
             response = await supertestAsApmReadUserWithoutMlAccess.get(
-              `/api/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
+              `/internal/apm/service-map?start=${start}&end=${end}&environment=ENVIRONMENT_ALL`
             );
           });
 
@@ -267,7 +267,7 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
           it('returns service map elements', async () => {
             response = await supertest.get(
               url.format({
-                pathname: '/api/apm/service-map',
+                pathname: '/internal/apm/service-map',
                 query: {
                   environment: 'ENVIRONMENT_ALL',
                   start: metadata.start,
@@ -284,14 +284,14 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
       });
     });
 
-    describe('/api/apm/service-map/service/{serviceName}', () => {
+    describe('/internal/apm/service-map/service/{serviceName}', () => {
       it('returns an object with data', async () => {
         const q = querystring.stringify({
           start: metadata.start,
           end: metadata.end,
           environment: 'ENVIRONMENT_ALL',
         });
-        const response = await supertest.get(`/api/apm/service-map/service/opbeans-node?${q}`);
+        const response = await supertest.get(`/internal/apm/service-map/service/opbeans-node?${q}`);
 
         expect(response.status).to.be(200);
 
@@ -309,14 +309,14 @@ export default function serviceMapsApiTests({ getService }: FtrProviderContext) 
       });
     });
 
-    describe('/api/apm/service-map/backend/{backendName}', () => {
+    describe('/internal/apm/service-map/backend/{backendName}', () => {
       it('returns an object with data', async () => {
         const q = querystring.stringify({
           start: metadata.start,
           end: metadata.end,
           environment: 'ENVIRONMENT_ALL',
         });
-        const response = await supertest.get(`/api/apm/service-map/backend/postgresql?${q}`);
+        const response = await supertest.get(`/internal/apm/service-map/backend/postgresql?${q}`);
 
         expect(response.status).to.be(200);
 

--- a/x-pack/test/apm_api_integration/tests/service_overview/dependencies/index.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/dependencies/index.ts
@@ -37,7 +37,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('handles the empty state', async () => {
         const response = await apmApiClient.readUser({
-          endpoint: `GET /api/apm/services/{serviceName}/dependencies`,
+          endpoint: `GET /internal/apm/services/{serviceName}/dependencies`,
           params: {
             path: { serviceName: 'opbeans-java' },
             query: {
@@ -61,7 +61,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       let response: {
         status: number;
-        body: APIReturnType<'GET /api/apm/services/{serviceName}/dependencies'>;
+        body: APIReturnType<'GET /internal/apm/services/{serviceName}/dependencies'>;
       };
 
       const indices = {
@@ -212,7 +212,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         response = await apmApiClient.readUser({
-          endpoint: `GET /api/apm/services/{serviceName}/dependencies`,
+          endpoint: `GET /internal/apm/services/{serviceName}/dependencies`,
           params: {
             path: { serviceName: 'opbeans-java' },
             query: {
@@ -309,12 +309,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       let response: {
         status: number;
-        body: APIReturnType<'GET /api/apm/services/{serviceName}/dependencies'>;
+        body: APIReturnType<'GET /internal/apm/services/{serviceName}/dependencies'>;
       };
 
       before(async () => {
         response = await apmApiClient.readUser({
-          endpoint: `GET /api/apm/services/{serviceName}/dependencies`,
+          endpoint: `GET /internal/apm/services/{serviceName}/dependencies`,
           params: {
             path: { serviceName: 'opbeans-python' },
             query: {

--- a/x-pack/test/apm_api_integration/tests/service_overview/get_service_node_ids.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/get_service_node_ids.ts
@@ -22,7 +22,7 @@ export async function getServiceNodeIds({
   count?: number;
 }) {
   const { body } = await apmApiSupertest({
-    endpoint: `GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`,
+    endpoint: `GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`,
     params: {
       path: { serviceName },
       query: {

--- a/x-pack/test/apm_api_integration/tests/service_overview/instance_details.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instance_details.ts
@@ -14,7 +14,7 @@ import { getServiceNodeIds } from './get_service_node_ids';
 import { createApmApiClient } from '../../common/apm_api_supertest';
 
 type ServiceOverviewInstanceDetails =
-  APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -31,7 +31,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         it('handles empty state', async () => {
           const response = await supertest.get(
             url.format({
-              pathname: '/api/apm/services/opbeans-java/service_overview_instances/details/foo',
+              pathname:
+                '/internal/apm/services/opbeans-java/service_overview_instances/details/foo',
               query: {
                 start,
                 end,
@@ -62,7 +63,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           serviceNodeIds = await getServiceNodeIds({ apmApiSupertest, start, end });
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/service_overview_instances/details/${serviceNodeIds[0]}`,
+              pathname: `/internal/apm/services/opbeans-java/service_overview_instances/details/${serviceNodeIds[0]}`,
               query: {
                 start,
                 end,
@@ -89,7 +90,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles empty state when instance id not found', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: '/api/apm/services/opbeans-java/service_overview_instances/details/foo',
+            pathname: '/internal/apm/services/opbeans-java/service_overview_instances/details/foo',
             query: {
               start,
               end,

--- a/x-pack/test/apm_api_integration/tests/service_overview/instances_detailed_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instances_detailed_statistics.ts
@@ -26,7 +26,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   interface Response {
     status: number;
-    body: APIReturnType<'GET /api/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
+    body: APIReturnType<'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics'>;
   }
 
   registry.when(
@@ -37,7 +37,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         it('handles the empty state', async () => {
           const response: Response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics`,
+              pathname: `/internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics`,
               query: {
                 latencyAggregationType: 'avg',
                 start,
@@ -75,7 +75,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         beforeEach(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics`,
+              pathname: `/internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics`,
               query: {
                 latencyAggregationType: 'avg',
                 start,
@@ -129,7 +129,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         beforeEach(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/service_overview_instances/detailed_statistics`,
+              pathname: `/internal/apm/services/opbeans-java/service_overview_instances/detailed_statistics`,
               query: {
                 latencyAggregationType: 'avg',
                 numBuckets: 20,

--- a/x-pack/test/apm_api_integration/tests/service_overview/instances_main_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instances_main_statistics.ts
@@ -29,7 +29,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       describe('when data is not loaded', () => {
         it('handles the empty state', async () => {
           const response = await apmApiClient.readUser({
-            endpoint: `GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`,
+            endpoint: `GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`,
             params: {
               path: { serviceName: 'opbeans-java' },
               query: {
@@ -58,12 +58,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       describe('fetching java data', () => {
         let response: {
-          body: APIReturnType<`GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`>;
+          body: APIReturnType<`GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`>;
         };
 
         beforeEach(async () => {
           response = await apmApiClient.readUser({
-            endpoint: `GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`,
+            endpoint: `GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`,
             params: {
               path: { serviceName: 'opbeans-java' },
               query: {
@@ -129,12 +129,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       describe('fetching non-java data', () => {
         let response: {
-          body: APIReturnType<`GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`>;
+          body: APIReturnType<`GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`>;
         };
 
         beforeEach(async () => {
           response = await apmApiClient.readUser({
-            endpoint: `GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`,
+            endpoint: `GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`,
             params: {
               path: { serviceName: 'opbeans-ruby' },
               query: {
@@ -197,12 +197,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       describe('fetching java data', () => {
         let response: {
-          body: APIReturnType<`GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`>;
+          body: APIReturnType<`GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`>;
         };
 
         beforeEach(async () => {
           response = await apmApiClient.readUser({
-            endpoint: `GET /api/apm/services/{serviceName}/service_overview_instances/main_statistics`,
+            endpoint: `GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics`,
             params: {
               path: { serviceName: 'opbeans-java' },
               query: {

--- a/x-pack/test/apm_api_integration/tests/services/agent.ts
+++ b/x-pack/test/apm_api_integration/tests/services/agent.ts
@@ -21,7 +21,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   registry.when('Agent name when data is not loaded', { config: 'basic', archives: [] }, () => {
     it('handles the empty state', async () => {
       const response = await supertest.get(
-        `/api/apm/services/opbeans-node/agent?start=${start}&end=${end}`
+        `/internal/apm/services/opbeans-node/agent?start=${start}&end=${end}`
       );
 
       expect(response.status).to.be(200);
@@ -35,7 +35,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('returns the agent name', async () => {
         const response = await supertest.get(
-          `/api/apm/services/opbeans-node/agent?start=${start}&end=${end}`
+          `/internal/apm/services/opbeans-node/agent?start=${start}&end=${end}`
         );
 
         expect(response.status).to.be(200);

--- a/x-pack/test/apm_api_integration/tests/services/error_groups_detailed_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/services/error_groups_detailed_statistics.ts
@@ -16,7 +16,7 @@ import { createApmApiClient } from '../../common/apm_api_supertest';
 import { getErrorGroupIds } from './get_error_group_ids';
 
 type ErrorGroupsDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/error_groups/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/error_groups/detailed_statistics'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -35,7 +35,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/error_groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/error_groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -63,7 +63,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/error_groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/error_groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -98,7 +98,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns an empty state when requested groupIds are not available in the given time range', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/error_groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/error_groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -133,7 +133,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/error_groups/detailed_statistics`,
+              pathname: `/internal/apm/services/opbeans-java/error_groups/detailed_statistics`,
               query: {
                 numBuckets: 20,
                 transactionType: 'request',
@@ -179,7 +179,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns an empty state when requested groupIds are not available in the given time range', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/error_groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/error_groups/detailed_statistics`,
             query: {
               numBuckets: 20,
               transactionType: 'request',

--- a/x-pack/test/apm_api_integration/tests/services/error_groups_main_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/services/error_groups_main_statistics.ts
@@ -13,7 +13,7 @@ import { registry } from '../../common/registry';
 import { APIReturnType } from '../../../../plugins/apm/public/services/rest/createCallApmApi';
 
 type ErrorGroupsMainStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/error_groups/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/error_groups/main_statistics'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -29,7 +29,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles empty state', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/error_groups/main_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/error_groups/main_statistics`,
             query: {
               start,
               end,
@@ -56,7 +56,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns the correct data', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/error_groups/main_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/error_groups/main_statistics`,
             query: {
               start,
               end,

--- a/x-pack/test/apm_api_integration/tests/services/get_error_group_ids.ts
+++ b/x-pack/test/apm_api_integration/tests/services/get_error_group_ids.ts
@@ -21,7 +21,7 @@ export async function getErrorGroupIds({
   count?: number;
 }) {
   const { body } = await apmApiSupertest({
-    endpoint: `GET /api/apm/services/{serviceName}/error_groups/main_statistics`,
+    endpoint: `GET /internal/apm/services/{serviceName}/error_groups/main_statistics`,
     params: {
       path: { serviceName },
       query: {

--- a/x-pack/test/apm_api_integration/tests/services/service_details.ts
+++ b/x-pack/test/apm_api_integration/tests/services/service_details.ts
@@ -24,7 +24,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles the empty state', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/metadata/details`,
+            pathname: `/internal/apm/services/opbeans-java/metadata/details`,
             query: { start, end },
           })
         );
@@ -42,7 +42,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns java service details', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/metadata/details`,
+            pathname: `/internal/apm/services/opbeans-java/metadata/details`,
             query: { start, end },
           })
         );
@@ -88,7 +88,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns python service details', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-python/metadata/details`,
+            pathname: `/internal/apm/services/opbeans-python/metadata/details`,
             query: { start, end },
           })
         );

--- a/x-pack/test/apm_api_integration/tests/services/service_icons.ts
+++ b/x-pack/test/apm_api_integration/tests/services/service_icons.ts
@@ -21,7 +21,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     it('handles the empty state', async () => {
       const response = await supertest.get(
         url.format({
-          pathname: `/api/apm/services/opbeans-java/metadata/icons`,
+          pathname: `/internal/apm/services/opbeans-java/metadata/icons`,
           query: { start, end },
         })
       );
@@ -38,7 +38,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns java service icons', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/metadata/icons`,
+            pathname: `/internal/apm/services/opbeans-java/metadata/icons`,
             query: { start, end },
           })
         );
@@ -57,7 +57,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns python service icons', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-python/metadata/icons`,
+            pathname: `/internal/apm/services/opbeans-python/metadata/icons`,
             query: { start, end },
           })
         );

--- a/x-pack/test/apm_api_integration/tests/services/services_detailed_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/services/services_detailed_statistics.ts
@@ -13,7 +13,8 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { APIReturnType } from '../../../../plugins/apm/public/services/rest/createCallApmApi';
 import { isFiniteNumber } from '../../../../plugins/apm/common/utils/is_finite_number';
 
-type ServicesDetailedStatisticsReturn = APIReturnType<'GET /api/apm/services/detailed_statistics'>;
+type ServicesDetailedStatisticsReturn =
+  APIReturnType<'GET /internal/apm/services/detailed_statistics'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -30,7 +31,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles the empty state', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/detailed_statistics`,
+            pathname: `/internal/apm/services/detailed_statistics`,
             query: {
               start,
               end,
@@ -56,7 +57,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       before(async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/detailed_statistics`,
+            pathname: `/internal/apm/services/detailed_statistics`,
             query: {
               start,
               end,
@@ -107,7 +108,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns empty when empty service names is passed', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/detailed_statistics`,
+            pathname: `/internal/apm/services/detailed_statistics`,
             query: {
               start,
               end,
@@ -124,7 +125,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('filters by environment', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/detailed_statistics`,
+            pathname: `/internal/apm/services/detailed_statistics`,
             query: {
               start,
               end,
@@ -141,7 +142,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('filters by kuery', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/detailed_statistics`,
+            pathname: `/internal/apm/services/detailed_statistics`,
             query: {
               start,
               end,
@@ -165,7 +166,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       before(async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/detailed_statistics`,
+            pathname: `/internal/apm/services/detailed_statistics`,
             query: {
               start: moment(end).subtract(15, 'minutes').toISOString(),
               end,

--- a/x-pack/test/apm_api_integration/tests/services/throughput.ts
+++ b/x-pack/test/apm_api_integration/tests/services/throughput.ts
@@ -14,7 +14,7 @@ import archives_metadata from '../../common/fixtures/es_archiver/archives_metada
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { registry } from '../../common/registry';
 
-type ThroughputReturn = APIReturnType<'GET /api/apm/services/{serviceName}/throughput'>;
+type ThroughputReturn = APIReturnType<'GET /internal/apm/services/{serviceName}/throughput'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
@@ -25,7 +25,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   registry.when('Throughput when data is not loaded', { config: 'basic', archives: [] }, () => {
     it('handles the empty state', async () => {
       const response = await apmApiClient.readUser({
-        endpoint: 'GET /api/apm/services/{serviceName}/throughput',
+        endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
         params: {
           path: {
             serviceName: 'opbeans-java',
@@ -54,7 +54,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       describe('when querying without kql filter', () => {
         before(async () => {
           const response = await apmApiClient.readUser({
-            endpoint: 'GET /api/apm/services/{serviceName}/throughput',
+            endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
             params: {
               path: {
                 serviceName: 'opbeans-java',
@@ -108,7 +108,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       describe('with kql filter to force transaction-based UI', () => {
         before(async () => {
           const response = await apmApiClient.readUser({
-            endpoint: 'GET /api/apm/services/{serviceName}/throughput',
+            endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
             params: {
               path: {
                 serviceName: 'opbeans-java',
@@ -144,7 +144,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       before(async () => {
         const response = await apmApiClient.readUser({
-          endpoint: 'GET /api/apm/services/{serviceName}/throughput',
+          endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
           params: {
             path: {
               serviceName: 'opbeans-java',

--- a/x-pack/test/apm_api_integration/tests/services/top_services.ts
+++ b/x-pack/test/apm_api_integration/tests/services/top_services.ts
@@ -33,7 +33,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('handles the empty state', async () => {
         const response = await supertest.get(
-          `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+          `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
         );
 
         expect(response.status).to.be(200);
@@ -49,14 +49,14 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       let response: {
         status: number;
-        body: APIReturnType<'GET /api/apm/services'>;
+        body: APIReturnType<'GET /internal/apm/services'>;
       };
 
       let sortedItems: typeof response.body.items;
 
       before(async () => {
         response = await supertest.get(
-          `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+          `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
         );
         sortedItems = sortBy(response.body.items, 'serviceName');
       });
@@ -192,15 +192,15 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('includes services that only report metric data', async () => {
         interface Response {
           status: number;
-          body: APIReturnType<'GET /api/apm/services'>;
+          body: APIReturnType<'GET /internal/apm/services'>;
         }
 
         const [unfilteredResponse, filteredResponse] = await Promise.all([
           supertest.get(
-            `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+            `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
           ) as Promise<Response>,
           supertest.get(
-            `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=${encodeURIComponent(
+            `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=${encodeURIComponent(
               'not (processor.event:transaction)'
             )}`
           ) as Promise<Response>,
@@ -231,12 +231,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         describe('and fetching a list of services', () => {
           let response: {
             status: number;
-            body: APIReturnType<'GET /api/apm/services'>;
+            body: APIReturnType<'GET /internal/apm/services'>;
           };
 
           before(async () => {
             response = await supertest.get(
-              `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+              `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
             );
           });
 
@@ -282,7 +282,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         let response: PromiseReturnType<typeof supertest.get>;
         before(async () => {
           response = await supertestAsApmReadUserWithoutMlAccess.get(
-            `/api/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+            `/internal/apm/services?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
           );
         });
 
@@ -307,7 +307,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         let response: PromiseReturnType<typeof supertest.get>;
         before(async () => {
           response = await supertest.get(
-            `/api/apm/services?environment=ENVIRONMENT_ALL&start=${start}&end=${end}&kuery=${encodeURIComponent(
+            `/internal/apm/services?environment=ENVIRONMENT_ALL&start=${start}&end=${end}&kuery=${encodeURIComponent(
               'service.name:opbeans-java'
             )}`
           );

--- a/x-pack/test/apm_api_integration/tests/services/transaction_types.ts
+++ b/x-pack/test/apm_api_integration/tests/services/transaction_types.ts
@@ -26,7 +26,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('handles empty state', async () => {
         const response = await supertest.get(
-          `/api/apm/services/opbeans-node/transaction_types?start=${start}&end=${end}`
+          `/internal/apm/services/opbeans-node/transaction_types?start=${start}&end=${end}`
         );
 
         expect(response.status).to.be(200);
@@ -42,7 +42,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('handles empty state', async () => {
         const response = await supertest.get(
-          `/api/apm/services/opbeans-node/transaction_types?start=${start}&end=${end}`
+          `/internal/apm/services/opbeans-node/transaction_types?start=${start}&end=${end}`
         );
 
         expect(response.status).to.be(200);

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/basic.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/basic.ts
@@ -17,12 +17,12 @@ export default function apiTest({ getService }: FtrProviderContext) {
   type SupertestAsUser = typeof noAccessUser | typeof readUser | typeof writeUser;
 
   function getJobs(user: SupertestAsUser) {
-    return user.get(`/api/apm/settings/anomaly-detection/jobs`).set('kbn-xsrf', 'foo');
+    return user.get(`/internal/apm/settings/anomaly-detection/jobs`).set('kbn-xsrf', 'foo');
   }
 
   function createJobs(user: SupertestAsUser, environments: string[]) {
     return user
-      .post(`/api/apm/settings/anomaly-detection/jobs`)
+      .post(`/internal/apm/settings/anomaly-detection/jobs`)
       .send({ environments })
       .set('kbn-xsrf', 'foo');
   }

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/no_access_user.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/no_access_user.ts
@@ -13,12 +13,12 @@ export default function apiTest({ getService }: FtrProviderContext) {
   const noAccessUser = getService('legacySupertestAsNoAccessUser');
 
   function getJobs() {
-    return noAccessUser.get(`/api/apm/settings/anomaly-detection/jobs`).set('kbn-xsrf', 'foo');
+    return noAccessUser.get(`/internal/apm/settings/anomaly-detection/jobs`).set('kbn-xsrf', 'foo');
   }
 
   function createJobs(environments: string[]) {
     return noAccessUser
-      .post(`/api/apm/settings/anomaly-detection/jobs`)
+      .post(`/internal/apm/settings/anomaly-detection/jobs`)
       .send({ environments })
       .set('kbn-xsrf', 'foo');
   }

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/read_user.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/read_user.ts
@@ -13,12 +13,12 @@ export default function apiTest({ getService }: FtrProviderContext) {
   const apmReadUser = getService('legacySupertestAsApmReadUser');
 
   function getJobs() {
-    return apmReadUser.get(`/api/apm/settings/anomaly-detection/jobs`).set('kbn-xsrf', 'foo');
+    return apmReadUser.get(`/internal/apm/settings/anomaly-detection/jobs`).set('kbn-xsrf', 'foo');
   }
 
   function createJobs(environments: string[]) {
     return apmReadUser
-      .post(`/api/apm/settings/anomaly-detection/jobs`)
+      .post(`/internal/apm/settings/anomaly-detection/jobs`)
       .send({ environments })
       .set('kbn-xsrf', 'foo');
   }

--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.ts
@@ -15,12 +15,14 @@ export default function apiTest({ getService }: FtrProviderContext) {
   const legacyWriteUserClient = getService('legacySupertestAsApmWriteUser');
 
   function getJobs() {
-    return apmApiClient.writeUser({ endpoint: `GET /api/apm/settings/anomaly-detection/jobs` });
+    return apmApiClient.writeUser({
+      endpoint: `GET /internal/apm/settings/anomaly-detection/jobs`,
+    });
   }
 
   function createJobs(environments: string[]) {
     return apmApiClient.writeUser({
-      endpoint: `POST /api/apm/settings/anomaly-detection/jobs`,
+      endpoint: `POST /internal/apm/settings/anomaly-detection/jobs`,
       params: {
         body: { environments },
       },

--- a/x-pack/test/apm_api_integration/tests/settings/custom_link.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/custom_link.ts
@@ -126,7 +126,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
 
       it('fetches a transaction sample', async () => {
         const response = await apmApiClient.readUser({
-          endpoint: 'GET /api/apm/settings/custom_links/transaction',
+          endpoint: 'GET /internal/apm/settings/custom_links/transaction',
           params: {
             query: {
               'service.name': 'opbeans-java',
@@ -141,7 +141,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
 
   function searchCustomLinks(filters?: any) {
     return apmApiClient.readUser({
-      endpoint: 'GET /api/apm/settings/custom_links',
+      endpoint: 'GET /internal/apm/settings/custom_links',
       params: {
         query: filters,
       },
@@ -152,7 +152,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
     log.debug('creating configuration', customLink);
 
     return apmApiClient.writeUser({
-      endpoint: 'POST /api/apm/settings/custom_links',
+      endpoint: 'POST /internal/apm/settings/custom_links',
       params: {
         body: customLink,
       },
@@ -163,7 +163,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
     log.debug('updating configuration', id, customLink);
 
     return apmApiClient.writeUser({
-      endpoint: 'PUT /api/apm/settings/custom_links/{id}',
+      endpoint: 'PUT /internal/apm/settings/custom_links/{id}',
       params: {
         path: { id },
         body: customLink,
@@ -175,7 +175,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
     log.debug('deleting configuration', id);
 
     return apmApiClient.writeUser({
-      endpoint: 'DELETE /api/apm/settings/custom_links/{id}',
+      endpoint: 'DELETE /internal/apm/settings/custom_links/{id}',
       params: { path: { id } },
     });
   }

--- a/x-pack/test/apm_api_integration/tests/traces/top_traces.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/top_traces.ts
@@ -24,7 +24,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   registry.when('Top traces when data is not loaded', { config: 'basic', archives: [] }, () => {
     it('handles empty state', async () => {
       const response = await supertest.get(
-        `/api/apm/traces?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+        `/internal/apm/traces?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
       );
 
       expect(response.status).to.be(200);
@@ -39,7 +39,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       let response: any;
       before(async () => {
         response = await supertest.get(
-          `/api/apm/traces?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
+          `/internal/apm/traces?start=${start}&end=${end}&environment=ENVIRONMENT_ALL&kuery=`
         );
       });
 

--- a/x-pack/test/apm_api_integration/tests/traces/trace_by_id.tsx
+++ b/x-pack/test/apm_api_integration/tests/traces/trace_by_id.tsx
@@ -22,7 +22,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   registry.when('Trace does not exist', { config: 'basic', archives: [] }, () => {
     it('handles empty state', async () => {
       const response = await apmApiSupertest({
-        endpoint: `GET /api/apm/traces/{traceId}`,
+        endpoint: `GET /internal/apm/traces/{traceId}`,
         params: {
           path: { traceId: 'foo' },
           query: { start, end },
@@ -35,10 +35,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   });
 
   registry.when('Trace exists', { config: 'basic', archives: [archiveName] }, () => {
-    let response: SupertestReturnType<`GET /api/apm/traces/{traceId}`>;
+    let response: SupertestReturnType<`GET /internal/apm/traces/{traceId}`>;
     before(async () => {
       response = await apmApiSupertest({
-        endpoint: `GET /api/apm/traces/{traceId}`,
+        endpoint: `GET /internal/apm/traces/{traceId}`,
         params: {
           path: { traceId: '64d0014f7530df24e549dd17cc0a8895' },
           query: { start, end },

--- a/x-pack/test/apm_api_integration/tests/transactions/breakdown.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/breakdown.ts
@@ -24,7 +24,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   registry.when('Breakdown when data is not loaded', { config: 'basic', archives: [] }, () => {
     it('handles the empty state', async () => {
       const response = await supertest.get(
-        `/api/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&environment=ENVIRONMENT_ALL&kuery=`
+        `/internal/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&environment=ENVIRONMENT_ALL&kuery=`
       );
       expect(response.status).to.be(200);
       expect(response.body).to.eql({ timeseries: [] });
@@ -37,7 +37,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     () => {
       it('returns the transaction breakdown for a service', async () => {
         const response = await supertest.get(
-          `/api/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&environment=ENVIRONMENT_ALL&kuery=`
+          `/internal/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&environment=ENVIRONMENT_ALL&kuery=`
         );
 
         expect(response.status).to.be(200);
@@ -45,7 +45,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
       it('returns the transaction breakdown for a transaction group', async () => {
         const response = await supertest.get(
-          `/api/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&transactionName=${transactionName}&environment=ENVIRONMENT_ALL&kuery=`
+          `/internal/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&transactionName=${transactionName}&environment=ENVIRONMENT_ALL&kuery=`
         );
 
         expect(response.status).to.be(200);
@@ -104,7 +104,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
       it('returns the transaction breakdown sorted by name', async () => {
         const response = await supertest.get(
-          `/api/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&environment=ENVIRONMENT_ALL&kuery=`
+          `/internal/apm/services/opbeans-node/transaction/charts/breakdown?start=${start}&end=${end}&transactionType=${transactionType}&environment=ENVIRONMENT_ALL&kuery=`
         );
 
         expect(response.status).to.be(200);

--- a/x-pack/test/apm_api_integration/tests/transactions/error_rate.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/error_rate.ts
@@ -15,7 +15,7 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { registry } from '../../common/registry';
 
 type ErrorRate =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/charts/error_rate'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -30,7 +30,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     it('handles the empty state', async () => {
       const response = await supertest.get(
         format({
-          pathname: '/api/apm/services/opbeans-java/transactions/charts/error_rate',
+          pathname: '/internal/apm/services/opbeans-java/transactions/charts/error_rate',
           query: { start, end, transactionType, environment: 'ENVIRONMENT_ALL', kuery: '' },
         })
       );
@@ -46,7 +46,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     it('handles the empty state with comparison data', async () => {
       const response = await supertest.get(
         format({
-          pathname: '/api/apm/services/opbeans-java/transactions/charts/error_rate',
+          pathname: '/internal/apm/services/opbeans-java/transactions/charts/error_rate',
           query: {
             transactionType,
             start: moment(end).subtract(15, 'minutes').toISOString(),
@@ -78,7 +78,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           const response = await supertest.get(
             format({
-              pathname: '/api/apm/services/opbeans-java/transactions/charts/error_rate',
+              pathname: '/internal/apm/services/opbeans-java/transactions/charts/error_rate',
               query: { start, end, transactionType, environment: 'ENVIRONMENT_ALL', kuery: '' },
             })
           );
@@ -138,7 +138,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           const response = await supertest.get(
             format({
-              pathname: '/api/apm/services/opbeans-java/transactions/charts/error_rate',
+              pathname: '/internal/apm/services/opbeans-java/transactions/charts/error_rate',
               query: {
                 transactionType,
                 start: moment(end).subtract(15, 'minutes').toISOString(),

--- a/x-pack/test/apm_api_integration/tests/transactions/latency.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/latency.ts
@@ -15,7 +15,7 @@ import archives_metadata from '../../common/fixtures/es_archiver/archives_metada
 import { registry } from '../../common/registry';
 
 type LatencyChartReturnType =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/charts/latency'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/charts/latency'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -31,7 +31,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns 400 when latencyAggregationType is not informed', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+            pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
             query: {
               start,
               end,
@@ -47,7 +47,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns 400 when transactionType is not informed', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+            pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
             query: {
               start,
               end,
@@ -63,7 +63,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles the empty state', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+            pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
             query: {
               start,
               end,
@@ -96,7 +96,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
               query: {
                 start,
                 end,
@@ -121,7 +121,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
               query: {
                 start,
                 end,
@@ -146,7 +146,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
               query: {
                 start,
                 end,
@@ -176,7 +176,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
               query: {
                 latencyAggregationType: 'avg',
                 transactionType: 'request',
@@ -217,7 +217,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-node/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-node/transactions/charts/latency`,
               query: {
                 start,
                 end,
@@ -257,7 +257,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-java/transactions/charts/latency`,
               query: {
                 start,
                 end,
@@ -279,7 +279,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-python/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-python/transactions/charts/latency`,
               query: {
                 start,
                 end,
@@ -319,7 +319,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/transactions/charts/latency`,
+              pathname: `/internal/apm/services/opbeans-java/transactions/charts/latency`,
               query: {
                 start,
                 end,

--- a/x-pack/test/apm_api_integration/tests/transactions/trace_samples.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/trace_samples.ts
@@ -17,7 +17,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const archiveName = 'apm_8.0.0';
   const metadata = archives_metadata[archiveName];
 
-  const url = `/api/apm/services/opbeans-java/transactions/traces/samples?${qs.stringify({
+  const url = `/internal/apm/services/opbeans-java/transactions/traces/samples?${qs.stringify({
     environment: 'ENVIRONMENT_ALL',
     kuery: '',
     start: metadata.start,

--- a/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_detailed_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_detailed_statistics.ts
@@ -16,7 +16,7 @@ import { registry } from '../../common/registry';
 import { removeEmptyCoordinates, roundNumber } from '../../utils';
 
 type TransactionsGroupsDetailedStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/detailed_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/detailed_statistics'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -32,7 +32,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles the empty state', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -59,7 +59,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns the correct data', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -113,7 +113,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns the correct data for latency aggregation 99th percentile', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -161,7 +161,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns empty when transaction name is not found', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
             query: {
               start,
               end,
@@ -185,7 +185,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         before(async () => {
           const response = await supertest.get(
             url.format({
-              pathname: `/api/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
+              pathname: `/internal/apm/services/opbeans-java/transactions/groups/detailed_statistics`,
               query: {
                 numBuckets: 20,
                 transactionType: 'request',

--- a/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_main_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_main_statistics.ts
@@ -14,7 +14,7 @@ import archives from '../../common/fixtures/es_archiver/archives_metadata';
 import { registry } from '../../common/registry';
 
 type TransactionsGroupsPrimaryStatistics =
-  APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/main_statistics'>;
+  APIReturnType<'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics'>;
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
@@ -29,7 +29,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('handles the empty state', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/main_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/main_statistics`,
             query: {
               start,
               end,
@@ -57,7 +57,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns the correct data', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/main_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/main_statistics`,
             query: {
               start,
               end,
@@ -132,7 +132,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       it('returns the correct data for latency aggregation 99th percentile', async () => {
         const response = await supertest.get(
           url.format({
-            pathname: `/api/apm/services/opbeans-java/transactions/groups/main_statistics`,
+            pathname: `/internal/apm/services/opbeans-java/transactions/groups/main_statistics`,
             query: {
               start,
               end,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Relocate internal APM API endpoints to /internal  (#114196)