### PR TITLE
[7.x] Use 'max' agg instead of 'top_hits' as we just need the timestamp field now (#113667)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/threshold.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/threshold.ts
@@ -25,7 +25,6 @@ import { TypeOfFieldMap } from '../../../../../../rule_registry/common/field_map
 import { SERVER_APP_ID } from '../../../../../common/constants';
 import { ANCHOR_DATE } from '../../../../../common/detection_engine/schemas/response/rules_schema.mocks';
 import { getListArrayMock } from '../../../../../common/detection_engine/schemas/types/lists.mock';
-import { sampleDocNoSortId } from '../../signals/__mocks__/es_results';
 import { flattenWithPrefix } from '../factories/utils/flatten_with_prefix';
 import { RulesFieldMap } from '../field_maps';
 import {
@@ -60,19 +59,8 @@ export const mockThresholdResults = {
                   {
                     key: 'tardigrade',
                     doc_count: 3,
-                    top_threshold_hits: {
-                      hits: {
-                        total: {
-                          value: 1,
-                          relation: 'eq',
-                        },
-                        hits: [
-                          {
-                            ...sampleDocNoSortId(),
-                            'host.name': 'tardigrade',
-                          },
-                        ],
-                      },
+                    max_timestamp: {
+                      value_as_string: '2020-04-20T21:26:30.000Z',
                     },
                     cardinality_count: {
                       value: 3,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/bulk_create_threshold_signals.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/bulk_create_threshold_signals.test.ts
@@ -7,7 +7,7 @@
 
 import { loggingSystemMock } from '../../../../../../../../src/core/server/mocks';
 import { ThresholdNormalized } from '../../../../../common/detection_engine/schemas/common/schemas';
-import { sampleDocNoSortId, sampleDocSearchResultsNoSortId } from '../__mocks__/es_results';
+import { sampleDocSearchResultsNoSortId } from '../__mocks__/es_results';
 import { sampleThresholdSignalHistory } from '../__mocks__/threshold_signal_history.mock';
 import { calculateThresholdSignalUuid } from '../utils';
 import { transformThresholdResultsToEcs } from './bulk_create_threshold_signals';
@@ -40,10 +40,8 @@ describe('transformThresholdNormalizedResultsToEcs', () => {
                     {
                       key: 'garden-gnomes',
                       doc_count: 12,
-                      top_threshold_hits: {
-                        hits: {
-                          hits: [sampleDocNoSortId('abcd')],
-                        },
+                      max_timestamp: {
+                        value_as_string: '2020-04-20T21:27:45+0000',
                       },
                       cardinality_count: {
                         value: 7,
@@ -208,10 +206,8 @@ describe('transformThresholdNormalizedResultsToEcs', () => {
               {
                 key: '',
                 doc_count: 15,
-                top_threshold_hits: {
-                  hits: {
-                    hits: [sampleDocNoSortId('abcd')],
-                  },
+                max_timestamp: {
+                  value_as_string: '2020-04-20T21:27:45+0000',
                 },
                 cardinality_count: {
                   value: 7,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/bulk_create_threshold_signals.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/bulk_create_threshold_signals.ts
@@ -4,6 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+import { TIMESTAMP } from '@kbn/rule-data-utils';
+
 import { get } from 'lodash/fp';
 import set from 'set-value';
 import {
@@ -96,7 +99,7 @@ const getTransformedHits = (
               ...val.terms,
             ].filter((term) => term.field != null),
             cardinality: val.cardinality,
-            topThresholdHits: val.topThresholdHits,
+            maxTimestamp: val.maxTimestamp,
             docCount: val.docCount,
           };
           acc.push(el as MultiAggBucket);
@@ -117,7 +120,7 @@ const getTransformedHits = (
                 },
               ]
             : undefined,
-          topThresholdHits: bucket.top_threshold_hits,
+          maxTimestamp: bucket.max_timestamp.value_as_string,
           docCount: bucket.doc_count,
         };
         acc.push(el as MultiAggBucket);
@@ -132,28 +135,15 @@ const getTransformedHits = (
     0,
     aggParts.field
   ).reduce((acc: Array<BaseHit<SignalSource>>, bucket) => {
-    const hit = bucket.topThresholdHits?.hits.hits[0];
-    if (hit == null) {
-      return acc;
-    }
-
-    const timestampArray = get(timestampOverride ?? '@timestamp', hit.fields);
-    if (timestampArray == null) {
-      return acc;
-    }
-
-    const timestamp = timestampArray[0];
-    if (typeof timestamp !== 'string') {
-      return acc;
-    }
-
     const termsHash = getThresholdTermsHash(bucket.terms);
     const signalHit = signalHistory[termsHash];
 
     const source = {
-      '@timestamp': timestamp,
+      [TIMESTAMP]: bucket.maxTimestamp,
       ...bucket.terms.reduce<object>((termAcc, term) => {
         if (!term.field.startsWith('signal.')) {
+          // We don't want to overwrite `signal.*` fields.
+          // See: https://github.com/elastic/kibana/issues/83218
           return {
             ...termAcc,
             [term.field]: term.value,
@@ -170,7 +160,7 @@ const getTransformedHits = (
         // the `original_time` of the signal (the timestamp of the latest event
         // in the set).
         from:
-          signalHit?.lastSignalTimestamp != null ? new Date(signalHit!.lastSignalTimestamp) : from,
+          signalHit?.lastSignalTimestamp != null ? new Date(signalHit.lastSignalTimestamp) : from,
       },
     };
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/find_threshold_signals.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/find_threshold_signals.test.ts
@@ -58,22 +58,9 @@ describe('findThresholdSignals', () => {
               min_doc_count: 100,
             },
             aggs: {
-              top_threshold_hits: {
-                top_hits: {
-                  sort: [
-                    {
-                      '@timestamp': {
-                        order: 'desc',
-                      },
-                    },
-                  ],
-                  fields: [
-                    {
-                      field: '*',
-                      include_unmapped: true,
-                    },
-                  ],
-                  size: 1,
+              max_timestamp: {
+                max: {
+                  field: '@timestamp',
                 },
               },
             },
@@ -108,22 +95,9 @@ describe('findThresholdSignals', () => {
               size: 10000,
             },
             aggs: {
-              top_threshold_hits: {
-                top_hits: {
-                  sort: [
-                    {
-                      '@timestamp': {
-                        order: 'desc',
-                      },
-                    },
-                  ],
-                  fields: [
-                    {
-                      field: '*',
-                      include_unmapped: true,
-                    },
-                  ],
-                  size: 1,
+              max_timestamp: {
+                max: {
+                  field: '@timestamp',
                 },
               },
             },
@@ -166,22 +140,9 @@ describe('findThresholdSignals', () => {
                   size: 10000,
                 },
                 aggs: {
-                  top_threshold_hits: {
-                    top_hits: {
-                      sort: [
-                        {
-                          '@timestamp': {
-                            order: 'desc',
-                          },
-                        },
-                      ],
-                      fields: [
-                        {
-                          field: '*',
-                          include_unmapped: true,
-                        },
-                      ],
-                      size: 1,
+                  max_timestamp: {
+                    max: {
+                      field: '@timestamp',
                     },
                   },
                 },
@@ -245,22 +206,9 @@ describe('findThresholdSignals', () => {
                       script: 'params.cardinalityCount >= 2',
                     },
                   },
-                  top_threshold_hits: {
-                    top_hits: {
-                      sort: [
-                        {
-                          '@timestamp': {
-                            order: 'desc',
-                          },
-                        },
-                      ],
-                      fields: [
-                        {
-                          field: '*',
-                          include_unmapped: true,
-                        },
-                      ],
-                      size: 1,
+                  max_timestamp: {
+                    max: {
+                      field: '@timestamp',
                     },
                   },
                 },
@@ -319,22 +267,9 @@ describe('findThresholdSignals', () => {
                   script: 'params.cardinalityCount >= 5',
                 },
               },
-              top_threshold_hits: {
-                top_hits: {
-                  sort: [
-                    {
-                      '@timestamp': {
-                        order: 'desc',
-                      },
-                    },
-                  ],
-                  fields: [
-                    {
-                      field: '*',
-                      include_unmapped: true,
-                    },
-                  ],
-                  size: 1,
+              max_timestamp: {
+                max: {
+                  field: '@timestamp',
                 },
               },
             },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/find_threshold_signals.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold/find_threshold_signals.ts
@@ -6,6 +6,7 @@
  */
 
 import { set } from '@elastic/safer-lodash-set';
+import { TIMESTAMP } from '@kbn/rule-data-utils';
 
 import {
   ThresholdNormalized,
@@ -50,22 +51,9 @@ export const findThresholdSignals = async ({
 }> => {
   // Leaf aggregations used below
   const leafAggs = {
-    top_threshold_hits: {
-      top_hits: {
-        sort: [
-          {
-            [timestampOverride ?? '@timestamp']: {
-              order: 'desc' as const,
-            },
-          },
-        ],
-        fields: [
-          {
-            field: '*',
-            include_unmapped: true,
-          },
-        ],
-        size: 1,
+    max_timestamp: {
+      max: {
+        field: timestampOverride != null ? timestampOverride : TIMESTAMP,
       },
     },
     ...(threshold.cardinality?.length

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
@@ -19,7 +19,7 @@ import {
   AlertExecutorOptions,
   AlertServices,
 } from '../../../../../alerting/server';
-import { BaseSearchResponse, SearchHit, TermAggregationBucket } from '../../types';
+import { TermAggregationBucket } from '../../types';
 import {
   EqlSearchResponse,
   BaseHit,
@@ -332,7 +332,9 @@ export interface SearchAfterAndBulkCreateReturnType {
 }
 
 export interface ThresholdAggregationBucket extends TermAggregationBucket {
-  top_threshold_hits: BaseSearchResponse<SignalSource>;
+  max_timestamp: {
+    value_as_string: string;
+  };
   cardinality_count: {
     value: number;
   };
@@ -348,13 +350,7 @@ export interface MultiAggBucket {
     value: string;
   }>;
   docCount: number;
-  topThresholdHits?:
-    | {
-        hits: {
-          hits: SearchHit[];
-        };
-      }
-    | undefined;
+  maxTimestamp: string;
 }
 
 export interface ThresholdQueryBucket extends TermAggregationBucket {

--- a/x-pack/plugins/security_solution/server/lib/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/types.ts
@@ -74,10 +74,8 @@ export type SearchHit = SearchResponse<object>['hits']['hits'][0];
 export interface TermAggregationBucket {
   key: string;
   doc_count: number;
-  top_threshold_hits?: {
-    hits: {
-      hits: SearchHit[];
-    };
+  max_timestamp: {
+    value_as_string: string;
   };
   cardinality_count?: {
     value: number;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use 'max' agg instead of 'top_hits' as we just need the timestamp field now (#113667)