### PR TITLE
[QA][refactor] Use ui settings - sample data

### DIFF
--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -157,7 +157,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const today = moment().format('MMM D, YYYY');
       const from = `${today} @ 00:00:00.000`;
       const to = `${today} @ 23:59:59.999`;
-      await PageObjects.common.time({ from, to });
+      await PageObjects.common.setTime({ from, to });
       await PageObjects.common.navigateToApp('discover');
     }
   });

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -19,33 +19,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const renderable = getService('renderable');
   const dashboardExpect = getService('dashboardExpect');
   const PageObjects = getPageObjects(['common', 'header', 'home', 'dashboard', 'timePicker']);
-  const kibanaServer = getService('kibanaServer');
-
-  interface UrlData {
-    appName: string;
-    subUrl: string;
-    opts: { useActualUrl: boolean };
-  }
-  const timeAndNav = (range: { from: string; to: string }) => (urlData: UrlData) => async () => {
-    await kibanaServer.uiSettings.replace({ 'timepicker:timeDefaults': JSON.stringify(range) });
-    await nav(urlData);
-
-    async function nav(urlObj: UrlData) {
-      const { appName, subUrl, opts } = urlObj;
-      const { useActualUrl } = opts;
-      await PageObjects.common.navigateToUrl(appName, subUrl, { useActualUrl });
-    }
-  };
-
-  const today = moment().format('MMM D, YYYY');
-  const from = `${today} @ 00:00:00.000`;
-  const to = `${today} @ 23:59:59.999`;
-
-  const navToday = timeAndNav({ from, to })({
-    appName: 'home',
-    subUrl: '/tutorial_directory/sampleData',
-    opts: { useActualUrl: true },
-  });
 
   describe('sample data', function describeIndexTests() {
     before(async () => {
@@ -58,7 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await security.testUser.restoreDefaults();
-      await kibanaServer.uiSettings.unset('timepicker:timeDefaults');
+      await PageObjects.common.unsetTime();
     });
 
     it('should display registered flights sample data sets', async () => {
@@ -109,7 +82,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample flights data set dashboard', async () => {
-        await navToday();
+        await timeNav();
         await PageObjects.home.launchSampleDashboard('flights');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
@@ -134,7 +107,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample logs data set dashboard', async () => {
-        await navToday();
+        await timeNav();
         await PageObjects.home.launchSampleDashboard('logs');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
@@ -143,7 +116,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample ecommerce data set dashboard', async () => {
-        await navToday();
+        await timeNav();
         await PageObjects.home.launchSampleDashboard('ecommerce');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
@@ -179,5 +152,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(isInstalled).to.be(false);
       });
     });
+
+    async function timeNav() {
+      const today = moment().format('MMM D, YYYY');
+      const from = `${today} @ 00:00:00.000`;
+      const to = `${today} @ 23:59:59.999`;
+      await PageObjects.common.time({ from, to });
+      await PageObjects.common.navigateToApp('discover');
+    }
   });
 }

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -75,6 +75,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('dashboard', () => {
       beforeEach(async () => {
+        await time()
         await PageObjects.common.navigateToUrl('home', '/tutorial_directory/sampleData', {
           useActualUrl: true,
         });
@@ -82,7 +83,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample flights data set dashboard', async () => {
-        await timeNav();
         await PageObjects.home.launchSampleDashboard('flights');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
@@ -107,7 +107,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample logs data set dashboard', async () => {
-        await timeNav();
         await PageObjects.home.launchSampleDashboard('logs');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
@@ -116,7 +115,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample ecommerce data set dashboard', async () => {
-        await timeNav();
         await PageObjects.home.launchSampleDashboard('ecommerce');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
@@ -153,12 +151,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    async function timeNav() {
+    async function time() {
       const today = moment().format('MMM D, YYYY');
       const from = `${today} @ 00:00:00.000`;
       const to = `${today} @ 23:59:59.999`;
       await PageObjects.common.setTime({ from, to });
-      await PageObjects.common.navigateToApp('discover');
+      // await PageObjects.common.navigateToApp('discover');
     }
   });
 }

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -75,7 +75,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     describe('dashboard', () => {
       beforeEach(async () => {
-        await time()
+        await time();
         await PageObjects.common.navigateToUrl('home', '/tutorial_directory/sampleData', {
           useActualUrl: true,
         });

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -156,7 +156,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const from = `${today} @ 00:00:00.000`;
       const to = `${today} @ 23:59:59.999`;
       await PageObjects.common.setTime({ from, to });
-      // await PageObjects.common.navigateToApp('discover');
     }
   });
 }

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -502,7 +502,7 @@ export class CommonPageObject extends FtrService {
     }
   }
 
-  async time(time: { from: string; to: string }) {
+  async setTime(time: { from: string; to: string }) {
     await this.kibanaServer.uiSettings.replace({ 'timepicker:timeDefaults': JSON.stringify(time) });
   }
 

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -30,6 +30,7 @@ export class CommonPageObject extends FtrService {
   private readonly globalNav = this.ctx.getService('globalNav');
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly loginPage = this.ctx.getPageObject('login');
+  private readonly kibanaServer = this.ctx.getService('kibanaServer');
 
   private readonly defaultTryTimeout = this.config.get('timeouts.try');
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
@@ -499,5 +500,13 @@ export class CommonPageObject extends FtrService {
     } else {
       await this.testSubjects.exists(validator);
     }
+  }
+
+  async time(time: { from: string; to: string }) {
+    await this.kibanaServer.uiSettings.replace({ 'timepicker:timeDefaults': JSON.stringify(time) });
+  }
+
+  async unsetTime() {
+    await this.kibanaServer.uiSettings.unset('timepicker:timeDefaults');
   }
 }


### PR DESCRIPTION
[skip-ci]

Use ui settings instead of setting absolute range
for timepicker.

Add 2 time functions to the common page,
set the time, unset the time.
The user handles their own navigation.

Helps with: https://github.com/elastic/kibana/issues/113998