### PR TITLE
[buildkite] buildkite dependencies need to install before print_agent_links

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-node .buildkite/scripts/lifecycle/print_agent_links.js || true
-
-echo '--- Job Environment Setup'
-
+echo '--- Install buildkite dependencies'
 cd '.buildkite'
 retry 5 15 yarn install
 cd -
+
+node .buildkite/scripts/lifecycle/print_agent_links.js || true
+
+echo '--- Job Environment Setup'
 
 BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/kibana-issues/dev/buildkite-ci)"
 export BUILDKITE_TOKEN

--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
+BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/kibana-issues/dev/buildkite-ci)"
+export BUILDKITE_TOKEN
+
 echo '--- Install buildkite dependencies'
 cd '.buildkite'
 retry 5 15 yarn install
@@ -12,9 +15,6 @@ cd -
 node .buildkite/scripts/lifecycle/print_agent_links.js || true
 
 echo '--- Job Environment Setup'
-
-BUILDKITE_TOKEN="$(retry 5 5 vault read -field=buildkite_token_all_jobs secret/kibana-issues/dev/buildkite-ci)"
-export BUILDKITE_TOKEN
 
 # Set up a custom ES Snapshot Manifest if one has been specified for this build
 {


### PR DESCRIPTION
[skip-ci]

The first agent links invocation is currently quietly broken in CI (quietly because of the `|| true`) because it's running before `yarn install`. This isn't causing any problems besides the links being missing from the beginning of the job.