### PR TITLE
[7.x] [Maps] fix docvalue_fields·js functional test (#114527)

### DIFF
--- a/x-pack/test/functional/apps/maps/documents_source/docvalue_fields.js
+++ b/x-pack/test/functional/apps/maps/documents_source/docvalue_fields.js
@@ -11,11 +11,9 @@ export default function ({ getPageObjects, getService }) {
   const PageObjects = getPageObjects(['maps']);
   const security = getService('security');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/114418
-  describe.skip('docvalue_fields', () => {
+  describe('docvalue_fields', () => {
     before(async () => {
       await security.testUser.setRoles(['global_maps_read', 'test_logstash_reader'], false);
-      await PageObjects.maps.loadSavedMap('document example');
     });
 
     after(async () => {
@@ -46,11 +44,14 @@ export default function ({ getPageObjects, getService }) {
     it('should format date fields as epoch_millis when data driven styling is applied to a date field', async () => {
       await PageObjects.maps.loadSavedMap('document example with data driven styles on date field');
       const { rawResponse: response } = await PageObjects.maps.getResponse();
-      const firstHit = response.hits.hits[0];
-      expect(firstHit).to.only.have.keys(['_id', '_index', '_type', '_score', 'fields']);
-      expect(firstHit.fields).to.only.have.keys(['@timestamp', 'bytes', 'geo.coordinates']);
-      expect(firstHit.fields['@timestamp']).to.be.an('array');
-      expect(firstHit.fields['@timestamp'][0]).to.eql('1442709321445');
+      const targetHit = response.hits.hits.find((hit) => {
+        return hit._id === 'AU_x3_g4GFA8no6QjkSR';
+      });
+      expect(targetHit).not.to.be(undefined);
+      expect(targetHit).to.only.have.keys(['_id', '_index', '_type', '_score', 'fields']);
+      expect(targetHit.fields).to.only.have.keys(['@timestamp', 'bytes', 'geo.coordinates']);
+      expect(targetHit.fields['@timestamp']).to.be.an('array');
+      expect(targetHit.fields['@timestamp'][0]).to.eql('1442709321445');
     });
   });
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Maps] fix docvalue_fields·js functional test (#114527)