### PR TITLE
[7.15] Wait for a yellow source before starting reindex (#113382)

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
@@ -791,6 +791,11 @@ describe('migration actions', () => {
               `);
     });
     it('resolves left wait_for_task_completion_timeout when the task does not finish within the timeout', async () => {
+      await waitForIndexStatusYellow({
+        client,
+        index: '.kibana_1',
+      })();
+
       const res = (await reindex({
         client,
         sourceIndex: 'existing_index_with_docs',


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Wait for a yellow source before starting reindex (#113382)