### PR TITLE
[7.x] [APM] Disabling apm e2e test (#114544)

### DIFF
--- a/vars/tasks.groovy
+++ b/vars/tasks.groovy
@@ -146,13 +146,14 @@ def functionalXpack(Map params = [:]) {
       }
     }
 
-    whenChanged([
-      'x-pack/plugins/apm/',
-    ]) {
-      if (githubPr.isPr()) {
-        task(kibanaPipeline.functionalTestProcess('xpack-APMCypress', './test/scripts/jenkins_apm_cypress.sh'))
-      }
-    }
+    //temporarily disable apm e2e test since it's breaking.
+    // whenChanged([
+    //   'x-pack/plugins/apm/',
+    // ]) {
+    //   if (githubPr.isPr()) {
+    //     task(kibanaPipeline.functionalTestProcess('xpack-APMCypress', './test/scripts/jenkins_apm_cypress.sh'))
+    //   }
+    // }
 
     whenChanged([
       'x-pack/plugins/uptime/',


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Disabling apm e2e test (#114544)