### PR TITLE
[7.15] [DOCS] Reformats the Logs settings tables into definition lists (#114140)

### DIFF
--- a/docs/settings/general-infra-logs-ui-settings.asciidoc
+++ b/docs/settings/general-infra-logs-ui-settings.asciidoc
@@ -1,30 +1,27 @@
-[cols="2*<"]
-|===
-| `xpack.infra.enabled`
-  | Set to `false` to disable the Logs and Metrics app plugin {kib}. Defaults to `true`.
+`xpack.infra.enabled`::
+deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported."]
+Set to `false` to disable the Logs and Metrics app plugin {kib}. Defaults to `true`.
 
-| `xpack.infra.sources.default.logAlias`
-  | Index pattern for matching indices that contain log data. Defaults to `filebeat-*,kibana_sample_data_logs*`. To match multiple wildcard patterns, use a comma to separate the names, with no space after the comma. For example, `logstash-app1-*,default-logs-*`.
+`xpack.infra.sources.default.logAlias`::
+Index pattern for matching indices that contain log data. Defaults to `filebeat-*,kibana_sample_data_logs*`. To match multiple wildcard patterns, use a comma to separate the names, with no space after the comma. For example, `logstash-app1-*,default-logs-*`.
 
-| `xpack.infra.sources.default.metricAlias`
-  | Index pattern for matching indices that contain Metricbeat data. Defaults to `metricbeat-*`. To match multiple wildcard patterns, use a comma to separate the names, with no space after the comma. For example, `logstash-app1-*,default-logs-*`.
+`xpack.infra.sources.default.metricAlias`::
+Index pattern for matching indices that contain Metricbeat data. Defaults to `metricbeat-*`. To match multiple wildcard patterns, use a comma to separate the names, with no space after the comma. For example, `logstash-app1-*,default-logs-*`.
 
-| `xpack.infra.sources.default.fields.timestamp`
-  | Timestamp used to sort log entries. Defaults to `@timestamp`.
+`xpack.infra.sources.default.fields.timestamp`::
+Timestamp used to sort log entries. Defaults to `@timestamp`.
 
-| `xpack.infra.sources.default.fields.message`
-  | Fields used to display messages in the Logs app. Defaults to `['message', '@message']`.
+`xpack.infra.sources.default.fields.message`::
+Fields used to display messages in the Logs app. Defaults to `['message', '@message']`.
 
-| `xpack.infra.sources.default.fields.tiebreaker`
-  | Field used to break ties between two entries with the same timestamp. Defaults to `_doc`.
+`xpack.infra.sources.default.fields.tiebreaker`::
+Field used to break ties between two entries with the same timestamp. Defaults to `_doc`.
 
-| `xpack.infra.sources.default.fields.host`
-  | Field used to identify hosts. Defaults to `host.name`.
+`xpack.infra.sources.default.fields.host`::
+Field used to identify hosts. Defaults to `host.name`.
 
-| `xpack.infra.sources.default.fields.container`
-  | Field used to identify Docker containers. Defaults to `container.id`.
+`xpack.infra.sources.default.fields.container`::
+Field used to identify Docker containers. Defaults to `container.id`.
 
-| `xpack.infra.sources.default.fields.pod`
-  | Field used to identify Kubernetes pods. Defaults to `kubernetes.pod.uid`.
-
-|===
+`xpack.infra.sources.default.fields.pod`::
+Field used to identify Kubernetes pods. Defaults to `kubernetes.pod.uid`.


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Reformats the Logs settings tables into definition lists (#114140)