### PR TITLE
[7.15] [DOCS] Reformats the Machine learning settings tables into definition lists (#114143)

### DIFF
--- a/docs/settings/ml-settings.asciidoc
+++ b/docs/settings/ml-settings.asciidoc
@@ -11,17 +11,14 @@ enabled by default.
 [[general-ml-settings-kb]]
 ==== General {ml} settings
 
-[cols="2*<"]
-|===
-| `xpack.ml.enabled` {ess-icon}
-  | Set to `true` (default) to enable {kib} {ml-features}. +
-  +
-  If set to `false` in `kibana.yml`, the {ml} icon is hidden in this {kib}
-  instance. If `xpack.ml.enabled` is set to `true` in `elasticsearch.yml`, however,
-  you can still use the {ml} APIs. To disable {ml} entirely, see the
-  {ref}/ml-settings.html[{es} {ml} settings].
-
-|===
+`xpack.ml.enabled` {ess-icon}::
+deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported."]
+Set to `true` (default) to enable {kib} {ml-features}. +
++
+If set to `false` in `kibana.yml`, the {ml} icon is hidden in this {kib}
+instance. If `xpack.ml.enabled` is set to `true` in `elasticsearch.yml`, however,
+you can still use the {ml} APIs. To disable {ml} entirely, refer to
+{ref}/ml-settings.html[{es} {ml} settings].
 
 [[advanced-ml-settings-kb]]
 ==== Advanced {ml} settings


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Reformats the Machine learning settings tables into definition lists (#114143)