### PR TITLE
[7.14] [DOCS] Reformats the Spaces settings tables into definition lists (#114146)

### DIFF
--- a/docs/settings/spaces-settings.asciidoc
+++ b/docs/settings/spaces-settings.asciidoc
@@ -12,16 +12,13 @@ roles when Security is enabled.
 [[spaces-settings]]
 ==== Spaces settings
 
-[cols="2*<"]
-|===
-| `xpack.spaces.enabled`
-  | Set to `true` (default) to enable Spaces in {kib}.
-    This setting is deprecated. Starting in 8.0, it will not be possible to disable this plugin.
+`xpack.spaces.enabled`::
+deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported."]
+Set to `true` (default) to enable Spaces in {kib}.
+This setting is deprecated. Starting in 8.0, it will not be possible to disable this plugin.
 
-| `xpack.spaces.maxSpaces`
-  | The maximum amount of Spaces that can be used with this instance of {kib}. Some operations
-  in {kib} return all spaces using a single `_search` from {es}, so this must be
-  set lower than the `index.max_result_window` in {es}.
-  Defaults to `1000`.
-
-|===
+`xpack.spaces.maxSpaces`::
+The maximum amount of Spaces that can be used with this instance of {kib}. Some operations
+in {kib} return all spaces using a single `_search` from {es}, so this must be
+set lower than the `index.max_result_window` in {es}.
+Defaults to `1000`.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - [DOCS] Reformats the Spaces settings tables into definition lists (#114146)