### PR TITLE
[Reporting/Docs] remove note about host name set to "0" for 8.0

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -79,11 +79,6 @@ The protocol for accessing {kib}, typically `http` or `https`.
 [[xpack-kibanaServer-hostname]] `xpack.reporting.kibanaServer.hostname`::
 The hostname for accessing {kib}, if different from the <<server-host, `server.host`>> value.
 
-NOTE: Reporting authenticates requests on the {kib} page only when the hostname matches the
-<<xpack-kibanaServer-hostname, `xpack.reporting.kibanaServer.hostname`>> setting. Therefore Reporting fails if the
-set value redirects to another server. For that reason, `"0"` is an invalid setting
-because, in the Reporting browser, it becomes an automatic redirect to `"0.0.0.0"`.
-
 [float]
 [[reporting-job-queue-settings]]
 ==== Background job settings


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/113306

Users do not need the note that `0` is an invalid value of `server.host` and `xpack.reporting.kibanaServer.hostname` in 8.0. Both of those configurations have a schema that prevents the value from being `0` in the code.

References: 
 - https://github.com/elastic/kibana/blob/45ce7d6e970bc8d7cd56f72dc147464576b3905c/src/core/server/http/http_config.ts#L34
 - https://github.com/elastic/kibana/blob/45ce7d6e970bc8d7cd56f72dc147464576b3905c/x-pack/plugins/reporting/server/config/schema.ts#L12