### PR TITLE
Fix Canvas double render by preventing workpad and assets from being reloaded if it's already available

### DIFF
--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.test.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.test.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useWorkpad } from './use_workpad';
 
@@ -61,14 +60,20 @@ describe('useWorkpad', () => {
       workpad: workpadResponse,
     });
 
-    renderHook(() => useWorkpad(workpadId, true, getRedirectPath));
+    const { waitFor, unmount } = renderHook(() => useWorkpad(workpadId, true, getRedirectPath));
 
-    await waitFor(() => expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId));
+    try {
+      await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(3));
 
-    expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId);
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setAssets', payload: assets });
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setWorkpad', payload: workpad });
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setZoomScale', payload: 1 });
+      expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'setAssets', payload: assets });
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'setWorkpad', payload: workpad });
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'setZoomScale', payload: 1 });
+    } catch (e) {
+      throw e;
+    } finally {
+      unmount();
+    }
   });
 
   test('sets alias id of workpad on a conflict', async () => {
@@ -81,17 +86,23 @@ describe('useWorkpad', () => {
       aliasId,
     });
 
-    renderHook(() => useWorkpad(workpadId, true, getRedirectPath));
+    const { waitFor, unmount } = renderHook(() => useWorkpad(workpadId, true, getRedirectPath));
 
-    await waitFor(() => expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId));
+    try {
+      await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(3));
 
-    expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId);
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setAssets', payload: assets });
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'setWorkpad',
-      payload: { ...workpad, aliasId },
-    });
-    expect(mockDispatch).toHaveBeenCalledWith({ type: 'setZoomScale', payload: 1 });
+      expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'setAssets', payload: assets });
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'setWorkpad',
+        payload: { ...workpad, aliasId },
+      });
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'setZoomScale', payload: 1 });
+    } catch (e) {
+      throw e;
+    } finally {
+      unmount();
+    }
   });
 
   test('redirects on alias match', async () => {
@@ -104,10 +115,14 @@ describe('useWorkpad', () => {
       aliasId,
     });
 
-    renderHook(() => useWorkpad(workpadId, true, getRedirectPath));
-
-    await waitFor(() => expect(mockResolveWorkpad).toHaveBeenCalledWith(workpadId));
-
-    expect(mockRedirectLegacyUrl).toBeCalledWith(`#${aliasId}`, 'Workpad');
+    const { waitFor, unmount } = renderHook(() => useWorkpad(workpadId, true, getRedirectPath));
+    try {
+      await waitFor(() => expect(mockRedirectLegacyUrl).toHaveBeenCalled());
+      expect(mockRedirectLegacyUrl).toBeCalledWith(`#${aliasId}`, 'Workpad');
+    } catch (e) {
+      throw e;
+    } finally {
+      unmount();
+    }
   });
 });

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -33,7 +33,9 @@ export const useWorkpad = (
   const storedWorkpad = useSelector(getWorkpad);
   const [error, setError] = useState<string | Error | undefined>(undefined);
 
-  const [resolveOutcome, setResolveOutcome] = useState<string | undefined>(undefined);
+  const [resolveInfo, setResolveInfo] = useState<
+    { aliasId: string | undefined; outcome: string } | undefined
+  >(undefined);
 
   useEffect(() => {
     (async () => {
@@ -44,7 +46,7 @@ export const useWorkpad = (
           workpad: { assets, ...workpad },
         } = await workpadService.resolve(workpadId);
 
-        setResolveOutcome(outcome);
+        setResolveInfo({ aliasId, outcome });
 
         if (outcome === 'conflict') {
           workpad.aliasId = aliasId;
@@ -61,12 +63,14 @@ export const useWorkpad = (
 
   useEffect(() => {
     (async () => {
-      const aliasId = storedWorkpad?.aliasId;
-      if (resolveOutcome === 'aliasMatch' && platformService.redirectLegacyUrl && aliasId) {
+      if (!resolveInfo) return;
+
+      const { aliasId, outcome } = resolveInfo;
+      if (outcome === 'aliasMatch' && platformService.redirectLegacyUrl && aliasId) {
         platformService.redirectLegacyUrl(`#${getRedirectPath(aliasId)}`, getWorkpadLabel());
       }
     })();
-  }, [storedWorkpad, resolveOutcome, getRedirectPath, platformService]);
+  }, [storedWorkpad, resolveInfo, getRedirectPath, platformService]);
 
   return [storedWorkpad.id === workpadId ? storedWorkpad : undefined, error];
 };

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -28,6 +28,7 @@ export const useWorkpad = (
   getRedirectPath: (workpadId: string) => string
 ): [CanvasWorkpad | undefined, string | Error | undefined] => {
   const workpadService = useWorkpadService();
+  const workpadResolve = workpadService.resolve;
   const platformService = usePlatformService();
   const dispatch = useDispatch();
   const storedWorkpad = useSelector(getWorkpad);
@@ -44,7 +45,7 @@ export const useWorkpad = (
           outcome,
           aliasId,
           workpad: { assets, ...workpad },
-        } = await workpadService.resolve(workpadId);
+        } = await workpadResolve(workpadId);
 
         setResolveInfo({ aliasId, outcome });
 
@@ -59,7 +60,7 @@ export const useWorkpad = (
         setError(e as Error | string);
       }
     })();
-  }, [workpadId, dispatch, setError, loadPages, workpadService]);
+  }, [workpadId, dispatch, setError, loadPages, workpadResolve]);
 
   useEffect(() => {
     (async () => {

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -46,9 +46,12 @@ export const useWorkpad = (
           workpad.aliasId = aliasId;
         }
 
-        dispatch(setAssets(assets));
-        dispatch(setWorkpad(workpad, { loadPages }));
-        dispatch(setZoomScale(1));
+        // Only reload workpad and assets if we're on a new workpad
+        if (storedWorkpad.id !== workpadId) {
+          dispatch(setAssets(assets));
+          dispatch(setWorkpad(workpad, { loadPages }));
+          dispatch(setZoomScale(1));
+        }
 
         if (outcome === 'aliasMatch' && platformService.redirectLegacyUrl && aliasId) {
           platformService.redirectLegacyUrl(`#${getRedirectPath(aliasId)}`, getWorkpadLabel());
@@ -57,7 +60,16 @@ export const useWorkpad = (
         setError(e as Error | string);
       }
     })();
-  }, [workpadId, dispatch, setError, loadPages, workpadService, getRedirectPath, platformService]);
+  }, [
+    workpadId,
+    dispatch,
+    setError,
+    loadPages,
+    workpadService,
+    storedWorkpad,
+    getRedirectPath,
+    platformService,
+  ]);
 
   return [storedWorkpad.id === workpadId ? storedWorkpad : undefined, error];
 };

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -70,7 +70,7 @@ export const useWorkpad = (
         platformService.redirectLegacyUrl(`#${getRedirectPath(aliasId)}`, getWorkpadLabel());
       }
     })();
-  }, [storedWorkpad, resolveInfo, getRedirectPath, platformService]);
+  }, [resolveInfo, getRedirectPath, platformService]);
 
   return [storedWorkpad.id === workpadId ? storedWorkpad : undefined, error];
 };

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -63,7 +63,7 @@ export const useWorkpad = (
   }, [workpadId, dispatch, setError, loadPages, workpadResolve]);
 
   useEffect(() => {
-    (async () => {
+    (() => {
       if (!resolveInfo) return;
 
       const { aliasId, outcome } = resolveInfo;


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/114340

The problem is caused by the `getRedirectPath` and how it's being passed to the `useWorkpad` hook. The `getRedirectPath` callback is updated whenever a redirect happens or a page is changed within the workpad. This was causing the hook within `useWorkpad` to change since one of its dependencies (`getRedirectPath`) was changing and it reloaded everything on the workpad.

My proposed fix here is to the useWorkpad hook into two effects:
1. The first effect is responsible for loading and setting the workpad in state
2. The second effect is responsible for updating the redirect path when it gets updated.

Now, when redirect path is changed with a page update or redirect, the workpad won't be re-loaded again.

