### PR TITLE
[ci-metrics] Use git rev-parse for branch

### DIFF
--- a/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
+++ b/packages/kbn-dev-utils/src/ci_stats_reporter/ci_stats_reporter.ts
@@ -130,7 +130,7 @@ export class CiStatsReporter {
     }
 
     try {
-      const { stdout } = await execa('git', ['branch', '--show-current']);
+      const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
       branch = stdout;
     } catch (e) {
       this.log.debug(e.message);

--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -9075,7 +9075,7 @@ class CiStatsReporter {
     try {
       const {
         stdout
-      } = await (0, _execa.default)('git', ['branch', '--show-current']);
+      } = await (0, _execa.default)('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
       branch = stdout;
     } catch (e) {
       this.log.debug(e.message);


### PR DESCRIPTION
`--show-current` was added in 2.22, which is still relatively new.