### PR TITLE
[Actions] Fixed actions telemetry for multiple namespaces usage

### DIFF
--- a/x-pack/plugins/actions/server/usage/actions_telemetry.test.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.test.ts
@@ -116,7 +116,7 @@ Object {
 
   test('getInUseTotalCount', async () => {
     const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
-    mockEsClient.search.mockReturnValue(
+    mockEsClient.search.mockReturnValueOnce(
       // @ts-expect-error not full search response
       elasticsearchClientMock.createSuccessTransportRequestPromise({
         aggregations: {
@@ -134,28 +134,37 @@ Object {
         },
       })
     );
-    const actionsBulkGet = jest.fn();
-    actionsBulkGet.mockReturnValue({
-      saved_objects: [
-        {
-          id: '1',
-          attributes: {
-            actionTypeId: '.server-log',
-          },
+
+    mockEsClient.search.mockReturnValueOnce(
+      // @ts-expect-error not full search response
+      elasticsearchClientMock.createSuccessTransportRequestPromise({
+        hits: {
+          hits: [
+            {
+              action: {
+                id: '1',
+                actionTypeId: '.server-log',
+              },
+              namespaces: {
+                default: 1,
+              },
+            },
+            {
+              action: {
+                id: '2',
+                actionTypeId: '.slack',
+              },
+              namespaces: {
+                test: 1,
+              },
+            },
+          ],
         },
-        {
-          id: '123',
-          attributes: {
-            actionTypeId: '.slack',
-          },
-        },
-      ],
-    });
-    const telemetry = await getInUseTotalCount(mockEsClient, actionsBulkGet, 'test');
+      })
+    );
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test');
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(1);
-    expect(actionsBulkGet).toHaveBeenCalledTimes(1);
-
     expect(telemetry).toMatchInlineSnapshot(`
 Object {
   "countByAlertHistoryConnectorType": 0,
@@ -170,7 +179,7 @@ Object {
 
   test('getInUseTotalCount should count preconfigured alert history connector usage', async () => {
     const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
-    mockEsClient.search.mockReturnValue(
+    mockEsClient.search.mockReturnValueOnce(
       // @ts-expect-error not full search response
       elasticsearchClientMock.createSuccessTransportRequestPromise({
         aggregations: {
@@ -202,28 +211,36 @@ Object {
         },
       })
     );
-    const actionsBulkGet = jest.fn();
-    actionsBulkGet.mockReturnValue({
-      saved_objects: [
-        {
-          id: '1',
-          attributes: {
-            actionTypeId: '.server-log',
-          },
+    mockEsClient.search.mockReturnValueOnce(
+      // @ts-expect-error not full search response
+      elasticsearchClientMock.createSuccessTransportRequestPromise({
+        hits: {
+          hits: [
+            {
+              action: {
+                id: '1',
+                actionTypeId: '.server-log',
+              },
+              namespaces: {
+                default: 1,
+              },
+            },
+            {
+              action: {
+                id: '2',
+                actionTypeId: '.slack',
+              },
+              namespaces: {
+                test: 1,
+              },
+            },
+          ],
         },
-        {
-          id: '123',
-          attributes: {
-            actionTypeId: '.slack',
-          },
-        },
-      ],
-    });
-    const telemetry = await getInUseTotalCount(mockEsClient, actionsBulkGet, 'test');
+      })
+    );
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test');
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(1);
-    expect(actionsBulkGet).toHaveBeenCalledTimes(1);
-
     expect(telemetry).toMatchInlineSnapshot(`
 Object {
   "countByAlertHistoryConnectorType": 1,
@@ -399,34 +416,45 @@ Object {
         },
       })
     );
-    const actionsBulkGet = jest.fn();
-    actionsBulkGet.mockReturnValue({
-      saved_objects: [
-        {
-          id: '1',
-          attributes: {
-            actionTypeId: '.server-log',
-          },
+    mockEsClient.search.mockReturnValueOnce(
+      // @ts-expect-error not full search response
+      elasticsearchClientMock.createSuccessTransportRequestPromise({
+        hits: {
+          hits: [
+            {
+              action: {
+                id: '1',
+                actionTypeId: '.server-log',
+              },
+              namespaces: {
+                default: 1,
+              },
+            },
+            {
+              action: {
+                id: '2',
+                actionTypeId: '.slack',
+              },
+              namespaces: {
+                test: 1,
+              },
+            },
+            {
+              action: {
+                id: '3',
+                actionTypeId: '.email',
+              },
+              namespaces: {
+                test: 1,
+              },
+            },
+          ],
         },
-        {
-          id: '123',
-          attributes: {
-            actionTypeId: '.slack',
-          },
-        },
-        {
-          id: '456',
-          attributes: {
-            actionTypeId: '.email',
-          },
-        },
-      ],
-    });
-    const telemetry = await getInUseTotalCount(mockEsClient, actionsBulkGet, 'test');
+      })
+    );
+    const telemetry = await getInUseTotalCount(mockEsClient, 'test');
 
     expect(mockEsClient.search).toHaveBeenCalledTimes(1);
-    expect(actionsBulkGet).toHaveBeenCalledTimes(1);
-
     expect(telemetry).toMatchInlineSnapshot(`
 Object {
   "countByAlertHistoryConnectorType": 1,

--- a/x-pack/plugins/actions/server/usage/actions_telemetry.test.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.test.ts
@@ -141,21 +141,19 @@ Object {
         hits: {
           hits: [
             {
-              action: {
-                id: '1',
-                actionTypeId: '.server-log',
-              },
-              namespaces: {
-                default: 1,
+              _source: {
+                action: {
+                  id: '1',
+                  actionTypeId: '.server-log',
+                },
               },
             },
             {
-              action: {
-                id: '2',
-                actionTypeId: '.slack',
-              },
-              namespaces: {
-                test: 1,
+              _source: {
+                action: {
+                  id: '2',
+                  actionTypeId: '.slack',
+                },
               },
             },
           ],
@@ -164,7 +162,7 @@ Object {
     );
     const telemetry = await getInUseTotalCount(mockEsClient, 'test');
 
-    expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    expect(mockEsClient.search).toHaveBeenCalledTimes(2);
     expect(telemetry).toMatchInlineSnapshot(`
 Object {
   "countByAlertHistoryConnectorType": 0,
@@ -217,21 +215,19 @@ Object {
         hits: {
           hits: [
             {
-              action: {
-                id: '1',
-                actionTypeId: '.server-log',
-              },
-              namespaces: {
-                default: 1,
+              _source: {
+                action: {
+                  id: '1',
+                  actionTypeId: '.server-log',
+                },
               },
             },
             {
-              action: {
-                id: '2',
-                actionTypeId: '.slack',
-              },
-              namespaces: {
-                test: 1,
+              _source: {
+                action: {
+                  id: '2',
+                  actionTypeId: '.slack',
+                },
               },
             },
           ],
@@ -240,7 +236,7 @@ Object {
     );
     const telemetry = await getInUseTotalCount(mockEsClient, 'test');
 
-    expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    expect(mockEsClient.search).toHaveBeenCalledTimes(2);
     expect(telemetry).toMatchInlineSnapshot(`
 Object {
   "countByAlertHistoryConnectorType": 1,
@@ -376,7 +372,7 @@ Object {
 
   test('getInUseTotalCount() accounts for preconfigured connectors', async () => {
     const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
-    mockEsClient.search.mockReturnValue(
+    mockEsClient.search.mockReturnValueOnce(
       // @ts-expect-error not full search response
       elasticsearchClientMock.createSuccessTransportRequestPromise({
         aggregations: {
@@ -422,30 +418,27 @@ Object {
         hits: {
           hits: [
             {
-              action: {
-                id: '1',
-                actionTypeId: '.server-log',
-              },
-              namespaces: {
-                default: 1,
-              },
-            },
-            {
-              action: {
-                id: '2',
-                actionTypeId: '.slack',
-              },
-              namespaces: {
-                test: 1,
+              _source: {
+                action: {
+                  id: '1',
+                  actionTypeId: '.server-log',
+                },
               },
             },
             {
-              action: {
-                id: '3',
-                actionTypeId: '.email',
+              _source: {
+                action: {
+                  id: '2',
+                  actionTypeId: '.slack',
+                },
               },
-              namespaces: {
-                test: 1,
+            },
+            {
+              _source: {
+                action: {
+                  id: '3',
+                  actionTypeId: '.email',
+                },
               },
             },
           ],
@@ -454,7 +447,7 @@ Object {
     );
     const telemetry = await getInUseTotalCount(mockEsClient, 'test');
 
-    expect(mockEsClient.search).toHaveBeenCalledTimes(1);
+    expect(mockEsClient.search).toHaveBeenCalledTimes(2);
     expect(telemetry).toMatchInlineSnapshot(`
 Object {
   "countByAlertHistoryConnectorType": 1,

--- a/x-pack/plugins/actions/server/usage/actions_telemetry.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.ts
@@ -254,10 +254,9 @@ export async function getInUseTotalCount(
     body: { hits: actions },
   } = await esClient.search<{
     action: ActionResult;
-    namespaces: string[];
   }>({
     index: kibanaIndex,
-    _source_includes: ['action', 'namespaces'],
+    _source_includes: ['action'],
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/actions/server/usage/actions_telemetry.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import {
-  ElasticsearchClient,
-  SavedObjectsBaseOptions,
-  SavedObjectsBulkGetObject,
-  SavedObjectsBulkResponse,
-} from 'kibana/server';
+import { ElasticsearchClient } from 'kibana/server';
 import { AlertHistoryEsIndexConnectorId } from '../../common';
 import { ActionResult, PreConfiguredAction } from '../types';
 
@@ -86,10 +81,6 @@ export async function getTotalCount(
 
 export async function getInUseTotalCount(
   esClient: ElasticsearchClient,
-  actionsBulkGet: (
-    objects?: SavedObjectsBulkGetObject[] | undefined,
-    options?: SavedObjectsBaseOptions | undefined
-  ) => Promise<SavedObjectsBulkResponse<ActionResult<Record<string, unknown>>>>,
   kibanaIndex: string
 ): Promise<{
   countTotal: number;
@@ -259,15 +250,35 @@ export async function getInUseTotalCount(
   const preconfiguredActionsAggs =
     // @ts-expect-error aggegation type is not specified
     actionResults.aggregations.preconfigured_actions?.preconfiguredActionRefIds.value;
-  const bulkFilter = Object.entries(aggs.connectorIds).map(([key]) => ({
-    id: key,
-    type: 'action',
-    fields: ['id', 'actionTypeId'],
-  }));
-  const actions = await actionsBulkGet(bulkFilter);
-  const countByActionTypeId = actions.saved_objects.reduce(
+  const {
+    body: { hits: actions },
+  } = await esClient.search<{
+    action: ActionResult;
+    namespaces: string[];
+  }>({
+    index: kibanaIndex,
+    _source_includes: ['action', 'namespaces'],
+    body: {
+      query: {
+        bool: {
+          must: [
+            {
+              term: { type: 'action' },
+            },
+            {
+              terms: {
+                _id: Object.entries(aggs.connectorIds).map(([key]) => `action:${key}`),
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const countByActionTypeId = actions.hits.reduce(
     (actionTypeCount: Record<string, number>, action) => {
-      const alertTypeId = replaceFirstAndLastDotSymbols(action.attributes.actionTypeId);
+      const actionSource = action._source!;
+      const alertTypeId = replaceFirstAndLastDotSymbols(actionSource.action.actionTypeId);
       const currentCount =
         actionTypeCount[alertTypeId] !== undefined ? actionTypeCount[alertTypeId] : 0;
       actionTypeCount[alertTypeId] = currentCount + 1;

--- a/x-pack/plugins/actions/server/usage/task.ts
+++ b/x-pack/plugins/actions/server/usage/task.ts
@@ -5,19 +5,14 @@
  * 2.0.
  */
 
-import {
-  Logger,
-  CoreSetup,
-  SavedObjectsBulkGetObject,
-  SavedObjectsBaseOptions,
-} from 'kibana/server';
+import { Logger, CoreSetup } from 'kibana/server';
 import moment from 'moment';
 import {
   RunContext,
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '../../../task_manager/server';
-import { ActionResult, PreConfiguredAction } from '../types';
+import { PreConfiguredAction } from '../types';
 import { getTotalCount, getInUseTotalCount } from './actions_telemetry';
 
 export const TELEMETRY_TASK_TYPE = 'actions_telemetry';
@@ -83,22 +78,12 @@ export function telemetryTaskRunner(
           },
         ]) => client.asInternalUser
       );
-    const actionsBulkGet = (
-      objects?: SavedObjectsBulkGetObject[],
-      options?: SavedObjectsBaseOptions
-    ) => {
-      return core
-        .getStartServices()
-        .then(([{ savedObjects }]) =>
-          savedObjects.createInternalRepository(['action']).bulkGet<ActionResult>(objects, options)
-        );
-    };
     return {
       async run() {
         const esClient = await getEsClient();
         return Promise.all([
           getTotalCount(esClient, kibanaIndex, preconfiguredActions),
-          getInUseTotalCount(esClient, actionsBulkGet, kibanaIndex),
+          getInUseTotalCount(esClient, kibanaIndex),
         ])
           .then(([totalAggegations, totalInUse]) => {
             return {


### PR DESCRIPTION
## Summary

Current PR fixing the bug in actions telemetry, when connectors and actions were created in multiple spaces.
After making actions saved object 'multiple-isolated', we didn't change the action telemetry task, which used SavedObjects bulkGet method, which has next restrictions for the namespaces search:
```
For isolated object types (registered with `namespaceType: 'single'` or `namespaceType: 'multiple-isolated'`): 
this option can only be used to specify a single space, and the "All spaces" identifier (`'*'`) is not allowed. 
```
That's why for the objects created in non default space, the error message in console was appeared each time the telemetry task was executed.

Steps to reproduce:
1. Create multiple spaces
2. In each space create a rule with actions
3. Run telemetry task and observe the error message in the console log
`Error executing actions telemetry task: TypeError: Cannot read property 'actionTypeId' of undefined.`