### PR TITLE
[App Search] [Crawler] Add tooltip to explain path pattern

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_rules_table.tsx
@@ -9,7 +9,16 @@ import React from 'react';
 
 import { useActions } from 'kea';
 
-import { EuiCode, EuiFieldText, EuiLink, EuiSelect, EuiText } from '@elastic/eui';
+import {
+  EuiCode,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIconTip,
+  EuiLink,
+  EuiSelect,
+  EuiText,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -27,6 +36,7 @@ import {
   getReadableCrawlerPolicy,
   getReadableCrawlerRule,
 } from '../types';
+import { getCrawlRulePathPatternTooltip } from '../utils';
 
 interface CrawlRulesTableProps {
   description?: React.ReactNode;
@@ -130,13 +140,24 @@ export const CrawlRulesTable: React.FC<CrawlRulesTableProps> = ({
     },
     {
       editingRender: (crawlRule, onChange, { isInvalid, isLoading }) => (
-        <EuiFieldText
-          fullWidth
-          value={(crawlRule as CrawlRule).pattern}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={isLoading}
-          isInvalid={isInvalid}
-        />
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem>
+            <EuiFieldText
+              fullWidth
+              value={(crawlRule as CrawlRule).pattern}
+              onChange={(e) => onChange(e.target.value)}
+              disabled={isLoading}
+              isInvalid={isInvalid}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiIconTip
+              content={getCrawlRulePathPatternTooltip(crawlRule as CrawlRule)}
+              type="iInCircle"
+              position="top"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ),
       render: (crawlRule) => <EuiCode>{(crawlRule as CrawlRule).pattern}</EuiCode>,
       name: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
@@ -26,6 +26,7 @@ import {
   crawlRequestServerToClient,
   getDeleteDomainConfirmationMessage,
   getDeleteDomainSuccessMessage,
+  getCrawlRulePathPatternTooltip,
 } from './utils';
 
 const DEFAULT_CRAWL_RULE: CrawlRule = {
@@ -290,5 +291,30 @@ describe('getDeleteDomainConfirmationMessage', () => {
 describe('getDeleteDomainSuccessMessage', () => {
   it('includes the url', () => {
     expect(getDeleteDomainSuccessMessage('https://elastic.co/')).toContain('https://elastic.co');
+  });
+});
+
+describe('getCrawlRulePathPatternTooltip', () => {
+  it('includes regular expression', () => {
+    const crawlRule: CrawlRule = {
+      id: '-',
+      policy: CrawlerPolicies.allow,
+      rule: CrawlerRules.regex,
+      pattern: '.*',
+    };
+
+    expect(getCrawlRulePathPatternTooltip(crawlRule)).toContain('regular expression');
+  });
+
+  it('includes meta', () => {
+    const crawlRule: CrawlRule = {
+      id: '-',
+      policy: CrawlerPolicies.allow,
+      rule: CrawlerRules.beginsWith,
+      pattern: '/elastic',
+    };
+
+    expect(getCrawlRulePathPatternTooltip(crawlRule)).not.toContain('regular expression');
+    expect(getCrawlRulePathPatternTooltip(crawlRule)).toContain('meta');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -16,6 +16,8 @@ import {
   CrawlerDomainValidationStep,
   CrawlRequestFromServer,
   CrawlRequest,
+  CrawlRule,
+  CrawlerRules,
   CrawlEventFromServer,
   CrawlEvent,
 } from './types';
@@ -156,6 +158,26 @@ export const getDeleteDomainSuccessMessage = (domainUrl: string) => {
       values: {
         domainUrl,
       },
+    }
+  );
+};
+
+export const getCrawlRulePathPatternTooltip = (crawlRule: CrawlRule) => {
+  if (crawlRule.rule === CrawlerRules.regex) {
+    return i18n.translate(
+      'xpack.enterpriseSearch.appSearch.crawler.crawlRulesTable.regexPathPatternTooltip',
+      {
+        defaultMessage:
+          'The path pattern is a regular expression compatible with the Ruby language regular expression engine.',
+      }
+    );
+  }
+
+  return i18n.translate(
+    'xpack.enterpriseSearch.appSearch.crawler.crawlRulesTable.pathPatternTooltip',
+    {
+      defaultMessage:
+        'The path pattern is a literal string except for the asterisk (*) character, which is a meta character that will match anything.',
     }
   );
 };


### PR DESCRIPTION
## Summary

7.13.0 adds a wildcard character to (non-regex) path patterns. This change updates the UI help text to explain this.

![CleanShot 2021-10-13 at 13 28 56](https://user-images.githubusercontent.com/809707/137124751-7de85de1-0438-4706-a5a6-c9b0a0421340.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
