### PR TITLE
[Stack Monitoring] fix feature controls functional test

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/page_template.tsx
@@ -92,7 +92,7 @@ export const PageTemplate: React.FC<PageTemplateProps> = ({
   };
 
   return (
-    <div className="app-container">
+    <div className="app-container" data-test-subj="monitoringAppContainer">
       <ActionMenu>
         <AlertsDropdown />
       </ActionMenu>

--- a/x-pack/plugins/monitoring/public/directives/main/index.html
+++ b/x-pack/plugins/monitoring/public/directives/main/index.html
@@ -1,4 +1,4 @@
-<div class="app-container">
+<div class="app-container" data-test-subj="monitoringAppContainer">
   <div class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive">
     <div class="euiFlexItem euiFlexItem--flexGrowZero">
       <div class="euiFlexGroup euiFlexGroup--gutterNone euiFlexGroup--justifyContentSpaceEvenly euiFlexGroup--responsive euiFlexGroup--directionColumn">

--- a/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_spaces.ts
+++ b/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_spaces.ts
@@ -52,7 +52,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           basePath: '/s/custom_space',
         });
 
-        const exists = await find.existsByCssSelector('monitoring-main');
+        const exists = await find.existsByCssSelector('.app-container');
         expect(exists).to.be(true);
       });
     });

--- a/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_spaces.ts
+++ b/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_spaces.ts
@@ -52,7 +52,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           basePath: '/s/custom_space',
         });
 
-        const exists = await find.existsByCssSelector('.app-container');
+        const exists = await find.existsByCssSelector('[data-test-subj="monitoringAppContainer"]');
         expect(exists).to.be(true);
       });
     });


### PR DESCRIPTION
## Summary
Fixes #114638

One test was broken as it was targeting the `monitoring-main` element that don't exist in react. Updated the test to target the direct child of the `monitoring-main` element which exists in both angular and react versions.

![app-container-element](https://user-images.githubusercontent.com/5239883/137126734-a20ea63e-f493-40d2-a69c-ba75ba9f8f73.png)

### Testing
- set render_react_app to true
- start test server `node scripts/functional_tests_server --config x-pack/test/functional/config.js`
- run tests `node scripts/functional_test_runner --config x-pack/test/functional/config.js --grep "Monitoring app feature controls"`

```
...
     └-> "after all" hook in "feature controls"
   └-> "after all" hook in "Monitoring app"

7 passing (1.0m)
```