### PR TITLE
[Upgrade Assistant] Added "accept changes" header

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/__snapshots__/warning_step.test.tsx.snap
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/__snapshots__/warning_step.test.tsx.snap
@@ -23,6 +23,18 @@ exports[`WarningsFlyoutStep renders 1`] = `
       </p>
     </EuiCallOut>
     <EuiSpacer />
+    <EuiTitle
+      size="s"
+    >
+      <h3>
+        <FormattedMessage
+          defaultMessage="Accept changes"
+          id="xpack.upgradeAssistant.checkupTab.reindexing.flyout.warningsStep.acceptChangesTitle"
+          values={Object {}}
+        />
+      </h3>
+    </EuiTitle>
+    <EuiSpacer />
   </EuiFlyoutBody>
   <EuiFlyoutFooter>
     <EuiFlexGroup

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/warnings_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/reindex/flyout/warnings_step.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiSpacer,
+  EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -107,6 +108,15 @@ export const WarningsFlyoutStep: React.FunctionComponent<WarningsConfirmationFly
           </p>
         </EuiCallOut>
 
+        <EuiSpacer />
+        <EuiTitle size="s">
+          <h3>
+            <FormattedMessage
+              id="xpack.upgradeAssistant.checkupTab.reindexing.flyout.warningsStep.acceptChangesTitle"
+              defaultMessage="Accept changes"
+            />
+          </h3>
+        </EuiTitle>
         <EuiSpacer />
 
         {warnings.map((warning, index) => {


### PR DESCRIPTION
## Summary

This PR adds "Accept changes" header to the reindex flyout when the user needs to accept destructive changes that will be applied to the index. 

### Screenshot 
<img width="498" alt="Screenshot 2021-10-13 at 15 13 41" src="https://user-images.githubusercontent.com/6585477/137141356-dfc7131c-e2a1-4d04-a458-1d0fcb41703b.png">

