### PR TITLE
[ML] APM Correlations: Round duration values to be used in range aggregations.

### DIFF
--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.test.ts
@@ -106,8 +106,8 @@ describe('query_histogram_range_steps', () => {
       );
 
       expect(resp.length).toEqual(100);
-      expect(resp[0]).toEqual(9.260965422132594);
-      expect(resp[99]).toEqual(18521.930844265193);
+      expect(resp[0]).toEqual(9);
+      expect(resp[99]).toEqual(18522);
       expect(esClientSearchMock).toHaveBeenCalledTimes(1);
     });
   });

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.ts
@@ -19,10 +19,11 @@ import { getRequestBase } from './get_request_base';
 
 const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
   // A d3 based scale function as a helper to get equally distributed bins on a log scale.
+  // We round the final values because the ES range agg we used won't accept numbers with decimals for `transaction.duration.us`.
   const logFn = scaleLog().domain([min, max]).range([1, steps]);
   return [...Array(steps).keys()]
     .map(logFn.invert)
-    .map((d) => (isNaN(d) ? 0 : d));
+    .map((d) => (isNaN(d) ? 0 : Math.round(d)));
 };
 
 export const getHistogramIntervalRequest = (

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.ts
@@ -19,7 +19,7 @@ import { getRequestBase } from './get_request_base';
 
 const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
   // A d3 based scale function as a helper to get equally distributed bins on a log scale.
-  // We round the final values because the ES range agg we used won't accept numbers with decimals for `transaction.duration.us`.
+  // We round the final values because the ES range agg we use won't accept numbers with decimals for `transaction.duration.us`.
   const logFn = scaleLog().domain([min, max]).range([1, steps]);
   return [...Array(steps).keys()]
     .map(logFn.invert)


### PR DESCRIPTION
## Summary

Relates to #114734

A change in the ES range agg (https://github.com/elastic/elasticsearch/pull/78344) no longer accepts numbers with decimals if the underlying field is typed as `long`. This PR fixes the issue by rounding the values we pass on to the range agg. This will unblock ES snapshot promotion.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
