### PR TITLE
[Stack Monitoring] fix beats pages test-subj attributes

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/beats/beats_template.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/beats/beats_template.tsx
@@ -23,6 +23,7 @@ export const BeatsTemplate: React.FC<BeatsTemplateProps> = ({ instance, ...props
         defaultMessage: 'Overview',
       }),
       route: '/beats',
+      testSubj: 'beatsOverviewPage',
     });
     tabs.push({
       id: 'instances',
@@ -30,6 +31,7 @@ export const BeatsTemplate: React.FC<BeatsTemplateProps> = ({ instance, ...props
         defaultMessage: 'Instances',
       }),
       route: '/beats/beats',
+      testSubj: 'beatsListingPage',
     });
   } else {
     tabs.push({

--- a/x-pack/plugins/monitoring/public/application/pages/beats/instances.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/beats/instances.tsx
@@ -71,11 +71,7 @@ export const BeatsInstancesPage: React.FC<ComponentProps> = ({ clusters }) => {
   ]);
 
   return (
-    <BeatsTemplate
-      title={title}
-      pageTitle={pageTitle}
-      getPageData={getPageData}
-    >
+    <BeatsTemplate title={title} pageTitle={pageTitle} getPageData={getPageData}>
       <div data-test-subj="monitoringBeatsInstancesApp">
         <SetupModeRenderer
           productName={BEATS_SYSTEM_ID}

--- a/x-pack/plugins/monitoring/public/application/pages/beats/instances.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/beats/instances.tsx
@@ -75,7 +75,6 @@ export const BeatsInstancesPage: React.FC<ComponentProps> = ({ clusters }) => {
       title={title}
       pageTitle={pageTitle}
       getPageData={getPageData}
-      data-test-subj="beatsListingPage"
     >
       <div data-test-subj="monitoringBeatsInstancesApp">
         <SetupModeRenderer

--- a/x-pack/plugins/monitoring/public/application/pages/beats/overview.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/beats/overview.tsx
@@ -72,11 +72,7 @@ export const BeatsOverviewPage: React.FC<ComponentProps> = ({ clusters }) => {
   };
 
   return (
-    <BeatsTemplate
-      title={title}
-      pageTitle={pageTitle}
-      getPageData={getPageData}
-    >
+    <BeatsTemplate title={title} pageTitle={pageTitle} getPageData={getPageData}>
       <div>{renderOverview(data)}</div>
     </BeatsTemplate>
   );

--- a/x-pack/plugins/monitoring/public/application/pages/beats/overview.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/beats/overview.tsx
@@ -76,9 +76,8 @@ export const BeatsOverviewPage: React.FC<ComponentProps> = ({ clusters }) => {
       title={title}
       pageTitle={pageTitle}
       getPageData={getPageData}
-      data-test-subj="beatsOverviewPage"
     >
-      <div data-test-subj="beatsOverviewPage">{renderOverview(data)}</div>
+      <div>{renderOverview(data)}</div>
     </BeatsTemplate>
   );
 };


### PR DESCRIPTION
## Summary

Fixes functional tests that rely on the test-subj attribute to target dom elements #114802

### Testing

- set render_react_app to true
- start test server node scripts/functional_tests_server --config x-pack/test/functional/config.js
- run tests node scripts/functional_test_runner --config x-pack/test/functional/config.js --grep "Monitoring app beats"

```
...
...
     └-> "after all" hook for "cluster status bar shows correct information"
     └-> "after all" hook for "cluster status bar shows correct information"
   └-> "after all" hook in "Monitoring app"

5 passing (2.0m)
```