### PR TITLE
[7.x] [Observability] [Exploratory View] limit breakdown to one series (#113888)

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
@@ -71,9 +71,16 @@ export function UrlStorageContextProvider({
 
   const setSeries = useCallback((seriesIndex: number, newValue: SeriesUrl) => {
     setAllSeries((prevAllSeries) => {
+      const seriesWithCurrentBreakdown = prevAllSeries.findIndex((series) => series.breakdown);
       const newStateRest = prevAllSeries.map((series, index) => {
         if (index === seriesIndex) {
-          return newValue;
+          return {
+            ...newValue,
+            breakdown:
+              seriesWithCurrentBreakdown === seriesIndex || seriesWithCurrentBreakdown === -1
+                ? newValue.breakdown
+                : undefined,
+          };
         }
         return series;
       });

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/breakdown/breakdowns.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/breakdown/breakdowns.test.tsx
@@ -55,4 +55,24 @@ describe('Breakdowns', function () {
     });
     expect(setSeries).toHaveBeenCalledTimes(1);
   });
+
+  it('should disable breakdowns when a different series has a breakdown', function () {
+    const initSeries = {
+      data: [mockUxSeries, { ...mockUxSeries, breakdown: undefined }],
+      breakdown: USER_AGENT_OS,
+    };
+
+    render(
+      <Breakdowns
+        seriesId={1}
+        seriesConfig={dataViewSeries}
+        series={{ ...mockUxSeries, breakdown: undefined }}
+      />,
+      { initSeries }
+    );
+
+    const button = screen.getByText('No breakdown');
+
+    expect(button).toHaveAttribute('disabled');
+  });
 });

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/breakdown/breakdowns.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/breakdown/breakdowns.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { EuiSuperSelect } from '@elastic/eui';
+import styled from 'styled-components';
+import { EuiSuperSelect, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useSeriesStorage } from '../../hooks/use_series_storage';
 import { LABEL_FIELDS_BREAKDOWN, USE_BREAK_DOWN_COLUMN } from '../../configurations/constants';
@@ -19,7 +20,14 @@ interface Props {
 }
 
 export function Breakdowns({ seriesConfig, seriesId, series }: Props) {
-  const { setSeries } = useSeriesStorage();
+  const { setSeries, allSeries } = useSeriesStorage();
+
+  const indexOfSeriesWithBreakdown = allSeries.findIndex((seriesT) => {
+    return Boolean(seriesT.breakdown);
+  });
+  const currentSeriesHasBreakdown = indexOfSeriesWithBreakdown === seriesId;
+  const anySeriesHasBreakdown = indexOfSeriesWithBreakdown !== -1;
+  const differentSeriesHasBreakdown = anySeriesHasBreakdown && !currentSeriesHasBreakdown;
 
   const selectedBreakdown = series.breakdown;
   const NO_BREAKDOWN = 'no_breakdown';
@@ -69,13 +77,28 @@ export function Breakdowns({ seriesConfig, seriesId, series }: Props) {
     valueOfSelected = LABEL_FIELDS_BREAKDOWN;
   }
 
+  function Select() {
+    return (
+      <EuiSuperSelect
+        options={options}
+        valueOfSelected={valueOfSelected}
+        onChange={(value) => onOptionChange(value)}
+        data-test-subj={'seriesBreakdown'}
+        disabled={differentSeriesHasBreakdown}
+      />
+    );
+  }
+
   return (
-    <EuiSuperSelect
-      options={options}
-      valueOfSelected={valueOfSelected}
-      onChange={(value) => onOptionChange(value)}
-      data-test-subj={'seriesBreakdown'}
-    />
+    <Wrapper>
+      {differentSeriesHasBreakdown ? (
+        <EuiToolTip content={BREAKDOWN_WARNING} position="top">
+          <Select />
+        </EuiToolTip>
+      ) : (
+        <Select />
+      )}
+    </Wrapper>
   );
 }
 
@@ -85,3 +108,13 @@ export const NO_BREAK_DOWN_LABEL = i18n.translate(
     defaultMessage: 'No breakdown',
   }
 );
+
+export const BREAKDOWN_WARNING = i18n.translate('xpack.observability.exp.breakDownFilter.warning', {
+  defaultMessage: 'Breakdowns can be applied to only one series at a time.',
+});
+
+const Wrapper = styled.span`
+  .euiToolTipAnchor {
+    width: 100%;
+  }
+`;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Observability] [Exploratory View] limit breakdown to one series (#113888)