### PR TITLE
[DOCS] Removes capitalized attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -13,12 +13,8 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 :es-docker-image: {es-docker-repo}:{version}
 :blob:            {kib-repo}blob/{branch}/
 :security-ref:    https://www.elastic.co/community/security/
-:Data-Sources:    Data Views
-:Data-source:     Data view
 :data-source:     data view
-:Data-sources:    Data views
 :data-sources:    data views
-:A-data-source:   A data view
 :a-data-source:   a data view
 
 include::{docs-root}/shared/attributes.asciidoc[]


### PR DESCRIPTION
## Summary

Since Asciidoc is unable to recognize capitalization in attributes, removing the data source attributes that include capitalization.