### PR TITLE
[7.x] [DOCS] Removes capitalized attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -14,12 +14,8 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 :blob:           {kib-repo}blob/{branch}/
 :security-ref:   https://www.elastic.co/community/security/
 
-:Data-Sources:    Index Patterns
-:Data-source:     Index pattern
 :data-source:     index pattern
-:Data-sources:    Index patterns
 :data-sources:    index patterns
-:A-data-source:   An index pattern
 :a-data-source:   an index pattern
 
 include::{docs-root}/shared/attributes.asciidoc[]


### PR DESCRIPTION
## Summary

Since Asciidoc is unable to recognize capitalization in attributes, removing the data source attributes that include capitalization.
