### PR TITLE
[App Search] Fixed numbering on Curation Suggestion Detail View

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion.tsx
@@ -132,7 +132,7 @@ export const CurationSuggestion: React.FC = () => {
                             result={result}
                             isMetaEngine={isMetaEngine}
                             schemaForTypeHighlights={engine.schema}
-                            resultPosition={index + 1}
+                            resultPosition={index + existingCurationResults.length + 1}
                           />
                         </EuiFlexItem>
                       ))}
@@ -152,7 +152,7 @@ export const CurationSuggestion: React.FC = () => {
                             result={result}
                             isMetaEngine={isMetaEngine}
                             schemaForTypeHighlights={engine.schema}
-                            resultPosition={index + 1}
+                            resultPosition={index + suggestedPromotedDocuments.length + 1}
                           />
                         </EuiFlexItem>
                       ))}


### PR DESCRIPTION
## Summary

This is a simple PR to update the numbering on the Curation Suggestion Detail View to continue from Promoted through Organic.

![screencapture-localhost-5601-qlu-app-enterprise-search-app-search-engines-pokemon-curations-suggestions-a-bat-pokemon-2021-10-13-12_45_47](https://user-images.githubusercontent.com/1427475/137177804-129ecf8c-09b3-4d25-ab56-37fc5328d54a.png)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
