### PR TITLE
Update kibana to EMS 7.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@elastic/charts": "37.0.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.21",
-    "@elastic/ems-client": "7.15.0",
+    "@elastic/ems-client": "7.16.0",
     "@elastic/eui": "39.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/maki": "6.3.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -74,7 +74,7 @@ export const DEV_ONLY_LICENSE_ALLOWED = ['MPL-2.0'];
 export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
-  '@elastic/ems-client@7.15.0': ['Elastic License 2.0'],
+  '@elastic/ems-client@7.16.0': ['Elastic License 2.0'],
   '@elastic/eui@39.0.0': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/src/plugins/maps_ems/common/index.ts
+++ b/src/plugins/maps_ems/common/index.ts
@@ -10,7 +10,7 @@ export const TMS_IN_YML_ID = 'TMS in config/kibana.yml';
 
 export const DEFAULT_EMS_FILE_API_URL = 'https://vector.maps.elastic.co';
 export const DEFAULT_EMS_TILE_API_URL = 'https://tiles.maps.elastic.co';
-export const DEFAULT_EMS_LANDING_PAGE_URL = 'https://maps.elastic.co/v7.15';
+export const DEFAULT_EMS_LANDING_PAGE_URL = 'https://maps.elastic.co/v7.16';
 export const DEFAULT_EMS_FONT_LIBRARY_URL =
   'https://tiles.maps.elastic.co/fonts/{fontstack}/{range}.pbf';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,10 +2389,10 @@
     ms "^2.1.3"
     secure-json-parse "^2.4.0"
 
-"@elastic/ems-client@7.15.0":
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.15.0.tgz#c101d7f83aa56463bcc385fd4eb883c6ea3ae9fc"
-  integrity sha512-BAAAVPhoaH6SGrfuO6U0MVRg4lvblhJ9VqYlMf3dZN9uDBB+12CUtb6t6Kavn5Tr3nS6X3tU/KKsuomo5RrEeQ==
+"@elastic/ems-client@7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-7.16.0.tgz#92db94126bac0b95fbf156fe609f68979e7af4b6"
+  integrity sha512-NgMB5vqj6I7lxVsysrz6eB1EW6gsZj7SWWs79WSiiKQeNuRg82tJhvbHQnWezjIS4UKOtoGxZsg475EHVZB46g==
   dependencies:
     "@types/geojson" "^7946.0.7"
     "@types/lru-cache" "^5.1.0"
@@ -2400,7 +2400,7 @@
     "@types/topojson-specification" "^1.0.1"
     lodash "^4.17.15"
     lru-cache "^6.0.0"
-    semver "7.3.2"
+    semver "^7.3.2"
     topojson-client "^3.1.0"
 
 "@elastic/eslint-config-kibana@link:bazel-bin/packages/elastic-eslint-config-kibana":
@@ -25810,15 +25810,15 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.2, semver@^7.2.1, semver@^7.3.2, semver@~7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
 semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.2.1, semver@^7.3.2, semver@~7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"


### PR DESCRIPTION
## Summary

Updates Kibana to use Elastic Maps Service 7.16. 

* bump `@elastic/ems-client` to 7.16.0
* update EMS landing page url to https://maps.elastic.co/v7.16
