### PR TITLE
[renovate] Configure Cypress

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.js
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.js
@@ -60,7 +60,7 @@ const uploadPipeline = (pipelineContent) => {
         /^x-pack\/test\/security_solution_cypress/,
         /^x-pack\/plugins\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
         /^x-pack\/plugins\/triggers_actions_ui\/public\/application\/context\/actions_connectors_context\.tsx/,
-      ])
+      ]) || process.env.GITHUB_PR_LABELS.includes('ci:all-cypress-suites')
     ) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/security_solution.yml'));
     }
@@ -69,7 +69,7 @@ const uploadPipeline = (pipelineContent) => {
     // if (
     //   await doAnyChangesMatch([
     //     /^x-pack\/plugins\/apm/,
-    //   ])
+    //   ]) || process.env.GITHUB_PR_LABELS.includes('ci:all-cypress-suites')
     // ) {
     //   pipeline.push(getPipeline('.buildkite/pipelines/pull_request/apm_cypress.yml'));
     // }

--- a/renovate.json5
+++ b/renovate.json5
@@ -94,6 +94,15 @@
         enabled: true,
       },
       {
+        groupName: 'cypress',
+        packageNames: ['eslint-plugin-cypress'],
+        matchPackagePatterns: ["^cypress"],
+        reviewers: ['Team:apm', 'Team: SecuritySolution'],
+        matchBaseBranches: ['master'],
+        labels: ['buildkite-ci', 'ci:all-cypress-suites'],
+        enabled: true,
+      }
+      {
         groupName: 'platform security modules',
         packageNames: [
           'broadcast-channel',


### PR DESCRIPTION
Followup to https://github.com/elastic/kibana/pull/114831#discussion_r728309201

Add configuration to Renovate for Cypress.

- Tags teams currently using Cypress
- Adds `buildkite-ci` label to run on Buildkite
- Adds`ci:all-cypress-suites` label to trigger all Cypress suites to run to ensure there are no failures caused by the bump.