### PR TITLE
[DOCS] Removes coming tag from 6.8.20 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -112,8 +112,6 @@ Review important information about the {kib} 6.x.x releases.
 [[release-notes-6.8.20]]
 == {kib} 6.8.20
 
-coming::[6.8.20]
-
 For information about the {kib} 6.8.20 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the coming tag from the 6.8.20 release notes.