### PR TITLE
[Stack Monitoring] Convert Access Denied page to React

### DIFF
--- a/x-pack/plugins/monitoring/public/application/hooks/use_request_error_handler.tsx
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_request_error_handler.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React, { useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
 import { includes } from 'lodash';
 import { IHttpFetchError } from 'kibana/public';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -34,11 +35,12 @@ export function formatMonitoringError(err: IHttpFetchError) {
 
 export const useRequestErrorHandler = () => {
   const { services } = useKibana<MonitoringStartPluginDependencies>();
+  const history = useHistory();
   return useCallback(
     (err: IHttpFetchError) => {
       if (err.response?.status === 403) {
         // redirect to error message view
-        history.replaceState(null, '', '#/access-denied');
+        history.push('/access-denied');
       } else if (err.response?.status === 404 && !includes(window.location.hash, 'no-data')) {
         // pass through if this is a 404 and we're already on the no-data page
         const formattedError = formatMonitoringError(err);
@@ -74,6 +76,6 @@ export const useRequestErrorHandler = () => {
         });
       }
     },
-    [services.notifications]
+    [history, services.notifications?.toasts]
   );
 };

--- a/x-pack/plugins/monitoring/public/application/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/index.tsx
@@ -55,6 +55,7 @@ import { LogStashNodeAdvancedPage } from './pages/logstash/advanced';
 // import { LogStashNodePipelinesPage } from './pages/logstash/node_pipelines';
 import { LogStashNodePage } from './pages/logstash/node';
 import { LogStashNodePipelinesPage } from './pages/logstash/node_pipelines';
+import { AccessDeniedPage } from './pages/access_denied';
 
 export const renderApp = (
   core: CoreStart,
@@ -94,6 +95,7 @@ const MonitoringApp: React.FC<{
               <BreadcrumbContainer.Provider history={history}>
                 <Router history={history}>
                   <Switch>
+                    <Route path="/access-denied" component={AccessDeniedPage} />
                     <Route path="/no-data" component={NoDataPage} />
                     <Route path="/loading" component={LoadingPage} />
                     <RouteInit

--- a/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { EuiPanel, EuiCallOut, EuiButton } from '@elastic/eui';
+import useInterval from 'react-use/lib/useInterval';
+import { Redirect } from 'react-router-dom';
+import { ComponentProps } from '../../route_init';
+import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
+import { MonitoringStartPluginDependencies } from '../../../types';
+
+export const AccessDeniedPage: React.FC<ComponentProps> = () => {
+  const { services } = useKibana<MonitoringStartPluginDependencies>();
+  const [hasAccess, setHasAccess] = useState<boolean>(false);
+
+  useInterval(() => {
+    async function tryPrivilege() {
+      if (services.http?.fetch) {
+        try {
+          const response = await services.http?.fetch<{ has_access: boolean }>(
+            '../api/monitoring/v1/check_access'
+          );
+          setHasAccess(response.has_access);
+        } catch (e) {
+          setHasAccess(false);
+        }
+      }
+    }
+    tryPrivilege();
+  }, 5000);
+
+  const title = i18n.translate('xpack.monitoring.accessDeniedTitle', {
+    defaultMessage: 'Access Denied',
+  });
+
+  if (hasAccess) {
+    return <Redirect to="/home" />;
+  }
+  return (
+    <EuiPanel paddingSize="m">
+      <EuiCallOut title={title} color="danger" iconType="alert">
+        <p>
+          <FormattedMessage
+            id="xpack.monitoring.accessDenied.notAuthorizedDescription"
+            defaultMessage="You are not authorized to access Monitoring. To use Monitoring, you
+        need the privileges granted by both the `{kibanaAdmin}` and
+        `{monitoringUser}` roles."
+            values={{ kibanaAdmin: 'kibana_admin', monitoringUser: 'monitoring_user ' }}
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id="xpack.monitoring.accessDenied.clusterNotConfiguredDescription"
+            defaultMessage="If you are attempting to access a dedicated monitoring cluster, this
+        might be because you are logged in as a user that is not configured on
+        the monitoring cluster."
+          />
+        </p>
+        <p>
+          <EuiButton href="../app/home">
+            <FormattedMessage
+              id="xpack.monitoring.accessDenied.backToKibanaButtonLabel"
+              defaultMessage="Back to Kibana"
+            />
+          </EuiButton>
+        </p>
+      </EuiCallOut>
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/access_denied/index.tsx
@@ -44,7 +44,7 @@ export const AccessDeniedPage: React.FC<ComponentProps> = () => {
   }
   return (
     <EuiPanel paddingSize="m">
-      <EuiCallOut title={title} color="danger" iconType="alert">
+      <EuiCallOut title={title} color="danger" iconType="alert" data-test-subj="accessDeniedTitle">
         <p>
           <FormattedMessage
             id="xpack.monitoring.accessDenied.notAuthorizedDescription"


### PR DESCRIPTION
## Summary

This PR closes #111763 by migrating the view to a React page. I also had to update the way the error handler was doing the `/access-denied` redirect since the previous code wasn't actually working. I also update the design to use EUI.

### Before
![image](https://user-images.githubusercontent.com/41702/137191037-8475d2c0-6413-47bf-bd75-70c00cb59210.png)

### After
![image](https://user-images.githubusercontent.com/41702/137191227-ebc0e5c1-676c-422b-81b3-d30f4ff80ca9.png)


To test this you will need to throw a `forbidden` using `import { forbidden } from '@hapi/boom';` in the  [server/routes/api/v1/cluster/clusters.js](https://github.com/elastic/kibana/blob/master/x-pack/plugins/monitoring/server/routes/api/v1/cluster/clusters.js) route.