### PR TITLE
[7.13] [DOCS] Documents monitoring.cluster_alerts.allowedSpaces (#114669)

### DIFF
--- a/docs/settings/spaces-settings.asciidoc
+++ b/docs/settings/spaces-settings.asciidoc
@@ -5,23 +5,23 @@
 <titleabbrev>Spaces settings</titleabbrev>
 ++++
 
-By default, Spaces is enabled in Kibana, and you can secure Spaces using
-roles when Security is enabled.
+By default, spaces is enabled in {kib}. To secure spaces, <<security-settings-kb,enable security>>.
 
-[float]
-[[spaces-settings]]
-==== Spaces settings
+`xpack.spaces.enabled`::
+deprecated:[7.16.0,"In 8.0 and later, this setting will no longer be supported and it will not be possible to disable this plugin."]
+To enable spaces, set to `true`. 
+The default is `true`.
 
-[cols="2*<"]
-|===
-| `xpack.spaces.enabled`
-  | Set to `true` (default) to enable Spaces in {kib}.
-    This setting is deprecated. Starting in 8.0, it will not be possible to disable this plugin.
+`xpack.spaces.maxSpaces`::
+The maximum number of spaces that you can use with the {kib} instance. Some {kib} operations
+return all spaces using a single `_search` from {es}, so you must
+configure this setting lower than the `index.max_result_window` in {es}.
+The default is `1000`.
 
-| `xpack.spaces.maxSpaces`
-  | The maximum amount of Spaces that can be used with this instance of {kib}. Some operations
-  in {kib} return all spaces using a single `_search` from {es}, so this must be
-  set lower than the `index.max_result_window` in {es}.
-  Defaults to `1000`.
-
-|===
+`monitoring.cluster_alerts-allowedSpaces` {ess-icon}:: 
+Specifies the spaces where cluster alerts are automatically generated. 
+You must specify all spaces where you want to generate alerts, including the default space. 
+When the default space is unspecified, {kib} is unable to generate an alert for the default space.
+{es} clusters that run on {es} services are all containers. To send monitoring data 
+from your self-managed {es} installation to {es} services, set to `false`. 
+The default is `true`.


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [DOCS] Documents monitoring.cluster_alerts.allowedSpaces (#114669)