### PR TITLE
[Workplace Search] Fix button order and remove extra source name label

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_sidebar/private_sources_sidebar.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_sidebar/private_sources_sidebar.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiSideNav } from '@elastic/eui';
+import { EuiSideNav, EuiSideNavItemType } from '@elastic/eui';
 
 import { AppLogic } from '../../../app_logic';
 import {
@@ -35,10 +35,10 @@ export const PrivateSourcesSidebar = () => {
     : PRIVATE_VIEW_ONLY_PAGE_DESCRIPTION;
 
   const {
-    contentSource: { id = '', name = '' },
+    contentSource: { id = '' },
   } = useValues(SourceLogic);
 
-  const navItems = [{ id, name, items: useSourceSubNav() }];
+  const navItems = [{ id, items: useSourceSubNav() }] as Array<EuiSideNavItemType<unknown>>;
 
   return (
     <>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_sidebar/private_sources_sidebar.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/personal_dashboard_sidebar/private_sources_sidebar.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiSideNav, EuiSideNavItemType } from '@elastic/eui';
+import { EuiSideNav } from '@elastic/eui';
 
 import { AppLogic } from '../../../app_logic';
 import {
@@ -38,7 +38,7 @@ export const PrivateSourcesSidebar = () => {
     contentSource: { id = '' },
   } = useValues(SourceLogic);
 
-  const navItems = [{ id, items: useSourceSubNav() }] as Array<EuiSideNavItemType<unknown>>;
+  const navItems = [{ id, name: '', items: useSourceSubNav() }];
 
   return (
     <>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -119,6 +119,7 @@ export const Overview: React.FC = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const closeModal = () => setIsModalVisible(false);
   const handleSyncClick = () => setIsModalVisible(true);
+  const showSyncTriggerCallout = !custom && isIndexedSource && isOrganization;
 
   const onSyncConfirm = () => {
     initializeSourceSynchronization(id);
@@ -586,7 +587,7 @@ export const Overview: React.FC = () => {
                 )}
               </>
             )}
-            {isIndexedSource && isOrganization && syncTriggerCallout}
+            {showSyncTriggerCallout && syncTriggerCallout}
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -491,7 +491,7 @@ export const Overview: React.FC = () => {
         <EuiText size="s">
           <FormattedMessage
             id="xpack.enterpriseSearch.workplaceSearch.sources.synchronizationCallout"
-            defaultMessage="Configure {syncFrequencyLink} or permissions {blockTimeWindowsLink}."
+            defaultMessage="Configure {syncFrequencyLink} or {blockTimeWindowsLink}."
             values={{
               syncFrequencyLink: (
                 <EuiLinkTo to={getContentSourcePath(SYNC_FREQUENCY_PATH, id, isOrganization)}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_sub_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_sub_nav.tsx
@@ -37,7 +37,7 @@ export const useSourceSubNav = () => {
   if (!id) return undefined;
 
   const isCustom = serviceType === CUSTOM_SERVICE_TYPE;
-  const showSynchronization = isIndexedSource && isOrganization;
+  const showSynchronization = isIndexedSource && isOrganization && !isCustom;
 
   const navItems: Array<EuiSideNavItemType<unknown>> = [
     {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -75,9 +75,6 @@ export const Security: React.FC = () => {
   };
 
   const headerActions = [
-    <EuiButtonEmpty disabled={!unsavedChanges || dataLoading} onClick={resetState}>
-      {RESET_BUTTON}
-    </EuiButtonEmpty>,
     <EuiButton
       disabled={!hasPlatinumLicense || !unsavedChanges || dataLoading}
       onClick={showConfirmModal}
@@ -86,6 +83,9 @@ export const Security: React.FC = () => {
     >
       {SAVE_SETTINGS_BUTTON}
     </EuiButton>,
+    <EuiButtonEmpty disabled={!unsavedChanges || dataLoading} onClick={resetState}>
+      {RESET_BUTTON}
+    </EuiButtonEmpty>,
   ];
 
   const allSourcesToggle = (


### PR DESCRIPTION
## Summary

This PR fixes a few minor issues. 

1. Remove extra name from the Private source sidebar. The main subNav component now has the name visible for both org and private sources

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/1869731/137194740-abe8b275-85c8-4ea5-8af4-0cca4b7f5cc5.png)  | ![after](https://user-images.githubusercontent.com/1869731/137194735-c20f4396-b260-4d44-bd95-61be06321b55.png)  |

2. Fix the button order on the Security page to match other views.

| Before | After |
| ------------- | ------------- |
| ![before2](https://user-images.githubusercontent.com/1869731/137194969-12520131-af30-4571-99c3-df1645d2ca7c.png)  | ![after2](https://user-images.githubusercontent.com/1869731/137194972-92e296e7-0804-4039-88b3-24a7cb9f7389.png)  |

3. Fix a typo 
4. Remove Synchronization items (sidebar nav items and Sync button) from custom sources
