### PR TITLE
[Observability] [Exploratory View] remove the filter buttons from the exploratory view legend

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
@@ -183,6 +183,10 @@ const Wrapper = styled(EuiPanel)`
   width: 100%;
   overflow-x: auto;
   position: relative;
+
+  .echLegendItem__action {
+    display: none;
+  }
 `;
 
 const ShowPreview = styled(EuiButtonEmpty)`


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/114868

Hide filter buttons from the exploratory view legend

Before
<img width="118" alt="Screen Shot 2021-10-13 at 1 07 13 PM" src="https://user-images.githubusercontent.com/11356435/137201140-ea334d2e-eceb-486a-962b-b965f61631cc.png">

After
<img width="136" alt="Screen Shot 2021-10-13 at 3 30 04 PM" src="https://user-images.githubusercontent.com/11356435/137201121-81a44514-a5ca-4a31-9eed-0a063429368c.png">
