### PR TITLE
[Alerting] Updating `alert` and `action` display name to reflect new terminology

### DIFF
--- a/x-pack/plugins/actions/server/saved_objects/index.ts
+++ b/x-pack/plugins/actions/server/saved_objects/index.ts
@@ -40,6 +40,7 @@ export function setupSavedObjects(
     mappings: mappings.action as SavedObjectsTypeMappingDefinition,
     migrations: getActionsMigrations(encryptedSavedObjects),
     management: {
+      displayName: 'connector',
       defaultSearchField: 'name',
       importableAndExportable: true,
       getTitle(savedObject: SavedObject<RawAction>) {

--- a/x-pack/plugins/alerting/server/saved_objects/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/index.ts
@@ -58,6 +58,7 @@ export function setupSavedObjects(
     migrations: getMigrations(encryptedSavedObjects, isPreconfigured),
     mappings: mappings.alert as SavedObjectsTypeMappingDefinition,
     management: {
+      displayName: 'rule',
       importableAndExportable: true,
       getTitle(ruleSavedObject: SavedObject<RawAlert>) {
         return `Rule: [${ruleSavedObject.attributes.name}]`;


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/113253

## Summary

Now shows up in saved objects management UI with correct terminology

<img width="479" alt="Screen Shot 2021-10-13 at 4 56 28 PM" src="https://user-images.githubusercontent.com/13104637/137211668-e0a531ea-709e-4cb8-b6ba-950aca96a2cb.png">
<img width="992" alt="Screen Shot 2021-10-13 at 4 56 43 PM" src="https://user-images.githubusercontent.com/13104637/137211675-9fb31e82-93af-4d8f-afd1-c7155cc8b5a9.png">


