### PR TITLE
[Fleet] fix cloudwatch category assignment

### DIFF
--- a/src/plugins/home/server/tutorials/cloudwatch_logs/index.ts
+++ b/src/plugins/home/server/tutorials/cloudwatch_logs/index.ts
@@ -53,6 +53,6 @@ export function cloudwatchLogsSpecProvider(context: TutorialContext): TutorialSc
     onPrem: onPremInstructions([], context),
     elasticCloud: cloudInstructions(),
     onPremElasticCloud: onPremCloudInstructions(),
-    integrationBrowserCategories: ['security', 'network', 'web'],
+    integrationBrowserCategories: ['aws', 'cloud', 'datastore', 'security', 'network'],
   };
 }


### PR DESCRIPTION
Cloudwatch needs to be same category assignment as the aws-beats. 