### PR TITLE
[Fleet] Clean up inaccurate comments about policy templates

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_configure_package.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_configure_package.tsx
@@ -49,7 +49,6 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
   );
 
   // Configure inputs (and their streams)
-  // Assume packages only export one config template for now
   const renderConfigureInputs = () =>
     packagePolicyTemplates.length ? (
       <>

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -69,7 +69,6 @@ export async function getPackages(
 }
 
 // Get package names for packages which cannot have more than one package policy on an agent policy
-// Assume packages only export one policy template for now
 export async function getLimitedPackages(options: {
   savedObjectsClient: SavedObjectsClientContract;
 }): Promise<string[]> {


### PR DESCRIPTION
## Summary

These comments are inaccurate as we do account for multiple policy templates in a package now.

Self-shipping once CI is green.