### PR TITLE
Insights telemetry collection -- Alert Status Updates

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/insights/constants.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/insights/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const INSIGHTS_BUFFER_INTERVAL = 10_000;
+
+// TODO: Expand Telemetry UI interface to get telemetry url, etc.
+export const TELEMETRY_URL = 'foo';

--- a/x-pack/plugins/security_solution/common/detection_engine/insights/index.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/insights/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+export { InsightsService } from './insights';

--- a/x-pack/plugins/security_solution/common/detection_engine/insights/insights.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/insights/insights.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Observable, Subscription } from 'rxjs';
+
+interface AlertContext {
+  alert_id: string;
+  rule_id?: string;
+}
+
+interface DismissAlertAction {
+  dismiss_timestamp: string;
+}
+interface AcknowledgeAlertAction {
+  acknowledge_timestamp: string;
+}
+
+type InsightsContext = AlertContext;
+type InsightsAction = DismissAlertAction | AcknowledgeAlertAction;
+
+export interface InsightsPayload {
+  state: {
+    page: string;
+    pageload_timestamp: string;
+    cluster_id: string;
+    user_id: string;
+    session_id: string;
+    context: InsightsContext;
+  };
+  action: InsightsAction;
+}
+
+// Generic insights service class that works with the insights observable
+// Both server and client plugins instancates a singleton version of this class
+export class InsightsService {
+  private observable: Observable<IInsights> | null = null;
+  private subscription: Subscription | null = null;
+  private buffer: InsightsPayload[] | null = null;
+
+  public start(insights$: Observable<IInsights>) {
+    this.observable = insights$;
+    this.subscription = this.observable.subscribe(this.updateInformation.bind(this));
+  }
+
+  public stop() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+}
+
+export const isAtLeast = (insights: IInsights | null, level: InsightsType): boolean => {
+  return !!insights && insights.isAvailable && insights.isActive && insights.hasAtLeast(level);
+};

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -127,7 +127,6 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         ...coreStart,
         ...startPlugins,
         storage: this.storage,
-        security: plugins.security,
       };
       return services;
     })();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/open_close_signals_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/open_close_signals_route.ts
@@ -12,13 +12,17 @@ import {
   SetSignalsStatusSchemaDecoded,
   setSignalsStatusSchema,
 } from '../../../../../common/detection_engine/schemas/request/set_signal_status_schema';
+import { SetupPlugins } from '../../../../plugin';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { DETECTION_ENGINE_SIGNALS_STATUS_URL } from '../../../../../common/constants';
 import { buildSiemResponse } from '../utils';
 
 import { buildRouteValidation } from '../../../../utils/build_validation/route_validation';
 
-export const setSignalsStatusRoute = (router: SecuritySolutionPluginRouter) => {
+export const setSignalsStatusRoute = (
+  router: SecuritySolutionPluginRouter,
+  security: SetupPlugins['security']
+) => {
   router.post(
     {
       path: DETECTION_ENGINE_SIGNALS_STATUS_URL,
@@ -58,6 +62,16 @@ export const setSignalsStatusRoute = (router: SecuritySolutionPluginRouter) => {
         };
       }
       try {
+        // TODO: Add INSIGHTS Payload Creation and publication here.
+        /*
+         InsightsService.addAlertStatusUpdates(
+           alert_ids: string[],
+           status: string,
+           security: SetupPlugins['security'],
+           cluster_id: string,
+
+           )
+        */
         const { body } = await esClient.updateByQuery({
           index: siemClient.getSignalsIndex(),
           conflicts: conflicts ?? 'abort',

--- a/x-pack/plugins/security_solution/server/lib/telemetry/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/__mocks__/index.ts
@@ -8,8 +8,24 @@
 import { ConcreteTaskInstance, TaskStatus } from '../../../../../task_manager/server';
 import { TelemetryEventsSender } from '../sender';
 import { TelemetryReceiver } from '../receiver';
+import { TelemetryCoordinator } from '../coordinator';
 import { SecurityTelemetryTaskConfig } from '../task';
 import { PackagePolicy } from '../../../../../fleet/common/types/models/package_policy';
+
+export const createMockTelemetryCoordinator = (
+  enableTelemetry?: boolean
+): jest.Mocked<TelemetryCoordinator> => {
+  return {
+    setup: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    fetchTelemetryUrl: jest.fn(),
+    queueTelemetryEvents: jest.fn(),
+    isTelemetryOptedIn: jest.fn().mockReturnValue(enableTelemetry ?? jest.fn()),
+    sendIfDue: jest.fn(),
+    sendOnDemand: jest.fn(),
+  } as unknown as jest.Mocked<TelemetryCoordinator>;
+};
 
 /**
  * Creates a mocked Telemetry Events Sender

--- a/x-pack/plugins/security_solution/server/lib/telemetry/constants.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/constants.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+export const TELEMETRY_USAGE_LABEL_PREFIX: string[] = ['security_telemetry'];
+
 export const TELEMETRY_MAX_BUFFER_SIZE = 100;
 
 export const MAX_SECURITY_LIST_TELEMETRY_BATCH = 100;

--- a/x-pack/plugins/security_solution/server/lib/telemetry/coordinator.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/coordinator.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cloneDeep } from 'lodash';
+import { Logger } from 'src/core/server';
+import { UsageCounter } from 'src/plugins/usage_collection/server';
+import { TelemetryPluginStart, TelemetryPluginSetup } from 'src/plugins/telemetry/server';
+import { TelemetryEventsSender } from './sender';
+import { TelemetryReceiver } from './receiver';
+import { TelemetryEvent } from './types';
+import { createTelemetryTaskConfigs } from './tasks';
+import { createUsageCounterLabel } from './helpers';
+import {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '../../../../task_manager/server';
+import { TELEMETRY_MAX_BUFFER_SIZE, TELEMETRY_USAGE_LABEL_PREFIX } from './constants';
+import { SecurityTelemetryTask, SecurityTelemetryTaskConfig } from './task';
+
+const USAGE_LABEL_PREFIX: string[] = TELEMETRY_USAGE_LABEL_PREFIX.concat(['coordinator']);
+
+export class TelemetryCoordinator {
+  private readonly initialCheckDelayMs = 10 * 1000;
+  private readonly checkIntervalMs = 60 * 1000;
+  private readonly logger: Logger;
+  private maxQueueSize = TELEMETRY_MAX_BUFFER_SIZE;
+  private telemetryStart?: TelemetryPluginStart;
+  private telemetrySetup?: TelemetryPluginSetup;
+  private intervalId?: NodeJS.Timeout;
+  private isSending = false;
+  private queue: TelemetryEvent[] = [];
+  private isOptedIn?: boolean = true; // Assume true until the first check
+  private telemetryUsageCounter?: UsageCounter;
+  private telemetryTasks?: SecurityTelemetryTask[];
+  private sender: TelemetryEventsSender;
+  private receiver: TelemetryReceiver | undefined;
+
+  constructor(logger: Logger) {
+    this.logger = logger.get('telemetry_events');
+    this.sender = new TelemetryEventsSender(this.logger);
+  }
+
+  public async isTelemetryOptedIn() {
+    this.isOptedIn = await this.telemetryStart?.getIsOptedIn();
+    return this.isOptedIn === true;
+  }
+
+  public queueTelemetryEvents(events: TelemetryEvent[]) {
+    const qlength = this.queue.length;
+
+    if (events.length === 0) {
+      return;
+    }
+
+    this.logger.debug(`Queue events`);
+
+    if (qlength >= this.maxQueueSize) {
+      // we're full already
+      return;
+    }
+
+    if (events.length > this.maxQueueSize - qlength) {
+      this.telemetryUsageCounter?.incrementCounter({
+        counterName: createUsageCounterLabel(USAGE_LABEL_PREFIX.concat(['queue_stats'])),
+        counterType: 'docs_lost',
+        incrementBy: events.length,
+      });
+      this.telemetryUsageCounter?.incrementCounter({
+        counterName: createUsageCounterLabel(USAGE_LABEL_PREFIX.concat(['queue_stats'])),
+        counterType: 'num_capacity_exceeded',
+        incrementBy: 1,
+      });
+      this.queue.push(...this.sender.processEvents(events.slice(0, this.maxQueueSize - qlength)));
+    } else {
+      this.queue.push(...this.sender.processEvents(events));
+    }
+  }
+
+  private async sendIfDue() {
+    if (this.isSending) {
+      return;
+    }
+
+    if (this.queue.length === 0) {
+      return;
+    }
+
+    try {
+      this.isSending = true;
+      this.isOptedIn = await this.isTelemetryOptedIn();
+      if (!this.isOptedIn) {
+        this.logger.debug(`Telemetry is not opted-in.`);
+        this.queue = [];
+        this.isSending = false;
+        return;
+      }
+
+      const [telemetryUrl, clusterInfo, licenseInfo] = await Promise.all([
+        this.sender.fetchTelemetryUrl('alerts-endpoint'),
+        this.receiver?.fetchClusterInfo(),
+        this.receiver?.fetchLicenseInfo(),
+      ]);
+
+      this.logger.debug(`Telemetry URL: ${telemetryUrl}`);
+      this.logger.debug(
+        `cluster_uuid: ${clusterInfo?.cluster_uuid} cluster_name: ${clusterInfo?.cluster_name}`
+      );
+
+      const toSend: TelemetryEvent[] = cloneDeep(this.queue).map((event) => ({
+        ...event,
+        ...(licenseInfo ? { license: this.receiver?.copyLicenseFields(licenseInfo) } : {}),
+        cluster_uuid: clusterInfo?.cluster_uuid,
+        cluster_name: clusterInfo?.cluster_name,
+      }));
+      this.queue = [];
+
+      await this.sender.sendEvents(
+        toSend,
+        telemetryUrl,
+        'alerts-endpoint',
+        clusterInfo?.cluster_uuid,
+        clusterInfo?.version?.number,
+        licenseInfo?.uid
+      );
+    } catch (err) {
+      this.logger.warn(`Error sending telemetry events data: ${err}`);
+      this.queue = [];
+    }
+    this.isSending = false;
+  }
+
+  /**
+   * This function sends events to the elastic telemetry channel. Caution is required
+   * because it does no allowlist filtering at send time. The function call site is
+   * responsible for ensuring sure no sensitive material is in telemetry events.
+   *
+   * @param channel the elastic telemetry channel
+   * @param toSend telemetry events
+   */
+  public async sendOnDemand(channel: string, toSend: unknown[]) {
+    try {
+      const [telemetryUrl, clusterInfo, licenseInfo] = await Promise.all([
+        this.sender.fetchTelemetryUrl(channel),
+        this.receiver?.fetchClusterInfo(),
+        this.receiver?.fetchLicenseInfo(),
+      ]);
+
+      this.logger.debug(`Telemetry URL: ${telemetryUrl}`);
+      this.logger.debug(
+        `cluster_uuid: ${clusterInfo?.cluster_uuid} cluster_name: ${clusterInfo?.cluster_name}`
+      );
+
+      await this.sender.sendEvents(
+        toSend,
+        telemetryUrl,
+        channel,
+        clusterInfo?.cluster_uuid,
+        clusterInfo?.version?.number,
+        licenseInfo?.uid
+      );
+    } catch (err) {
+      this.logger.warn(`Error sending telemetry events data: ${err}`);
+    }
+  }
+
+  public setup(
+    telemetryReceiver: TelemetryReceiver,
+    telemetrySetup?: TelemetryPluginSetup,
+    taskManager?: TaskManagerSetupContract,
+    telemetryUsageCounter?: UsageCounter
+  ) {
+    this.telemetrySetup = telemetrySetup;
+    this.telemetryUsageCounter = telemetryUsageCounter;
+    if (taskManager) {
+      this.telemetryTasks = createTelemetryTaskConfigs().map(
+        (config: SecurityTelemetryTaskConfig) => {
+          const task = new SecurityTelemetryTask(
+            config,
+            this.logger,
+            this.sender,
+            telemetryReceiver
+          );
+          task.register(taskManager);
+          return task;
+        }
+      );
+    }
+  }
+
+  public start(
+    telemetryStart?: TelemetryPluginStart,
+    taskManager?: TaskManagerStartContract,
+    receiver?: TelemetryReceiver
+  ) {
+    this.telemetryStart = telemetryStart;
+    this.receiver = receiver;
+
+    if (taskManager && this.telemetryTasks) {
+      this.logger.debug(`Starting security telemetry tasks`);
+      this.telemetryTasks.forEach((task) => task.start(taskManager));
+    }
+
+    this.logger.debug(`Starting local task`);
+    setTimeout(() => {
+      this.sendIfDue();
+      this.intervalId = setInterval(() => this.sendIfDue(), this.checkIntervalMs);
+    }, this.initialCheckDelayMs);
+  }
+
+  public stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/server/lib/telemetry/coordinator.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/coordinator.ts
@@ -36,12 +36,13 @@ export class TelemetryCoordinator {
   private isOptedIn?: boolean = true; // Assume true until the first check
   private telemetryUsageCounter?: UsageCounter;
   private telemetryTasks?: SecurityTelemetryTask[];
-  private sender: TelemetryEventsSender;
-  private receiver: TelemetryReceiver | undefined;
+  public sender: TelemetryEventsSender;
+  public receiver: TelemetryReceiver;
 
   constructor(logger: Logger) {
     this.logger = logger.get('telemetry_events');
     this.sender = new TelemetryEventsSender(this.logger);
+    this.receiver = new TelemetryReceiver(this.logger);
   }
 
   public async isTelemetryOptedIn() {
@@ -178,12 +179,7 @@ export class TelemetryCoordinator {
     if (taskManager) {
       this.telemetryTasks = createTelemetryTaskConfigs().map(
         (config: SecurityTelemetryTaskConfig) => {
-          const task = new SecurityTelemetryTask(
-            config,
-            this.logger,
-            this.sender,
-            telemetryReceiver
-          );
+          const task = new SecurityTelemetryTask(config, this.logger, this);
           task.register(taskManager);
           return task;
         }
@@ -192,9 +188,9 @@ export class TelemetryCoordinator {
   }
 
   public start(
+    receiver: TelemetryReceiver,
     telemetryStart?: TelemetryPluginStart,
-    taskManager?: TaskManagerStartContract,
-    receiver?: TelemetryReceiver
+    taskManager?: TaskManagerStartContract
   ) {
     this.telemetryStart = telemetryStart;
     this.receiver = receiver;

--- a/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts
@@ -13,94 +13,34 @@ import { Logger } from 'src/core/server';
 import { TelemetryPluginStart, TelemetryPluginSetup } from 'src/plugins/telemetry/server';
 import { UsageCounter } from 'src/plugins/usage_collection/server';
 import { TelemetryEvent } from './types';
-/*
-import {
-  TaskManagerSetupContract,
-  TaskManagerStartContract,
-} from '../../../../task_manager/server';
-*/
-// /import { TelemetryReceiver } from './receiver';
 import { allowlistEventFields, copyAllowlistedFields } from './filters';
-// /import { createTelemetryTaskConfigs } from './tasks';
 import { createUsageCounterLabel } from './helpers';
-// /import { TelemetryEvent } from './types';
-// /import { TELEMETRY_MAX_BUFFER_SIZE } from './constants';
 import { TELEMETRY_USAGE_LABEL_PREFIX } from './constants';
-// /import { SecurityTelemetryTask, SecurityTelemetryTaskConfig } from './task';
 
 const USAGE_LABEL_PREFIX: string[] = TELEMETRY_USAGE_LABEL_PREFIX.concat(['sender']);
 
 export class TelemetryEventsSender {
-  // /private readonly initialCheckDelayMs = 10 * 1000;
-  // /private readonly checkIntervalMs = 60 * 1000;
   private readonly logger: Logger;
-  // /private maxQueueSize = TELEMETRY_MAX_BUFFER_SIZE;
   private telemetryStart?: TelemetryPluginStart;
   private telemetrySetup?: TelemetryPluginSetup;
-  // /private intervalId?: NodeJS.Timeout;
-  // /private isSending = false;
-  // /private receiver: TelemetryReceiver | undefined;
-  // /private queue: TelemetryEvent[] = [];
-  // /private isOptedIn?: boolean = true; // Assume true until the first check
 
   private telemetryUsageCounter?: UsageCounter;
-  // /private telemetryTasks?: SecurityTelemetryTask[];
 
   constructor(logger: Logger) {
     this.logger = logger.get('telemetry_events');
   }
 
-  public setup(
-    // /telemetryReceiver: TelemetryReceiver,
-    telemetrySetup?: TelemetryPluginSetup,
-    // /taskManager?: TaskManagerSetupContract,
-    telemetryUsageCounter?: UsageCounter
-  ) {
+  public setup(telemetrySetup?: TelemetryPluginSetup, telemetryUsageCounter?: UsageCounter) {
     this.telemetrySetup = telemetrySetup;
     this.telemetryUsageCounter = telemetryUsageCounter;
-    /*  
-    if (taskManager) {
-      this.telemetryTasks = createTelemetryTaskConfigs().map(
-        (config: SecurityTelemetryTaskConfig) => {
-          const task = new SecurityTelemetryTask(config, this.logger, this, telemetryReceiver);
-          task.register(taskManager);
-          return task;
-        }
-      );
-    }
-    */
   }
 
-  public start(
-    telemetryStart?: TelemetryPluginStart
-    // /taskManager?: TaskManagerStartContract,
-    // /receiver?: TelemetryReceiver
-  ) {
+  public start(telemetryStart?: TelemetryPluginStart) {
     this.telemetryStart = telemetryStart;
-    // /this.receiver = receiver;
-
-    /*
-    if (taskManager && this.telemetryTasks) {
-      this.logger.debug(`Starting security telemetry tasks`);
-      this.telemetryTasks.forEach((task) => task.start(taskManager));
-    }
-    */
-
     this.logger.debug(`Starting local task`);
-    /*
-    setTimeout(() => {
-      this.sendIfDue();
-      this.intervalId = setInterval(() => this.sendIfDue(), this.checkIntervalMs);
-    }, this.initialCheckDelayMs);
-    */
   }
 
   public stop() {
-    /*
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-    }
-    */
     this.logger.debug('Stopping Telemetry Sender.');
   }
 

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/detection_rule.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/detection_rule.test.ts
@@ -7,7 +7,7 @@
 
 import { loggingSystemMock } from 'src/core/server/mocks';
 import { createTelemetryDetectionRuleListsTaskConfig } from './detection_rule';
-import { createMockTelemetryEventsSender, createMockTelemetryReceiver } from '../__mocks__';
+import { createMockTelemetryCoordinator } from '../__mocks__';
 
 describe('security detection rule task test', () => {
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
@@ -21,18 +21,16 @@ describe('security detection rule task test', () => {
       last: undefined,
       current: new Date().toISOString(),
     };
-    const mockTelemetryEventsSender = createMockTelemetryEventsSender();
-    const mockTelemetryReceiver = createMockTelemetryReceiver();
+    const mockTelemetryCoordinator = createMockTelemetryCoordinator();
     const telemetryDetectionRuleListsTaskConfig = createTelemetryDetectionRuleListsTaskConfig(1);
 
     await telemetryDetectionRuleListsTaskConfig.runTask(
       'test-id',
       logger,
-      mockTelemetryReceiver,
-      mockTelemetryEventsSender,
+      mockTelemetryCoordinator,
       testTaskExecutionPeriod
     );
 
-    expect(mockTelemetryReceiver.fetchDetectionRules).toHaveBeenCalled();
+    expect(mockTelemetryCoordinator.receiver.fetchDetectionRules).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.test.ts
@@ -7,7 +7,7 @@
 
 import { loggingSystemMock } from 'src/core/server/mocks';
 import { createTelemetryDiagnosticsTaskConfig } from './diagnostic';
-import { createMockTelemetryEventsSender, createMockTelemetryReceiver } from '../__mocks__';
+import { createMockTelemetryCoordinator } from '../__mocks__';
 
 describe('diagnostics telemetry task test', () => {
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
@@ -26,24 +26,22 @@ describe('diagnostics telemetry task test', () => {
       last: new Date().toISOString(),
       current: new Date().toISOString(),
     };
-    const mockTelemetryEventsSender = createMockTelemetryEventsSender();
-    const mockTelemetryReceiver = createMockTelemetryReceiver(testDiagnosticsAlerts);
+    const mockTelemetryCoordinator = createMockTelemetryCoordinator();
     const telemetryDiagnoticsTaskConfig = createTelemetryDiagnosticsTaskConfig();
 
     await telemetryDiagnoticsTaskConfig.runTask(
       'test-id',
       logger,
-      mockTelemetryReceiver,
-      mockTelemetryEventsSender,
+      mockTelemetryCoordinator,
       testTaskExecutionPeriod
     );
 
-    expect(mockTelemetryReceiver.fetchDiagnosticAlerts).toHaveBeenCalledWith(
+    expect(mockTelemetryCoordinator.receiver.fetchDiagnosticAlerts).toHaveBeenCalledWith(
       testTaskExecutionPeriod.last,
       testTaskExecutionPeriod.current
     );
 
-    expect(mockTelemetryEventsSender.queueTelemetryEvents).toHaveBeenCalledWith(
+    expect(mockTelemetryCoordinator.queueTelemetryEvents).toHaveBeenCalledWith(
       testDiagnosticsAlerts.hits.hits.flatMap((doc) => [doc._source])
     );
   });

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.ts
@@ -7,9 +7,8 @@
 
 import { Logger } from 'src/core/server';
 import { getPreviousDiagTaskTimestamp } from '../helpers';
-import { TelemetryEventsSender } from '../sender';
+import { TelemetryCoordinator } from '../coordinator';
 import { TelemetryEvent } from '../types';
-import { TelemetryReceiver } from '../receiver';
 import { TaskExecutionPeriod } from '../task';
 
 export function createTelemetryDiagnosticsTaskConfig() {
@@ -23,15 +22,14 @@ export function createTelemetryDiagnosticsTaskConfig() {
     runTask: async (
       taskId: string,
       logger: Logger,
-      receiver: TelemetryReceiver,
-      sender: TelemetryEventsSender,
+      coordinator: TelemetryCoordinator,
       taskExecutionPeriod: TaskExecutionPeriod
     ) => {
       if (!taskExecutionPeriod.last) {
         throw new Error('last execution timestamp is required');
       }
 
-      const response = await receiver.fetchDiagnosticAlerts(
+      const response = await coordinator.receiver.fetchDiagnosticAlerts(
         taskExecutionPeriod.last,
         taskExecutionPeriod.current
       );
@@ -46,7 +44,7 @@ export function createTelemetryDiagnosticsTaskConfig() {
       const diagAlerts: TelemetryEvent[] = hits.flatMap((h) =>
         h._source != null ? [h._source] : []
       );
-      sender.queueTelemetryEvents(diagAlerts);
+      coordinator.queueTelemetryEvents(diagAlerts);
       return diagAlerts.length;
     },
   };

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/endpoint.test.ts
@@ -7,7 +7,7 @@
 
 import { loggingSystemMock } from 'src/core/server/mocks';
 import { createTelemetryEndpointTaskConfig } from './endpoint';
-import { createMockTelemetryEventsSender, createMockTelemetryReceiver } from '../__mocks__';
+import { createMockTelemetryCoordinator } from '../__mocks__';
 
 describe('endpoint telemetry task test', () => {
   let logger: ReturnType<typeof loggingSystemMock.createLogger>;
@@ -21,24 +21,22 @@ describe('endpoint telemetry task test', () => {
       last: new Date().toISOString(),
       current: new Date().toISOString(),
     };
-    const mockTelemetryEventsSender = createMockTelemetryEventsSender();
-    const mockTelemetryReceiver = createMockTelemetryReceiver();
+    const mockTelemetryCoordinator = createMockTelemetryCoordinator();
     const telemetryEndpointTaskConfig = createTelemetryEndpointTaskConfig(1);
 
     await telemetryEndpointTaskConfig.runTask(
       'test-id',
       logger,
-      mockTelemetryReceiver,
-      mockTelemetryEventsSender,
+      mockTelemetryCoordinator,
       testTaskExecutionPeriod
     );
 
-    expect(mockTelemetryReceiver.fetchFleetAgents).toHaveBeenCalled();
-    expect(mockTelemetryReceiver.fetchEndpointMetrics).toHaveBeenCalledWith(
+    expect(mockTelemetryCoordinator.receiver.fetchFleetAgents).toHaveBeenCalled();
+    expect(mockTelemetryCoordinator.receiver.fetchEndpointMetrics).toHaveBeenCalledWith(
       testTaskExecutionPeriod.last,
       testTaskExecutionPeriod.current
     );
-    expect(mockTelemetryReceiver.fetchEndpointPolicyResponses).toHaveBeenCalledWith(
+    expect(mockTelemetryCoordinator.receiver.fetchEndpointPolicyResponses).toHaveBeenCalledWith(
       testTaskExecutionPeriod.last,
       testTaskExecutionPeriod.current
     );

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/security_lists.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/security_lists.test.ts
@@ -7,7 +7,7 @@
 
 import { loggingSystemMock } from 'src/core/server/mocks';
 import { createTelemetrySecurityListTaskConfig } from './security_lists';
-import { createMockTelemetryEventsSender, createMockTelemetryReceiver } from '../__mocks__';
+import { createMockTelemetryCoordinator } from '../__mocks__';
 import {
   ENDPOINT_LIST_ID,
   ENDPOINT_EVENT_FILTERS_LIST_ID,
@@ -25,21 +25,21 @@ describe('security list telemetry task test', () => {
       last: undefined,
       current: new Date().toISOString(),
     };
-    const mockTelemetryEventsSender = createMockTelemetryEventsSender();
-    const mockTelemetryReceiver = createMockTelemetryReceiver();
+    const mockTelemetryCoordinator = createMockTelemetryCoordinator();
     const telemetrySecurityListTaskConfig = createTelemetrySecurityListTaskConfig(1);
 
     await telemetrySecurityListTaskConfig.runTask(
       'test-id',
       logger,
-      mockTelemetryReceiver,
-      mockTelemetryEventsSender,
+      mockTelemetryCoordinator,
       testTaskExecutionPeriod
     );
 
-    expect(mockTelemetryReceiver.fetchTrustedApplications).toHaveBeenCalled();
-    expect(mockTelemetryReceiver.fetchEndpointList).toHaveBeenCalledWith(ENDPOINT_LIST_ID);
-    expect(mockTelemetryReceiver.fetchEndpointList).toHaveBeenCalledWith(
+    expect(mockTelemetryCoordinator.receiver.fetchTrustedApplications).toHaveBeenCalled();
+    expect(mockTelemetryCoordinator.receiver.fetchEndpointList).toHaveBeenCalledWith(
+      ENDPOINT_LIST_ID
+    );
+    expect(mockTelemetryCoordinator.receiver.fetchEndpointList).toHaveBeenCalledWith(
       ENDPOINT_EVENT_FILTERS_LIST_ID
     );
   });

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/security_lists.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/security_lists.ts
@@ -17,8 +17,7 @@ import {
   TELEMETRY_CHANNEL_LISTS,
 } from '../constants';
 import { batchTelemetryRecords, templateExceptionList } from '../helpers';
-import { TelemetryEventsSender } from '../sender';
-import { TelemetryReceiver } from '../receiver';
+import { TelemetryCoordinator } from '../coordinator';
 import { TaskExecutionPeriod } from '../task';
 
 export function createTelemetrySecurityListTaskConfig(maxTelemetryBatch: number) {
@@ -31,48 +30,49 @@ export function createTelemetrySecurityListTaskConfig(maxTelemetryBatch: number)
     runTask: async (
       taskId: string,
       logger: Logger,
-      receiver: TelemetryReceiver,
-      sender: TelemetryEventsSender,
+      coordinator: TelemetryCoordinator,
       taskExecutionPeriod: TaskExecutionPeriod
     ) => {
       let count = 0;
 
       // Lists Telemetry: Trusted Applications
 
-      const trustedApps = await receiver.fetchTrustedApplications();
+      const trustedApps = await coordinator.receiver.fetchTrustedApplications();
       if (trustedApps?.data) {
         const trustedAppsJson = templateExceptionList(trustedApps.data, LIST_TRUSTED_APPLICATION);
         logger.debug(`Trusted Apps: ${trustedAppsJson}`);
         count += trustedAppsJson.length;
 
         batchTelemetryRecords(trustedAppsJson, maxTelemetryBatch).forEach((batch) =>
-          sender.sendOnDemand(TELEMETRY_CHANNEL_LISTS, batch)
+          coordinator.sendOnDemand(TELEMETRY_CHANNEL_LISTS, batch)
         );
       }
 
       // Lists Telemetry: Endpoint Exceptions
 
-      const epExceptions = await receiver.fetchEndpointList(ENDPOINT_LIST_ID);
+      const epExceptions = await coordinator.receiver.fetchEndpointList(ENDPOINT_LIST_ID);
       if (epExceptions?.data) {
         const epExceptionsJson = templateExceptionList(epExceptions.data, LIST_ENDPOINT_EXCEPTION);
         logger.debug(`EP Exceptions: ${epExceptionsJson}`);
         count += epExceptionsJson.length;
 
         batchTelemetryRecords(epExceptionsJson, maxTelemetryBatch).forEach((batch) =>
-          sender.sendOnDemand(TELEMETRY_CHANNEL_LISTS, batch)
+          coordinator.sendOnDemand(TELEMETRY_CHANNEL_LISTS, batch)
         );
       }
 
       // Lists Telemetry: Endpoint Event Filters
 
-      const epFilters = await receiver.fetchEndpointList(ENDPOINT_EVENT_FILTERS_LIST_ID);
+      const epFilters = await coordinator.receiver.fetchEndpointList(
+        ENDPOINT_EVENT_FILTERS_LIST_ID
+      );
       if (epFilters?.data) {
         const epFiltersJson = templateExceptionList(epFilters.data, LIST_ENDPOINT_EVENT_FILTER);
         logger.debug(`EP Event Filters: ${epFiltersJson}`);
         count += epFiltersJson.length;
 
         batchTelemetryRecords(epFiltersJson, maxTelemetryBatch).forEach((batch) =>
-          sender.sendOnDemand(TELEMETRY_CHANNEL_LISTS, batch)
+          coordinator.sendOnDemand(TELEMETRY_CHANNEL_LISTS, batch)
         );
       }
 

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -96,6 +96,7 @@ import {
 import { licenseService } from './lib/license';
 import { PolicyWatcher } from './endpoint/lib/policy/license_watch';
 import { parseExperimentalConfigValue } from '../common/experimental_features';
+import { InsightsService } from '../common/detection_engine/insights';
 import { migrateArtifactsToFleet } from './endpoint/lib/artifacts/migrate_artifacts_to_fleet';
 import aadFieldConversion from './lib/detection_engine/routes/index/signal_aad_mapping.json';
 import { alertsFieldMap } from './lib/detection_engine/rule_types/field_maps/alerts';
@@ -165,6 +166,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
   private checkMetadataTransformsTask: CheckMetadataTransformsTask | undefined;
   private artifactsCache: LRU<string, Buffer>;
   private telemetryUsageCounter?: UsageCounter;
+  private insightsService: InsightsService;
 
   constructor(context: PluginInitializerContext) {
     this.context = context;
@@ -175,6 +177,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     this.artifactsCache = new LRU<string, Buffer>({ max: 3, maxAge: 1000 * 60 * 5 });
     this.telemetryEventsSender = new TelemetryEventsSender(this.logger);
     this.telemetryReceiver = new TelemetryReceiver(this.logger);
+    // How do we initialize the InsightsService Here? The ClusterID is passed in at constructor time, though it doesn't need to be?
 
     this.logger.debug('plugin initialized');
   }
@@ -295,6 +298,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       );
     }
 
+    // TODO: Pass InsightsService into the initRoutes?
     // TODO We need to get the endpoint routes inside of initRoutes
     initRoutes(
       router,

--- a/x-pack/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/plugins/security_solution/server/routes/index.ts
@@ -118,7 +118,7 @@ export const initRoutes = (
   // Detection Engine Signals routes that have the REST endpoints of /api/detection_engine/signals
   // POST /api/detection_engine/signals/status
   // Example usage can be found in security_solution/server/lib/detection_engine/scripts/signals
-  setSignalsStatusRoute(router);
+  setSignalsStatusRoute(router, security);
   querySignalsRoute(router, config);
   getSignalsMigrationStatusRoute(router);
   createSignalsMigrationRoute(router, security);


### PR DESCRIPTION
## Summary

This PR is intended to be an initial implementation of collecting client-side insights telemetry inside the detection engine for  
usage of product improvement and eventual recommendation systems. More context can be found here: https://github.com/elastic/security-team/issues/1423


 To that effect, the PR will add the following:
- [ ] Expand the telemetry plugin to allow for client-side importers to grab the infra telemetry channel info at runtime
- [ ] Instrument `updateAlertStatus` api to emit insights events to the `InsightsService` when alert statuses are modified
- [ ] Ensure that InsightsService uses `rxjs` Observables with a buffer to minimize user performance impact.
- [ ] Ensure that the InsightsService respects the `telemetryStart?.getIsOptedIn()` setting when determining whether to emit events
- [ ] Ensure that the InsightsService only emits events for Cloud users.
- [ ] Ensure that the InsightsService anonymizes userinfo with a hash+salt.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)

### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
