### PR TITLE
[Security Solution][Endpoint] Small adjustments in policy page

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/flyout/policy_trusted_apps_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/flyout/policy_trusted_apps_flyout.tsx
@@ -241,7 +241,7 @@ export const PolicyTrustedAppsFlyout = React.memo(() => {
             >
               <FormattedMessage
                 id="xpack.securitySolution.endpoint.policy.trustedApps.layout.flyout.confirm"
-                defaultMessage="Assing to {policyName}"
+                defaultMessage="Assign to {policyName}"
                 values={{
                   policyName,
                 }}

--- a/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/trusted_apps_grid/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/trusted_apps/view/components/trusted_apps_grid/index.tsx
@@ -54,7 +54,7 @@ const RootWrapper = styled.div`
 
 const BACK_TO_TRUSTED_APPS_LABEL = i18n.translate(
   'xpack.securitySolution.trustedapps.grid.policyDetailsLinkBackLabel',
-  { defaultMessage: 'Back to trusted Applications' }
+  { defaultMessage: 'Back to trusted applications' }
 );
 
 const EDIT_TRUSTED_APP_ACTION_LABEL = i18n.translate(
@@ -120,6 +120,12 @@ export const TrustedAppsGrid = memo(() => {
               ],
               href: getAppUrl({ path: currentPagePath }),
             },
+            onCancelNavigateTo: [
+              APP_ID,
+              {
+                path: currentPagePath,
+              },
+            ],
           };
 
           policyToNavOptionsMap[policyId] = {


### PR DESCRIPTION
## Summary

- Correct the capitalization in the trusted apps breadcrum

- Typo on Assign to "Policy" button on Policy details flyout

- Can we ensure that the cancel button takes the user back to the trusted apps list page instead of the endpoint list page


![policy page adjustments](https://user-images.githubusercontent.com/15727784/137282868-5a65efd4-8f69-4de8-92e7-22492d7ab291.gif)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
