### PR TITLE
[Security Solution][Endpoint] Remove refresh button from policy trusted apps flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/search_exceptions/search_exceptions.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/search_exceptions/search_exceptions.test.tsx
@@ -15,23 +15,10 @@ import {
 import { EndpointDocGenerator } from '../../../../common/endpoint/generate_data';
 
 import { SearchExceptions, SearchExceptionsProps } from '.';
+jest.mock('../../../common/components/user_privileges/use_endpoint_privileges');
 
 let onSearchMock: jest.Mock;
 const mockUseEndpointPrivileges = useEndpointPrivileges as jest.Mock;
-
-jest.mock('../../../common/components/user_privileges/use_endpoint_privileges', () => {
-  return {
-    ...jest.requireActual('../../../common/components/user_privileges/use_endpoint_privileges'),
-    useEndpointPrivileges: jest.fn(() => {
-      return {
-        loading: false,
-        canAccessEndpointManagement: true,
-        canAccessFleet: false,
-        isPlatinumPlus: true,
-      };
-    }),
-  };
-});
 
 describe('Search exceptions', () => {
   let appTestContext: AppContextTestRender;

--- a/x-pack/plugins/security_solution/public/management/components/search_exceptions/search_exceptions.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/search_exceptions/search_exceptions.tsx
@@ -19,6 +19,7 @@ export interface SearchExceptionsProps {
   policyList?: ImmutableArray<PolicyData>;
   defaultExcludedPolicies?: string;
   defaultIncludedPolicies?: string;
+  hideRefreshButton?: boolean;
   onSearch(query: string, includedPolicies?: string, excludedPolicies?: string): void;
 }
 
@@ -31,6 +32,7 @@ export const SearchExceptions = memo<SearchExceptionsProps>(
     policyList,
     defaultIncludedPolicies,
     defaultExcludedPolicies,
+    hideRefreshButton = false,
   }) => {
     const { isPlatinumPlus } = useEndpointPrivileges();
     const [query, setQuery] = useState<string>(defaultValue);
@@ -101,13 +103,15 @@ export const SearchExceptions = memo<SearchExceptionsProps>(
           </EuiFlexItem>
         ) : null}
 
-        <EuiFlexItem grow={false} onClick={handleOnSearch} data-test-subj="searchButton">
-          <EuiButton iconType="refresh">
-            {i18n.translate('xpack.securitySolution.management.search.button', {
-              defaultMessage: 'Refresh',
-            })}
-          </EuiButton>
-        </EuiFlexItem>
+        {!hideRefreshButton ? (
+          <EuiFlexItem grow={false} onClick={handleOnSearch} data-test-subj="searchButton">
+            <EuiButton iconType="refresh">
+              {i18n.translate('xpack.securitySolution.management.search.button', {
+                defaultMessage: 'Refresh',
+              })}
+            </EuiButton>
+          </EuiFlexItem>
+        ) : null}
       </EuiFlexGroup>
     );
   }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/flyout/policy_trusted_apps_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/flyout/policy_trusted_apps_flyout.tsx
@@ -182,6 +182,7 @@ export const PolicyTrustedAppsFlyout = React.memo(() => {
               defaultMessage: 'Search trusted applications',
             }
           )}
+          hideRefreshButton
         />
         <EuiSpacer size="m" />
 


### PR DESCRIPTION
## Summary

- Removes refresh button on TA flyout and refactors unit test.

![hide refresh button](https://user-images.githubusercontent.com/15727784/137302602-89e08cbc-68f2-4068-a554-a5f8ddf682d5.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
