### PR TITLE
[Stack monitoring] Fix clusters functional tests when react is enabled

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/cluster/overview_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/cluster/overview_page.tsx
@@ -50,7 +50,7 @@ export const ClusterOverview: React.FC<{}> = () => {
       {
         id: 'clusterName',
         label: clusters[0].cluster_name,
-        testSubj: 'clusterName',
+        testSubj: 'overviewTabsclusterName',
         route: '/overview',
       },
     ];

--- a/x-pack/plugins/monitoring/public/application/route_init.tsx
+++ b/x-pack/plugins/monitoring/public/application/route_init.tsx
@@ -57,7 +57,7 @@ export const RouteInit: React.FC<RouteInitProps> = ({
 
     // check if we need to redirect because of attempt at unsupported multi-cluster monitoring
     const clusterSupported = cluster.isSupported || clusters.length === 1;
-    if (location.pathname !== 'home' && !clusterSupported) {
+    if (location.pathname !== '/home' && !clusterSupported) {
       return <Redirect to="/home" />;
     }
   }

--- a/x-pack/plugins/monitoring/public/directives/main/index.html
+++ b/x-pack/plugins/monitoring/public/directives/main/index.html
@@ -299,7 +299,7 @@
     </div>
 
     <div ng-if="monitoringMain.inOverview" class="euiTabs" role="navigation">
-      <a class="euiTab" data-test-subj="clusterName">{{ pageData.cluster_name }}</a>
+      <a class="euiTab" data-test-subj="overviewTabsclusterName">{{ pageData.cluster_name }}</a>
     </div>
 
     <div ng-if="monitoringMain.inAlerts" class="euiTabs" role="navigation">

--- a/x-pack/test/functional/services/monitoring/cluster_overview.js
+++ b/x-pack/test/functional/services/monitoring/cluster_overview.js
@@ -12,8 +12,7 @@ export function MonitoringClusterOverviewProvider({ getService }) {
   const retry = getService('retry');
 
   const SUBJ_CLUSTER_ALERTS = `clusterAlertsContainer`;
-  const SUBJ_CLUSTER_OVERVIEW = 'clusterOverviewContainer';
-  const SUBJ_CLUSTER_NAME = `${SUBJ_CLUSTER_OVERVIEW} > clusterName`;
+  const SUBJ_CLUSTER_NAME = `overviewTabsclusterName`;
 
   const SUBJ_ES_PANEL = `clusterItemContainerElasticsearch`;
   const SUBJ_ES_STATUS = `${SUBJ_ES_PANEL} > statusIcon`;


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/114821

#### Reviewer notes
* Enable react migration by setting [`render_react_app`](https://github.com/elastic/kibana/blob/9fb16d54c520392b933846e902a7afd9520a8a87/x-pack/plugins/monitoring/server/config.ts#L54) to true
* start test server node scripts/functional_tests_server --config x-pack/test/functional/config.js
* Run `node scripts/functional_test_runner --config x-pack/test/functional/config.js --grep "Monitoring app Cluster"` to execute only cluster listing and cluster overview page.