### PR TITLE
[Security Solutions] Fix host isolation exception list showing up on the exceptions list

### DIFF
--- a/packages/kbn-securitysolution-io-ts-list-types/src/typescript_types/index.ts
+++ b/packages/kbn-securitysolution-io-ts-list-types/src/typescript_types/index.ts
@@ -43,6 +43,7 @@ export interface UseExceptionListsProps {
   initialPagination?: Pagination;
   showTrustedApps: boolean;
   showEventFilters: boolean;
+  showHostIsolationExceptions: boolean;
 }
 
 export interface UseExceptionListProps {

--- a/packages/kbn-securitysolution-list-hooks/src/use_exception_lists/index.ts
+++ b/packages/kbn-securitysolution-list-hooks/src/use_exception_lists/index.ts
@@ -41,6 +41,7 @@ const DEFAULT_PAGINATION = {
  * @param notifications kibana service for displaying toasters
  * @param showTrustedApps boolean - include/exclude trusted app lists
  * @param showEventFilters boolean - include/exclude event filters lists
+ * @param showHostIsolationExceptions boolean - include/exclude host isolation exceptions lists
  * @param initialPagination
  *
  */
@@ -53,6 +54,7 @@ export const useExceptionLists = ({
   notifications,
   showTrustedApps = false,
   showEventFilters = false,
+  showHostIsolationExceptions = false,
 }: UseExceptionListsProps): ReturnExceptionLists => {
   const [exceptionLists, setExceptionLists] = useState<ExceptionListSchema[]>([]);
   const [pagination, setPagination] = useState<Pagination>(initialPagination);
@@ -62,8 +64,14 @@ export const useExceptionLists = ({
   const namespaceTypesAsString = useMemo(() => namespaceTypes.join(','), [namespaceTypes]);
   const filters = useMemo(
     (): string =>
-      getFilters({ filters: filterOptions, namespaceTypes, showTrustedApps, showEventFilters }),
-    [namespaceTypes, filterOptions, showTrustedApps, showEventFilters]
+      getFilters({
+        filters: filterOptions,
+        namespaceTypes,
+        showTrustedApps,
+        showEventFilters,
+        showHostIsolationExceptions,
+      }),
+    [namespaceTypes, filterOptions, showTrustedApps, showEventFilters, showHostIsolationExceptions]
   );
 
   const fetchData = useCallback(async (): Promise<void> => {

--- a/packages/kbn-securitysolution-list-utils/src/get_filters/index.test.ts
+++ b/packages/kbn-securitysolution-list-utils/src/get_filters/index.test.ts
@@ -10,16 +10,58 @@ import { getFilters } from '.';
 
 describe('getFilters', () => {
   describe('single', () => {
-    test('it properly formats when no filters passed and "showTrustedApps" is false', () => {
+    test('it properly formats when no filters passed "showTrustedApps", "showEventFilters", and "showHostIsolationExceptions" is false', () => {
       const filter = getFilters({
         filters: {},
         namespaceTypes: ['single'],
         showTrustedApps: false,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*)'
+        '(not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+    test('it properly formats when no filters passed "showTrustedApps", "showEventFilters", and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: {},
+        namespaceTypes: ['single'],
+        showTrustedApps: true,
+        showEventFilters: true,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is false', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['single'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: false,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['single'],
+        showTrustedApps: true,
+        showEventFilters: true,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (exception-list.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -29,23 +71,11 @@ describe('getFilters', () => {
         namespaceTypes: ['single'],
         showTrustedApps: true,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when filters passed and "showTrustedApps" is false', () => {
-      const filter = getFilters({
-        filters: { created_by: 'moi', name: 'Sample' },
-        namespaceTypes: ['single'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -55,23 +85,11 @@ describe('getFilters', () => {
         namespaceTypes: ['single'],
         showTrustedApps: true,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when no filters passed and "showEventFilters" is false', () => {
-      const filter = getFilters({
-        filters: {},
-        namespaceTypes: ['single'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -81,23 +99,11 @@ describe('getFilters', () => {
         namespaceTypes: ['single'],
         showTrustedApps: false,
         showEventFilters: true,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when filters passed and "showEventFilters" is false', () => {
-      const filter = getFilters({
-        filters: { created_by: 'moi', name: 'Sample' },
-        namespaceTypes: ['single'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*)'
+        '(not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -107,25 +113,96 @@ describe('getFilters', () => {
         namespaceTypes: ['single'],
         showTrustedApps: false,
         showEventFilters: true,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when no filters passed and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: {},
+        namespaceTypes: ['single'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it if filters passed and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['single'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
   });
 
   describe('agnostic', () => {
-    test('it properly formats when no filters passed and "showTrustedApps" is false', () => {
+    test('it properly formats when no filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is false', () => {
       const filter = getFilters({
         filters: {},
         namespaceTypes: ['agnostic'],
         showTrustedApps: false,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when no filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: {},
+        namespaceTypes: ['agnostic'],
+        showTrustedApps: true,
+        showEventFilters: true,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is false', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['agnostic'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: false,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+    test('it properly formats when filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['agnostic'],
+        showTrustedApps: true,
+        showEventFilters: true,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -135,23 +212,11 @@ describe('getFilters', () => {
         namespaceTypes: ['agnostic'],
         showTrustedApps: true,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when filters passed and "showTrustedApps" is false', () => {
-      const filter = getFilters({
-        filters: { created_by: 'moi', name: 'Sample' },
-        namespaceTypes: ['agnostic'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -161,23 +226,11 @@ describe('getFilters', () => {
         namespaceTypes: ['agnostic'],
         showTrustedApps: true,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when no filters passed and "showEventFilters" is false', () => {
-      const filter = getFilters({
-        filters: {},
-        namespaceTypes: ['agnostic'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -187,23 +240,11 @@ describe('getFilters', () => {
         namespaceTypes: ['agnostic'],
         showTrustedApps: false,
         showEventFilters: true,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when filters passed and "showEventFilters" is false', () => {
-      const filter = getFilters({
-        filters: { created_by: 'moi', name: 'Sample' },
-        namespaceTypes: ['agnostic'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -213,25 +254,96 @@ describe('getFilters', () => {
         namespaceTypes: ['agnostic'],
         showTrustedApps: false,
         showEventFilters: true,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when no filters passed and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: {},
+        namespaceTypes: ['agnostic'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it if filters passed and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['agnostic'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list-agnostic.attributes.created_by:moi) AND (exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
   });
 
   describe('single, agnostic', () => {
-    test('it properly formats when no filters passed and "showTrustedApps" is false', () => {
+    test('it properly formats when no filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is false', () => {
       const filter = getFilters({
         filters: {},
         namespaceTypes: ['single', 'agnostic'],
         showTrustedApps: false,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+    test('it properly formats when no filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: {},
+        namespaceTypes: ['single', 'agnostic'],
+        showTrustedApps: true,
+        showEventFilters: true,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions* OR exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is false', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['single', 'agnostic'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: false,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when filters passed and "showTrustedApps", "showEventFilters" and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['single', 'agnostic'],
+        showTrustedApps: true,
+        showEventFilters: true,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions* OR exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -241,23 +353,11 @@ describe('getFilters', () => {
         namespaceTypes: ['single', 'agnostic'],
         showTrustedApps: true,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when filters passed and "showTrustedApps" is false', () => {
-      const filter = getFilters({
-        filters: { created_by: 'moi', name: 'Sample' },
-        namespaceTypes: ['single', 'agnostic'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -267,23 +367,11 @@ describe('getFilters', () => {
         namespaceTypes: ['single', 'agnostic'],
         showTrustedApps: true,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when no filters passed and "showEventFilters" is false', () => {
-      const filter = getFilters({
-        filters: {},
-        namespaceTypes: ['single', 'agnostic'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -293,23 +381,11 @@ describe('getFilters', () => {
         namespaceTypes: ['single', 'agnostic'],
         showTrustedApps: false,
         showEventFilters: true,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
-      );
-    });
-
-    test('it properly formats when filters passed and "showEventFilters" is false', () => {
-      const filter = getFilters({
-        filters: { created_by: 'moi', name: 'Sample' },
-        namespaceTypes: ['single', 'agnostic'],
-        showTrustedApps: false,
-        showEventFilters: false,
-      });
-
-      expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
 
@@ -319,10 +395,38 @@ describe('getFilters', () => {
         namespaceTypes: ['single', 'agnostic'],
         showTrustedApps: false,
         showEventFilters: true,
+        showHostIsolationExceptions: false,
       });
 
       expect(filter).toEqual(
-        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*)'
+        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+    test('it properly formats when no filters passed and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: {},
+        namespaceTypes: ['single', 'agnostic'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions* OR exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+      );
+    });
+
+    test('it properly formats when filters passed and "showHostIsolationExceptions" is true', () => {
+      const filter = getFilters({
+        filters: { created_by: 'moi', name: 'Sample' },
+        namespaceTypes: ['single', 'agnostic'],
+        showTrustedApps: false,
+        showEventFilters: false,
+        showHostIsolationExceptions: true,
+      });
+
+      expect(filter).toEqual(
+        '(exception-list.attributes.created_by:moi OR exception-list-agnostic.attributes.created_by:moi) AND (exception-list.attributes.name.text:Sample OR exception-list-agnostic.attributes.name.text:Sample) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions* OR exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
       );
     });
   });

--- a/packages/kbn-securitysolution-list-utils/src/get_filters/index.ts
+++ b/packages/kbn-securitysolution-list-utils/src/get_filters/index.ts
@@ -11,12 +11,14 @@ import { getGeneralFilters } from '../get_general_filters';
 import { getSavedObjectTypes } from '../get_saved_object_types';
 import { getTrustedAppsFilter } from '../get_trusted_apps_filter';
 import { getEventFiltersFilter } from '../get_event_filters_filter';
+import { getHostIsolationExceptionsFilter } from '../get_host_isolation_exceptions_filter';
 
 export interface GetFiltersParams {
   filters: ExceptionListFilter;
   namespaceTypes: NamespaceType[];
   showTrustedApps: boolean;
   showEventFilters: boolean;
+  showHostIsolationExceptions: boolean;
 }
 
 export const getFilters = ({
@@ -24,12 +26,17 @@ export const getFilters = ({
   namespaceTypes,
   showTrustedApps,
   showEventFilters,
+  showHostIsolationExceptions,
 }: GetFiltersParams): string => {
   const namespaces = getSavedObjectTypes({ namespaceType: namespaceTypes });
   const generalFilters = getGeneralFilters(filters, namespaces);
   const trustedAppsFilter = getTrustedAppsFilter(showTrustedApps, namespaces);
   const eventFiltersFilter = getEventFiltersFilter(showEventFilters, namespaces);
-  return [generalFilters, trustedAppsFilter, eventFiltersFilter]
+  const hostIsolationExceptionsFilter = getHostIsolationExceptionsFilter(
+    showHostIsolationExceptions,
+    namespaces
+  );
+  return [generalFilters, trustedAppsFilter, eventFiltersFilter, hostIsolationExceptionsFilter]
     .filter((filter) => filter.trim() !== '')
     .join(' AND ');
 };

--- a/packages/kbn-securitysolution-list-utils/src/get_host_isolation_exceptions_filter/index.test.ts
+++ b/packages/kbn-securitysolution-list-utils/src/get_host_isolation_exceptions_filter/index.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getHostIsolationExceptionsFilter } from '.';
+
+describe('getHostIsolationExceptionsFilter', () => {
+  test('it returns filter to search for "exception-list" namespace host isolation exceptions', () => {
+    const filter = getHostIsolationExceptionsFilter(true, ['exception-list']);
+
+    expect(filter).toEqual(
+      '(exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+    );
+  });
+
+  test('it returns filter to search for "exception-list" and "agnostic" namespace host isolation exceptions', () => {
+    const filter = getHostIsolationExceptionsFilter(true, [
+      'exception-list',
+      'exception-list-agnostic',
+    ]);
+
+    expect(filter).toEqual(
+      '(exception-list.attributes.list_id: endpoint_host_isolation_exceptions* OR exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+    );
+  });
+
+  test('it returns filter to exclude "exception-list" namespace host isolation exceptions', () => {
+    const filter = getHostIsolationExceptionsFilter(false, ['exception-list']);
+
+    expect(filter).toEqual(
+      '(not exception-list.attributes.list_id: endpoint_host_isolation_exceptions*)'
+    );
+  });
+
+  test('it returns filter to exclude "exception-list" and "agnostic" namespace host isolation exceptions', () => {
+    const filter = getHostIsolationExceptionsFilter(false, [
+      'exception-list',
+      'exception-list-agnostic',
+    ]);
+
+    expect(filter).toEqual(
+      '(not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)'
+    );
+  });
+});

--- a/packages/kbn-securitysolution-list-utils/src/get_host_isolation_exceptions_filter/index.ts
+++ b/packages/kbn-securitysolution-list-utils/src/get_host_isolation_exceptions_filter/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID } from '@kbn/securitysolution-list-constants';
+import { SavedObjectType } from '../types';
+
+export const getHostIsolationExceptionsFilter = (
+  showFilter: boolean,
+  namespaceTypes: SavedObjectType[]
+): string => {
+  if (showFilter) {
+    const filters = namespaceTypes.map((namespace) => {
+      return `${namespace}.attributes.list_id: ${ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID}*`;
+    });
+    return `(${filters.join(' OR ')})`;
+  } else {
+    const filters = namespaceTypes.map((namespace) => {
+      return `not ${namespace}.attributes.list_id: ${ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID}*`;
+    });
+    return `(${filters.join(' AND ')})`;
+  }
+};

--- a/x-pack/plugins/lists/public/exceptions/hooks/use_exception_lists.test.ts
+++ b/x-pack/plugins/lists/public/exceptions/hooks/use_exception_lists.test.ts
@@ -49,6 +49,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -86,6 +87,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -127,6 +129,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: true,
         })
       );
@@ -137,7 +140,7 @@ describe('useExceptionLists', () => {
 
       expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
         filters:
-          '(exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)',
+          '(exception-list.attributes.list_id: endpoint_trusted_apps* OR exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
         http: mockKibanaHttpService,
         namespaceTypes: 'single,agnostic',
         pagination: { page: 1, perPage: 20 },
@@ -163,6 +166,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -173,7 +177,7 @@ describe('useExceptionLists', () => {
 
       expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
         filters:
-          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)',
+          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
         http: mockKibanaHttpService,
         namespaceTypes: 'single,agnostic',
         pagination: { page: 1, perPage: 20 },
@@ -199,6 +203,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: true,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -209,7 +214,7 @@ describe('useExceptionLists', () => {
 
       expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
         filters:
-          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*)',
+          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (exception-list.attributes.list_id: endpoint_event_filters* OR exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
         http: mockKibanaHttpService,
         namespaceTypes: 'single,agnostic',
         pagination: { page: 1, perPage: 20 },
@@ -235,6 +240,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -245,7 +251,81 @@ describe('useExceptionLists', () => {
 
       expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
         filters:
-          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)',
+          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
+        http: mockKibanaHttpService,
+        namespaceTypes: 'single,agnostic',
+        pagination: { page: 1, perPage: 20 },
+        signal: new AbortController().signal,
+      });
+    });
+  });
+
+  test('fetches host isolation exceptions lists if "hostIsolationExceptionsFilter" is true', async () => {
+    const spyOnfetchExceptionLists = jest.spyOn(api, 'fetchExceptionLists');
+
+    await act(async () => {
+      const { waitForNextUpdate } = renderHook<UseExceptionListsProps, ReturnExceptionLists>(() =>
+        useExceptionLists({
+          errorMessage: 'Uh oh',
+          filterOptions: {},
+          http: mockKibanaHttpService,
+          initialPagination: {
+            page: 1,
+            perPage: 20,
+            total: 0,
+          },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
+          showEventFilters: false,
+          showHostIsolationExceptions: true,
+          showTrustedApps: false,
+        })
+      );
+      // NOTE: First `waitForNextUpdate` is initialization
+      // Second call applies the params
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+
+      expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
+        filters:
+          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (exception-list.attributes.list_id: endpoint_host_isolation_exceptions* OR exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
+        http: mockKibanaHttpService,
+        namespaceTypes: 'single,agnostic',
+        pagination: { page: 1, perPage: 20 },
+        signal: new AbortController().signal,
+      });
+    });
+  });
+
+  test('does not fetch host isolation exceptions lists if "showHostIsolationExceptions" is false', async () => {
+    const spyOnfetchExceptionLists = jest.spyOn(api, 'fetchExceptionLists');
+
+    await act(async () => {
+      const { waitForNextUpdate } = renderHook<UseExceptionListsProps, ReturnExceptionLists>(() =>
+        useExceptionLists({
+          errorMessage: 'Uh oh',
+          filterOptions: {},
+          http: mockKibanaHttpService,
+          initialPagination: {
+            page: 1,
+            perPage: 20,
+            total: 0,
+          },
+          namespaceTypes: ['single', 'agnostic'],
+          notifications: mockKibanaNotificationsService,
+          showEventFilters: false,
+          showHostIsolationExceptions: false,
+          showTrustedApps: false,
+        })
+      );
+      // NOTE: First `waitForNextUpdate` is initialization
+      // Second call applies the params
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+
+      expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
+        filters:
+          '(not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
         http: mockKibanaHttpService,
         namespaceTypes: 'single,agnostic',
         pagination: { page: 1, perPage: 20 },
@@ -274,6 +354,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -284,7 +365,7 @@ describe('useExceptionLists', () => {
 
       expect(spyOnfetchExceptionLists).toHaveBeenCalledWith({
         filters:
-          '(exception-list.attributes.created_by:Moi OR exception-list-agnostic.attributes.created_by:Moi) AND (exception-list.attributes.name.text:Sample Endpoint OR exception-list-agnostic.attributes.name.text:Sample Endpoint) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*)',
+          '(exception-list.attributes.created_by:Moi OR exception-list-agnostic.attributes.created_by:Moi) AND (exception-list.attributes.name.text:Sample Endpoint OR exception-list-agnostic.attributes.name.text:Sample Endpoint) AND (not exception-list.attributes.list_id: endpoint_trusted_apps* AND not exception-list-agnostic.attributes.list_id: endpoint_trusted_apps*) AND (not exception-list.attributes.list_id: endpoint_event_filters* AND not exception-list-agnostic.attributes.list_id: endpoint_event_filters*) AND (not exception-list.attributes.list_id: endpoint_host_isolation_exceptions* AND not exception-list-agnostic.attributes.list_id: endpoint_host_isolation_exceptions*)',
         http: mockKibanaHttpService,
         namespaceTypes: 'single,agnostic',
         pagination: { page: 1, perPage: 20 },
@@ -318,6 +399,7 @@ describe('useExceptionLists', () => {
             namespaceTypes,
             notifications,
             showEventFilters,
+            showHostIsolationExceptions: false,
             showTrustedApps,
           }),
         {
@@ -333,6 +415,7 @@ describe('useExceptionLists', () => {
             namespaceTypes: ['single'],
             notifications: mockKibanaNotificationsService,
             showEventFilters: false,
+            showHostIsolationExceptions: false,
             showTrustedApps: false,
           },
         }
@@ -354,6 +437,7 @@ describe('useExceptionLists', () => {
         namespaceTypes: ['single', 'agnostic'],
         notifications: mockKibanaNotificationsService,
         showEventFilters: false,
+        showHostIsolationExceptions: false,
         showTrustedApps: false,
       });
       // NOTE: Only need one call here because hook already initilaized
@@ -382,6 +466,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );
@@ -421,6 +506,7 @@ describe('useExceptionLists', () => {
           namespaceTypes: ['single', 'agnostic'],
           notifications: mockKibanaNotificationsService,
           showEventFilters: false,
+          showHostIsolationExceptions: false,
           showTrustedApps: false,
         })
       );

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/exceptions/exceptions_table.tsx
@@ -85,6 +85,7 @@ export const ExceptionListsTable = React.memo(() => {
       notifications,
       showTrustedApps: false,
       showEventFilters: false,
+      showHostIsolationExceptions: false,
     });
   const [loadingTableInfo, exceptionListsWithRuleRefs, exceptionsListsRef] = useAllExceptionLists({
     exceptionLists: exceptions ?? [],


### PR DESCRIPTION
## Summary

Solves https://github.com/elastic/kibana/issues/113741#

Fixes an issue where the host isolation exception list show up as an exception list in the exceptions tab.

The host isolation exceptions list is an internal exception list not to be manipulated by the user directly from the exceptions tab.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

