### PR TITLE
[7.x] chore(NA): fixes a typo on persist_bazel_cache.sh comment (#114943)

### DIFF
--- a/.buildkite/scripts/common/persist_bazel_cache.sh
+++ b/.buildkite/scripts/common/persist_bazel_cache.sh
@@ -5,10 +5,11 @@ source .buildkite/scripts/common/util.sh
 KIBANA_BUILDBUDDY_CI_API_KEY=$(retry 5 5 vault read -field=value secret/kibana-issues/dev/kibana-buildbuddy-ci-api-key)
 export KIBANA_BUILDBUDDY_CI_API_KEY
 
+# overwrites the file checkout .bazelrc file with the one intended for CI env
 cp "$KIBANA_DIR/src/dev/ci_setup/.bazelrc-ci" "$KIBANA_DIR/.bazelrc"
 
 ###
-### append auth token to buildbuddy into "$HOME/.bazelrc";
+### append auth token to buildbuddy into "$KIBANA_DIR/.bazelrc";
 ###
 echo "# Appended by .buildkite/scripts/persist_bazel_cache.sh" >> "$KIBANA_DIR/.bazelrc"
 echo "build --remote_header=x-buildbuddy-api-key=$KIBANA_BUILDBUDDY_CI_API_KEY" >> "$KIBANA_DIR/.bazelrc"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore(NA): fixes a typo on persist_bazel_cache.sh comment (#114943)