### PR TITLE
[Vega] Replacing the 'interval' property should only happen for the date_histogram aggregation

### DIFF
--- a/src/plugins/vis_types/vega/public/data_model/es_query_parser.test.js
+++ b/src/plugins/vis_types/vega/public/data_model/es_query_parser.test.js
@@ -178,11 +178,23 @@ describe(`EsQueryParser.injectQueryContextVars`, () => {
   );
   test(
     `%autointerval% = true`,
-    check({ interval: { '%autointerval%': true } }, { calendar_interval: `1h` }, ctxObj)
+    check(
+      { date_histogram: { interval: { '%autointerval%': true } } },
+      { date_histogram: { calendar_interval: `1h` } },
+      ctxObj
+    )
   );
   test(
     `%autointerval% = 10`,
-    check({ interval: { '%autointerval%': 10 } }, { fixed_interval: `3h` }, ctxObj)
+    check(
+      { date_histogram: { interval: { '%autointerval%': 10 } } },
+      { date_histogram: { fixed_interval: `3h` } },
+      ctxObj
+    )
+  );
+  test(
+    `histogram with interval`,
+    check({ histogram: { interval: 1 } }, { histogram: { interval: 1 } }, ctxObj)
   );
   test(`%timefilter% = min`, check({ a: { '%timefilter%': 'min' } }, { a: rangeStart }));
   test(`%timefilter% = max`, check({ a: { '%timefilter%': 'max' } }, { a: rangeEnd }));

--- a/src/plugins/vis_types/vega/public/data_model/es_query_parser.ts
+++ b/src/plugins/vis_types/vega/public/data_model/es_query_parser.ts
@@ -235,7 +235,8 @@ export class EsQueryParser {
         interval?: { '%autointerval%': true | number } | string;
       }
     >,
-    isQuery: boolean
+    isQuery: boolean,
+    key?: string
   ) {
     if (obj && typeof obj === 'object') {
       if (Array.isArray(obj)) {
@@ -281,9 +282,8 @@ export class EsQueryParser {
           if (!subObj || typeof obj !== 'object') continue;
 
           // replace "interval" with ES acceptable fixed_interval / calendar_interval
-          if (prop === 'interval') {
+          if (prop === 'interval' && key === 'date_histogram') {
             let intervalString: string;
-
             if (typeof subObj === 'string') {
               intervalString = subObj;
             } else if (subObj[AUTOINTERVAL]) {
@@ -322,7 +322,7 @@ export class EsQueryParser {
               this._createRangeFilter(subObj);
               continue;
             case undefined:
-              this._injectContextVars(subObj, isQuery);
+              this._injectContextVars(subObj, isQuery, prop);
               continue;
             default:
               throw new Error(


### PR DESCRIPTION
## Summary

Fix regression of #109090.  This replacement should only happen for the `date_histogram` aggregation


### Screens
`Actual`: 
![image](https://user-images.githubusercontent.com/20072247/137329418-52b3aedb-bd89-4182-b20b-151848bfdcde.png)


`Expected`: 
![image](https://user-images.githubusercontent.com/20072247/137329272-3f05f290-db1f-49b4-af38-91a2c8176b94.png)



