### PR TITLE
[7.x] [Discover] Rename default column in the advanced settings (#114100)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/utils/get_state_defaults.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_state_defaults.ts
@@ -6,9 +6,13 @@
  * Side Public License, v 1.
  */
 
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 import { IUiSettingsClient } from 'kibana/public';
-import { DEFAULT_COLUMNS_SETTING, SORT_DEFAULT_ORDER_SETTING } from '../../../../../common';
+import {
+  DEFAULT_COLUMNS_SETTING,
+  SEARCH_FIELDS_FROM_SOURCE,
+  SORT_DEFAULT_ORDER_SETTING,
+} from '../../../../../common';
 import { SavedSearch } from '../../../../saved_searches';
 import { DataPublicPluginStart } from '../../../../../../data/public';
 
@@ -18,6 +22,9 @@ import { getDefaultSort, getSortArray } from '../components/doc_table';
 function getDefaultColumns(savedSearch: SavedSearch, config: IUiSettingsClient) {
   if (savedSearch.columns && savedSearch.columns.length > 0) {
     return [...savedSearch.columns];
+  }
+  if (config.get(SEARCH_FIELDS_FROM_SOURCE) && isEqual(config.get(DEFAULT_COLUMNS_SETTING), [])) {
+    return ['_source'];
   }
   return [...config.get(DEFAULT_COLUMNS_SETTING)];
 }

--- a/src/plugins/discover/public/application/helpers/state_helpers.ts
+++ b/src/plugins/discover/public/application/helpers/state_helpers.ts
@@ -24,6 +24,7 @@ export function handleSourceColumnState<TState extends { columns?: string[] }>(
   }
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
   const defaultColumns = uiSettings.get(DEFAULT_COLUMNS_SETTING);
+
   if (useNewFieldsApi) {
     // if fields API is used, filter out the source column
     let cleanedColumns = state.columns.filter((column) => column !== '_source');
@@ -39,9 +40,13 @@ export function handleSourceColumnState<TState extends { columns?: string[] }>(
   } else if (state.columns.length === 0) {
     // if _source fetching is used and there are no column, switch back to default columns
     // this can happen if the fields API was previously used
+    const columns = defaultColumns;
+    if (columns.length === 0) {
+      columns.push('_source');
+    }
     return {
       ...state,
-      columns: [...defaultColumns],
+      columns: [...columns],
     };
   }
 

--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -33,9 +33,10 @@ export const getUiSettings: () => Record<string, UiSettingsParams> = () => ({
     name: i18n.translate('discover.advancedSettings.defaultColumnsTitle', {
       defaultMessage: 'Default columns',
     }),
-    value: ['_source'],
+    value: [],
     description: i18n.translate('discover.advancedSettings.defaultColumnsText', {
-      defaultMessage: 'Columns displayed by default in the Discovery tab',
+      defaultMessage:
+        'Columns displayed by default in the Discover app. If empty, a summary of the document will be displayed.',
     }),
     category: ['discover'],
     schema: schema.arrayOf(schema.string()),

--- a/test/functional/apps/discover/_discover_fields_api.ts
+++ b/test/functional/apps/discover/_discover_fields_api.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const PageObjects = getPageObjects(['common', 'discover', 'header', 'timePicker']);
+  const PageObjects = getPageObjects(['common', 'discover', 'header', 'timePicker', 'settings']);
   const defaultSettings = {
     defaultIndex: 'logstash-*',
     'discover:searchFieldsFromSource': false,
@@ -66,6 +66,28 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.isShowingDocViewer();
       await PageObjects.discover.clickDocViewerTab(1);
       await PageObjects.discover.expectSourceViewerToExist();
+    });
+
+    it('switches to _source column when fields API is no longer used', async function () {
+      await PageObjects.settings.navigateTo();
+      await PageObjects.settings.clickKibanaSettings();
+      await PageObjects.settings.toggleAdvancedSettingCheckbox('discover:searchFieldsFromSource');
+
+      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.timePicker.setDefaultAbsoluteRange();
+
+      expect(await PageObjects.discover.getDocHeader()).to.have.string('_source');
+    });
+
+    it('switches to Document column when fields API is used', async function () {
+      await PageObjects.settings.navigateTo();
+      await PageObjects.settings.clickKibanaSettings();
+      await PageObjects.settings.toggleAdvancedSettingCheckbox('discover:searchFieldsFromSource');
+
+      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.timePicker.setDefaultAbsoluteRange();
+
+      expect(await PageObjects.discover.getDocHeader()).to.have.string('Document');
     });
   });
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Discover] Rename default column in the advanced settings (#114100)