### PR TITLE
[App Search] Fix handling of body-less meta engine responses

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/app_search/source_engines.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/source_engines.test.ts
@@ -92,6 +92,7 @@ describe('source engine routes', () => {
     it('creates a request to enterprise search', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/as/engines/:name/source_engines/bulk_create',
+        hasJsonResponse: false,
       });
     });
   });
@@ -145,6 +146,7 @@ describe('source engine routes', () => {
     it('creates a request to enterprise search', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/as/engines/:name/source_engines/:source_engine_name',
+        hasJsonResponse: false,
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/source_engines.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/source_engines.ts
@@ -45,6 +45,7 @@ export function registerSourceEnginesRoutes({
     },
     enterpriseSearchRequestHandler.createRequest({
       path: '/as/engines/:name/source_engines/bulk_create',
+      hasJsonResponse: false,
     })
   );
 
@@ -60,6 +61,7 @@ export function registerSourceEnginesRoutes({
     },
     enterpriseSearchRequestHandler.createRequest({
       path: '/as/engines/:name/source_engines/:source_engine_name',
+      hasJsonResponse: false,
     })
   );
 }


### PR DESCRIPTION
## Summary

The issue is that we're trying to parse the JSON response body when in fact we don't return a response body. See recording:

https://user-images.githubusercontent.com/809707/137354509-cb878d6b-2caf-47ea-88f0-bf893f0c69d1.mp4

XHR response:

```json
{"statusCode":502,"error":"Bad Gateway","message":"Error connecting to Enterprise Search: invalid json response body at http://localhost:3002/as/engines/m1/source_engines/bulk_create reason: Unexpected end of JSON input"}
```

Kibana logs:

```
[2021-10-14T17:35:23.745+02:00][ERROR][plugins.enterpriseSearch] Error connecting to Enterprise Search: invalid json response body at http://localhost:3002/as/engines/m1/source_engines/bulk_create reason: Unexpected end of JSON input
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios