### PR TITLE
[7.x] docs: fix config names (#114903)

### DIFF
--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -484,8 +484,7 @@ An example is below.
 [[api-create-apm-index-pattern]]
 ==== Customize the APM index pattern
 
-As an alternative to updating <<apm-settings-in-kibana,`apm_oss.indexPattern`>> in your `kibana.yml` configuration file,
-you can use Kibana's <<saved-objects-api-update,update object API>> to update the default APM index pattern on the fly.
+Use Kibana's <<saved-objects-api-update,update object API>> to update the default APM index pattern on the fly.
 
 The following example sets the default APM app index pattern to `some-other-pattern-*`:
 

--- a/docs/apm/troubleshooting.asciidoc
+++ b/docs/apm/troubleshooting.asciidoc
@@ -76,7 +76,7 @@ If you change the default, you must also configure the `setup.template.name` and
 See {apm-server-ref}/configuration-template.html[Load the Elasticsearch index template].
 If the Elasticsearch index template has already been successfully loaded to the index,
 you can customize the indices that the APM app uses to display data.
-Navigate to *APM* > *Settings* > *Indices*, and change all `xpack.apm.*Pattern` values to
+Navigate to *APM* > *Settings* > *Indices*, and change all `xpack.apm.indices.*` values to
 include the new index pattern. For example: `customIndexName-*`.
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: fix config names (#114903)