### PR TITLE
[Fleet] Validate package policy immediately after dry run data is available

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -200,10 +200,19 @@ export const EditPackagePolicyForm = memo<{
 
             if (packageData?.response) {
               setPackageInfo(packageData.response);
-              setValidationResults(
-                validatePackagePolicy(newPackagePolicy, packageData.response, safeLoad)
+
+              const newValidationResults = validatePackagePolicy(
+                newPackagePolicy,
+                packageData.response,
+                safeLoad
               );
-              setFormState('VALID');
+              setValidationResults(newValidationResults);
+
+              if (validationHasErrors(newValidationResults)) {
+                setFormState('INVALID');
+              } else {
+                setFormState('VALID');
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Previously, we were setting the edit package policy form's state to `VALID` once data was fetched, regardless of whether we received validation errors. In cases where we perform a dry run and there are conflicts, the form state wasn't reflecting the actual `INVALID` state of the underlying policy. 

Now, we report the actual valid/invalid state based on the validation we were already performing anyway, so users get form errors related to the conflicts if available.
