### PR TITLE
[Workplace Search] Fix loading state bug and update button

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/blocked_window_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/blocked_window_item.test.tsx
@@ -16,7 +16,7 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 
 import {
-  EuiButton,
+  EuiButtonIcon,
   EuiDatePicker,
   EuiDatePickerRange,
   EuiSelect,
@@ -53,7 +53,7 @@ describe('BlockedWindowItem', () => {
 
   it('handles remove button click', () => {
     const wrapper = shallow(<BlockedWindowItem {...props} />);
-    wrapper.find(EuiButton).simulate('click');
+    wrapper.find(EuiButtonIcon).simulate('click');
 
     expect(removeBlockedWindow).toHaveBeenCalledWith(0);
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/blocked_window_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/blocked_window_item.tsx
@@ -11,7 +11,7 @@ import { useActions, useValues } from 'kea';
 import moment from 'moment';
 
 import {
-  EuiButton,
+  EuiButtonIcon,
   EuiDatePicker,
   EuiDatePickerRange,
   EuiFlexGroup,
@@ -179,9 +179,14 @@ export const BlockedWindowItem: React.FC<Props> = ({ blockedWindow, index }) => 
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill color="danger" onClick={() => removeBlockedWindow(index)}>
-            {REMOVE_BUTTON}
-          </EuiButton>
+          <EuiButtonIcon
+            display="base"
+            iconType="trash"
+            color="danger"
+            onClick={() => removeBlockedWindow(index)}
+            aria-label={REMOVE_BUTTON}
+            title={REMOVE_BUTTON}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="s" />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -112,6 +112,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
       {
         setContentSource: () => false,
         resetSourceState: () => true,
+        removeContentSource: () => true,
       },
     ],
     buttonLoading: [
@@ -119,7 +120,6 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
       {
         setButtonNotLoading: () => false,
         resetSourceState: () => false,
-        removeContentSource: () => true,
       },
     ],
     sectionLoading: [


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2114

## Summary

This PR fixes an issue where 2 buttons were both loading on the source settings page. We now show the entire page as loading until the source is deleted.

| Before | After |
| ------------- | ------------- |
| ![loading-before](https://user-images.githubusercontent.com/1869731/137371054-c6e1e138-e0a0-415a-9980-3cdfc301e10c.gif)  | ![loading-after](https://user-images.githubusercontent.com/1869731/137371057-87a624da-5310-4782-8fdf-1ac29e1a8ef0.gif)  |

Also, the text button on the Source Synchronization blocked windows table row has been replaced with an icon button:

| Before | After |
| ------------- | ------------- |
| ![btn-before](https://user-images.githubusercontent.com/1869731/137371193-9961fa88-65d1-4448-a2d9-5bea5b417ba8.png)  | ![btn-after](https://user-images.githubusercontent.com/1869731/137371195-90afd7a6-7f32-4639-9e18-0674c995bead.png) |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
