### PR TITLE
[Runtime field editor] Fix preview error when not enough privileges

### DIFF
--- a/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
+++ b/src/plugins/index_pattern_field_editor/__jest__/client_integration/field_editor_flyout_preview.test.ts
@@ -366,6 +366,7 @@ describe('Field editor Preview panel', () => {
           subTitle: 'First doc - subTitle',
           title: 'First doc - title',
         },
+        documentId: '001',
         index: 'testIndex',
         script: {
           source: 'echo("hello")',

--- a/src/plugins/index_pattern_field_editor/public/components/preview/field_preview_context.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/preview/field_preview_context.tsx
@@ -369,10 +369,7 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
 
       setPreviewResponse({
         fields: [],
-        error: {
-          code: 'PAINLESS_SCRIPT_ERROR',
-          error: parseEsError(error, false) ?? fallBackError,
-        },
+        error: { code: 'PAINLESS_SCRIPT_ERROR', error: parseEsError(error, true) ?? fallBackError },
       });
     } else {
       const [value] = values;

--- a/src/plugins/index_pattern_field_editor/public/components/preview/field_preview_context.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/preview/field_preview_context.tsx
@@ -335,6 +335,7 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
       document: params.document!,
       context: `${params.type!}_field` as FieldPreviewContext,
       script: params.script!,
+      documentId: currentDocId,
     });
 
     if (currentApiCall !== previewCount.current) {
@@ -368,7 +369,10 @@ export const FieldPreviewProvider: FunctionComponent = ({ children }) => {
 
       setPreviewResponse({
         fields: [],
-        error: { code: 'PAINLESS_SCRIPT_ERROR', error: parseEsError(error, true) ?? fallBackError },
+        error: {
+          code: 'PAINLESS_SCRIPT_ERROR',
+          error: parseEsError(error, false) ?? fallBackError,
+        },
       });
     } else {
       const [value] = values;

--- a/src/plugins/index_pattern_field_editor/public/lib/api.ts
+++ b/src/plugins/index_pattern_field_editor/public/lib/api.ts
@@ -16,11 +16,13 @@ export const initApi = (httpClient: HttpSetup) => {
     context,
     script,
     document,
+    documentId,
   }: {
     index: string;
     context: FieldPreviewContext;
     script: { source: string } | null;
     document: Record<string, any>;
+    documentId: string;
   }) => {
     return sendRequest<FieldPreviewResponse>(httpClient, {
       path: `${API_BASE_PATH}/field_preview`,
@@ -30,6 +32,7 @@ export const initApi = (httpClient: HttpSetup) => {
         context,
         script,
         document,
+        documentId,
       },
     });
   };

--- a/src/plugins/index_pattern_field_editor/public/lib/runtime_field_validation.ts
+++ b/src/plugins/index_pattern_field_editor/public/lib/runtime_field_validation.ts
@@ -68,7 +68,7 @@ export const parseEsError = (
     return null;
   }
 
-  const scriptError = isScriptError ? error : getScriptExceptionError(error.caused_by ?? error);
+  const scriptError = isScriptError ? error : getScriptExceptionError(error.caused_by);
 
   if (scriptError === null) {
     return null;

--- a/src/plugins/index_pattern_field_editor/public/lib/runtime_field_validation.ts
+++ b/src/plugins/index_pattern_field_editor/public/lib/runtime_field_validation.ts
@@ -68,7 +68,7 @@ export const parseEsError = (
     return null;
   }
 
-  const scriptError = isScriptError ? error : getScriptExceptionError(error.caused_by);
+  const scriptError = isScriptError ? error : getScriptExceptionError(error.caused_by ?? error);
 
   if (scriptError === null) {
     return null;

--- a/src/plugins/index_pattern_field_editor/server/routes/field_preview.ts
+++ b/src/plugins/index_pattern_field_editor/server/routes/field_preview.ts
@@ -71,7 +71,10 @@ export const registerFieldPreviewRoute = ({ router }: RouteDependencies): void =
         // Return 200 with error object
         const handleCustomError = () => {
           return res.ok({
-            body: { values: [], ...error.body },
+            body: {
+              values: [],
+              error: error.body.error.failed_shards[0]?.reason ?? {},
+            },
           });
         };
 

--- a/src/plugins/index_pattern_field_editor/server/routes/field_preview.ts
+++ b/src/plugins/index_pattern_field_editor/server/routes/field_preview.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { estypes } from '@elastic/elasticsearch';
 import { schema } from '@kbn/config-schema';
-import { HttpResponsePayload } from 'kibana/server';
 
 import { API_BASE_PATH } from '../../common/constants';
 import { RouteDependencies } from '../types';
@@ -26,6 +26,7 @@ const bodySchema = schema.object({
     schema.literal('long_field'),
   ]),
   document: schema.object({}, { unknowns: 'allow' }),
+  documentId: schema.string(),
 });
 
 export const registerFieldPreviewRoute = ({ router }: RouteDependencies): void => {
@@ -39,25 +40,33 @@ export const registerFieldPreviewRoute = ({ router }: RouteDependencies): void =
     async (ctx, req, res) => {
       const { client } = ctx.core.elasticsearch;
 
-      const body = JSON.stringify({
-        script: req.body.script,
-        context: req.body.context,
-        context_setup: {
-          document: req.body.document,
-          index: req.body.index,
-        } as any,
-      });
+      const type = req.body.context.split('_field')[0] as estypes.MappingRuntimeFieldType;
+      const body = {
+        runtime_mappings: {
+          my_runtime_field: {
+            type,
+            script: req.body.script,
+          },
+        },
+        size: 1,
+        query: {
+          term: {
+            _id: req.body.documentId,
+          },
+        },
+        fields: ['my_runtime_field'],
+      };
 
       try {
-        const response = await client.asCurrentUser.scriptsPainlessExecute({
-          // @ts-expect-error `ExecutePainlessScriptRequest.body` does not allow `string`
+        const response = await client.asCurrentUser.search({
+          index: req.body.index,
           body,
         });
 
-        const fieldValue = response.body.result as any[] as HttpResponsePayload;
+        const fieldValue = response.body.hits.hits[0]?.fields?.my_runtime_field ?? '';
 
         return res.ok({ body: { values: fieldValue } });
-      } catch (error) {
+      } catch (error: any) {
         // Assume invalid painless script was submitted
         // Return 200 with error object
         const handleCustomError = () => {


### PR DESCRIPTION
There is a current limitation in the ES Painless `_execute` API that requires too many privileges (`cluster privileges [manage,all])`. This is a problem when previewing a runtime field script.

This PR brings a temporary fix to this problem by not using the `_execute` API but the `_search` API.

## How to test

* Create a new role with only the `read` and `view_index_metadata` privilege on one of the indices
* Assign a new user to that role and log into Kibana with that user
* Navigate to the index pattern management app, select your index pattern and create a new field
* Write a simple script (e.g. `emit('hello');`). --> You should see the preview of the script in the panel.
* Change the script with `emit(123);` --> you should get a casting error

Fixes https://github.com/elastic/kibana/issues/114034
Fixes https://github.com/elastic/kibana/issues/114036
Fixes https://github.com/elastic/infra/issues/31927