### PR TITLE
[ci] Explicitly define tasks for ES snapshot build

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -61,7 +61,14 @@ export DOCKER_TLS_CERTDIR="$CERTS_DIR"
 export DOCKER_HOST=localhost:2377
 
 echo "--- Build Elasticsearch"
-./gradlew -Dbuild.docker=true assemble --parallel
+./gradlew \
+  :distribution:archives:darwin-aarch64-tar:assemble \
+  :distribution:archives:darwin-tar:assemble \
+  :distribution:docker:docker-export:assemble \
+  :distribution:archives:linux-aarch64-tar:assemble \
+  :distribution:archives:linux-tar:assemble \
+  :distribution:archives:windows-zip:assemble \
+  --parallel
 
 echo "--- Create distribution archives"
 find distribution -type f \( -name 'elasticsearch-*-*-*-*.tar.gz' -o -name 'elasticsearch-*-*-*-*.zip' \) -not -path '*no-jdk*' -not -path '*build-context*' -exec cp {} "$destination" \;

--- a/packages/kbn-es/src/utils/build_snapshot.js
+++ b/packages/kbn-es/src/utils/build_snapshot.js
@@ -26,6 +26,7 @@ const onceEvent = (emitter, event) => new Promise((resolve) => emitter.once(even
  * @returns {Object} containing archive and optional plugins
  *
  * Gradle tasks:
+ *   $ ./gradlew tasks --all | grep 'distribution.*assemble\s'
  *   :distribution:archives:darwin-tar:assemble
  *   :distribution:archives:linux-tar:assemble
  *   :distribution:archives:windows-zip:assemble


### PR DESCRIPTION
The `assemble` task has broken for us quite a few times in the past, and today. Let's use more explicit tasks to create what we need.

Tested here https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/235.