### PR TITLE
[Workplace Search] Update copy and move links inline for Sync Scheduling

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency.tsx
@@ -26,10 +26,10 @@ import { ViewContentHeader } from '../../../../components/shared/view_content_he
 import { NAV, RESET_BUTTON } from '../../../../constants';
 import { DIFFERENT_SYNC_TYPES_DOCS_URL } from '../../../../routes';
 import {
+  LEARN_MORE_LINK,
   SOURCE_FREQUENCY_DESCRIPTION,
   SOURCE_SYNC_FREQUENCY_TITLE,
   BLOCKED_TIME_WINDOWS_TITLE,
-  SYNC_FREQUENCY_LINK_LABEL,
   SYNC_UNSAVED_CHANGES_MESSAGE,
 } from '../../constants';
 import { SourceLogic } from '../../source_logic';
@@ -84,16 +84,6 @@ export const Frequency: React.FC<FrequencyProps> = ({ tabId }) => {
     </EuiFlexGroup>
   );
 
-  const docsLinks = (
-    <EuiFlexGroup>
-      <EuiFlexItem grow={false}>
-        <EuiLink href={DIFFERENT_SYNC_TYPES_DOCS_URL} external>
-          {SYNC_FREQUENCY_LINK_LABEL}
-        </EuiLink>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-
   return (
     <SourceLayout
       pageChrome={[
@@ -109,10 +99,16 @@ export const Frequency: React.FC<FrequencyProps> = ({ tabId }) => {
       />
       <ViewContentHeader
         title={NAV.SYNCHRONIZATION_FREQUENCY}
-        description={SOURCE_FREQUENCY_DESCRIPTION}
+        description={
+          <>
+            {SOURCE_FREQUENCY_DESCRIPTION}{' '}
+            <EuiLink href={DIFFERENT_SYNC_TYPES_DOCS_URL} external>
+              {LEARN_MORE_LINK}
+            </EuiLink>
+          </>
+        }
         action={actions}
       />
-      {docsLinks}
       <EuiSpacer />
       <EuiTabbedContent tabs={tabs} selectedTab={tabs[tabId]} onTabClick={onSelectedTabChanged} />
     </SourceLayout>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/objects_and_assets.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/objects_and_assets.tsx
@@ -27,11 +27,11 @@ import { ViewContentHeader } from '../../../../components/shared/view_content_he
 import { NAV, RESET_BUTTON } from '../../../../constants';
 import { OBJECTS_AND_ASSETS_DOCS_URL } from '../../../../routes';
 import {
+  LEARN_MORE_LINK,
   SYNC_MANAGEMENT_CONTENT_EXTRACTION_LABEL,
   SYNC_MANAGEMENT_THUMBNAILS_LABEL,
   SYNC_MANAGEMENT_THUMBNAILS_GLOBAL_CONFIG_LABEL,
   SOURCE_OBJECTS_AND_ASSETS_DESCRIPTION,
-  OBJECTS_AND_ASSETS_LINK_LABEL,
   SOURCE_OBJECTS_AND_ASSETS_LABEL,
   SYNC_UNSAVED_CHANGES_MESSAGE,
 } from '../../constants';
@@ -84,12 +84,16 @@ export const ObjectsAndAssets: React.FC = () => {
       />
       <ViewContentHeader
         title={NAV.SYNCHRONIZATION_OBJECTS_AND_ASSETS}
-        description={SOURCE_OBJECTS_AND_ASSETS_DESCRIPTION}
+        description={
+          <>
+            {SOURCE_OBJECTS_AND_ASSETS_DESCRIPTION}{' '}
+            <EuiLink href={OBJECTS_AND_ASSETS_DOCS_URL} external>
+              {LEARN_MORE_LINK}
+            </EuiLink>
+          </>
+        }
         action={actions}
       />
-      <EuiLink href={OBJECTS_AND_ASSETS_DOCS_URL} external>
-        {OBJECTS_AND_ASSETS_LINK_LABEL}
-      </EuiLink>
       <EuiHorizontalRule />
       <EuiText size="m">{SOURCE_OBJECTS_AND_ASSETS_LABEL}</EuiText>
       <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization.test.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiLink, EuiCallOut, EuiSwitch } from '@elastic/eui';
+import { EuiCallOut, EuiSwitch } from '@elastic/eui';
 
 import { Synchronization } from './synchronization';
 
@@ -28,7 +28,6 @@ describe('Synchronization', () => {
   it('renders when config enabled', () => {
     const wrapper = shallow(<Synchronization />);
 
-    expect(wrapper.find(EuiLink)).toHaveLength(1);
     expect(wrapper.find(EuiSwitch)).toHaveLength(1);
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/synchronization.tsx
@@ -15,12 +15,12 @@ import { ViewContentHeader } from '../../../../components/shared/view_content_he
 import { NAV } from '../../../../constants';
 import { SYNCHRONIZATION_DOCS_URL } from '../../../../routes';
 import {
+  LEARN_MORE_LINK,
   SOURCE_SYNCHRONIZATION_DESCRIPTION,
   SYNCHRONIZATION_DISABLED_TITLE,
   SYNCHRONIZATION_DISABLED_DESCRIPTION,
   SOURCE_SYNCHRONIZATION_TOGGLE_LABEL,
   SOURCE_SYNCHRONIZATION_TOGGLE_DESCRIPTION,
-  SYNCHRONIZATION_LINK_LABEL,
 } from '../../constants';
 import { SourceLogic } from '../../source_logic';
 import { SourceLayout } from '../source_layout';
@@ -65,11 +65,15 @@ export const Synchronization: React.FC = () => {
     >
       <ViewContentHeader
         title={NAV.SYNCHRONIZATION}
-        description={SOURCE_SYNCHRONIZATION_DESCRIPTION}
+        description={
+          <>
+            {SOURCE_SYNCHRONIZATION_DESCRIPTION}{' '}
+            <EuiLink href={SYNCHRONIZATION_DOCS_URL} external>
+              {LEARN_MORE_LINK}
+            </EuiLink>
+          </>
+        }
       />
-      <EuiLink href={SYNCHRONIZATION_DOCS_URL} external>
-        {SYNCHRONIZATION_LINK_LABEL}
-      </EuiLink>
       <EuiSpacer />
       {isSyncConfigEnabled ? syncToggle : syncDisabledCallout}
     </SourceLayout>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/constants.ts
@@ -531,7 +531,7 @@ export const SOURCE_SYNCHRONIZATION_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.sourceSynchronizationDescription',
   {
     defaultMessage:
-      'Synchronization provides control over data being indexed from the content source. Enable synchronization of data from the content source to Workplace Search.',
+      'Enable or disable synchronization of data from this content source to Workplace Search.',
   }
 );
 
@@ -539,7 +539,7 @@ export const SOURCE_FREQUENCY_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.sourceFrequencyDescription',
   {
     defaultMessage:
-      'Schedule the frequency of data synchronization between Workplace search and the content source. Indexing schedules that occur less frequently lower the burden on third-party servers, while more frequent will ensure your data is up-to-date.',
+      'Manage the frequency of data synchronization from Workplace search to this content source. Sync more frequently to ensure your data is up to date. Sync less frequently to reduce the burden on third party servers.',
   }
 );
 
@@ -547,7 +547,7 @@ export const SOURCE_OBJECTS_AND_ASSETS_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.sourceObjectsAndAssetsDescription',
   {
     defaultMessage:
-      'Customize the indexing rules that determine what data is synchronized from this content source to Workplace Search.',
+      'Customize the indexing rules that determine which objects and assets are synchronized from this content source to Workplace Search.',
   }
 );
 
@@ -636,13 +636,6 @@ export const BLOCKED_TIME_WINDOWS_TITLE = i18n.translate(
   }
 );
 
-export const SYNCHRONIZATION_LINK_LABEL = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.sources.synchronizationLinkLabel',
-  {
-    defaultMessage: 'Learn more about synchronization',
-  }
-);
-
 export const SYNCHRONIZATION_DISABLED_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.synchronizationDisabledTitle',
   {
@@ -654,20 +647,6 @@ export const SYNCHRONIZATION_DISABLED_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.synchronizationDisabledDescription',
   {
     defaultMessage: 'Contact your administrator to enable synchronization controls.',
-  }
-);
-
-export const SYNC_FREQUENCY_LINK_LABEL = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.sources.syncFrequencyLinkLabel',
-  {
-    defaultMessage: 'Learn more about synchronization frequency',
-  }
-);
-
-export const OBJECTS_AND_ASSETS_LINK_LABEL = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.sources.objectsAndAssetsLinkLabel',
-  {
-    defaultMessage: 'Learn more about Objects and assets',
   }
 );
 


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1945
closes https://github.com/elastic/workplace-search-team/issues/2053

## Summary

Update copy and move links inline for Sync Scheduling

![sync](https://user-images.githubusercontent.com/1869731/137376210-c91ba67f-4c3d-47e2-9e0a-c1069be97304.png)

![freq](https://user-images.githubusercontent.com/1869731/137376710-1cc8b129-722a-46df-bb9c-7673bdcfe80f.png)

![objects](https://user-images.githubusercontent.com/1869731/137376216-089a8289-03d7-4cea-a594-9053286d5038.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
