### PR TITLE
[data views] DataViewBase now requires a title

### DIFF
--- a/packages/kbn-es-query/src/es_query/build_es_query.test.ts
+++ b/packages/kbn-es-query/src/es_query/build_es_query.test.ts
@@ -12,13 +12,14 @@ import { luceneStringToDsl } from './lucene_string_to_dsl';
 import { decorateQuery } from './decorate_query';
 import { MatchAllFilter, Query } from '../filters';
 import { fields } from '../filters/stubs';
-import { IndexPatternBase } from './types';
+import { DataViewBase } from './types';
 
 jest.mock('../kuery/grammar');
 
 describe('build query', () => {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     fields,
+    title: 'dataView',
   };
 
   describe('buildEsQuery', () => {

--- a/packages/kbn-es-query/src/es_query/from_filters.test.ts
+++ b/packages/kbn-es-query/src/es_query/from_filters.test.ts
@@ -9,11 +9,12 @@
 import { buildQueryFromFilters } from './from_filters';
 import { ExistsFilter, Filter, MatchAllFilter } from '../filters';
 import { fields } from '../filters/stubs';
-import { IndexPatternBase } from './types';
+import { DataViewBase } from './types';
 
 describe('build query', () => {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     fields,
+    title: 'dataView',
   };
 
   describe('buildQueryFromFilters', () => {

--- a/packages/kbn-es-query/src/es_query/from_kuery.test.ts
+++ b/packages/kbn-es-query/src/es_query/from_kuery.test.ts
@@ -9,14 +9,15 @@
 import { buildQueryFromKuery } from './from_kuery';
 import { fromKueryExpression, toElasticsearchQuery } from '../kuery';
 import { fields } from '../filters/stubs';
-import { IndexPatternBase } from './types';
+import { DataViewBase } from './types';
 import { Query } from '..';
 
 jest.mock('../kuery/grammar');
 
 describe('build query', () => {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     fields,
+    title: 'dataView',
   };
 
   describe('buildQueryFromKuery', () => {

--- a/packages/kbn-es-query/src/es_query/handle_nested_filter.test.ts
+++ b/packages/kbn-es-query/src/es_query/handle_nested_filter.test.ts
@@ -9,12 +9,13 @@
 import { handleNestedFilter } from './handle_nested_filter';
 import { fields } from '../filters/stubs';
 import { buildPhraseFilter, buildQueryFilter } from '../filters';
-import { IndexPatternBase } from './types';
+import { DataViewBase } from './types';
 
 describe('handleNestedFilter', function () {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     id: 'logstash-*',
     fields,
+    title: 'dataView',
   };
 
   it("should return the filter's query wrapped in nested query if the target field is nested", () => {

--- a/packages/kbn-es-query/src/es_query/types.ts
+++ b/packages/kbn-es-query/src/es_query/types.ts
@@ -65,7 +65,7 @@ export type IndexPatternFieldBase = DataViewFieldBase;
 export interface DataViewBase {
   fields: DataViewFieldBase[];
   id?: string;
-  title?: string;
+  title: string;
 }
 
 /**

--- a/packages/kbn-es-query/src/filters/build_filters/build_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/build_filter.test.ts
@@ -7,13 +7,14 @@
  */
 
 import { buildFilter, FilterStateStore, FILTERS } from '.';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 import { fields as stubFields } from '../stubs';
 
 describe('buildFilter', () => {
-  const stubIndexPattern: IndexPatternBase = {
+  const stubIndexPattern: DataViewBase = {
     id: 'logstash-*',
     fields: stubFields,
+    title: 'dataView',
   };
 
   it('should build phrase filters', () => {

--- a/packages/kbn-es-query/src/filters/build_filters/exists_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/exists_filter.test.ts
@@ -6,13 +6,14 @@
  * Side Public License, v 1.
  */
 
-import { IndexPatternBase } from '../../es_query';
+import { DataViewBase } from '../../es_query';
 import { buildExistsFilter, getExistsFilterField } from './exists_filter';
 import { fields } from '../stubs/fields.mocks';
 
 describe('exists filter', function () {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     fields,
+    title: 'dataView',
   };
 
   describe('getExistsFilterField', function () {

--- a/packages/kbn-es-query/src/filters/build_filters/get_filter_field.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/get_filter_field.test.ts
@@ -9,13 +9,14 @@
 import { buildPhraseFilter } from './phrase_filter';
 import { buildQueryFilter } from './query_string_filter';
 import { getFilterField } from './get_filter_field';
-import { IndexPatternBase } from '../../es_query';
+import { DataViewBase } from '../../es_query';
 import { fields } from '../stubs/fields.mocks';
 
 describe('getFilterField', function () {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     id: 'logstash-*',
     fields,
+    title: 'dataView',
   };
 
   it('should return the field name from known filter types that target a specific field', () => {

--- a/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/phrase_filter.test.ts
@@ -13,16 +13,17 @@ import {
   PhraseFilter,
 } from './phrase_filter';
 import { fields, getField } from '../stubs';
-import { IndexPatternBase } from '../../es_query';
+import { DataViewBase } from '../../es_query';
 import { estypes } from '@elastic/elasticsearch';
 
 describe('Phrase filter builder', () => {
-  let indexPattern: IndexPatternBase;
+  let indexPattern: DataViewBase;
 
   beforeEach(() => {
     indexPattern = {
       id: 'id',
       fields,
+      title: 'dataView',
     };
   });
 
@@ -151,8 +152,9 @@ describe('buildInlineScriptForPhraseFilter', () => {
 });
 
 describe('getPhraseFilterField', function () {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     fields,
+    title: 'dataView',
   };
 
   it('should return the name of the field a phrase query is targeting', () => {

--- a/packages/kbn-es-query/src/filters/build_filters/phrases_filter.test.ts
+++ b/packages/kbn-es-query/src/filters/build_filters/phrases_filter.test.ts
@@ -6,13 +6,14 @@
  * Side Public License, v 1.
  */
 
-import { IndexPatternBase } from '../../es_query';
+import { DataViewBase } from '../../es_query';
 import { buildPhrasesFilter, getPhrasesFilterField } from './phrases_filter';
 import { fields } from '../stubs';
 
 describe('phrases filter', function () {
-  const indexPattern: IndexPatternBase = {
+  const indexPattern: DataViewBase = {
     fields,
+    title: 'dataView',
   };
 
   describe('getPhrasesFilterField', function () {

--- a/packages/kbn-es-query/src/kuery/ast/ast.test.ts
+++ b/packages/kbn-es-query/src/kuery/ast/ast.test.ts
@@ -8,18 +8,19 @@
 
 import { fromKueryExpression, fromLiteralExpression, toElasticsearchQuery } from './ast';
 import { nodeTypes } from '../node_types';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 import { KueryNode } from '../types';
 import { fields } from '../../filters/stubs';
 
 jest.mock('../grammar');
 
 describe('kuery AST API', () => {
-  let indexPattern: IndexPatternBase;
+  let indexPattern: DataViewBase;
 
   beforeEach(() => {
     indexPattern = {
       fields,
+      title: 'dataView',
     };
   });
 

--- a/packages/kbn-es-query/src/kuery/functions/and.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/and.test.ts
@@ -10,7 +10,7 @@ import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
 import * as ast from '../ast';
 import * as and from './and';
-import { IndexPatternBase } from '../../es_query';
+import { DataViewBase } from '../../es_query';
 
 jest.mock('../grammar');
 
@@ -19,11 +19,12 @@ const childNode2 = nodeTypes.function.buildNode('is', 'extension', 'jpg');
 
 describe('kuery functions', () => {
   describe('and', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/exists.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/exists.test.ts
@@ -8,7 +8,7 @@
 
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 
 jest.mock('../grammar');
 
@@ -17,11 +17,12 @@ import * as exists from './exists';
 
 describe('kuery functions', () => {
   describe('exists', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/geo_bounding_box.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/geo_bounding_box.test.ts
@@ -9,7 +9,7 @@
 import { get } from 'lodash';
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 
 import * as geoBoundingBox from './geo_bounding_box';
 import { JsonObject } from '@kbn/utility-types';
@@ -29,11 +29,12 @@ const params = {
 
 describe('kuery functions', () => {
   describe('geoBoundingBox', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/geo_polygon.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/geo_polygon.test.ts
@@ -8,7 +8,7 @@
 
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 
 import * as geoPolygon from './geo_polygon';
 
@@ -31,11 +31,12 @@ const points = [
 
 describe('kuery functions', () => {
   describe('geoPolygon', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/is.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/is.test.ts
@@ -10,18 +10,19 @@ import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
 
 import * as is from './is';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 import { estypes } from '@elastic/elasticsearch';
 
 jest.mock('../grammar');
 
 describe('kuery functions', () => {
   describe('is', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/nested.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/nested.test.ts
@@ -8,7 +8,7 @@
 
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 
 import * as ast from '../ast';
 
@@ -20,11 +20,12 @@ const childNode = nodeTypes.function.buildNode('is', 'child', 'foo');
 
 describe('kuery functions', () => {
   describe('nested', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/not.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/not.test.ts
@@ -8,7 +8,7 @@
 
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 
 import * as ast from '../ast';
 import * as not from './not';
@@ -19,11 +19,12 @@ const childNode = nodeTypes.function.buildNode('is', 'extension', 'jpg');
 
 describe('kuery functions', () => {
   describe('not', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/or.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/or.test.ts
@@ -8,7 +8,7 @@
 
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 
 import * as ast from '../ast';
 
@@ -20,11 +20,12 @@ const childNode2 = nodeTypes.function.buildNode('is', 'extension', 'jpg');
 
 describe('kuery functions', () => {
   describe('or', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/range.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/range.test.ts
@@ -9,7 +9,7 @@
 import { get } from 'lodash';
 import { nodeTypes } from '../node_types';
 import { fields } from '../../filters/stubs';
-import { IndexPatternBase } from '../..';
+import { DataViewBase } from '../..';
 import { RangeFilterParams } from '../../filters';
 
 import * as range from './range';
@@ -18,11 +18,12 @@ jest.mock('../grammar');
 
 describe('kuery functions', () => {
   describe('range', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/utils/get_full_field_name_node.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/utils/get_full_field_name_node.test.ts
@@ -8,17 +8,18 @@
 
 import { nodeTypes } from '../../node_types';
 import { fields } from '../../../filters/stubs';
-import { IndexPatternBase } from '../../..';
+import { DataViewBase } from '../../..';
 import { getFullFieldNameNode } from './get_full_field_name_node';
 
 jest.mock('../../grammar');
 
 describe('getFullFieldNameNode', function () {
-  let indexPattern: IndexPatternBase;
+  let indexPattern: DataViewBase;
 
   beforeEach(() => {
     indexPattern = {
       fields,
+      title: 'dataView',
     };
   });
 

--- a/packages/kbn-es-query/src/kuery/node_types/function.test.ts
+++ b/packages/kbn-es-query/src/kuery/node_types/function.test.ts
@@ -10,18 +10,19 @@ import { nodeTypes } from './index';
 
 import { buildNode, buildNodeWithArgumentNodes, toElasticsearchQuery } from './function';
 import { toElasticsearchQuery as isFunctionToElasticsearchQuery } from '../functions/is';
-import { IndexPatternBase } from '../../es_query';
+import { DataViewBase } from '../../es_query';
 import { fields } from '../../filters/stubs/fields.mocks';
 
 jest.mock('../grammar');
 
 describe('kuery node types', () => {
   describe('function', () => {
-    let indexPattern: IndexPatternBase;
+    let indexPattern: DataViewBase;
 
     beforeEach(() => {
       indexPattern = {
         fields,
+        title: 'dataView',
       };
     });
 

--- a/src/plugins/data/common/search/expressions/kibana_context.test.ts
+++ b/src/plugins/data/common/search/expressions/kibana_context.test.ts
@@ -205,7 +205,7 @@ describe('kibanaContextFn', () => {
   it('deduplicates duplicated filters and keeps the first enabled filter', async () => {
     const { fn } = kibanaContextFn;
     const filter1 = buildFilter(
-      { fields: [] },
+      { fields: [], title: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,
@@ -217,7 +217,7 @@ describe('kibanaContextFn', () => {
       FilterStateStore.APP_STATE
     );
     const filter2 = buildFilter(
-      { fields: [] },
+      { fields: [], title: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,
@@ -230,7 +230,7 @@ describe('kibanaContextFn', () => {
     );
 
     const filter3 = buildFilter(
-      { fields: [] },
+      { fields: [], title: 'dataView' },
       { name: 'test', type: 'test' },
       FILTERS.PHRASE,
       false,

--- a/x-pack/plugins/infra/public/containers/with_kuery_autocompletion.tsx
+++ b/x-pack/plugins/infra/public/containers/with_kuery_autocompletion.tsx
@@ -83,7 +83,6 @@ class WithKueryAutocompletionComponent extends React.Component<
         query: expression,
         selectionStart: cursorPosition,
         selectionEnd: cursorPosition,
-        // @ts-expect-error (until data service updates to new types)
         indexPatterns: [indexPattern],
         boolFilter: [],
       })) || [];


### PR DESCRIPTION
## Summary

DataViewBase is replacing IIndexPattern. Unfortunately it allowed `undefined` for title which isn't allowed with IIndexPattern presenting a problem for code that transitioning from one type to the other. This PR fixes the incompatibility.