### PR TITLE
[App Search] Add web crawler toggle to log retention settings view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
@@ -19,12 +19,14 @@ import { AppLogic } from '../../../app_logic';
 import { SETTINGS_PATH } from '../../../routes';
 import { ANALYTICS_TITLE } from '../../analytics';
 import { API_LOGS_TITLE } from '../../api_logs';
+import { CRAWLER_TITLE } from '../../crawler';
 
 import { LogRetentionLogic, LogRetentionOptions, renderLogRetentionDate } from '../index';
 
 const TITLE_MAP = {
   [LogRetentionOptions.Analytics]: ANALYTICS_TITLE,
   [LogRetentionOptions.API]: API_LOGS_TITLE,
+  [LogRetentionOptions.Crawler]: CRAWLER_TITLE,
 };
 
 interface Props {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
@@ -33,6 +33,11 @@ describe('LogRetentionLogic', () => {
       enabled: true,
       retention_policy: { is_default: true, min_age_days: 180 },
     },
+    crawler: {
+      disabled_at: null,
+      enabled: true,
+      retention_policy: { is_default: true, min_age_days: 180 },
+    },
   };
 
   const TYPICAL_CLIENT_LOG_RETENTION = {
@@ -42,6 +47,11 @@ describe('LogRetentionLogic', () => {
       retentionPolicy: { isDefault: true, minAgeDays: 180 },
     },
     api: {
+      disabledAt: null,
+      enabled: true,
+      retentionPolicy: { isDefault: true, minAgeDays: 180 },
+    },
+    crawler: {
       disabledAt: null,
       enabled: true,
       retentionPolicy: { isDefault: true, minAgeDays: 180 },
@@ -146,6 +156,11 @@ describe('LogRetentionLogic', () => {
               enabled: true,
               retentionPolicy: null,
             },
+            crawler: {
+              disabledAt: null,
+              enabled: true,
+              retentionPolicy: null,
+            },
           });
 
           expect(LogRetentionLogic.values).toEqual({
@@ -157,6 +172,11 @@ describe('LogRetentionLogic', () => {
                 retentionPolicy: null,
               },
               analytics: {
+                disabledAt: null,
+                enabled: true,
+                retentionPolicy: null,
+              },
+              crawler: {
                 disabledAt: null,
                 enabled: true,
                 retentionPolicy: null,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/constants.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/constants.tsx
@@ -37,6 +37,16 @@ const CAPITALIZATION_MAP = {
       { defaultMessage: 'API' }
     ),
   },
+  [LogRetentionOptions.Crawler]: {
+    capitalized: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.logRetention.type.crawler.title.capitalized',
+      { defaultMessage: 'Web crawler' }
+    ),
+    lowercase: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.logRetention.type.crawler.title.lowercase',
+      { defaultMessage: 'web crawler' }
+    ),
+  },
 };
 
 interface Props {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/types.ts
@@ -8,11 +8,13 @@
 export enum LogRetentionOptions {
   Analytics = 'analytics',
   API = 'api',
+  Crawler = 'crawler',
 }
 
 export interface LogRetention {
   [LogRetentionOptions.Analytics]: LogRetentionSettings;
   [LogRetentionOptions.API]: LogRetentionSettings;
+  [LogRetentionOptions.Crawler]: LogRetentionSettings;
 }
 
 export interface LogRetentionPolicy {
@@ -29,6 +31,7 @@ export interface LogRetentionSettings {
 export interface LogRetentionServer {
   [LogRetentionOptions.Analytics]: LogRetentionServerSettings;
   [LogRetentionOptions.API]: LogRetentionServerSettings;
+  [LogRetentionOptions.Crawler]: LogRetentionServerSettings;
 }
 
 export interface LogRetentionServerPolicy {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/utils/convert_log_retention.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/utils/convert_log_retention.test.ts
@@ -21,6 +21,11 @@ describe('convertLogRetentionFromServerToClient', () => {
           enabled: true,
           retention_policy: { is_default: true, min_age_days: 180 },
         },
+        crawler: {
+          disabled_at: null,
+          enabled: true,
+          retention_policy: { is_default: true, min_age_days: 180 },
+        },
       })
     ).toEqual({
       analytics: {
@@ -29,6 +34,11 @@ describe('convertLogRetentionFromServerToClient', () => {
         retentionPolicy: { isDefault: true, minAgeDays: 180 },
       },
       api: {
+        disabledAt: null,
+        enabled: true,
+        retentionPolicy: { isDefault: true, minAgeDays: 180 },
+      },
+      crawler: {
         disabledAt: null,
         enabled: true,
         retentionPolicy: { isDefault: true, minAgeDays: 180 },
@@ -49,6 +59,11 @@ describe('convertLogRetentionFromServerToClient', () => {
           enabled: true,
           retention_policy: { is_default: true, min_age_days: null },
         },
+        crawler: {
+          disabled_at: null,
+          enabled: true,
+          retention_policy: { is_default: true, min_age_days: null },
+        },
       })
     ).toEqual({
       analytics: {
@@ -57,6 +72,11 @@ describe('convertLogRetentionFromServerToClient', () => {
         retentionPolicy: null,
       },
       api: {
+        disabledAt: null,
+        enabled: true,
+        retentionPolicy: { isDefault: true, minAgeDays: null },
+      },
+      crawler: {
         disabledAt: null,
         enabled: true,
         retentionPolicy: { isDefault: true, minAgeDays: null },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/utils/convert_log_retention.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/utils/convert_log_retention.ts
@@ -24,6 +24,9 @@ export const convertLogRetentionFromServerToClient = (
   [LogRetentionOptions.API]: convertLogRetentionSettingsFromServerToClient(
     logRetention[LogRetentionOptions.API]
   ),
+  [LogRetentionOptions.Crawler]: convertLogRetentionSettingsFromServerToClient(
+    logRetention[LogRetentionOptions.Crawler]
+  ),
 });
 
 const convertLogRetentionSettingsFromServerToClient = ({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.test.tsx
@@ -39,6 +39,13 @@ describe('<LogRetentionConfirmationModal />', () => {
           minAgeDays: 7,
         },
       },
+      crawler: {
+        enabled: true,
+        retentionPolicy: {
+          isDefault: true,
+          minAgeDays: 7,
+        },
+      },
     },
   };
 
@@ -120,6 +127,44 @@ describe('<LogRetentionConfirmationModal />', () => {
       setMockValues({
         ...values,
         openedModal: LogRetentionOptions.API,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      const genericConfirmationModal = logRetentionPanel.find(GenericConfirmationModal);
+      genericConfirmationModal.prop('onClose')();
+      expect(actions.closeModals).toHaveBeenCalled();
+    });
+  });
+
+  describe('crawler', () => {
+    it('renders the Crawler panel when openedModal is set to Crawler', () => {
+      setMockValues({
+        ...values,
+        openedModal: LogRetentionOptions.Crawler,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      expect(
+        logRetentionPanel.find('[data-test-subj="CrawlerLogRetentionConfirmationModal"]').length
+      ).toBe(1);
+    });
+
+    it('calls saveLogRetention on save when showing crawler', () => {
+      setMockValues({
+        ...values,
+        openedModal: LogRetentionOptions.Crawler,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      const genericConfirmationModal = logRetentionPanel.find(GenericConfirmationModal);
+      genericConfirmationModal.prop('onSave')();
+      expect(actions.saveLogRetention).toHaveBeenCalledWith(LogRetentionOptions.Crawler, false);
+    });
+
+    it('calls closeModals on close', () => {
+      setMockValues({
+        ...values,
+        openedModal: LogRetentionOptions.Crawler,
       });
 
       const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.tsx
@@ -133,6 +133,54 @@ export const LogRetentionConfirmationModal: React.FC = () => {
           onSave={() => saveLogRetention(LogRetentionOptions.API, false)}
         />
       )}
+
+      {openedModal === LogRetentionOptions.Crawler && (
+        <GenericConfirmationModal
+          data-test-subj="CrawlerLogRetentionConfirmationModal"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.crawler.title',
+            {
+              defaultMessage: 'Disable Web Crawler writes',
+            }
+          )}
+          subheading={
+            logRetention &&
+            logRetention?.[LogRetentionOptions.Crawler].retentionPolicy?.minAgeDays &&
+            i18n.translate(
+              'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.crawler.subheading',
+              {
+                defaultMessage:
+                  'Your Web Crawler Logs are currently being stored for {minAgeDays} days.',
+                values: {
+                  minAgeDays:
+                    logRetention?.[LogRetentionOptions.Crawler].retentionPolicy?.minAgeDays,
+                },
+              }
+            )
+          }
+          description={
+            <>
+              <p>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.crawler.description',
+                  {
+                    defaultMessage:
+                      'When you disable writing, engines stop logging Web Crawler events. Your existing data is deleted according to the storage time frame.',
+                  }
+                )}
+              </p>
+              <p>
+                <strong>
+                  <EuiTextColor color="danger">{CANNOT_BE_RECOVERED_TEXT}</EuiTextColor>
+                </strong>
+              </p>
+            </>
+          }
+          target={DISABLE_TEXT}
+          onClose={closeModals}
+          onSave={() => saveLogRetention(LogRetentionOptions.Crawler, false)}
+        />
+      )}
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.test.tsx
@@ -101,7 +101,7 @@ describe('<LogRetentionPanel />', () => {
     ).toEqual(true);
   });
 
-  it('enables both switches when isLogRetentionUpdating is false', () => {
+  it('enables all switches when isLogRetentionUpdating is false', () => {
     setMockValues({
       isLogRetentionUpdating: false,
       logRetention: mockLogRetention({}),
@@ -113,9 +113,12 @@ describe('<LogRetentionPanel />', () => {
     expect(
       logRetentionPanel.find('[data-test-subj="LogRetentionPanelAPISwitch"]').prop('disabled')
     ).toEqual(false);
+    expect(
+      logRetentionPanel.find('[data-test-subj="LogRetentionPanelCrawlerSwitch"]').prop('disabled')
+    ).toEqual(false);
   });
 
-  it('disables both switches when isLogRetentionUpdating is true', () => {
+  it('disables all switches when isLogRetentionUpdating is true', () => {
     setMockValues({
       isLogRetentionUpdating: true,
       logRetention: mockLogRetention({}),
@@ -127,6 +130,9 @@ describe('<LogRetentionPanel />', () => {
     ).toEqual(true);
     expect(
       logRetentionPanel.find('[data-test-subj="LogRetentionPanelAPISwitch"]').prop('disabled')
+    ).toEqual(true);
+    expect(
+      logRetentionPanel.find('[data-test-subj="LogRetentionPanelCrawlerSwitch"]').prop('disabled')
     ).toEqual(true);
   });
 
@@ -150,7 +156,7 @@ describe('<LogRetentionPanel />', () => {
     setMockValues({
       isLogRetentionUpdating: false,
       logRetention: mockLogRetention({
-        analytics: {
+        api: {
           enabled: false,
         },
       }),
@@ -158,6 +164,20 @@ describe('<LogRetentionPanel />', () => {
     const logRetentionPanel = shallow(<LogRetentionPanel />);
     logRetentionPanel.find('[data-test-subj="LogRetentionPanelAPISwitch"]').simulate('change');
     expect(actions.toggleLogRetention).toHaveBeenCalledWith('api');
+  });
+
+  it('calls toggleLogRetention when crawler log retention option is changed', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        crawler: {
+          enabled: false,
+        },
+      }),
+    });
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    logRetentionPanel.find('[data-test-subj="LogRetentionPanelCrawlerSwitch"]').simulate('change');
+    expect(actions.toggleLogRetention).toHaveBeenCalledWith('crawler');
   });
 });
 
@@ -173,6 +193,11 @@ const mockLogRetention = (logRetention: Partial<LogRetention>) => {
       enabled: true,
       retentionPolicy: { isDefault: true, minAgeDays: 180 },
     },
+    crawler: {
+      disabledAt: null,
+      enabled: true,
+      retentionPolicy: { isDefault: true, minAgeDays: 180 },
+    },
   };
 
   return {
@@ -183,6 +208,10 @@ const mockLogRetention = (logRetention: Partial<LogRetention>) => {
     api: {
       ...baseLogRetention.api,
       ...logRetention.api,
+    },
+    crawler: {
+      ...baseLogRetention.crawler,
+      ...logRetention.crawler,
     },
   };
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
@@ -32,6 +32,7 @@ export const LogRetentionPanel: React.FC = () => {
   const hasILM = logRetention !== null;
   const analyticsLogRetentionSettings = logRetention?.[LogRetentionOptions.Analytics];
   const apiLogRetentionSettings = logRetention?.[LogRetentionOptions.API];
+  const crawlerLogRetentionSettings = logRetention?.[LogRetentionOptions.Crawler];
 
   useEffect(() => {
     fetchLogRetention();
@@ -98,6 +99,33 @@ export const LogRetentionPanel: React.FC = () => {
           onChange={() => toggleLogRetention(LogRetentionOptions.API)}
           disabled={isLogRetentionUpdating}
           data-test-subj="LogRetentionPanelAPISwitch"
+        />
+      </EuiText>
+      <EuiSpacer size="m" />
+      <EuiText>
+        <EuiSwitch
+          label={
+            <>
+              <strong>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.settings.logRetention.crawler.label',
+                  {
+                    defaultMessage: 'Web Crawler Logs',
+                  }
+                )}
+              </strong>
+              {': '}
+              {hasILM && (
+                <EuiTextColor color="subdued">
+                  <LogRetentionMessage type={LogRetentionOptions.Crawler} />
+                </EuiTextColor>
+              )}
+            </>
+          }
+          checked={!!crawlerLogRetentionSettings?.enabled}
+          onChange={() => toggleLogRetention(LogRetentionOptions.Crawler)}
+          disabled={isLogRetentionUpdating}
+          data-test-subj="LogRetentionPanelCrawlerSwitch"
         />
       </EuiText>
       <EuiSpacer size="l" />

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/settings.test.ts
@@ -57,13 +57,21 @@ describe('log settings routes', () => {
 
     describe('validates', () => {
       it('validates good data', () => {
-        const request = {
+        mockRouter.shouldValidate({
           body: {
             analytics: { enabled: true },
+          },
+        });
+        mockRouter.shouldValidate({
+          body: {
             api: { enabled: true },
           },
-        };
-        mockRouter.shouldValidate(request);
+        });
+        mockRouter.shouldValidate({
+          body: {
+            crawler: { enabled: true },
+          },
+        });
       });
 
       it('rejects bad data', () => {

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/settings.ts
@@ -38,6 +38,11 @@ export function registerSettingsRoutes({
               enabled: schema.boolean(),
             })
           ),
+          crawler: schema.maybe(
+            schema.object({
+              enabled: schema.boolean(),
+            })
+          ),
         }),
       },
     },


### PR DESCRIPTION
## Summary

Adds a toggle for web crawler logs in the log retention settings view

## Screenshots

<img width="800" alt="Screen Shot 2021-10-14 at 9 40 19 PM" src="https://user-images.githubusercontent.com/2479295/137419480-4672b736-efc0-44df-bdce-6ecaecb517fc.png">

<img width="800" alt="Screen Shot 2021-10-14 at 9 40 30 PM" src="https://user-images.githubusercontent.com/2479295/137419484-b56ba344-3218-4b83-8e85-0fa9eaede079.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

