### PR TITLE
[Stack Monitoring] fix error handling during executeCheck

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/no_data/no_data_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/no_data/no_data_page.tsx
@@ -220,12 +220,10 @@ async function executeCheck(checker: SettingsChecker, http: { fetch: any }): Pro
 
     return { found, reason };
   } catch (err: any) {
-    const { data } = err;
-
     return {
       error: true,
       found: false,
-      errorReason: data,
+      errorReason: err.body,
     };
   }
 }

--- a/x-pack/plugins/monitoring/public/components/no_data/reasons/__snapshots__/we_tried.test.js.snap
+++ b/x-pack/plugins/monitoring/public/components/no_data/reasons/__snapshots__/we_tried.test.js.snap
@@ -1,15 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WeTried should render "we tried" message 1`] = `
-Array [
+<div
+  data-test-subj="weTriedContainer"
+>
   <h2
     class="euiTitle euiTitle--large"
   >
     We couldn't activate monitoring
-  </h2>,
+  </h2>
   <hr
     class="euiHorizontalRule euiHorizontalRule--half euiHorizontalRule--marginLarge"
-  />,
+  />
   <div
     class="euiText euiText--medium eui-textLeft"
   >
@@ -19,6 +21,6 @@ Array [
     <p>
       If data is in your cluster, your monitoring dashboards will show up here.
     </p>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/x-pack/plugins/monitoring/public/components/no_data/reasons/we_tried.js
+++ b/x-pack/plugins/monitoring/public/components/no_data/reasons/we_tried.js
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import { EuiText, EuiHorizontalRule, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 export function WeTried() {
   return (
-    <Fragment>
+    <div data-test-subj="weTriedContainer">
       <EuiTitle size="l">
         <h2>
           <FormattedMessage
@@ -36,6 +36,6 @@ export function WeTried() {
           />
         </p>
       </EuiText>
-    </Fragment>
+    </div>
   );
 }

--- a/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_security.ts
+++ b/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_security.ts
@@ -13,6 +13,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const security = getService('security');
   const appsMenu = getService('appsMenu');
   const PageObjects = getPageObjects(['common', 'security']);
+  const noData = getService('monitoringNoData');
 
   describe('security', () => {
     before(async () => {
@@ -101,6 +102,33 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('shows monitoring navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
         expect(navLinks).to.contain('Stack Monitoring');
+      });
+    });
+
+    describe('monitoring_user and kibana_admin roles', function () {
+      this.tags(['skipCloud']);
+      before(async () => {
+        await security.user.create('monitoring_kibana_admin_user', {
+          password: 'monitoring_user-password',
+          roles: ['monitoring_user', 'kibana_admin'],
+          full_name: 'monitoring user',
+        });
+
+        await PageObjects.security.login(
+          'monitoring_kibana_admin_user',
+          'monitoring_user-password'
+        );
+      });
+
+      after(async () => {
+        await security.user.delete('monitoring_kibana_admin_user');
+      });
+
+      it('denies enabling monitoring without enough permissions', async () => {
+        await PageObjects.common.navigateToApp('monitoring');
+        await noData.isOnNoDataPage();
+        await noData.clickSetupWithSelfMonitoring();
+        await noData.isOnNoDataPageMonitoringEnablementDenied();
       });
     });
   });

--- a/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_security.ts
+++ b/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_security.ts
@@ -128,7 +128,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await PageObjects.common.navigateToApp('monitoring');
         await noData.isOnNoDataPage();
         await noData.clickSetupWithSelfMonitoring();
-        await noData.isOnNoDataPageMonitoringEnablementDenied();
+        expect(await noData.isOnNoDataPageMonitoringEnablementDenied()).to.be(true);
       });
     });
   });

--- a/x-pack/test/functional/services/monitoring/no_data.js
+++ b/x-pack/test/functional/services/monitoring/no_data.js
@@ -30,5 +30,13 @@ export function MonitoringNoDataProvider({ getService }) {
       const pageId = await retry.try(() => testSubjects.find('noDataContainer'));
       return pageId !== null;
     }
+
+    async isOnNoDataPageMonitoringEnablementDenied() {
+      return testSubjects.exists('weTriedContainer');
+    }
+
+    async clickSetupWithSelfMonitoring() {
+      await testSubjects.click('useInternalCollection');
+    }
   })();
 }


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/kibana/issues/114999

- fixes bug where `data` property did not exist in the response, changed to body
- adds functional test for this case
- update the jest test

### Test
- flaky test runner: https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/2018/
- Create a user with `kibana_admin` and `monitoring_user`
- login as that user and navigate to the monitoring app
- With no monitoring data yet being collected, in the react version, try to turn on self monitoring and you should see:
![Screen Shot 2021-10-14 at 9 26 32 AM](https://user-images.githubusercontent.com/1676003/137327486-2b01edb2-0591-43e6-98fb-adbaaf7b952f.png)
They get this page because they don't have enough permissions to turn on monitoring.  Not the best messaging but the errors make it clear the problem.