### PR TITLE
[Security Solution][Endpoint] Fixes Policy Details page to display an error if policy id (from URL) is invalid

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/administration_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/administration_list_page.tsx
@@ -67,7 +67,7 @@ export const AdministrationListPage: FC<AdministrationListPageProps & CommonProp
           pageTitle={header}
           description={description}
           bottomBorder={hasBottomBorder}
-          rightSideItems={[actions]}
+          rightSideItems={actions ? [actions] : undefined}
           restrictWidth={restrictWidth}
           data-test-subj={getTestId('header')}
         />

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_details.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_details.tsx
@@ -8,8 +8,9 @@
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { useLocation } from 'react-router-dom';
+import { EuiLoadingSpinner, EuiPageTemplate } from '@elastic/eui';
 import { usePolicyDetailsSelector } from './policy_hooks';
-import { policyDetails, agentStatusSummary } from '../store/policy_details/selectors';
+import { policyDetails, agentStatusSummary, isLoading } from '../store/policy_details/selectors';
 import { AgentsSummary } from './agents_summary';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { PolicyTabs } from './tabs';
@@ -33,6 +34,7 @@ export const PolicyDetails = React.memo(() => {
   const { getAppUrl } = useAppUrl();
 
   // Store values
+  const loading = usePolicyDetailsSelector(isLoading);
   const policyItem = usePolicyDetailsSelector(policyDetails);
   const policyAgentStatusSummary = usePolicyDetailsSelector(agentStatusSummary);
 
@@ -91,7 +93,15 @@ export const PolicyDetails = React.memo(() => {
       restrictWidth={true}
       hasBottomBorder={!isTrustedAppsByPolicyEnabled} // TODO: Remove this and related code when removing FF
     >
-      {isTrustedAppsByPolicyEnabled ? (
+      {loading ? (
+        <EuiPageTemplate template="centeredContent">
+          <EuiLoadingSpinner
+            className="essentialAnimation"
+            size="xl"
+            data-test-subj="policyDetailsLoading"
+          />
+        </EuiPageTemplate>
+      ) : isTrustedAppsByPolicyEnabled ? (
         <PolicyTabs />
       ) : (
         // TODO: Remove this and related code when removing FF

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/policy_form_layout.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/policy_form_layout.test.tsx
@@ -30,7 +30,6 @@ describe('Policy Form Layout', () => {
   const generator = new EndpointDocGenerator();
   let history: AppContextTestRender['history'];
   let coreStart: AppContextTestRender['coreStart'];
-  let middlewareSpy: AppContextTestRender['middlewareSpy'];
   let http: typeof coreStart.http;
   let render: (ui: Parameters<typeof mount>[0]) => ReturnType<typeof mount>;
   let policyPackagePolicy: ReturnType<typeof generator.generatePolicyPackagePolicy>;
@@ -40,7 +39,7 @@ describe('Policy Form Layout', () => {
     const appContextMockRenderer = createAppRootMockRenderer();
     const AppWrapper = appContextMockRenderer.AppWrapper;
 
-    ({ history, coreStart, middlewareSpy } = appContextMockRenderer);
+    ({ history, coreStart } = appContextMockRenderer);
     render = (ui) => mount(ui, { wrappingComponent: AppWrapper });
     http = coreStart.http;
   });
@@ -52,33 +51,6 @@ describe('Policy Form Layout', () => {
     jest.clearAllMocks();
   });
 
-  describe('when displayed with invalid id', () => {
-    let releaseApiFailure: () => void;
-    beforeEach(() => {
-      http.get.mockImplementation(async () => {
-        await new Promise((_, reject) => {
-          releaseApiFailure = reject.bind(null, new Error('policy not found'));
-        });
-      });
-      history.push(policyDetailsPathUrl);
-      policyFormLayoutView = render(<PolicyFormLayout />);
-    });
-
-    it('should NOT display timeline', async () => {
-      expect(policyFormLayoutView.find('flyoutOverlay')).toHaveLength(0);
-    });
-
-    it('should show loader followed by error message', async () => {
-      expect(policyFormLayoutView.find('EuiLoadingSpinner').length).toBe(1);
-      releaseApiFailure();
-      await middlewareSpy.waitForAction('serverFailedToReturnPolicyDetailsData');
-      policyFormLayoutView.update();
-      const callout = policyFormLayoutView.find('EuiCallOut');
-      expect(callout).toHaveLength(1);
-      expect(callout.prop('color')).toEqual('danger');
-      expect(callout.text()).toEqual('policy not found');
-    });
-  });
   describe('when displayed with valid id', () => {
     let asyncActions: Promise<unknown> = Promise.resolve();
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/policy_form_layout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_forms/components/policy_form_layout.tsx
@@ -11,7 +11,6 @@ import {
   EuiFlexItem,
   EuiButton,
   EuiButtonEmpty,
-  EuiCallOut,
   EuiLoadingSpinner,
   EuiBottomBar,
   EuiSpacer,
@@ -27,7 +26,6 @@ import {
   agentStatusSummary,
   updateStatus,
   isLoading,
-  apiError,
 } from '../../../store/policy_details/selectors';
 
 import { toMountPoint } from '../../../../../../../../../../src/plugins/kibana_react/public';
@@ -58,7 +56,6 @@ export const PolicyFormLayout = React.memo(() => {
   const policyAgentStatusSummary = usePolicyDetailsSelector(agentStatusSummary);
   const policyUpdateStatus = usePolicyDetailsSelector(updateStatus);
   const isPolicyLoading = usePolicyDetailsSelector(isLoading);
-  const policyApiError = usePolicyDetailsSelector(apiError);
 
   // Local state
   const [showConfirm, setShowConfirm] = useState<boolean>(false);
@@ -136,13 +133,7 @@ export const PolicyFormLayout = React.memo(() => {
   if (!policyItem) {
     return (
       <SecuritySolutionPageWrapper noTimeline>
-        {isPolicyLoading ? (
-          <EuiLoadingSpinner size="xl" />
-        ) : policyApiError ? (
-          <EuiCallOut color="danger" title={policyApiError?.error}>
-            <span data-test-subj="policyDetailsIdNotFoundMessage">{policyApiError?.message}</span>
-          </EuiCallOut>
-        ) : null}
+        {isPolicyLoading ? <EuiLoadingSpinner size="xl" /> : null}
         <SpyRoute pageName={SecurityPageName.administration} />
       </SecuritySolutionPageWrapper>
     );


### PR DESCRIPTION
## Summary

- Moves the check for API errors, while retrieving the Policy Details from the API, from the Policy form layout to the overall Policy Details page - done prior to displaying the sub-tabs. (same behaviour as prior to tabs being introduced)
- Moves tests for this page condition from the policy setting form

![olm-1853-polidy-details-handle-loading-error](https://user-images.githubusercontent.com/56442535/137397741-2c7de6b2-fe14-4d91-88af-a8d48a153ae4.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
