### PR TITLE
[Security Solution] [Sourcerer] Timeline Reset button, bug fix

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/pick_events.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/pick_events.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, render, prettyDOM } from '@testing-library/react';
+import React from 'react';
+import { PickEventType } from './pick_events';
+import {
+  createSecuritySolutionStorageMock,
+  kibanaObservable,
+  mockGlobalState,
+  SUB_PLUGINS_REDUCER,
+  TestProviders,
+} from '../../../../common/mock';
+import { TimelineEventsType } from '../../../../../common';
+import { createStore } from '../../../../common/store';
+import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
+
+describe('pick_events', () => {
+  const defaultProps = {
+    eventType: 'all' as TimelineEventsType,
+    onChangeEventTypeAndIndexesName: jest.fn(),
+  };
+  const initialPatterns = [
+    ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline].selectedPatterns,
+    mockGlobalState.sourcerer.signalIndexName,
+  ];
+  const { storage } = createSecuritySolutionStorageMock();
+  const state = {
+    ...mockGlobalState,
+    sourcerer: {
+      ...mockGlobalState.sourcerer,
+      kibanaIndexPatterns: [
+        { id: '1234', title: 'auditbeat-*' },
+        { id: '9100', title: 'filebeat-*' },
+        { id: '9100', title: 'auditbeat-*,filebeat-*' },
+        { id: '5678', title: 'auditbeat-*,.siem-signals-default' },
+      ],
+      configIndexPatterns:
+        mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline].selectedPatterns,
+      signalIndexName: mockGlobalState.sourcerer.signalIndexName,
+      sourcererScopes: {
+        ...mockGlobalState.sourcerer.sourcererScopes,
+        [SourcererScopeName.timeline]: {
+          ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.timeline],
+          loading: false,
+          selectedPatterns: ['filebeat-*'],
+        },
+      },
+    },
+  };
+  const store = createStore(state, SUB_PLUGINS_REDUCER, kibanaObservable, storage);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+  it('renders', () => {
+    const wrapper = render(
+      <TestProviders>
+        <PickEventType {...defaultProps} />
+      </TestProviders>
+    );
+    fireEvent.click(wrapper.getByTestId('sourcerer-timeline-trigger'));
+    expect(wrapper.getByTestId('timeline-sourcerer').textContent).toEqual(
+      initialPatterns.sort().join('')
+    );
+  });
+  it('correctly filters options', () => {
+    const wrapper = render(
+      <TestProviders store={store}>
+        <PickEventType {...defaultProps} />
+      </TestProviders>
+    );
+    fireEvent.click(wrapper.getByTestId('sourcerer-timeline-trigger'));
+    fireEvent.click(wrapper.getByTestId('comboBoxToggleListButton'));
+    const optionNodes = wrapper.getAllByTestId('sourcerer-option');
+    expect(optionNodes.length).toBe(9);
+  });
+  it('reset button works', () => {
+    const wrapper = render(
+      <TestProviders store={store}>
+        <PickEventType {...defaultProps} />
+      </TestProviders>
+    );
+    fireEvent.click(wrapper.getByTestId('sourcerer-timeline-trigger'));
+    expect(wrapper.getByTestId('timeline-sourcerer').textContent).toEqual('filebeat-*');
+
+    fireEvent.click(wrapper.getByTestId('sourcerer-reset'));
+    expect(wrapper.getByTestId('timeline-sourcerer').textContent).toEqual(
+      initialPatterns.sort().join('')
+    );
+    fireEvent.click(wrapper.getByTestId('comboBoxToggleListButton'));
+    const optionNodes = wrapper.getAllByTestId('sourcerer-option');
+    expect(optionNodes.length).toBe(2);
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/pick_events.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/pick_events.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { fireEvent, render, prettyDOM } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { PickEventType } from './pick_events';
 import {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/pick_events.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/pick_events.tsx
@@ -144,7 +144,7 @@ const PickEventTypeComponents: React.FC<PickEventTypeProps> = ({
         ...kibanaIndexPatterns.map((kip) => kip.title),
         signalIndexName,
       ].reduce<Array<EuiComboBoxOptionOption<string>>>((acc, index) => {
-        if (index != null && !acc.some((o) => o.label.includes(index))) {
+        if (index != null && !acc.some((o) => o.label === index)) {
           return [...acc, { label: index, value: index }];
         }
         return acc;
@@ -153,16 +153,15 @@ const PickEventTypeComponents: React.FC<PickEventTypeProps> = ({
   );
 
   const renderOption = useCallback(
-    (option) => {
-      const { value } = option;
+    ({ value }) => {
       if (kibanaIndexPatterns.some((kip) => kip.title === value)) {
         return (
-          <>
+          <span data-test-subj="sourcerer-option">
             <EuiIcon type="logoKibana" size="s" /> {value}
-          </>
+          </span>
         );
       }
-      return <>{value}</>;
+      return <span data-test-subj="sourcerer-option">{value}</span>;
     },
     [kibanaIndexPatterns]
   );
@@ -193,14 +192,14 @@ const PickEventTypeComponents: React.FC<PickEventTypeProps> = ({
       setFilterEventType(filter);
       if (filter === 'all') {
         setSelectedOptions(
-          [...configIndexPatterns, signalIndexName ?? ''].map((indexSelected) => ({
+          [...configIndexPatterns.sort(), signalIndexName ?? ''].map((indexSelected) => ({
             label: indexSelected,
             value: indexSelected,
           }))
         );
       } else if (filter === 'raw') {
         setSelectedOptions(
-          configIndexPatterns.map((indexSelected) => ({
+          configIndexPatterns.sort().map((indexSelected) => ({
             label: indexSelected,
             value: indexSelected,
           }))
@@ -240,14 +239,8 @@ const PickEventTypeComponents: React.FC<PickEventTypeProps> = ({
   }, [filterEventType, onChangeEventTypeAndIndexesName, selectedOptions]);
 
   const resetDataSources = useCallback(() => {
-    setSelectedOptions(
-      sourcererScope.selectedPatterns.map((indexSelected) => ({
-        label: indexSelected,
-        value: indexSelected,
-      }))
-    );
-    setFilterEventType(eventType);
-  }, [eventType, sourcererScope.selectedPatterns]);
+    onChangeFilter('all');
+  }, [onChangeFilter]);
 
   const comboBox = useMemo(
     () => (


### PR DESCRIPTION
Fixes the timeline sourcerer bug in https://github.com/elastic/kibana/issues/98466 as well as another bug with timeline sourcerer options. Both of these bugs were on the `pick_events` component

This fix does not need to go into `v8.0.0` as https://github.com/elastic/kibana/pull/114805 removes the `pick_events` component

## Bug 1
**Steps**: Make changes to the timeline sourcerer from the "All data sources" default. Press save. Open and press "Reset" button. 
### **Before**: Observe UI does not reset to the "All data sources" default
![bug1](https://user-images.githubusercontent.com/6935300/137404274-f6de10bd-972f-4292-9d9a-4718f611ab9a.gif)
### **After**: Observe UI does reset to the "All data sources" default
![fix1](https://user-images.githubusercontent.com/6935300/137404282-75745bf7-bcc2-40a9-a114-003930c30dbe.gif)

## Bug 1
**Steps**: Create a Kibana index pattern like `auditbeat-*,.siem-signals-default`. Open timeline sourcerer. Close box option for `.siem-signals-default`
### **Before**: Observe sourcerer options do not update to include `.siem-signals-default`
![bug2](https://user-images.githubusercontent.com/6935300/137404549-8ff6c3f3-64cd-4d4a-b18e-897268935972.gif)
### **After**: Observe sourcerer options update to include `.siem-signals-default`
![fix2](https://user-images.githubusercontent.com/6935300/137404541-8381094c-d112-4578-82a4-d9e264af242d.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
