### PR TITLE
Add LevelIconTips to be more explicit about the difference between critical and warning issues

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/fix_issues_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/fix_issues_step.tsx
@@ -70,7 +70,7 @@ export const getFixIssuesStep = ({
           <p>
             <FormattedMessage
               id="xpack.upgradeAssistant.overview.fixIssuesStepDescription"
-              defaultMessage="Update your Elasticsearch and Kibana deployments to be compatible with {nextMajor}.0. Critical issues must be resolved before you upgrade."
+              defaultMessage="Update your Elasticsearch and Kibana deployments to be compatible with {nextMajor}.0. Critical issues must be resolved before you upgrade. Warning issues can be ignored at your discretion."
               values={{ nextMajor }}
             />
           </p>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/deprecation_count.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/deprecation_count.tsx
@@ -6,9 +6,10 @@
  */
 
 import React, { FunctionComponent } from 'react';
-
 import { EuiFlexGroup, EuiFlexItem, EuiHealth } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
+import { LevelInfoTip } from './level_info_tip';
 
 const i18nTexts = {
   getCriticalStatusLabel: (count: number) =>
@@ -39,14 +40,31 @@ export const DeprecationCount: FunctionComponent<Props> = ({
   return (
     <EuiFlexGroup>
       <EuiFlexItem grow={false}>
-        <EuiHealth color="danger" data-test-subj="criticalDeprecationsCount">
-          {i18nTexts.getCriticalStatusLabel(totalCriticalDeprecations)}
-        </EuiHealth>
+        <EuiFlexGroup gutterSize="xs" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiHealth color="danger" data-test-subj="criticalDeprecationsCount">
+              {i18nTexts.getCriticalStatusLabel(totalCriticalDeprecations)}
+            </EuiHealth>
+          </EuiFlexItem>
+
+          <EuiFlexItem>
+            <LevelInfoTip level="critical" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
+
       <EuiFlexItem grow={false}>
-        <EuiHealth color="subdued" data-test-subj="warningDeprecationsCount">
-          {i18nTexts.getWarningStatusLabel(totalWarningDeprecations)}
-        </EuiHealth>
+        <EuiFlexGroup gutterSize="xs" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiHealth color="subdued" data-test-subj="warningDeprecationsCount">
+              {i18nTexts.getWarningStatusLabel(totalWarningDeprecations)}
+            </EuiHealth>
+          </EuiFlexItem>
+
+          <EuiFlexItem>
+            <LevelInfoTip level="warning" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/index.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/index.ts
@@ -9,3 +9,4 @@ export { NoDeprecationsPrompt } from './no_deprecations';
 export { DeprecationCount } from './deprecation_count';
 export { DeprecationBadge } from './deprecation_badge';
 export { DeprecationsPageLoadingError } from './deprecations_page_loading_error';
+export { LevelInfoTip } from './level_info_tip';

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/level_info_tip.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/level_info_tip.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FunctionComponent } from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiIconTip } from '@elastic/eui';
+
+const i18nTexts = {
+  critical: i18n.translate('xpack.upgradeAssistant.levelInfoTip.criticalLabel', {
+    defaultMessage: 'Critical issues must be resolved before you upgrade',
+  }),
+  warning: i18n.translate('xpack.upgradeAssistant.levelInfoTip.warningLabel', {
+    defaultMessage: 'Warning issues can be ignored at your discretion',
+  }),
+};
+
+interface Props {
+  level: 'critical' | 'warning';
+}
+
+export const LevelInfoTip: FunctionComponent<Props> = ({ level }) => {
+  return <EuiIconTip content={i18nTexts[level]} position="top" type="iInCircle" />;
+};


### PR DESCRIPTION
## Summary

I added EuiIconTips to the ~~overview and~~ deprecations tables to offer the same guidance I provided in https://github.com/elastic/kibana/issues/114197#issuecomment-943546267. Due to some accessibility problems in EUI (https://github.com/elastic/eui/issues/5273), I'm only going to add these tips to the deprecation tables. I opened https://github.com/elastic/kibana/pull/115129 to add these tips to the overview once the accessibility problems have been addressed.

In the meantime, I updated the Overview page description for the "Fix issues" step to explain "warning" issues.

## Screenshots

![image](https://user-images.githubusercontent.com/1238659/137428117-ca963ac2-ab0d-41f8-a3f2-b25ffa6c1517.png)


![image](https://user-images.githubusercontent.com/1238659/137411802-c9c04eba-2081-4899-95e8-6670915da1c3.png)

![image](https://user-images.githubusercontent.com/1238659/137411806-6db6f458-f6a2-4571-a91b-4361118aade5.png)
