### PR TITLE
[skip-ci] Use LevelIconTips to explain critical vs warning issues on UA overview page

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/components/deprecation_issues_panel.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/components/deprecation_issues_panel.tsx
@@ -13,6 +13,7 @@ import { i18n } from '@kbn/i18n';
 import { reactRouterNavigate } from '../../../../../shared_imports';
 import { DeprecationSource } from '../../../../../../common/types';
 import { getDeprecationsUpperLimit } from '../../../../lib/utils';
+import { LevelInfoTip } from '../../../shared';
 import { LoadingIssuesError } from './loading_issues_error';
 import { NoDeprecationIssues } from './no_deprecation_issues';
 
@@ -100,7 +101,15 @@ export const DeprecationIssuesPanel = (props: Props) => {
                 )
               }
               titleElement="span"
-              description={i18nTexts.criticalDeprecationsTitle}
+              description={
+                <EuiFlexGroup gutterSize="xs" alignItems="center">
+                  <EuiFlexItem grow={false}>{i18nTexts.criticalDeprecationsTitle}</EuiFlexItem>
+
+                  <EuiFlexItem>
+                    <LevelInfoTip level="critical" />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
               titleColor="danger"
               isLoading={isLoading}
             />
@@ -123,7 +132,15 @@ export const DeprecationIssuesPanel = (props: Props) => {
                 )
               }
               titleElement="span"
-              description={i18nTexts.warningDeprecationsTitle}
+              description={
+                <EuiFlexGroup gutterSize="xs" alignItems="center">
+                  <EuiFlexItem grow={false}>{i18nTexts.warningDeprecationsTitle}</EuiFlexItem>
+
+                  <EuiFlexItem>
+                    <LevelInfoTip level="warning" />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
               isLoading={isLoading}
             />
           </EuiFlexItem>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/deprecation_count.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/deprecation_count.tsx
@@ -6,9 +6,10 @@
  */
 
 import React, { FunctionComponent } from 'react';
-
 import { EuiFlexGroup, EuiFlexItem, EuiHealth } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
+import { LevelInfoTip } from './level_info_tip';
 
 const i18nTexts = {
   getCriticalStatusLabel: (count: number) =>
@@ -39,14 +40,31 @@ export const DeprecationCount: FunctionComponent<Props> = ({
   return (
     <EuiFlexGroup>
       <EuiFlexItem grow={false}>
-        <EuiHealth color="danger" data-test-subj="criticalDeprecationsCount">
-          {i18nTexts.getCriticalStatusLabel(totalCriticalDeprecations)}
-        </EuiHealth>
+        <EuiFlexGroup gutterSize="xs" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiHealth color="danger" data-test-subj="criticalDeprecationsCount">
+              {i18nTexts.getCriticalStatusLabel(totalCriticalDeprecations)}
+            </EuiHealth>
+          </EuiFlexItem>
+
+          <EuiFlexItem>
+            <LevelInfoTip level="critical" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
+
       <EuiFlexItem grow={false}>
-        <EuiHealth color="subdued" data-test-subj="warningDeprecationsCount">
-          {i18nTexts.getWarningStatusLabel(totalWarningDeprecations)}
-        </EuiHealth>
+        <EuiFlexGroup gutterSize="xs" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiHealth color="subdued" data-test-subj="warningDeprecationsCount">
+              {i18nTexts.getWarningStatusLabel(totalWarningDeprecations)}
+            </EuiHealth>
+          </EuiFlexItem>
+
+          <EuiFlexItem>
+            <LevelInfoTip level="warning" />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/index.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/index.ts
@@ -9,3 +9,4 @@ export { NoDeprecationsPrompt } from './no_deprecations';
 export { DeprecationCount } from './deprecation_count';
 export { DeprecationBadge } from './deprecation_badge';
 export { DeprecationsPageLoadingError } from './deprecations_page_loading_error';
+export { LevelInfoTip } from './level_info_tip';

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/level_info_tip.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/level_info_tip.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FunctionComponent } from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiIconTip } from '@elastic/eui';
+
+const i18nTexts = {
+  critical: i18n.translate('xpack.upgradeAssistant.levelInfoTip.criticalLabel', {
+    defaultMessage: 'Critical issues must be addressed before upgrading',
+  }),
+  warning: i18n.translate('xpack.upgradeAssistant.levelInfoTip.warningLabel', {
+    defaultMessage: 'Warning issues can be ignored at your discretion',
+  }),
+};
+
+interface Props {
+  level: 'critical' | 'warning';
+}
+
+export const LevelInfoTip: FunctionComponent<Props> = ({ level }) => {
+  return <EuiIconTip content={i18nTexts[level]} position="top" type="iInCircle" />;
+};


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/115820

## Summary

Extracted from https://github.com/elastic/kibana/pull/115121.

I added EuiIconTips to the overview page to offer the same guidance I provided in https://github.com/elastic/kibana/issues/114197#issuecomment-943546267. This PR is blocked by some accessibility problems in EUI (https://github.com/elastic/eui/issues/5273).

## Screenshots

![image](https://user-images.githubusercontent.com/1238659/137411797-2ae74604-ec8d-4fea-87bd-5c6fdd760c36.png)