### PR TITLE
[7.15] [Lens] Fix filters not being cleaned when navigating to another visualisation

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/mounter.tsx
@@ -167,13 +167,6 @@ export async function mountApp(
       ? historyLocationState.payload
       : undefined;
 
-  // Clear app-specific filters when navigating to Lens. Necessary because Lens
-  // can be loaded without a full page refresh. If the user navigates to Lens from Discover
-  // we keep the filters
-  if (!initialContext) {
-    data.query.filterManager.setAppFilters([]);
-  }
-
   if (embeddableEditorIncomingState?.searchSessionId) {
     data.search.session.continue(embeddableEditorIncomingState.searchSessionId);
   }
@@ -202,7 +195,13 @@ export async function mountApp(
       trackUiEvent('loaded');
       const initialInput = getInitialInput(props.id, props.editByValue);
 
-      lensStore.dispatch(loadInitial({ redirectCallback, initialInput, emptyState }));
+      // Clear app-specific filters when navigating to Lens. Necessary because Lens
+      // can be loaded without a full page refresh. If the user navigates to Lens from Discover
+      // we keep the filters
+      if (!initialContext) {
+        data.query.filterManager.setAppFilters([]);
+      }
+      lensStore.dispatch(loadInitial({ redirectCallback, initialInput }));
 
       return (
         <Provider store={lensStore}>

--- a/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/index.ts
@@ -23,8 +23,7 @@ export const initMiddleware = (storeDeps: LensStoreDeps) => (store: MiddlewareAP
         store,
         storeDeps,
         action.payload.redirectCallback,
-        action.payload.initialInput,
-        action.payload.emptyState
+        action.payload.initialInput
       );
     } else if (lensSlice.actions.navigateAway.match(action)) {
       return unsubscribeFromExternalContext();

--- a/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.test.tsx
+++ b/x-pack/plugins/lens/public/state_management/init_middleware/load_initial.test.tsx
@@ -15,8 +15,6 @@ import {
 import { act } from 'react-dom/test-utils';
 import { loadInitial } from './load_initial';
 import { LensEmbeddableInput } from '../../embeddable';
-import { getPreloadedState } from '../lens_slice';
-import { LensAppState } from '..';
 
 const defaultSavedObjectId = '1234';
 const preloadedState = {
@@ -167,10 +165,9 @@ describe('Mounter', () => {
         }),
       });
 
-      const emptyState = getPreloadedState(storeDeps) as LensAppState;
       services.attributeService.unwrapAttributes = jest.fn();
       await act(async () => {
-        await loadInitial(lensStore, storeDeps, jest.fn(), undefined, emptyState);
+        await loadInitial(lensStore, storeDeps, jest.fn(), undefined);
       });
 
       expect(lensStore.getState()).toEqual({

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -48,9 +48,11 @@ export const getPreloadedState = ({
   const state = {
     ...initialState,
     isLoading: true,
-    query: data.query.queryString.getQuery(),
     // Do not use app-specific filters from previous app,
     // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
+    query: !initialContext
+      ? data.query.queryString.getDefaultQuery()
+      : data.query.queryString.getQuery(),
     filters: !initialContext
       ? data.query.filterManager.getGlobalFilters()
       : data.query.filterManager.getFilters(),
@@ -300,7 +302,6 @@ export const lensSlice = createSlice({
       payload: PayloadAction<{
         initialInput?: LensEmbeddableInput;
         redirectCallback: (savedObjectId?: string) => void;
-        emptyState: LensAppState;
       }>
     ) => state,
   },

--- a/x-pack/test/functional/apps/lens/geo_field.ts
+++ b/x-pack/test/functional/apps/lens/geo_field.ts
@@ -15,6 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('should visualize geo fields in maps', async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');
+      await PageObjects.lens.switchDataPanelIndexPattern('logstash-*');
       await PageObjects.timePicker.setAbsoluteRange(
         'Sep 22, 2015 @ 00:00:00.000',
         'Sep 22, 2015 @ 04:00:00.000'

--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -11,6 +11,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const browser = getService('browser');
   const log = getService('log');
   const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
 
   describe('lens app', () => {
     before(async () => {
@@ -18,16 +19,23 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await browser.setWindowSize(1280, 800);
       await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
       await esArchiver.load('x-pack/test/functional/es_archives/lens/basic');
+      await kibanaServer.importExport.load(
+        'x-pack/test/functional/fixtures/kbn_archiver/lens/default'
+      );
     });
 
     after(async () => {
       await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
       await esArchiver.unload('x-pack/test/functional/es_archives/lens/basic');
+      await kibanaServer.importExport.unload(
+        'x-pack/test/functional/fixtures/kbn_archiver/lens/default'
+      );
     });
 
     describe('', function () {
       this.tags(['ciGroup3', 'skipFirefox']);
       loadTestFile(require.resolve('./smokescreen'));
+      loadTestFile(require.resolve('./persistent_context'));
     });
 
     describe('', function () {
@@ -37,7 +45,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       loadTestFile(require.resolve('./table'));
       loadTestFile(require.resolve('./runtime_fields'));
       loadTestFile(require.resolve('./dashboard'));
-      loadTestFile(require.resolve('./persistent_context'));
       loadTestFile(require.resolve('./colors'));
       loadTestFile(require.resolve('./chart_data'));
       loadTestFile(require.resolve('./time_shift'));

--- a/x-pack/test/functional/apps/lens/persistent_context.ts
+++ b/x-pack/test/functional/apps/lens/persistent_context.ts
@@ -9,11 +9,20 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['visualize', 'lens', 'header', 'timePicker']);
+  const PageObjects = getPageObjects([
+    'visualize',
+    'lens',
+    'header',
+    'timePicker',
+    'common',
+    'navigationalSearch',
+  ]);
   const browser = getService('browser');
   const filterBar = getService('filterBar');
   const appsMenu = getService('appsMenu');
   const security = getService('security');
+  const listingTable = getService('listingTable');
+  const queryBar = getService('queryBar');
 
   describe('lens query context', () => {
     before(async () => {
@@ -25,6 +34,122 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await security.testUser.restoreDefaults();
+    });
+
+    describe('Navigation search', () => {
+      describe('when opening from empty visualization to existing one', () => {
+        before(async () => {
+          await PageObjects.visualize.navigateToNewVisualization();
+          await PageObjects.visualize.clickVisType('lens');
+          await PageObjects.lens.goToTimeRange();
+          await PageObjects.navigationalSearch.focus();
+          await PageObjects.navigationalSearch.searchFor('type:lens lnsTableVis');
+          await PageObjects.navigationalSearch.clickOnOption(0);
+          await PageObjects.lens.waitForWorkspaceWithVisualization();
+        });
+        it('filters, time and query reflect the visualization state', async () => {
+          expect(await PageObjects.lens.getDatatableHeaderText(1)).to.equal(
+            '404 › Median of bytes'
+          );
+          expect(await PageObjects.lens.getDatatableHeaderText(2)).to.equal(
+            '503 › Median of bytes'
+          );
+          expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('TG');
+          expect(await PageObjects.lens.getDatatableCellText(0, 1)).to.eql('9,931');
+        });
+        it('preserves time range', async () => {
+          const timePickerValues = await PageObjects.timePicker.getTimeConfigAsAbsoluteTimes();
+          expect(timePickerValues.start).to.eql(PageObjects.timePicker.defaultStartTime);
+          expect(timePickerValues.end).to.eql(PageObjects.timePicker.defaultEndTime);
+          // data is correct and top nav is correct
+        });
+        it('loads filters', async () => {
+          const filterCount = await filterBar.getFilterCount();
+          expect(filterCount).to.equal(1);
+        });
+        it('loads query', async () => {
+          const query = await queryBar.getQueryString();
+          expect(query).to.equal('extension.raw : "jpg" or extension.raw : "gif" ');
+        });
+      });
+      describe('when opening from existing visualization to empty one', () => {
+        before(async () => {
+          await PageObjects.visualize.gotoVisualizationLandingPage();
+          await listingTable.searchForItemWithName('lnsTableVis');
+          await PageObjects.lens.clickVisualizeListItemTitle('lnsTableVis');
+          await PageObjects.lens.goToTimeRange();
+          await PageObjects.navigationalSearch.focus();
+          await PageObjects.navigationalSearch.searchFor('type:application lens');
+          await PageObjects.navigationalSearch.clickOnOption(0);
+          await PageObjects.lens.waitForEmptyWorkspace();
+          await PageObjects.lens.switchToVisualization('lnsMetric');
+          await PageObjects.lens.dragFieldToWorkspace('@timestamp');
+        });
+        it('preserves time range', async () => {
+          // fill the navigation search and select empty
+          // see the time
+          const timePickerValues = await PageObjects.timePicker.getTimeConfigAsAbsoluteTimes();
+          expect(timePickerValues.start).to.eql(PageObjects.timePicker.defaultStartTime);
+          expect(timePickerValues.end).to.eql(PageObjects.timePicker.defaultEndTime);
+        });
+        it('cleans filters', async () => {
+          const filterCount = await filterBar.getFilterCount();
+          expect(filterCount).to.equal(0);
+        });
+        it('cleans query', async () => {
+          const query = await queryBar.getQueryString();
+          expect(query).to.equal('');
+        });
+        it('filters, time and query reflect the visualization state', async () => {
+          await PageObjects.lens.assertMetric('Unique count of @timestamp', '14,181');
+        });
+      });
+    });
+
+    describe('Switching in Visualize App', () => {
+      it('when moving from existing to empty workspace, preserves time range, cleans filters and query', async () => {
+        // go to existing vis
+        await PageObjects.visualize.gotoVisualizationLandingPage();
+        await listingTable.searchForItemWithName('lnsTableVis');
+        await PageObjects.lens.clickVisualizeListItemTitle('lnsTableVis');
+        await PageObjects.lens.goToTimeRange();
+        // go to empty vis
+        await PageObjects.lens.goToListingPageViaBreadcrumbs();
+        await PageObjects.visualize.clickNewVisualization();
+        await PageObjects.visualize.waitForGroupsSelectPage();
+        await PageObjects.visualize.clickVisType('lens');
+        await PageObjects.lens.waitForEmptyWorkspace();
+        await PageObjects.lens.switchToVisualization('lnsMetric');
+        await PageObjects.lens.dragFieldToWorkspace('@timestamp');
+
+        const timePickerValues = await PageObjects.timePicker.getTimeConfigAsAbsoluteTimes();
+        expect(timePickerValues.start).to.eql(PageObjects.timePicker.defaultStartTime);
+        expect(timePickerValues.end).to.eql(PageObjects.timePicker.defaultEndTime);
+        const filterCount = await filterBar.getFilterCount();
+        expect(filterCount).to.equal(0);
+        const query = await queryBar.getQueryString();
+        expect(query).to.equal('');
+        await PageObjects.lens.assertMetric('Unique count of @timestamp', '14,181');
+      });
+      it('when moving from empty to existing workspace, preserves time range and loads filters and query', async () => {
+        // go to existing vis
+        await PageObjects.lens.goToListingPageViaBreadcrumbs();
+        await listingTable.searchForItemWithName('lnsTableVis');
+        await PageObjects.lens.clickVisualizeListItemTitle('lnsTableVis');
+
+        expect(await PageObjects.lens.getDatatableHeaderText(1)).to.equal('404 › Median of bytes');
+        expect(await PageObjects.lens.getDatatableHeaderText(2)).to.equal('503 › Median of bytes');
+        expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('TG');
+        expect(await PageObjects.lens.getDatatableCellText(0, 1)).to.eql('9,931');
+
+        const timePickerValues = await PageObjects.timePicker.getTimeConfigAsAbsoluteTimes();
+        expect(timePickerValues.start).to.eql(PageObjects.timePicker.defaultStartTime);
+        expect(timePickerValues.end).to.eql(PageObjects.timePicker.defaultEndTime);
+        const filterCount = await filterBar.getFilterCount();
+        expect(filterCount).to.equal(1);
+        const query = await queryBar.getQueryString();
+        expect(query).to.equal('extension.raw : "jpg" or extension.raw : "gif" ');
+      });
     });
 
     it('should carry over time range and pinned filters to discover', async () => {

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/default.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/default.json
@@ -1,0 +1,153 @@
+{
+  "attributes": {
+    "fields": "[{\"name\":\"referer\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"agent\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.og:image:width\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.og:type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"xss.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"headings.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:description\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"meta.user.lastname\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.article:tag.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"geo.dest\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.twitter:image\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.article:section.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"utc_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.twitter:card\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"meta.char\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"clientip\",\"type\":\"ip\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:image:height\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"host\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"machine.ram\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"links\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"id\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"@tags.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"phpmemory\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.twitter:card.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"ip\",\"type\":\"ip\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:image\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.article:modified_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.og:site_name.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"request.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.article:tag\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"agent.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"spaces\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.twitter:site.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"headings\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"_source\",\"type\":\"_source\",\"count\":0,\"scripted\":false,\"indexed\":false,\"analyzed\":false,\"doc_values\":false},{\"name\":\"relatedContent.og:image.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"request\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"index.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"extension\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"memory\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"_index\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":false,\"analyzed\":false,\"doc_values\":false},{\"name\":\"relatedContent.twitter:site\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.twitter:description\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.og:url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"geo.coordinates\",\"type\":\"geo_point\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.url.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"meta.related\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.twitter:title.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:title.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"response.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"@message.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"machine.os\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.article:section\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.og:url.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"xss\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"links.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:title\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"geo.srcdest\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"url.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"extension.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"machine.os.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"@tags\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"host.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:type.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"geo.src\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"spaces.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:image:height.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"url\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.twitter:description.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:site_name\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.twitter:title\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"@message\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.twitter:image.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"bytes\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"response\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"meta.user.firstname\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":true,\"doc_values\":false},{\"name\":\"relatedContent.og:image:width.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.og:description.raw\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"relatedContent.article:published_time\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true},{\"name\":\"_id\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":false,\"analyzed\":false,\"doc_values\":false},{\"name\":\"_type\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":false,\"analyzed\":false,\"doc_values\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"indexed\":false,\"analyzed\":false,\"doc_values\":false},{\"name\":\"nestedField.child\",\"type\":\"string\",\"count\":0,\"scripted\":false,\"indexed\":true,\"analyzed\":false,\"doc_values\":true,\"subType\":{\"nested\":{\"path\":\"nestedField\"}}}]",
+    "timeFieldName": "@timestamp",
+    "title": "logstash-*"
+  },
+  "coreMigrationVersion": "7.15.0",
+  "id": "logstash-*",
+  "migrationVersion": {
+    "index-pattern": "7.11.0"
+  },
+  "references": [],
+  "type": "index-pattern",
+  "version": "WzIsMl0="
+}
+
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "datasourceStates": {
+        "indexpattern": {
+          "layers": {
+              "4ba1a1be-6e67-434b-b3a0-f30db8ea5395": {
+                "columnOrder": [
+                  "70d52318-354d-47d5-b33b-43d50eb34425",
+                  "bafe3009-1776-4227-a0fe-b0d6ccbb4961",
+                  "3dc0bd55-2087-4e60-aea2-f9910714f7db"
+                ],
+                "columns": {
+                  "3dc0bd55-2087-4e60-aea2-f9910714f7db": {
+                    "dataType": "number",
+                    "isBucketed": false,
+                    "label": "Median of bytes",
+                    "operationType": "median",
+                    "scale": "ratio",
+                    "sourceField": "bytes"
+                  },
+                  "70d52318-354d-47d5-b33b-43d50eb34425": {
+                    "dataType": "string",
+                    "isBucketed": true,
+                    "label": "Top values of response.raw",
+                    "operationType": "terms",
+                    "params": {
+                      "missingBucket": false,
+                      "orderBy": {
+                        "columnId": "3dc0bd55-2087-4e60-aea2-f9910714f7db",
+                        "type": "column"
+                      },
+                      "orderDirection": "desc",
+                      "otherBucket": true,
+                      "size": 3
+                    },
+                    "scale": "ordinal",
+                    "sourceField": "response.raw"
+                  },
+                  "bafe3009-1776-4227-a0fe-b0d6ccbb4961": {
+                    "dataType": "string",
+                    "isBucketed": true,
+                    "label": "Top values of geo.src",
+                    "operationType": "terms",
+                    "params": {
+                      "orderBy": {
+                        "columnId": "3dc0bd55-2087-4e60-aea2-f9910714f7db",
+                        "type": "column"
+                      },
+                      "orderDirection": "desc",
+                      "size": 7
+                    },
+                    "scale": "ordinal",
+                    "sourceField": "geo.src"
+                  }
+                },
+                "incompleteColumns": {}
+              }
+          }
+        }
+      },
+      "filters": [
+        {
+          "$state": {
+            "store": "appState"
+          },
+          "meta": {
+            "alias": null,
+            "disabled": false,
+            "indexRefName": "filter-index-pattern-0",
+            "key": "response",
+            "negate": true,
+            "params": {
+              "query": "200"
+            },
+            "type": "phrase"
+          },
+          "query": {
+            "match_phrase": {
+              "response": "200"
+            }
+          }
+        }
+      ],
+      "query": {
+        "language": "kuery",
+        "query": "extension.raw : \"jpg\" or extension.raw : \"gif\" "
+      },
+      "visualization": {
+        "columns": [
+          {
+            "columnId": "bafe3009-1776-4227-a0fe-b0d6ccbb4961",
+            "isTransposed": false
+          },
+          {
+            "columnId": "3dc0bd55-2087-4e60-aea2-f9910714f7db",
+            "isTransposed": false
+          },
+          {
+            "columnId": "70d52318-354d-47d5-b33b-43d50eb34425",
+            "isTransposed": true
+          }
+        ],
+        "layerId": "4ba1a1be-6e67-434b-b3a0-f30db8ea5395",
+        "layerType": "data"
+      }
+    },
+    "title": "lnsTableVis",
+    "visualizationType": "lnsDatatable"
+},
+  "coreMigrationVersion": "7.15.0",
+  "id": "a800e2b0-268c-11ec-b2b6-f1bd289a74d4",
+  "migrationVersion": {
+    "lens": "7.15.0"
+  },
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-4ba1a1be-6e67-434b-b3a0-f30db8ea5395",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "filter-index-pattern-0",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "updated_at": "2020-11-23T19:57:52.834Z",
+  "version": "WzUyLDJd"
+}

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -247,6 +247,18 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       });
     },
 
+    async waitForEmptyWorkspace() {
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`empty-workspace`);
+      });
+    },
+
+    async waitForWorkspaceWithVisualization() {
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`lnsVisualizationContainer`);
+      });
+    },
+
     async waitForFieldMissing(field: string) {
       await retry.try(async () => {
         await testSubjects.missingOrFail(`lnsFieldListPanelField-${field}`);
@@ -1077,6 +1089,17 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
 
     async toggleFullscreen() {
       await testSubjects.click('lnsFormula-fullscreen');
+    },
+
+    async goToListingPageViaBreadcrumbs() {
+      await retry.try(async () => {
+        await testSubjects.click('breadcrumb first');
+        if (await testSubjects.exists('appLeaveConfirmModal')) {
+          await testSubjects.exists('confirmModalConfirmButton');
+          await testSubjects.click('confirmModalConfirmButton');
+        }
+        await testSubjects.existOrFail('visualizationLandingPage', { timeout: 3000 });
+      });
     },
 
     async typeFormula(formula: string) {


### PR DESCRIPTION
## Summary

Backport for https://github.com/elastic/kibana/pull/114137 for 7.15


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
