### PR TITLE
[7.x] Improve `CodeEditor` wrapper (#114500)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -108,7 +108,7 @@ pageLoadAssetSize:
   data: 491273
   dataViews: 42532
   fieldFormats: 65209
-  kibanaReact: 99422
+  kibanaReact: 84422
   uiActions: 35121
   dataEnhanced: 24980
   embeddable: 87309

--- a/src/plugins/discover/public/application/components/source_viewer/__snapshots__/source_viewer.test.tsx.snap
+++ b/src/plugins/discover/public/application/components/source_viewer/__snapshots__/source_viewer.test.tsx.snap
@@ -594,9 +594,13 @@ exports[`Source Viewer component renders json code editor 1`] = `
                     fallback={<Fallback />}
                   >
                     <Fallback>
-                      <EuiDelayRender
-                        delay={500}
-                      />
+                      <div
+                        style={Object {}}
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </div>
                     </Fallback>
                   </Suspense>
                 </EuiErrorBoundary>

--- a/src/plugins/kibana_react/public/code_editor/code_editor.tsx
+++ b/src/plugins/kibana_react/public/code_editor/code_editor.tsx
@@ -14,6 +14,7 @@ import { monaco } from '@kbn/monaco';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import classNames from 'classnames';
+import './register_languages';
 
 import {
   DARK_THEME,

--- a/src/plugins/kibana_react/public/code_editor/code_editor_field.tsx
+++ b/src/plugins/kibana_react/public/code_editor/code_editor_field.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import darkTheme from '@elastic/eui/dist/eui_theme_dark.json';
+import lightTheme from '@elastic/eui/dist/eui_theme_light.json';
+import { EuiFormControlLayout } from '@elastic/eui';
+import { CodeEditor, Props } from './code_editor';
+
+/**
+ * Renders a Monaco code editor in the same style as other EUI form fields.
+ */
+export const CodeEditorField: React.FunctionComponent<Props> = (props) => {
+  const { width, height, options, fullWidth, useDarkTheme } = props;
+  const theme = useDarkTheme ? darkTheme : lightTheme;
+  const style = {
+    width,
+    height,
+    backgroundColor: options?.readOnly
+      ? theme.euiFormBackgroundReadOnlyColor
+      : theme.euiFormBackgroundColor,
+  };
+
+  return (
+    <EuiFormControlLayout
+      append={<div hidden />}
+      style={style}
+      readOnly={options?.readOnly}
+      fullWidth={fullWidth}
+    >
+      <CodeEditor {...props} transparentBackground />
+    </EuiFormControlLayout>
+  );
+};

--- a/src/plugins/kibana_react/public/code_editor/languages/constants.ts
+++ b/src/plugins/kibana_react/public/code_editor/languages/constants.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { LANG as CssLang } from './css/constants';
+export { LANG as MarkdownLang } from './markdown/constants';
+export { LANG as YamlLang } from './yaml/constants';
+export { LANG as HandlebarsLang } from './handlebars/constants';

--- a/src/plugins/kibana_react/public/url_template_editor/url_template_editor.tsx
+++ b/src/plugins/kibana_react/public/url_template_editor/url_template_editor.tsx
@@ -66,7 +66,7 @@ export const UrlTemplateEditor: React.FC<UrlTemplateEditorProps> = ({
       return;
     }
 
-    const { dispose } = monaco.languages.registerCompletionItemProvider(HandlebarsLang.ID, {
+    const { dispose } = monaco.languages.registerCompletionItemProvider(HandlebarsLang, {
       triggerCharacters: ['{', '/', '?', '&', '='],
       provideCompletionItems(model, position, context, token) {
         const { lineNumber } = position;
@@ -124,7 +124,7 @@ export const UrlTemplateEditor: React.FC<UrlTemplateEditorProps> = ({
   return (
     <div className={'urlTemplateEditor__container'} onKeyDown={handleKeyDown}>
       <Editor
-        languageId={HandlebarsLang.ID}
+        languageId={HandlebarsLang}
         height={height}
         value={value}
         onChange={onChange}

--- a/src/plugins/vis_types/timeseries/public/application/components/markdown_editor.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/markdown_editor.js
@@ -116,7 +116,7 @@ export class MarkdownEditor extends Component {
         <div className="tvbMarkdownEditor__editor">
           <CodeEditor
             editorDidMount={this.handleOnLoad}
-            languageId={MarkdownLang.ID}
+            languageId={MarkdownLang}
             options={{
               fontSize: '14px',
               wordWrap: 'on',

--- a/src/plugins/vis_types/timeseries/public/application/components/panel_config/markdown.tsx
+++ b/src/plugins/vis_types/timeseries/public/application/components/panel_config/markdown.tsx
@@ -283,7 +283,7 @@ export class MarkdownPanelConfig extends Component<
             <EuiSpacer size="s" />
             <CodeEditor
               height="500px"
-              languageId={CssLang.ID}
+              languageId={CssLang}
               options={{ fontSize: 14 }}
               value={model.markdown_less ?? ''}
               onChange={this.handleCSSChange}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Improve `CodeEditor` wrapper (#114500)