### PR TITLE
[Fleet] Don't auto upgrade policies for AUTO_UPDATE packages

### DIFF
--- a/x-pack/plugins/fleet/server/services/managed_package_policies.ts
+++ b/x-pack/plugins/fleet/server/services/managed_package_policies.ts
@@ -6,8 +6,13 @@
  */
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from 'src/core/server';
+import semverGte from 'semver/functions/gte';
 
-import type { UpgradePackagePolicyDryRunResponseItem } from '../../common';
+import type {
+  Installation,
+  PackageInfo,
+  UpgradePackagePolicyDryRunResponseItem,
+} from '../../common';
 
 import { appContextService } from './app_context';
 import { getInstallation, getPackageInfo } from './epm/packages';
@@ -15,7 +20,7 @@ import { packagePolicyService } from './package_policy';
 
 export interface UpgradeManagedPackagePoliciesResult {
   packagePolicyId: string;
-  diff: UpgradePackagePolicyDryRunResponseItem['diff'];
+  diff?: UpgradePackagePolicyDryRunResponseItem['diff'];
   errors: any;
 }
 
@@ -48,13 +53,16 @@ export const upgradeManagedPackagePolicies = async (
       pkgName: packagePolicy.package.name,
     });
 
-    const isPolicyVersionAlignedWithInstalledVersion =
-      packageInfo.version === installedPackage?.version;
+    if (!installedPackage) {
+      results.push({
+        packagePolicyId,
+        errors: [`${packagePolicy.package.name} is not installed`],
+      });
 
-    const shouldUpgradePolicies =
-      !isPolicyVersionAlignedWithInstalledVersion && packageInfo.keepPoliciesUpToDate;
+      continue;
+    }
 
-    if (shouldUpgradePolicies) {
+    if (shouldUpgradePolicies(packageInfo, installedPackage)) {
       // Since upgrades don't report diffs/errors, we need to perform a dry run first in order
       // to notify the user of any granular policy upgrade errors that occur during Fleet's
       // preconfiguration check
@@ -88,3 +96,15 @@ export const upgradeManagedPackagePolicies = async (
 
   return results;
 };
+
+export function shouldUpgradePolicies(
+  packageInfo: PackageInfo,
+  installedPackage: Installation
+): boolean {
+  const isPolicyVersionGteInstalledVersion = semverGte(
+    packageInfo.version,
+    installedPackage.version
+  );
+
+  return !isPolicyVersionGteInstalledVersion && !!packageInfo.keepPoliciesUpToDate;
+}

--- a/x-pack/plugins/fleet/server/services/managed_package_policies.ts
+++ b/x-pack/plugins/fleet/server/services/managed_package_policies.ts
@@ -8,7 +8,6 @@
 import type { ElasticsearchClient, SavedObjectsClientContract } from 'src/core/server';
 
 import type { UpgradePackagePolicyDryRunResponseItem } from '../../common';
-import { AUTO_UPDATE_PACKAGES } from '../../common';
 
 import { appContextService } from './app_context';
 import { getInstallation, getPackageInfo } from './epm/packages';

--- a/x-pack/plugins/fleet/server/services/managed_package_policies.ts
+++ b/x-pack/plugins/fleet/server/services/managed_package_policies.ts
@@ -53,9 +53,7 @@ export const upgradeManagedPackagePolicies = async (
       packageInfo.version === installedPackage?.version;
 
     const shouldUpgradePolicies =
-      !isPolicyVersionAlignedWithInstalledVersion &&
-      (AUTO_UPDATE_PACKAGES.some((pkg) => pkg.name === packageInfo.name) ||
-        packageInfo.keepPoliciesUpToDate);
+      !isPolicyVersionAlignedWithInstalledVersion && packageInfo.keepPoliciesUpToDate;
 
     if (shouldUpgradePolicies) {
       // Since upgrades don't report diffs/errors, we need to perform a dry run first in order


### PR DESCRIPTION
## Summary

Ref https://github.com/elastic/kibana/pull/114914#pullrequestreview-780401978

We had an error in our logic for automatic package policies update via the `keep_policies_up_to_date` flag that incorrectly upgraded policies for any package flagged as `AUTO_UPDATE` in 

https://github.com/elastic/kibana/blob/50e4ae71792a68440c33ff8e2829285dffb92e35/x-pack/plugins/fleet/common/constants/epm.ts#L42-L46

It feels like this should have been caught by our unit tests, but I'm not sure whether we should try to mock this `AUTO_UPDATE_PACKAGES` list, or use a "hardcoded" package name in our tests. Open to suggestions here, as I would like to make sure this case is covered by automated tests.

