### PR TITLE
[Fleet] Make integration names globally unique

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_define_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_define_package_policy.tsx
@@ -22,16 +22,12 @@ import {
 
 import styled from 'styled-components';
 
-import type {
-  AgentPolicy,
-  PackageInfo,
-  PackagePolicy,
-  NewPackagePolicy,
-  RegistryVarsEntry,
-} from '../../../types';
+import type { AgentPolicy, PackageInfo, NewPackagePolicy, RegistryVarsEntry } from '../../../types';
 import { packageToPackagePolicy, pkgKeyFromPackageInfo } from '../../../services';
 import { Loading } from '../../../components';
-import { useStartServices } from '../../../hooks';
+import { useStartServices, useGetPackagePolicies } from '../../../hooks';
+import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../../../../../constants';
+import { SO_SEARCH_LIMIT } from '../../../../../../common';
 
 import { isAdvancedVar } from './services';
 import type { PackagePolicyValidationResults } from './services';
@@ -65,6 +61,14 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
     submitAttempted,
   }) => {
     const { docLinks } = useStartServices();
+
+    // Fetch all packagePolicies having the package name
+    const { data: packagePolicyData, isLoading: isLoadingPackagePolicies } = useGetPackagePolicies({
+      perPage: SO_SEARCH_LIMIT,
+      page: 1,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageInfo.name}`,
+    });
+
     // Form show/hide states
     const [isShowingAdvanced, setIsShowingAdvanced] = useState<boolean>(false);
 
@@ -84,20 +88,29 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
 
     // Update package policy's package and agent policy info
     useEffect(() => {
+      if (isLoadingPackagePolicies) {
+        return;
+      }
       const pkg = packagePolicy.package;
       const currentPkgKey = pkg ? pkgKeyFromPackageInfo(pkg) : '';
       const pkgKey = pkgKeyFromPackageInfo(packageInfo);
 
       // If package has changed, create shell package policy with input&stream values based on package info
       if (currentPkgKey !== pkgKey) {
-        // Existing package policies on the agent policy using the package name, retrieve highest number appended to package policy name
+        // Retrieve highest number appended to package policy name and increment it by one
         const pkgPoliciesNamePattern = new RegExp(`${packageInfo.name}-(\\d+)`);
-        const pkgPoliciesWithMatchingNames = agentPolicy
-          ? (agentPolicy.package_policies as PackagePolicy[])
+        const pkgPoliciesWithMatchingNames = packagePolicyData?.items
+          ? packagePolicyData.items
               .filter((ds) => Boolean(ds.name.match(pkgPoliciesNamePattern)))
               .map((ds) => parseInt(ds.name.match(pkgPoliciesNamePattern)![1], 10))
               .sort((a, b) => a - b)
           : [];
+
+        const incrementedName = `${packageInfo.name}-${
+          pkgPoliciesWithMatchingNames.length
+            ? pkgPoliciesWithMatchingNames[pkgPoliciesWithMatchingNames.length - 1] + 1
+            : 1
+        }`;
 
         updatePackagePolicy(
           packageToPackagePolicy(
@@ -105,12 +118,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
             agentPolicy?.id || '',
             packagePolicy.output_id,
             packagePolicy.namespace,
-            packagePolicy.name ||
-              `${packageInfo.name}-${
-                pkgPoliciesWithMatchingNames.length
-                  ? pkgPoliciesWithMatchingNames[pkgPoliciesWithMatchingNames.length - 1] + 1
-                  : 1
-              }`,
+            packagePolicy.name || incrementedName,
             packagePolicy.description,
             integrationToEnable
           )
@@ -124,7 +132,15 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
           namespace: agentPolicy.namespace,
         });
       }
-    }, [packagePolicy, agentPolicy, packageInfo, updatePackagePolicy, integrationToEnable]);
+    }, [
+      packagePolicy,
+      agentPolicy,
+      packageInfo,
+      updatePackagePolicy,
+      integrationToEnable,
+      packagePolicyData,
+      isLoadingPackagePolicies,
+    ]);
 
     return validationResults ? (
       <FormGroupResponsiveFields

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -410,12 +410,16 @@ class AgentPolicyService {
       options
     );
 
-    // Copy all package policies
+    // Copy all package policies and append (copy) to their names
     if (baseAgentPolicy.package_policies.length) {
       const newPackagePolicies = (baseAgentPolicy.package_policies as PackagePolicy[]).map(
         (packagePolicy: PackagePolicy) => {
           const { id: packagePolicyId, version, ...newPackagePolicy } = packagePolicy;
-          return newPackagePolicy;
+          const updatedPackagePolicy = {
+            ...newPackagePolicy,
+            name: `${packagePolicy.name} (copy)`,
+          };
+          return updatedPackagePolicy;
         }
       );
       await packagePolicyService.bulkCreate(

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -366,14 +366,14 @@ class PackagePolicyService {
     if (!oldPackagePolicy) {
       throw new Error('Package policy not found');
     }
-
+    // Check that the name does not exist already but exclude the current package policy
     const existingPoliciesWithName = await this.list(soClient, {
       perPage: 1,
       kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: "${packagePolicy.name}"`,
     });
+    const filtered = (existingPoliciesWithName?.items || []).filter((p) => p.id !== id);
 
-    // Check that the name does not exist already
-    if ((existingPoliciesWithName?.items || []).length > 0) {
+    if (filtered.length > 0) {
       throw new IngestManagerError('There is already a package with the same name');
     }
 

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -42,7 +42,6 @@ import type {
 } from '../../common';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 import {
-  HostedAgentPolicyRestrictionRelatedError,
   IngestManagerError,
   ingestErrorToResponseOptions,
   PackagePolicyIneligibleForUpgradeError,
@@ -108,24 +107,14 @@ class PackagePolicyService {
       skipEnsureInstalled?: boolean;
     }
   ): Promise<PackagePolicy> {
-    // Check that its agent policy does not have a package policy with the same name
-    const parentAgentPolicy = await agentPolicyService.get(soClient, packagePolicy.policy_id);
-    if (!parentAgentPolicy) {
-      throw new Error('Agent policy not found');
-    }
-    if (parentAgentPolicy.is_managed && !options?.force) {
-      throw new HostedAgentPolicyRestrictionRelatedError(
-        `Cannot add integrations to hosted agent policy ${parentAgentPolicy.id}`
-      );
-    }
-    if (
-      (parentAgentPolicy.package_policies as PackagePolicy[]).find(
-        (siblingPackagePolicy) => siblingPackagePolicy.name === packagePolicy.name
-      )
-    ) {
-      throw new IngestManagerError(
-        'There is already a package with the same name on this agent policy'
-      );
+    const existingPoliciesWithName = await this.list(soClient, {
+      perPage: 1,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: "${packagePolicy.name}"`,
+    });
+
+    // Check that the name does not exist already
+    if (existingPoliciesWithName.items.length > 0) {
+      throw new IngestManagerError('There is already a package with the same name');
     }
     let elasticsearch: PackagePolicy['elasticsearch'];
     // Add ids to stream
@@ -378,18 +367,14 @@ class PackagePolicyService {
       throw new Error('Package policy not found');
     }
 
-    // Check that its agent policy does not have a package policy with the same name
-    const parentAgentPolicy = await agentPolicyService.get(soClient, packagePolicy.policy_id);
-    if (!parentAgentPolicy) {
-      throw new Error('Agent policy not found');
-    }
-    if (
-      (parentAgentPolicy.package_policies as PackagePolicy[]).find(
-        (siblingPackagePolicy) =>
-          siblingPackagePolicy.id !== id && siblingPackagePolicy.name === packagePolicy.name
-      )
-    ) {
-      throw new Error('There is already a package with the same name on this agent policy');
+    const existingPoliciesWithName = await this.list(soClient, {
+      perPage: 1,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: "${packagePolicy.name}"`,
+    });
+
+    // Check that the name does not exist already
+    if (existingPoliciesWithName.items.length > 0) {
+      throw new IngestManagerError('There is already a package with the same name');
     }
 
     let inputs = restOfPackagePolicy.inputs.map((input) =>

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -318,12 +318,12 @@ class PackagePolicyService {
     });
 
     return {
-      items: packagePolicies.saved_objects.map((packagePolicySO) => ({
+      items: packagePolicies?.saved_objects.map((packagePolicySO) => ({
         id: packagePolicySO.id,
         version: packagePolicySO.version,
         ...packagePolicySO.attributes,
       })),
-      total: packagePolicies.total,
+      total: packagePolicies?.total,
       page,
       perPage,
     };
@@ -373,7 +373,7 @@ class PackagePolicyService {
     });
 
     // Check that the name does not exist already
-    if (existingPoliciesWithName.items.length > 0) {
+    if ((existingPoliciesWithName?.items || []).length > 0) {
       throw new IngestManagerError('There is already a package with the same name');
     }
 

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -276,5 +276,53 @@ export default function (providerContext: FtrProviderContext) {
         })
         .expect(400);
     });
+
+    it('should return a 400 if there is a package policy with the same name on a different policy', async function () {
+      const { body: agentPolicyResponse } = await supertest
+        .post(`/api/fleet/agent_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'Test policy',
+          namespace: 'default',
+        });
+      const otherAgentPolicyId = agentPolicyResponse.item.id;
+
+      await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'same-name-test-2',
+          description: '',
+          namespace: 'default',
+          policy_id: otherAgentPolicyId,
+          enabled: true,
+          output_id: '',
+          inputs: [],
+          package: {
+            name: 'filetest',
+            title: 'For File Tests',
+            version: '0.1.0',
+          },
+        })
+        .expect(200);
+      await supertest
+        .post(`/api/fleet/package_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'same-name-test-2',
+          description: '',
+          namespace: 'default',
+          policy_id: agentPolicyId,
+          enabled: true,
+          output_id: '',
+          inputs: [],
+          package: {
+            name: 'filetest',
+            title: 'For File Tests',
+            version: '0.1.0',
+          },
+        })
+        .expect(400);
+    });
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -68,7 +68,7 @@ export default function (providerContext: FtrProviderContext) {
         .post(`/api/fleet/package_policies`)
         .set('kbn-xsrf', 'xxxx')
         .send({
-          name: 'filetest-1',
+          name: 'filetest',
           description: '',
           namespace: 'default',
           policy_id: hostedPolicy.id,
@@ -85,7 +85,7 @@ export default function (providerContext: FtrProviderContext) {
 
       expect(responseWithoutForce.statusCode).to.be(400);
       expect(responseWithoutForce.message).to.contain(
-        'Cannot add integrations to hosted agent policy'
+        'Cannot update integrations of hosted agent policy'
       );
 
       // try same request with `force: true`
@@ -122,7 +122,7 @@ export default function (providerContext: FtrProviderContext) {
         .post(`/api/fleet/package_policies`)
         .set('kbn-xsrf', 'xxxx')
         .send({
-          name: 'filetest-1',
+          name: 'filetest-2',
           description: '',
           namespace: 'default',
           policy_id: agentPolicyId,
@@ -282,7 +282,7 @@ export default function (providerContext: FtrProviderContext) {
         .post(`/api/fleet/agent_policies`)
         .set('kbn-xsrf', 'xxxx')
         .send({
-          name: 'Test policy',
+          name: 'Test policy 2',
           namespace: 'default',
         });
       const otherAgentPolicyId = agentPolicyResponse.item.id;

--- a/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
@@ -179,6 +179,36 @@ export default function (providerContext: FtrProviderContext) {
         .expect(500);
     });
 
+    it('should return a 500 if there is another package policy with the same name on a different policy', async function () {
+      const { body: agentPolicyResponse } = await supertest
+        .post(`/api/fleet/agent_policies`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'Test policy',
+          namespace: 'default',
+        });
+      const otherAgentPolicyId = agentPolicyResponse.item.id;
+
+      await supertest
+        .put(`/api/fleet/package_policies/${packagePolicyId2}`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({
+          name: 'filetest-1',
+          description: '',
+          namespace: 'updated_namespace',
+          policy_id: otherAgentPolicyId,
+          enabled: true,
+          output_id: '',
+          inputs: [],
+          package: {
+            name: 'filetest',
+            title: 'For File Tests',
+            version: '0.1.0',
+          },
+        })
+        .expect(500);
+    });
+
     it('should work with frozen input vars', async function () {
       await supertest
         .put(`/api/fleet/package_policies/${packagePolicyId}`)

--- a/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
@@ -158,7 +158,7 @@ export default function (providerContext: FtrProviderContext) {
         });
     });
 
-    it('should return a 500 if there is another package policy with the same name', async function () {
+    it('should return a 400 if there is another package policy with the same name', async function () {
       await supertest
         .put(`/api/fleet/package_policies/${packagePolicyId2}`)
         .set('kbn-xsrf', 'xxxx')
@@ -176,15 +176,15 @@ export default function (providerContext: FtrProviderContext) {
             version: '0.1.0',
           },
         })
-        .expect(500);
+        .expect(400);
     });
 
-    it('should return a 500 if there is another package policy with the same name on a different policy', async function () {
+    it('should return a 400 if there is another package policy with the same name on a different policy', async function () {
       const { body: agentPolicyResponse } = await supertest
         .post(`/api/fleet/agent_policies`)
         .set('kbn-xsrf', 'xxxx')
         .send({
-          name: 'Test policy',
+          name: 'Test policy 2',
           namespace: 'default',
         });
       const otherAgentPolicyId = agentPolicyResponse.item.id;
@@ -206,7 +206,7 @@ export default function (providerContext: FtrProviderContext) {
             version: '0.1.0',
           },
         })
-        .expect(500);
+        .expect(400);
     });
 
     it('should work with frozen input vars', async function () {


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/72948

Closes #116475

Currently, when installing an integration package, the name has to be unique per agent policy. This allows to have several integrations across policies having the same name, which can be confusing for the user.

This PR changes the logic in `PackagePolicyService` to ensure that the name is globally unique and updates the component `step_define_package_policy` to change the naming displayed in the form to be incremented based on all the package policies.


### Repro steps
**Test case 1 (Adding an integration with an already used name)**
- Add an integration (for instance apache)
- Go to the integration's `policies` tab ( `app/integrations/detail/apache-1.1.1/policies`), and click on `Add Apache`
- When the editor opens up put the same name as before.
- You should see a popup "There is already a package with the same name"
- Repeat this case both with the same agent policy and with a different one

**Test case 2 (Adding an integration with a unique name)**
- Click on `Add Apache`
- In the editor choose a different name
- The integration should install regularly

**Test case 3 (Pre-filled name increments globally)**
- Click on `Add Apache`
- Regardless of which agent policy you choose, check that the pre-filled name in the form is the highest number already present, incremented by one
- For instance, if you had `Apache-2` it should now be `Apache-3`:
![Screenshot 2021-10-20 at 16 26 37](https://user-images.githubusercontent.com/16084106/138112691-eadcbc12-af2d-46cb-a2d4-c1ba283cb739.png)
- If you just install it should work regularly

**Test case 4 (Upgrading a policy)**
- Upgrade a policy (with or without conflicts)
- The name shouldn't change

**Test case 5 (Duplicating an agent policy)**
- Duplicate an agent policy, then open it
- All the installed integration should now have name with format `Name (copy)`

![Screenshot 2021-10-29 at 16 22 57](https://user-images.githubusercontent.com/16084106/139451882-368a4cb2-cc48-4a3b-91e7-a6cd16c299cb.png)
### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
