### PR TITLE
[Canvas] Removes by-value embeddable lab flag

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -436,6 +436,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'labs:canvas:byValueEmbeddable': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'labs:canvas:useDataService': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -119,6 +119,7 @@ export interface UsageStats {
   'banners:textColor': string;
   'banners:backgroundColor': string;
   'labs:canvas:enable_ui': boolean;
+  'labs:canvas:byValueEmbeddable': boolean;
   'labs:canvas:useDataService': boolean;
   'labs:presentation:timeToPresent': boolean;
   'labs:dashboard:enable_ui': boolean;

--- a/src/plugins/presentation_util/common/labs.ts
+++ b/src/plugins/presentation_util/common/labs.ts
@@ -10,8 +10,9 @@ import { i18n } from '@kbn/i18n';
 
 export const LABS_PROJECT_PREFIX = 'labs:';
 export const DEFER_BELOW_FOLD = `${LABS_PROJECT_PREFIX}dashboard:deferBelowFold` as const;
+export const BY_VALUE_EMBEDDABLE = `${LABS_PROJECT_PREFIX}canvas:byValueEmbeddable` as const;
 
-export const projectIDs = [DEFER_BELOW_FOLD] as const;
+export const projectIDs = [DEFER_BELOW_FOLD, BY_VALUE_EMBEDDABLE] as const;
 export const environmentNames = ['kibana', 'browser', 'session'] as const;
 export const solutionNames = ['canvas', 'dashboard', 'presentation'] as const;
 
@@ -33,6 +34,19 @@ export const projects: { [ID in ProjectID]: ProjectConfig & { id: ID } } = {
         'Any panels below "the fold"-- the area hidden beyond the bottom of the window, accessed by scrolling-- will not be loaded immediately, but only when they enter the viewport',
     }),
     solutions: ['dashboard'],
+  },
+  [BY_VALUE_EMBEDDABLE]: {
+    id: BY_VALUE_EMBEDDABLE,
+    isActive: true,
+    isDisplayed: true,
+    environments: ['kibana', 'browser', 'session'],
+    name: i18n.translate('presentationUtil.labs.enableByValueEmbeddableName', {
+      defaultMessage: 'By-Value Embeddables',
+    }),
+    description: i18n.translate('presentationUtil.labs.enableByValueEmbeddableDescription', {
+      defaultMessage: 'Enables support for by-value embeddables in Canvas',
+    }),
+    solutions: ['canvas'],
   },
 };
 

--- a/src/plugins/presentation_util/common/labs.ts
+++ b/src/plugins/presentation_util/common/labs.ts
@@ -10,9 +10,8 @@ import { i18n } from '@kbn/i18n';
 
 export const LABS_PROJECT_PREFIX = 'labs:';
 export const DEFER_BELOW_FOLD = `${LABS_PROJECT_PREFIX}dashboard:deferBelowFold` as const;
-export const BY_VALUE_EMBEDDABLE = `${LABS_PROJECT_PREFIX}canvas:byValueEmbeddable` as const;
 
-export const projectIDs = [DEFER_BELOW_FOLD, BY_VALUE_EMBEDDABLE] as const;
+export const projectIDs = [DEFER_BELOW_FOLD] as const;
 export const environmentNames = ['kibana', 'browser', 'session'] as const;
 export const solutionNames = ['canvas', 'dashboard', 'presentation'] as const;
 
@@ -34,19 +33,6 @@ export const projects: { [ID in ProjectID]: ProjectConfig & { id: ID } } = {
         'Any panels below "the fold"-- the area hidden beyond the bottom of the window, accessed by scrolling-- will not be loaded immediately, but only when they enter the viewport',
     }),
     solutions: ['dashboard'],
-  },
-  [BY_VALUE_EMBEDDABLE]: {
-    id: BY_VALUE_EMBEDDABLE,
-    isActive: true,
-    isDisplayed: true,
-    environments: ['kibana', 'browser', 'session'],
-    name: i18n.translate('presentationUtil.labs.enableByValueEmbeddableName', {
-      defaultMessage: 'By-Value Embeddables',
-    }),
-    description: i18n.translate('presentationUtil.labs.enableByValueEmbeddableDescription', {
-      defaultMessage: 'Enables support for by-value embeddables in Canvas',
-    }),
-    solutions: ['canvas'],
   },
 };
 

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -7671,6 +7671,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "labs:canvas:byValueEmbeddable": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "labs:canvas:useDataService": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/plugins/canvas/canvas_plugin_src/expression_types/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/expression_types/embeddable.ts
@@ -6,12 +6,11 @@
  */
 
 import { ExpressionTypeDefinition } from '../../../../../src/plugins/expressions';
-import { EmbeddableInput } from '../../../../../src/plugins/embeddable/common/';
+import { EmbeddableInput } from '../../types';
 import { EmbeddableTypes } from './embeddable_types';
 
 export const EmbeddableExpressionType = 'embeddable';
 export { EmbeddableTypes, EmbeddableInput };
-
 export interface EmbeddableExpression<Input extends EmbeddableInput> {
   /**
    * The type of the expression result

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { embeddable } from './embeddable';
+import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
+import { ExpressionValueFilter } from '../../../types';
+import { encode } from '../../../common/lib/embeddable_dataurl';
+
+const filterContext: ExpressionValueFilter = {
+  type: 'filter',
+  and: [
+    {
+      type: 'filter',
+      and: [],
+      value: 'filter-value',
+      column: 'filter-column',
+      filterType: 'exactly',
+    },
+    {
+      type: 'filter',
+      and: [],
+      column: 'time-column',
+      filterType: 'time',
+      from: '2019-06-04T04:00:00.000Z',
+      to: '2019-06-05T04:00:00.000Z',
+    },
+  ],
+};
+
+describe('embeddable', () => {
+  const fn = embeddable().fn;
+  const config = {
+    id: 'some-id',
+    timerange: { from: '15m', to: 'now' },
+    title: 'test embeddable',
+  };
+
+  const args = {
+    config: encode(config),
+    type: 'visualization',
+  };
+
+  it('accepts null context', () => {
+    const expression = fn(null, args, {} as any);
+
+    expect(expression.input.filters).toEqual([]);
+  });
+
+  it('accepts filter context', () => {
+    const expression = fn(filterContext, args, {} as any);
+    const embeddableFilters = getQueryFilters(filterContext.and);
+
+    expect(expression.input.filters).toEqual(embeddableFilters);
+  });
+});

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.test.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { embeddable } from './embeddable';
+import { embeddableFunctionFactory } from './embeddable';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
 import { ExpressionValueFilter } from '../../../types';
 import { encode } from '../../../common/lib/embeddable_dataurl';
+import { InitializeArguments } from '.';
 
 const filterContext: ExpressionValueFilter = {
   type: 'filter',
@@ -32,7 +33,7 @@ const filterContext: ExpressionValueFilter = {
 };
 
 describe('embeddable', () => {
-  const fn = embeddable().fn;
+  const fn = embeddableFunctionFactory({} as InitializeArguments)().fn;
   const config = {
     id: 'some-id',
     timerange: { from: '15m', to: 'now' },

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
+import { TimeRange } from 'src/plugins/data/public';
+import { Filter } from '@kbn/es-query';
+import { ExpressionValueFilter } from '../../../types';
+import {
+  EmbeddableExpressionType,
+  EmbeddableExpression,
+  EmbeddableInput as Input,
+} from '../../expression_types';
+import { getFunctionHelp } from '../../../i18n';
+import { SavedObjectReference } from '../../../../../../src/core/types';
+import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
+import { decode, encode } from '../../../common/lib/embeddable_dataurl';
+
+interface Arguments {
+  config: string;
+  type: string;
+}
+
+const defaultTimeRange = {
+  from: 'now-15m',
+  to: 'now',
+};
+
+export type EmbeddableInput = Input & {
+  timeRange?: TimeRange;
+  filters?: Filter[];
+  savedObjectId: string;
+};
+
+const baseEmbeddableInput = {
+  timeRange: defaultTimeRange,
+  disableTriggers: true,
+  renderMode: 'noInteractivity',
+};
+
+type Return = EmbeddableExpression<EmbeddableInput>;
+
+export function embeddable(): ExpressionFunctionDefinition<
+  'embeddable',
+  ExpressionValueFilter | null,
+  Arguments,
+  Return
+> {
+  const { help, args: argHelp } = getFunctionHelp().embeddable;
+
+  return {
+    name: 'embeddable',
+    help,
+    args: {
+      config: {
+        aliases: ['_'],
+        types: ['string'],
+        required: true,
+        help: argHelp.config,
+      },
+      type: {
+        types: ['string'],
+        required: true,
+        help: argHelp.type,
+      },
+    },
+    context: {
+      types: ['filter'],
+    },
+    type: EmbeddableExpressionType,
+    fn: (input, args) => {
+      const filters = input ? input.and : [];
+
+      const embeddableInput = decode(args.config) as EmbeddableInput;
+
+      return {
+        type: EmbeddableExpressionType,
+        input: {
+          ...baseEmbeddableInput,
+          ...embeddableInput,
+          filters: getQueryFilters(filters),
+        },
+        generatedAt: Date.now(),
+        embeddableType: args.type,
+      };
+    },
+
+    extract(state) {
+      const input = decode(state.config[0] as string);
+      const refName = 'embeddable.id';
+
+      const references: SavedObjectReference[] = [
+        {
+          name: refName,
+          type: state.type[0] as string,
+          id: input.savedObjectId as string,
+        },
+      ];
+
+      return {
+        state,
+        references,
+      };
+    },
+
+    inject(state, references) {
+      const reference = references.find((ref) => ref.name === 'embeddable.id');
+      if (reference) {
+        const input = decode(state.config[0] as string);
+        input.savedObjectId = reference.id;
+        state.config[0] = encode(input);
+      }
+      return state;
+    },
+  };
+}

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
@@ -6,14 +6,8 @@
  */
 
 import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
-import { TimeRange } from 'src/plugins/data/public';
-import { Filter } from '@kbn/es-query';
-import { ExpressionValueFilter } from '../../../types';
-import {
-  EmbeddableExpressionType,
-  EmbeddableExpression,
-  EmbeddableInput as Input,
-} from '../../expression_types';
+import { ExpressionValueFilter, EmbeddableInput } from '../../../types';
+import { EmbeddableExpressionType, EmbeddableExpression } from '../../expression_types';
 import { getFunctionHelp } from '../../../i18n';
 import { SavedObjectReference } from '../../../../../../src/core/types';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
@@ -27,12 +21,6 @@ interface Arguments {
 const defaultTimeRange = {
   from: 'now-15m',
   to: 'now',
-};
-
-export type EmbeddableInput = Input & {
-  timeRange?: TimeRange;
-  filters?: Filter[];
-  savedObjectId: string;
 };
 
 const baseEmbeddableInput = {

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/index.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/index.ts
@@ -9,5 +9,6 @@ import { savedLens } from './saved_lens';
 import { savedMap } from './saved_map';
 import { savedSearch } from './saved_search';
 import { savedVisualization } from './saved_visualization';
+import { embeddable } from './embeddable';
 
-export const functions = [savedLens, savedMap, savedVisualization, savedSearch];
+export const functions = [embeddable, savedLens, savedMap, savedSearch, savedVisualization];

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/index.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/index.ts
@@ -5,10 +5,26 @@
  * 2.0.
  */
 
+import { EmbeddableStart } from 'src/plugins/embeddable/public';
+import { embeddableFunctionFactory } from './embeddable';
 import { savedLens } from './saved_lens';
 import { savedMap } from './saved_map';
 import { savedSearch } from './saved_search';
 import { savedVisualization } from './saved_visualization';
-import { embeddable } from './embeddable';
 
-export const functions = [embeddable, savedLens, savedMap, savedSearch, savedVisualization];
+export interface InitializeArguments {
+  embeddablePersistableStateService: {
+    extract: EmbeddableStart['extract'];
+    inject: EmbeddableStart['inject'];
+  };
+}
+
+export function initFunctions(initialize: InitializeArguments) {
+  return [
+    embeddableFunctionFactory(initialize),
+    savedLens,
+    savedMap,
+    savedSearch,
+    savedVisualization,
+  ];
+}

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_lens.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_lens.ts
@@ -9,9 +9,8 @@ import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
 import { PaletteOutput } from 'src/plugins/charts/common';
 import { Filter as DataFilter } from '@kbn/es-query';
 import { TimeRange } from 'src/plugins/data/common';
-import { EmbeddableInput } from 'src/plugins/embeddable/common';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
-import { ExpressionValueFilter, TimeRange as TimeRangeArg } from '../../../types';
+import { ExpressionValueFilter, EmbeddableInput, TimeRange as TimeRangeArg } from '../../../types';
 import {
   EmbeddableTypes,
   EmbeddableExpressionType,
@@ -27,7 +26,7 @@ interface Arguments {
 }
 
 export type SavedLensInput = EmbeddableInput & {
-  id: string;
+  savedObjectId: string;
   timeRange?: TimeRange;
   filters: DataFilter[];
   palette?: PaletteOutput;
@@ -73,18 +72,19 @@ export function savedLens(): ExpressionFunctionDefinition<
       },
     },
     type: EmbeddableExpressionType,
-    fn: (input, args) => {
+    fn: (input, { id, timerange, title, palette }) => {
       const filters = input ? input.and : [];
 
       return {
         type: EmbeddableExpressionType,
         input: {
-          id: args.id,
+          id,
+          savedObjectId: id,
           filters: getQueryFilters(filters),
-          timeRange: args.timerange || defaultTimeRange,
-          title: args.title === null ? undefined : args.title,
+          timeRange: timerange || defaultTimeRange,
+          title: title === null ? undefined : title,
           disableTriggers: true,
-          palette: args.palette,
+          palette,
         },
         embeddableType: EmbeddableTypes.lens,
         generatedAt: Date.now(),

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_map.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_map.ts
@@ -30,7 +30,7 @@ const defaultTimeRange = {
   to: 'now',
 };
 
-type Output = EmbeddableExpression<MapEmbeddableInput>;
+type Output = EmbeddableExpression<MapEmbeddableInput & { savedObjectId: string }>;
 
 export function savedMap(): ExpressionFunctionDefinition<
   'savedMap',
@@ -85,8 +85,9 @@ export function savedMap(): ExpressionFunctionDefinition<
       return {
         type: EmbeddableExpressionType,
         input: {
-          attributes: { title: '' },
           id: args.id,
+          attributes: { title: '' },
+          savedObjectId: args.id,
           filters: getQueryFilters(filters),
           timeRange: args.timerange || defaultTimeRange,
           refreshConfig: {

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
@@ -25,7 +25,7 @@ interface Arguments {
   title: string | null;
 }
 
-type Output = EmbeddableExpression<VisualizeInput>;
+type Output = EmbeddableExpression<VisualizeInput & { savedObjectId: string }>;
 
 const defaultTimeRange = {
   from: 'now-15m',
@@ -94,6 +94,7 @@ export function savedVisualization(): ExpressionFunctionDefinition<
         type: EmbeddableExpressionType,
         input: {
           id,
+          savedObjectId: id,
           disableTriggers: true,
           timeRange: timerange || defaultTimeRange,
           filters: getQueryFilters(filters),

--- a/x-pack/plugins/canvas/canvas_plugin_src/plugin.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/plugin.ts
@@ -7,6 +7,7 @@
 
 import { CoreSetup, CoreStart, Plugin } from 'src/core/public';
 import { ChartsPluginStart } from 'src/plugins/charts/public';
+import { PresentationUtilPluginStart } from 'src/plugins/presentation_util/public';
 import { CanvasSetup } from '../public';
 import { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
 import { UiActionsStart } from '../../../../src/plugins/ui_actions/public';
@@ -25,6 +26,7 @@ export interface StartDeps {
   uiActions: UiActionsStart;
   inspector: InspectorStart;
   charts: ChartsPluginStart;
+  presentationUtil: PresentationUtilPluginStart;
 }
 
 export type SetupInitializer<T> = (core: CoreSetup<StartDeps>, plugins: SetupDeps) => T;

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
@@ -57,9 +57,6 @@ export const embeddableRendererFactory = (
     reuseDomNode: true,
     render: async (domNode, { input, embeddableType }, handlers) => {
       const uniqueId = handlers.getElementId();
-      const isByValueEnabled = plugins.presentationUtil.labsService.isProjectEnabled(
-        'labs:canvas:byValueEmbeddable'
-      );
 
       if (!embeddablesRegistry[uniqueId]) {
         const factory = Array.from(plugins.embeddable.getEmbeddableFactories()).find(
@@ -103,7 +100,7 @@ export const embeddableRendererFactory = (
             updatedInput,
             embeddableType,
             palettes,
-            isByValueEnabled
+            true
           );
 
           if (updatedExpression) {

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
@@ -10,6 +10,7 @@ import { EmbeddableTypes, EmbeddableInput } from '../../expression_types';
 import { toExpression as mapToExpression } from './input_type_to_expression/map';
 import { toExpression as visualizationToExpression } from './input_type_to_expression/visualization';
 import { toExpression as lensToExpression } from './input_type_to_expression/lens';
+import { toExpression as genericToExpression } from './input_type_to_expression/embeddable';
 
 export const inputToExpressionTypeMap = {
   [EmbeddableTypes.map]: mapToExpression,
@@ -23,8 +24,13 @@ export const inputToExpressionTypeMap = {
 export function embeddableInputToExpression(
   input: EmbeddableInput,
   embeddableType: string,
-  palettes: PaletteRegistry
+  palettes: PaletteRegistry,
+  useGenericEmbeddable?: boolean
 ): string | undefined {
+  if (useGenericEmbeddable) {
+    return genericToExpression(input, embeddableType);
+  }
+
   if (inputToExpressionTypeMap[embeddableType]) {
     return inputToExpressionTypeMap[embeddableType](input as any, palettes);
   }

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { toExpression } from './embeddable';
+import { EmbeddableInput } from '../../../../types';
+import { decode } from '../../../../common/lib/embeddable_dataurl';
+import { fromExpression } from '@kbn/interpreter/common';
+
+describe('toExpression', () => {
+  describe('by-reference embeddable input', () => {
+    const baseEmbeddableInput = {
+      id: 'elementId',
+      savedObjectId: 'embeddableId',
+      filters: [],
+    };
+
+    it('converts to an embeddable expression', () => {
+      const input: EmbeddableInput = baseEmbeddableInput;
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      expect(ast.type).toBe('expression');
+      expect(ast.chain[0].function).toBe('embeddable');
+      expect(ast.chain[0].arguments.type[0]).toBe('visualization');
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config.savedObjectId).toStrictEqual(input.savedObjectId);
+    });
+
+    it('includes optional input values', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: 'title',
+        timeRange: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+      expect(config).toHaveProperty('timeRange');
+      expect(config.timeRange).toHaveProperty('from', input.timeRange?.from);
+      expect(config.timeRange).toHaveProperty('to', input.timeRange?.to);
+    });
+
+    it('includes empty panel title', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: '',
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+    });
+  });
+
+  describe('by-value embeddable input', () => {
+    const baseEmbeddableInput = {
+      id: 'elementId',
+      disableTriggers: true,
+      filters: [],
+    };
+    it('converts to an embeddable expression', () => {
+      const input: EmbeddableInput = baseEmbeddableInput;
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      expect(ast.type).toBe('expression');
+      expect(ast.chain[0].function).toBe('embeddable');
+      expect(ast.chain[0].arguments.type[0]).toBe('visualization');
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+      expect(config.filters).toStrictEqual(input.filters);
+      expect(config.disableTriggers).toStrictEqual(input.disableTriggers);
+    });
+
+    it('includes optional input values', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: 'title',
+        timeRange: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+      expect(config).toHaveProperty('timeRange');
+      expect(config.timeRange).toHaveProperty('from', input.timeRange?.from);
+      expect(config.timeRange).toHaveProperty('to', input.timeRange?.to);
+    });
+
+    it('includes empty panel title', () => {
+      const input: EmbeddableInput = {
+        ...baseEmbeddableInput,
+        title: '',
+      };
+
+      const expression = toExpression(input, 'visualization');
+      const ast = fromExpression(expression);
+
+      const config = decode(ast.chain[0].arguments.config[0] as string);
+
+      expect(config).toHaveProperty('title', input.title);
+    });
+  });
+});

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { encode } from '../../../../common/lib/embeddable_dataurl';
+import { EmbeddableInput } from '../../../expression_types';
+
+export function toExpression(input: EmbeddableInput, embeddableType: string): string {
+  return `embeddable config="${encode(input)}" type="${embeddableType}"`;
+}

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.test.ts
@@ -11,7 +11,8 @@ import { fromExpression, Ast } from '@kbn/interpreter/common';
 import { chartPluginMock } from 'src/plugins/charts/public/mocks';
 
 const baseEmbeddableInput = {
-  id: 'embeddableId',
+  id: 'elementId',
+  savedObjectId: 'embeddableId',
   filters: [],
 };
 
@@ -27,7 +28,7 @@ describe('toExpression', () => {
     expect(ast.type).toBe('expression');
     expect(ast.chain[0].function).toBe('savedLens');
 
-    expect(ast.chain[0].arguments.id).toStrictEqual([input.id]);
+    expect(ast.chain[0].arguments.id).toStrictEqual([input.savedObjectId]);
 
     expect(ast.chain[0].arguments).not.toHaveProperty('title');
     expect(ast.chain[0].arguments).not.toHaveProperty('timerange');

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/lens.ts
@@ -14,7 +14,7 @@ export function toExpression(input: SavedLensInput, palettes: PaletteRegistry): 
 
   expressionParts.push('savedLens');
 
-  expressionParts.push(`id="${input.id}"`);
+  expressionParts.push(`id="${input.savedObjectId}"`);
 
   if (input.title !== undefined) {
     expressionParts.push(`title="${input.title}"`);

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { toExpression } from './map';
-import { MapEmbeddableInput } from '../../../../../../plugins/maps/public/embeddable';
 import { fromExpression, Ast } from '@kbn/interpreter/common';
 
 const baseSavedMapInput = {
+  id: 'elementId',
   attributes: { title: '' },
-  id: 'embeddableId',
+  savedObjectId: 'embeddableId',
   filters: [],
   isLayerTOCOpen: false,
   refreshConfig: {
@@ -23,7 +23,7 @@ const baseSavedMapInput = {
 
 describe('toExpression', () => {
   it('converts to a savedMap expression', () => {
-    const input: MapEmbeddableInput = {
+    const input = {
       ...baseSavedMapInput,
     };
 
@@ -33,7 +33,7 @@ describe('toExpression', () => {
     expect(ast.type).toBe('expression');
     expect(ast.chain[0].function).toBe('savedMap');
 
-    expect(ast.chain[0].arguments.id).toStrictEqual([input.id]);
+    expect(ast.chain[0].arguments.id).toStrictEqual([input.savedObjectId]);
 
     expect(ast.chain[0].arguments).not.toHaveProperty('title');
     expect(ast.chain[0].arguments).not.toHaveProperty('center');
@@ -41,7 +41,7 @@ describe('toExpression', () => {
   });
 
   it('includes optional input values', () => {
-    const input: MapEmbeddableInput = {
+    const input = {
       ...baseSavedMapInput,
       mapCenter: {
         lat: 1,
@@ -73,7 +73,7 @@ describe('toExpression', () => {
   });
 
   it('includes empty panel title', () => {
-    const input: MapEmbeddableInput = {
+    const input = {
       ...baseSavedMapInput,
       title: '',
     };

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/map.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { MapEmbeddableInput } from '../../../../../../plugins/maps/public/embeddable';
+import { MapEmbeddableInput } from '../../../../../../plugins/maps/public';
 
-export function toExpression(input: MapEmbeddableInput): string {
+export function toExpression(input: MapEmbeddableInput & { savedObjectId: string }): string {
   const expressionParts = [] as string[];
 
   expressionParts.push('savedMap');
-  expressionParts.push(`id="${input.id}"`);
+
+  expressionParts.push(`id="${input.savedObjectId}"`);
 
   if (input.title !== undefined) {
     expressionParts.push(`title="${input.title}"`);

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.test.ts
@@ -9,7 +9,8 @@ import { toExpression } from './visualization';
 import { fromExpression, Ast } from '@kbn/interpreter/common';
 
 const baseInput = {
-  id: 'embeddableId',
+  id: 'elementId',
+  savedObjectId: 'embeddableId',
 };
 
 describe('toExpression', () => {
@@ -24,7 +25,7 @@ describe('toExpression', () => {
     expect(ast.type).toBe('expression');
     expect(ast.chain[0].function).toBe('savedVisualization');
 
-    expect(ast.chain[0].arguments.id).toStrictEqual([input.id]);
+    expect(ast.chain[0].arguments.id).toStrictEqual([input.savedObjectId]);
   });
 
   it('includes timerange if given', () => {

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/visualization.ts
@@ -7,11 +7,11 @@
 
 import { VisualizeInput } from 'src/plugins/visualizations/public';
 
-export function toExpression(input: VisualizeInput): string {
+export function toExpression(input: VisualizeInput & { savedObjectId: string }): string {
   const expressionParts = [] as string[];
 
   expressionParts.push('savedVisualization');
-  expressionParts.push(`id="${input.id}"`);
+  expressionParts.push(`id="${input.savedObjectId}"`);
 
   if (input.title !== undefined) {
     expressionParts.push(`title="${input.title}"`);

--- a/x-pack/plugins/canvas/common/lib/embeddable_dataurl.ts
+++ b/x-pack/plugins/canvas/common/lib/embeddable_dataurl.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EmbeddableInput } from '../../canvas_plugin_src/expression_types';
+
+export const encode = (input: Partial<EmbeddableInput>) =>
+  Buffer.from(JSON.stringify(input)).toString('base64');
+export const decode = (serializedInput: string) =>
+  JSON.parse(Buffer.from(serializedInput, 'base64').toString());

--- a/x-pack/plugins/canvas/common/lib/embeddable_dataurl.ts
+++ b/x-pack/plugins/canvas/common/lib/embeddable_dataurl.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EmbeddableInput } from '../../canvas_plugin_src/expression_types';
+import { EmbeddableInput } from '../../types';
 
 export const encode = (input: Partial<EmbeddableInput>) =>
   Buffer.from(JSON.stringify(input)).toString('base64');

--- a/x-pack/plugins/canvas/i18n/functions/dict/embeddable.ts
+++ b/x-pack/plugins/canvas/i18n/functions/dict/embeddable.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { embeddable } from '../../../canvas_plugin_src/functions/external/embeddable';
+import { FunctionHelp } from '../function_help';
+import { FunctionFactory } from '../../../types';
+
+export const help: FunctionHelp<FunctionFactory<typeof embeddable>> = {
+  help: i18n.translate('xpack.canvas.functions.embeddableHelpText', {
+    defaultMessage: `Returns an embeddable with the provided configuration`,
+  }),
+  args: {
+    config: i18n.translate('xpack.canvas.functions.embeddable.args.idHelpText', {
+      defaultMessage: `The base64 encoded embeddable input object`,
+    }),
+    type: i18n.translate('xpack.canvas.functions.embeddable.args.typeHelpText', {
+      defaultMessage: `The embeddable type`,
+    }),
+  },
+};

--- a/x-pack/plugins/canvas/i18n/functions/dict/embeddable.ts
+++ b/x-pack/plugins/canvas/i18n/functions/dict/embeddable.ts
@@ -6,11 +6,11 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { embeddable } from '../../../canvas_plugin_src/functions/external/embeddable';
+import { embeddableFunctionFactory } from '../../../canvas_plugin_src/functions/external/embeddable';
 import { FunctionHelp } from '../function_help';
 import { FunctionFactory } from '../../../types';
 
-export const help: FunctionHelp<FunctionFactory<typeof embeddable>> = {
+export const help: FunctionHelp<FunctionFactory<ReturnType<typeof embeddableFunctionFactory>>> = {
   help: i18n.translate('xpack.canvas.functions.embeddableHelpText', {
     defaultMessage: `Returns an embeddable with the provided configuration`,
   }),

--- a/x-pack/plugins/canvas/i18n/functions/function_help.ts
+++ b/x-pack/plugins/canvas/i18n/functions/function_help.ts
@@ -27,6 +27,7 @@ import { help as demodata } from './dict/demodata';
 import { help as doFn } from './dict/do';
 import { help as dropdownControl } from './dict/dropdown_control';
 import { help as eq } from './dict/eq';
+import { help as embeddable } from './dict/embeddable';
 import { help as escount } from './dict/escount';
 import { help as esdocs } from './dict/esdocs';
 import { help as essql } from './dict/essql';
@@ -182,6 +183,7 @@ export const getFunctionHelp = (): FunctionHelpDict => ({
   do: doFn,
   dropdownControl,
   eq,
+  embeddable,
   escount,
   esdocs,
   essql,

--- a/x-pack/plugins/canvas/public/application.tsx
+++ b/x-pack/plugins/canvas/public/application.tsx
@@ -111,6 +111,7 @@ export const initializeCanvas = async (
     prependBasePath: coreStart.http.basePath.prepend,
     types: setupPlugins.expressions.getTypes(),
     paletteService: await setupPlugins.charts.palettes.getPalettes(),
+    embeddablesService: startPlugins.embeddable,
   });
 
   for (const fn of canvasFunctions) {

--- a/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import { EuiFlyout, EuiFlyoutHeader, EuiFlyoutBody, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -27,38 +27,44 @@ const strings = {
 };
 export interface Props {
   onClose: () => void;
-  onSelect: (id: string, embeddableType: string) => void;
+  onSelect: (id: string, embeddableType: string, isByValueEnabled?: boolean) => void;
   availableEmbeddables: string[];
+  isByValueEnabled?: boolean;
 }
 
-export const AddEmbeddableFlyout: FC<Props> = ({ onSelect, availableEmbeddables, onClose }) => {
+export const AddEmbeddableFlyout: FC<Props> = ({
+  onSelect,
+  availableEmbeddables,
+  onClose,
+  isByValueEnabled,
+}) => {
   const embeddablesService = useEmbeddablesService();
   const platformService = usePlatformService();
   const { getEmbeddableFactories } = embeddablesService;
   const { getSavedObjects, getUISettings } = platformService;
 
-  const onAddPanel = (id: string, savedObjectType: string, name: string) => {
-    const embeddableFactories = getEmbeddableFactories();
+  const onAddPanel = useCallback(
+    (id: string, savedObjectType: string) => {
+      const embeddableFactories = getEmbeddableFactories();
+      // Find the embeddable type from the saved object type
+      const found = Array.from(embeddableFactories).find((embeddableFactory) => {
+        return Boolean(
+          embeddableFactory.savedObjectMetaData &&
+            embeddableFactory.savedObjectMetaData.type === savedObjectType
+        );
+      });
 
-    // Find the embeddable type from the saved object type
-    const found = Array.from(embeddableFactories).find((embeddableFactory) => {
-      return Boolean(
-        embeddableFactory.savedObjectMetaData &&
-          embeddableFactory.savedObjectMetaData.type === savedObjectType
-      );
-    });
+      const foundEmbeddableType = found ? found.type : 'unknown';
 
-    const foundEmbeddableType = found ? found.type : 'unknown';
-
-    onSelect(id, foundEmbeddableType);
-  };
+      onSelect(id, foundEmbeddableType, isByValueEnabled);
+    },
+    [isByValueEnabled, getEmbeddableFactories, onSelect]
+  );
 
   const embeddableFactories = getEmbeddableFactories();
 
   const availableSavedObjects = Array.from(embeddableFactories)
-    .filter((factory) => {
-      return availableEmbeddables.includes(factory.type);
-    })
+    .filter((factory) => isByValueEnabled || availableEmbeddables.includes(factory.type))
     .map((factory) => factory.savedObjectMetaData)
     .filter<SavedObjectMetaData<{}>>(function (
       maybeSavedObjectMetaData

--- a/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -27,17 +27,11 @@ const strings = {
 };
 export interface Props {
   onClose: () => void;
-  onSelect: (id: string, embeddableType: string, isByValueEnabled?: boolean) => void;
+  onSelect: (id: string, embeddableType: string) => void;
   availableEmbeddables: string[];
-  isByValueEnabled?: boolean;
 }
 
-export const AddEmbeddableFlyout: FC<Props> = ({
-  onSelect,
-  availableEmbeddables,
-  onClose,
-  isByValueEnabled,
-}) => {
+export const AddEmbeddableFlyout: FC<Props> = ({ onSelect, availableEmbeddables, onClose }) => {
   const embeddablesService = useEmbeddablesService();
   const platformService = usePlatformService();
   const { getEmbeddableFactories } = embeddablesService;
@@ -56,15 +50,14 @@ export const AddEmbeddableFlyout: FC<Props> = ({
 
       const foundEmbeddableType = found ? found.type : 'unknown';
 
-      onSelect(id, foundEmbeddableType, isByValueEnabled);
+      onSelect(id, foundEmbeddableType);
     },
-    [isByValueEnabled, getEmbeddableFactories, onSelect]
+    [getEmbeddableFactories, onSelect]
   );
 
   const embeddableFactories = getEmbeddableFactories();
 
   const availableSavedObjects = Array.from(embeddableFactories)
-    .filter((factory) => isByValueEnabled || availableEmbeddables.includes(factory.type))
     .map((factory) => factory.savedObjectMetaData)
     .filter<SavedObjectMetaData<{}>>(function (
       maybeSavedObjectMetaData

--- a/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -8,12 +8,14 @@
 import React, { useMemo, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { encode } from '../../../common/lib/embeddable_dataurl';
 import { AddEmbeddableFlyout as Component, Props as ComponentProps } from './flyout.component';
 // @ts-expect-error untyped local
 import { addElement } from '../../state/actions/elements';
 import { getSelectedPage } from '../../state/selectors/workpad';
 import { EmbeddableTypes } from '../../../canvas_plugin_src/expression_types/embeddable';
 import { State } from '../../../types';
+import { useLabsService } from '../../services';
 
 const allowedEmbeddables = {
   [EmbeddableTypes.map]: (id: string) => {
@@ -65,6 +67,9 @@ export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
   availableEmbeddables,
   ...restProps
 }) => {
+  const labsService = useLabsService();
+  const isByValueEnabled = labsService.isProjectEnabled('labs:canvas:byValueEmbeddable');
+
   const dispatch = useDispatch();
   const pageId = useSelector<State, string>((state) => getSelectedPage(state));
 
@@ -74,18 +79,26 @@ export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
   );
 
   const onSelect = useCallback(
-    (id: string, type: string) => {
+    (id: string, type: string): void => {
       const partialElement = {
         expression: `markdown "Could not find embeddable for type ${type}" | render`,
       };
-      if (allowedEmbeddables[type]) {
+
+      // If by-value is enabled, we'll handle both by-reference and by-value embeddables
+      // with the new generic `embeddable` function
+      if (isByValueEnabled) {
+        const config = encode({ id });
+        partialElement.expression = `embeddable config="${config}" 
+  type="${type}" 
+| render`;
+      } else if (allowedEmbeddables[type]) {
         partialElement.expression = allowedEmbeddables[type](id);
       }
 
       addEmbeddable(pageId, partialElement);
       restProps.onClose();
     },
-    [addEmbeddable, pageId, restProps]
+    [addEmbeddable, pageId, restProps, isByValueEnabled]
   );
 
   return (
@@ -93,6 +106,7 @@ export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
       {...restProps}
       availableEmbeddables={availableEmbeddables || []}
       onSelect={onSelect}
+      isByValueEnabled={isByValueEnabled}
     />
   );
 };

--- a/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -85,9 +85,10 @@ export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
       };
 
       // If by-value is enabled, we'll handle both by-reference and by-value embeddables
-      // with the new generic `embeddable` function
+      // with the new generic `embeddable` function.
+      // Otherwise we fallback to the embeddable type specific expressions.
       if (isByValueEnabled) {
-        const config = encode({ id });
+        const config = encode({ savedObjectId: id });
         partialElement.expression = `embeddable config="${config}" 
   type="${type}" 
 | render`;

--- a/x-pack/plugins/canvas/public/components/hooks/workpad/index.tsx
+++ b/x-pack/plugins/canvas/public/components/hooks/workpad/index.tsx
@@ -6,3 +6,5 @@
  */
 
 export { useDownloadWorkpad, useDownloadRenderedWorkpad } from './use_download_workpad';
+
+export { useIncomingEmbeddable } from './use_incoming_embeddable';

--- a/x-pack/plugins/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
+++ b/x-pack/plugins/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
@@ -9,7 +9,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { CANVAS_APP } from '../../../../common/lib';
 import { encode } from '../../../../common/lib/embeddable_dataurl';
-import { useEmbeddablesService, useLabsService } from '../../../services';
+import { useEmbeddablesService } from '../../../services';
 // @ts-expect-error unconverted file
 import { addElement } from '../../../state/actions/elements';
 // @ts-expect-error unconverted file
@@ -23,16 +23,14 @@ import { clearValue } from '../../../state/actions/resolved_args';
 
 export const useIncomingEmbeddable = (pageId: string) => {
   const embeddablesService = useEmbeddablesService();
-  const labsService = useLabsService();
   const dispatch = useDispatch();
-  const isByValueEnabled = labsService.isProjectEnabled('labs:canvas:byValueEmbeddable');
   const stateTransferService = embeddablesService.getStateTransfer();
 
   // fetch incoming embeddable from state transfer service.
   const incomingEmbeddable = stateTransferService.getIncomingEmbeddablePackage(CANVAS_APP, true);
 
   useEffect(() => {
-    if (isByValueEnabled && incomingEmbeddable) {
+    if (incomingEmbeddable) {
       const { embeddableId, input, type } = incomingEmbeddable;
 
       const config = encode(input);
@@ -59,5 +57,5 @@ export const useIncomingEmbeddable = (pageId: string) => {
         dispatch(addElement(pageId, { expression }));
       }
     }
-  }, [dispatch, pageId, incomingEmbeddable, isByValueEnabled]);
+  }, [dispatch, pageId, incomingEmbeddable]);
 };

--- a/x-pack/plugins/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
+++ b/x-pack/plugins/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { CANVAS_APP } from '../../../../common/lib';
+import { encode } from '../../../../common/lib/embeddable_dataurl';
+import { useEmbeddablesService, useLabsService } from '../../../services';
+// @ts-expect-error unconverted file
+import { addElement } from '../../../state/actions/elements';
+// @ts-expect-error unconverted file
+import { selectToplevelNodes } from '../../../state/actions/transient';
+
+import {
+  updateEmbeddableExpression,
+  fetchEmbeddableRenderable,
+} from '../../../state/actions/embeddable';
+import { clearValue } from '../../../state/actions/resolved_args';
+
+export const useIncomingEmbeddable = (pageId: string) => {
+  const embeddablesService = useEmbeddablesService();
+  const labsService = useLabsService();
+  const dispatch = useDispatch();
+  const isByValueEnabled = labsService.isProjectEnabled('labs:canvas:byValueEmbeddable');
+  const stateTransferService = embeddablesService.getStateTransfer();
+
+  // fetch incoming embeddable from state transfer service.
+  const incomingEmbeddable = stateTransferService.getIncomingEmbeddablePackage(CANVAS_APP, true);
+
+  useEffect(() => {
+    if (isByValueEnabled && incomingEmbeddable) {
+      const { embeddableId, input, type } = incomingEmbeddable;
+
+      const config = encode(input);
+      const expression = `embeddable config="${config}"
+  type="${type}" 
+| render`;
+
+      if (embeddableId) {
+        // clear out resolved arg for old embeddable
+        const argumentPath = [embeddableId, 'expressionRenderable'];
+        dispatch(clearValue({ path: argumentPath }));
+
+        // update existing embeddable expression
+        dispatch(
+          updateEmbeddableExpression({ elementId: embeddableId, embeddableExpression: expression })
+        );
+
+        // update resolved args
+        dispatch(fetchEmbeddableRenderable(embeddableId));
+
+        // select new embeddable element
+        dispatch(selectToplevelNodes([embeddableId]));
+      } else {
+        dispatch(addElement(pageId, { expression }));
+      }
+    }
+  }, [dispatch, pageId, incomingEmbeddable, isByValueEnabled]);
+};

--- a/x-pack/plugins/canvas/public/components/workpad/workpad.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad/workpad.tsx
@@ -27,6 +27,7 @@ import { WorkpadRoutingContext } from '../../routes/workpad';
 import { usePlatformService } from '../../services';
 import { Workpad as WorkpadComponent, Props } from './workpad.component';
 import { State } from '../../../types';
+import { useIncomingEmbeddable } from '../hooks';
 
 type ContainerProps = Pick<Props, 'registerLayout' | 'unregisterLayout'>;
 
@@ -57,6 +58,9 @@ export const Workpad: FC<ContainerProps> = (props) => {
       zoomScale: getZoomScale(state),
     };
   });
+
+  const pageId = propsFromState.pages[propsFromState.selectedPageNumber - 1].id;
+  useIncomingEmbeddable(pageId);
 
   const fetchAllRenderables = useCallback(() => {
     dispatch(fetchAllRenderablesAction());

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/__stories__/element_menu.stories.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/__stories__/element_menu.stories.tsx
@@ -130,5 +130,9 @@ You can use standard Markdown in here, but you can also access your piped-in dat
 };
 
 storiesOf('components/WorkpadHeader/ElementMenu', module).add('default', () => (
-  <ElementMenu elements={testElements} addElement={action('addElement')} />
+  <ElementMenu
+    elements={testElements}
+    addElement={action('addElement')}
+    createNewEmbeddable={action('createNewEmbeddable')}
+  />
 ));

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.component.tsx
@@ -18,6 +18,7 @@ import { ElementSpec } from '../../../../types';
 import { flattenPanelTree } from '../../../lib/flatten_panel_tree';
 import { AssetManager } from '../../asset_manager';
 import { SavedElementsModal } from '../../saved_elements_modal';
+import { useLabsService } from '../../../services';
 
 interface CategorizedElementLists {
   [key: string]: ElementSpec[];
@@ -112,7 +113,7 @@ const categorizeElementsByType = (elements: ElementSpec[]): { [key: string]: Ele
   return categories;
 };
 
-interface Props {
+export interface Props {
   /**
    * Dictionary of elements from elements registry
    */
@@ -120,10 +121,20 @@ interface Props {
   /**
    * Handler for adding a selected element to the workpad
    */
-  addElement: (element: ElementSpec) => void;
+  addElement: (element: Partial<ElementSpec>) => void;
+  /**
+   * Crete new embeddable
+   */
+  createNewEmbeddable: () => void;
 }
 
-export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) => {
+export const ElementMenu: FunctionComponent<Props> = ({
+  elements,
+  addElement,
+  createNewEmbeddable,
+}) => {
+  const labsService = useLabsService();
+  const isByValueEnabled = labsService.isProjectEnabled('labs:canvas:byValueEmbeddable');
   const [isAssetModalVisible, setAssetModalVisible] = useState(false);
   const [isSavedElementsModalVisible, setSavedElementsModalVisible] = useState(false);
 
@@ -199,6 +210,18 @@ export const ElementMenu: FunctionComponent<Props> = ({ elements, addElement }) 
             closePopover();
           },
         },
+        // TODO: Remove this menu option. This is a temporary menu options just for testing,
+        // will be removed once toolbar is implemented
+        isByValueEnabled
+          ? {
+              name: 'Lens',
+              icon: <EuiIcon type="lensApp" size="m" />,
+              onClick: () => {
+                createNewEmbeddable();
+                closePopover();
+              },
+            }
+          : {},
       ],
     };
   };

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/element_menu.tsx
@@ -5,4 +5,34 @@
  * 2.0.
  */
 
-export * from './element_menu.component';
+import React, { FC, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { trackCanvasUiMetric, METRIC_TYPE } from '../../../../public/lib/ui_metric';
+import { CANVAS_APP } from '../../../../common/lib';
+import { ElementMenu as Component, Props } from './element_menu.component';
+import { useEmbeddablesService } from '../../../services';
+
+export const ElementMenu: FC<Omit<Props, 'createNewEmbeddable'>> = (props) => {
+  const embeddablesService = useEmbeddablesService();
+  const stateTransferService = embeddablesService.getStateTransfer();
+  const { pathname, search } = useLocation();
+
+  const createNewEmbeddable = useCallback(() => {
+    const path = '#/';
+    const appId = 'lens';
+
+    if (trackCanvasUiMetric) {
+      trackCanvasUiMetric(METRIC_TYPE.CLICK, `${appId}:create`);
+    }
+
+    stateTransferService.navigateToEditor(appId, {
+      path,
+      state: {
+        originatingApp: CANVAS_APP,
+        originatingPath: `#/${pathname}${search}`,
+      },
+    });
+  }, [pathname, search, stateTransferService]);
+
+  return <Component {...props} createNewEmbeddable={createNewEmbeddable} />;
+};

--- a/x-pack/plugins/canvas/public/plugin.tsx
+++ b/x-pack/plugins/canvas/public/plugin.tsx
@@ -90,17 +90,6 @@ export class CanvasPlugin
   public setup(coreSetup: CoreSetup<CanvasStartDeps>, setupPlugins: CanvasSetupDeps) {
     const { api: canvasApi, registries } = getPluginApi(setupPlugins.expressions);
 
-    // Set the nav link to the last saved url if we have one in storage
-    const lastPath = getSessionStorage().get(
-      `${SESSIONSTORAGE_LASTPATH}:${coreSetup.http.basePath.get()}`
-    );
-
-    if (lastPath) {
-      this.appUpdater.next(() => ({
-        defaultPath: `#${lastPath}`,
-      }));
-    }
-
     coreSetup.application.register({
       category: DEFAULT_APP_CATEGORIES.kibana,
       id: CANVAS_APP,
@@ -172,5 +161,16 @@ export class CanvasPlugin
 
   public start(coreStart: CoreStart, startPlugins: CanvasStartDeps) {
     initLoadingIndicator(coreStart.http.addLoadingCountSource);
+
+    // Set the nav link to the last saved url if we have one in storage
+    const lastPath = getSessionStorage().get(
+      `${SESSIONSTORAGE_LASTPATH}:${coreStart.http.basePath.get()}`
+    );
+
+    if (lastPath) {
+      this.appUpdater.next(() => ({
+        defaultPath: `#${lastPath}`,
+      }));
+    }
   }
 }

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_workpad.ts
@@ -46,9 +46,11 @@ export const useWorkpad = (
           workpad.aliasId = aliasId;
         }
 
-        dispatch(setAssets(assets));
-        dispatch(setWorkpad(workpad, { loadPages }));
-        dispatch(setZoomScale(1));
+        if (storedWorkpad.id !== workpadId || storedWorkpad.aliasId !== aliasId) {
+          dispatch(setAssets(assets));
+          dispatch(setWorkpad(workpad, { loadPages }));
+          dispatch(setZoomScale(1));
+        }
 
         if (outcome === 'aliasMatch' && platformService.redirectLegacyUrl && aliasId) {
           platformService.redirectLegacyUrl(`#${getRedirectPath(aliasId)}`, getWorkpadLabel());
@@ -57,7 +59,17 @@ export const useWorkpad = (
         setError(e as Error | string);
       }
     })();
-  }, [workpadId, dispatch, setError, loadPages, workpadService, getRedirectPath, platformService]);
+  }, [
+    workpadId,
+    dispatch,
+    setError,
+    loadPages,
+    workpadService,
+    getRedirectPath,
+    platformService,
+    storedWorkpad.id,
+    storedWorkpad.aliasId,
+  ]);
 
   return [storedWorkpad.id === workpadId ? storedWorkpad : undefined, error];
 };

--- a/x-pack/plugins/canvas/public/services/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/embeddables.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { EmbeddableFactory } from '../../../../../src/plugins/embeddable/public';
+import {
+  EmbeddableFactory,
+  EmbeddableStateTransfer,
+} from '../../../../../src/plugins/embeddable/public';
 
 export interface CanvasEmbeddablesService {
   getEmbeddableFactories: () => IterableIterator<EmbeddableFactory>;
+  getStateTransfer: () => EmbeddableStateTransfer;
 }

--- a/x-pack/plugins/canvas/public/services/kibana/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/embeddables.ts
@@ -16,4 +16,5 @@ export type EmbeddablesServiceFactory = KibanaPluginServiceFactory<
 
 export const embeddablesServiceFactory: EmbeddablesServiceFactory = ({ startPlugins }) => ({
   getEmbeddableFactories: startPlugins.embeddable.getEmbeddableFactories,
+  getStateTransfer: startPlugins.embeddable.getStateTransfer,
 });

--- a/x-pack/plugins/canvas/public/services/stubs/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/embeddables.ts
@@ -14,4 +14,5 @@ const noop = (..._args: any[]): any => {};
 
 export const embeddablesServiceFactory: EmbeddablesServiceFactory = () => ({
   getEmbeddableFactories: noop,
+  getStateTransfer: noop,
 });

--- a/x-pack/plugins/canvas/public/state/reducers/embeddable.ts
+++ b/x-pack/plugins/canvas/public/state/reducers/embeddable.ts
@@ -40,7 +40,7 @@ export const embeddableReducer = handleActions<
 
       const element = pageWithElement.elements.find((elem) => elem.id === elementId);
 
-      if (!element) {
+      if (!element || element.expression === embeddableExpression) {
         return workpadState;
       }
 

--- a/x-pack/plugins/canvas/server/plugin.ts
+++ b/x-pack/plugins/canvas/server/plugin.ts
@@ -82,7 +82,7 @@ export class CanvasPlugin implements Plugin {
     const globalConfig = this.initializerContext.config.legacy.get();
     registerCanvasUsageCollector(plugins.usageCollection, globalConfig.kibana.index);
 
-    setupInterpreter(expressionsFork);
+    setupInterpreter(expressionsFork, { embeddablesService: plugins.embeddable });
 
     coreSetup.getStartServices().then(([_, depsStart]) => {
       const strategy = essqlSearchStrategyProvider();

--- a/x-pack/plugins/canvas/server/setup_interpreter.ts
+++ b/x-pack/plugins/canvas/server/setup_interpreter.ts
@@ -6,10 +6,18 @@
  */
 
 import { ExpressionsServerSetup } from 'src/plugins/expressions/server';
+import { EmbeddableSetup } from 'src/plugins/embeddable/server';
 import { functions } from '../canvas_plugin_src/functions/server';
-import { functions as externalFunctions } from '../canvas_plugin_src/functions/external';
+import { initFunctions as initExternalFunctions } from '../canvas_plugin_src/functions/external';
 
-export function setupInterpreter(expressions: ExpressionsServerSetup) {
+interface InterpreterDependencies {
+  embeddablesService: EmbeddableSetup;
+}
+
+export function setupInterpreter(
+  expressions: ExpressionsServerSetup,
+  dependencies: InterpreterDependencies
+) {
   functions.forEach((f) => expressions.registerFunction(f));
   externalFunctions.forEach((f) => expressions.registerFunction(f));
 }

--- a/x-pack/plugins/canvas/types/embeddables.ts
+++ b/x-pack/plugins/canvas/types/embeddables.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TimeRange } from 'src/plugins/data/public';
+import { Filter } from '@kbn/es-query';
+import { EmbeddableInput as Input } from '../../../../src/plugins/embeddable/common/';
+
+export type EmbeddableInput = Input & {
+  timeRange?: TimeRange;
+  filters?: Filter[];
+  savedObjectId?: string;
+};

--- a/x-pack/plugins/canvas/types/index.ts
+++ b/x-pack/plugins/canvas/types/index.ts
@@ -9,6 +9,7 @@ export * from '../../../../src/plugins/expressions/common';
 export * from './assets';
 export * from './canvas';
 export * from './elements';
+export * from './embeddables';
 export * from './filters';
 export * from './functions';
 export * from './renderers';


### PR DESCRIPTION
## Summary

Blocked by #113827.

This removes the by-value embeddable flag. Since I'm not merging this piece by piece into master and will be merging in this entire feature all at once from the feature branch (#113827), there isn't much benefit to keeping this behind a lab flag.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
