### PR TITLE
[Canvas] Adds support for palette in embeddable function

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/embeddable.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { PaletteOutput } from 'src/plugins/charts/common';
 import { ExpressionFunctionDefinition } from 'src/plugins/expressions/common';
 import { ExpressionValueFilter, EmbeddableInput } from '../../../types';
 import { EmbeddableExpressionType, EmbeddableExpression } from '../../expression_types';
@@ -17,6 +18,7 @@ import { InitializeArguments } from '.';
 export interface Arguments {
   config: string;
   type: string;
+  palette?: PaletteOutput;
 }
 
 const defaultTimeRange = {
@@ -55,6 +57,11 @@ export function embeddableFunctionFactory({
           required: true,
           help: argHelp.config,
         },
+        palette: {
+          types: ['palette'],
+          help: argHelp.palette,
+          required: false,
+        },
         type: {
           types: ['string'],
           required: true,
@@ -76,6 +83,7 @@ export function embeddableFunctionFactory({
             ...baseEmbeddableInput,
             ...embeddableInput,
             filters: getQueryFilters(filters),
+            palette: args.palette,
           },
           generatedAt: Date.now(),
           embeddableType: args.type,

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
@@ -28,7 +28,7 @@ export function embeddableInputToExpression(
   useGenericEmbeddable?: boolean
 ): string | undefined {
   if (useGenericEmbeddable) {
-    return genericToExpression(input, embeddableType);
+    return genericToExpression(input, embeddableType, palettes);
   }
 
   if (inputToExpressionTypeMap[embeddableType]) {

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { toExpression } from './embeddable';
-import { EmbeddableInput } from '../../../../types';
-import { decode } from '../../../../common/lib/embeddable_dataurl';
 import { fromExpression } from '@kbn/interpreter/common';
+import { chartPluginMock } from 'src/plugins/charts/public/mocks';
+import { decode } from '../../../../common/lib/embeddable_dataurl';
+import { EmbeddableInput } from '../../../../types';
+import { toExpression } from './embeddable';
 
 describe('toExpression', () => {
   describe('by-reference embeddable input', () => {
@@ -21,7 +22,11 @@ describe('toExpression', () => {
     it('converts to an embeddable expression', () => {
       const input: EmbeddableInput = baseEmbeddableInput;
 
-      const expression = toExpression(input, 'visualization');
+      const expression = toExpression(
+        input,
+        'visualization',
+        chartPluginMock.createPaletteRegistry()
+      );
       const ast = fromExpression(expression);
 
       expect(ast.type).toBe('expression');
@@ -43,7 +48,11 @@ describe('toExpression', () => {
         },
       };
 
-      const expression = toExpression(input, 'visualization');
+      const expression = toExpression(
+        input,
+        'visualization',
+        chartPluginMock.createPaletteRegistry()
+      );
       const ast = fromExpression(expression);
 
       const config = decode(ast.chain[0].arguments.config[0] as string);
@@ -60,7 +69,11 @@ describe('toExpression', () => {
         title: '',
       };
 
-      const expression = toExpression(input, 'visualization');
+      const expression = toExpression(
+        input,
+        'visualization',
+        chartPluginMock.createPaletteRegistry()
+      );
       const ast = fromExpression(expression);
 
       const config = decode(ast.chain[0].arguments.config[0] as string);
@@ -78,12 +91,12 @@ describe('toExpression', () => {
     it('converts to an embeddable expression', () => {
       const input: EmbeddableInput = baseEmbeddableInput;
 
-      const expression = toExpression(input, 'visualization');
+      const expression = toExpression(input, 'lens', chartPluginMock.createPaletteRegistry());
       const ast = fromExpression(expression);
 
       expect(ast.type).toBe('expression');
       expect(ast.chain[0].function).toBe('embeddable');
-      expect(ast.chain[0].arguments.type[0]).toBe('visualization');
+      expect(ast.chain[0].arguments.type[0]).toBe('lens');
 
       const config = decode(ast.chain[0].arguments.config[0] as string);
       expect(config.filters).toStrictEqual(input.filters);
@@ -100,7 +113,7 @@ describe('toExpression', () => {
         },
       };
 
-      const expression = toExpression(input, 'visualization');
+      const expression = toExpression(input, 'lens', chartPluginMock.createPaletteRegistry());
       const ast = fromExpression(expression);
 
       const config = decode(ast.chain[0].arguments.config[0] as string);
@@ -117,7 +130,7 @@ describe('toExpression', () => {
         title: '',
       };
 
-      const expression = toExpression(input, 'visualization');
+      const expression = toExpression(input, 'lens', chartPluginMock.createPaletteRegistry());
       const ast = fromExpression(expression);
 
       const config = decode(ast.chain[0].arguments.config[0] as string);

--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.ts
@@ -5,9 +5,34 @@
  * 2.0.
  */
 
+import { toExpression as toExpressionString } from '@kbn/interpreter/common';
+import { PaletteRegistry } from 'src/plugins/charts/public';
 import { encode } from '../../../../common/lib/embeddable_dataurl';
 import { EmbeddableInput } from '../../../expression_types';
 
-export function toExpression(input: EmbeddableInput, embeddableType: string): string {
-  return `embeddable config="${encode(input)}" type="${embeddableType}"`;
+/*
+  Take the input from an embeddable and the type of embeddable and convert it into an expression
+*/
+export function toExpression(
+  input: EmbeddableInput,
+  embeddableType: string,
+  palettes: PaletteRegistry
+): string {
+  const expressionParts = [] as string[];
+
+  expressionParts.push('embeddable');
+
+  expressionParts.push(`config="${encode(input)}"`);
+
+  expressionParts.push(`type="${embeddableType}"`);
+
+  if (input.palette) {
+    expressionParts.push(
+      `palette={${toExpressionString(
+        palettes.get(input.palette.name).toExpression(input.palette.params)
+      )}}`
+    );
+  }
+
+  return expressionParts.join(' ');
 }

--- a/x-pack/plugins/canvas/i18n/functions/dict/embeddable.ts
+++ b/x-pack/plugins/canvas/i18n/functions/dict/embeddable.ts
@@ -18,6 +18,9 @@ export const help: FunctionHelp<FunctionFactory<ReturnType<typeof embeddableFunc
     config: i18n.translate('xpack.canvas.functions.embeddable.args.idHelpText', {
       defaultMessage: `The base64 encoded embeddable input object`,
     }),
+    palette: i18n.translate('xpack.canvas.functions.embeddable.args.paletteHelpText', {
+      defaultMessage: `The color palette to use for the embeddable. Only compatible with the Lens visualization`,
+    }),
     type: i18n.translate('xpack.canvas.functions.embeddable.args.typeHelpText', {
       defaultMessage: `The embeddable type`,
     }),

--- a/x-pack/plugins/canvas/types/embeddables.ts
+++ b/x-pack/plugins/canvas/types/embeddables.ts
@@ -7,10 +7,12 @@
 
 import { TimeRange } from 'src/plugins/data/public';
 import { Filter } from '@kbn/es-query';
+import { PaletteOutput } from 'src/plugins/charts/common';
 import { EmbeddableInput as Input } from '../../../../src/plugins/embeddable/common/';
 
 export type EmbeddableInput = Input & {
   timeRange?: TimeRange;
   filters?: Filter[];
   savedObjectId?: string;
+  palette?: PaletteOutput;
 };


### PR DESCRIPTION
## Summary

This adds the `palette` argument to the `embeddable` function. This argument is only compatible with lens type embeddables, but I added it to maintain feature parity with the existing `savedLens` function.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)