### PR TITLE
fixing visualize enbeddableRendered event

### DIFF
--- a/src/plugins/vis_default_editor/public/default_editor.tsx
+++ b/src/plugins/vis_default_editor/public/default_editor.tsx
@@ -60,9 +60,10 @@ function DefaultEditor({
       return;
     }
 
-    embeddableHandler.render(visRef.current);
-    setTimeout(() => {
-      eventEmitter.emit('embeddableRendered');
+    embeddableHandler.render(visRef.current).then(() => {
+      setTimeout(async () => {
+        eventEmitter.emit('embeddableRendered');
+      });
     });
 
     return () => embeddableHandler.destroy();

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -358,7 +358,7 @@ export class VisualizeEmbeddable
     this.subscriptions.push(this.handler.loading$.subscribe(this.onContainerLoading));
     this.subscriptions.push(this.handler.render$.subscribe(this.onContainerRender));
 
-    this.updateHandler();
+    await this.updateHandler();
   }
 
   public destroy() {


### PR DESCRIPTION
## Summary

visualize default editor was emitting `embeddableRendered` event too early as it was not awaiting for `visualize_embeddable` to finish with `render` method

