### PR TITLE
[Security Solution][Endpoint] Fix unhandled promise rejections in skipped tests

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/search_exceptions/search_exceptions.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/search_exceptions/search_exceptions.test.tsx
@@ -20,7 +20,6 @@ jest.mock('../../../common/components/user_privileges/use_endpoint_privileges');
 let onSearchMock: jest.Mock;
 const mockUseEndpointPrivileges = useEndpointPrivileges as jest.Mock;
 
-// unhandled promise rejection: https://github.com/elastic/kibana/issues/112699
 describe('Search exceptions', () => {
   let appTestContext: AppContextTestRender;
   let renderResult: ReturnType<AppContextTestRender['render']>;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
@@ -122,30 +122,27 @@ export const endpointActivityLogHttpMock =
         const responseData = fleetActionGenerator.generateResponse({
           agent_id: endpointMetadata.agent.id,
         });
-
         return {
-          body: {
-            page: 1,
-            pageSize: 50,
-            startDate: 'now-1d',
-            endDate: 'now',
-            data: [
-              {
-                type: 'response',
-                item: {
-                  id: '',
-                  data: responseData,
-                },
+          page: 1,
+          pageSize: 50,
+          startDate: 'now-1d',
+          endDate: 'now',
+          data: [
+            {
+              type: 'response',
+              item: {
+                id: '',
+                data: responseData,
               },
-              {
-                type: 'action',
-                item: {
-                  id: '',
-                  data: actionData,
-                },
+            },
+            {
+              type: 'action',
+              item: {
+                id: '',
+                data: actionData,
               },
-            ],
-          },
+            },
+          ],
         };
       },
     },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
@@ -49,8 +49,6 @@ import {
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
 } from '../../../../../common/endpoint/constants';
-import { italic } from 'chalk';
-import { iteratee } from 'lodash';
 
 jest.mock('../../policy/store/services/ingest', () => ({
   sendGetAgentConfigList: () => Promise.resolve({ items: [] }),
@@ -63,7 +61,6 @@ jest.mock('../../../../common/lib/kibana');
 
 type EndpointListStore = Store<Immutable<EndpointState>, Immutable<AppAction>>;
 
-// unhandled promise rejection: https://github.com/elastic/kibana/issues/112699
 describe('endpoint list middleware', () => {
   const getKibanaServicesMock = KibanaServices.get as jest.Mock;
   let fakeCoreStart: jest.Mocked<CoreStart>;
@@ -390,27 +387,22 @@ describe('endpoint list middleware', () => {
       expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalled();
     });
 
-    it.only('should call get Activity Log API with correct paging options', async () => {
-      console.log('aaaaaaa');
+    it('should call get Activity Log API with correct paging options', async () => {
       dispatchUserChangedUrl();
-      console.log('eeeeeeee');
       const updatePagingDispatched = waitForAction('endpointDetailsActivityLogUpdatePaging');
-      console.log('iiiiiii');
       dispatchGetActivityLogPaging({ page: 3 });
-      console.log('ooooooo');
 
-      //   await updatePagingDispatched;
-      //   console.log('uuuuuuu');
+      await updatePagingDispatched;
 
-      //   expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledWith({
-      //     path: expect.any(String),
-      //     query: {
-      //       page: 3,
-      //       page_size: 50,
-      //       start_date: 'now-1d',
-      //       end_date: 'now',
-      //     },
-      //   });
+      expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledWith({
+        path: expect.any(String),
+        query: {
+          page: 3,
+          page_size: 50,
+          start_date: 'now-1d',
+          end_date: 'now',
+        },
+      });
     });
   });
 

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
@@ -49,6 +49,8 @@ import {
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
 } from '../../../../../common/endpoint/constants';
+import { italic } from 'chalk';
+import { iteratee } from 'lodash';
 
 jest.mock('../../policy/store/services/ingest', () => ({
   sendGetAgentConfigList: () => Promise.resolve({ items: [] }),
@@ -62,7 +64,7 @@ jest.mock('../../../../common/lib/kibana');
 type EndpointListStore = Store<Immutable<EndpointState>, Immutable<AppAction>>;
 
 // unhandled promise rejection: https://github.com/elastic/kibana/issues/112699
-describe.skip('endpoint list middleware', () => {
+describe('endpoint list middleware', () => {
   const getKibanaServicesMock = KibanaServices.get as jest.Mock;
   let fakeCoreStart: jest.Mocked<CoreStart>;
   let depsStart: DepsStartMock;
@@ -388,23 +390,27 @@ describe.skip('endpoint list middleware', () => {
       expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalled();
     });
 
-    it('should call get Activity Log API with correct paging options', async () => {
+    it.only('should call get Activity Log API with correct paging options', async () => {
+      console.log('aaaaaaa');
       dispatchUserChangedUrl();
-
+      console.log('eeeeeeee');
       const updatePagingDispatched = waitForAction('endpointDetailsActivityLogUpdatePaging');
+      console.log('iiiiiii');
       dispatchGetActivityLogPaging({ page: 3 });
+      console.log('ooooooo');
 
-      await updatePagingDispatched;
+      //   await updatePagingDispatched;
+      //   console.log('uuuuuuu');
 
-      expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledWith({
-        path: expect.any(String),
-        query: {
-          page: 3,
-          page_size: 50,
-          start_date: 'now-1d',
-          end_date: 'now',
-        },
-      });
+      //   expect(mockedApis.responseProvider.activityLogResponse).toHaveBeenCalledWith({
+      //     path: expect.any(String),
+      //     query: {
+      //       page: 3,
+      //       page_size: 50,
+      //       start_date: 'now-1d',
+      //       end_date: 'now',
+      //     },
+      //   });
     });
   });
 

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.ts
@@ -682,12 +682,14 @@ async function endpointDetailsActivityLogPagingMiddleware({
   coreStart: CoreStart;
 }) {
   const { getState, dispatch } = store;
+  console.log('this is called!');
   try {
     const { disabled, page, pageSize, startDate, endDate } = getActivityLogDataPaging(getState());
     // don't page when paging is disabled or when date ranges are invalid
     if (disabled) {
       return;
     }
+    console.log('this is called! 22');
     if (getIsInvalidDateRange({ startDate, endDate })) {
       dispatch({
         type: 'endpointDetailsActivityLogUpdateIsInvalidDateRange',
@@ -695,71 +697,83 @@ async function endpointDetailsActivityLogPagingMiddleware({
           isInvalidDateRange: true,
         },
       });
+      console.log('this is called! 3333');
       return;
     }
 
+    console.log('this is called! 44444');
     dispatch({
       type: 'endpointDetailsActivityLogUpdateIsInvalidDateRange',
       payload: {
         isInvalidDateRange: false,
       },
     });
+    console.log('this is called! 55555');
     dispatch({
       type: 'endpointDetailsActivityLogChanged',
       // ts error to be fixed when AsyncResourceState is refactored (#830)
       // @ts-expect-error
       payload: createLoadingResourceState<ActivityLog>(getActivityLogData(getState())),
     });
+    console.log('this is called! 66666');
     const route = resolvePathVariables(ENDPOINT_ACTION_LOG_ROUTE, {
       agent_id: selectedAgent(getState()),
     });
-    const activityLog = await coreStart.http.get<ActivityLog>(route, {
-      query: {
-        page,
-        page_size: pageSize,
-        start_date: startDate,
-        end_date: endDate,
-      },
-    });
+    console.log('this is called! 777777');
+    // const activityLog = await coreStart.http.get<ActivityLog>(route, {
+    //   query: {
+    //     page,
+    //     page_size: pageSize,
+    //     start_date: startDate,
+    //     end_date: endDate,
+    //   },
+    // });
 
-    const lastLoadedLogData = getLastLoadedActivityLogData(getState());
-    if (lastLoadedLogData !== undefined) {
-      const updatedLogDataItems = (
-        [...new Set([...lastLoadedLogData.data, ...activityLog.data])] as ActivityLog['data']
-      ).sort((a, b) =>
-        new Date(b.item.data['@timestamp']) > new Date(a.item.data['@timestamp']) ? 1 : -1
-      );
+    // console.log('this is called! 88888');
+    // const lastLoadedLogData = getLastLoadedActivityLogData(getState());
+    // console.log('this is called! 99999');
+    // if (lastLoadedLogData !== undefined) {
+    //   const updatedLogDataItems = (
+    //     [...new Set([...lastLoadedLogData.data, ...activityLog.data])] as ActivityLog['data']
+    //   ).sort((a, b) =>
+    //     new Date(b.item.data['@timestamp']) > new Date(a.item.data['@timestamp']) ? 1 : -1
+    //   );
+    //   console.log('this is called! 1000000');
 
-      const updatedLogData = {
-        page: activityLog.page,
-        pageSize: activityLog.pageSize,
-        startDate: activityLog.startDate,
-        endDate: activityLog.endDate,
-        data: activityLog.page === 1 ? activityLog.data : updatedLogDataItems,
-      };
-      dispatch({
-        type: 'endpointDetailsActivityLogChanged',
-        payload: createLoadedResourceState<ActivityLog>(updatedLogData),
-      });
-      if (!activityLog.data.length) {
-        dispatch({
-          type: 'endpointDetailsActivityLogUpdatePaging',
-          payload: {
-            disabled: true,
-            page: activityLog.page > 1 ? activityLog.page - 1 : 1,
-            pageSize: activityLog.pageSize,
-            startDate: activityLog.startDate,
-            endDate: activityLog.endDate,
-          },
-        });
-      }
-    } else {
-      dispatch({
-        type: 'endpointDetailsActivityLogChanged',
-        payload: createLoadedResourceState<ActivityLog>(activityLog),
-      });
-    }
+    //   const updatedLogData = {
+    //     page: activityLog.page,
+    //     pageSize: activityLog.pageSize,
+    //     startDate: activityLog.startDate,
+    //     endDate: activityLog.endDate,
+    //     data: activityLog.page === 1 ? activityLog.data : updatedLogDataItems,
+    //   };
+    //   console.log('this is called! 11111111');
+    //   dispatch({
+    //     type: 'endpointDetailsActivityLogChanged',
+    //     payload: createLoadedResourceState<ActivityLog>(updatedLogData),
+    //   });
+    //   console.log('eeeee', activityLog.data);
+    //   if (!activityLog.data.length) {
+    //     dispatch({
+    //       type: 'endpointDetailsActivityLogUpdatePaging',
+    //       payload: {
+    //         disabled: true,
+    //         page: activityLog.page > 1 ? activityLog.page - 1 : 1,
+    //         pageSize: activityLog.pageSize,
+    //         startDate: activityLog.startDate,
+    //         endDate: activityLog.endDate,
+    //       },
+    //     });
+    //   }
+    // } else {
+    //   console.log('this is called! 12222222');
+    //   dispatch({
+    //     type: 'endpointDetailsActivityLogChanged',
+    //     payload: createLoadedResourceState<ActivityLog>(activityLog),
+    //   });
+    // }
   } catch (error) {
+    console.log('this is the error', error);
     dispatch({
       type: 'endpointDetailsActivityLogChanged',
       payload: createFailedResourceState<ActivityLog>(error.body ?? error),

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.test.tsx
@@ -42,7 +42,6 @@ let coreStart: AppContextTestRender['coreStart'];
 let http: typeof coreStart.http;
 const generator = new EndpointDocGenerator();
 
-// unhandled promise rejection: https://github.com/elastic/kibana/issues/112699
 describe.skip('Policy trusted apps layout', () => {
   beforeEach(() => {
     mockedContext = createAppRootMockRenderer();

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.test.tsx
@@ -64,10 +64,10 @@ describe('Policy trusted apps layout', () => {
 
         // GET Agent status for agent policy
         if (path === '/api/fleet/agent-status') {
-          return {
+          return Promise.resolve({
             results: { events: 0, total: 5, online: 3, error: 1, offline: 1 },
             success: true,
-          };
+          });
         }
 
         // Get package data


### PR DESCRIPTION
## Summary

Fixes some unhandled promise rejections after upgrade node version and reenable skipped tests.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
