### PR TITLE
[Security Solution][Detections] Fix a bug in siem-detection-engine-rule-status Saved Object migration to SO references

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/migrations.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/migrations.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { IRuleStatusSOAttributes } from '../../../../plugins/security_solution/server/lib/detection_engine/rules/types';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
@@ -112,6 +113,30 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(response.body._source?.['siem-detection-engine-rule-status'].alertId).to.eql(
           undefined
         );
+      });
+
+      it('migrates legacy siem-detection-engine-rule-status and retains other attributes as the same attributes as before', async () => {
+        const response = await es.get<{
+          'siem-detection-engine-rule-status': IRuleStatusSOAttributes;
+        }>({
+          index: '.kibana',
+          id: 'siem-detection-engine-rule-status:d62d2980-27c4-11ec-92b0-f7b47106bb35',
+        });
+        expect(response.statusCode).to.eql(200);
+
+        expect(response.body._source?.['siem-detection-engine-rule-status']).to.eql({
+          statusDate: '2021-10-11T20:51:26.622Z',
+          status: 'succeeded',
+          lastFailureAt: '2021-10-11T18:10:08.982Z',
+          lastSuccessAt: '2021-10-11T20:51:26.622Z',
+          lastFailureMessage:
+            '4 days (323690920ms) were not queried between this rule execution and the last execution, so signals may have been missed. Consider increasing your look behind time or adding more Kibana instances. name: "Threshy" id: "fb1046a0-0452-11ec-9b15-d13d79d162f3" rule id: "b789c80f-f6d8-41f1-8b4f-b4a23342cde2" signals index: ".siem-signals-spong-default"',
+          lastSuccessMessage: 'succeeded',
+          gap: '4 days',
+          bulkCreateTimeDurations: ['34.49'],
+          searchAfterTimeDurations: ['62.58'],
+          lastLookBackDate: null,
+        });
       });
     });
   });


### PR DESCRIPTION
**Ticket:** https://github.com/elastic/kibana/issues/107068
**Follow-up after:** https://github.com/elastic/kibana/pull/114585

## Summary

The existing migration function `legacyMigrateRuleAlertIdSOReferences` that migrates `alertId` fields to SO references array did not include all the other attributes of a `siem-detection-engine-rule-status` doc being migrated to the resulting doc.

This PR includes a fix and an integration test for that.

## Run the test

To run the test, in one terminal execute:

```
cd ${KIBANA_HOME} && node scripts/functional_tests_server --config x-pack/test/detection_engine_api_integration/security_and_spaces/config.ts
```

In another terminal execute:

```
cd ${KIBANA_HOME} && node scripts/functional_test_runner --config x-pack/test/detection_engine_api_integration/security_and_spaces/config.ts --include=x-pack/test/detection_engine_api_integration/security_and_spaces/tests/migrations.ts
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
