### PR TITLE
[Fleet] Fix for NaN agents in modal when package is not installed

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/settings/update_button.tsx
@@ -114,18 +114,20 @@ export const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
     return Array.isArray(arr) && arr.every((p) => typeof p === 'string');
   }
 
-  const agentCount = useMemo(
-    () =>
-      agentPolicyData?.items.reduce((acc, item) => {
-        const existingPolicies = isStringArray(item?.package_policies)
-          ? (item?.package_policies as string[]).filter((p) => packagePolicyIds.includes(p))
-          : (item?.package_policies as PackagePolicy[]).filter((p) =>
+  const agentCount = useMemo(() => {
+    if (!agentPolicyData?.items) return 0;
+
+    return agentPolicyData.items.reduce((acc, item) => {
+      const existingPolicies = item?.package_policies
+        ? isStringArray(item.package_policies)
+          ? (item.package_policies as string[]).filter((p) => packagePolicyIds.includes(p))
+          : (item.package_policies as PackagePolicy[]).filter((p) =>
               packagePolicyIds.includes(p.id)
-            );
-        return (acc += existingPolicies.length > 0 && item?.agents ? item?.agents : 0);
-      }, 0),
-    [agentPolicyData, packagePolicyIds]
-  );
+            )
+        : [];
+      return (acc += existingPolicies.length > 0 && item?.agents ? item?.agents : 0);
+    }, 0);
+  }, [agentPolicyData, packagePolicyIds]);
 
   const conflictCount = useMemo(
     () => dryRunData?.filter((item) => item.hasErrors).length,


### PR DESCRIPTION
## Summary
Fixes #115177

- Go to an older version of a package, like `app/fleet/integrations/nginx-1.1.0/add-integration` 
- On `settings` tab click on `Install assets`
- With `Upgrade integration policies` checked, click on "Update to latest version"
- The modal should show 0 agents:

![Screenshot 2021-10-18 at 14 57 44](https://user-images.githubusercontent.com/16084106/137735345-2d8edfe8-89e7-4fec-b0ea-0dd0e64c6eb5.png)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
