### PR TITLE
[Index Management] Unskip and fix tests

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/http_requests.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/http_requests.ts
@@ -28,6 +28,14 @@ const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
     ]);
   };
 
+  const setReloadIndicesResponse = (response: HttpResponse = []) => {
+    server.respondWith('POST', `${API_BASE_PATH}/indices/reload`, [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(response),
+    ]);
+  };
+
   const setLoadDataStreamsResponse = (response: HttpResponse = []) => {
     server.respondWith('GET', `${API_BASE_PATH}/data_streams`, [
       200,
@@ -118,6 +126,7 @@ const registerHttpRequestMockHelpers = (server: SinonFakeServer) => {
   return {
     setLoadTemplatesResponse,
     setLoadIndicesResponse,
+    setReloadIndicesResponse,
     setLoadDataStreamsResponse,
     setLoadDataStreamResponse,
     setDeleteDataStreamResponse,

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.helpers.ts
@@ -47,9 +47,12 @@ export const setup = async (overridingDependencies: any = {}): Promise<IndicesTe
    */
 
   const clickContextMenuOption = async (optionDataTestSubject: string) => {
-    const { find } = testBed;
-    const contextMenu = find('indexContextMenu');
-    contextMenu.find(`button[data-test-subj="${optionDataTestSubject}"]`).simulate('click');
+    const { find, component } = testBed;
+
+    await act(async () => {
+      find(`indexContextMenu.${optionDataTestSubject}`).simulate('click');
+    });
+    component.update();
   };
 
   const clickIncludeHiddenIndicesToggle = () => {
@@ -57,9 +60,13 @@ export const setup = async (overridingDependencies: any = {}): Promise<IndicesTe
     find('indexTableIncludeHiddenIndicesToggle').simulate('click');
   };
 
-  const clickManageContextMenuButton = () => {
-    const { find } = testBed;
-    find('indexActionsContextMenuButton').simulate('click');
+  const clickManageContextMenuButton = async () => {
+    const { find, component } = testBed;
+
+    await act(async () => {
+      find('indexActionsContextMenuButton').simulate('click');
+    });
+    component.update();
   };
 
   const getIncludeHiddenIndicesToggleStatus = () => {

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.test.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.test.ts
@@ -10,7 +10,7 @@ import { act } from 'react-dom/test-utils';
 import { API_BASE_PATH } from '../../../common/constants';
 import { setupEnvironment, nextTick } from '../helpers';
 import { IndicesTestBed, setup } from './indices_tab.helpers';
-import { createDataStreamPayload } from './data_streams_tab.helpers';
+import { createDataStreamPayload, createNonDataStreamIndex } from './data_streams_tab.helpers';
 
 /**
  * The below import is required to avoid a console error warn from the "brace" package
@@ -23,9 +23,14 @@ import { createMemoryHistory } from 'history';
 stubWebWorker();
 
 // unhandled promise rejection https://github.com/elastic/kibana/issues/112699
-describe.skip('<IndexManagementHome />', () => {
-  const { server, httpRequestsMockHelpers } = setupEnvironment();
+describe('<IndexManagementHome />', () => {
   let testBed: IndicesTestBed;
+  let server: ReturnType<typeof setupEnvironment>['server'];
+  let httpRequestsMockHelpers: ReturnType<typeof setupEnvironment>['httpRequestsMockHelpers'];
+
+  beforeEach(() => {
+    ({ server, httpRequestsMockHelpers } = setupEnvironment());
+  });
 
   afterAll(() => {
     server.restore();
@@ -108,19 +113,9 @@ describe.skip('<IndexManagementHome />', () => {
 
   describe('index detail panel with % character in index name', () => {
     const indexName = 'test%';
+
     beforeEach(async () => {
-      const index = {
-        health: 'green',
-        status: 'open',
-        primary: 1,
-        replica: 1,
-        documents: 10000,
-        documents_deleted: 100,
-        size: '156kb',
-        primary_size: '156kb',
-        name: indexName,
-      };
-      httpRequestsMockHelpers.setLoadIndicesResponse([index]);
+      httpRequestsMockHelpers.setLoadIndicesResponse([createNonDataStreamIndex(indexName)]);
 
       testBed = await setup();
       const { component, find } = testBed;
@@ -165,20 +160,11 @@ describe.skip('<IndexManagementHome />', () => {
 
   describe('index actions', () => {
     const indexName = 'testIndex';
-    beforeEach(async () => {
-      const index = {
-        health: 'green',
-        status: 'open',
-        primary: 1,
-        replica: 1,
-        documents: 10000,
-        documents_deleted: 100,
-        size: '156kb',
-        primary_size: '156kb',
-        name: indexName,
-      };
 
-      httpRequestsMockHelpers.setLoadIndicesResponse([index]);
+    beforeEach(async () => {
+      httpRequestsMockHelpers.setLoadIndicesResponse([createNonDataStreamIndex(indexName)]);
+      httpRequestsMockHelpers.setReloadIndicesResponse({ indexNames: [indexName] });
+
       testBed = await setup();
       const { find, component } = testBed;
       component.update();
@@ -188,11 +174,15 @@ describe.skip('<IndexManagementHome />', () => {
 
     test('should be able to flush index', async () => {
       const { actions } = testBed;
+
       await actions.clickManageContextMenuButton();
       await actions.clickContextMenuOption('flushIndexMenuButton');
 
-      const latestRequest = server.requests[server.requests.length - 1];
-      expect(latestRequest.url).toBe(`${API_BASE_PATH}/indices/flush`);
+      const requestsCount = server.requests.length;
+      expect(server.requests[requestsCount - 2].url).toBe(`${API_BASE_PATH}/indices/flush`);
+      // After the indices are flushed, we imediately reload them. So we need to expect to see
+      // a reload server call also.
+      expect(server.requests[requestsCount - 1].url).toBe(`${API_BASE_PATH}/indices/reload`);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/115312

### Summary

As a result of the upgrade from kibana to node 16.x (see https://github.com/elastic/kibana/issues/98650) one of our tests broke with an unhandled promise error. The error itself was originated in the [reloadIndicesSuccess](https://github.com/elastic/kibana/blob/master/x-pack/plugins/index_management/public/application/store/reducers/indices.js#L45) action handler from the indices reducer with an error saying that `indices.forEach` is not a function.

Upon closer having a closer look, it turns out that when the tests are run the `indices` variable was  just `DefaultSinonMockServerResponse`. Meaning that we were just forgetting to mock an API call which in our case was the reload api called by the [flushIndices](https://github.com/elastic/kibana/blob/master/x-pack/plugins/index_management/public/application/store/actions/flush_indices.js#L26) action.

This PR unskips the test, refactors them a little bit and fixes the broken test.