### PR TITLE
Fix alerts Count table title overflow wraps prematurely

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.tsx
@@ -94,7 +94,7 @@ export const AlertsCountPanel = memo<AlertsCountPanelProps>(
         <KpiPanel hasBorder data-test-subj="alertsCountPanel">
           <HeaderSection
             id={uniqueQueryId}
-            title={i18n.COUNT_TABLE_TITLE}
+            title={<span className="eui-textBreakNormal">{i18n.COUNT_TABLE_TITLE}</span>}
             titleSize="s"
             hideSubtitle
           >

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/index.tsx
@@ -257,7 +257,11 @@ export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
     }, [showLinkToAlerts, goToDetectionEngine, formatUrl]);
 
     const titleText = useMemo(
-      () => (onlyField == null ? title : i18n.TOP(onlyField)),
+      () => (
+        <span className="eui-textBreakNormal">
+          {onlyField == null ? title : i18n.TOP(onlyField)}
+        </span>
+      ),
       [onlyField, title]
     );
 


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/112036

## Summary

Add `eui-textBreakNormal` utility class to alert page Count table and Trend graph titles.

<img width="1529" alt="Screenshot 2021-10-18 at 14 42 28" src="https://user-images.githubusercontent.com/1490444/137733075-de336487-0918-4529-a13b-4b7ae9feb7a7.png">

<img width="1183" alt="Screenshot 2021-10-18 at 14 42 50" src="https://user-images.githubusercontent.com/1490444/137733071-46063a94-e70e-4037-b448-e22f8d4cb613.png">


<img width="804" alt="Screenshot 2021-10-18 at 14 43 14" src="https://user-images.githubusercontent.com/1490444/137733069-4ca586f4-e752-49ba-8064-7e00b87f9492.png">
