### PR TITLE
Remove transaction breakdown metrics

### DIFF
--- a/x-pack/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
@@ -209,8 +209,6 @@ exports[`Error TBT_FIELD 1`] = `undefined`;
 
 exports[`Error TRACE_ID 1`] = `"trace id"`;
 
-exports[`Error TRANSACTION_BREAKDOWN_COUNT 1`] = `undefined`;
-
 exports[`Error TRANSACTION_DOM_INTERACTIVE 1`] = `undefined`;
 
 exports[`Error TRANSACTION_DURATION 1`] = `undefined`;
@@ -447,8 +445,6 @@ exports[`Span SPAN_TYPE 1`] = `"span type"`;
 exports[`Span TBT_FIELD 1`] = `undefined`;
 
 exports[`Span TRACE_ID 1`] = `"trace id"`;
-
-exports[`Span TRANSACTION_BREAKDOWN_COUNT 1`] = `undefined`;
 
 exports[`Span TRANSACTION_DOM_INTERACTIVE 1`] = `undefined`;
 
@@ -700,8 +696,6 @@ exports[`Transaction SPAN_TYPE 1`] = `undefined`;
 exports[`Transaction TBT_FIELD 1`] = `undefined`;
 
 exports[`Transaction TRACE_ID 1`] = `"trace id"`;
-
-exports[`Transaction TRANSACTION_BREAKDOWN_COUNT 1`] = `undefined`;
 
 exports[`Transaction TRANSACTION_DOM_INTERACTIVE 1`] = `undefined`;
 

--- a/x-pack/plugins/apm/common/elasticsearch_fieldnames.ts
+++ b/x-pack/plugins/apm/common/elasticsearch_fieldnames.ts
@@ -51,7 +51,6 @@ export const TRANSACTION_RESULT = 'transaction.result';
 export const TRANSACTION_NAME = 'transaction.name';
 export const TRANSACTION_ID = 'transaction.id';
 export const TRANSACTION_SAMPLED = 'transaction.sampled';
-export const TRANSACTION_BREAKDOWN_COUNT = 'transaction.breakdown.count';
 export const TRANSACTION_PAGE_URL = 'transaction.page.url';
 // for transaction metrics
 export const TRANSACTION_ROOT = 'transaction.root';

--- a/x-pack/plugins/apm/dev_docs/apm_queries.md
+++ b/x-pack/plugins/apm/dev_docs/apm_queries.md
@@ -315,28 +315,6 @@ GET apm-*-metric-*,metrics-apm*/_search?terminate_after=1000
 
 The above example is overly simplified. In reality [we do a bit more](https://github.com/elastic/kibana/blob/fe9b5332e157fd456f81aecfd4ffa78d9e511a66/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/index.ts#L51-L71) to properly calculate memory usage inside containers. Please note that an [Exists Query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html) is used in the filter context in the query to ensure that the memory fields exist.
 
-
-
-# Transaction breakdown metrics
-
-A pre-aggregations of transaction documents where `transaction.breakdown.count` is the number of original transactions.
-
-Noteworthy fields: `transaction.name`, `transaction.type`
-
-#### Sample document
-
-```json
-{
-  "@timestamp": "2021-09-27T21:59:59.828Z",
-  "processor.event": "metric",
-  "metricset.name": "transaction_breakdown",
-  "transaction.breakdown.count": 12,
-  "transaction.name": "GET /api/products",
-  "transaction.type": "request"
-}
-}
-```
-
 # Span breakdown metrics
 
 A pre-aggregations of span documents where `span.self_time.count` is the number of original spans. Measures the "self-time" for a span type, and optional subtype, within a transaction group. 

--- a/x-pack/plugins/apm/ftr_e2e/cypress/tasks/es_archiver.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/tasks/es_archiver.ts
@@ -5,26 +5,29 @@
  * 2.0.
  */
 
-import Path from 'path';
+import path from 'path';
 import { execSync } from 'child_process';
 
-const ES_ARCHIVE_DIR = './cypress/fixtures/es_archiver';
+const ES_ARCHIVE_DIR = path.resolve(
+  __dirname,
+  '../../cypress/fixtures/es_archiver'
+);
 
 // Otherwise execSync would inject NODE_TLS_REJECT_UNAUTHORIZED=0 and node would abort if used over https
 const NODE_TLS_REJECT_UNAUTHORIZED = '1';
 
-export const esArchiverLoad = (folder: string) => {
-  const path = Path.join(ES_ARCHIVE_DIR, folder);
+export const esArchiverLoad = (archiveName: string) => {
+  const archivePath = path.join(ES_ARCHIVE_DIR, archiveName);
   execSync(
-    `node ../../../../scripts/es_archiver load "${path}" --config ../../../test/functional/config.js`,
+    `node ../../../../scripts/es_archiver load "${archivePath}" --config ../../../test/functional/config.js`,
     { env: { ...process.env, NODE_TLS_REJECT_UNAUTHORIZED }, stdio: 'inherit' }
   );
 };
 
-export const esArchiverUnload = (folder: string) => {
-  const path = Path.join(ES_ARCHIVE_DIR, folder);
+export const esArchiverUnload = (archiveName: string) => {
+  const archivePath = path.join(ES_ARCHIVE_DIR, archiveName);
   execSync(
-    `node ../../../../scripts/es_archiver unload "${path}" --config ../../../test/functional/config.js`,
+    `node ../../../../scripts/es_archiver unload "${archivePath}" --config ../../../test/functional/config.js`,
     { env: { ...process.env, NODE_TLS_REJECT_UNAUTHORIZED }, stdio: 'inherit' }
   );
 };

--- a/x-pack/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -142,7 +142,7 @@ Object {
           },
           Object {
             "exists": Object {
-              "field": "transaction.breakdown.count",
+              "field": "span.self_time.sum.us",
             },
           },
         ],
@@ -265,20 +265,8 @@ Object {
             },
           },
           Object {
-            "bool": Object {
-              "minimum_should_match": 1,
-              "should": Array [
-                Object {
-                  "exists": Object {
-                    "field": "span.self_time.sum.us",
-                  },
-                },
-                Object {
-                  "exists": Object {
-                    "field": "transaction.breakdown.count",
-                  },
-                },
-              ],
+            "exists": Object {
+              "field": "span.self_time.sum.us",
             },
           },
           Object {

--- a/x-pack/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -45,11 +45,6 @@ Object {
               "field": "span.self_time.sum.us",
             },
           },
-          "total_transaction_breakdown_count": Object {
-            "sum": Object {
-              "field": "transaction.breakdown.count",
-            },
-          },
           "types": Object {
             "aggs": Object {
               "subtypes": Object {
@@ -92,11 +87,6 @@ Object {
       "sum_all_self_times": Object {
         "sum": Object {
           "field": "span.self_time.sum.us",
-        },
-      },
-      "total_transaction_breakdown_count": Object {
-        "sum": Object {
-          "field": "transaction.breakdown.count",
         },
       },
       "types": Object {
@@ -151,20 +141,8 @@ Object {
             },
           },
           Object {
-            "bool": Object {
-              "minimum_should_match": 1,
-              "should": Array [
-                Object {
-                  "exists": Object {
-                    "field": "span.self_time.sum.us",
-                  },
-                },
-                Object {
-                  "exists": Object {
-                    "field": "transaction.breakdown.count",
-                  },
-                },
-              ],
+            "exists": Object {
+              "field": "transaction.breakdown.count",
             },
           },
         ],
@@ -189,11 +167,6 @@ Object {
           "sum_all_self_times": Object {
             "sum": Object {
               "field": "span.self_time.sum.us",
-            },
-          },
-          "total_transaction_breakdown_count": Object {
-            "sum": Object {
-              "field": "transaction.breakdown.count",
             },
           },
           "types": Object {
@@ -238,11 +211,6 @@ Object {
       "sum_all_self_times": Object {
         "sum": Object {
           "field": "span.self_time.sum.us",
-        },
-      },
-      "total_transaction_breakdown_count": Object {
-        "sum": Object {
-          "field": "transaction.breakdown.count",
         },
       },
       "types": Object {

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
@@ -86,14 +86,7 @@ export async function getTransactionBreakdown({
     ...rangeQuery(start, end),
     ...environmentQuery(environment),
     ...kqlQuery(kuery),
-    {
-      bool: {
-        should: [
-          { exists: { field: SPAN_SELF_TIME_SUM } },
-        ],
-        minimum_should_match: 1,
-      },
-    },
+    { exists: { field: SPAN_SELF_TIME_SUM } },
   ];
 
   if (transactionName) {

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
@@ -51,11 +51,6 @@ export async function getTransactionBreakdown({
         field: SPAN_SELF_TIME_SUM,
       },
     },
-    total_transaction_breakdown_count: {
-      sum: {
-        field: TRANSACTION_BREAKDOWN_COUNT,
-      },
-    },
     types: {
       terms: {
         field: SPAN_TYPE,

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
@@ -90,7 +90,6 @@ export async function getTransactionBreakdown({
       bool: {
         should: [
           { exists: { field: SPAN_SELF_TIME_SUM } },
-          { exists: { field: TRANSACTION_BREAKDOWN_COUNT } },
         ],
         minimum_should_match: 1,
       },

--- a/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/routes/transactions/breakdown/index.ts
@@ -15,7 +15,6 @@ import {
   SPAN_SELF_TIME_SUM,
   TRANSACTION_TYPE,
   TRANSACTION_NAME,
-  TRANSACTION_BREAKDOWN_COUNT,
 } from '../../../../common/elasticsearch_fieldnames';
 import { Setup } from '../../../lib/helpers/setup_request';
 import { rangeQuery, kqlQuery } from '../../../../../observability/server';

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/constants/elasticsearch_fieldnames.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/configurations/constants/elasticsearch_fieldnames.ts
@@ -49,7 +49,6 @@ export const TRANSACTION_RESULT = 'transaction.result';
 export const TRANSACTION_NAME = 'transaction.name';
 export const TRANSACTION_ID = 'transaction.id';
 export const TRANSACTION_SAMPLED = 'transaction.sampled';
-export const TRANSACTION_BREAKDOWN_COUNT = 'transaction.breakdown.count';
 export const TRANSACTION_PAGE_URL = 'transaction.page.url';
 // for transaction metrics
 export const TRANSACTION_ROOT = 'transaction.root';


### PR DESCRIPTION
Agents are going to stop collecting these as they aren't used in the UI. See also https://github.com/elastic/apm/issues/505#issuecomment-943325753