### PR TITLE
[7.x] [Security Solution] Fix casing for host isolation exceptions name and hide search bar when no entries (#115349)

### DIFF
--- a/packages/kbn-securitysolution-list-constants/src/index.ts
+++ b/packages/kbn-securitysolution-list-constants/src/index.ts
@@ -73,6 +73,6 @@ export const ENDPOINT_EVENT_FILTERS_LIST_DESCRIPTION = 'Endpoint Security Event 
 
 export const ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID = 'endpoint_host_isolation_exceptions';
 export const ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_NAME =
-  'Endpoint Security Host Isolation Exceptions List';
+  'Endpoint Security Host isolation exceptions List';
 export const ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_DESCRIPTION =
-  'Endpoint Security Host Isolation Exceptions List';
+  'Endpoint Security Host isolation exceptions List';

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/reducer.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/reducer.test.ts
@@ -13,7 +13,7 @@ import { hostIsolationExceptionsPageReducer } from './reducer';
 import { getCurrentLocation } from './selector';
 import { createEmptyHostIsolationException } from '../utils';
 
-describe('Host Isolation Exceptions Reducer', () => {
+describe('Host isolation exceptions Reducer', () => {
   let initialState: HostIsolationExceptionsPageState;
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/delete_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/delete_modal.test.tsx
@@ -104,7 +104,7 @@ describe('When on the host isolation exceptions delete modal', () => {
     });
 
     expect(coreStart.notifications.toasts.addSuccess).toHaveBeenCalledWith(
-      '"some name" has been removed from the Host Isolation Exceptions list.'
+      '"some name" has been removed from the Host isolation exceptions list.'
     );
   });
 
@@ -129,7 +129,7 @@ describe('When on the host isolation exceptions delete modal', () => {
     });
 
     expect(coreStart.notifications.toasts.addDanger).toHaveBeenCalledWith(
-      'Unable to remove "some name" from the Host Isolation Exceptions list. Reason: That\'s not true. That\'s impossible'
+      'Unable to remove "some name" from the Host isolation exceptions list. Reason: That\'s not true. That\'s impossible'
     );
   });
 });

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/delete_modal.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/delete_modal.tsx
@@ -54,7 +54,7 @@ export const HostIsolationExceptionDeleteModal = memo<{}>(() => {
         i18n.translate(
           'xpack.securitySolution.hostIsolationExceptions.deletionDialog.deleteSuccess',
           {
-            defaultMessage: '"{name}" has been removed from the Host Isolation Exceptions list.',
+            defaultMessage: '"{name}" has been removed from the Host isolation exceptions list.',
             values: { name: exception?.name },
           }
         )
@@ -72,7 +72,7 @@ export const HostIsolationExceptionDeleteModal = memo<{}>(() => {
           'xpack.securitySolution.hostIsolationExceptions.deletionDialog.deleteFailure',
           {
             defaultMessage:
-              'Unable to remove "{name}" from the Host Isolation Exceptions list. Reason: {message}',
+              'Unable to remove "{name}" from the Host isolation exceptions list. Reason: {message}',
             values: { name: exception?.name, message: deleteError.message },
           }
         )
@@ -86,7 +86,7 @@ export const HostIsolationExceptionDeleteModal = memo<{}>(() => {
         <EuiModalHeaderTitle>
           <FormattedMessage
             id="xpack.securitySolution.hostIsolationExceptions.deletionDialog.title"
-            defaultMessage="Delete Host Isolation Exception"
+            defaultMessage="Delete Host isolation exception"
           />
         </EuiModalHeaderTitle>
       </EuiModalHeader>

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/empty.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/empty.tsx
@@ -25,7 +25,7 @@ export const HostIsolationExceptionsEmptyState = memo<{ onAdd: () => void }>(({ 
         <h2>
           <FormattedMessage
             id="xpack.securitySolution.hostIsolationExceptions.listEmpty.title"
-            defaultMessage="Add your first Host Isolation Exception"
+            defaultMessage="Add your first Host isolation exception"
           />
         </h2>
       }
@@ -39,7 +39,7 @@ export const HostIsolationExceptionsEmptyState = memo<{ onAdd: () => void }>(({ 
         <EuiButton fill onClick={onAdd} data-test-subj="hostIsolationExceptions">
           <FormattedMessage
             id="xpack.securitySolution.hostIsolationExceptions.listEmpty.addButton"
-            defaultMessage="Add Host Isolation Exception"
+            defaultMessage="Add Host isolation exception"
           />
         </EuiButton>
       }

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
@@ -179,7 +179,7 @@ export const HostIsolationExceptionsForm: React.FC<{
       <EuiText size="s">
         <FormattedMessage
           id="xpack.securitySolution.hostIsolationExceptions.form.description"
-          defaultMessage="Add an IP to the Host Isolation Exceptions. Only accepts IPv4 with optional CIDR"
+          defaultMessage="Add an IP to the Host isolation exceptions. Only accepts IPv4 with optional CIDR"
         />
       </EuiText>
       <EuiSpacer size="m" />

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form_flyout.tsx
@@ -181,12 +181,12 @@ export const HostIsolationExceptionsFormFlyout: React.FC<{}> = memo(() => {
         {exception?.item_id ? (
           <FormattedMessage
             id="xpack.securitySolution.hostIsolationExceptions.flyout.editButton"
-            defaultMessage="Edit Host Isolation Exception"
+            defaultMessage="Edit Host isolation exception"
           />
         ) : (
           <FormattedMessage
             id="xpack.securitySolution.hostIsolationExceptions.flyout.createButton"
-            defaultMessage="Add Host Isolation Exception"
+            defaultMessage="Add Host isolation exception"
           />
         )}
       </EuiButton>
@@ -206,14 +206,14 @@ export const HostIsolationExceptionsFormFlyout: React.FC<{}> = memo(() => {
             <h2>
               <FormattedMessage
                 id="xpack.securitySolution.hostIsolationExceptions.flyout.editTitle"
-                defaultMessage="Edit Host Isolation Exception"
+                defaultMessage="Edit Host isolation exception"
               />
             </h2>
           ) : (
             <h2>
               <FormattedMessage
                 id="xpack.securitySolution.hostIsolationExceptions.flyout.title"
-                defaultMessage="Add Host Isolation Exception"
+                defaultMessage="Add Host isolation exception"
               />
             </h2>
           )}

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/translations.ts
@@ -32,7 +32,7 @@ export const NAME_ERROR = i18n.translate(
 export const DESCRIPTION_PLACEHOLDER = i18n.translate(
   'xpack.securitySolution.hostIsolationExceptions.form.description.placeholder',
   {
-    defaultMessage: 'Describe your Host Isolation Exception',
+    defaultMessage: 'Describe your Host isolation exception',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.test.tsx
@@ -67,11 +67,18 @@ describe('When on the host isolation exceptions page', () => {
         await dataReceived();
         expect(renderResult.getByTestId('hostIsolationExceptionsEmpty')).toBeTruthy();
       });
+
+      it('should not display the search bar', async () => {
+        render();
+        await dataReceived();
+        expect(renderResult.queryByTestId('searchExceptions')).toBeFalsy();
+      });
     });
     describe('And data exists', () => {
       beforeEach(async () => {
         getHostIsolationExceptionItemsMock.mockImplementation(getFoundExceptionListItemSchemaMock);
       });
+
       it('should show loading indicator while retrieving data', async () => {
         let releaseApiResponse: (value?: unknown) => void;
 
@@ -86,6 +93,12 @@ describe('When on the host isolation exceptions page', () => {
         releaseApiResponse!();
         await wasReceived;
         expect(renderResult.container.querySelector('.euiProgress')).toBeNull();
+      });
+
+      it('should display the search bar', async () => {
+        render();
+        await dataReceived();
+        expect(renderResult.getByTestId('searchExceptions')).toBeTruthy();
       });
 
       it('should show items on the list', async () => {
@@ -113,6 +126,7 @@ describe('When on the host isolation exceptions page', () => {
         ).toEqual(' Server is too far away');
       });
     });
+
     describe('is license platinum plus', () => {
       beforeEach(() => {
         isPlatinumPlusMock.mockReturnValue(true);
@@ -131,6 +145,7 @@ describe('When on the host isolation exceptions page', () => {
         expect(renderResult.queryByTestId('hostIsolationExceptionsCreateEditFlyout')).toBeTruthy();
       });
     });
+
     describe('is not license platinum plus', () => {
       beforeEach(() => {
         isPlatinumPlusMock.mockReturnValue(false);

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
@@ -127,7 +127,7 @@ export const HostIsolationExceptionsList = () => {
       title={
         <FormattedMessage
           id="xpack.securitySolution.hostIsolationExceptions.list.pageTitle"
-          defaultMessage="Host Isolation Exceptions"
+          defaultMessage="Host isolation exceptions"
         />
       }
       actions={
@@ -141,7 +141,7 @@ export const HostIsolationExceptionsList = () => {
           >
             <FormattedMessage
               id="xpack.securitySolution.hostIsolationExceptions.list.addButton"
-              defaultMessage="Add Host Isolation Exception"
+              defaultMessage="Add Host isolation exception"
             />
           </EuiButton>
         ) : (
@@ -151,18 +151,23 @@ export const HostIsolationExceptionsList = () => {
     >
       {showFlyout && <HostIsolationExceptionsFormFlyout />}
 
-      <SearchExceptions
-        defaultValue={location.filter}
-        onSearch={handleOnSearch}
-        placeholder={i18n.translate(
-          'xpack.securitySolution.hostIsolationExceptions.search.placeholder',
-          {
-            defaultMessage: 'Search on the fields below: name, description, ip',
-          }
-        )}
-      />
-      <EuiSpacer size="l" />
       {itemToDelete ? <HostIsolationExceptionDeleteModal /> : null}
+
+      {listItems.length ? (
+        <SearchExceptions
+          defaultValue={location.filter}
+          onSearch={handleOnSearch}
+          placeholder={i18n.translate(
+            'xpack.securitySolution.hostIsolationExceptions.search.placeholder',
+            {
+              defaultMessage: 'Search on the fields below: name, description, ip',
+            }
+          )}
+        />
+      ) : null}
+
+      <EuiSpacer size="l" />
+
       <PaginatedContent<ExceptionListItemSchema, typeof ArtifactEntryCard>
         items={listItems}
         ItemComponent={ArtifactEntryCard}

--- a/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/host_isolation_exceptions/index.ts
@@ -31,7 +31,7 @@ export const cli = () => {
       }
     },
     {
-      description: 'Load Host Isolation Exceptions',
+      description: 'Load Host isolation exceptions',
       flags: {
         string: ['kibana'],
         default: {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution] Fix casing for host isolation exceptions name and hide search bar when no entries (#115349)