### PR TITLE
Update heading on telemetry management section.

### DIFF
--- a/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
+++ b/src/plugins/telemetry_management_section/public/components/__snapshots__/telemetry_management_section.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
           loading={false}
           setting={
             Object {
-              "ariaName": "Provide usage statistics",
+              "ariaName": "Provide usage data",
               "category": Array [],
               "defVal": true,
               "description": <React.Fragment>
@@ -109,7 +109,7 @@ exports[`TelemetryManagementSectionComponent renders as expected 1`] = `
                   />
                 </p>
               </React.Fragment>,
-              "displayName": "Provide usage statistics",
+              "displayName": "Provide usage data",
               "isCustom": true,
               "isOverridden": false,
               "name": "telemetry:enabled",

--- a/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
+++ b/src/plugins/telemetry_management_section/public/components/telemetry_management_section.tsx
@@ -116,14 +116,14 @@ export class TelemetryManagementSection extends Component<Props, State> {
                 setting={{
                   type: 'boolean',
                   name: 'telemetry:enabled',
-                  displayName: i18n.translate('telemetry.provideUsageStatisticsTitle', {
-                    defaultMessage: 'Provide usage statistics',
+                  displayName: i18n.translate('telemetry.provideUsageDataTitle', {
+                    defaultMessage: 'Provide usage data',
                   }),
                   value: enabled,
                   description: this.renderDescription(),
                   defVal: true,
-                  ariaName: i18n.translate('telemetry.provideUsageStatisticsAriaName', {
-                    defaultMessage: 'Provide usage statistics',
+                  ariaName: i18n.translate('telemetry.provideUsageDataAriaName', {
+                    defaultMessage: 'Provide usage data',
                   }),
                   requiresPageReload: false,
                   category: [],

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4514,8 +4514,6 @@
     "telemetry.optInNoticeSeenErrorToastText": "通知の消去中にエラーが発生しました",
     "telemetry.optInSuccessOff": "使用状況データ収集がオフです。",
     "telemetry.optInSuccessOn": "使用状況データ収集がオンです。",
-    "telemetry.provideUsageStatisticsAriaName": "使用統計を提供",
-    "telemetry.provideUsageStatisticsTitle": "使用統計を提供",
     "telemetry.readOurUsageDataPrivacyStatementLinkText": "プライバシーポリシー",
     "telemetry.securityData": "Endpoint Security データ",
     "telemetry.telemetryBannerDescription": "Elastic Stackの改善にご協力ください使用状況データの収集は現在無効です。使用状況データの収集を有効にすると、製品とサービスを管理して改善することができます。詳細については、{privacyStatementLink}をご覧ください。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4559,8 +4559,6 @@
     "telemetry.optInNoticeSeenErrorToastText": "关闭声明时发生错误",
     "telemetry.optInSuccessOff": "使用情况数据收集已关闭。",
     "telemetry.optInSuccessOn": "使用情况数据收集已打开。",
-    "telemetry.provideUsageStatisticsAriaName": "提供使用情况统计",
-    "telemetry.provideUsageStatisticsTitle": "提供使用情况统计",
     "telemetry.readOurUsageDataPrivacyStatementLinkText": "隐私声明",
     "telemetry.securityData": "终端安全数据",
     "telemetry.telemetryBannerDescription": "想帮助我们改进 Elastic Stack？数据使用情况收集当前已禁用。启用使用情况数据收集可帮助我们管理并改善产品和服务。有关更多详情，请参阅我们的{privacyStatementLink}。",


### PR DESCRIPTION
## Summary

In the backref'd issue we deemed it appropriate to change the word 'statistics' with 'data' given the data solutions are now collecting to improve the user experience.

<img width="1293" alt="Screenshot 2021-10-18 at 18 40 54" src="https://user-images.githubusercontent.com/8960296/137780911-17a8d2c8-efec-437a-8e31-f76c0d486708.png">
### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
