### PR TITLE
[Reporting] Clean up browser download code

### DIFF
--- a/x-pack/build_chromium/README.md
+++ b/x-pack/build_chromium/README.md
@@ -99,7 +99,15 @@ are created in x64 using cross-compiling. CentOS is not supported for building C
 ## Artifacts
 
 After the build completes, there will be a .zip file and a .md5 file in `~/chromium/chromium/src/out/headless`. These are named like so: `chromium-{first_7_of_SHA}-{platform}-{arch}`, for example: `chromium-4747cc2-linux-x64`.
-The zip files and md5 files are copied to a staging bucket in GCP storage.
+The zip files and md5 files are copied to a **staging** bucket in GCP storage.
+
+To publish the built artifacts for bunding in Kibana, copy the files from the `headless_shell_staging` bucket to the `headless_shell` bucket.
+```
+gsutil cp gs://headless_shell_staging/chromium-d163fd7-linux_arm64.md5 gs://headless_shell/
+gsutil cp gs://headless_shell_staging/chromium-d163fd7-linux_arm64.zip gs://headless_shell/
+```
+
+IMPORTANT: Do not replace builds in the `headless_shell` bucket that are referenced in an active Kibana branch. CI tests on that branch will fail since the archive checksum no longer matches the original version.
 
 ## Testing
 Search the Puppeteer Github repo for known issues that could affect our use case, and make sure to test anywhere that is affected.

--- a/x-pack/plugins/reporting/server/browsers/chromium/paths.ts
+++ b/x-pack/plugins/reporting/server/browsers/chromium/paths.ts
@@ -14,6 +14,7 @@ interface PackageInfo {
   archiveChecksum: string;
   binaryChecksum: string;
   binaryRelativePath: string;
+  revision: number;
 }
 
 enum BaseUrl {
@@ -32,8 +33,6 @@ interface CommonPackageInfo extends PackageInfo {
 }
 
 export class ChromiumArchivePaths {
-  public readonly revision = '856583';
-
   public readonly packages: Array<CustomPackageInfo | CommonPackageInfo> = [
     {
       platform: 'darwin',
@@ -43,6 +42,7 @@ export class ChromiumArchivePaths {
       binaryChecksum: 'dfcd6e007214175997663c50c8d871ea',
       binaryRelativePath: 'headless_shell-darwin_x64/headless_shell',
       location: 'custom',
+      revision: 856583,
     },
     {
       platform: 'linux',
@@ -52,6 +52,7 @@ export class ChromiumArchivePaths {
       binaryChecksum: '99cfab472d516038b94ef86649e52871',
       binaryRelativePath: 'headless_shell-linux_x64/headless_shell',
       location: 'custom',
+      revision: 856583,
     },
     {
       platform: 'linux',
@@ -61,6 +62,7 @@ export class ChromiumArchivePaths {
       binaryChecksum: '13baccf2e5c8385cb9d9588db6a9e2c2',
       binaryRelativePath: 'headless_shell-linux_arm64/headless_shell',
       location: 'custom',
+      revision: 856583,
     },
     {
       platform: 'win32',
@@ -71,6 +73,7 @@ export class ChromiumArchivePaths {
       binaryRelativePath: 'chrome-win\\chrome.exe',
       location: 'common',
       archivePath: 'Win',
+      revision: 856583,
     },
   ];
 
@@ -82,7 +85,10 @@ export class ChromiumArchivePaths {
   }
 
   public resolvePath(p: PackageInfo) {
-    return path.resolve(this.archivesPath, p.archiveFilename);
+    // We're (going to be) downloading Chromium for both Mac x64 and Mac Arm,
+    // therefore we need to distinguish the download folder by architecture,
+    // because both downloads are "chrome-mac.zip".
+    return path.resolve(this.archivesPath, p.architecture, p.archiveFilename);
   }
 
   public getAllArchiveFilenames(): string[] {
@@ -91,9 +97,9 @@ export class ChromiumArchivePaths {
 
   public getDownloadUrl(p: CustomPackageInfo | CommonPackageInfo) {
     if (p.location === 'common') {
-      return `${BaseUrl.common}/${p.archivePath}/${this.revision}/${p.archiveFilename}`;
+      return `${BaseUrl.common}/${p.archivePath}/${p.revision}/${p.archiveFilename}`;
     }
-    return BaseUrl.custom + '/' + p.archiveFilename;
+    return BaseUrl.custom + '/' + p.archiveFilename; // revision is not used for URL if package is a custom build
   }
 
   public getBinaryPath(p: PackageInfo) {

--- a/x-pack/plugins/reporting/server/browsers/download/download.ts
+++ b/x-pack/plugins/reporting/server/browsers/download/download.ts
@@ -49,6 +49,8 @@ export async function download(
           resolve();
         });
     });
+  } catch (err) {
+    throw new Error(`Unable to download ${url}: ${err}`);
   } finally {
     closeSync(handle);
   }

--- a/x-pack/plugins/reporting/server/browsers/download/ensure_downloaded.test.ts
+++ b/x-pack/plugins/reporting/server/browsers/download/ensure_downloaded.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import path from 'path';
 import mockFs from 'mock-fs';
 import { existsSync, readdirSync } from 'fs';
 import { chromium } from '../chromium';
@@ -27,16 +28,16 @@ describe('ensureBrowserDownloaded', () => {
     } as unknown as typeof logger;
 
     (md5 as jest.MockedFunction<typeof md5>).mockImplementation(
-      async (path) =>
+      async (packagePath) =>
         chromium.paths.packages.find(
-          (packageInfo) => chromium.paths.resolvePath(packageInfo) === path
+          (packageInfo) => chromium.paths.resolvePath(packageInfo) === packagePath
         )?.archiveChecksum ?? 'some-md5'
     );
 
     (download as jest.MockedFunction<typeof download>).mockImplementation(
-      async (_url, path) =>
+      async (_url, packagePath) =>
         chromium.paths.packages.find(
-          (packageInfo) => chromium.paths.resolvePath(packageInfo) === path
+          (packageInfo) => chromium.paths.resolvePath(packageInfo) === packagePath
         )?.archiveChecksum ?? 'some-md5'
     );
 
@@ -93,11 +94,16 @@ describe('ensureBrowserDownloaded', () => {
       await ensureBrowserDownloaded(logger);
 
       expect(download).not.toHaveBeenCalled();
-      expect(readdirSync(chromium.paths.archivesPath)).toEqual(
-        expect.arrayContaining(
-          chromium.paths.packages.map(({ archiveFilename }) => archiveFilename)
-        )
-      );
+      const paths = [
+        readdirSync(path.resolve(chromium.paths.archivesPath + '/x64')),
+        readdirSync(path.resolve(chromium.paths.archivesPath + '/arm64')),
+      ];
+      paths[0].sort();
+      paths[1].sort();
+      expect(paths).toMatchObject([
+        ['chrome-win.zip', 'chromium-d163fd7-darwin_x64.zip', 'chromium-d163fd7-linux_x64.zip'],
+        ['chromium-d163fd7-linux_arm64.zip'],
+      ]);
     });
 
     it('should download again if md5 hash different', async () => {

--- a/x-pack/plugins/reporting/server/browsers/download/ensure_downloaded.ts
+++ b/x-pack/plugins/reporting/server/browsers/download/ensure_downloaded.ts
@@ -15,7 +15,6 @@ import { download } from './download';
 /**
  * Check for the downloaded archive of each requested browser type and
  * download them if they are missing or their checksum is invalid
- * @return {Promise<undefined>}
  */
 export async function ensureBrowserDownloaded(logger: GenericLevelLogger) {
   await ensureDownloaded([chromium], logger);
@@ -25,18 +24,19 @@ export async function ensureBrowserDownloaded(logger: GenericLevelLogger) {
  * Clears the unexpected files in the browsers archivesPath
  * and ensures that all packages/archives are downloaded and
  * that their checksums match the declared value
- * @param  {BrowserSpec} browsers
- * @return {Promise<undefined>}
  */
 async function ensureDownloaded(browsers: BrowserDownload[], logger: GenericLevelLogger) {
   await Promise.all(
     browsers.map(async ({ paths: pSet }) => {
-      (
-        await del(`${pSet.archivesPath}/**/*`, {
-          force: true,
-          ignore: pSet.getAllArchiveFilenames(),
-        })
-      ).forEach((path) => logger.warning(`Deleting unexpected file ${path}`));
+      const removedFiles = await del(`${pSet.archivesPath}/**/*`, {
+        force: true,
+        onlyFiles: true,
+        ignore: pSet.getAllArchiveFilenames(),
+      });
+
+      removedFiles.forEach((path) => {
+        logger.warning(`Deleting unexpected file ${path}`);
+      });
 
       const invalidChecksums: string[] = [];
       await Promise.all(
@@ -44,22 +44,44 @@ async function ensureDownloaded(browsers: BrowserDownload[], logger: GenericLeve
           const { archiveFilename, archiveChecksum } = p;
           if (archiveFilename && archiveChecksum) {
             const path = pSet.resolvePath(p);
+            const pathExists = existsSync(path);
 
-            if (existsSync(path) && (await md5(path)) === archiveChecksum) {
-              logger.debug(`Browser archive exists in ${path}`);
+            let foundChecksum: string | null = null;
+            try {
+              foundChecksum = await md5(path);
+            } catch (err) {
+              // ignore file not existing
+            }
+
+            if (pathExists && foundChecksum === archiveChecksum) {
+              logger.debug(`Browser archive for ${p.platform}/${p.architecture} found in ${path} `);
               return;
+            }
+
+            if (!pathExists) {
+              logger.warning(
+                `Browser archive for ${p.platform}/${p.architecture} not found in ${path}.`
+              );
+            }
+            if (foundChecksum !== archiveChecksum) {
+              logger.warning(
+                `Browser archive checksum for ${p.platform}/${p.architecture} ` +
+                  `is ${foundChecksum} but ${archiveChecksum} was expected.`
+              );
             }
 
             const url = pSet.getDownloadUrl(p);
             try {
               const downloadedChecksum = await download(url, path, logger);
               if (downloadedChecksum !== archiveChecksum) {
+                logger.warning(
+                  `Invalid checksum for ${p.platform}/${p.architecture}: ` +
+                    `expected ${archiveChecksum} got ${downloadedChecksum}`
+                );
                 invalidChecksums.push(`${url} => ${path}`);
               }
             } catch (err) {
-              const message = new Error(`Failed to download ${url}`);
-              logger.error(err);
-              throw message;
+              throw new Error(`Failed to download ${url}: ${err}`);
             }
           }
         })

--- a/x-pack/plugins/reporting/server/browsers/index.ts
+++ b/x-pack/plugins/reporting/server/browsers/index.ts
@@ -28,7 +28,8 @@ export interface BrowserDownload {
 }
 
 export const initializeBrowserDriverFactory = async (core: ReportingCore, logger: LevelLogger) => {
-  const { binaryPath$ } = installBrowser(logger);
+  const chromiumLogger = logger.clone(['chromium']);
+  const { binaryPath$ } = installBrowser(chromiumLogger);
   const binaryPath = await binaryPath$.pipe(first()).toPromise();
-  return chromium.createDriverFactory(core, binaryPath, logger);
+  return chromium.createDriverFactory(core, binaryPath, chromiumLogger);
 };


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
