### PR TITLE
[Fleet, App search] Add App Search ingestion methods to the unified integrations view

### DIFF
--- a/src/plugins/custom_integrations/common/index.ts
+++ b/src/plugins/custom_integrations/common/index.ts
@@ -49,6 +49,7 @@ export const INTEGRATION_CATEGORY_DISPLAY = {
   project_management: 'Project Management',
   software_development: 'Software Development',
   upload_file: 'Upload a file',
+  website_search: 'Website Search',
 };
 
 /**

--- a/x-pack/plugins/enterprise_search/server/integrations.ts
+++ b/x-pack/plugins/enterprise_search/server/integrations.ts
@@ -322,7 +322,7 @@ export const registerEnterpriseSearchIntegrations = (
       },
     ],
     shipper: 'enterprise_search',
-    isBeta: true, // TODO: replace with false when Crawler goes GA
+    isBeta: false,
   });
 
   customIntegrations.registerCustomIntegration({

--- a/x-pack/plugins/enterprise_search/server/integrations.ts
+++ b/x-pack/plugins/enterprise_search/server/integrations.ts
@@ -301,4 +301,67 @@ export const registerEnterpriseSearchIntegrations = (
       ...integration,
     });
   });
+
+  customIntegrations.registerCustomIntegration({
+    id: 'app_search_web_crawler',
+    title: i18n.translate('xpack.enterpriseSearch.appSearch.integrations.webCrawlerName', {
+      defaultMessage: 'Web Crawler',
+    }),
+    description: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.integrations.webCrawlerDescription',
+      {
+        defaultMessage: "Add search to your website with App Search's web crawler.",
+      }
+    ),
+    categories: ['website_search'],
+    uiInternalPath: '/app/enterprise_search/app_search/engines/new?method=crawler',
+    icons: [
+      {
+        type: 'eui',
+        src: 'globe',
+      },
+    ],
+    shipper: 'enterprise_search',
+    isBeta: true, // TODO: replace with false when Crawler goes GA
+  });
+
+  customIntegrations.registerCustomIntegration({
+    id: 'app_search_json',
+    title: i18n.translate('xpack.enterpriseSearch.appSearch.integrations.jsonName', {
+      defaultMessage: 'JSON',
+    }),
+    description: i18n.translate('xpack.enterpriseSearch.appSearch.integrations.jsonDescription', {
+      defaultMessage: 'Search over your JSON data with App Search.',
+    }),
+    categories: ['upload_file'],
+    uiInternalPath: '/app/enterprise_search/app_search/engines/new?method=json',
+    icons: [
+      {
+        type: 'eui',
+        src: 'exportAction',
+      },
+    ],
+    shipper: 'enterprise_search',
+    isBeta: false,
+  });
+
+  customIntegrations.registerCustomIntegration({
+    id: 'app_search_api',
+    title: i18n.translate('xpack.enterpriseSearch.appSearch.integrations.apiName', {
+      defaultMessage: 'API',
+    }),
+    description: i18n.translate('xpack.enterpriseSearch.appSearch.integrations.apiDescription', {
+      defaultMessage: "Add search to your application with App Search's robust APIs.",
+    }),
+    categories: ['custom'],
+    uiInternalPath: '/app/enterprise_search/app_search/engines/new?method=api',
+    icons: [
+      {
+        type: 'eui',
+        src: 'editorCodeBlock',
+      },
+    ],
+    shipper: 'enterprise_search',
+    isBeta: false,
+  });
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/113825

This PR adds App Search ingestion methods to the Fleet integration UX. All copy was taken from this comment: https://github.com/elastic/kibana/issues/114332#issuecomment-941050273

Web crawler:

https://user-images.githubusercontent.com/11838280/137792394-c56eedf0-3f61-4373-909d-549878eba8dd.mp4

JSON:

https://user-images.githubusercontent.com/11838280/137792625-d2b5510e-4dfb-46a3-a2a4-5904501b4688.mp4

API:

https://user-images.githubusercontent.com/11838280/137792780-5dcc2acb-3075-466b-9131-e4c566ab8b48.mp4

There is one case where this flow doesn't work and that's when the Enterprise Search backend is not available (for example, it was not added to deployment). The issue is already open: https://github.com/elastic/kibana/issues/115266

Similar PR for Workplace Search integrations: https://github.com/elastic/kibana/pull/114919

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
