### PR TITLE
[App Search] Update "overrides" badge

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_table.test.tsx
@@ -88,7 +88,7 @@ describe('SuggestionsTable', () => {
     wrapper = renderColumn(0)('test', {});
     expect(wrapper.find(EuiBadge)).toHaveLength(0);
 
-    wrapper = renderColumn(0)('test', { override_curation_id: '1-2-3' });
+    wrapper = renderColumn(0)('test', { override_manual_curation: true });
     expect(wrapper.find(EuiBadge).prop('children')).toEqual('Overrides');
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_table.tsx
@@ -42,7 +42,7 @@ const columns: Array<EuiBasicTableColumn<CurationSuggestion>> = [
     render: (query: string, curation: CurationSuggestion) => (
       <EuiLinkTo to={getSuggestionRoute(query)}>
         {query}
-        {curation.override_curation_id && (
+        {curation.override_manual_curation && (
           <>
             <EuiBadge iconType="alert" color="warning" className="suggestionsTableBadge">
               {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
@@ -15,7 +15,7 @@ export interface CurationSuggestion {
   status: 'pending' | 'applied' | 'automated' | 'rejected' | 'disabled';
   curation_id?: string;
   operation: 'create' | 'update' | 'delete';
-  override_curation_id?: string;
+  override_manual_curation?: boolean;
 }
 
 export interface Curation {


### PR DESCRIPTION
## Summary

The data on the backend changed, so we needed to updated our logic which shows "overrides" badges.

![screencapture-localhost-5601-zgz-app-enterprise-search-app-search-engines-pokemon-curations-2021-10-18-15_03_02](https://user-images.githubusercontent.com/1427475/137791527-1c4882cf-7b99-40a4-adbe-6d38ef1414f3.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
