### PR TITLE
[Fleet] Fix is_managed behavior in preconfiguration service

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -238,7 +238,12 @@ export async function ensurePreconfiguredPackagesAndPolicies(
       );
 
       if (!created) {
-        if (!policy?.is_managed) return { created, policy };
+        if (!policy) {
+          return { created, policy };
+        }
+        if (!policy.is_managed && !preconfiguredAgentPolicy.is_managed) {
+          return { created, policy };
+        }
         const { hasChanged, fields } = comparePreconfiguredPolicyToCurrent(
           preconfiguredAgentPolicy,
           policy


### PR DESCRIPTION
## Summary

Related to #113921 

When an agent policy that was not managed become managed the preconfiguration service do not take this in account. 
Also with the current implementation of the preconfiguration service we add the `is_managed:true` flag to a policy not during the creation of the agent policy Saved object but at the end of the preconfiguration, so if an error happen the preconfigured policy will never be updated,= never be a managed policy and some package policy could be missing (I think this happened a few time in cloud).

## How to tests/Reproduce the bug

1. add a policy to your kibana.dev.yml 
```yaml
xpack.fleet.agentPolicies:
  - name: Test agent policy
    id: test-policy
    monitoring_enabled: []
    package_policies: []
```    
1. navigate to fleet and check the policy is created 
1. Update the policy in your kibana.dev.yml 
```
xpack.fleet.agentPolicies:
  - name: Test agent policy
    is_managed: true
    id: test-policy
    monitoring_enabled: []
    # data_output_id: output-123
    # monitoring_output_id: output-123
    package_policies:
      - package:
          name: fleet_server
        name: Fleet Server
        inputs:
          - type: fleet-server
            keep_enabled: true
```
1. with my fix when you navigate to kibana you should the policy as managed (with the fleet server package policy. , not working for now)