### PR TITLE
Disable the experimental `metrics_entities` plugin by default.

### DIFF
--- a/x-pack/plugins/metrics_entities/server/index.ts
+++ b/x-pack/plugins/metrics_entities/server/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
+
 import { PluginInitializerContext } from '../../../../src/core/server';
 
 import { MetricsEntitiesPlugin } from './plugin';
@@ -17,3 +19,10 @@ export const plugin = (initializerContext: PluginInitializerContext): MetricsEnt
 };
 
 export { MetricsEntitiesPluginSetup, MetricsEntitiesPluginStart } from './types';
+
+export const config = {
+  schema: schema.object({
+    // This plugin is experimental and should be disabled by default.
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
+};


### PR DESCRIPTION
## Summary

Disable the experimental `metrics_entities` plugin by default. This is required due to the following change: https://github.com/elastic/kibana/issues/89584

## TODO
- [x] The items on the checklist and risk matrix need to be addressed.
- [x] Validate that the plugin is correctly disabled by default
- [x] Validate that the plugin now works when enabled via configuration key.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
  - We'll defer this decision until after FF.
- [ ] [~~Unit or functional tests~~](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)

### Risk Matrix

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| This plugin was enabled by default in past releases (I assume?) Is this a breaking change? | High | The plugin adds HTTP routes that do CRUD on transforms. These routes would be unavailable until the plugin was re-enabled | This may be irrelevant as the plugin is experimental, but we don't have telemetry to back that up. Do we have any known users of this plugin that we could communicate with? |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
