### PR TITLE
[7.x] [ML] APM Correlations: Get trace samples tab overall distribution via APM endpoint. (#114615)

### DIFF
--- a/x-pack/plugins/apm/common/search_strategies/failed_transactions_correlations/types.ts
+++ b/x-pack/plugins/apm/common/search_strategies/failed_transactions_correlations/types.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import {
-  FieldValuePair,
-  HistogramItem,
-  RawResponseBase,
-  SearchStrategyClientParams,
-} from '../types';
+import { FieldValuePair, HistogramItem } from '../types';
 
 import { FAILED_TRANSACTIONS_IMPACT_THRESHOLD } from './constants';
 import { FieldStats } from '../field_stats_types';
@@ -33,11 +28,7 @@ export interface FailedTransactionsCorrelationsParams {
   percentileThreshold: number;
 }
 
-export type FailedTransactionsCorrelationsRequestParams =
-  FailedTransactionsCorrelationsParams & SearchStrategyClientParams;
-
-export interface FailedTransactionsCorrelationsRawResponse
-  extends RawResponseBase {
+export interface FailedTransactionsCorrelationsRawResponse {
   log: string[];
   failedTransactionsCorrelations?: FailedTransactionsCorrelation[];
   percentileThresholdValue?: number;

--- a/x-pack/plugins/apm/common/search_strategies/latency_correlations/types.ts
+++ b/x-pack/plugins/apm/common/search_strategies/latency_correlations/types.ts
@@ -5,12 +5,7 @@
  * 2.0.
  */
 
-import {
-  FieldValuePair,
-  HistogramItem,
-  RawResponseBase,
-  SearchStrategyClientParams,
-} from '../types';
+import { FieldValuePair, HistogramItem } from '../types';
 import { FieldStats } from '../field_stats_types';
 
 export interface LatencyCorrelation extends FieldValuePair {
@@ -33,10 +28,7 @@ export interface LatencyCorrelationsParams {
   analyzeCorrelations: boolean;
 }
 
-export type LatencyCorrelationsRequestParams = LatencyCorrelationsParams &
-  SearchStrategyClientParams;
-
-export interface LatencyCorrelationsRawResponse extends RawResponseBase {
+export interface LatencyCorrelationsRawResponse {
   log: string[];
   overallHistogram?: HistogramItem[];
   percentileThresholdValue?: number;

--- a/x-pack/plugins/apm/common/search_strategies/types.ts
+++ b/x-pack/plugins/apm/common/search_strategies/types.ts
@@ -31,14 +31,24 @@ export interface RawResponseBase {
   took: number;
 }
 
-export interface SearchStrategyClientParams {
+export interface SearchStrategyClientParamsBase {
   environment: string;
   kuery: string;
   serviceName?: string;
   transactionName?: string;
   transactionType?: string;
+}
+
+export interface RawSearchStrategyClientParams
+  extends SearchStrategyClientParamsBase {
   start?: string;
   end?: string;
+}
+
+export interface SearchStrategyClientParams
+  extends SearchStrategyClientParamsBase {
+  start: number;
+  end: number;
 }
 
 export interface SearchStrategyServerParams {

--- a/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.test.tsx
@@ -19,6 +19,7 @@ import type { IKibanaSearchResponse } from 'src/plugins/data/public';
 import { EuiThemeProvider } from 'src/plugins/kibana_react/common';
 import { createKibanaReactContext } from 'src/plugins/kibana_react/public';
 import type { LatencyCorrelationsRawResponse } from '../../../../common/search_strategies/latency_correlations/types';
+import type { RawResponseBase } from '../../../../common/search_strategies/types';
 import { MockUrlParamsContextProvider } from '../../../context/url_params_context/mock_url_params_context_provider';
 import { ApmPluginContextValue } from '../../../context/apm_plugin/apm_plugin_context';
 import {
@@ -34,7 +35,9 @@ function Wrapper({
   dataSearchResponse,
 }: {
   children?: ReactNode;
-  dataSearchResponse: IKibanaSearchResponse<LatencyCorrelationsRawResponse>;
+  dataSearchResponse: IKibanaSearchResponse<
+    LatencyCorrelationsRawResponse & RawResponseBase
+  >;
 }) {
   const mockDataSearch = jest.fn(() => of(dataSearchResponse));
 

--- a/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.test.tsx
@@ -8,43 +8,24 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React, { ReactNode } from 'react';
-import { of } from 'rxjs';
 
 import { CoreStart } from 'kibana/public';
 import { merge } from 'lodash';
-import { dataPluginMock } from 'src/plugins/data/public/mocks';
-import type { IKibanaSearchResponse } from 'src/plugins/data/public';
 import { EuiThemeProvider } from 'src/plugins/kibana_react/common';
 import { createKibanaReactContext } from 'src/plugins/kibana_react/public';
-import type { LatencyCorrelationsRawResponse } from '../../../../../common/search_strategies/latency_correlations/types';
 import { MockUrlParamsContextProvider } from '../../../../context/url_params_context/mock_url_params_context_provider';
 import { ApmPluginContextValue } from '../../../../context/apm_plugin/apm_plugin_context';
 import {
   mockApmPluginContextValue,
   MockApmPluginContextWrapper,
 } from '../../../../context/apm_plugin/mock_apm_plugin_context';
+import * as useFetcherModule from '../../../../hooks/use_fetcher';
 import { fromQuery } from '../../../shared/Links/url_helpers';
 
 import { getFormattedSelection, TransactionDistribution } from './index';
 
-function Wrapper({
-  children,
-  dataSearchResponse,
-}: {
-  children?: ReactNode;
-  dataSearchResponse: IKibanaSearchResponse<LatencyCorrelationsRawResponse>;
-}) {
-  const mockDataSearch = jest.fn(() => of(dataSearchResponse));
-
-  const dataPluginMockStart = dataPluginMock.createStartContract();
+function Wrapper({ children }: { children?: ReactNode }) {
   const KibanaReactContext = createKibanaReactContext({
-    data: {
-      ...dataPluginMockStart,
-      search: {
-        ...dataPluginMockStart.search,
-        search: mockDataSearch,
-      },
-    },
     usageCollection: { reportUiCounter: () => {} },
   } as Partial<CoreStart>);
 
@@ -105,18 +86,14 @@ describe('transaction_details/distribution', () => {
 
   describe('TransactionDistribution', () => {
     it('shows loading indicator when the service is running and returned no results yet', async () => {
+      jest.spyOn(useFetcherModule, 'useFetcher').mockImplementation(() => ({
+        data: {},
+        refetch: () => {},
+        status: useFetcherModule.FETCH_STATUS.LOADING,
+      }));
+
       render(
-        <Wrapper
-          dataSearchResponse={{
-            isRunning: true,
-            rawResponse: {
-              ccsWarning: false,
-              took: 1234,
-              latencyCorrelations: [],
-              log: [],
-            },
-          }}
-        >
+        <Wrapper>
           <TransactionDistribution
             onChartSelection={jest.fn()}
             onClearSelection={jest.fn()}
@@ -132,18 +109,14 @@ describe('transaction_details/distribution', () => {
     });
 
     it("doesn't show loading indicator when the service isn't running", async () => {
+      jest.spyOn(useFetcherModule, 'useFetcher').mockImplementation(() => ({
+        data: { percentileThresholdValue: 1234, overallHistogram: [] },
+        refetch: () => {},
+        status: useFetcherModule.FETCH_STATUS.SUCCESS,
+      }));
+
       render(
-        <Wrapper
-          dataSearchResponse={{
-            isRunning: false,
-            rawResponse: {
-              ccsWarning: false,
-              took: 1234,
-              latencyCorrelations: [],
-              log: [],
-            },
-          }}
-        >
+        <Wrapper>
           <TransactionDistribution
             onChartSelection={jest.fn()}
             onClearSelection={jest.fn()}

--- a/x-pack/plugins/apm/public/hooks/use_search_strategy.ts
+++ b/x-pack/plugins/apm/public/hooks/use_search_strategy.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../../src/plugins/data/public';
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
 
-import type { SearchStrategyClientParams } from '../../common/search_strategies/types';
+import type { RawSearchStrategyClientParams } from '../../common/search_strategies/types';
 import type { RawResponseBase } from '../../common/search_strategies/types';
 import type {
   LatencyCorrelationsParams,
@@ -77,13 +77,15 @@ interface SearchStrategyReturnBase<TRawResponse extends RawResponseBase> {
 export function useSearchStrategy(
   searchStrategyName: typeof APM_SEARCH_STRATEGIES.APM_LATENCY_CORRELATIONS,
   searchStrategyParams: LatencyCorrelationsParams
-): SearchStrategyReturnBase<LatencyCorrelationsRawResponse>;
+): SearchStrategyReturnBase<LatencyCorrelationsRawResponse & RawResponseBase>;
 
 // Function overload for Failed Transactions Correlations
 export function useSearchStrategy(
   searchStrategyName: typeof APM_SEARCH_STRATEGIES.APM_FAILED_TRANSACTIONS_CORRELATIONS,
   searchStrategyParams: FailedTransactionsCorrelationsParams
-): SearchStrategyReturnBase<FailedTransactionsCorrelationsRawResponse>;
+): SearchStrategyReturnBase<
+  FailedTransactionsCorrelationsRawResponse & RawResponseBase
+>;
 
 export function useSearchStrategy<
   TRawResponse extends RawResponseBase,
@@ -145,7 +147,7 @@ export function useSearchStrategy<
     // Submit the search request using the `data.search` service.
     searchSubscription$.current = data.search
       .search<
-        IKibanaSearchRequest<SearchStrategyClientParams & (TParams | {})>,
+        IKibanaSearchRequest<RawSearchStrategyClientParams & (TParams | {})>,
         IKibanaSearchResponse<TRawResponse>
       >(request, {
         strategy: searchStrategyName,

--- a/x-pack/plugins/apm/server/lib/latency/get_overall_latency_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/latency/get_overall_latency_distribution.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+
+import { ProcessorEvent } from '../../../common/processor_event';
+
+import { withApmSpan } from '../../utils/with_apm_span';
+
+import {
+  getHistogramIntervalRequest,
+  getHistogramRangeSteps,
+} from '../search_strategies/queries/query_histogram_range_steps';
+import { getTransactionDurationRangesRequest } from '../search_strategies/queries/query_ranges';
+
+import { getPercentileThresholdValue } from './get_percentile_threshold_value';
+import type {
+  OverallLatencyDistributionOptions,
+  OverallLatencyDistributionResponse,
+} from './types';
+
+export async function getOverallLatencyDistribution(
+  options: OverallLatencyDistributionOptions
+) {
+  return withApmSpan('get_overall_latency_distribution', async () => {
+    const overallLatencyDistribution: OverallLatencyDistributionResponse = {
+      log: [],
+    };
+
+    const { setup, ...rawParams } = options;
+    const { apmEventClient } = setup;
+    const params = {
+      // pass on an empty index because we're using only the body attribute
+      // of the request body getters we're reusing from search strategies.
+      index: '',
+      ...rawParams,
+    };
+
+    // #1: get 95th percentile to be displayed as a marker in the log log chart
+    overallLatencyDistribution.percentileThresholdValue =
+      await getPercentileThresholdValue(options);
+
+    // finish early if we weren't able to identify the percentileThresholdValue.
+    if (!overallLatencyDistribution.percentileThresholdValue) {
+      return overallLatencyDistribution;
+    }
+
+    // #2: get histogram range steps
+    const steps = 100;
+
+    const { body: histogramIntervalRequestBody } =
+      getHistogramIntervalRequest(params);
+
+    const histogramIntervalResponse = (await apmEventClient.search(
+      'get_histogram_interval',
+      {
+        // TODO: add support for metrics
+        apm: { events: [ProcessorEvent.transaction] },
+        body: histogramIntervalRequestBody,
+      }
+    )) as {
+      aggregations?: {
+        transaction_duration_min: estypes.AggregationsValueAggregate;
+        transaction_duration_max: estypes.AggregationsValueAggregate;
+      };
+      hits: { total: estypes.SearchTotalHits };
+    };
+
+    if (
+      !histogramIntervalResponse.aggregations ||
+      histogramIntervalResponse.hits.total.value === 0
+    ) {
+      return overallLatencyDistribution;
+    }
+
+    const min =
+      histogramIntervalResponse.aggregations.transaction_duration_min.value;
+    const max =
+      histogramIntervalResponse.aggregations.transaction_duration_max.value * 2;
+
+    const histogramRangeSteps = getHistogramRangeSteps(min, max, steps);
+
+    // #3: get histogram chart data
+    const { body: transactionDurationRangesRequestBody } =
+      getTransactionDurationRangesRequest(params, histogramRangeSteps);
+
+    const transactionDurationRangesResponse = (await apmEventClient.search(
+      'get_transaction_duration_ranges',
+      {
+        // TODO: add support for metrics
+        apm: { events: [ProcessorEvent.transaction] },
+        body: transactionDurationRangesRequestBody,
+      }
+    )) as {
+      aggregations?: {
+        logspace_ranges: estypes.AggregationsMultiBucketAggregate<{
+          from: number;
+          doc_count: number;
+        }>;
+      };
+    };
+
+    if (!transactionDurationRangesResponse.aggregations) {
+      return overallLatencyDistribution;
+    }
+
+    overallLatencyDistribution.overallHistogram =
+      transactionDurationRangesResponse.aggregations.logspace_ranges.buckets
+        .map((d) => ({
+          key: d.from,
+          doc_count: d.doc_count,
+        }))
+        .filter((d) => d.key !== undefined);
+
+    return overallLatencyDistribution;
+  });
+}

--- a/x-pack/plugins/apm/server/lib/latency/get_percentile_threshold_value.ts
+++ b/x-pack/plugins/apm/server/lib/latency/get_percentile_threshold_value.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+
+import { ProcessorEvent } from '../../../common/processor_event';
+
+import { getTransactionDurationPercentilesRequest } from '../search_strategies/queries/query_percentiles';
+
+import type { OverallLatencyDistributionOptions } from './types';
+
+export async function getPercentileThresholdValue(
+  options: OverallLatencyDistributionOptions
+) {
+  const { setup, percentileThreshold, ...rawParams } = options;
+  const { apmEventClient } = setup;
+  const params = {
+    // pass on an empty index because we're using only the body attribute
+    // of the request body getters we're reusing from search strategies.
+    index: '',
+    ...rawParams,
+  };
+
+  const { body: transactionDurationPercentilesRequestBody } =
+    getTransactionDurationPercentilesRequest(params, [percentileThreshold]);
+
+  const transactionDurationPercentilesResponse = (await apmEventClient.search(
+    'get_transaction_duration_percentiles',
+    {
+      // TODO: add support for metrics
+      apm: { events: [ProcessorEvent.transaction] },
+      body: transactionDurationPercentilesRequestBody,
+    }
+  )) as {
+    aggregations?: {
+      transaction_duration_percentiles: estypes.AggregationsTDigestPercentilesAggregate;
+    };
+  };
+
+  if (!transactionDurationPercentilesResponse.aggregations) {
+    return;
+  }
+
+  const percentilesResponseThresholds =
+    transactionDurationPercentilesResponse.aggregations
+      .transaction_duration_percentiles?.values ?? {};
+
+  return percentilesResponseThresholds[`${percentileThreshold}.0`];
+}

--- a/x-pack/plugins/apm/server/lib/latency/types.ts
+++ b/x-pack/plugins/apm/server/lib/latency/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Setup } from '../helpers/setup_request';
+import { CorrelationsOptions } from '../search_strategies/queries/get_filters';
+
+export interface OverallLatencyDistributionOptions extends CorrelationsOptions {
+  percentileThreshold: number;
+  setup: Setup;
+}
+
+export interface OverallLatencyDistributionResponse {
+  log: string[];
+  percentileThresholdValue?: number;
+  overallHistogram?: Array<{
+    key: number;
+    doc_count: number;
+  }>;
+}

--- a/x-pack/plugins/apm/server/lib/search_strategies/failed_transactions_correlations/index.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/failed_transactions_correlations/index.ts
@@ -5,8 +5,4 @@
  * 2.0.
  */
 
-export {
-  failedTransactionsCorrelationsSearchServiceProvider,
-  FailedTransactionsCorrelationsSearchServiceProvider,
-  FailedTransactionsCorrelationsSearchStrategy,
-} from './failed_transactions_correlations_search_service';
+export { failedTransactionsCorrelationsSearchServiceProvider } from './failed_transactions_correlations_search_service';

--- a/x-pack/plugins/apm/server/lib/search_strategies/latency_correlations/index.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/latency_correlations/index.ts
@@ -5,8 +5,4 @@
  * 2.0.
  */
 
-export {
-  latencyCorrelationsSearchServiceProvider,
-  LatencyCorrelationsSearchServiceProvider,
-  LatencyCorrelationsSearchStrategy,
-} from './latency_correlations_search_service';
+export { latencyCorrelationsSearchServiceProvider } from './latency_correlations_search_service';

--- a/x-pack/plugins/apm/server/lib/search_strategies/latency_correlations/latency_correlations_search_service.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/latency_correlations/latency_correlations_search_service.ts
@@ -8,15 +8,13 @@
 import { range } from 'lodash';
 import type { ElasticsearchClient } from 'src/core/server';
 
-import type { ISearchStrategy } from '../../../../../../../src/plugins/data/server';
-import {
-  IKibanaSearchRequest,
-  IKibanaSearchResponse,
-} from '../../../../../../../src/plugins/data/common';
-
-import type { SearchStrategyServerParams } from '../../../../common/search_strategies/types';
 import type {
-  LatencyCorrelationsRequestParams,
+  RawResponseBase,
+  SearchStrategyClientParams,
+  SearchStrategyServerParams,
+} from '../../../../common/search_strategies/types';
+import type {
+  LatencyCorrelationsParams,
   LatencyCorrelationsRawResponse,
 } from '../../../../common/search_strategies/latency_correlations/types';
 
@@ -38,21 +36,16 @@ import type { SearchServiceProvider } from '../search_strategy_provider';
 import { latencyCorrelationsSearchServiceStateProvider } from './latency_correlations_search_service_state';
 import { fetchFieldsStats } from '../queries/field_stats/get_fields_stats';
 
-export type LatencyCorrelationsSearchServiceProvider = SearchServiceProvider<
-  LatencyCorrelationsRequestParams,
-  LatencyCorrelationsRawResponse
->;
-
-export type LatencyCorrelationsSearchStrategy = ISearchStrategy<
-  IKibanaSearchRequest<LatencyCorrelationsRequestParams>,
-  IKibanaSearchResponse<LatencyCorrelationsRawResponse>
+type LatencyCorrelationsSearchServiceProvider = SearchServiceProvider<
+  LatencyCorrelationsParams & SearchStrategyClientParams,
+  LatencyCorrelationsRawResponse & RawResponseBase
 >;
 
 export const latencyCorrelationsSearchServiceProvider: LatencyCorrelationsSearchServiceProvider =
   (
     esClient: ElasticsearchClient,
     getApmIndices: () => Promise<ApmIndicesConfig>,
-    searchServiceParams: LatencyCorrelationsRequestParams,
+    searchServiceParams: LatencyCorrelationsParams & SearchStrategyClientParams,
     includeFrozen: boolean
   ) => {
     const { addLogMessage, getLogMessages } = searchServiceLogProvider();
@@ -61,7 +54,9 @@ export const latencyCorrelationsSearchServiceProvider: LatencyCorrelationsSearch
 
     async function fetchCorrelations() {
       let params:
-        | (LatencyCorrelationsRequestParams & SearchStrategyServerParams)
+        | (LatencyCorrelationsParams &
+            SearchStrategyClientParams &
+            SearchStrategyServerParams)
         | undefined;
 
       try {

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/field_stats/get_field_stats.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/field_stats/get_field_stats.test.ts
@@ -15,8 +15,8 @@ import { fetchFieldsStats } from './get_fields_stats';
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/get_query_with_params.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/get_query_with_params.test.ts
@@ -14,8 +14,8 @@ describe('correlations', () => {
       const query = getQueryWithParams({
         params: {
           index: 'apm-*',
-          start: '2020',
-          end: '2021',
+          start: 1577836800000,
+          end: 1609459200000,
           includeFrozen: false,
           environment: ENVIRONMENT_ALL.value,
           kuery: '',
@@ -45,8 +45,8 @@ describe('correlations', () => {
           index: 'apm-*',
           serviceName: 'actualServiceName',
           transactionName: 'actualTransactionName',
-          start: '2020',
-          end: '2021',
+          start: 1577836800000,
+          end: 1609459200000,
           environment: 'dev',
           kuery: '',
           includeFrozen: false,
@@ -93,8 +93,8 @@ describe('correlations', () => {
       const query = getQueryWithParams({
         params: {
           index: 'apm-*',
-          start: '2020',
-          end: '2021',
+          start: 1577836800000,
+          end: 1609459200000,
           includeFrozen: false,
           environment: ENVIRONMENT_ALL.value,
           kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/get_query_with_params.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/get_query_with_params.ts
@@ -6,15 +6,10 @@
  */
 
 import type { estypes } from '@elastic/elasticsearch';
-import { getOrElse } from 'fp-ts/lib/Either';
-import { pipe } from 'fp-ts/lib/pipeable';
-import * as t from 'io-ts';
-import { failure } from 'io-ts/lib/PathReporter';
 import type {
   FieldValuePair,
   SearchStrategyParams,
 } from '../../../../common/search_strategies/types';
-import { rangeRt } from '../../../routes/default_api_types';
 import { getCorrelationsFilters } from './get_filters';
 
 export const getTermsQuery = ({ fieldName, fieldValue }: FieldValuePair) => {
@@ -36,22 +31,14 @@ export const getQueryWithParams = ({ params, termFilters }: QueryParams) => {
     transactionName,
   } = params;
 
-  // converts string based start/end to epochmillis
-  const decodedRange = pipe(
-    rangeRt.decode({ start, end }),
-    getOrElse<t.Errors, { start: number; end: number }>((errors) => {
-      throw new Error(failure(errors).join('\n'));
-    })
-  );
-
   const correlationFilters = getCorrelationsFilters({
     environment,
     kuery,
     serviceName,
     transactionType,
     transactionName,
-    start: decodedRange.start,
-    end: decodedRange.end,
+    start,
+    end,
   });
 
   return {

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/get_request_base.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/get_request_base.test.ts
@@ -16,6 +16,8 @@ describe('correlations', () => {
         includeFrozen: true,
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
+        start: 1577836800000,
+        end: 1609459200000,
       });
       expect(requestBase).toEqual({
         index: 'apm-*',
@@ -29,6 +31,8 @@ describe('correlations', () => {
         index: 'apm-*',
         environment: ENVIRONMENT_ALL.value,
         kuery: '',
+        start: 1577836800000,
+        end: 1609459200000,
       });
       expect(requestBase).toEqual({
         index: 'apm-*',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_correlation.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_correlation.test.ts
@@ -18,8 +18,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_field_candidates.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_field_candidates.test.ts
@@ -20,8 +20,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_field_value_pairs.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_field_value_pairs.test.ts
@@ -20,8 +20,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_fractions.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_fractions.test.ts
@@ -17,8 +17,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram.test.ts
@@ -17,8 +17,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.test.ts
@@ -17,8 +17,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histogram_range_steps.ts
@@ -17,7 +17,11 @@ import type { SearchStrategyParams } from '../../../../common/search_strategies/
 import { getQueryWithParams } from './get_query_with_params';
 import { getRequestBase } from './get_request_base';
 
-const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
+export const getHistogramRangeSteps = (
+  min: number,
+  max: number,
+  steps: number
+) => {
   // A d3 based scale function as a helper to get equally distributed bins on a log scale.
   // We round the final values because the ES range agg we use won't accept numbers with decimals for `transaction.duration.us`.
   const logFn = scaleLog().domain([min, max]).range([1, steps]);

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histograms_generator.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_histograms_generator.test.ts
@@ -17,8 +17,8 @@ import { fetchTransactionDurationHistograms } from './query_histograms_generator
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_percentiles.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_percentiles.test.ts
@@ -17,8 +17,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/queries/query_ranges.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/queries/query_ranges.test.ts
@@ -17,8 +17,8 @@ import {
 
 const params = {
   index: 'apm-*',
-  start: '2020',
-  end: '2021',
+  start: 1577836800000,
+  end: 1609459200000,
   includeFrozen: false,
   environment: ENVIRONMENT_ALL.value,
   kuery: '',

--- a/x-pack/plugins/apm/server/lib/search_strategies/search_strategy_provider.test.ts
+++ b/x-pack/plugins/apm/server/lib/search_strategies/search_strategy_provider.test.ts
@@ -13,7 +13,7 @@ import { IKibanaSearchRequest } from '../../../../../../src/plugins/data/common'
 
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 import type { LatencyCorrelationsParams } from '../../../common/search_strategies/latency_correlations/types';
-import type { SearchStrategyClientParams } from '../../../common/search_strategies/types';
+import type { RawSearchStrategyClientParams } from '../../../common/search_strategies/types';
 
 import type { ApmIndicesConfig } from '../settings/apm_indices/get_apm_indices';
 
@@ -112,7 +112,7 @@ describe('APM Correlations search strategy', () => {
     let mockDeps: SearchStrategyDependencies;
     let params: Required<
       IKibanaSearchRequest<
-        LatencyCorrelationsParams & SearchStrategyClientParams
+        LatencyCorrelationsParams & RawSearchStrategyClientParams
       >
     >['params'];
 

--- a/x-pack/plugins/apm/server/routes/get_global_apm_server_route_repository.ts
+++ b/x-pack/plugins/apm/server/routes/get_global_apm_server_route_repository.ts
@@ -17,6 +17,7 @@ import { environmentsRouteRepository } from './environments';
 import { errorsRouteRepository } from './errors';
 import { apmFleetRouteRepository } from './fleet';
 import { indexPatternRouteRepository } from './index_pattern';
+import { latencyDistributionRouteRepository } from './latency_distribution';
 import { metricsRouteRepository } from './metrics';
 import { observabilityOverviewRouteRepository } from './observability_overview';
 import { rumRouteRepository } from './rum_client';
@@ -41,6 +42,7 @@ const getTypedGlobalApmServerRouteRepository = () => {
     .merge(indexPatternRouteRepository)
     .merge(environmentsRouteRepository)
     .merge(errorsRouteRepository)
+    .merge(latencyDistributionRouteRepository)
     .merge(metricsRouteRepository)
     .merge(observabilityOverviewRouteRepository)
     .merge(rumRouteRepository)

--- a/x-pack/plugins/apm/server/routes/latency_distribution.ts
+++ b/x-pack/plugins/apm/server/routes/latency_distribution.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as t from 'io-ts';
+import { toNumberRt } from '@kbn/io-ts-utils';
+import { getOverallLatencyDistribution } from '../lib/latency/get_overall_latency_distribution';
+import { setupRequest } from '../lib/helpers/setup_request';
+import { createApmServerRoute } from './create_apm_server_route';
+import { createApmServerRouteRepository } from './create_apm_server_route_repository';
+import { environmentRt, kueryRt, rangeRt } from './default_api_types';
+
+const latencyOverallDistributionRoute = createApmServerRoute({
+  endpoint: 'GET /internal/apm/latency/overall_distribution',
+  params: t.type({
+    query: t.intersection([
+      t.partial({
+        serviceName: t.string,
+        transactionName: t.string,
+        transactionType: t.string,
+      }),
+      environmentRt,
+      kueryRt,
+      rangeRt,
+      t.type({
+        percentileThreshold: toNumberRt,
+      }),
+    ]),
+  }),
+  options: { tags: ['access:apm'] },
+  handler: async (resources) => {
+    const setup = await setupRequest(resources);
+
+    const {
+      environment,
+      kuery,
+      serviceName,
+      transactionType,
+      transactionName,
+      start,
+      end,
+      percentileThreshold,
+    } = resources.params.query;
+
+    return getOverallLatencyDistribution({
+      environment,
+      kuery,
+      serviceName,
+      transactionType,
+      transactionName,
+      start,
+      end,
+      percentileThreshold,
+      setup,
+    });
+  },
+});
+
+export const latencyDistributionRouteRepository =
+  createApmServerRouteRepository().add(latencyOverallDistributionRoute);

--- a/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { IKibanaSearchRequest } from '../../../../../src/plugins/data/common';
 
 import type { FailedTransactionsCorrelationsParams } from '../../../../plugins/apm/common/search_strategies/failed_transactions_correlations/types';
-import type { SearchStrategyClientParams } from '../../../../plugins/apm/common/search_strategies/types';
+import type { RawSearchStrategyClientParams } from '../../../../plugins/apm/common/search_strategies/types';
 import { APM_SEARCH_STRATEGIES } from '../../../../plugins/apm/common/search_strategies/constants';
 
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -23,7 +23,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   const getRequestBody = () => {
     const request: IKibanaSearchRequest<
-      FailedTransactionsCorrelationsParams & SearchStrategyClientParams
+      FailedTransactionsCorrelationsParams & RawSearchStrategyClientParams
     > = {
       params: {
         environment: 'ENVIRONMENT_ALL',

--- a/x-pack/test/apm_api_integration/tests/correlations/latency.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/latency.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { IKibanaSearchRequest } from '../../../../../src/plugins/data/common';
 
 import type { LatencyCorrelationsParams } from '../../../../plugins/apm/common/search_strategies/latency_correlations/types';
-import type { SearchStrategyClientParams } from '../../../../plugins/apm/common/search_strategies/types';
+import type { RawSearchStrategyClientParams } from '../../../../plugins/apm/common/search_strategies/types';
 import { APM_SEARCH_STRATEGIES } from '../../../../plugins/apm/common/search_strategies/constants';
 
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -22,16 +22,17 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const supertest = getService('legacySupertestAsApmReadUser');
 
   const getRequestBody = () => {
-    const request: IKibanaSearchRequest<LatencyCorrelationsParams & SearchStrategyClientParams> = {
-      params: {
-        environment: 'ENVIRONMENT_ALL',
-        start: '2020',
-        end: '2021',
-        kuery: '',
-        percentileThreshold: 95,
-        analyzeCorrelations: true,
-      },
-    };
+    const request: IKibanaSearchRequest<LatencyCorrelationsParams & RawSearchStrategyClientParams> =
+      {
+        params: {
+          environment: 'ENVIRONMENT_ALL',
+          start: '2020',
+          end: '2021',
+          kuery: '',
+          percentileThreshold: 95,
+          analyzeCorrelations: true,
+        },
+      };
 
     return {
       batch: [

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -175,6 +175,10 @@ export default function apmApiIntegrationTests(providerContext: FtrProviderConte
       loadTestFile(require.resolve('./transactions/error_rate'));
     });
 
+    describe('transactions/latency_overall_distribution', function () {
+      loadTestFile(require.resolve('./transactions/latency_overall_distribution'));
+    });
+
     describe('transactions/latency', function () {
       loadTestFile(require.resolve('./transactions/latency'));
     });

--- a/x-pack/test/apm_api_integration/tests/transactions/latency_overall_distribution.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/latency_overall_distribution.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { registry } from '../../common/registry';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const apmApiClient = getService('apmApiClient');
+
+  const endpoint = 'GET /internal/apm/latency/overall_distribution';
+
+  // This matches the parameters used for the other tab's search strategy approach in `../correlations/*`.
+  const getOptions = () => ({
+    params: {
+      query: {
+        environment: 'ENVIRONMENT_ALL',
+        start: '2020',
+        end: '2021',
+        kuery: '',
+        percentileThreshold: '95',
+      },
+    },
+  });
+
+  registry.when(
+    'latency overall distribution without data',
+    { config: 'trial', archives: [] },
+    () => {
+      it('handles the empty state', async () => {
+        const response = await apmApiClient.readUser({
+          endpoint,
+          ...getOptions(),
+        });
+
+        expect(response.status).to.be(200);
+        expect(response.body?.percentileThresholdValue).to.be(undefined);
+        expect(response.body?.overallHistogram?.length).to.be(undefined);
+      });
+    }
+  );
+
+  registry.when(
+    'latency overall distribution with data and default args',
+    // This uses the same archive used for the other tab's search strategy approach in `../correlations/*`.
+    { config: 'trial', archives: ['8.0.0'] },
+    () => {
+      it('returns percentileThresholdValue and overall histogram', async () => {
+        const response = await apmApiClient.readUser({
+          endpoint,
+          ...getOptions(),
+        });
+
+        expect(response.status).to.eql(200);
+        // This matches the values returned for the other tab's search strategy approach in `../correlations/*`.
+        expect(response.body?.percentileThresholdValue).to.be(1309695.875);
+        expect(response.body?.overallHistogram?.length).to.be(101);
+      });
+    }
+  );
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] APM Correlations: Get trace samples tab overall distribution via APM endpoint. (#114615)