### PR TITLE
[Workplace Search] Handle edge case when estimates are empty for source

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -130,7 +130,7 @@ interface SourceActivity {
 
 export interface SyncEstimate {
   duration?: string;
-  nextStart: string;
+  nextStart?: string;
   lastRun?: string;
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency_item.test.tsx
@@ -122,4 +122,10 @@ describe('FrequencyItem', () => {
       expect(setSyncFrequency).toHaveBeenCalledWith('full', '3', 'minutes');
     });
   });
+
+  it('handles edge case where estimate is empty', () => {
+    const wrapper = shallow(<FrequencyItem {...props} estimate={{}} />);
+
+    expect(wrapper.find('[data-test-subj="SyncEstimates"]')).toHaveLength(0);
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/synchronization/frequency_item.tsx
@@ -53,6 +53,7 @@ export const FrequencyItem: React.FC<Props> = ({
   const estimateDisplay = durationEstimate && moment.duration(durationEstimate).humanize();
   const nextStartIsPast = moment().isAfter(nextStart);
   const nextStartTime = nextStartIsPast ? NEXT_SYNC_RUNNING_MESSAGE : moment(nextStart).fromNow();
+  const showEstimates = lastRun || nextStart || durationEstimate;
 
   const frequencyItemLabel = (
     <FormattedMessage
@@ -143,10 +144,15 @@ export const FrequencyItem: React.FC<Props> = ({
           <EuiIconTip title={label} type="iInCircle" content={description} />
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer />
-      <EuiText>
-        {lastRun && lastRunSummary} {nextStartSummary} {estimateDisplay && estimateSummary}
-      </EuiText>
+      {showEstimates && (
+        <>
+          <EuiSpacer />
+          <EuiText data-test-subj="SyncEstimates">
+            {lastRun && lastRunSummary} {nextStart && nextStartSummary}{' '}
+            {estimateDisplay && estimateSummary}
+          </EuiText>
+        </>
+      )}
       <EuiSpacer size="s" />
     </>
   );


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2117

## Summary

There is an edge case where a connector does not sync and there is no estimate of next syncs in the UI. In this case, we simply omit the estimates from the UI.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
