### PR TITLE
[TSVB] Fixes the long text problem that appears behind the gauge chart

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/visualizations/views/gauge.js
+++ b/src/plugins/vis_types/timeseries/public/application/visualizations/views/gauge.js
@@ -75,6 +75,7 @@ export class Gauge extends Component {
             top: this.state.top || 0,
             left: this.state.left || 0,
             transform: `matrix(${scale}, 0, 0, ${scale}, ${translateX}, ${translateY})`,
+            zIndex: 1,
           },
           valueColor: {
             color: this.props.valueColor,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/87811

In TSVB gauges, there are cases that the label is very long and can be hidden behind the chart.

<img width="859" alt="Screenshot 2021-10-19 at 11 22 55 AM" src="https://user-images.githubusercontent.com/17003240/137872885-e3018bfb-a773-4fb4-96da-269fbb16bfa6.png">

This PR fixes the problem 
![image](https://user-images.githubusercontent.com/17003240/137876420-bf886aee-36b9-43ce-b569-f55f7361260b.png)
