### PR TITLE
[ES client] Rename deprecated params

### DIFF
--- a/src/plugins/data_views/server/fetcher/lib/es_api.test.js
+++ b/src/plugins/data_views/server/fetcher/lib/es_api.test.js
@@ -61,7 +61,7 @@ describe('server/index_patterns/service/lib/es_api', () => {
       expect(resp).toBe(football);
     });
 
-    it('sets ignoreUnavailable and allowNoIndices params', async () => {
+    it('sets ignore_unavailable and allow_no_indices params', async () => {
       const getAlias = sinon.stub();
       const callCluster = {
         indices: {
@@ -149,7 +149,7 @@ describe('server/index_patterns/service/lib/es_api', () => {
       expect(resp).toBe(football);
     });
 
-    it('sets ignoreUnavailable, allowNoIndices, and fields params', async () => {
+    it('sets ignore_unavailable, allow_no_indices, and fields params', async () => {
       const fieldCaps = sinon.stub();
       const callCluster = {
         indices: {

--- a/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.test.ts
@@ -26,7 +26,7 @@ describe('getSavedObjectsCounts', () => {
     expect(results).toStrictEqual([]);
     expect(esClient.search).toHaveBeenCalledWith({
       index: '.kibana',
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       filter_path: 'aggregations.types.buckets',
       body: {
         size: 0,
@@ -41,7 +41,7 @@ describe('getSavedObjectsCounts', () => {
     await getSavedObjectsCounts(esClient, '.kibana');
     expect(esClient.search).toHaveBeenCalledWith({
       index: '.kibana',
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       filter_path: 'aggregations.types.buckets',
       body: {
         size: 0,
@@ -56,7 +56,7 @@ describe('getSavedObjectsCounts', () => {
     await getSavedObjectsCounts(esClient, '.kibana', ['type_one', 'type_two']);
     expect(esClient.search).toHaveBeenCalledWith({
       index: '.kibana',
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       filter_path: 'aggregations.types.buckets',
       body: {
         size: 0,

--- a/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.test.ts
@@ -27,7 +27,7 @@ describe('getSavedObjectsCounts', () => {
     expect(esClient.search).toHaveBeenCalledWith({
       index: '.kibana',
       ignoreUnavailable: true,
-      filterPath: 'aggregations.types.buckets',
+      filter_path: 'aggregations.types.buckets',
       body: {
         size: 0,
         query: { match_all: {} },
@@ -42,7 +42,7 @@ describe('getSavedObjectsCounts', () => {
     expect(esClient.search).toHaveBeenCalledWith({
       index: '.kibana',
       ignoreUnavailable: true,
-      filterPath: 'aggregations.types.buckets',
+      filter_path: 'aggregations.types.buckets',
       body: {
         size: 0,
         query: { match_all: {} },
@@ -57,7 +57,7 @@ describe('getSavedObjectsCounts', () => {
     expect(esClient.search).toHaveBeenCalledWith({
       index: '.kibana',
       ignoreUnavailable: true,
-      filterPath: 'aggregations.types.buckets',
+      filter_path: 'aggregations.types.buckets',
       body: {
         size: 0,
         query: { terms: { type: ['type_one', 'type_two'] } },

--- a/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.ts
@@ -17,7 +17,7 @@ export async function getSavedObjectsCounts(
 
   const savedObjectCountSearchParams = {
     index: kibanaIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     filter_path: 'aggregations.types.buckets',
     body: {
       size: 0,

--- a/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/saved_objects_counts/get_saved_object_counts.ts
@@ -18,7 +18,7 @@ export async function getSavedObjectsCounts(
   const savedObjectCountSearchParams = {
     index: kibanaIndex,
     ignoreUnavailable: true,
-    filterPath: 'aggregations.types.buckets',
+    filter_path: 'aggregations.types.buckets',
     body: {
       size: 0,
       query,

--- a/x-pack/plugins/canvas/server/collectors/custom_element_collector.ts
+++ b/x-pack/plugins/canvas/server/collectors/custom_element_collector.ts
@@ -147,7 +147,7 @@ const customElementCollector: TelemetryCollector = async function customElementC
   const customElementParams = {
     size: 10000,
     index: kibanaIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     filter_path: [`hits.hits._source.${CUSTOM_ELEMENT_TYPE}.content`],
     body: { query: { bool: { filter: { term: { type: CUSTOM_ELEMENT_TYPE } } } } },
   };

--- a/x-pack/plugins/canvas/server/collectors/custom_element_collector.ts
+++ b/x-pack/plugins/canvas/server/collectors/custom_element_collector.ts
@@ -148,7 +148,7 @@ const customElementCollector: TelemetryCollector = async function customElementC
     size: 10000,
     index: kibanaIndex,
     ignoreUnavailable: true,
-    filterPath: [`hits.hits._source.${CUSTOM_ELEMENT_TYPE}.content`],
+    filter_path: [`hits.hits._source.${CUSTOM_ELEMENT_TYPE}.content`],
     body: { query: { bool: { filter: { term: { type: CUSTOM_ELEMENT_TYPE } } } } },
   };
 

--- a/x-pack/plugins/canvas/server/collectors/workpad_collector.ts
+++ b/x-pack/plugins/canvas/server/collectors/workpad_collector.ts
@@ -381,7 +381,7 @@ const workpadCollector: TelemetryCollector = async function (kibanaIndex, esClie
   const searchParams = {
     size: 10000, // elasticsearch index.max_result_window default value
     index: kibanaIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     filter_path: ['hits.hits._source.canvas-workpad', '-hits.hits._source.canvas-workpad.assets'],
     body: { query: { bool: { filter: { term: { type: CANVAS_TYPE } } } } },
   };

--- a/x-pack/plugins/canvas/server/collectors/workpad_collector.ts
+++ b/x-pack/plugins/canvas/server/collectors/workpad_collector.ts
@@ -382,7 +382,7 @@ const workpadCollector: TelemetryCollector = async function (kibanaIndex, esClie
     size: 10000, // elasticsearch index.max_result_window default value
     index: kibanaIndex,
     ignoreUnavailable: true,
-    filterPath: ['hits.hits._source.canvas-workpad', '-hits.hits._source.canvas-workpad.assets'],
+    filter_path: ['hits.hits._source.canvas-workpad', '-hits.hits._source.canvas-workpad.assets'],
     body: { query: { bool: { filter: { term: { type: CANVAS_TYPE } } } } },
   };
 

--- a/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
@@ -71,7 +71,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
     const esQuery = {
       allowNoIndices: true,
       index: resolvedLogSourceConfiguration.indices,
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       body: {
         size: size + 1, // Extra one to test if it has more before or after
         track_total_hits: false,
@@ -141,7 +141,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
     const query = {
       allowNoIndices: true,
       index: resolvedLogSourceConfiguration.indices,
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       body: {
         aggregations: {
           count_by_date: {

--- a/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
@@ -69,7 +69,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
     };
 
     const esQuery = {
-      allowNoIndices: true,
+      allow_no_indices: true,
       index: resolvedLogSourceConfiguration.indices,
       ignore_unavailable: true,
       body: {
@@ -139,7 +139,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
     );
 
     const query = {
-      allowNoIndices: true,
+      allow_no_indices: true,
       index: resolvedLogSourceConfiguration.indices,
       ignore_unavailable: true,
       body: {

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/lib/check_valid_node.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/lib/check_valid_node.ts
@@ -15,7 +15,7 @@ export const checkValidNode = async (
 ): Promise<boolean> => {
   const params = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: indexPattern,
     terminateAfter: 1,
     body: {

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/lib/check_valid_node.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/lib/check_valid_node.ts
@@ -14,7 +14,7 @@ export const checkValidNode = async (
   id: string
 ): Promise<boolean> => {
   const params = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     index: indexPattern,
     terminateAfter: 1,

--- a/x-pack/plugins/infra/server/lib/adapters/source_status/elasticsearch_source_status_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/source_status/elasticsearch_source_status_adapter.ts
@@ -18,13 +18,13 @@ export class InfraElasticsearchSourceStatusAdapter implements InfraSourceStatusA
       this.framework
         .callWithRequest(requestContext, 'indices.getAlias', {
           name: aliasName,
-          filterPath: '*.settings.index.uuid', // to keep the response size as small as possible
+          filter_path: '*.settings.index.uuid', // to keep the response size as small as possible
         })
         .catch(withDefaultIfNotFound<InfraDatabaseGetIndicesResponse>({})),
       this.framework
         .callWithRequest(requestContext, 'indices.get', {
           index: aliasName,
-          filterPath: '*.settings.index.uuid', // to keep the response size as small as possible
+          filter_path: '*.settings.index.uuid', // to keep the response size as small as possible
         })
         .catch(withDefaultIfNotFound<InfraDatabaseGetIndicesResponse>({})),
     ]);

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
@@ -66,7 +66,7 @@ export const createLogEntryDatasetsQuery = (
 
 const defaultRequestParameters = {
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   trackScores: false,
   trackTotalHits: false,
 };

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
@@ -67,7 +67,7 @@ export const createLogEntryDatasetsQuery = (
 const defaultRequestParameters = {
   allow_no_indices: true,
   ignore_unavailable: true,
-  trackScores: false,
+  track_scores: false,
   trackTotalHits: false,
 };
 

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
@@ -68,7 +68,7 @@ const defaultRequestParameters = {
   allow_no_indices: true,
   ignore_unavailable: true,
   track_scores: false,
-  trackTotalHits: false,
+  track_total_hits: false,
 };
 
 const compositeDatasetKeyRT = rt.type({

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/queries/log_entry_datasets.ts
@@ -65,7 +65,7 @@ export const createLogEntryDatasetsQuery = (
 });
 
 const defaultRequestParameters = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   trackScores: false,
   trackTotalHits: false,

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
@@ -7,7 +7,7 @@
 
 export const defaultRequestParameters = {
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   trackScores: false,
   trackTotalHits: false,
 };

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
@@ -8,7 +8,7 @@
 export const defaultRequestParameters = {
   allow_no_indices: true,
   ignore_unavailable: true,
-  trackScores: false,
+  track_scores: false,
   trackTotalHits: false,
 };
 

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
@@ -6,7 +6,7 @@
  */
 
 export const defaultRequestParameters = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   trackScores: false,
   trackTotalHits: false,

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/common.ts
@@ -9,7 +9,7 @@ export const defaultRequestParameters = {
   allow_no_indices: true,
   ignore_unavailable: true,
   track_scores: false,
-  trackTotalHits: false,
+  track_total_hits: false,
 };
 
 export const createJobIdFilters = (jobId: string) => [

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
@@ -28,7 +28,7 @@ describe('createMetricsHostAnomaliesQuery', () => {
       })
     ).toMatchObject({
       allowNoIndices: true,
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       trackScores: false,
       trackTotalHits: false,
       body: {

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
@@ -30,7 +30,7 @@ describe('createMetricsHostAnomaliesQuery', () => {
       allow_no_indices: true,
       ignore_unavailable: true,
       track_scores: false,
-      trackTotalHits: false,
+      track_total_hits: false,
       body: {
         query: {
           bool: {

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
@@ -29,7 +29,7 @@ describe('createMetricsHostAnomaliesQuery', () => {
     ).toMatchObject({
       allow_no_indices: true,
       ignore_unavailable: true,
-      trackScores: false,
+      track_scores: false,
       trackTotalHits: false,
       body: {
         query: {

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_host_anomalies.test.ts
@@ -27,7 +27,7 @@ describe('createMetricsHostAnomaliesQuery', () => {
         pagination,
       })
     ).toMatchObject({
-      allowNoIndices: true,
+      allow_no_indices: true,
       ignore_unavailable: true,
       trackScores: false,
       trackTotalHits: false,

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
@@ -28,7 +28,7 @@ describe('createMetricsK8sAnomaliesQuery', () => {
       })
     ).toMatchObject({
       allowNoIndices: true,
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       trackScores: false,
       trackTotalHits: false,
       body: {

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
@@ -27,7 +27,7 @@ describe('createMetricsK8sAnomaliesQuery', () => {
         pagination,
       })
     ).toMatchObject({
-      allowNoIndices: true,
+      allow_no_indices: true,
       ignore_unavailable: true,
       trackScores: false,
       trackTotalHits: false,

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
@@ -30,7 +30,7 @@ describe('createMetricsK8sAnomaliesQuery', () => {
       allow_no_indices: true,
       ignore_unavailable: true,
       track_scores: false,
-      trackTotalHits: false,
+      track_total_hits: false,
       body: {
         query: {
           bool: {

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.test.ts
@@ -29,7 +29,7 @@ describe('createMetricsK8sAnomaliesQuery', () => {
     ).toMatchObject({
       allow_no_indices: true,
       ignore_unavailable: true,
-      trackScores: false,
+      track_scores: false,
       trackTotalHits: false,
       body: {
         query: {

--- a/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
@@ -7,7 +7,7 @@
 
 export const defaultRequestParameters = {
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   trackScores: false,
   trackTotalHits: false,
 };

--- a/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
@@ -8,7 +8,7 @@
 export const defaultRequestParameters = {
   allow_no_indices: true,
   ignore_unavailable: true,
-  trackScores: false,
+  track_scores: false,
   trackTotalHits: false,
 };
 

--- a/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
@@ -6,7 +6,7 @@
  */
 
 export const defaultRequestParameters = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   trackScores: false,
   trackTotalHits: false,

--- a/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
+++ b/x-pack/plugins/infra/server/lib/log_analysis/queries/common.ts
@@ -9,7 +9,7 @@ export const defaultRequestParameters = {
   allow_no_indices: true,
   ignore_unavailable: true,
   track_scores: false,
-  trackTotalHits: false,
+  track_total_hits: false,
 };
 
 export const createJobIdFilters = (jobId: string) => [

--- a/x-pack/plugins/infra/server/lib/metrics/index.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/index.ts
@@ -48,7 +48,7 @@ export const query = async (
 
   const params = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: options.indexPattern,
     body: {
       size: 0,

--- a/x-pack/plugins/infra/server/lib/metrics/index.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/index.ts
@@ -47,7 +47,7 @@ export const query = async (
   ];
 
   const params = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     index: options.indexPattern,
     body: {

--- a/x-pack/plugins/infra/server/lib/sources/has_data.ts
+++ b/x-pack/plugins/infra/server/lib/sources/has_data.ts
@@ -12,7 +12,7 @@ export const hasData = async (index: string, client: ESSearchClient) => {
     index,
     allowNoIndices: true,
     terminate_after: 1,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       size: 0,
     },

--- a/x-pack/plugins/infra/server/lib/sources/has_data.ts
+++ b/x-pack/plugins/infra/server/lib/sources/has_data.ts
@@ -10,7 +10,7 @@ import { ESSearchClient } from '../metrics/types';
 export const hasData = async (index: string, client: ESSearchClient) => {
   const params = {
     index,
-    allowNoIndices: true,
+    allow_no_indices: true,
     terminate_after: 1,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/infra/server/routes/inventory_metadata/lib/get_cloud_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/inventory_metadata/lib/get_cloud_metadata.ts
@@ -41,7 +41,7 @@ export const getCloudMetadata = async (
 
   const metricQuery = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: sourceConfiguration.metricAlias,
     body: {
       query: {

--- a/x-pack/plugins/infra/server/routes/inventory_metadata/lib/get_cloud_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/inventory_metadata/lib/get_cloud_metadata.ts
@@ -40,7 +40,7 @@ export const getCloudMetadata = async (
   }
 
   const metricQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     index: sourceConfiguration.metricAlias,
     body: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_cloud_metric_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_cloud_metric_metadata.ts
@@ -27,7 +27,7 @@ export const getCloudMetricsMetadata = async (
 ): Promise<InfraCloudMetricsAdapterResponse> => {
   const metricQuery = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: sourceConfiguration.metricAlias,
     body: {
       query: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_cloud_metric_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_cloud_metric_metadata.ts
@@ -26,7 +26,7 @@ export const getCloudMetricsMetadata = async (
   timeRange: { from: number; to: number }
 ): Promise<InfraCloudMetricsAdapterResponse> => {
   const metricQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     index: sourceConfiguration.metricAlias,
     body: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_metric_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_metric_metadata.ts
@@ -33,7 +33,7 @@ export const getMetricMetadata = async (
   const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
   const metricQuery = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: sourceConfiguration.metricAlias,
     body: {
       query: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_metric_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_metric_metadata.ts
@@ -32,7 +32,7 @@ export const getMetricMetadata = async (
 ): Promise<InfraMetricsAdapterResponse> => {
   const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
   const metricQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     index: sourceConfiguration.metricAlias,
     body: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
@@ -54,7 +54,7 @@ export const getNodeInfo = async (
   const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     terminateAfter: 1,
     index: sourceConfiguration.metricAlias,
     body: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
@@ -53,7 +53,7 @@ export const getNodeInfo = async (
   const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
   const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     terminateAfter: 1,
     index: sourceConfiguration.metricAlias,

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_pod_node_name.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_pod_node_name.ts
@@ -23,7 +23,7 @@ export const getPodNodeName = async (
   const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     terminateAfter: 1,
     index: sourceConfiguration.metricAlias,
     body: {

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_pod_node_name.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_pod_node_name.ts
@@ -22,7 +22,7 @@ export const getPodNodeName = async (
   const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
   const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     terminateAfter: 1,
     index: sourceConfiguration.metricAlias,

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
@@ -23,7 +23,7 @@ export const getDatasetForField = async (
 ) => {
   const params = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     terminateAfter: 1,
     index: indexPattern,
     body: {

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
@@ -22,7 +22,7 @@ export const getDatasetForField = async (
   timerange: { field: string; to: number; from: number }
 ) => {
   const params = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     terminateAfter: 1,
     index: indexPattern,

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/query_total_groupings.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/query_total_groupings.ts
@@ -42,7 +42,7 @@ export const queryTotalGroupings = async (
 
   const params = {
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: options.indexPattern,
     body: {
       size: 0,

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/query_total_groupings.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/query_total_groupings.ts
@@ -41,7 +41,7 @@ export const queryTotalGroupings = async (
   }
 
   const params = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     index: options.indexPattern,
     body: {

--- a/x-pack/plugins/infra/server/utils/calculate_metric_interval.ts
+++ b/x-pack/plugins/infra/server/utils/calculate_metric_interval.ts
@@ -37,7 +37,7 @@ export const calculateMetricInterval = async (
   const query = {
     allowNoIndices: true,
     index: options.indexPattern,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/infra/server/utils/calculate_metric_interval.ts
+++ b/x-pack/plugins/infra/server/utils/calculate_metric_interval.ts
@@ -35,7 +35,7 @@ export const calculateMetricInterval = async (
     from = options.timerange.to - inventoryModel.metrics.defaultTimeRangeInSeconds * 1000;
   }
   const query = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: options.indexPattern,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch/get_last_recovery.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch/get_last_recovery.ts
@@ -107,7 +107,7 @@ export async function getLastRecovery(req: LegacyRequest, esIndexPattern: string
   const mbParams = {
     index: esIndexPattern,
     size,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       _source: ['elasticsearch.index.recovery', '@timestamp'],
       sort: { timestamp: { order: 'desc', unmapped_type: 'long' } },

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/all/query.all_actions.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/all/query.all_actions.dsl.ts
@@ -22,7 +22,7 @@ export const buildActionsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: '.fleet-actions',
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       // query: { bool: { filter } },
       query: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/all/query.all_actions.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/all/query.all_actions.dsl.ts
@@ -20,7 +20,7 @@ export const buildActionsQuery = ({
   // const filter = [...createQueryFilterClauses(filterQuery)];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: '.fleet-actions',
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/details/query.action_details.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/details/query.action_details.dsl.ts
@@ -25,7 +25,7 @@ export const buildActionDetailsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: '.fleet-actions',
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       query: { bool: { filter } },
       size: 1,

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/details/query.action_details.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/details/query.action_details.dsl.ts
@@ -23,7 +23,7 @@ export const buildActionDetailsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: '.fleet-actions',
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/results/query.action_results.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/results/query.action_results.dsl.ts
@@ -27,7 +27,7 @@ export const buildActionResultsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: '.fleet-actions-results*',
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggs: {
         aggs: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/results/query.action_results.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/actions/results/query.action_results.dsl.ts
@@ -25,7 +25,7 @@ export const buildActionResultsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: '.fleet-actions-results*',
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/agents/query.all_agents.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/agents/query.all_agents.dsl.ts
@@ -23,7 +23,7 @@ export const buildAgentsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: '.fleet-agents',
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/agents/query.all_agents.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/agents/query.all_agents.dsl.ts
@@ -21,7 +21,7 @@ export const buildAgentsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: '.fleet-agents',
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/results/query.all_results.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/results/query.all_results.dsl.ts
@@ -38,7 +38,7 @@ export const buildResultsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: `logs-${OSQUERY_INTEGRATION_NAME}.result*`,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggs: {
         count_by_agent_id: {

--- a/x-pack/plugins/osquery/server/search_strategy/osquery/factory/results/query.all_results.dsl.ts
+++ b/x-pack/plugins/osquery/server/search_strategy/osquery/factory/results/query.all_results.dsl.ts
@@ -36,7 +36,7 @@ export const buildResultsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: `logs-${OSQUERY_INTEGRATION_NAME}.result*`,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/reporting/server/usage/get_reporting_usage.ts
+++ b/x-pack/plugins/reporting/server/usage/get_reporting_usage.ts
@@ -148,7 +148,7 @@ export async function getReportingUsage(
   const reportingIndex = REPORTING_SYSTEM_INDEX;
   const params = {
     index: `${reportingIndex}-*`,
-    filterPath: 'aggregations.*.buckets',
+    filter_path: 'aggregations.*.buckets',
     body: {
       size: 0,
       aggs: {

--- a/x-pack/plugins/rollup/server/collectors/helpers.ts
+++ b/x-pack/plugins/rollup/server/collectors/helpers.ts
@@ -32,7 +32,7 @@ export async function fetchRollupIndexPatterns(kibanaIndex: string, esClient: El
   const searchParams = {
     size: ES_MAX_RESULT_WINDOW_DEFAULT_VALUE,
     index: kibanaIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     filter_path: ['hits.hits._id'],
     body: {
       query: {

--- a/x-pack/plugins/rollup/server/collectors/helpers.ts
+++ b/x-pack/plugins/rollup/server/collectors/helpers.ts
@@ -33,7 +33,7 @@ export async function fetchRollupIndexPatterns(kibanaIndex: string, esClient: El
     size: ES_MAX_RESULT_WINDOW_DEFAULT_VALUE,
     index: kibanaIndex,
     ignoreUnavailable: true,
-    filterPath: ['hits.hits._id'],
+    filter_path: ['hits.hits._id'],
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/query.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/query.ts
@@ -29,7 +29,7 @@ export const buildEventEnrichmentQuery: SecuritySolutionFactory<CtiQueries.event
 
     return {
       allowNoIndices: true,
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       index: defaultIndex,
       body: {
         _source: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/query.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/query.ts
@@ -28,7 +28,7 @@ export const buildEventEnrichmentQuery: SecuritySolutionFactory<CtiQueries.event
     ];
 
     return {
-      allowNoIndices: true,
+      allow_no_indices: true,
       ignore_unavailable: true,
       index: defaultIndex,
       body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
@@ -57,7 +57,7 @@ describe('parseEventEnrichmentResponse', () => {
           },
         },
       },
-      ignoreUnavailable: true,
+      ignore_unavailable: true,
       index: ['filebeat-*'],
     });
     const parsedInspect = JSON.parse(parsedResponse.inspect.dsl[0]);

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
@@ -18,7 +18,7 @@ describe('parseEventEnrichmentResponse', () => {
     const parsedResponse = await parseEventEnrichmentResponse(options, response);
 
     const expectedInspect = expect.objectContaining({
-      allowNoIndices: true,
+      allow_no_indices: true,
       body: {
         _source: false,
         fields: ['*'],

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
@@ -622,7 +622,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             docvalue_fields: mockOptions.docValueFields,
@@ -821,7 +821,7 @@ export const expectedDsl = {
     docvalue_fields: mockOptions.docValueFields,
     size: 0,
   },
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
@@ -611,7 +611,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -783,7 +783,7 @@ export const mockBuckets: HostAggEsItem = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   track_total_hits: false,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts.dsl.ts
@@ -42,7 +42,7 @@ export const buildHostsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts.dsl.ts
@@ -40,7 +40,7 @@ export const buildHostsQuery = ({
   const agg = { host_count: { cardinality: { field: 'host.name' } } };
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts_entities.dsl.ts
@@ -42,7 +42,7 @@ export const buildHostsQueryEntities = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/query.all_hosts_entities.dsl.ts
@@ -40,7 +40,7 @@ export const buildHostsQueryEntities = ({
   const agg = { host_count: { cardinality: { field: 'host.name' } } };
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/__mocks__/index.ts
@@ -2160,7 +2160,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             docvalue_fields: mockOptions.docValueFields,
             aggregations: {
@@ -2382,7 +2382,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     docvalue_fields: mockOptions.docValueFields,
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/__mocks__/index.ts
@@ -2149,7 +2149,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -2371,7 +2371,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query.dsl.ts
@@ -63,7 +63,7 @@ export const buildQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query.dsl.ts
@@ -61,7 +61,7 @@ export const buildQuery = ({
   };
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query_entities.dsl.ts
@@ -43,7 +43,7 @@ export const buildQueryEntities = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/authentications/dsl/query_entities.dsl.ts
@@ -41,7 +41,7 @@ export const buildQueryEntities = ({
   };
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
@@ -1312,7 +1312,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             aggregations: {
@@ -1426,7 +1426,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: false,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/__mocks__/index.ts
@@ -1301,7 +1301,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -1415,7 +1415,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
@@ -37,7 +37,7 @@ export const buildHostDetailsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
@@ -35,7 +35,7 @@ export const buildHostDetailsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications.dsl.ts
@@ -40,7 +40,7 @@ export const buildHostsKpiAuthenticationsQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications.dsl.ts
@@ -39,7 +39,7 @@ export const buildHostsKpiAuthenticationsQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications_entities.dsl.ts
@@ -29,7 +29,7 @@ export const buildHostsKpiAuthenticationsQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/authentications/query.hosts_kpi_authentications_entities.dsl.ts
@@ -28,7 +28,7 @@ export const buildHostsKpiAuthenticationsQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts.dsl.ts
@@ -29,7 +29,7 @@ export const buildHostsKpiHostsQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts.dsl.ts
@@ -28,7 +28,7 @@ export const buildHostsKpiHostsQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts_entities.dsl.ts
@@ -29,7 +29,7 @@ export const buildHostsKpiHostsQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/hosts/query.hosts_kpi_hosts_entities.dsl.ts
@@ -28,7 +28,7 @@ export const buildHostsKpiHostsQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips.dsl.ts
@@ -29,7 +29,7 @@ export const buildHostsKpiUniqueIpsQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips.dsl.ts
@@ -28,7 +28,7 @@ export const buildHostsKpiUniqueIpsQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips_entities.dsl.ts
@@ -29,7 +29,7 @@ export const buildHostsKpiUniqueIpsQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/kpi/unique_ips/query.hosts_kpi_unique_ips_entities.dsl.ts
@@ -28,7 +28,7 @@ export const buildHostsKpiUniqueIpsQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/__mocks__/index.ts
@@ -135,7 +135,7 @@ export const formattedSearchStrategyFirstResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             query: { bool: { filter: [{ term: { 'host.name': 'siem-kibana' } }] } },
@@ -201,7 +201,7 @@ export const formattedSearchStrategyLastResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             query: { bool: { filter: [{ term: { 'host.name': 'siem-kibana' } }] } },
@@ -236,7 +236,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: false,
   body: {
     _source: ['@timestamp'],

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/__mocks__/index.ts
@@ -124,7 +124,7 @@ export const formattedSearchStrategyFirstResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -190,7 +190,7 @@ export const formattedSearchStrategyLastResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -225,7 +225,7 @@ export const formattedSearchStrategyLastResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/query.first_or_last_seen_host.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/query.first_or_last_seen_host.dsl.ts
@@ -19,7 +19,7 @@ export const buildFirstOrLastSeenHostQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/query.first_or_last_seen_host.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/last_first_seen/query.first_or_last_seen_host.dsl.ts
@@ -17,7 +17,7 @@ export const buildFirstOrLastSeenHostQuery = ({
   const filter = [{ term: { 'host.name': hostName } }];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/__mocks__/index.ts
@@ -128,7 +128,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             aggregations: {
@@ -341,7 +341,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: false,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/__mocks__/index.ts
@@ -117,7 +117,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -330,7 +330,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/query.overview_host.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/query.overview_host.dsl.ts
@@ -30,7 +30,7 @@ export const buildOverviewHostQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/query.overview_host.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/overview/query.overview_host.dsl.ts
@@ -28,7 +28,7 @@ export const buildOverviewHostQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/risk_score/query.hosts_risk.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/risk_score/query.hosts_risk.dsl.ts
@@ -33,7 +33,7 @@ export const buildHostsRiskScoreQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: false,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       query: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/risk_score/query.hosts_risk.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/risk_score/query.hosts_risk.dsl.ts
@@ -32,7 +32,7 @@ export const buildHostsRiskScoreQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: false,
+    allow_no_indices: false,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/__mocks__/index.ts
@@ -4311,7 +4311,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             aggregations: {
               process_count: { cardinality: { field: 'process.name' } },
@@ -4446,7 +4446,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     aggregations: {
       process_count: { cardinality: { field: 'process.name' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/__mocks__/index.ts
@@ -4300,7 +4300,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -4435,7 +4435,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/dsl/query.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/dsl/query.dsl.ts
@@ -50,7 +50,7 @@ export const buildQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggregations: {
         ...agg,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/dsl/query.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/uncommon_processes/dsl/query.dsl.ts
@@ -48,7 +48,7 @@ export const buildQuery = ({
   };
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
@@ -42,7 +42,7 @@ export const formattedAlertsSearchStrategyResponse: MatrixHistogramStrategyRespo
             'winlogbeat-*',
           ],
           allowNoIndices: true,
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: true,
           body: {
             aggregations: {
@@ -164,7 +164,7 @@ export const expectedDsl = {
     },
     size: 0,
   },
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',
@@ -210,7 +210,7 @@ export const formattedAnomaliesSearchStrategyResponse: MatrixHistogramStrategyRe
             'winlogbeat-*',
           ],
           allowNoIndices: true,
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: true,
           body: {
             aggs: {
@@ -393,7 +393,7 @@ export const formattedAuthenticationsSearchStrategyResponse: MatrixHistogramStra
             'winlogbeat-*',
           ],
           allowNoIndices: true,
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: true,
           body: {
             aggregations: {
@@ -960,7 +960,7 @@ export const formattedEventsSearchStrategyResponse: MatrixHistogramStrategyRespo
             'winlogbeat-*',
           ],
           allowNoIndices: true,
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: true,
           body: {
             aggregations: {
@@ -1938,7 +1938,7 @@ export const formattedDnsSearchStrategyResponse: MatrixHistogramStrategyResponse
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             aggregations: {
               dns_count: { cardinality: { field: 'dns.question.registered_domain' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/__mocks__/index.ts
@@ -41,7 +41,7 @@ export const formattedAlertsSearchStrategyResponse: MatrixHistogramStrategyRespo
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          allowNoIndices: true,
+          allow_no_indices: true,
           ignore_unavailable: true,
           track_total_hits: true,
           body: {
@@ -127,7 +127,7 @@ export const formattedAlertsSearchStrategyResponse: MatrixHistogramStrategyRespo
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   track_total_hits: false,
   body: {
     aggregations: {
@@ -209,7 +209,7 @@ export const formattedAnomaliesSearchStrategyResponse: MatrixHistogramStrategyRe
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          allowNoIndices: true,
+          allow_no_indices: true,
           ignore_unavailable: true,
           track_total_hits: true,
           body: {
@@ -392,7 +392,7 @@ export const formattedAuthenticationsSearchStrategyResponse: MatrixHistogramStra
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          allowNoIndices: true,
+          allow_no_indices: true,
           ignore_unavailable: true,
           track_total_hits: true,
           body: {
@@ -959,7 +959,7 @@ export const formattedEventsSearchStrategyResponse: MatrixHistogramStrategyRespo
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          allowNoIndices: true,
+          allow_no_indices: true,
           ignore_unavailable: true,
           track_total_hits: true,
           body: {
@@ -1927,7 +1927,7 @@ export const formattedDnsSearchStrategyResponse: MatrixHistogramStrategyResponse
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/__mocks__/index.ts
@@ -37,7 +37,7 @@ export const expectedDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/__mocks__/index.ts
@@ -36,7 +36,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/query.alerts_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/query.alerts_histogram.dsl.ts
@@ -84,7 +84,7 @@ export const buildAlertsHistogramQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       aggregations: getHistogramAggregation(),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/query.alerts_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/alerts/query.alerts_histogram.dsl.ts
@@ -83,7 +83,7 @@ export const buildAlertsHistogramQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/__mocks__/index.ts
@@ -37,7 +37,7 @@ export const expectedDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/__mocks__/index.ts
@@ -36,7 +36,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/query.anomalies_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/query.anomalies_histogram.dsl.ts
@@ -65,7 +65,7 @@ export const buildAnomaliesHistogramQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       aggs: getHistogramAggregation(),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/query.anomalies_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/anomalies/query.anomalies_histogram.dsl.ts
@@ -64,7 +64,7 @@ export const buildAnomaliesHistogramQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/__mocks__/index.ts
@@ -36,7 +36,7 @@ export const expectedDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/__mocks__/index.ts
@@ -35,7 +35,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram.dsl.ts
@@ -77,7 +77,7 @@ export const buildAuthenticationsHistogramQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       aggregations: getHistogramAggregation(),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram.dsl.ts
@@ -76,7 +76,7 @@ export const buildAuthenticationsHistogramQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram_entities.dsl.ts
@@ -60,7 +60,7 @@ export const buildAuthenticationsHistogramQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       aggregations: getHistogramAggregation(),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/authentications/query.authentications_histogram_entities.dsl.ts
@@ -59,7 +59,7 @@ export const buildAuthenticationsHistogramQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/__mocks__/index.ts
@@ -37,7 +37,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     aggregations: {
       dns_count: { cardinality: { field: 'dns.question.registered_domain' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/__mocks__/index.ts
@@ -26,7 +26,7 @@ export const mockOptions = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/query.dns_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/query.dns_histogram.dsl.ts
@@ -79,7 +79,7 @@ export const buildDnsHistogramQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/query.dns_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/dns/query.dns_histogram.dsl.ts
@@ -77,7 +77,7 @@ export const buildDnsHistogramQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/__mocks__/index.ts
@@ -41,7 +41,7 @@ export const expectedDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {
@@ -96,7 +96,7 @@ export const expectedThresholdDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {
@@ -153,7 +153,7 @@ export const expectedThresholdMissingFieldDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {
@@ -244,7 +244,7 @@ export const expectedThresholdWithCardinalityDsl = {
     },
     size: 0,
   },
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',
@@ -270,7 +270,7 @@ export const expectedThresholdWithGroupFieldsAndCardinalityDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {
@@ -365,7 +365,7 @@ export const expectedThresholdGroupWithCardinalityDsl = {
     },
     size: 0,
   },
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',
@@ -391,7 +391,7 @@ export const expectedIpIncludingMissingDataDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {
@@ -454,7 +454,7 @@ export const expectedIpNotIncludingMissingDataDsl = {
     'winlogbeat-*',
   ],
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: true,
   body: {
     aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/__mocks__/index.ts
@@ -40,7 +40,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {
@@ -95,7 +95,7 @@ export const expectedThresholdDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {
@@ -152,7 +152,7 @@ export const expectedThresholdMissingFieldDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {
@@ -197,7 +197,7 @@ export const expectedThresholdMissingFieldDsl = {
 };
 
 export const expectedThresholdWithCardinalityDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   body: {
     aggregations: {
       eventActionGroup: {
@@ -269,7 +269,7 @@ export const expectedThresholdWithGroupFieldsAndCardinalityDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {
@@ -316,7 +316,7 @@ export const expectedThresholdWithGroupFieldsAndCardinalityDsl = {
 };
 
 export const expectedThresholdGroupWithCardinalityDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   body: {
     aggregations: {
       eventActionGroup: {
@@ -390,7 +390,7 @@ export const expectedIpIncludingMissingDataDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {
@@ -453,7 +453,7 @@ export const expectedIpNotIncludingMissingDataDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   track_total_hits: true,
   body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/query.events_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/query.events_histogram.dsl.ts
@@ -153,7 +153,7 @@ export const buildEventsHistogramQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       aggregations: getHistogramAggregation(),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/query.events_histogram.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/matrix_histogram/events/query.events_histogram.dsl.ts
@@ -152,7 +152,7 @@ export const buildEventsHistogramQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/__mocks__/index.ts
@@ -315,7 +315,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             docvalue_fields: mockOptions.docValueFields,
@@ -457,7 +457,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: false,
   body: {
     aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/__mocks__/index.ts
@@ -304,7 +304,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -446,7 +446,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/query.details_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/query.details_network.dsl.ts
@@ -105,7 +105,7 @@ export const buildNetworkDetailsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/query.details_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/details/query.details_network.dsl.ts
@@ -103,7 +103,7 @@ export const buildNetworkDetailsQuery = ({
   ip,
 }: NetworkDetailsRequestOptions) => {
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/__mocks__/index.ts
@@ -142,7 +142,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             aggregations: {
               dns_count: { cardinality: { field: 'dns.question.registered_domain' } },
@@ -214,7 +214,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     aggregations: {
       dns_count: { cardinality: { field: 'dns.question.registered_domain' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/__mocks__/index.ts
@@ -131,7 +131,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -203,7 +203,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/query.dns_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/query.dns_network.dsl.ts
@@ -90,7 +90,7 @@ export const buildDnsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/query.dns_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/dns/query.dns_network.dsl.ts
@@ -88,7 +88,7 @@ export const buildDnsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/__mocks__/index.ts
@@ -624,7 +624,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             aggregations: {
               http_count: { cardinality: { field: 'url.path' } },
@@ -682,7 +682,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     aggregations: {
       http_count: { cardinality: { field: 'url.path' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/__mocks__/index.ts
@@ -613,7 +613,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -671,7 +671,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/query.http_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/query.http_network.dsl.ts
@@ -38,7 +38,7 @@ export const buildHttpQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggregations: {
         ...getCountAgg(),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/query.http_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/http/query.http_network.dsl.ts
@@ -36,7 +36,7 @@ export const buildHttpQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kip_dns_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kip_dns_entities.dsl.ts
@@ -29,7 +29,7 @@ export const buildDnsQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kip_dns_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kip_dns_entities.dsl.ts
@@ -28,7 +28,7 @@ export const buildDnsQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kpi_dns.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kpi_dns.dsl.ts
@@ -57,7 +57,7 @@ export const buildDnsQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       query: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kpi_dns.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/dns/query.network_kpi_dns.dsl.ts
@@ -56,7 +56,7 @@ export const buildDnsQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events.dsl.ts
@@ -31,7 +31,7 @@ export const buildNetworkEventsQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       query: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events.dsl.ts
@@ -30,7 +30,7 @@ export const buildNetworkEventsQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events_entities.dsl.ts
@@ -29,7 +29,7 @@ export const buildNetworkEventsQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/network_events/query.network_kpi_network_events_entities.dsl.ts
@@ -28,7 +28,7 @@ export const buildNetworkEventsQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes.dsl.ts
@@ -57,7 +57,7 @@ export const buildTlsHandshakeQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       query: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes.dsl.ts
@@ -56,7 +56,7 @@ export const buildTlsHandshakeQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes_entities.dsl.ts
@@ -29,7 +29,7 @@ export const buildTlsHandshakeQueryEntities = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/tls_handshakes/query.network_kpi_tls_handshakes_entities.dsl.ts
@@ -28,7 +28,7 @@ export const buildTlsHandshakeQueryEntities = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_flows/query.network_kpi_unique_flows.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_flows/query.network_kpi_unique_flows.dsl.ts
@@ -31,7 +31,7 @@ export const buildUniqueFlowsQuery = ({
   const dslQuery = {
     index: defaultIndex,
     allowNoIndices: true,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_flows/query.network_kpi_unique_flows.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_flows/query.network_kpi_unique_flows.dsl.ts
@@ -30,7 +30,7 @@ export const buildUniqueFlowsQuery = ({
 
   const dslQuery = {
     index: defaultIndex,
-    allowNoIndices: true,
+    allow_no_indices: true,
     ignore_unavailable: true,
     track_total_hits: false,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips.dsl.ts
@@ -86,7 +86,7 @@ export const buildUniquePrivateIpsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips.dsl.ts
@@ -84,7 +84,7 @@ export const buildUniquePrivateIpsQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips_entities.dsl.ts
@@ -86,7 +86,7 @@ export const buildUniquePrivateIpsQueryEntities = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/kpi/unique_private_ips/query.network_kpi_unique_private_ips_entities.dsl.ts
@@ -84,7 +84,7 @@ export const buildUniquePrivateIpsQueryEntities = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/__mocks__/index.ts
@@ -112,7 +112,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             aggregations: {
@@ -207,7 +207,7 @@ export const formattedSearchStrategyResponse = {
 
 export const expectedDsl = {
   allowNoIndices: true,
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/__mocks__/index.ts
@@ -101,7 +101,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -206,7 +206,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   ignore_unavailable: true,
   index: [
     'apm-*-transaction*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/query.overview_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/query.overview_network.dsl.ts
@@ -30,7 +30,7 @@ export const buildOverviewNetworkQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggregations: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/query.overview_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/overview/query.overview_network.dsl.ts
@@ -28,7 +28,7 @@ export const buildOverviewNetworkQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/__mocks__/index.ts
@@ -70,7 +70,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             aggs: {
@@ -125,7 +125,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   track_total_hits: false,
   body: {
     aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/__mocks__/index.ts
@@ -59,7 +59,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -114,7 +114,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/query.tls_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/query.tls_network.dsl.ts
@@ -77,7 +77,7 @@ export const buildNetworkTlsQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/query.tls_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/tls/query.tls_network.dsl.ts
@@ -75,7 +75,7 @@ export const buildNetworkTlsQuery = ({
   const filter = ip ? [...defaultFilter, { term: { [`${flowTarget}.ip`]: ip } }] : defaultFilter;
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/__mocks__/index.ts
@@ -69,7 +69,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             aggregations: {
               top_countries_count: { cardinality: { field: 'destination.geo.country_iso_code' } },
@@ -129,7 +129,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     aggregations: {
       top_countries_count: { cardinality: { field: 'destination.geo.country_iso_code' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/__mocks__/index.ts
@@ -58,7 +58,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -118,7 +118,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network.dsl.ts
@@ -44,7 +44,7 @@ export const buildTopCountriesQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggregations: {
         ...getCountAgg(flowTarget),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network.dsl.ts
@@ -42,7 +42,7 @@ export const buildTopCountriesQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network_entities.dsl.ts
@@ -49,7 +49,7 @@ export const buildTopCountriesQueryEntities = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggregations: {
         ...getCountAgg(flowTarget),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/query.top_countries_network_entities.dsl.ts
@@ -47,7 +47,7 @@ export const buildTopCountriesQueryEntities = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/__mocks__/index.ts
@@ -821,7 +821,7 @@ export const formattedSearchStrategyResponse: NetworkTopNFlowStrategyResponse = 
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           body: {
             aggregations: {
               top_n_flow_count: { cardinality: { field: 'source.ip' } },
@@ -889,7 +889,7 @@ export const expectedDsl = {
     'packetbeat-*',
     'winlogbeat-*',
   ],
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   body: {
     aggregations: {
       top_n_flow_count: { cardinality: { field: 'source.ip' } },

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/__mocks__/index.ts
@@ -810,7 +810,7 @@ export const formattedSearchStrategyResponse: NetworkTopNFlowStrategyResponse = 
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -878,7 +878,7 @@ export const formattedSearchStrategyResponse: NetworkTopNFlowStrategyResponse = 
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network.dsl.ts
@@ -44,7 +44,7 @@ export const buildTopNFlowQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggregations: {
         ...getCountAgg(flowTarget),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network.dsl.ts
@@ -42,7 +42,7 @@ export const buildTopNFlowQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network_entities.dsl.ts
@@ -49,7 +49,7 @@ export const buildTopNFlowQueryEntities = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggregations: {
         ...getCountAgg(flowTarget),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network_entities.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network_entities.dsl.ts
@@ -47,7 +47,7 @@ export const buildTopNFlowQueryEntities = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/__mocks__/index.ts
@@ -130,7 +130,7 @@ export const formattedSearchStrategyResponse = {
             'packetbeat-*',
             'winlogbeat-*',
           ],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             aggs: {
@@ -209,7 +209,7 @@ export const expectedDsl = {
     },
     size: 0,
   },
-  ignoreUnavailable: true,
+  ignore_unavailable: true,
   index: [
     'apm-*-transaction*',
     'traces-apm*',

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/__mocks__/index.ts
@@ -119,7 +119,7 @@ export const formattedSearchStrategyResponse = {
     dsl: [
       JSON.stringify(
         {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: [
             'apm-*-transaction*',
             'traces-apm*',
@@ -175,7 +175,7 @@ export const formattedSearchStrategyResponse = {
 };
 
 export const expectedDsl = {
-  allowNoIndices: true,
+  allow_no_indices: true,
   track_total_hits: false,
   body: {
     aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/query.users_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/query.users_network.dsl.ts
@@ -36,7 +36,7 @@ export const buildUsersQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: false,
     body: {
       aggs: {

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/query.users_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/users/query.users_network.dsl.ts
@@ -34,7 +34,7 @@ export const buildUsersQuery = ({
   ];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: false,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_rules/query.host_rules.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_rules/query.host_rules.dsl.ts
@@ -32,7 +32,7 @@ export const buildHostRulesQuery = ({
   return {
     allowNoIndices: true,
     index: defaultIndex, // can stop getting this from sourcerer and assume default detections index if we want
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_rules/query.host_rules.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_rules/query.host_rules.dsl.ts
@@ -30,7 +30,7 @@ export const buildHostRulesQuery = ({
   ];
 
   return {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex, // can stop getting this from sourcerer and assume default detections index if we want
     ignore_unavailable: true,
     track_total_hits: true,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_tactics/query.host_tactics.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_tactics/query.host_tactics.dsl.ts
@@ -32,7 +32,7 @@ export const buildHostTacticsQuery = ({
   return {
     allowNoIndices: true,
     index: defaultIndex, // can stop getting this from sourcerer and assume default detections index if we want
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_tactics/query.host_tactics.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/host_tactics/query.host_tactics.dsl.ts
@@ -30,7 +30,7 @@ export const buildHostTacticsQuery = ({
   ];
 
   return {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex, // can stop getting this from sourcerer and assume default detections index if we want
     ignore_unavailable: true,
     track_total_hits: true,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/risk_score/query.risk_score.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/risk_score/query.risk_score.dsl.ts
@@ -33,7 +33,7 @@ export const buildRiskScoreQuery = ({
   return {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/risk_score/query.risk_score.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/risk_score/query.risk_score.dsl.ts
@@ -31,7 +31,7 @@ export const buildRiskScoreQuery = ({
   ];
 
   return {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     track_total_hits: true,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/user_rules/query.user_rules.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/user_rules/query.user_rules.dsl.ts
@@ -32,7 +32,7 @@ export const buildUserRulesQuery = ({
   return {
     allowNoIndices: true,
     index: defaultIndex, // can stop getting this from sourcerer and assume default detections index if we want
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     track_total_hits: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/user_rules/query.user_rules.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/ueba/user_rules/query.user_rules.dsl.ts
@@ -30,7 +30,7 @@ export const buildUserRulesQuery = ({
   ];
 
   return {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex, // can stop getting this from sourcerer and assume default detections index if we want
     ignore_unavailable: true,
     track_total_hits: true,

--- a/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
@@ -189,7 +189,7 @@ export const getDetectionRuleMetrics = async (
   const ruleSearchOptions: RuleSearchParams = {
     body: { query: { bool: { filter: { term: { 'alert.alertTypeId': SIGNALS_ID } } } } },
     filter_path: [],
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     index: kibanaIndex,
     size: MAX_RESULTS_WINDOW,
   };

--- a/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/detection_rule_helpers.ts
@@ -188,7 +188,7 @@ export const getDetectionRuleMetrics = async (
   let rulesUsage: DetectionRulesTypeUsage = initialDetectionRulesUsage;
   const ruleSearchOptions: RuleSearchParams = {
     body: { query: { bool: { filter: { term: { 'alert.alertTypeId': SIGNALS_ID } } } } },
-    filterPath: [],
+    filter_path: [],
     ignoreUnavailable: true,
     index: kibanaIndex,
     size: MAX_RESULTS_WINDOW,

--- a/x-pack/plugins/security_solution/server/usage/detections/types.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/types.ts
@@ -17,8 +17,8 @@ interface RuleSearchBody {
 
 export interface RuleSearchParams {
   body: RuleSearchBody;
-  filterPath: string[];
-  ignoreUnavailable: boolean;
+  filter_path: string[];
+  ignore_unavailable: boolean;
   index: string;
   size: number;
 }

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/policy_edit.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/policy_edit.test.ts
@@ -153,7 +153,7 @@ describe('<PolicyEdit />', () => {
           schedule,
           repository,
           config: {
-            ignoreUnavailable: true,
+            ignore_unavailable: true,
           },
           retention: {
             ...retention,

--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/policy_edit.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/policy_edit.test.ts
@@ -153,7 +153,7 @@ describe('<PolicyEdit />', () => {
           schedule,
           repository,
           config: {
-            ignore_unavailable: true,
+            ignoreUnavailable: true,
           },
           retention: {
             ...retention,

--- a/x-pack/plugins/snapshot_restore/server/routes/api/validate_schemas.ts
+++ b/x-pack/plugins/snapshot_restore/server/routes/api/validate_schemas.ts
@@ -13,7 +13,7 @@ export const nameParameterSchema = schema.object({
 
 const snapshotConfigSchema = schema.object({
   indices: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
-  ignore_unavailable: schema.maybe(schema.boolean()),
+  ignoreUnavailable: schema.maybe(schema.boolean()),
   includeGlobalState: schema.maybe(schema.boolean()),
   partial: schema.maybe(schema.boolean()),
   metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
@@ -200,6 +200,6 @@ export const restoreSettingsSchema = schema.object({
   partial: schema.maybe(schema.boolean()),
   indexSettings: schema.maybe(schema.string()),
   ignoreIndexSettings: schema.maybe(schema.arrayOf(schema.string())),
-  ignore_unavailable: schema.maybe(schema.boolean()),
+  ignoreUnavailable: schema.maybe(schema.boolean()),
   includeAliases: schema.maybe(schema.boolean()),
 });

--- a/x-pack/plugins/snapshot_restore/server/routes/api/validate_schemas.ts
+++ b/x-pack/plugins/snapshot_restore/server/routes/api/validate_schemas.ts
@@ -13,7 +13,7 @@ export const nameParameterSchema = schema.object({
 
 const snapshotConfigSchema = schema.object({
   indices: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
-  ignoreUnavailable: schema.maybe(schema.boolean()),
+  ignore_unavailable: schema.maybe(schema.boolean()),
   includeGlobalState: schema.maybe(schema.boolean()),
   partial: schema.maybe(schema.boolean()),
   metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
@@ -200,6 +200,6 @@ export const restoreSettingsSchema = schema.object({
   partial: schema.maybe(schema.boolean()),
   indexSettings: schema.maybe(schema.string()),
   ignoreIndexSettings: schema.maybe(schema.arrayOf(schema.string())),
-  ignoreUnavailable: schema.maybe(schema.boolean()),
+  ignore_unavailable: schema.maybe(schema.boolean()),
   includeAliases: schema.maybe(schema.boolean()),
 });

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.ts
@@ -65,7 +65,7 @@ export const buildTimelineEventsAllQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
       aggregations: {

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/all/query.events_all.dsl.ts
@@ -63,7 +63,7 @@ export const buildTimelineEventsAllQuery = ({
     });
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.test.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.test.ts
@@ -22,7 +22,7 @@ describe('buildTimelineDetailsQuery', () => {
 
     expect(query).toMatchInlineSnapshot(`
       Object {
-        "allowNoIndices": true,
+        "allow_no_indices": true,
         "body": Object {
           "_source": true,
           "docvalue_fields": Array [
@@ -53,7 +53,7 @@ describe('buildTimelineDetailsQuery', () => {
             },
           },
         },
-        "ignoreUnavailable": true,
+        "ignore_unavailable": true,
         "index": ".siem-signals-default",
         "size": 1,
       }

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
@@ -35,7 +35,7 @@ export const buildTimelineDetailsQuery = (
   return {
     allowNoIndices: true,
     index: indexName,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       docvalue_fields: docValueFields,
       query,

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/details/query.events_details.dsl.ts
@@ -33,7 +33,7 @@ export const buildTimelineDetailsQuery = (
         };
 
   return {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: indexName,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/kpi/query.kpi.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/kpi/query.kpi.dsl.ts
@@ -46,7 +46,7 @@ export const buildTimelineKpiQuery = ({
   const dslQuery = {
     allowNoIndices: true,
     index: defaultIndex,
-    ignoreUnavailable: true,
+    ignore_unavailable: true,
     body: {
       aggs: {
         userCount: {

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/kpi/query.kpi.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/kpi/query.kpi.dsl.ts
@@ -44,7 +44,7 @@ export const buildTimelineKpiQuery = ({
   const filter = [...filterClause, ...getTimerangeFilter(timerange), { match_all: {} }];
 
   const dslQuery = {
-    allowNoIndices: true,
+    allow_no_indices: true,
     index: defaultIndex,
     ignore_unavailable: true,
     body: {

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/last_event_time/query.events_last_event_time.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/last_event_time/query.events_last_event_time.dsl.ts
@@ -40,7 +40,7 @@ export const buildLastEventTimeQuery = ({
           return {
             allowNoIndices: true,
             index: indicesToQuery.network,
-            ignoreUnavailable: true,
+            ignore_unavailable: true,
             track_total_hits: false,
             body: {
               ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
@@ -63,7 +63,7 @@ export const buildLastEventTimeQuery = ({
           return {
             allowNoIndices: true,
             index: indicesToQuery.hosts,
-            ignoreUnavailable: true,
+            ignore_unavailable: true,
             track_total_hits: false,
             body: {
               ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),
@@ -87,7 +87,7 @@ export const buildLastEventTimeQuery = ({
         return {
           allowNoIndices: true,
           index: indicesToQuery[indexKey],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           track_total_hits: false,
           body: {
             ...(!isEmpty(docValueFields) ? { docvalue_fields: docValueFields } : {}),

--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/last_event_time/query.events_last_event_time.dsl.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/events/last_event_time/query.events_last_event_time.dsl.ts
@@ -38,7 +38,7 @@ export const buildLastEventTimeQuery = ({
       case LastEventIndexKey.ipDetails:
         if (details.ip) {
           return {
-            allowNoIndices: true,
+            allow_no_indices: true,
             index: indicesToQuery.network,
             ignore_unavailable: true,
             track_total_hits: false,
@@ -61,7 +61,7 @@ export const buildLastEventTimeQuery = ({
       case LastEventIndexKey.hostDetails:
         if (details.hostName) {
           return {
-            allowNoIndices: true,
+            allow_no_indices: true,
             index: indicesToQuery.hosts,
             ignore_unavailable: true,
             track_total_hits: false,
@@ -85,7 +85,7 @@ export const buildLastEventTimeQuery = ({
       case LastEventIndexKey.network:
       case LastEventIndexKey.ueba:
         return {
-          allowNoIndices: true,
+          allow_no_indices: true,
           index: indicesToQuery[indexKey],
           ignore_unavailable: true,
           track_total_hits: false,

--- a/x-pack/test/api_integration/apis/management/snapshot_restore/policies.ts
+++ b/x-pack/test/api_integration/apis/management/snapshot_restore/policies.ts
@@ -62,7 +62,7 @@ export default function ({ getService }: FtrProviderContext) {
             repository: REPO_NAME,
             config: {
               indices: ['my_index'],
-              ignoreUnavailable: true,
+              ignore_unavailable: true,
               partial: false,
               metadata: {
                 meta: 'my_meta',
@@ -140,7 +140,7 @@ export default function ({ getService }: FtrProviderContext) {
         repository: REPO_NAME,
         config: {
           indices: ['my_index'],
-          ignoreUnavailable: true,
+          ignore_unavailable: true,
           partial: false,
           metadata: {
             meta: 'my_meta',

--- a/x-pack/test/api_integration/apis/management/snapshot_restore/policies.ts
+++ b/x-pack/test/api_integration/apis/management/snapshot_restore/policies.ts
@@ -62,7 +62,7 @@ export default function ({ getService }: FtrProviderContext) {
             repository: REPO_NAME,
             config: {
               indices: ['my_index'],
-              ignore_unavailable: true,
+              ignoreUnavailable: true,
               partial: false,
               metadata: {
                 meta: 'my_meta',
@@ -140,7 +140,7 @@ export default function ({ getService }: FtrProviderContext) {
         repository: REPO_NAME,
         config: {
           indices: ['my_index'],
-          ignore_unavailable: true,
+          ignoreUnavailable: true,
           partial: false,
           metadata: {
             meta: 'my_meta',


### PR DESCRIPTION
## Summary

Extracted from https://github.com/elastic/kibana/pull/113950
In the next major release `@elastic/elasticsearch` client drops `camelCase` support for keys. 
Renames the next params:
- filterPath --> filter_path
- ignoreUnavailable --> ignore_unavailable
- allowNoIndices  --> allow_no_indices
- trackScores --> track_scores
- trackTotalHits --> track_total_hits

I'm going to port the changes to `7.x` to avoid merge conflicts during backports.
Let me know if you find other usages in the plugin code.