### PR TITLE
[App Search, Crawler] Fix validation step panel padding/whitespace

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
@@ -35,10 +35,7 @@ export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
   const showErrorMessage = step.state === 'invalid' || step.state === 'warning';
 
   return (
-    <EuiPanel
-      hasShadow={false}
-      color={domainValidationStateToPanelColor(step.state)}
-    >
+    <EuiPanel hasShadow={false} color={domainValidationStateToPanelColor(step.state)}>
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
           <ValidationStateIcon state={step.state} />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
@@ -57,8 +57,8 @@ export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
           </EuiMarkdownFormat>
           {action && (
             <>
+              <EuiSpacer size="s" />
               {action}
-              <EuiSpacer />
             </>
           )}
         </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/add_domain/validation_step_panel.tsx
@@ -33,13 +33,11 @@ export const ValidationStepPanel: React.FC<ValidationStepPanelProps> = ({
   action,
 }) => {
   const showErrorMessage = step.state === 'invalid' || step.state === 'warning';
-  const styleOverride = showErrorMessage ? { paddingBottom: 0 } : {};
 
   return (
     <EuiPanel
       hasShadow={false}
       color={domainValidationStateToPanelColor(step.state)}
-      style={styleOverride}
     >
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

This PR fixes some padding/whitespace issues which I think was introduced as part of the EUI upgrade: https://github.com/elastic/kibana/pull/113633

**Before:**

<img width="560" alt="CleanShot 2021-10-19 at 13 15 03@2x" src="https://user-images.githubusercontent.com/809707/137900256-f82eb79c-4ce9-4751-8dce-9e790a111948.png">
<img width="560" alt="CleanShot 2021-10-19 at 13 14 43@2x" src="https://user-images.githubusercontent.com/809707/137900372-b9f9089b-7b1a-4c01-8303-9e896b6ffac4.png">

**After:**

<img width="560" alt="CleanShot 2021-10-19 at 13 11 05@2x" src="https://user-images.githubusercontent.com/809707/137900280-a6da592d-3a87-4413-8797-a4605914ffcd.png">
<img width="560" alt="CleanShot 2021-10-19 at 13 13 44@2x" src="https://user-images.githubusercontent.com/809707/137900408-6e6f64d2-3ff0-4dee-8bad-b7bb8ec1ef98.png">