### PR TITLE
[Dashboards] Fix potential error from undefined

### DIFF
--- a/src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts
+++ b/src/plugins/dashboard/public/saved_dashboards/saved_dashboard.ts
@@ -114,14 +114,14 @@ export function createSavedDashboardClass(
         },
 
         // if this is null/undefined then the SavedObject will be assigned the defaults
-        id: typeof arg === 'string' ? arg : arg.id,
+        id: typeof arg === 'object' ? arg.id : arg,
 
         // default values that will get assigned if the doc is new
         defaults,
       });
 
-      const id: string = typeof arg === 'string' ? arg : arg.id;
-      const useResolve = typeof arg === 'string' ? false : arg.useResolve;
+      const id: string = typeof arg === 'object' ? arg.id : arg;
+      const useResolve = typeof arg === 'object' ? arg.useResolve : false;
 
       this.getFullPath = () => `/app/dashboards#${createDashboardEditUrl(this.aliasId || this.id)}`;
 


### PR DESCRIPTION
The 7.x backport for the Dashboard Resolve PR was failing on a test that was skipped on master.  I fixed this issue on the backport, and I'm unsure if it's even possible to get to this state anymore (the failing test was on importing a JSON saved object so the arg was `undefined`) but I wanted to make sure master was protected in case there was some other scenario that was not tested.  