### PR TITLE
Change default session idle timeout to 8 hours.

### DIFF
--- a/docs/settings/security-settings.asciidoc
+++ b/docs/settings/security-settings.asciidoc
@@ -272,7 +272,7 @@ You can configure the following settings in the `kibana.yml` file.
 
 |[[xpack-session-idleTimeout]] `xpack.security.session.idleTimeout` {ess-icon}
   | Ensures that user sessions will expire after a period of inactivity. This and <<xpack-session-lifespan,`xpack.security.session.lifespan`>> are both
-highly recommended. You can also specify this setting for <<xpack-security-provider-session-idleTimeout, every provider separately>>. If this is set to `0`, then sessions will never expire due to inactivity. By default, this value is 1 hour.
+highly recommended. You can also specify this setting for <<xpack-security-provider-session-idleTimeout, every provider separately>>. If this is set to `0`, then sessions will never expire due to inactivity. By default, this value is 8 hours.
 
 2+a|
 [TIP]

--- a/docs/user/security/session-management.asciidoc
+++ b/docs/user/security/session-management.asciidoc
@@ -12,7 +12,7 @@ To manage user sessions programmatically, {kib} exposes <<session-management-api
 ==== Session idle timeout
 
 You can use `xpack.security.session.idleTimeout` to expire sessions after a period of inactivity. This and `xpack.security.session.lifespan` are both highly recommended.
-By default, sessions expire after 1 hour of inactivity. To define another value for a sliding session expiration, set the  property in the `kibana.yml` configuration file. The idle timeout is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, set the idle timeout to expire sessions after 30 minutes of inactivity:
+By default, sessions expire after 8 hours of inactivity. To define another value for a sliding session expiration, set the  property in the `kibana.yml` configuration file. The idle timeout is formatted as a duration of `<count>[ms|s|m|h|d|w|M|Y]` (e.g. '20m', '24h', '7d', '1w'). For example, set the idle timeout to expire sessions after 30 minutes of inactivity:
 
 --
 [source,yaml]

--- a/x-pack/plugins/security/server/config.test.ts
+++ b/x-pack/plugins/security/server/config.test.ts
@@ -63,7 +63,7 @@ describe('config schema', () => {
         "secureCookies": false,
         "session": Object {
           "cleanupInterval": "PT1H",
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "P30D",
         },
         "showInsecureClusterWarning": true,
@@ -117,7 +117,7 @@ describe('config schema', () => {
         "secureCookies": false,
         "session": Object {
           "cleanupInterval": "PT1H",
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "P30D",
         },
         "showInsecureClusterWarning": true,
@@ -170,7 +170,7 @@ describe('config schema', () => {
         "secureCookies": false,
         "session": Object {
           "cleanupInterval": "PT1H",
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "P30D",
         },
         "showInsecureClusterWarning": true,
@@ -1768,7 +1768,7 @@ describe('createConfig()', () => {
       expect(createMockConfig().session.getExpirationTimeouts({ type: 'basic', name: 'basic1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "P30D",
         }
       `);
@@ -1818,7 +1818,7 @@ describe('createConfig()', () => {
         })
       ).toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "PT0.456S",
         }
       `);
@@ -1852,7 +1852,7 @@ describe('createConfig()', () => {
           createMockConfig({ session: { lifespan: 456 } }).session.getExpirationTimeouts(provider)
         ).toMatchInlineSnapshot(`
           Object {
-            "idleTimeout": "PT1H",
+            "idleTimeout": "PT8H",
             "lifespan": "PT0.456S",
           }
         `);
@@ -1933,14 +1933,14 @@ describe('createConfig()', () => {
       expect(configWithoutGlobal.session.getExpirationTimeouts({ type: 'basic', name: 'basic1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "PT0.654S",
         }
       `);
       expect(configWithoutGlobal.session.getExpirationTimeouts({ type: 'saml', name: 'saml1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "PT11M5.544S",
         }
       `);
@@ -1957,7 +1957,7 @@ describe('createConfig()', () => {
       expect(configWithGlobal.session.getExpirationTimeouts({ type: 'basic', name: 'basic1' }))
         .toMatchInlineSnapshot(`
         Object {
-          "idleTimeout": "PT1H",
+          "idleTimeout": "PT8H",
           "lifespan": "PT0.654S",
         }
       `);

--- a/x-pack/plugins/security/server/config.ts
+++ b/x-pack/plugins/security/server/config.ts
@@ -211,7 +211,7 @@ export const ConfigSchema = schema.object({
   ),
   session: schema.object({
     idleTimeout: schema.oneOf([schema.duration(), schema.literal(null)], {
-      defaultValue: schema.duration().validate('1h'),
+      defaultValue: schema.duration().validate('8h'),
     }),
     lifespan: schema.oneOf([schema.duration(), schema.literal(null)], {
       defaultValue: schema.duration().validate('30d'),

--- a/x-pack/plugins/security/server/usage_collector/security_usage_collector.test.ts
+++ b/x-pack/plugins/security/server/usage_collector/security_usage_collector.test.ts
@@ -47,7 +47,7 @@ describe('Security UsageCollector', () => {
     enabledAuthProviders: ['basic'],
     loginSelectorEnabled: false,
     httpAuthSchemes: ['apikey', 'bearer'],
-    sessionIdleTimeoutInMinutes: 60,
+    sessionIdleTimeoutInMinutes: 480,
     sessionLifespanInMinutes: 43200,
     sessionCleanupInMinutes: 60,
   };


### PR DESCRIPTION
## Summary

As the result of this discussion https://github.com/elastic/cloud/issues/85029#issuecomment-946660437 we decided to bump default session idle timeout from 1 hour to 8 hours.

__Note:__ I've updated the release note in https://github.com/elastic/kibana/pull/106061 to mention `8h` instead of `1h`. Deprecation notice is updated in https://github.com/elastic/kibana/pull/115020

__Follow up for:__ https://github.com/elastic/kibana/pull/106061
