### PR TITLE
[Stack monitoring] Remove react migration feature flag

### DIFF
--- a/x-pack/plugins/monitoring/public/plugin.ts
+++ b/x-pack/plugins/monitoring/public/plugin.ts
@@ -133,7 +133,6 @@ export class MonitoringPlugin
       ['showLicenseExpiration', monitoring.ui.show_license_expiration],
       ['showCgroupMetricsElasticsearch', monitoring.ui.container.elasticsearch.enabled],
       ['showCgroupMetricsLogstash', monitoring.ui.container.logstash.enabled],
-      ['renderReactApp', monitoring.ui.render_react_app],
     ];
   }
 

--- a/x-pack/plugins/monitoring/server/config.test.ts
+++ b/x-pack/plugins/monitoring/server/config.test.ts
@@ -106,7 +106,6 @@ describe('config schema', () => {
             "index": "metricbeat-*",
           },
           "min_interval_seconds": 10,
-          "render_react_app": true,
           "show_license_expiration": true,
         },
       }

--- a/x-pack/plugins/monitoring/server/config.ts
+++ b/x-pack/plugins/monitoring/server/config.ts
@@ -50,7 +50,6 @@ export const configSchema = schema.object({
     }),
     min_interval_seconds: schema.number({ defaultValue: 10 }),
     show_license_expiration: schema.boolean({ defaultValue: true }),
-    render_react_app: schema.boolean({ defaultValue: true }),
   }),
   kibana: schema.object({
     collection: schema.object({


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/115504.

It removes the feature flag introduced for the Stack Monitoring react migration
