### PR TITLE
[vscode] disable ts-server logging to boost performance 

### DIFF
--- a/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
+++ b/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
@@ -50,4 +50,8 @@ export const MANAGED_CONFIG_KEYS: ManagedConfigKey[] = [
     key: 'typescript.tsserver.maxTsServerMemory',
     value: 4096,
   },
+  {
+    key: 'typescript.tsserver.log',
+    value: 'off',
+  },
 ];


### PR DESCRIPTION
## Summary

![Screen Shot 2021-10-19 at 16 50 06](https://user-images.githubusercontent.com/20814186/137945462-f045ad2d-a54d-43f4-986d-24985cff98dd.png)

^ sometimes i get this when vscode is opened 

figured we'd probably want to squeeze as much performance as possible
so i added `"typescript.tsserver.log": "off"` to `managed_config_keys.ts`

i think anyone who needs to debug the TS server logs can use the `// self managed` option, but otherwise we don't want it to impact performance.


