### PR TITLE
[App Search] Put History tab behind platinum check

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
@@ -78,6 +78,8 @@ describe('Curations', () => {
 
     tabs.at(2).simulate('click');
     expect(actions.onSelectPageTab).toHaveBeenNthCalledWith(3, 'settings');
+    // The settings tab should NOT have an icon next to it
+    expect(tabs.at(2).prop('prepend')).toBeUndefined();
   });
 
   it('renders less tabs when less than platinum license', () => {
@@ -88,6 +90,8 @@ describe('Curations', () => {
 
     const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
     expect(tabs.length).toBe(2);
+    // The settings tab should have an icon next to it
+    expect(tabs.at(1).prop('prepend')).not.toBeUndefined();
   });
 
   it('renders an overview view', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
@@ -25,6 +25,7 @@ import { CurationsSettings } from './curations_settings';
 
 describe('Curations', () => {
   const values = {
+    // CurationsLogic
     dataLoading: false,
     curations: [
       {
@@ -46,6 +47,8 @@ describe('Curations', () => {
       },
     },
     selectedPageTab: 'overview',
+    // LicensingLogic
+    hasPlatinumLicense: true,
   };
 
   const actions = {
@@ -75,6 +78,16 @@ describe('Curations', () => {
 
     tabs.at(2).simulate('click');
     expect(actions.onSelectPageTab).toHaveBeenNthCalledWith(3, 'settings');
+  });
+
+  it('renders less tabs when less than platinum license', () => {
+    setMockValues({ ...values, hasPlatinumLicense: false });
+    const wrapper = shallow(<Curations />);
+
+    expect(getPageTitle(wrapper)).toEqual('Curated results');
+
+    const tabs = getPageHeaderTabs(wrapper).find(EuiTab);
+    expect(tabs.length).toBe(2);
   });
 
   it('renders an overview view', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
@@ -11,6 +11,7 @@ import { useValues, useActions } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
+import { LicensingLogic } from '../../../../shared/licensing';
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 
 import { ENGINE_CURATIONS_NEW_PATH } from '../../../routes';
@@ -28,39 +29,41 @@ import { CurationsSettings } from './curations_settings';
 export const Curations: React.FC = () => {
   const { dataLoading, curations, meta, selectedPageTab } = useValues(CurationsLogic);
   const { loadCurations, onSelectPageTab } = useActions(CurationsLogic);
+  const { hasPlatinumLicense } = useValues(LicensingLogic);
 
-  const pageTabs = [
-    {
-      label: i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.curations.overviewPageTabLabel',
-        {
-          defaultMessage: 'Overview',
-        }
-      ),
-      isSelected: selectedPageTab === 'overview',
-      onClick: () => onSelectPageTab('overview'),
-    },
-    {
-      label: i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.curations.historyPageTabLabel',
-        {
-          defaultMessage: 'History',
-        }
-      ),
-      isSelected: selectedPageTab === 'history',
-      onClick: () => onSelectPageTab('history'),
-    },
-    {
-      label: i18n.translate(
-        'xpack.enterpriseSearch.appSearch.engine.curations.settingsPageTabLabel',
-        {
-          defaultMessage: 'Settings',
-        }
-      ),
-      isSelected: selectedPageTab === 'settings',
-      onClick: () => onSelectPageTab('settings'),
-    },
-  ];
+  const OVERVIEW_TAB = {
+    label: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.engine.curations.overviewPageTabLabel',
+      {
+        defaultMessage: 'Overview',
+      }
+    ),
+    isSelected: selectedPageTab === 'overview',
+    onClick: () => onSelectPageTab('overview'),
+  };
+
+  const HISTORY_TAB = {
+    label: i18n.translate('xpack.enterpriseSearch.appSearch.engine.curations.historyPageTabLabel', {
+      defaultMessage: 'History',
+    }),
+    isSelected: selectedPageTab === 'history',
+    onClick: () => onSelectPageTab('history'),
+  };
+
+  const SETTINGS_TAB = {
+    label: i18n.translate(
+      'xpack.enterpriseSearch.appSearch.engine.curations.settingsPageTabLabel',
+      {
+        defaultMessage: 'Settings',
+      }
+    ),
+    isSelected: selectedPageTab === 'settings',
+    onClick: () => onSelectPageTab('settings'),
+  };
+
+  const pageTabs = hasPlatinumLicense
+    ? [OVERVIEW_TAB, HISTORY_TAB, SETTINGS_TAB]
+    : [OVERVIEW_TAB, SETTINGS_TAB];
 
   useEffect(() => {
     loadCurations();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
@@ -9,6 +9,7 @@ import React, { useEffect } from 'react';
 
 import { useValues, useActions } from 'kea';
 
+import { EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { LicensingLogic } from '../../../../shared/licensing';
@@ -63,7 +64,13 @@ export const Curations: React.FC = () => {
 
   const pageTabs = hasPlatinumLicense
     ? [OVERVIEW_TAB, HISTORY_TAB, SETTINGS_TAB]
-    : [OVERVIEW_TAB, SETTINGS_TAB];
+    : [
+        OVERVIEW_TAB,
+        {
+          ...SETTINGS_TAB,
+          prepend: <EuiIcon type="cheer" />,
+        },
+      ];
 
   useEffect(() => {
     loadCurations();


### PR DESCRIPTION
## Summary

The "History" tab was not behind a Platinum license check so was causing some odd behavior. I put it behind a license check.

I also added an icon to the "Settings" tab when less-than-platinum.

Less-than-platinum:
![screencapture-localhost-5601-bpz-app-enterprise-search-app-search-engines-pokemon-curations-2021-10-19-15_46_25](https://user-images.githubusercontent.com/1427475/137980082-04368bd0-c16f-4a2f-8e70-8af8a3f83b64.png)

Platinum-or-greater:
![screencapture-localhost-5601-bpz-app-enterprise-search-app-search-engines-pokemon-curations-2021-10-19-15_22_36](https://user-images.githubusercontent.com/1427475/137976818-1a38b108-a3b2-475d-87a2-398009267bc9.png)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
