### PR TITLE
docs: Fix hard-coded APM link

### DIFF
--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -26,7 +26,7 @@ For this reason, it is still essential to set custom default configurations loca
 [float]
 ==== APM Server setup
 
-This feature requires https://www.elastic.co/guide/en/apm/server/master/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
+This feature requires {apm-server-ref-v}/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
 
 APM Server acts as a proxy between the agents and Kibana.
 Kibana communicates any changed settings to APM Server so that your agents only need to poll APM Server to determine which settings have changed.


### PR DESCRIPTION
The APM Server Reference will be removed from the doc build in `7.16`. Unfortunately, a hard-coded link to the APM Server Reference went unnoticed from `7.4` to `7.14`. In order to remove the book, I need to backport this PR all the way back to `7.4` 😬

Details:
```
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.10/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.11/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.12/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.13/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.14/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.4/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.5/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.6/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.7/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.8/agent-configuration.html contains broken links to:
 INFO::   - en/apm/server/master/setup-kibana-endpoint.html
 INFO::  /tmp/docsbuild/target_repo/html/en/kibana/7.9/agent-configuration.html contains broken links to:
```