### PR TITLE
[7.6] docs: fix links (#115642)

### DIFF
--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -22,7 +22,7 @@ For this reason, it is still important to set custom default configurations loca
 [float]
 ==== APM Server setup
 
-This feature requires https://www.elastic.co/guide/en/apm/server/master/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
+This feature requires {apm-server-ref-v}/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
 
 Why is additional configuration needed in APM Server?
 That's because APM Server acts as a proxy between the agents and Kibana.


### PR DESCRIPTION
Backports the following commits to 7.6:
 - docs: fix links (#115642)