### PR TITLE
Fix breadcrumbs not showing when opening a timeline from case details

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/components/case_view/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/case_view/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   getCaseDetailsUrl,
@@ -28,7 +28,6 @@ import { InvestigateInTimelineAction } from '../../../detections/components/aler
 import { useFetchAlertData } from './helpers';
 import { SEND_ALERT_TO_TIMELINE } from './translations';
 import { useInsertTimeline } from '../use_insert_timeline';
-import { SpyRoute } from '../../../common/utils/route/spy_routes';
 import * as timelineMarkdownPlugin from '../../../common/components/markdown_editor/plugins/timeline';
 import { CaseDetailsRefreshContext } from '../../../common/components/endpoint/host_isolation/endpoint_host_isolation_cases_context';
 import { getEndpointDetailsPath } from '../../../management/common/routing';
@@ -37,6 +36,7 @@ interface Props {
   caseId: string;
   subCaseId?: string;
   userCanCrud: boolean;
+  onCaseDataSuccess: (data: Case) => void;
 }
 
 export interface OnUpdateFields {
@@ -78,175 +78,163 @@ const InvestigateInTimelineActionComponent = (alertIds: string[]) => {
   );
 };
 
-export const CaseView = React.memo(({ caseId, subCaseId, userCanCrud }: Props) => {
-  const [spyState, setSpyState] = useState<{ caseTitle: string | undefined }>({
-    caseTitle: undefined,
-  });
+export const CaseView = React.memo(
+  ({ caseId, subCaseId, userCanCrud, onCaseDataSuccess }: Props) => {
+    const {
+      cases: casesUi,
+      application: { navigateToApp },
+    } = useKibana().services;
+    const dispatch = useDispatch();
+    const { formatUrl, search } = useFormatUrl(SecurityPageName.case);
+    const { formatUrl: detectionsFormatUrl, search: detectionsUrlSearch } = useFormatUrl(
+      SecurityPageName.rules
+    );
 
-  const onCaseDataSuccess = useCallback(
-    (data: Case) => {
-      if (spyState.caseTitle === undefined || spyState.caseTitle !== data.title) {
-        setSpyState({ caseTitle: data.title });
-      }
-    },
-    [spyState.caseTitle]
-  );
+    const allCasesLink = getCaseUrl(search);
+    const formattedAllCasesLink = formatUrl(allCasesLink);
+    const configureCasesHref = formatUrl(getConfigureCasesUrl());
 
-  const {
-    cases: casesUi,
-    application: { navigateToApp },
-  } = useKibana().services;
-  const dispatch = useDispatch();
-  const { formatUrl, search } = useFormatUrl(SecurityPageName.case);
-  const { formatUrl: detectionsFormatUrl, search: detectionsUrlSearch } = useFormatUrl(
-    SecurityPageName.rules
-  );
+    const caseDetailsLink = formatUrl(getCaseDetailsUrl({ id: caseId }), { absolute: true });
+    const getCaseDetailHrefWithCommentId = (commentId: string) =>
+      formatUrl(getCaseDetailsUrlWithCommentId({ id: caseId, commentId, subCaseId }), {
+        absolute: true,
+      });
 
-  const allCasesLink = getCaseUrl(search);
-  const formattedAllCasesLink = formatUrl(allCasesLink);
-  const configureCasesHref = formatUrl(getConfigureCasesUrl());
+    const getDetectionsRuleDetailsHref = useCallback(
+      (ruleId) => detectionsFormatUrl(getRuleDetailsUrl(ruleId ?? '', detectionsUrlSearch)),
+      [detectionsFormatUrl, detectionsUrlSearch]
+    );
 
-  const caseDetailsLink = formatUrl(getCaseDetailsUrl({ id: caseId }), { absolute: true });
-  const getCaseDetailHrefWithCommentId = (commentId: string) =>
-    formatUrl(getCaseDetailsUrlWithCommentId({ id: caseId, commentId, subCaseId }), {
-      absolute: true,
-    });
+    const showAlertDetails = useCallback(
+      (alertId: string, index: string) => {
+        dispatch(
+          timelineActions.toggleDetailPanel({
+            panelView: 'eventDetail',
+            timelineId: TimelineId.casePage,
+            params: {
+              eventId: alertId,
+              indexName: index,
+            },
+          })
+        );
+      },
+      [dispatch]
+    );
 
-  const getDetectionsRuleDetailsHref = useCallback(
-    (ruleId) => detectionsFormatUrl(getRuleDetailsUrl(ruleId ?? '', detectionsUrlSearch)),
-    [detectionsFormatUrl, detectionsUrlSearch]
-  );
-
-  const showAlertDetails = useCallback(
-    (alertId: string, index: string) => {
-      dispatch(
-        timelineActions.toggleDetailPanel({
-          panelView: 'eventDetail',
-          timelineId: TimelineId.casePage,
-          params: {
-            eventId: alertId,
-            indexName: index,
-          },
+    const endpointDetailsHref = (endpointId: string) =>
+      formatUrl(
+        getEndpointDetailsPath({
+          name: 'endpointActivityLog',
+          selected_endpoint: endpointId,
         })
       );
-    },
-    [dispatch]
-  );
 
-  const endpointDetailsHref = (endpointId: string) =>
-    formatUrl(
-      getEndpointDetailsPath({
-        name: 'endpointActivityLog',
-        selected_endpoint: endpointId,
-      })
+    const onComponentInitialized = useCallback(() => {
+      dispatch(
+        timelineActions.createTimeline({
+          id: TimelineId.casePage,
+          columns: [],
+          indexNames: [],
+          expandedDetail: {},
+          show: false,
+        })
+      );
+    }, [dispatch]);
+
+    const refreshRef = useRef<CaseViewRefreshPropInterface>(null);
+
+    return (
+      <CaseDetailsRefreshContext.Provider value={refreshRef}>
+        {casesUi.getCaseView({
+          refreshRef,
+          allCasesNavigation: {
+            href: formattedAllCasesLink,
+            onClick: async (e) => {
+              if (e) {
+                e.preventDefault();
+              }
+              return navigateToApp(APP_ID, {
+                deepLinkId: SecurityPageName.case,
+                path: allCasesLink,
+              });
+            },
+          },
+          caseDetailsNavigation: {
+            href: caseDetailsLink,
+            onClick: async (e) => {
+              if (e) {
+                e.preventDefault();
+              }
+              return navigateToApp(APP_ID, {
+                deepLinkId: SecurityPageName.case,
+                path: getCaseDetailsUrl({ id: caseId }),
+              });
+            },
+          },
+          caseId,
+          configureCasesNavigation: {
+            href: configureCasesHref,
+            onClick: async (e) => {
+              if (e) {
+                e.preventDefault();
+              }
+              return navigateToApp(APP_ID, {
+                deepLinkId: SecurityPageName.case,
+                path: getConfigureCasesUrl(search),
+              });
+            },
+          },
+          getCaseDetailHrefWithCommentId,
+          onCaseDataSuccess,
+          onComponentInitialized,
+          actionsNavigation: {
+            href: endpointDetailsHref,
+            onClick: (endpointId: string, e) => {
+              if (e) {
+                e.preventDefault();
+              }
+              return navigateToApp(APP_ID, {
+                path: getEndpointDetailsPath({
+                  name: 'endpointActivityLog',
+                  selected_endpoint: endpointId,
+                }),
+              });
+            },
+          },
+          ruleDetailsNavigation: {
+            href: getDetectionsRuleDetailsHref,
+            onClick: async (ruleId: string | null | undefined, e) => {
+              if (e) {
+                e.preventDefault();
+              }
+              return navigateToApp(APP_ID, {
+                deepLinkId: SecurityPageName.rules,
+                path: getRuleDetailsUrl(ruleId ?? ''),
+              });
+            },
+          },
+          showAlertDetails,
+          subCaseId,
+          timelineIntegration: {
+            editor_plugins: {
+              parsingPlugin: timelineMarkdownPlugin.parser,
+              processingPluginRenderer: timelineMarkdownPlugin.renderer,
+              uiPlugin: timelineMarkdownPlugin.plugin,
+            },
+            hooks: {
+              useInsertTimeline,
+            },
+            ui: {
+              renderInvestigateInTimelineActionComponent: InvestigateInTimelineActionComponent,
+              renderTimelineDetailsPanel: TimelineDetailsPanel,
+            },
+          },
+          useFetchAlertData,
+          userCanCrud,
+        })}
+      </CaseDetailsRefreshContext.Provider>
     );
-
-  const onComponentInitialized = useCallback(() => {
-    dispatch(
-      timelineActions.createTimeline({
-        id: TimelineId.casePage,
-        columns: [],
-        indexNames: [],
-        expandedDetail: {},
-        show: false,
-      })
-    );
-  }, [dispatch]);
-
-  const refreshRef = useRef<CaseViewRefreshPropInterface>(null);
-
-  return (
-    <CaseDetailsRefreshContext.Provider value={refreshRef}>
-      {casesUi.getCaseView({
-        refreshRef,
-        allCasesNavigation: {
-          href: formattedAllCasesLink,
-          onClick: async (e) => {
-            if (e) {
-              e.preventDefault();
-            }
-            return navigateToApp(APP_ID, {
-              deepLinkId: SecurityPageName.case,
-              path: allCasesLink,
-            });
-          },
-        },
-        caseDetailsNavigation: {
-          href: caseDetailsLink,
-          onClick: async (e) => {
-            if (e) {
-              e.preventDefault();
-            }
-            return navigateToApp(APP_ID, {
-              deepLinkId: SecurityPageName.case,
-              path: getCaseDetailsUrl({ id: caseId }),
-            });
-          },
-        },
-        caseId,
-        configureCasesNavigation: {
-          href: configureCasesHref,
-          onClick: async (e) => {
-            if (e) {
-              e.preventDefault();
-            }
-            return navigateToApp(APP_ID, {
-              deepLinkId: SecurityPageName.case,
-              path: getConfigureCasesUrl(search),
-            });
-          },
-        },
-        getCaseDetailHrefWithCommentId,
-        onCaseDataSuccess,
-        onComponentInitialized,
-        actionsNavigation: {
-          href: endpointDetailsHref,
-          onClick: (endpointId: string, e) => {
-            if (e) {
-              e.preventDefault();
-            }
-            return navigateToApp(APP_ID, {
-              path: getEndpointDetailsPath({
-                name: 'endpointActivityLog',
-                selected_endpoint: endpointId,
-              }),
-            });
-          },
-        },
-        ruleDetailsNavigation: {
-          href: getDetectionsRuleDetailsHref,
-          onClick: async (ruleId: string | null | undefined, e) => {
-            if (e) {
-              e.preventDefault();
-            }
-            return navigateToApp(APP_ID, {
-              deepLinkId: SecurityPageName.rules,
-              path: getRuleDetailsUrl(ruleId ?? ''),
-            });
-          },
-        },
-        showAlertDetails,
-        subCaseId,
-        timelineIntegration: {
-          editor_plugins: {
-            parsingPlugin: timelineMarkdownPlugin.parser,
-            processingPluginRenderer: timelineMarkdownPlugin.renderer,
-            uiPlugin: timelineMarkdownPlugin.plugin,
-          },
-          hooks: {
-            useInsertTimeline,
-          },
-          ui: {
-            renderInvestigateInTimelineActionComponent: InvestigateInTimelineActionComponent,
-            renderTimelineDetailsPanel: TimelineDetailsPanel,
-          },
-        },
-        useFetchAlertData,
-        userCanCrud,
-      })}
-      <SpyRoute state={spyState} pageName={SecurityPageName.case} />
-    </CaseDetailsRefreshContext.Provider>
-  );
-});
+  }
+);
 
 CaseView.displayName = 'CaseView';

--- a/x-pack/plugins/security_solution/public/cases/pages/case_details.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/case_details.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { SecurityPageName } from '../../app/types';
@@ -17,6 +17,7 @@ import { getCaseUrl } from '../../common/components/link_to';
 import { navTabs } from '../../app/home/home_navigations';
 import { CaseView } from '../components/case_view';
 import { APP_ID } from '../../../common/constants';
+import { Case } from '../../../../cases/common';
 
 export const CaseDetailsPage = React.memo(() => {
   const {
@@ -38,6 +39,19 @@ export const CaseDetailsPage = React.memo(() => {
     }
   }, [userPermissions, navigateToApp, search]);
 
+  const [spyState, setSpyState] = useState<{ caseTitle: string | undefined }>({
+    caseTitle: undefined,
+  });
+
+  const onCaseDataSuccess = useCallback(
+    (data: Case) => {
+      if (spyState.caseTitle === undefined || spyState.caseTitle !== data.title) {
+        setSpyState({ caseTitle: data.title });
+      }
+    },
+    [spyState.caseTitle]
+  );
+
   return caseId != null ? (
     <>
       <SecuritySolutionPageWrapper noPadding>
@@ -45,9 +59,10 @@ export const CaseDetailsPage = React.memo(() => {
           caseId={caseId}
           subCaseId={subCaseId}
           userCanCrud={userPermissions?.crud ?? false}
+          onCaseDataSuccess={onCaseDataSuccess}
         />
       </SecuritySolutionPageWrapper>
-      <SpyRoute pageName={SecurityPageName.case} />
+      <SpyRoute state={spyState} pageName={SecurityPageName.case} />
     </>
   ) : null;
 });


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/115608

## Summary

The breadCrumb for cases detail comes from the `state` props provided to `SpyRoute`. `CaseView` component sets this property. I discovered that `CaseDetailsPage` was also rendering `SpyRoute` and not providing the state property. `SpyRoute` must render only once per page, so I deleted the one from `CaseDetailsPage`.

<img width="379" alt="Screenshot 2021-10-20 at 11 25 27" src="https://user-images.githubusercontent.com/1490444/138066728-b972eef3-7c9c-419e-a0d1-b6cb041cba6b.png">

