### PR TITLE
[XY axis] Fixes the scale type on a terms aggregation on a number field

### DIFF
--- a/src/plugins/vis_types/xy/public/config/get_axis.test.ts
+++ b/src/plugins/vis_types/xy/public/config/get_axis.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getScale } from './get_axis';
+import type { Scale } from '../types';
+
+describe('getScale', () => {
+  const axisScale = {
+    type: 'linear',
+    mode: 'normal',
+    scaleType: 'linear',
+  } as Scale;
+
+  it('returns linear type for a number', () => {
+    const format = { id: 'number' };
+    const scale = getScale(axisScale, {}, format, true);
+    expect(scale.type).toBe('linear');
+  });
+
+  it('returns ordinal type for a terms aggregation on a number field', () => {
+    const format = {
+      id: 'terms',
+      params: {
+        id: 'number',
+        otherBucketLabel: 'Other',
+        missingBucketLabel: 'Missing',
+      },
+    };
+    const scale = getScale(axisScale, {}, format, true);
+    expect(scale.type).toBe('ordinal');
+  });
+
+  it('returns ordinal type for a terms aggregation on a string field', () => {
+    const format = {
+      id: 'terms',
+      params: {
+        id: 'string',
+        otherBucketLabel: 'Other',
+        missingBucketLabel: 'Missing',
+      },
+    };
+    const scale = getScale(axisScale, {}, format, true);
+    expect(scale.type).toBe('ordinal');
+  });
+
+  it('returns ordinal type for a range aggregation on a number field', () => {
+    const format = {
+      id: 'range',
+      params: {
+        id: 'number',
+      },
+    };
+    const scale = getScale(axisScale, {}, format, true);
+    expect(scale.type).toBe('ordinal');
+  });
+
+  it('returns time type for a date histogram aggregation', () => {
+    const format = {
+      id: 'date',
+      params: {
+        pattern: 'HH:mm',
+      },
+    };
+    const scale = getScale(axisScale, { date: true }, format, true);
+    expect(scale.type).toBe('time');
+  });
+
+  it('returns linear type for an histogram aggregation', () => {
+    const format = { id: 'number' };
+    const scale = getScale(axisScale, { interval: 1 }, format, true);
+    expect(scale.type).toBe('linear');
+  });
+});

--- a/src/plugins/vis_types/xy/public/config/get_axis.ts
+++ b/src/plugins/vis_types/xy/public/config/get_axis.ts
@@ -120,7 +120,7 @@ function getScaleType(
   return type;
 }
 
-function getScale<S extends XScaleType | YScaleType>(
+export function getScale<S extends XScaleType | YScaleType>(
   scale: Scale,
   params: Aspect['params'],
   format: Aspect['format'],
@@ -130,7 +130,10 @@ function getScale<S extends XScaleType | YScaleType>(
     isCategoryAxis
       ? getScaleType(
           scale,
-          format?.id === 'number' || (format?.params?.id === 'number' && format?.id !== 'range'),
+          format?.id === 'number' ||
+            (format?.params?.id === 'number' &&
+              format?.id !== BUCKET_TYPES.RANGE &&
+              format?.id !== BUCKET_TYPES.TERMS),
           'date' in params,
           'interval' in params
         )


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/115340

This PR fixes a bug that exists when you try to create a horizontal axis with a terms aggregation on a number field. Until now, it was treated as a linear type and as a result, the missing values were added to the axis. This is wrong, as in terms we don't want a linear scale but an ordinal.

Also some unit tests have been inserted that they are not only testing this scenario but also various others.

Before:
![image](https://user-images.githubusercontent.com/17003240/138073559-2eec74c7-94d7-4a66-8cc8-a2a31e82f68b.png)

After:
![image](https://user-images.githubusercontent.com/17003240/138073624-aca6ae86-6ca7-4fd0-842c-5e9356bdb462.png)


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios