### PR TITLE
Fix save session UI appears in report

### DIFF
--- a/x-pack/plugins/data_enhanced/kibana.json
+++ b/x-pack/plugins/data_enhanced/kibana.json
@@ -8,7 +8,15 @@
     "githubTeam": "kibana-app-services"
   },
   "configPath": ["xpack", "data_enhanced"],
-  "requiredPlugins": ["bfetch", "data", "features", "management", "share", "taskManager"],
+  "requiredPlugins": [
+    "bfetch",
+    "data",
+    "features",
+    "management",
+    "share",
+    "taskManager",
+    "screenshotMode"
+  ],
   "optionalPlugins": ["kibanaUtils", "usageCollection", "security"],
   "server": true,
   "ui": true,

--- a/x-pack/plugins/data_enhanced/public/plugin.ts
+++ b/x-pack/plugins/data_enhanced/public/plugin.ts
@@ -22,6 +22,7 @@ import { toMountPoint } from '../../../../src/plugins/kibana_react/public';
 import { createConnectedSearchSessionIndicator } from './search';
 import { ConfigSchema } from '../config';
 import { Storage } from '../../../../src/plugins/kibana_utils/public';
+import { ScreenshotModePluginStart } from '../../../../src/plugins/screenshot_mode/public';
 
 export interface DataEnhancedSetupDependencies {
   bfetch: BfetchPublicSetup;
@@ -31,6 +32,7 @@ export interface DataEnhancedSetupDependencies {
 export interface DataEnhancedStartDependencies {
   data: DataPublicPluginStart;
   share: SharePluginStart;
+  screenshotMode: ScreenshotModePluginStart;
 }
 
 export type DataEnhancedSetup = ReturnType<DataEnhancedPlugin['setup']>;
@@ -77,6 +79,7 @@ export class DataEnhancedPlugin
                 .duration(this.config.search.sessions.notTouchedTimeout)
                 .asMilliseconds(),
               usageCollector: this.usageCollector,
+              tourDisabled: plugins.screenshotMode.isScreenshotMode(),
             })
           )
         ),

--- a/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/connected_search_session_indicator.test.tsx
+++ b/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/connected_search_session_indicator.test.tsx
@@ -39,6 +39,7 @@ timeFilter.getRefreshIntervalUpdate$.mockImplementation(() => refreshInterval$);
 timeFilter.getRefreshInterval.mockImplementation(() => refreshInterval$.getValue());
 
 const disableSaveAfterSessionCompletesTimeout = 5 * 60 * 1000;
+const tourDisabled = false;
 
 function Container({ children }: { children?: ReactNode }) {
   return <IntlProvider locale="en">{children}</IntlProvider>;
@@ -64,6 +65,7 @@ test("shouldn't show indicator in case no active search session", async () => {
     disableSaveAfterSessionCompletesTimeout,
     usageCollector,
     basePath,
+    tourDisabled,
   });
   const { getByTestId, container } = render(
     <Container>
@@ -92,6 +94,7 @@ test("shouldn't show indicator in case app hasn't opt-in", async () => {
     disableSaveAfterSessionCompletesTimeout,
     usageCollector,
     basePath,
+    tourDisabled,
   });
   const { getByTestId, container } = render(
     <Container>
@@ -122,6 +125,7 @@ test('should show indicator in case there is an active search session', async ()
     disableSaveAfterSessionCompletesTimeout,
     usageCollector,
     basePath,
+    tourDisabled,
   });
   const { getByTestId } = render(
     <Container>
@@ -147,6 +151,7 @@ test('should be disabled in case uiConfig says so ', async () => {
     disableSaveAfterSessionCompletesTimeout,
     usageCollector,
     basePath,
+    tourDisabled,
   });
 
   render(
@@ -170,6 +175,7 @@ test('should be disabled in case not enough permissions', async () => {
     storage,
     disableSaveAfterSessionCompletesTimeout,
     basePath,
+    tourDisabled,
   });
 
   render(
@@ -203,6 +209,7 @@ describe('Completed inactivity', () => {
       disableSaveAfterSessionCompletesTimeout,
       usageCollector,
       basePath,
+      tourDisabled,
     });
 
     render(
@@ -264,6 +271,7 @@ describe('tour steps', () => {
         disableSaveAfterSessionCompletesTimeout,
         usageCollector,
         basePath,
+        tourDisabled,
       });
       const rendered = render(
         <Container>
@@ -305,6 +313,7 @@ describe('tour steps', () => {
         disableSaveAfterSessionCompletesTimeout,
         usageCollector,
         basePath,
+        tourDisabled,
       });
       const rendered = render(
         <Container>
@@ -329,6 +338,51 @@ describe('tour steps', () => {
       expect(usageCollector.trackSessionIndicatorTourLoading).toHaveBeenCalledTimes(0);
       expect(usageCollector.trackSessionIndicatorTourRestored).toHaveBeenCalledTimes(0);
     });
+
+    test("doesn't show tour step on slow loading when tour is disabled", async () => {
+      const state$ = new BehaviorSubject(SearchSessionState.Loading);
+      const SearchSessionIndicator = createConnectedSearchSessionIndicator({
+        sessionService: { ...sessionService, state$ },
+        application,
+        storage,
+        disableSaveAfterSessionCompletesTimeout,
+        usageCollector,
+        basePath,
+        tourDisabled: true,
+      });
+      const rendered = render(
+        <Container>
+          <SearchSessionIndicator />
+        </Container>
+      );
+
+      await waitFor(() => rendered.getByTestId('searchSessionIndicator'));
+
+      expect(() => screen.getByTestId('searchSessionIndicatorPopoverContainer')).toThrow();
+
+      act(() => {
+        jest.advanceTimersByTime(10001);
+      });
+
+      expect(
+        screen.queryByTestId('searchSessionIndicatorPopoverContainer')
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+        state$.next(SearchSessionState.Completed);
+      });
+
+      expect(
+        screen.queryByTestId('searchSessionIndicatorPopoverContainer')
+      ).not.toBeInTheDocument();
+
+      expect(storage.get(TOUR_RESTORE_STEP_KEY)).toBeFalsy();
+      expect(storage.get(TOUR_TAKING_TOO_LONG_STEP_KEY)).toBeFalsy();
+
+      expect(usageCollector.trackSessionIndicatorTourLoading).toHaveBeenCalledTimes(0);
+      expect(usageCollector.trackSessionIndicatorTourRestored).toHaveBeenCalledTimes(0);
+    });
   });
 
   test('shows tour step for restored', async () => {
@@ -340,6 +394,7 @@ describe('tour steps', () => {
       disableSaveAfterSessionCompletesTimeout,
       usageCollector,
       basePath,
+      tourDisabled,
     });
     const rendered = render(
       <Container>
@@ -367,6 +422,7 @@ describe('tour steps', () => {
       disableSaveAfterSessionCompletesTimeout,
       usageCollector,
       basePath,
+      tourDisabled,
     });
     const rendered = render(
       <Container>

--- a/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/connected_search_session_indicator.tsx
+++ b/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/connected_search_session_indicator.tsx
@@ -31,6 +31,7 @@ export interface SearchSessionIndicatorDeps {
    * after the last search in the session has completed
    */
   disableSaveAfterSessionCompletesTimeout: number;
+  tourDisabled: boolean;
   usageCollector?: SearchUsageCollector;
 }
 
@@ -41,6 +42,7 @@ export const createConnectedSearchSessionIndicator = ({
   disableSaveAfterSessionCompletesTimeout,
   usageCollector,
   basePath,
+  tourDisabled,
 }: SearchSessionIndicatorDeps): React.FC => {
   const searchSessionsManagementUrl = basePath.prepend('/app/management/kibana/search_sessions');
 
@@ -113,6 +115,7 @@ export const createConnectedSearchSessionIndicator = ({
       searchSessionIndicator,
       state,
       saveDisabled,
+      tourDisabled,
       usageCollector
     );
 

--- a/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/search_session_tour.tsx
+++ b/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/search_session_tour.tsx
@@ -23,6 +23,7 @@ export function useSearchSessionTour(
   searchSessionIndicatorRef: SearchSessionIndicatorRef | null,
   state: SearchSessionState,
   searchSessionsDisabled: boolean,
+  disableSearchSessionsTour: boolean,
   usageCollector?: SearchUsageCollector
 ) {
   const markOpenedDone = useCallback(() => {
@@ -55,6 +56,7 @@ export function useSearchSessionTour(
 
   useEffect(() => {
     if (searchSessionsDisabled) return;
+    if (disableSearchSessionsTour) return;
     if (!searchSessionIndicatorRef) return;
     let timeoutHandle: number;
 
@@ -82,6 +84,7 @@ export function useSearchSessionTour(
     searchSessionIndicatorRef,
     state,
     searchSessionsDisabled,
+    disableSearchSessionsTour,
     markOpenedDone,
     markRestoredDone,
     usageCollector,

--- a/x-pack/plugins/data_enhanced/tsconfig.json
+++ b/x-pack/plugins/data_enhanced/tsconfig.json
@@ -22,6 +22,7 @@
     { "path": "../../../src/plugins/kibana_utils/tsconfig.json" },
     { "path": "../../../src/plugins/usage_collection/tsconfig.json" },
     { "path": "../../../src/plugins/management/tsconfig.json" },
+    { "path": "../../../src/plugins/screenshot_mode/tsconfig.json"},
     { "path": "../security/tsconfig.json" },
     { "path": "../task_manager/tsconfig.json" },
 


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/112267

If first user's search takes longer then 10 seconds we open a search session popup to prompt save or cancel the 
session.
This caused issue while generating reports, the popup appeared and resulting pdf/png

This pr disables popup auto-open when in screenshot mode


### How to test

Simulate long running visualization by using `shardDelay` agg in aggs based visualization:  Add `data.search.aggs.shardDelay.enabled: true` to enable the agg and create a vis with a delay longer the 10 seconds. 
Run dashboard report with that viz and check that search session popup isn't appearing anymore 
