### PR TITLE
[vscode] Exclude api_docs directory from search and watch

### DIFF
--- a/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
+++ b/packages/kbn-dev-utils/src/vscode_config/managed_config_keys.ts
@@ -20,21 +20,23 @@ export const MANAGED_CONFIG_KEYS: ManagedConfigKey[] = [
   {
     key: 'files.watcherExclude',
     value: {
-      ['**/.eslintcache']: true,
-      ['**/.es']: true,
-      ['**/.yarn-local-mirror']: true,
       ['**/.chromium']: true,
-      ['**/packages/kbn-pm/dist/index.js']: true,
+      ['**/.es']: true,
+      ['**/.eslintcache']: true,
+      ['**/.yarn-local-mirror']: true,
+      ['**/*.log']: true,
+      ['**/api_docs']: true,
       ['**/bazel-*']: true,
       ['**/node_modules']: true,
+      ['**/packages/kbn-pm/dist/index.js']: true,
       ['**/target']: true,
-      ['**/*.log']: true,
     },
   },
   {
     key: 'search.exclude',
     value: {
       ['**/packages/kbn-pm/dist/index.js']: true,
+      ['**/api_docs']: true,
     },
   },
   {


### PR DESCRIPTION
It's a generated directory and serves little (no?) purpose in searching.