### PR TITLE
[buildkite] Build PRs on buildkite by default

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -15,7 +15,8 @@
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
-      "skip_ci_labels": ["skip-ci", "jenkins-ci"]
+      "skip_ci_labels": ["skip-ci", "jenkins-ci"],
+      "skip_target_branches": ["6.8"]
     }
   ]
 }

--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -15,7 +15,7 @@
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
-      "labels": ["buildkite-ci"]
+      "skip_ci_labels": ["skip-ci", "jenkins-ci"]
     }
   ]
 }


### PR DESCRIPTION
- Add a `jenkins-ci` label that will build PRs on Jenkins if needed
- Remove `buildkite-ci` label requirement, which will cause all PRs to be built on Buildkite by default