### PR TITLE
[Security Solution][Timeline] Update event view actions column width

### DIFF
--- a/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
@@ -139,7 +139,7 @@ const EventRenderedViewComponent = ({
             </ActionsContainer>
           );
         },
-        width: '120px',
+        width: '152px',
       },
       {
         field: 'ecs.timestamp',


### PR DESCRIPTION
## Summary

The event view of timeline has an action column width defined in a separate place than the default view, so adding the analyze event button back caused the actions column to be too wide, this updates it to the correct value, current value + new button size, fixes https://github.com/elastic/kibana/issues/115705
![image](https://user-images.githubusercontent.com/56408403/138118853-ceeee4f1-450d-4f73-be2b-f4af472d01bb.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))



