### PR TITLE
[Canvas] Makes Canvas saved objects 'multiple-isolated'

### DIFF
--- a/x-pack/plugins/canvas/server/saved_objects/custom_element.ts
+++ b/x-pack/plugins/canvas/server/saved_objects/custom_element.ts
@@ -11,7 +11,8 @@ import { CUSTOM_ELEMENT_TYPE } from '../../common/lib/constants';
 export const customElementType: SavedObjectsType = {
   name: CUSTOM_ELEMENT_TYPE,
   hidden: false,
-  namespaceType: 'single',
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
   mappings: {
     dynamic: false,
     properties: {

--- a/x-pack/plugins/canvas/server/saved_objects/workpad.ts
+++ b/x-pack/plugins/canvas/server/saved_objects/workpad.ts
@@ -12,7 +12,8 @@ import { removeAttributesId } from './migrations/remove_attributes_id';
 export const workpadType: SavedObjectsType = {
   name: CANVAS_TYPE,
   hidden: false,
-  namespaceType: 'single',
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
   mappings: {
     dynamic: false,
     properties: {


### PR DESCRIPTION
Switches Canvas saved objects to be multiple-isolated in 8.0.0