### PR TITLE
[7.16] docs: update links to APM docs (#115664)

### DIFF
--- a/docs/apm/agent-configuration.asciidoc
+++ b/docs/apm/agent-configuration.asciidoc
@@ -24,16 +24,6 @@ APM agents will use local defaults until they're able to update the configuratio
 For this reason, it is still essential to set custom default configurations locally in each of your agents.
 
 [float]
-==== APM Server setup
-
-This feature requires {apm-server-ref}/setup-kibana-endpoint.html[Kibana endpoint configuration] in APM Server.
-In addition, if an APM agent is using {apm-server-ref}/configuration-anonymous.html[anonymous authentication] to communicate with the APM Server,
-the agent's service name must be included in the `apm-server.auth.anonymous.allow_service` list.
-
-APM Server acts as a proxy between the agents and Kibana.
-Kibana communicates any changed settings to APM Server so that your agents only need to poll APM Server to determine which settings have changed.
-
-[float]
 ==== Supported configurations
 
 Each Agent has a list of supported configurations.

--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -563,9 +563,7 @@ More information on Kibana's API is available in <<api,REST API>>.
 === RUM source map API
 
 IMPORTANT: This endpoint is only compatible with the
-{apm-server-ref}/apm-integration.html[APM integration for Elastic Agent].
-Users with a standalone APM Server should instead use the APM Server
-{apm-server-ref}/sourcemap-api.html[source map upload API].
+{apm-guide-ref}/index.html[APM integration for Elastic Agent].
 
 A source map allows minified files to be mapped back to original source code --
 allowing you to maintain the speed advantage of minified code,

--- a/docs/apm/apm-app-users.asciidoc
+++ b/docs/apm/apm-app-users.asciidoc
@@ -56,8 +56,8 @@ To create an APM reader user:
 include::./tab-widgets/apm-app-reader/widget.asciidoc[]
 --
 +
-TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
-Add the privileges under the **Data streams** tab.
+TIP: Using the deprecated APM Server binaries?
+Add the privileges under the **Classic APM indices** tab above.
 
 . Assign the `read-apm` role created in the previous step, and the following built-in roles to
 any APM reader users:
@@ -84,8 +84,8 @@ In some instances, you may wish to restrict certain Kibana apps that a user has 
 include::./tab-widgets/apm-app-reader/widget.asciidoc[]
 --
 +
-TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
-Add the privileges under the **Data streams** tab.
+TIP: Using the deprecated APM Server binaries?
+Add the privileges under the **Classic APM indices** tab above.
 
 . Assign feature privileges to any Kibana feature that the user needs access to.
 Here are two examples:
@@ -184,8 +184,8 @@ Central configuration users need to be able to view, create, update, and delete 
 include::./tab-widgets/central-config-users/widget.asciidoc[]
 --
 +
-TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
-Add the privileges under the **Data streams** tab.
+TIP: Using the deprecated APM Server binaries?
+Add the privileges under the **Classic APM indices** tab above.
 
 . Assign the `central-config-manager` role created in the previous step,
 and the following Kibana feature privileges to anyone who needs to manage central configurations:
@@ -211,8 +211,8 @@ but not create, update, or delete them.
 include::./tab-widgets/central-config-users/widget.asciidoc[]
 --
 +
-TIP: Using the {apm-server-ref-v}/apm-integration.html[APM integration for Elastic Agent]?
-Add the privileges under the **Data streams** tab.
+TIP: Using the deprecated APM Server binaries?
+Add the privileges under the **Classic APM indices** tab above.
 
 . Assign the `central-config-reader` role created in the previous step,
 and the following Kibana feature privileges to anyone who needs to read central configurations:

--- a/docs/apm/errors.asciidoc
+++ b/docs/apm/errors.asciidoc
@@ -2,7 +2,7 @@
 [[errors]]
 === Errors
 
-TIP: {apm-overview-ref-v}/errors.html[Errors] are groups of exceptions with a similar exception or log message.
+TIP: {apm-guide-ref}/data-model-errors.html[Errors] are groups of exceptions with a similar exception or log message.
 
 The *Errors* overview provides a high-level view of the exceptions that APM agents catch,
 or that users manually report with APM agent APIs.

--- a/docs/apm/getting-started.asciidoc
+++ b/docs/apm/getting-started.asciidoc
@@ -41,7 +41,11 @@ Notice something awry? Select a service or trace and dive deeper with:
 * <<metrics>>
 
 TIP: Want to learn more about the Elastic APM ecosystem?
+<<<<<<< HEAD
 See the {apm-overview-ref-v}/overview.html[APM Overview].
+=======
+See the {apm-guide-ref}/apm-overview.html[APM Overview].
+>>>>>>> 2daadc0d74d (docs: update links to APM docs (#115664))
 
 include::services.asciidoc[]
 

--- a/docs/apm/service-maps.asciidoc
+++ b/docs/apm/service-maps.asciidoc
@@ -41,7 +41,7 @@ We currently surface two types of service maps:
 === How do service maps work?
 
 Service maps rely on distributed traces to draw connections between services.
-As {apm-overview-ref-v}/distributed-tracing.html[distributed tracing] is enabled out-of-the-box for supported technologies, so are service maps.
+As {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] is enabled out-of-the-box for supported technologies, so are service maps.
 However, if a service isn't instrumented,
 or a `traceparent` header isn't being propagated to it,
 distributed tracing will not work, and the connection will not be drawn on the map.

--- a/docs/apm/spans.asciidoc
+++ b/docs/apm/spans.asciidoc
@@ -16,7 +16,7 @@ You also get a stack trace, which shows the SQL query in your code.
 Finally, APM knows which files are your code and which are just modules or libraries that you've installed.
 These library frames will be minimized by default in order to show you the most relevant stack trace.
 
-TIP: A {apm-overview-ref-v}/transaction-spans.html[span] is the duration of a single event.
+TIP: A {apm-guide-ref}/data-model-spans.html[span] is the duration of a single event.
 Spans are automatically captured by APM agents, and you can also define custom spans.
 Each span has a type and is defined by a different color in the timeline/waterfall visualization.
 

--- a/docs/apm/tab-widgets/apm-app-reader/widget.asciidoc
+++ b/docs/apm/tab-widgets/apm-app-reader/widget.asciidoc
@@ -2,28 +2,18 @@
 <div class="tabs" data-tab-group="apm-app-reader">
   <div role="tablist" aria-label="APM app reader">
     <button role="tab"
-            aria-selected="true"
+          aria-selected="true"
+          aria-controls="data-streams-tab"
+          id="data-streams"
+          tabindex="-1">
+      Data streams
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="classic-indices-tab"
             id="classic-indices">
       Classic APM indices
     </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="data-streams-tab"
-            id="data-streams"
-            tabindex="-1">
-      Data streams
-    </button>
-  </div>
-  <div tabindex="0"
-       role="tabpanel"
-       id="classic-indices-tab"
-       aria-labelledby="classic-indices">
-++++
-
-include::content.asciidoc[tag=classic-indices]
-
-++++
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -33,6 +23,16 @@ include::content.asciidoc[tag=classic-indices]
 ++++
 
 include::content.asciidoc[tag=data-streams]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="classic-indices-tab"
+       aria-labelledby="classic-indices">
+++++
+
+include::content.asciidoc[tag=classic-indices]
 
 ++++
   </div>

--- a/docs/apm/tab-widgets/central-config-users/widget.asciidoc
+++ b/docs/apm/tab-widgets/central-config-users/widget.asciidoc
@@ -2,28 +2,18 @@
 <div class="tabs" data-tab-group="central-config-manager">
   <div role="tablist" aria-label="Central config manager">
     <button role="tab"
-            aria-selected="true"
+          aria-selected="true"
+          aria-controls="data-streams-tab"
+          id="data-streams"
+          tabindex="-1">
+      Data streams
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="classic-indices-tab"
             id="classic-indices">
       Classic APM indices
     </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="data-streams-tab"
-            id="data-streams"
-            tabindex="-1">
-      Data streams
-    </button>
-  </div>
-  <div tabindex="0"
-       role="tabpanel"
-       id="classic-indices-tab"
-       aria-labelledby="classic-indices">
-++++
-
-include::content.asciidoc[tag=classic-indices]
-
-++++
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -33,6 +23,16 @@ include::content.asciidoc[tag=classic-indices]
 ++++
 
 include::content.asciidoc[tag=data-streams]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="classic-indices-tab"
+       aria-labelledby="classic-indices">
+++++
+
+include::content.asciidoc[tag=classic-indices]
 
 ++++
   </div>

--- a/docs/apm/transactions.asciidoc
+++ b/docs/apm/transactions.asciidoc
@@ -2,7 +2,7 @@
 [[transactions]]
 === Transactions
 
-TIP: A {apm-overview-ref-v}/transactions.html[transaction] describes an event captured by an Elastic APM agent instrumenting a service.
+TIP: A {apm-guide-ref}/data-model-transactions.html[transaction] describes an event captured by an Elastic APM agent instrumenting a service.
 APM agents automatically collect performance metrics on HTTP requests, database queries, and much more.
 
 [role="screenshot"]

--- a/docs/apm/troubleshooting.asciidoc
+++ b/docs/apm/troubleshooting.asciidoc
@@ -12,7 +12,7 @@ https://github.com/elastic/kibana/pulls[pull request] with your proposed changes
 If your issue is potentially related to other components of the APM ecosystem,
 don't forget to check our other troubleshooting guides or discussion forum:
 
-* {apm-server-ref}/troubleshooting.html[APM Server troubleshooting]
+* {apm-guide-ref}/troubleshoot-apm.html[APM Server troubleshooting]
 * {apm-dotnet-ref}/troubleshooting.html[.NET agent troubleshooting]
 * {apm-go-ref}/troubleshooting.html[Go agent troubleshooting]
 * {apm-ios-ref}/troubleshooting.html[iOS agent troubleshooting]
@@ -53,7 +53,7 @@ By default, this index template is created by APM Server on startup.
 However, this only happens if `setup.template.enabled` is `true` in `apm-server.yml`.
 You can create the index template manually by running `apm-server setup`.
 Take note that index templates *cannot* be applied retroactively -- they are only applied at index creation time.
-More information is available in {apm-server-ref}/apm-server-configuration.html[Set up and configure].
+More information is available in {apm-guide-ref}/apm-server-configuration.html[Set up and configure].
 
 You can check for the existence of an APM index template using the
 {ref}/indices-get-template.html[Get index template API].
@@ -68,12 +68,12 @@ GET /_template/apm-{version}
 *Using Logstash, Kafka, etc.*
 If you're not outputting data directly from APM Server to Elasticsearch (perhaps you're using Logstash or Kafka),
 then the index template will not be set up automatically. Instead, you'll need to
-{apm-server-ref}/apm-server-template.html[load the template manually].
+{apm-guide-ref}/apm-server-template.html[load the template manually].
 
 *Using a custom index names*
 This problem can also occur if you've customized the index name that you write APM data to.
 If you change the default, you must also configure the `setup.template.name` and `setup.template.pattern` options.
-See {apm-server-ref}/configuration-template.html[Load the Elasticsearch index template].
+See {apm-guide-ref}/configuration-template.html[Load the Elasticsearch index template].
 If the Elasticsearch index template has already been successfully loaded to the index,
 you can customize the indices that the APM app uses to display data.
 Navigate to *APM* > *Settings* > *Indices*, and change all `xpack.apm.indices.*` values to
@@ -118,8 +118,8 @@ Instead, we should strip away the unique information and group our transactions 
 In this case, that means naming all blog transactions, `/blog`, and all documentation transactions, `/guide`.
 
 If you feel like you'd be losing valuable information by following this naming convention, don't fret!
-You can always add additional metadata to your transactions using {apm-overview-ref-v}/metadata.html#labels-fields[labels] (indexed) or
-{apm-overview-ref-v}/metadata.html#custom-fields[custom context] (non-indexed).
+You can always add additional metadata to your transactions using {apm-guide-ref-v}/metadata.html#labels-fields[labels] (indexed) or
+{apm-guide-ref-v}/metadata.html#custom-fields[custom context] (non-indexed).
 
 After ensuring you've correctly named your transactions,
 you might still see an error in the APM app related to too many transaction names.
@@ -182,10 +182,10 @@ Selecting the `apm-*` index pattern shows a listing of every field defined in th
 *Ensure a field is searchable*
 There are two things you can do to if you'd like to ensure a field is searchable:
 
-1. Index your additional data as {apm-overview-ref-v}/metadata.html[labels] instead.
+1. Index your additional data as {apm-guide-ref}/metadata.html[labels] instead.
 These are dynamic by default, which means they will be indexed and become searchable and aggregatable.
 
-2. Use the {apm-server-ref}/configuration-template.html[`append_fields`] feature. As an example,
+2. Use the {apm-guide-ref}/configuration-template.html[`append_fields`] feature. As an example,
 adding the following to `apm-server.yml` will enable dynamic indexing for `http.request.cookies`:
 
 [source,yml]

--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -84,7 +84,7 @@ Changing these settings may disable features of the APM App.
 
 | `xpack.apm.searchAggregatedTransactions` {ess-icon}
   | experimental[] Enables Transaction histogram metrics. Defaults to `never` and aggregated transactions are not used. When set to `auto`, the UI will use metric indices over transaction indices for transactions if aggregated transactions are found. When set to `always`, additional configuration in APM Server is required.
-    See {apm-server-ref-v}/transaction-metrics.html[Configure transaction metrics] for more information.
+    See {apm-guide-ref}/transaction-metrics.html[Configure transaction metrics] for more information.
 
 | `xpack.apm.metricsInterval` {ess-icon}
   | Sets a `fixed_interval` for date histograms in metrics aggregations. Defaults to `30`.
@@ -93,22 +93,22 @@ Changing these settings may disable features of the APM App.
   | Set to `false` to disable cloud APM migrations. Defaults to `true`.
 
 | `xpack.apm.indices.error` {ess-icon}
-  | Matcher for all {apm-server-ref}/error-indices.html[error indices]. Defaults to `logs-apm*,apm-*`.
+  | Matcher for all error indices. Defaults to `logs-apm*,apm-*`.
 
 | `xpack.apm.indices.onboarding` {ess-icon}
   | Matcher for all onboarding indices. Defaults to `apm-*`.
 
 | `xpack.apm.indices.span` {ess-icon}
-  | Matcher for all {apm-server-ref}/span-indices.html[span indices]. Defaults to `traces-apm*,apm-*`.
+  | Matcher for all span indices. Defaults to `traces-apm*,apm-*`.
 
 | `xpack.apm.indices.transaction` {ess-icon}
-  | Matcher for all {apm-server-ref}/transaction-indices.html[transaction indices]. Defaults to `traces-apm*,apm-*`.
+  | Matcher for all transaction indices. Defaults to `traces-apm*,apm-*`.
 
 | `xpack.apm.indices.metric` {ess-icon}
-  | Matcher for all {apm-server-ref}/metricset-indices.html[metrics indices]. Defaults to `metrics-apm*,apm-*`.
+  | Matcher for all metrics indices. Defaults to `metrics-apm*,apm-*`.
 
 | `xpack.apm.indices.sourcemap` {ess-icon}
-  | Matcher for all {apm-server-ref}/sourcemap-indices.html[source map indices]. Defaults to `apm-*`.
+  | Matcher for all source map indices. Defaults to `apm-*`.
 
 |===
 

--- a/docs/user/security/tutorials/how-to-secure-access-to-kibana.asciidoc
+++ b/docs/user/security/tutorials/how-to-secure-access-to-kibana.asciidoc
@@ -13,7 +13,7 @@ This guide introduces you to three of {kib}'s security features: spaces, roles, 
 
 Do you have multiple teams or tenants using {kib}? Do you want a “playground” to experiment with new visualizations or alerts? If so, then <<xpack-spaces,{kib} Spaces>> can help.
 
-Think of a space as another instance of {kib}. A space allows you to organize your <<dashboard, dashboards>>, <<alerting-getting-started, alerts>>, <<xpack-ml, machine learning jobs>>, and much more into their own categories. For example, you might have a Marketing space for your marketeers to track the results of their campaigns, and an Engineering space for your developers to {apm-get-started-ref}/overview.html[monitor application performance].
+Think of a space as another instance of {kib}. A space allows you to organize your <<dashboard, dashboards>>, <<alerting-getting-started, alerts>>, <<xpack-ml, machine learning jobs>>, and much more into their own categories. For example, you might have a Marketing space for your marketeers to track the results of their campaigns, and an Engineering space for your developers to {apm-guide-ref}/apm-overview.html[monitor application performance].
 
 The assets you create in one space are isolated from other spaces, so when you enter a space, you only see the assets that belong to that space.
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - docs: update links to APM docs (#115664)