### PR TITLE
[backports]  7.16 should not be checked by default

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "upstream": "elastic/kibana",
   "targetBranchChoices": [
     { "name": "master", "checked": true },
-    { "name": "7.16", "checked": true },
+    "7.16",
     "7.15",
     "7.14",
     "7.13",


### PR DESCRIPTION
I missed it as part of https://github.com/elastic/kibana/pull/115783.