### PR TITLE
[Logs UI] [Metrics UI] Register deprecations for the logAlias and metricAlias config settings

### DIFF
--- a/x-pack/plugins/infra/server/deprecations.ts
+++ b/x-pack/plugins/infra/server/deprecations.ts
@@ -142,7 +142,7 @@ const FIELD_DEPRECATION_FACTORIES: Record<string, (configNames: string[]) => Dep
     }),
   };
 
-export const configDeprecations: ConfigDeprecationProvider = () => [
+export const configDeprecations: ConfigDeprecationProvider = ({ deprecate }) => [
   ...Object.keys(FIELD_DEPRECATION_FACTORIES).map(
     (key): ConfigDeprecation =>
       (completeConfig, rootPath, addDeprecation) => {
@@ -179,6 +179,8 @@ export const configDeprecations: ConfigDeprecationProvider = () => [
         return completeConfig;
       }
   ),
+  deprecate('sources.default.logAlias', '8.0.0'),
+  deprecate('sources.default.metricAlias', '8.0.0'),
 ];
 
 export const getInfraDeprecationsFactory =


### PR DESCRIPTION
## :memo: Summary

This adds deprecation notices for the `xpack.infra.sources.default.{log,metric}Alias` config settings, since those have been configurable via the UI for a long time and only served as fall-backs since.

## :hourglass_flowing_sand: Follow-up tasks

- Actually remove these settings in `master` for `8.0.0`.