### PR TITLE
Re-enable skipped unit tests due to migration to Node 16

### DIFF
--- a/x-pack/plugins/stack_alerts/server/plugin.test.ts
+++ b/x-pack/plugins/stack_alerts/server/plugin.test.ts
@@ -11,8 +11,7 @@ import { alertsMock } from '../../alerting/server/mocks';
 import { featuresPluginMock } from '../../features/server/mocks';
 import { BUILT_IN_ALERTS_FEATURE } from './feature';
 
-// unhandled promise rejection: https://github.com/elastic/kibana/issues/112699
-describe.skip('AlertingBuiltins Plugin', () => {
+describe('AlertingBuiltins Plugin', () => {
   describe('setup()', () => {
     let context: ReturnType<typeof coreMock['createPluginInitializerContext']>;
     let plugin: AlertingBuiltinsPlugin;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/114776

The fix was actually done as part of https://github.com/elastic/kibana/pull/113213/files#diff-292aed65996ababbf19c9d8ff150d68d3cd5b1b670d1cceb414a4164bfca1331, so this PR un-skips the test and ensures CI passes.