### PR TITLE
[buildkite] FTSR / limit concurrency and total jobs

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -17,12 +17,6 @@ const inputs = [
     default: 0,
     required: true,
   },
-  {
-    key: 'ftsr-concurrency',
-    text: 'Max concurrency per step',
-    default: 20,
-    required: true,
-  },
 ];
 
 for (let i = 1; i <= OSS_CI_GROUPS; i++) {

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -30,7 +30,7 @@ for (let i = 1; i <= XPACK_CI_GROUPS; i++) {
 const pipeline = {
   steps: [
     {
-      input: 'Number of Runs',
+      input: 'Number of Runs - Click Me',
       fields: inputs,
     },
     {

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -33,6 +33,7 @@ for (const key of keys) {
 }
 
 if (totalJobs > 500) {
+  console.error('+++ Too many tests');
   console.error(
     `Buildkite builds can only contain 500 steps in total. Found ${totalJobs} in total. Make sure your test runs are less than ${
       500 - initialJobs


### PR DESCRIPTION
- Limit overall number of steps to 500 (this is a limit for our org in Buildkite currently)
- Always set concurrency to 25, so 25 jobs will run in parallel at a time.