### PR TITLE
Refactors discover functional tests

### DIFF
--- a/test/functional/apps/discover/_discover.ts
+++ b/test/functional/apps/discover/_discover.ts
@@ -133,7 +133,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           return actualCount === expectedCount;
         });
         const newDurationHours = await PageObjects.timePicker.getTimeDurationInHours();
-        expect(Math.round(newDurationHours)).to.be(26);
+        expect(Math.ceil(newDurationHours)).to.be(26);
 
         await retry.waitFor('doc table containing the documents of the brushed range', async () => {
           const rowData = await PageObjects.discover.getDocTableField(1);

--- a/test/functional/apps/discover/_errors.ts
+++ b/test/functional/apps/discover/_errors.ts
@@ -24,7 +24,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async function () {
-      await esArchiver.load('test/functional/fixtures/es_archiver/empty_kibana');
+      // await esArchiver.load('test/functional/fixtures/es_archiver/empty_kibana');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/invalid_scripted_field');
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 
     describe('invalid scripted field error', () => {

--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -371,7 +371,8 @@ export class DiscoverPageObject extends FtrService {
   public async clickFieldListItemAdd(field: string) {
     // a filter check may make sense here, but it should be properly handled to make
     // it work with the _score and _source fields as well
-    if (await this.isFieldSelected(field)) {
+    const fieldIsSelected = await this.isFieldSelected(field);
+    if (fieldIsSelected) {
       return;
     }
     await this.clickFieldListItemToggle(field);
@@ -388,7 +389,8 @@ export class DiscoverPageObject extends FtrService {
   }
 
   public async isFieldSelected(field: string) {
-    if (!(await this.testSubjects.exists('fieldList-selected'))) {
+    const fieldExists = await this.testSubjects.exists('fieldList-selected');
+    if (!fieldExists) {
       return false;
     }
     const selectedList = await this.testSubjects.find('fieldList-selected');


### PR DESCRIPTION
Fix OSS ciGroup6 (discover functional tests)
Cause(s): 
- Tests not being cleaned up in after hook
- Behavior of Math functions 