### PR TITLE
[FLEET] Increase asset size limit for installing ML model packages

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -29,10 +29,11 @@ import { getArchiveEntry, setArchiveEntry, setArchiveFilelist, setPackageInfo } 
 import type { ArchiveEntry } from './index';
 import { parseAndVerifyPolicyTemplates, parseAndVerifyStreams } from './validation';
 
+const ONE_BYTE = 1024 * 1024;
 // could be anything, picked this from https://github.com/elastic/elastic-agent-client/issues/17
-const MAX_ES_ASSET_BYTES = 4 * 1024 * 1024;
+const MAX_ES_ASSET_BYTES = 4 * ONE_BYTE;
 // Updated to accomodate larger package size in some ML model packages
-const ML_MAX_ES_ASSET_BYTES = 50 * 1024 * 1024;
+const ML_MAX_ES_ASSET_BYTES = 50 * ONE_BYTE;
 
 export interface PackageAsset {
   package_name: string;

--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -30,7 +30,8 @@ import type { ArchiveEntry } from './index';
 import { parseAndVerifyPolicyTemplates, parseAndVerifyStreams } from './validation';
 
 // could be anything, picked this from https://github.com/elastic/elastic-agent-client/issues/17
-const MAX_ES_ASSET_BYTES = 4 * 1024 * 1024;
+// Updated to accomodate larger package size in some ML model packages
+const MAX_ES_ASSET_BYTES = 50 * 1024 * 1024;
 
 export interface PackageAsset {
   package_name: string;


### PR DESCRIPTION
## Summary

Increases asset size limit for ML model packages.
This is a potentially temporary change to accommodate DGA model (which is about 45mb) installation - the 4mb limit is kept for all other asset types as per https://github.com/elastic/elastic-agent-client/issues/17

This could be improved on in the future if necessary by making the limit an option to be passed in or other options discussed in the above issue.


### Checklist

Delete any items that are not applicable to this PR.
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
