### PR TITLE
[ML] Functional tests - re-activate a11y suite

### DIFF
--- a/x-pack/test/accessibility/apps/ml.ts
+++ b/x-pack/test/accessibility/apps/ml.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const a11y = getService('a11y');
   const ml = getService('ml');
 
-  // Failing: See https://github.com/elastic/kibana/issues/115666
-  describe.skip('ml', () => {
+  describe('ml', () => {
     const esArchiver = getService('esArchiver');
 
     before(async () => {


### PR DESCRIPTION
## Summary

This PR re-activates the ML accessibility test suite.

The suite has been skipped due to flakiness in the data viz time range selection, which should be fixed by #115592.

Closes #115666
