### PR TITLE
[7.16] remove any from filter persistable state (#115128)

### DIFF
--- a/src/plugins/data/common/query/persistable_state.ts
+++ b/src/plugins/data/common/query/persistable_state.ts
@@ -8,7 +8,6 @@
 
 import uuid from 'uuid';
 import { Filter } from '@kbn/es-query';
-import type { SerializableRecord } from '@kbn/utility-types';
 import { SavedObjectReference } from '../../../../core/types';
 
 export const extract = (filters: Filter[]) => {
@@ -51,12 +50,8 @@ export const inject = (filters: Filter[], references: SavedObjectReference[]) =>
   });
 };
 
-export const telemetry = (filters: SerializableRecord, collector: unknown) => {
+export const telemetry = (filters: Filter[], collector: unknown) => {
   return {};
-};
-
-export const migrateToLatest = (filters: Filter[], version: string) => {
-  return filters;
 };
 
 export const getAllMigrations = () => {

--- a/src/plugins/data/public/query/filter_manager/filter_manager.ts
+++ b/src/plugins/data/public/query/filter_manager/filter_manager.ts
@@ -26,13 +26,12 @@ import {
 import { PersistableStateService } from '../../../../kibana_utils/common/persistable_state';
 import {
   getAllMigrations,
-  migrateToLatest,
   inject,
   extract,
   telemetry,
 } from '../../../common/query/persistable_state';
 
-export class FilterManager implements PersistableStateService {
+export class FilterManager implements PersistableStateService<Filter[]> {
   private filters: Filter[] = [];
   private updated$: Subject<void> = new Subject();
   private fetch$: Subject<void> = new Subject();
@@ -228,16 +227,11 @@ export class FilterManager implements PersistableStateService {
     });
   }
 
-  // Filter needs to implement SerializableRecord
-  public extract = extract as any;
+  public extract = extract;
 
-  // Filter needs to implement SerializableRecord
-  public inject = inject as any;
+  public inject = inject;
 
   public telemetry = telemetry;
-
-  // Filter needs to implement SerializableRecord
-  public migrateToLatest = migrateToLatest as any;
 
   public getAllMigrations = getAllMigrations;
 }

--- a/src/plugins/data/server/query/query_service.ts
+++ b/src/plugins/data/server/query/query_service.ts
@@ -8,13 +8,7 @@
 
 import { CoreSetup, Plugin } from 'kibana/server';
 import { querySavedObjectType } from '../saved_objects';
-import {
-  extract,
-  inject,
-  telemetry,
-  migrateToLatest,
-  getAllMigrations,
-} from '../../common/query/persistable_state';
+import { extract, inject, telemetry, getAllMigrations } from '../../common/query/persistable_state';
 
 export class QueryService implements Plugin<void> {
   public setup(core: CoreSetup) {
@@ -25,7 +19,6 @@ export class QueryService implements Plugin<void> {
         extract,
         inject,
         telemetry,
-        migrateToLatest,
         getAllMigrations,
       },
     };

--- a/src/plugins/kibana_utils/common/persistable_state/types.ts
+++ b/src/plugins/kibana_utils/common/persistable_state/types.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { SerializableRecord } from '@kbn/utility-types';
+import type { SerializableRecord, Serializable } from '@kbn/utility-types';
 import { SavedObjectReference } from '../../../../core/types';
 
 /**
@@ -26,7 +26,7 @@ import { SavedObjectReference } from '../../../../core/types';
  * };
  * ```
  */
-export interface VersionedState<S extends SerializableRecord = SerializableRecord> {
+export interface VersionedState<S extends Serializable = Serializable> {
   version: string;
   state: S;
 }
@@ -116,7 +116,7 @@ export type PersistableStateDefinition<P extends SerializableRecord = Serializab
 /**
  * @todo Add description.
  */
-export interface PersistableStateService<P extends SerializableRecord = SerializableRecord> {
+export interface PersistableStateService<P extends Serializable = Serializable> {
   /**
    * Function which reports telemetry information. This function is essentially
    * a "reducer" - it receives the existing "stats" object and returns an

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/__snapshots__/index.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`Header rendering renders correctly against snapshot 1`] = `
         "filters": Array [],
         "getAllMigrations": [Function],
         "inject": [Function],
-        "migrateToLatest": [Function],
         "telemetry": [Function],
         "uiSettings": Object {
           "get": [MockFunction],


### PR DESCRIPTION
Backports the following commits to 7.16:
 - remove any from filter persistable state (#115128)