### PR TITLE
[Pie] Fixes the deprecation message on the legacy library switch

### DIFF
--- a/src/plugins/vis_types/pie/server/plugin.ts
+++ b/src/plugins/vis_types/pie/server/plugin.ts
@@ -14,8 +14,8 @@ import { CoreSetup, Plugin, UiSettingsParams } from 'kibana/server';
 import { LEGACY_PIE_CHARTS_LIBRARY } from '../common';
 
 export const getUiSettingsConfig: () => Record<string, UiSettingsParams<boolean>> = () => ({
-  // TODO: Remove this when vis_type_vislib is removed
-  // https://github.com/elastic/kibana/issues/56143
+  // TODO: Remove this when vislib pie is removed
+  // https://github.com/elastic/kibana/issues/111246
   [LEGACY_PIE_CHARTS_LIBRARY]: {
     name: i18n.translate('visTypePie.advancedSettings.visualization.legacyPieChartsLibrary.name', {
       defaultMessage: 'Pie legacy charts library',
@@ -33,7 +33,7 @@ export const getUiSettingsConfig: () => Record<string, UiSettingsParams<boolean>
         'visTypePie.advancedSettings.visualization.legacyPieChartsLibrary.deprecation',
         {
           defaultMessage:
-            'The legacy charts library for pie in visualize is deprecated and will not be supported as of 8.0.',
+            'The legacy charts library for pie in visualize is deprecated and will not be supported in a future version.',
         }
       ),
       docLinksKey: 'visualizationSettings',


### PR DESCRIPTION
## Summary

Fixes the tooltip message on the `Legacy pie chart library` advanced setting. It wrongly mentioned the v8 version which is wrong as we are most probably going to remove it in 8.2. We prefer to make the message more generic here as we are not quite sure about the target version.

![image](https://user-images.githubusercontent.com/17003240/138261485-41f0ee0c-5525-4826-9224-98246c03838b.png)