### PR TITLE
[Index Management] Forward port of the fix for indices table test

### DIFF
--- a/x-pack/plugins/index_management/__jest__/components/__snapshots__/index_table.test.js.snap
+++ b/x-pack/plugins/index_management/__jest__/components/__snapshots__/index_table.test.js.snap
@@ -22,7 +22,7 @@ exports[`index table force merge button works from context menu 3`] = `"open"`;
 
 exports[`index table open index button works from context menu 1`] = `"opening..."`;
 
-exports[`index table open index button works from context menu 2`] = `"opening..."`;
+exports[`index table open index button works from context menu 2`] = `"open"`;
 
 exports[`index table refresh button works from context menu 1`] = `"refreshing..."`;
 

--- a/x-pack/plugins/index_management/__jest__/components/index_table.test.js
+++ b/x-pack/plugins/index_management/__jest__/components/index_table.test.js
@@ -88,6 +88,14 @@ const snapshot = (rendered) => {
   expect(rendered).toMatchSnapshot();
 };
 
+const names = (rendered) => {
+  return findTestSubject(rendered, 'indexTableIndexNameLink');
+};
+
+const namesText = (rendered) => {
+  return names(rendered).map((button) => button.text());
+};
+
 const openMenuAndClickButton = (rendered, rowIndex, buttonSelector) => {
   // Select a row.
   const checkboxes = findTestSubject(rendered, 'indexTableRowCheckbox');
@@ -111,7 +119,8 @@ const testEditor = (rendered, buttonSelector, rowIndex = 0) => {
   snapshot(findTestSubject(rendered, 'detailPanelTabSelected').text());
 };
 
-const testAction = (rendered, buttonSelector, rowIndex = 0) => {
+const testAction = (rendered, buttonSelector, indexName = 'testy0') => {
+  const rowIndex = namesText(rendered).indexOf(indexName);
   // This is leaking some implementation details about how Redux works. Not sure exactly what's going on
   // but it looks like we're aware of how many Redux actions are dispatched in response to user interaction,
   // so we "time" our assertion based on how many Redux actions we observe. This is brittle because it
@@ -130,14 +139,6 @@ const testAction = (rendered, buttonSelector, rowIndex = 0) => {
   openMenuAndClickButton(rendered, rowIndex, buttonSelector);
   // take snapshot of initial state.
   snapshot(status(rendered, rowIndex));
-};
-
-const names = (rendered) => {
-  return findTestSubject(rendered, 'indexTableIndexNameLink');
-};
-
-const namesText = (rendered) => {
-  return names(rendered).map((button) => button.text());
 };
 
 const getActionMenuButtons = (rendered) => {
@@ -487,24 +488,23 @@ describe('index table', () => {
   });
 
   test('open index button works from context menu', async () => {
-    const rendered = mountWithIntl(component);
-    await runAllPromises();
-    rendered.update();
-
     const modifiedIndices = indices.map((index) => {
       return {
         ...index,
-        status: index.name === 'testy1' ? 'open' : index.status,
+        status: index.name === 'testy1' ? 'closed' : index.status,
       };
     });
 
-    server.respondWith(`${API_BASE_PATH}/indices/reload`, [
+    server.respondWith(`${API_BASE_PATH}/indices`, [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify(modifiedIndices),
     ]);
 
-    testAction(rendered, 'openIndexMenuButton', 1);
+    const rendered = mountWithIntl(component);
+    await runAllPromises();
+    rendered.update();
+    testAction(rendered, 'openIndexMenuButton', 'testy1');
   });
 
   test('show settings button works from context menu', async () => {


### PR DESCRIPTION
## Summary

This [PR](https://github.com/elastic/kibana/pull/114900) added specific `data-test-subj` to the context buttons in the indices table to make testing easier, but the [backport](https://github.com/elastic/kibana/pull/114959) to 7.16 was failing because of the differences between 8.0 and 7.16 in how indices are displayed. I added additional code to fix the failing tests and now this needs to be forward ported to master. 