### PR TITLE
[7.16] [CodeEditor] add support of triple quotes (#112656)

### DIFF
--- a/packages/kbn-monaco/src/xjson/grammar.test.ts
+++ b/packages/kbn-monaco/src/xjson/grammar.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createParser } from './grammar';
+
+describe('createParser', () => {
+  let parser: ReturnType<typeof createParser>;
+
+  beforeEach(() => {
+    parser = createParser();
+  });
+
+  test('should create a xjson grammar parser', () => {
+    expect(createParser()).toBeInstanceOf(Function);
+  });
+
+  test('should return no annotations in case of valid json', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": "file",
+          "value": "File",
+          "quotes": "'\\"",
+          "popup": {
+            "actions": [
+              "new",
+              "open",
+              "close"
+            ],
+            "menuitem": [
+              {"value": "New"},
+              {"value": "Open"},
+              {"value": "Close"}
+            ]
+          }
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [],
+      }
+    `);
+  });
+
+  test('should support triple quotes', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": """
+          file
+          """,
+          "value": "File"
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [],
+      }
+    `);
+  });
+
+  test('triple quotes should be correctly closed', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": """"
+          file
+          "",
+          "value": "File"
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [
+          Object {
+            "at": 36,
+            "text": "Expected ',' instead of '\\"'",
+            "type": "error",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('an escaped quote can be appended to the end of triple quotes', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": """
+          file
+          \\"""",
+          "value": "File"
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [],
+      }
+    `);
+  });
+
+  test('text values should be wrapper into quotes', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": id,
+          "value": "File"
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [
+          Object {
+            "at": 36,
+            "text": "Unexpected 'i'",
+            "type": "error",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('check for close quotes', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": "id,
+          "value": "File"
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [
+          Object {
+            "at": 52,
+            "text": "Expected ',' instead of 'v'",
+            "type": "error",
+          },
+        ],
+      }
+    `);
+  });
+  test('no duplicate keys', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": "id",
+          "id": "File"
+        }}
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [
+          Object {
+            "at": 53,
+            "text": "Duplicate key \\"id\\"",
+            "type": "warning",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('all curly quotes should be closed', () => {
+    expect(
+      parser(`
+        {"menu": {
+          "id": "id",
+          "name": "File"
+       }
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "annotations": Array [
+          Object {
+            "at": 82,
+            "text": "Expected ',' instead of ''",
+            "type": "error",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/packages/kbn-monaco/src/xjson/lexer_rules/xjson.ts
+++ b/packages/kbn-monaco/src/xjson/lexer_rules/xjson.ts
@@ -103,6 +103,7 @@ export const lexerRules: monaco.languages.IMonarchLanguage = {
 
     string_literal: [
       [/"""/, { token: 'punctuation.end_triple_quote', next: '@pop' }],
+      [/\\""""/, { token: 'punctuation.end_triple_quote', next: '@pop' }],
       [/./, { token: 'multi_string' }],
     ],
   },

--- a/src/plugins/data/common/search/aggs/param_types/json.test.ts
+++ b/src/plugins/data/common/search/aggs/param_types/json.test.ts
@@ -67,10 +67,34 @@ describe('JSON', function () {
       aggParam.write(aggConfig, output);
       expect(aggConfig.params).toHaveProperty(paramName);
 
-      expect(output.params).toEqual({
-        existing: 'true',
-        new_param: 'should exist in output',
-      });
+      expect(output.params).toMatchInlineSnapshot(`
+        Object {
+          "existing": "true",
+          "new_param": "should exist in output",
+        }
+      `);
+    });
+
+    it('should append param when valid JSON with triple quotes', () => {
+      const aggParam = initAggParam();
+      const jsonData = `{
+      "a": """
+        multiline string - line 1
+      """
+      }`;
+
+      aggConfig.params[paramName] = jsonData;
+
+      aggParam.write(aggConfig, output);
+      expect(aggConfig.params).toHaveProperty(paramName);
+
+      expect(output.params).toMatchInlineSnapshot(`
+        Object {
+          "a": "
+                multiline string - line 1
+              ",
+        }
+      `);
     });
 
     it('should not overwrite existing params', () => {

--- a/src/plugins/data/common/search/aggs/param_types/json.ts
+++ b/src/plugins/data/common/search/aggs/param_types/json.ts
@@ -11,6 +11,17 @@ import _ from 'lodash';
 import { IAggConfig } from '../agg_config';
 import { BaseParamType } from './base';
 
+function collapseLiteralStrings(xjson: string) {
+  const tripleQuotes = '"""';
+  const splitData = xjson.split(tripleQuotes);
+
+  for (let idx = 1; idx < splitData.length - 1; idx += 2) {
+    splitData[idx] = JSON.stringify(splitData[idx]);
+  }
+
+  return splitData.join('');
+}
+
 export class JsonParamType extends BaseParamType {
   constructor(config: Record<string, any>) {
     super(config);
@@ -26,9 +37,8 @@ export class JsonParamType extends BaseParamType {
           return;
         }
 
-        // handle invalid Json input
         try {
-          paramJson = JSON.parse(param);
+          paramJson = JSON.parse(collapseLiteralStrings(param));
         } catch (err) {
           return;
         }

--- a/src/plugins/vis_default_editor/kibana.json
+++ b/src/plugins/vis_default_editor/kibana.json
@@ -3,7 +3,7 @@
   "version": "kibana",
   "ui": true,
   "optionalPlugins": ["visualize"],
-  "requiredBundles": ["kibanaUtils", "kibanaReact", "data", "fieldFormats", "discover"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact", "data", "fieldFormats", "discover", "esUiShared"],
   "owner": {
     "name": "Vis Editors",
     "githubTeam": "kibana-vis-editors"

--- a/src/plugins/vis_default_editor/public/components/controls/raw_json.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/raw_json.tsx
@@ -14,6 +14,7 @@ import { EuiFormRow, EuiIconTip, EuiScreenReaderOnly } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { XJsonLang } from '@kbn/monaco';
 import { CodeEditor } from '../../../../kibana_react/public';
+import { XJson } from '../../../../es_ui_shared/public';
 
 import { AggParamEditorProps } from '../agg_param_props';
 
@@ -60,7 +61,7 @@ function RawJsonParamEditor({
       let isJsonValid = true;
       try {
         if (newValue) {
-          JSON.parse(newValue);
+          JSON.parse(XJson.collapseLiteralStrings(newValue));
         }
       } catch (e) {
         isJsonValid = false;


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [CodeEditor] add support of triple quotes (#112656)