### PR TITLE
[APM] Dark metadata icons on service overview page

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
@@ -50,7 +50,7 @@ export function IconPopover({
           <EuiIcon
             type={icon.type}
             size={icon.size ?? 'l'}
-            color={icon.color ?? 'text'}
+            color={icon.color}
           />
         </EuiButtonEmpty>
       }


### PR DESCRIPTION
closes #115955

<img width="510" alt="Screen Shot 2021-10-21 at 11 40 32 AM" src="https://user-images.githubusercontent.com/55978943/138311562-7c1a2d88-b6af-44a3-a7b1-1a3e8dd092d5.png">
