### PR TITLE
chore(NA): upgrades lmdb-store to v1.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -744,7 +744,7 @@
     "jsondiffpatch": "0.4.1",
     "license-checker": "^16.0.0",
     "listr": "^0.14.1",
-    "lmdb-store": "^1.6.8",
+    "lmdb-store": "^1.6.10",
     "marge": "^1.0.1",
     "micromatch": "3.1.10",
     "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -744,7 +744,7 @@
     "jsondiffpatch": "0.4.1",
     "license-checker": "^16.0.0",
     "listr": "^0.14.1",
-    "lmdb-store": "^1.6.10",
+    "lmdb-store": "^1.6.11",
     "marge": "^1.0.1",
     "micromatch": "3.1.10",
     "minimist": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19188,18 +19188,17 @@ listr@^0.14.1:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-lmdb-store@^1.6.8:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.6.8.tgz#f57c1fa4a8e8e7a73d58523d2bfbcee96782311f"
-  integrity sha512-Ltok13VVAfgO5Fdj/jVzXjPJZjefl1iENEHerZyAfAlzFUhvOrA73UdKItqmEPC338U29mm56ZBQr5NJQiKXow==
+lmdb-store@^1.6.10:
+  version "1.6.10"
+  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.6.10.tgz#1f4a4d2827c4045156dd9e6d21ca0f9cec8f1bba"
+  integrity sha512-eON9oD8NLM3DpJ+mQfzw24Pd/gVDxEaXmi+L53j092Oqc3C+pc1G6/a2bmmG9kAUfiwdd5tQMvhDOVpodpkaPA==
   dependencies:
-    mkdirp "^1.0.4"
     nan "^2.14.2"
     node-gyp-build "^4.2.3"
     ordered-binary "^1.0.0"
     weak-lru-cache "^1.0.0"
   optionalDependencies:
-    msgpackr "^1.3.7"
+    msgpackr "^1.4.7"
 
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.0"
@@ -20648,7 +20647,7 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msgpackr-extract@^1.0.13:
+msgpackr-extract@^1.0.14:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-1.0.14.tgz#87d3fe825d226e7f3d9fe136375091137f958561"
   integrity sha512-t8neMf53jNZRF+f0H9VvEUVvtjGZ21odSBRmFfjZiyxr9lKYY0mpY3kSWZAIc7YWXtCZGOvDQVx2oqcgGiRBrw==
@@ -20656,12 +20655,12 @@ msgpackr-extract@^1.0.13:
     nan "^2.14.2"
     node-gyp-build "^4.2.3"
 
-msgpackr@^1.3.7:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.4.2.tgz#52ddf0130ccdb1067957fe61c8be828e82bb29ce"
-  integrity sha512-6gvaU+3xIflium8eJcruT66kLQr14lgTEmXtDm7KKzBSWHljD7pqu3VBQv1PDipFD5UGXLTIxGg5hGbO/jTvxQ==
+msgpackr@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.4.7.tgz#d802ade841e7d2e873000b491cdda6574a3d5748"
+  integrity sha512-bhC8Ed1au3L3oHaR/fe4lk4w7PLGFcWQ5XY/Tk9N6tzDRz8YndjCG68TD8zcvYZoxNtw767eF/7VpaTpU9kf9w==
   optionalDependencies:
-    msgpackr-extract "^1.0.13"
+    msgpackr-extract "^1.0.14"
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19188,10 +19188,10 @@ listr@^0.14.1:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-lmdb-store@^1.6.10:
-  version "1.6.10"
-  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.6.10.tgz#1f4a4d2827c4045156dd9e6d21ca0f9cec8f1bba"
-  integrity sha512-eON9oD8NLM3DpJ+mQfzw24Pd/gVDxEaXmi+L53j092Oqc3C+pc1G6/a2bmmG9kAUfiwdd5tQMvhDOVpodpkaPA==
+lmdb-store@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.6.11.tgz#801da597af8c7a01c81f87d5cc7a7497e381236d"
+  integrity sha512-hIvoGmHGsFhb2VRCmfhodA/837ULtJBwRHSHKIzhMB7WtPH6BRLPsvXp1MwD3avqGzuZfMyZDUp3tccLvr721Q==
   dependencies:
     nan "^2.14.2"
     node-gyp-build "^4.2.3"


### PR DESCRIPTION
This PR upgrades lmdb-store into `v1.6.11` so we can benefit from the latest prebuilds for platforms where we need those.