### PR TITLE
[7.16] Unskip dashboard and dashboard panel a11y tests (#115102)

### DIFF
--- a/test/accessibility/apps/dashboard.ts
+++ b/test/accessibility/apps/dashboard.ts
@@ -15,8 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const listingTable = getService('listingTable');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/105171
-  describe.skip('Dashboard', () => {
+  describe('Dashboard', () => {
     const dashboardName = 'Dashboard Listing A11y';
     const clonedDashboardName = 'Dashboard Listing A11y Copy';
 

--- a/test/accessibility/apps/dashboard_panel.ts
+++ b/test/accessibility/apps/dashboard_panel.ts
@@ -14,8 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const inspector = getService('inspector');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/112920
-  describe.skip('Dashboard Panel', () => {
+  describe('Dashboard Panel', () => {
     before(async () => {
       await PageObjects.common.navigateToApp('dashboard');
       await testSubjects.click('dashboardListingTitleLink-[Flights]-Global-Flight-Dashboard');

--- a/test/accessibility/apps/discover.ts
+++ b/test/accessibility/apps/discover.ts
@@ -92,8 +92,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.discover.saveCurrentSavedQuery();
     });
 
-    // issue - https://github.com/elastic/kibana/issues/78488
-    it.skip('a11y test on saved queries list panel', async () => {
+    it('a11y test on saved queries list panel', async () => {
       await PageObjects.discover.clickSavedQueriesPopOver();
       await testSubjects.moveMouseTo(
         'saved-query-list-item load-saved-query-test-button saved-query-list-item-selected saved-query-list-item-selected'

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -13,6 +13,7 @@ export class HomePageObject extends FtrService {
   private readonly retry = this.ctx.getService('retry');
   private readonly find = this.ctx.getService('find');
   private readonly common = this.ctx.getPageObject('common');
+  private readonly log = this.ctx.getService('log');
 
   async clickSynopsis(title: string) {
     await this.testSubjects.click(`homeSynopsisLink${title}`);
@@ -27,7 +28,10 @@ export class HomePageObject extends FtrService {
   }
 
   async isSampleDataSetInstalled(id: string) {
-    return !(await this.testSubjects.exists(`addSampleDataSet${id}`));
+    const sampleDataCard = await this.testSubjects.find(`sampleDataSetCard${id}`);
+    const sampleDataCardInnerHTML = await sampleDataCard.getAttribute('innerHTML');
+    this.log.debug(sampleDataCardInnerHTML);
+    return sampleDataCardInnerHTML.includes('removeSampleDataSet');
   }
 
   async isWelcomeInterstitialDisplayed() {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Unskip dashboard and dashboard panel a11y tests (#115102)