### PR TITLE
[7.16] unskip kibana overview test from xpack and add the missing painless labs test to config.ts (#115240)

### DIFF
--- a/x-pack/test/accessibility/apps/kibana_overview.ts
+++ b/x-pack/test/accessibility/apps/kibana_overview.ts
@@ -12,7 +12,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const a11y = getService('a11y');
 
   // FLAKY: https://github.com/elastic/kibana/issues/98463
-  describe.skip('Kibana overview', () => {
+  describe('Kibana overview', () => {
     const esArchiver = getService('esArchiver');
 
     before(async () => {

--- a/x-pack/test/accessibility/config.ts
+++ b/x-pack/test/accessibility/config.ts
@@ -17,10 +17,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
     testFiles: [
       require.resolve('./apps/login_page'),
-      require.resolve('./apps/home'),
       require.resolve('./apps/kibana_overview'),
+      require.resolve('./apps/home'),
       require.resolve('./apps/grok_debugger'),
       require.resolve('./apps/search_profiler'),
+      require.resolve('./apps/painless_lab'),
       require.resolve('./apps/uptime'),
       require.resolve('./apps/spaces'),
       require.resolve('./apps/advanced_settings'),


### PR DESCRIPTION
Backports the following commits to 7.16:
 - unskip kibana overview test from xpack and add the missing painless labs test to config.ts (#115240)