### PR TITLE
Fix flaky functional test in saved objects managements -> delete SO

### DIFF
--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -49,16 +49,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const focusAndClickButton = async (buttonSubject: string) => {
     const button = await testSubjects.find(buttonSubject);
     await button.scrollIntoViewIfNecessary();
-    await delay(10);
+    await delay(100);
     await button.focus();
-    await delay(10);
+    await delay(100);
     await button.click();
     // Allow some time for the transition/animations to occur before assuming the click is done
-    await delay(10);
+    await delay(100);
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/68400
-  describe.skip('saved objects edition page', () => {
+  describe('saved objects edition page', () => {
     beforeEach(async () => {
       await esArchiver.load(
         'test/functional/fixtures/es_archiver/saved_objects_management/edit_saved_object'
@@ -119,7 +118,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           shouldUseHashForSubUrl: false,
         }
       );
-
+      // wait for the Edit view to load
       await focusAndClickButton('savedObjectEditDelete');
       await PageObjects.common.clickConfirmOnModal();
 

--- a/test/functional/page_objects/management/saved_objects_page.ts
+++ b/test/functional/page_objects/management/saved_objects_page.ts
@@ -107,6 +107,7 @@ export class SavedObjectsPageObject extends FtrService {
       if (isLoaded) {
         return true;
       } else {
+        this.log.debug(`still waiting for the table to load ${isLoaded}`);
         throw new Error('Waiting');
       }
     });


### PR DESCRIPTION
PR to replace backport for https://github.com/elastic/kibana/pull/115291.

We couldn't backport the fix to master because we only changed the Saved Objects Management edit view to read-only json view in master.

This PR only increases the waiting period for the page to load.