### PR TITLE
[7.16] [Security Solution][Endpoint] un-skip permissions FTR tests for endpoint (#115962)

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
@@ -20,8 +20,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const endpointTestResources = getService('endpointTestResources');
   const policyTestResources = getService('policyTestResources');
 
-  // Skipping Flakey test: https://github.com/elastic/kibana/issues/110309
-  describe.skip('Endpoint permissions:', () => {
+  describe('Endpoint permissions:', () => {
     let indexedData: IndexedHostsAndAlertsResponse;
 
     before(async () => {
@@ -62,7 +61,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await testSubjects.existOrFail('noIngestPermissions');
         });
 
-        it('should display endpoint data on Host Details', async () => {
+        // FIXME:PT skipped. need to fix security-team bug #1929
+        it.skip('should display endpoint data on Host Details', async () => {
           const endpoint = indexedData.hosts[0];
           await PageObjects.hosts.navigateToHostDetails(endpoint.host.name);
           const endpointSummary = await PageObjects.hosts.hostDetailsEndpointOverviewData();


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Security Solution][Endpoint] un-skip permissions FTR tests for endpoint (#115962)