### PR TITLE
[7.16] [Alerting] Changed alerting telemetry throttle and schedule time metrics to be numbers instead of strings (#115605)

### DIFF
--- a/x-pack/plugins/actions/server/usage/actions_telemetry.ts
+++ b/x-pack/plugins/actions/server/usage/actions_telemetry.ts
@@ -43,6 +43,7 @@ export async function getTotalCount(
 
   const { body: searchResult } = await esClient.search({
     index: kibanaIndex,
+    size: 0,
     body: {
       query: {
         bool: {
@@ -224,6 +225,7 @@ export async function getInUseTotalCount(
 
   const { body: actionResults } = await esClient.search({
     index: kibanaIndex,
+    size: 0,
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/alerting/server/usage/alerts_telemetry.ts
+++ b/x-pack/plugins/alerting/server/usage/alerts_telemetry.ts
@@ -233,6 +233,7 @@ export async function getTotalCountAggregations(
 
   const { body: results } = await esClient.search({
     index: kibanaInex,
+    size: 0,
     body: {
       query: {
         bool: {
@@ -284,22 +285,20 @@ export async function getTotalCountAggregations(
       {}
     ),
     throttle_time: {
-      min: `${aggregations.throttleTime.value.min}s`,
-      avg: `${
+      min: aggregations.throttleTime.value.min,
+      avg:
         aggregations.throttleTime.value.totalCount > 0
           ? aggregations.throttleTime.value.totalSum / aggregations.throttleTime.value.totalCount
-          : 0
-      }s`,
-      max: `${aggregations.throttleTime.value.max}s`,
+          : 0,
+      max: aggregations.throttleTime.value.max,
     },
     schedule_time: {
-      min: `${aggregations.intervalTime.value.min}s`,
-      avg: `${
+      min: aggregations.intervalTime.value.min,
+      avg:
         aggregations.intervalTime.value.totalCount > 0
           ? aggregations.intervalTime.value.totalSum / aggregations.intervalTime.value.totalCount
-          : 0
-      }s`,
-      max: `${aggregations.intervalTime.value.max}s`,
+          : 0,
+      max: aggregations.intervalTime.value.max,
     },
     connectors_per_alert: {
       min: aggregations.connectorsAgg.connectors.value.min,
@@ -316,6 +315,7 @@ export async function getTotalCountAggregations(
 export async function getTotalCountInUse(esClient: ElasticsearchClient, kibanaInex: string) {
   const { body: searchResult } = await esClient.search({
     index: kibanaInex,
+    size: 0,
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/alerting/server/usage/alerts_usage_collector.ts
+++ b/x-pack/plugins/alerting/server/usage/alerts_usage_collector.ts
@@ -75,14 +75,14 @@ export function createAlertsUsageCollector(
           count_active_total: 0,
           count_disabled_total: 0,
           throttle_time: {
-            min: '0s',
-            avg: '0s',
-            max: '0s',
+            min: 0,
+            avg: 0,
+            max: 0,
           },
           schedule_time: {
-            min: '0s',
-            avg: '0s',
-            max: '0s',
+            min: 0,
+            avg: 0,
+            max: 0,
           },
           connectors_per_alert: {
             min: 0,
@@ -100,14 +100,14 @@ export function createAlertsUsageCollector(
       count_active_total: { type: 'long' },
       count_disabled_total: { type: 'long' },
       throttle_time: {
-        min: { type: 'keyword' },
-        avg: { type: 'keyword' },
-        max: { type: 'keyword' },
+        min: { type: 'long' },
+        avg: { type: 'float' },
+        max: { type: 'long' },
       },
       schedule_time: {
-        min: { type: 'keyword' },
-        avg: { type: 'keyword' },
-        max: { type: 'keyword' },
+        min: { type: 'long' },
+        avg: { type: 'float' },
+        max: { type: 'long' },
       },
       connectors_per_alert: {
         min: { type: 'long' },

--- a/x-pack/plugins/alerting/server/usage/types.ts
+++ b/x-pack/plugins/alerting/server/usage/types.ts
@@ -13,14 +13,14 @@ export interface AlertsUsage {
   count_active_by_type: Record<string, number>;
   count_rules_namespaces: number;
   throttle_time: {
-    min: string;
-    avg: string;
-    max: string;
+    min: number;
+    avg: number;
+    max: number;
   };
   schedule_time: {
-    min: string;
-    avg: string;
-    max: string;
+    min: number;
+    avg: number;
+    max: number;
   };
   connectors_per_alert: {
     min: number;

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -144,26 +144,26 @@
         "throttle_time": {
           "properties": {
             "min": {
-              "type": "keyword"
+              "type": "long"
             },
             "avg": {
-              "type": "keyword"
+              "type": "float"
             },
             "max": {
-              "type": "keyword"
+              "type": "long"
             }
           }
         },
         "schedule_time": {
           "properties": {
             "min": {
-              "type": "keyword"
+              "type": "long"
             },
             "avg": {
-              "type": "keyword"
+              "type": "float"
             },
             "max": {
-              "type": "keyword"
+              "type": "long"
             }
           }
         },


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Alerting] Changed alerting telemetry throttle and schedule time metrics to be numbers instead of strings (#115605)