### PR TITLE
[Upgrade Assistant] Add missing error handler for system indices migration

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/migrate_system_indices.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/migrate_system_indices/migrate_system_indices.test.tsx
@@ -132,5 +132,36 @@ describe('Overview - Migrate system indices', () => {
       expect(exists('startSystemIndicesMigrationButton')).toBe(true);
       expect(find('startSystemIndicesMigrationButton').props().disabled).toBe(false);
     });
+
+    test('Handles errors from migration', async () => {
+      httpRequestsMockHelpers.setLoadSystemIndicesMigrationStatus({
+        migration_status: 'ERROR',
+        features: [
+          {
+            feature_name: 'kibana',
+            indices: [
+              {
+                index: '.kibana',
+                migration_status: 'ERROR',
+                failure_cause: {
+                  error: {
+                    type: 'mapper_parsing_exception',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      testBed = await setupOverviewPage();
+
+      const { exists } = testBed;
+
+      // Error is displayed
+      expect(exists('migrationFailedCallout')).toBe(true);
+      // CTA is enabled
+      expect(exists('startSystemIndicesMigrationButton')).toBe(true);
+    });
   });
 });

--- a/x-pack/plugins/upgrade_assistant/common/types.ts
+++ b/x-pack/plugins/upgrade_assistant/common/types.ts
@@ -242,6 +242,12 @@ export interface SystemIndicesMigrationFeature {
   indices: Array<{
     index: string;
     version: string;
+    failure_cause?: {
+      error: {
+        type: string;
+        reason: string;
+      };
+    };
   }>;
 }
 export interface SystemIndicesMigrationStatus {


### PR DESCRIPTION
### Summary

If the system indices migration fails on a specific feature/index, the user only knows that something failed when they open the details flyout. This PR adds a callout with the failure type and for which feature it failed right in the overview page to give better visibility to the user.

Note: We use the failure type instead of the reason because the cause can potentially be incredibly long (see screenshot).

**How to test**
1. Unzip [6.8-data-snapshot.zip](https://github.com/elastic/kibana/files/7408569/6.8-data-snapshot.zip) and start up ES as follows: `yarn es snapshot -E path.data=/path/to/6.8-data-snapshot`. This contains indices from 6.x that will require migration.
4. Navigate to `Stack Management` -> `Upgrade Assistant`
5. Verify that in the migration details flyout theres 3 system indices that require migration
6. Click the `Migrate indices` CTA and reload the page after. We need to manually reload due to a ES bug https://github.com/elastic/elasticsearch/issues/79680
7. Verify that an error callout is shown

If after following the steps you don't see any deprecations for es in upgrade assistant, try unzipping the folder in the `kibana/.es` folder and starting up es with: `yarn es snapshot -E path.data=../6.8-data-snapshot`

**Screenshots**

<details>
<summary>Overview of changes</summary>

// With error
![Screenshot 2021-10-25 at 10 32 47](https://user-images.githubusercontent.com/1191206/138663197-03cc9bc4-ea7c-4483-a28d-0ff73828a7ca.png)

// Using failure reason can be very long
![Screenshot 2021-10-25 at 10 48 54](https://user-images.githubusercontent.com/1191206/138664662-ecc5dadb-c157-4215-bc23-845a74e72503.png)

</details>