### PR TITLE
[7.16]  [TSVB] Error when selecting * for override index_pattern field on the string mode (#114450)

### DIFF
--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/get_interval_and_timefield.ts
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/get_interval_and_timefield.ts
@@ -24,9 +24,14 @@ export function getIntervalAndTimefield(
   { min, max, maxBuckets }: IntervalParams,
   series?: Series
 ) {
-  const timeField =
+  let timeField =
     (series?.override_index_pattern ? series.series_time_field : panel.time_field) ||
     index.indexPattern?.timeFieldName;
+
+  // should use @timestamp as default timeField for es indeces if user doesn't provide timeField
+  if (!panel.use_kibana_indexes && !timeField) {
+    timeField = '@timestamp';
+  }
 
   if (panel.use_kibana_indexes) {
     validateField(timeField!, index);


### PR DESCRIPTION
Backports the following commits to 7.16:
 -  [TSVB] Error when selecting * for override index_pattern field on the string mode (#114450)