### PR TITLE
[ML] Fix errors from annotations searches when event mapping is incorrect

### DIFF
--- a/x-pack/plugins/ml/common/types/annotations.ts
+++ b/x-pack/plugins/ml/common/types/annotations.ts
@@ -118,26 +118,8 @@ export function isAnnotations(arg: any): arg is Annotations {
   return arg.every((d: Annotation) => isAnnotation(d));
 }
 
-export interface FieldToBucket {
-  field: string;
-  missing?: string | number;
-}
-
-export interface FieldToBucketResult {
-  key: string;
-  doc_count: number;
-}
-
-export interface TermAggregationResult {
-  doc_count_error_upper_bound: number;
-  sum_other_doc_count: number;
-  buckets: FieldToBucketResult[];
-}
-
-export type EsAggregationResult = Record<string, TermAggregationResult>;
-
 export interface GetAnnotationsResponse {
-  aggregations?: EsAggregationResult;
+  totalCount: number;
   annotations: Record<string, Annotations>;
   error?: string;
   success: boolean;
@@ -145,6 +127,5 @@ export interface GetAnnotationsResponse {
 
 export interface AnnotationsTable {
   annotationsData: Annotations;
-  aggregations: EsAggregationResult;
   error?: string;
 }

--- a/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
+++ b/x-pack/plugins/ml/public/application/components/annotations/annotations_table/annotations_table.js
@@ -566,7 +566,6 @@ class AnnotationsTableUI extends Component {
     // Build the options to show in the Event type filter.
     // Do not try and run a search using a terms agg on the event field
     // because in 7.9 this field was incorrectly mapped as a text rather than keyword.
-    let filterOptions = [];
 
     // Always display options for user and delayed data types.
     const countsByEvent = {
@@ -575,16 +574,12 @@ class AnnotationsTableUI extends Component {
     };
     annotations.forEach((annotation) => {
       // Default to user type for annotations created in early releases which didn't have an event field
-      const event = annotation.event || ANNOTATION_EVENT_USER;
+      const event = annotation.event ?? ANNOTATION_EVENT_USER;
       if (countsByEvent[event] === undefined) {
         countsByEvent[event] = 0;
       }
-      countsByEvent[event] = ++countsByEvent[event];
+      countsByEvent[event]++;
     });
-    filterOptions = Object.keys(countsByEvent).map((eventType) => ({
-      key: eventType,
-      doc_count: countsByEvent[eventType],
-    }));
 
     const filters = [
       {
@@ -592,10 +587,10 @@ class AnnotationsTableUI extends Component {
         field: 'event',
         name: 'Event',
         multiSelect: 'or',
-        options: filterOptions.map((field) => ({
-          value: field.key,
-          name: field.key,
-          view: `${field.key} (${field.doc_count})`,
+        options: Object.entries(countsByEvent).map(([key, docCount]) => ({
+          value: key,
+          name: key,
+          view: `${key} (${docCount})`,
         })),
         'data-test-subj': 'mlAnnotationTableEventFilter',
       },

--- a/x-pack/plugins/ml/public/application/explorer/explorer.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer.js
@@ -255,13 +255,9 @@ export class ExplorerUI extends React.Component {
       tableData,
       swimLaneSeverity,
     } = this.props.explorerState;
-    const { annotationsData, aggregations, error: annotationsError } = annotations;
+    const { annotationsData, totalCount: allAnnotationsCnt, error: annotationsError } = annotations;
 
     const annotationsCnt = Array.isArray(annotationsData) ? annotationsData.length : 0;
-    const allAnnotationsCnt = Array.isArray(aggregations?.event?.buckets)
-      ? aggregations.event.buckets.reduce((acc, v) => acc + v.doc_count, 0)
-      : annotationsCnt;
-
     const badge =
       allAnnotationsCnt > annotationsCnt ? (
         <EuiBadge color={'hollow'}>
@@ -449,7 +445,6 @@ export class ExplorerUI extends React.Component {
                       <AnnotationsTable
                         jobIds={selectedJobIds}
                         annotations={annotationsData}
-                        aggregations={aggregations}
                         drillDown={true}
                         numberBadge={false}
                       />

--- a/x-pack/plugins/ml/public/application/explorer/reducers/explorer_reducer/state.ts
+++ b/x-pack/plugins/ml/public/application/explorer/reducers/explorer_reducer/state.ts
@@ -71,12 +71,10 @@ export function getExplorerDefaultState(): ExplorerState {
     overallAnnotations: {
       error: undefined,
       annotationsData: [],
-      aggregations: {},
     },
     annotations: {
       error: undefined,
       annotationsData: [],
-      aggregations: {},
     },
     anomalyChartsDataLoading: true,
     chartsData: getDefaultChartsData(),

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/annotations.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/annotations.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import {
-  Annotation,
-  FieldToBucket,
-  GetAnnotationsResponse,
-} from '../../../../common/types/annotations';
+import { Annotation, GetAnnotationsResponse } from '../../../../common/types/annotations';
 import { http, http$ } from '../http_service';
 import { basePath } from './index';
 
@@ -19,7 +15,6 @@ export const annotations = {
     earliestMs: number;
     latestMs: number;
     maxAnnotations: number;
-    fields?: FieldToBucket[];
     detectorIndex?: number;
     entities?: any[];
   }) {
@@ -36,7 +31,6 @@ export const annotations = {
     earliestMs: number | null;
     latestMs: number | null;
     maxAnnotations: number;
-    fields?: FieldToBucket[];
     detectorIndex?: number;
     entities?: any[];
   }) {

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart_with_tooltip.tsx
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart_with_tooltip.tsx
@@ -15,7 +15,6 @@ import { extractErrorMessage } from '../../../../../common/util/errors';
 import { Annotation } from '../../../../../common/types/annotations';
 import { useMlKibana, useNotifications } from '../../../contexts/kibana';
 import { getBoundsRoundedToInterval } from '../../../util/time_buckets';
-import { ANNOTATION_EVENT_USER } from '../../../../../common/constants/annotations';
 import { getControlsForDetector } from '../../get_controls_for_detector';
 import { MlAnnotationUpdatesContext } from '../../../contexts/ml/ml_annotation_updates_context';
 
@@ -88,12 +87,6 @@ export const TimeSeriesChartWithTooltips: FC<TimeSeriesChartWithTooltipsProps> =
           earliestMs: searchBounds.min.valueOf(),
           latestMs: searchBounds.max.valueOf(),
           maxAnnotations: ANNOTATIONS_TABLE_DEFAULT_QUERY_SIZE,
-          fields: [
-            {
-              field: 'event',
-              missing: ANNOTATION_EVENT_USER,
-            },
-          ],
           detectorIndex,
           entities: nonBlankEntities,
         });

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer.js
@@ -104,7 +104,6 @@ function getTimeseriesexplorerDefaultState() {
     entitiesLoading: false,
     entityValues: {},
     focusAnnotationData: [],
-    focusAggregations: {},
     focusAggregationInterval: {},
     focusChartData: undefined,
     focusForecastData: undefined,
@@ -935,7 +934,6 @@ export class TimeSeriesExplorer extends React.Component {
       focusAggregationInterval,
       focusAnnotationError,
       focusAnnotationData,
-      focusAggregations,
       focusChartData,
       focusForecastData,
       fullRefresh,
@@ -1257,7 +1255,6 @@ export class TimeSeriesExplorer extends React.Component {
                       detectors={detectors}
                       jobIds={[this.props.selectedJobId]}
                       annotations={focusAnnotationData}
-                      aggregations={focusAggregations}
                       isSingleMetricViewerLinkVisible={false}
                       isNumberBadgeVisible={true}
                     />

--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/get_focus_data.ts
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/timeseriesexplorer_utils/get_focus_data.ts
@@ -26,7 +26,6 @@ import {
 import { mlForecastService } from '../../services/forecast_service';
 import { mlFunctionToESAggregation } from '../../../../common/util/job_utils';
 import { GetAnnotationsResponse } from '../../../../common/types/annotations';
-import { ANNOTATION_EVENT_USER } from '../../../../common/constants/annotations';
 import { aggregationTypeTransform } from '../../../../common/util/anomaly_utils';
 
 export interface Interval {
@@ -42,7 +41,6 @@ export interface FocusData {
   focusAnnotationError?: string;
   focusAnnotationData?: any[];
   focusForecastData?: any;
-  focusAggregations?: any;
 }
 
 export function getFocusData(
@@ -98,12 +96,6 @@ export function getFocusData(
         earliestMs: searchBounds.min.valueOf(),
         latestMs: searchBounds.max.valueOf(),
         maxAnnotations: ANNOTATIONS_TABLE_DEFAULT_QUERY_SIZE,
-        fields: [
-          {
-            field: 'event',
-            missing: ANNOTATION_EVENT_USER,
-          },
-        ],
         detectorIndex,
         entities: nonBlankEntities,
       })
@@ -111,7 +103,7 @@ export function getFocusData(
         catchError((resp) =>
           of({
             annotations: {},
-            aggregations: {},
+            totalCount: 0,
             error: extractErrorMessage(resp),
             success: false,
           } as GetAnnotationsResponse)
@@ -168,7 +160,6 @@ export function getFocusData(
         if (annotations.error !== undefined) {
           refreshFocusData.focusAnnotationError = annotations.error;
           refreshFocusData.focusAnnotationData = [];
-          refreshFocusData.focusAggregations = {};
         } else {
           refreshFocusData.focusAnnotationData = (annotations.annotations[selectedJob.job_id] ?? [])
             .sort((a, b) => {
@@ -178,8 +169,6 @@ export function getFocusData(
               d.key = (i + 1).toString();
               return d;
             });
-
-          refreshFocusData.focusAggregations = annotations.aggregations;
         }
       }
 

--- a/x-pack/plugins/ml/server/models/annotation_service/__mocks__/get_annotations_request.json
+++ b/x-pack/plugins/ml/server/models/annotation_service/__mocks__/get_annotations_request.json
@@ -1,6 +1,7 @@
 {
   "index": ".ml-annotations-read",
   "size": 500,
+  "track_total_hits": true,
   "body": {
     "query": {
       "bool": {

--- a/x-pack/plugins/ml/server/models/annotation_service/annotation.ts
+++ b/x-pack/plugins/ml/server/models/annotation_service/annotation.ts
@@ -24,7 +24,6 @@ import {
   isAnnotations,
   getAnnotationFieldName,
   getAnnotationFieldValue,
-  EsAggregationResult,
 } from '../../../common/types/annotations';
 import { JobId } from '../../../common/types/anomaly_detection_jobs';
 
@@ -35,36 +34,27 @@ interface EsResult {
   _id: string;
 }
 
-export interface FieldToBucket {
-  field: string;
-  missing?: string | number;
-}
-
 export interface IndexAnnotationArgs {
   jobIds: string[];
   earliestMs: number | null;
   latestMs: number | null;
   maxAnnotations: number;
-  fields?: FieldToBucket[];
   detectorIndex?: number;
   entities?: any[];
   event?: Annotation['event'];
-}
-
-export interface AggTerm {
-  terms: FieldToBucket;
 }
 
 export interface GetParams {
   index: string;
   size: number;
   body: object;
+  track_total_hits: boolean;
 }
 
 export interface GetResponse {
   success: true;
   annotations: Record<JobId, Annotations>;
-  aggregations: EsAggregationResult;
+  totalCount: number;
 }
 
 export interface IndexParams {
@@ -118,7 +108,6 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
     earliestMs,
     latestMs,
     maxAnnotations,
-    fields,
     detectorIndex,
     entities,
     event,
@@ -126,7 +115,7 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
     const obj: GetResponse = {
       success: true,
       annotations: {},
-      aggregations: {},
+      totalCount: 0,
     };
 
     const boolCriteria: object[] = [];
@@ -215,18 +204,6 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
       });
     }
 
-    // Find unique buckets (e.g. events) from the queried annotations to show in dropdowns
-    const aggs: Record<string, AggTerm> = {};
-    if (fields) {
-      fields.forEach((fieldToBucket) => {
-        aggs[fieldToBucket.field] = {
-          terms: {
-            ...fieldToBucket,
-          },
-        };
-      });
-    }
-
     // Build should clause to further query for annotations in SMV
     // we want to show either the exact match with detector index and by/over/partition fields
     // OR annotations without any partition fields defined
@@ -276,6 +253,7 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
     const params: GetParams = {
       index: ML_ANNOTATIONS_INDEX_ALIAS_READ,
       size: maxAnnotations,
+      track_total_hits: true,
       body: {
         query: {
           bool: {
@@ -295,7 +273,6 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
             ...(shouldClauses ? { should: shouldClauses, minimum_should_match: 1 } : {}),
           },
         },
-        ...(fields ? { aggs } : {}),
       },
     };
 
@@ -307,6 +284,9 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
         // No need to translate, this will not be exposed in the UI.
         throw new Error(`Annotations couldn't be retrieved from Elasticsearch.`);
       }
+
+      // @ts-expect-error incorrect search response type
+      obj.totalCount = body.hits.total.value;
 
       // @ts-expect-error TODO fix search response types
       const docs: Annotations = get(body, ['hits', 'hits'], []).map((d: EsResult) => {
@@ -321,10 +301,6 @@ export function annotationProvider({ asInternalUser }: IScopedClusterClient) {
         } as Annotation;
       });
 
-      const aggregations = get(body, ['aggregations'], {}) as EsAggregationResult;
-      if (fields) {
-        obj.aggregations = aggregations;
-      }
       if (isAnnotations(docs) === false) {
         // No need to translate, this will not be exposed in the UI.
         throw new Error(`Annotations didn't pass integrity check.`);

--- a/x-pack/test/functional/apps/ml/anomaly_detection/annotations.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection/annotations.ts
@@ -262,56 +262,5 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.jobAnnotations.assertAnnotationsRowMissing(annotationId);
       });
     });
-
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/115849
-    describe.skip('with errors', function () {
-      before(async () => {
-        // Points the read/write aliases of annotations to an index with wrong mappings
-        // so we can simulate errors when requesting annotations.
-        await ml.testResources.setupBrokenAnnotationsIndexState(jobId);
-      });
-
-      it('displays error on broken annotation index and recovers after fix', async () => {
-        await ml.testExecution.logTestStep('loads from job list row link');
-        await ml.navigation.navigateToMl();
-        await ml.navigation.navigateToJobManagement();
-
-        await ml.jobTable.waitForJobsToLoad();
-        await ml.jobTable.filterWithSearchString(jobId, 1);
-
-        await ml.jobTable.clickOpenJobInSingleMetricViewerButton(jobId);
-        await ml.commonUI.waitForMlLoadingIndicatorToDisappear();
-
-        await ml.testExecution.logTestStep(
-          'should display the annotations section showing an error'
-        );
-        await ml.singleMetricViewer.assertAnnotationsExists('error');
-
-        await ml.testExecution.logTestStep('should navigate to anomaly explorer');
-        await ml.navigation.navigateToAnomalyExplorerViaSingleMetricViewer();
-
-        await ml.testExecution.logTestStep(
-          'should display the annotations section showing an error'
-        );
-        await ml.anomalyExplorer.assertAnnotationsPanelExists('error');
-
-        await ml.testExecution.logTestStep(
-          'should display the annotations section without an error'
-        );
-        // restores the aliases to point to the original working annotations index
-        // so we can run tests against successfully loaded annotations sections.
-        await ml.testResources.restoreAnnotationsIndexState();
-        await ml.anomalyExplorer.refreshPage();
-        await ml.anomalyExplorer.assertAnnotationsPanelExists('loaded');
-
-        await ml.testExecution.logTestStep('should navigate to single metric viewer');
-        await ml.navigation.navigateToSingleMetricViewerViaAnomalyExplorer();
-
-        await ml.testExecution.logTestStep(
-          'should display the annotations section without an error'
-        );
-        await ml.singleMetricViewer.assertAnnotationsExists('loaded');
-      });
-    });
   });
 }

--- a/x-pack/test/functional/services/ml/test_resources.ts
+++ b/x-pack/test/functional/services/ml/test_resources.ts
@@ -188,30 +188,6 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       }
     },
 
-    async restoreAnnotationsIndexState() {
-      // restore the original working state of pointing read/write aliases
-      // to the right annotations index.
-      await es.indices.updateAliases({
-        body: {
-          actions: [
-            { add: { index: '.ml-annotations-6', alias: '.ml-annotations-read', is_hidden: true } },
-            { remove: { index: '.ml-annotations-6-wrong-mapping', alias: '.ml-annotations-read' } },
-            {
-              add: { index: '.ml-annotations-6', alias: '.ml-annotations-write', is_hidden: true },
-            },
-            {
-              remove: { index: '.ml-annotations-6-wrong-mapping', alias: '.ml-annotations-write' },
-            },
-          ],
-        },
-      });
-
-      // deletes the temporary annotations index with wrong mappings
-      await es.indices.delete({
-        index: '.ml-annotations-6-wrong-mapping',
-      });
-    },
-
     async updateSavedSearchRequestBody(body: object, indexPatternTitle: string): Promise<object> {
       const indexPatternId = await this.getIndexPatternId(indexPatternTitle);
       if (indexPatternId === undefined) {

--- a/x-pack/test/functional/services/ml/test_resources.ts
+++ b/x-pack/test/functional/services/ml/test_resources.ts
@@ -188,67 +188,6 @@ export function MachineLearningTestResourcesProvider({ getService }: FtrProvider
       }
     },
 
-    async setupBrokenAnnotationsIndexState(jobId: string) {
-      // Creates a temporary annotations index with unsupported mappings.
-      await es.indices.create({
-        index: '.ml-annotations-6-wrong-mapping',
-        body: {
-          settings: {
-            number_of_shards: 1,
-          },
-          mappings: {
-            properties: {
-              field1: { type: 'text' },
-            },
-          },
-        },
-      });
-
-      // Ingests an annotation that will cause dynamic mapping to pick up the wrong field type.
-      es.create({
-        id: 'annotation_with_wrong_mapping',
-        index: '.ml-annotations-6-wrong-mapping',
-        body: {
-          annotation: 'Annotation with wrong mapping',
-          create_time: 1597393915910,
-          create_username: '_xpack',
-          timestamp: 1549756800000,
-          end_timestamp: 1549756800000,
-          job_id: jobId,
-          modified_time: 1597393915910,
-          modified_username: '_xpack',
-          type: 'annotation',
-          event: 'user',
-          detector_index: 0,
-        },
-      });
-
-      // Points the read/write aliases for annotations to the broken annotations index
-      // so we can run tests against a state where annotation endpoints return errors.
-      await es.indices.updateAliases({
-        body: {
-          actions: [
-            {
-              add: {
-                index: '.ml-annotations-6-wrong-mapping',
-                alias: '.ml-annotations-read',
-                is_hidden: true,
-              },
-            },
-            { remove: { index: '.ml-annotations-6', alias: '.ml-annotations-read' } },
-            {
-              add: {
-                index: '.ml-annotations-6-wrong-mapping',
-                alias: '.ml-annotations-write',
-                is_hidden: true,
-              },
-            },
-            { remove: { index: '.ml-annotations-6', alias: '.ml-annotations-write' } },
-          ],
-        },
-      });
-    },
-
     async restoreAnnotationsIndexState() {
       // restore the original working state of pointing read/write aliases
       // to the right annotations index.

--- a/x-pack/test/functional/services/ml/test_resources.ts
+++ b/x-pack/test/functional/services/ml/test_resources.ts
@@ -24,7 +24,6 @@ export enum SavedObjectType {
 export type MlTestResourcesi = ProvidedType<typeof MachineLearningTestResourcesProvider>;
 
 export function MachineLearningTestResourcesProvider({ getService }: FtrProviderContext) {
-  const es = getService('es');
   const kibanaServer = getService('kibanaServer');
   const log = getService('log');
   const supertest = getService('supertest');


### PR DESCRIPTION
## Summary

Fixes the errors which would be displayed when loading the annotations table displayed in the Single Metric Viewer, Anomaly Explorer and in the expanded rows of the anomaly detection jobs list, if the deployment had been upgraded from `7.9.0`, where the `event` field was [incorrectly mapped](https://www.elastic.co/guide/en/machine-learning/7.10/ml-troubleshooting.html#ml-troubleshooting-mappings) as `text` - see also #113409 and https://github.com/elastic/elasticsearch/issues/78439.

This fixes the issue by removing the  `terms` agg that was done on the `event` field of the annotations index, and instead populates the 'Event' filter dropdown of the table by looping through the query results and finding the unique set of values of the `event` field.

![image](https://user-images.githubusercontent.com/7405507/138676607-89878e41-155f-4032-91d5-e0cfb16e87ba.png)

Fixes #113409




