### PR TITLE
[Telemetry] add missing content-type to headers

### DIFF
--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -230,6 +230,7 @@ export class FetcherTask {
           method: 'post',
           body: stats,
           headers: {
+            'Content-Type': 'application/json',
             'X-Elastic-Stack-Version': this.currentKibanaVersion,
             'X-Elastic-Cluster-ID': clusterUuid,
             'X-Elastic-Content-Encoding': PAYLOAD_CONTENT_ENCODING,


### PR DESCRIPTION
v3 is expecting this header to be explicitly set