### PR TITLE
[Fleet] Fix showing deployment details callout on Cloud staging

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/components/header/deployment_details.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/components/header/deployment_details.tsx
@@ -32,7 +32,8 @@ export const DeploymentDetails = () => {
     !(
       cname.endsWith('elastic-cloud.com') ||
       cname.endsWith('found.io') ||
-      cname.endsWith('found.no')
+      cname.endsWith('found.no') ||
+      cname.endsWith('foundit.no')
     )
   ) {
     return null;


### PR DESCRIPTION
## Summary

Fixes #116076

This adds support for an additional cname suffix required to support this UI on Cloud staging.
