### PR TITLE
[Security Solution][Endpoint] Hide 'OR' button in event filters exception builder

### DIFF
--- a/x-pack/plugins/lists/public/exceptions/components/builder/exception_items_renderer.tsx
+++ b/x-pack/plugins/lists/public/exceptions/components/builder/exception_items_renderer.tsx
@@ -81,6 +81,7 @@ export interface ExceptionBuilderProps {
   isAndDisabled: boolean;
   isNestedDisabled: boolean;
   isOrDisabled: boolean;
+  isOrHidden?: boolean;
   listId: string;
   listNamespaceType: NamespaceType;
   listType: ExceptionListType;
@@ -103,6 +104,7 @@ export const ExceptionBuilderComponent = ({
   isAndDisabled,
   isNestedDisabled,
   isOrDisabled,
+  isOrHidden = false,
   listId,
   listNamespaceType,
   listType,
@@ -433,6 +435,7 @@ export const ExceptionBuilderComponent = ({
           <EuiFlexItem grow={1}>
             <BuilderLogicButtons
               isOrDisabled={isOrDisabled ? isOrDisabled : disableOr}
+              isOrHidden={isOrHidden}
               isAndDisabled={isAndDisabled ? isAndDisabled : disableAnd}
               isNestedDisabled={isNestedDisabled ? isNestedDisabled : disableNested}
               isNested={addNested}

--- a/x-pack/plugins/lists/public/exceptions/components/builder/logic_buttons.test.tsx
+++ b/x-pack/plugins/lists/public/exceptions/components/builder/logic_buttons.test.tsx
@@ -34,6 +34,25 @@ describe('BuilderLogicButtons', () => {
     expect(wrapper.find('[data-test-subj="exceptionsNestedButton"] button')).toHaveLength(0);
   });
 
+  test('it hides "or" button', () => {
+    const wrapper = mount(
+      <BuilderLogicButtons
+        isAndDisabled={false}
+        isOrDisabled={false}
+        isOrHidden={true}
+        isNestedDisabled={false}
+        isNested={false}
+        showNestedButton={false}
+        onOrClicked={jest.fn()}
+        onAndClicked={jest.fn()}
+        onNestedClicked={jest.fn()}
+        onAddClickWhenNested={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find('[data-test-subj="exceptionsOrButton"] button')).toHaveLength(0);
+  });
+
   test('it invokes "onOrClicked" when "or" button is clicked', () => {
     const onOrClicked = jest.fn();
 

--- a/x-pack/plugins/lists/public/exceptions/components/builder/logic_buttons.tsx
+++ b/x-pack/plugins/lists/public/exceptions/components/builder/logic_buttons.tsx
@@ -20,6 +20,7 @@ interface BuilderLogicButtonsProps {
   isNested: boolean;
   isNestedDisabled: boolean;
   isOrDisabled: boolean;
+  isOrHidden?: boolean;
   showNestedButton: boolean;
   onAddClickWhenNested: () => void;
   onAndClicked: () => void;
@@ -32,6 +33,7 @@ export const BuilderLogicButtons: React.FC<BuilderLogicButtonsProps> = ({
   isNested,
   isNestedDisabled = true,
   isOrDisabled = false,
+  isOrHidden = false,
   showNestedButton = false,
   onAddClickWhenNested,
   onAndClicked,
@@ -50,18 +52,20 @@ export const BuilderLogicButtons: React.FC<BuilderLogicButtonsProps> = ({
         {i18n.AND}
       </MyEuiButton>
     </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <MyEuiButton
-        fill
-        size="s"
-        iconType="plusInCircle"
-        onClick={onOrClicked}
-        isDisabled={isOrDisabled}
-        data-test-subj="exceptionsOrButton"
-      >
-        {i18n.OR}
-      </MyEuiButton>
-    </EuiFlexItem>
+    {!isOrHidden && (
+      <EuiFlexItem grow={false}>
+        <MyEuiButton
+          fill
+          size="s"
+          iconType="plusInCircle"
+          onClick={onOrClicked}
+          isDisabled={isOrDisabled}
+          data-test-subj="exceptionsOrButton"
+        >
+          {i18n.OR}
+        </MyEuiButton>
+      </EuiFlexItem>
+    )}
     {showNestedButton && (
       <EuiFlexItem grow={false}>
         <EuiButton

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/form/index.tsx
@@ -129,7 +129,8 @@ export const EventFiltersForm: React.FC<EventFiltersFormProps> = memo(
           listNamespaceType: 'agnostic',
           ruleName: RULE_NAME,
           indexPatterns,
-          isOrDisabled: true, // TODO: pending to be validated
+          isOrDisabled: true,
+          isOrHidden: true,
           isAndDisabled: false,
           isNestedDisabled: false,
           dataTestSubj: 'alert-exception-builder',


### PR DESCRIPTION
## Summary
Adds new optional flag to the exception builder that allows you hide the OR button.
This is needed for event filters since we don't want to display a disabled button by default and we want to hide it instead.
Also adds unit test case for the new code.

### Before
![image](https://user-images.githubusercontent.com/56395104/135644906-81d2bfa0-7d6b-48c3-9954-632eb01dd6d5.png)

### After
![hide or button in event filters](https://user-images.githubusercontent.com/15727784/138697408-d83550f1-0c3a-4810-ab51-11efb5203706.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
