### PR TITLE
[ML] Adding datafeed api tests

### DIFF
--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_stats_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_stats_with_spaces.ts
@@ -22,7 +22,7 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace1 = 'space1';
   const idSpace2 = 'space2';
 
-  async function getJobById(
+  async function getJobStatsById(
     jobOrGroup: string | undefined,
     expectedStatusCode: number,
     space?: string
@@ -31,7 +31,7 @@ export default ({ getService }: FtrProviderContext) => {
       .get(
         `${space ? `/s/${space}` : ''}/api/ml/anomaly_detectors${
           jobOrGroup ? `/${jobOrGroup}` : ''
-        }`
+        }/_stats`
       )
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
@@ -43,7 +43,7 @@ export default ({ getService }: FtrProviderContext) => {
     return body;
   }
 
-  describe('GET anomaly_detectors with spaces', () => {
+  describe('GET anomaly_detectors stats with spaces', () => {
     before(async () => {
       await spacesService.create({ id: idSpace1, name: 'space_one', disabledFeatures: [] });
       await spacesService.create({ id: idSpace2, name: 'space_two', disabledFeatures: [] });
@@ -62,80 +62,80 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fail with non-existing job', async () => {
-      await getJobById('non-existing-job', 404);
+      await getJobStatsById('non-existing-job', 404);
     });
 
     it('should return empty list with non-existing job wildcard', async () => {
-      const body = await getJobById('non-existing-job*', 200);
+      const body = await getJobStatsById('non-existing-job*', 200);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         0,
-        `response jobs list should be empty (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should be empty (got ${JSON.stringify(body.jobs)})`
       );
     });
 
     it('should fail with job from different space', async () => {
-      await getJobById(jobIdSpace1, 404, idSpace2);
+      await getJobStatsById(jobIdSpace1, 404, idSpace2);
     });
 
-    it('should return all jobs when not specifying id', async () => {
-      const body = await getJobById(undefined, 200, idSpace1);
+    it('should return all job stats when not specifying id', async () => {
+      const body = await getJobStatsById(undefined, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         1,
-        `response jobs list should contain correct job (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should contain correct job (got ${JSON.stringify(body.jobs)})`
       );
     });
 
     it('should return empty list when not specifying id in difference space', async () => {
-      const body = await getJobById(undefined, 200, idSpace2);
+      const body = await getJobStatsById(undefined, 200, idSpace2);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         0,
-        `response jobs list should be empty (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should be empty (got ${JSON.stringify(body.jobs)})`
       );
     });
 
-    it('should return job with job id from correct space', async () => {
-      const body = await getJobById(jobIdSpace1, 200, idSpace1);
+    it('should return job stats with job id from correct space', async () => {
+      const body = await getJobStatsById(jobIdSpace1, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         1,
-        `response jobs list should contain correct job (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should contain correct job (got ${JSON.stringify(body.jobs)})`
       );
     });
 
-    it('should return job with job wildcard from correct space', async () => {
-      const body = await getJobById(jobIdWildcardSpace1, 200, idSpace1);
+    it('should return job stats with job wildcard from correct space', async () => {
+      const body = await getJobStatsById(jobIdWildcardSpace1, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         1,
-        `response jobs list should contain correct job (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should contain correct job (got ${JSON.stringify(body.jobs)})`
       );
     });
 
     it('should return empty list with job wildcard from different space', async () => {
-      const body = await getJobById(jobIdWildcardSpace1, 200, idSpace2);
+      const body = await getJobStatsById(jobIdWildcardSpace1, 200, idSpace2);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         0,
-        `response jobs list should be empty (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should be empty (got ${JSON.stringify(body.jobs)})`
       );
     });
 
-    it('should return job by group from same space', async () => {
-      const body = await getJobById(jobGroupSpace1, 200, idSpace1);
+    it('should return job stats by group from same space', async () => {
+      const body = await getJobStatsById(jobGroupSpace1, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         1,
-        `response jobs list should have one element (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should have one element (got ${JSON.stringify(body.jobs)})`
       );
       expect(body.jobs[0].job_id).to.eql(
         jobIdSpace1,
@@ -143,13 +143,13 @@ export default ({ getService }: FtrProviderContext) => {
       );
     });
 
-    it('should return job by group wildcard from same space', async () => {
-      const body = await getJobById(jobGroupWildcardSpace1, 200, idSpace1);
+    it('should return job stats by group wildcard from same space', async () => {
+      const body = await getJobStatsById(jobGroupWildcardSpace1, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         1,
-        `response jobs list should have one element (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should have one element (got ${JSON.stringify(body.jobs)})`
       );
       expect(body.jobs[0].job_id).to.eql(
         jobIdSpace1,
@@ -158,16 +158,16 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fail with group from different space', async () => {
-      await getJobById(jobGroupSpace1, 404, idSpace2);
+      await getJobStatsById(jobGroupSpace1, 404, idSpace2);
     });
 
     it('should return empty list with group wildcard from different space', async () => {
-      const body = await getJobById(jobGroupWildcardSpace1, 200, idSpace2);
+      const body = await getJobStatsById(jobGroupWildcardSpace1, 200, idSpace2);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
       expect(body.jobs.length).to.eql(
         0,
-        `response jobs list should be empty (got ${JSON.stringify(body.jobs)})`
+        `response job stats list should be empty (got ${JSON.stringify(body.jobs)})`
       );
     });
   });

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/get_with_spaces.ts
@@ -71,6 +71,26 @@ export default ({ getService }: FtrProviderContext) => {
       await runRequest(jobIdSpace1, 404, idSpace2);
     });
 
+    it('should return job with job id from correct space', async () => {
+      const body = await runRequest(jobIdSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.jobs.length).to.eql(
+        1,
+        `response jobs list should contain correct job (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return job with job wildcard from correct space', async () => {
+      const body = await runRequest(jobIdWildcardSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.jobs.length).to.eql(
+        1,
+        `response jobs list should contain correct job (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
     it('should return empty list with job wildcard from different space', async () => {
       const body = await runRequest(jobIdWildcardSpace1, 200, idSpace2);
 

--- a/x-pack/test/api_integration/apis/ml/anomaly_detectors/index.ts
+++ b/x-pack/test/api_integration/apis/ml/anomaly_detectors/index.ts
@@ -12,6 +12,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./create'));
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./get_with_spaces'));
+    loadTestFile(require.resolve('./get_stats_with_spaces'));
     loadTestFile(require.resolve('./open_with_spaces'));
     loadTestFile(require.resolve('./close_with_spaces'));
     loadTestFile(require.resolve('./delete_with_spaces'));

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
@@ -21,9 +21,15 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace1 = 'space1';
   const idSpace2 = 'space2';
 
-  async function getDatafeedById(datafeedId: string, expectedStatusCode: number, space?: string) {
+  async function getDatafeedById(
+    datafeedId: string | undefined,
+    expectedStatusCode: number,
+    space?: string
+  ) {
     const { body } = await supertest
-      .get(`${space ? `/s/${space}` : ''}/api/ml/datafeeds/${datafeedId}/_stats`)
+      .get(
+        `${space ? `/s/${space}` : ''}/api/ml/datafeeds${datafeedId ? `/${datafeedId}` : ''}/_stats`
+      )
       .auth(
         USER.ML_VIEWER_ALL_SPACES,
         ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
@@ -70,6 +76,16 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should return datafeed stats with datafeed wildcard from correct space', async () => {
       const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        1,
+        `response datafeeds list should contain correct datafeed (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return all datafeed stats when not specifying id', async () => {
+      const body = await getDatafeedById(undefined, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.datafeeds.length).to.eql(

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
@@ -21,7 +21,7 @@ export default ({ getService }: FtrProviderContext) => {
   const idSpace1 = 'space1';
   const idSpace2 = 'space2';
 
-  async function getDatafeedById(
+  async function getDatafeedStatsById(
     datafeedId: string | undefined,
     expectedStatusCode: number,
     space?: string
@@ -61,11 +61,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fail with non-existing datafeed', async () => {
-      await getDatafeedById('non-existing-datafeed', 404);
+      await getDatafeedStatsById('non-existing-datafeed', 404);
     });
 
     it('should return datafeed stats with datafeed id from correct space', async () => {
-      const body = await getDatafeedById(datafeedIdSpace1, 200, idSpace1);
+      const body = await getDatafeedStatsById(datafeedIdSpace1, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.datafeeds.length).to.eql(
@@ -75,7 +75,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return datafeed stats with datafeed wildcard from correct space', async () => {
-      const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace1);
+      const body = await getDatafeedStatsById(datafeedIdWildcardSpace1, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.datafeeds.length).to.eql(
@@ -85,7 +85,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return all datafeed stats when not specifying id', async () => {
-      const body = await getDatafeedById(undefined, 200, idSpace1);
+      const body = await getDatafeedStatsById(undefined, 200, idSpace1);
 
       expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
       expect(body.datafeeds.length).to.eql(
@@ -95,7 +95,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should return empty list with non-existing datafeed wildcard', async () => {
-      const body = await getDatafeedById('non-existing-datafeed*', 200);
+      const body = await getDatafeedStatsById('non-existing-datafeed*', 200);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
       expect(body.datafeeds.length).to.eql(
@@ -105,11 +105,11 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fail with datafeed from different space', async () => {
-      await getDatafeedById(datafeedIdSpace1, 404, idSpace2);
+      await getDatafeedStatsById(datafeedIdSpace1, 404, idSpace2);
     });
 
     it('should return empty list with datafeed wildcard from different space', async () => {
-      const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace2);
+      const body = await getDatafeedStatsById(datafeedIdWildcardSpace1, 200, idSpace2);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
       expect(body.datafeeds.length).to.eql(

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_stats_with_spaces.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+
+export default ({ getService }: FtrProviderContext) => {
+  const ml = getService('ml');
+  const spacesService = getService('spaces');
+  const supertest = getService('supertestWithoutAuth');
+
+  const jobIdSpace1 = 'fq_single_space1';
+  const datafeedIdSpace1 = `datafeed-${jobIdSpace1}`;
+  const datafeedIdWildcardSpace1 = `datafeed-${jobIdSpace1}*`;
+  const idSpace1 = 'space1';
+  const idSpace2 = 'space2';
+
+  async function getDatafeedById(datafeedId: string, expectedStatusCode: number, space?: string) {
+    const { body } = await supertest
+      .get(`${space ? `/s/${space}` : ''}/api/ml/datafeeds/${datafeedId}/_stats`)
+      .auth(
+        USER.ML_VIEWER_ALL_SPACES,
+        ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
+      )
+      .set(COMMON_REQUEST_HEADERS)
+      .expect(expectedStatusCode);
+
+    return body;
+  }
+
+  describe('GET datafeed stats with spaces', () => {
+    before(async () => {
+      await spacesService.create({ id: idSpace1, name: 'space_one', disabledFeatures: [] });
+      await spacesService.create({ id: idSpace2, name: 'space_two', disabledFeatures: [] });
+
+      const jobConfig = ml.commonConfig.getADFqSingleMetricJobConfig(jobIdSpace1);
+      await ml.api.createAnomalyDetectionJob(jobConfig, idSpace1);
+      const datafeedConfig = ml.commonConfig.getADFqDatafeedConfig(jobIdSpace1);
+      await ml.api.createDatafeed(datafeedConfig, idSpace1);
+
+      await ml.testResources.setKibanaTimeZoneToUTC();
+    });
+
+    after(async () => {
+      await spacesService.delete(idSpace1);
+      await spacesService.delete(idSpace2);
+      await ml.api.cleanMlIndices();
+      await ml.testResources.cleanMLSavedObjects();
+    });
+
+    it('should fail with non-existing datafeed', async () => {
+      await getDatafeedById('non-existing-datafeed', 404);
+    });
+
+    it('should return datafeed stats with datafeed id from correct space', async () => {
+      const body = await getDatafeedById(datafeedIdSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        1,
+        `response datafeeds list should contain correct datafeed (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return datafeed stats with datafeed wildcard from correct space', async () => {
+      const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        1,
+        `response datafeeds list should contain correct datafeed (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return empty list with non-existing datafeed wildcard', async () => {
+      const body = await getDatafeedById('non-existing-datafeed*', 200);
+
+      expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        0,
+        `response datafeed list should be empty (got ${JSON.stringify(body.datafeeds)})`
+      );
+    });
+
+    it('should fail with datafeed from different space', async () => {
+      await getDatafeedById(datafeedIdSpace1, 404, idSpace2);
+    });
+
+    it('should return empty list with datafeed wildcard from different space', async () => {
+      const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace2);
+
+      expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        0,
+        `response datafeed list should be empty (got ${JSON.stringify(body.datafeeds)})`
+      );
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_with_spaces.ts
@@ -62,7 +62,37 @@ export default ({ getService }: FtrProviderContext) => {
       await getDatafeedById('non-existing-datafeed', 404);
     });
 
-    it('should return empty list with non-existing job wildcard', async () => {
+    it('should return datafeed with datafeed id from correct space', async () => {
+      const body = await getDatafeedById(datafeedIdSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        1,
+        `response datafeeds list should contain correct datafeed (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return datafeed with datafeed wildcard from correct space', async () => {
+      const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        1,
+        `response datafeeds list should contain correct datafeed (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return all datafeeds when not specifying id', async () => {
+      const body = await getDatafeedById(undefined, 200, idSpace1);
+
+      expect(body.count).to.eql(1, `response count should be 1 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        1,
+        `response datafeeds list should contain correct datafeed (got ${JSON.stringify(body.jobs)})`
+      );
+    });
+
+    it('should return empty list with non-existing datafeed wildcard', async () => {
       const body = await getDatafeedById('non-existing-datafeed*', 200);
 
       expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);

--- a/x-pack/test/api_integration/apis/ml/datafeeds/get_with_spaces.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/get_with_spaces.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { COMMON_REQUEST_HEADERS } from '../../../../functional/services/ml/common_api';
+
+export default ({ getService }: FtrProviderContext) => {
+  const ml = getService('ml');
+  const spacesService = getService('spaces');
+  const supertest = getService('supertestWithoutAuth');
+
+  const jobIdSpace1 = 'fq_single_space1';
+  const datafeedIdSpace1 = `datafeed-${jobIdSpace1}`;
+  const datafeedIdWildcardSpace1 = `datafeed-${jobIdSpace1}*`;
+  const idSpace1 = 'space1';
+  const idSpace2 = 'space2';
+
+  async function getDatafeedById(
+    datafeedId: string | undefined,
+    expectedStatusCode: number,
+    space?: string
+  ) {
+    const { body } = await supertest
+      .get(`${space ? `/s/${space}` : ''}/api/ml/datafeeds${datafeedId ? `/${datafeedId}` : ''}`)
+      .auth(
+        USER.ML_VIEWER_ALL_SPACES,
+        ml.securityCommon.getPasswordForUser(USER.ML_VIEWER_ALL_SPACES)
+      )
+      .set(COMMON_REQUEST_HEADERS)
+      .expect(expectedStatusCode);
+
+    return body;
+  }
+
+  describe('GET datafeeds with spaces', () => {
+    before(async () => {
+      await spacesService.create({ id: idSpace1, name: 'space_one', disabledFeatures: [] });
+      await spacesService.create({ id: idSpace2, name: 'space_two', disabledFeatures: [] });
+
+      const jobConfig = ml.commonConfig.getADFqSingleMetricJobConfig(jobIdSpace1);
+      await ml.api.createAnomalyDetectionJob(jobConfig, idSpace1);
+      const datafeedConfig = ml.commonConfig.getADFqDatafeedConfig(jobIdSpace1);
+      await ml.api.createDatafeed(datafeedConfig, idSpace1);
+
+      await ml.testResources.setKibanaTimeZoneToUTC();
+    });
+
+    after(async () => {
+      await spacesService.delete(idSpace1);
+      await spacesService.delete(idSpace2);
+      await ml.api.cleanMlIndices();
+      await ml.testResources.cleanMLSavedObjects();
+    });
+
+    it('should fail with non-existing datafeed', async () => {
+      await getDatafeedById('non-existing-datafeed', 404);
+    });
+
+    it('should return empty list with non-existing job wildcard', async () => {
+      const body = await getDatafeedById('non-existing-datafeed*', 200);
+
+      expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        0,
+        `response datafeed list should be empty (got ${JSON.stringify(body.datafeeds)})`
+      );
+    });
+
+    it('should fail with datafeed from different space', async () => {
+      await getDatafeedById(datafeedIdSpace1, 404, idSpace2);
+    });
+
+    it('should return empty list with datafeed wildcard from different space', async () => {
+      const body = await getDatafeedById(datafeedIdWildcardSpace1, 200, idSpace2);
+
+      expect(body.count).to.eql(0, `response count should be 0 (got ${body.count})`);
+      expect(body.datafeeds.length).to.eql(
+        0,
+        `response datafeed list should be empty (got ${JSON.stringify(body.datafeeds)})`
+      );
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/datafeeds/index.ts
+++ b/x-pack/test/api_integration/apis/ml/datafeeds/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('anomaly detectors', function () {
+    loadTestFile(require.resolve('./get_with_spaces'));
+    loadTestFile(require.resolve('./get_stats_with_spaces'));
+  });
+}

--- a/x-pack/test/api_integration/apis/ml/index.ts
+++ b/x-pack/test/api_integration/apis/ml/index.ts
@@ -72,6 +72,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./annotations'));
     loadTestFile(require.resolve('./anomaly_detectors'));
     loadTestFile(require.resolve('./calendars'));
+    loadTestFile(require.resolve('./datafeeds'));
     loadTestFile(require.resolve('./data_frame_analytics'));
     loadTestFile(require.resolve('./data_visualizer'));
     loadTestFile(require.resolve('./fields_service'));


### PR DESCRIPTION
Adds tests for datafeed get endpoints.
Includes adding a datafeed to a space and then getting the datafeed with various combinations of id and wildcarded ids and incorrect space ids.

Also adds tests for the anomaly detection api to cover getting jobs without an ID and getting job stats

Relates to https://github.com/elastic/kibana/issues/110949

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
