### PR TITLE
[Stack monitoring] Add page title to index advanced page

### DIFF
--- a/x-pack/plugins/monitoring/public/application/pages/elasticsearch/index_advanced_page.tsx
+++ b/x-pack/plugins/monitoring/public/application/pages/elasticsearch/index_advanced_page.tsx
@@ -87,7 +87,13 @@ export const ElasticsearchIndexAdvancedPage: React.FC<ComponentProps> = ({ clust
   }, [clusterUuid, services.data?.query.timefilter.timefilter, services.http, index]);
 
   return (
-    <ItemTemplate title={title} getPageData={getPageData} id={index} pageType="indices">
+    <ItemTemplate
+      title={title}
+      getPageData={getPageData}
+      id={index}
+      pageType="indices"
+      pageTitle={index}
+    >
       <SetupModeRenderer
         productName={ELASTICSEARCH_SYSTEM_ID}
         render={({ setupMode, flyoutComponent, bottomBarComponent }: SetupModeProps) => (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/116131

Adds the page title to the Index advanced page:

Before:

<img width="300" alt="Screenshot 2021-10-25 at 15 51 55" src="https://user-images.githubusercontent.com/2249229/138708251-8f01739c-38d3-4c5e-8341-61f707094b46.png">

After:
<img width="300" alt="Screenshot 2021-10-25 at 15 51 41" src="https://user-images.githubusercontent.com/2249229/138708451-70c292db-2c0e-4d89-811f-fc99b30500f6.png">


