### PR TITLE
[Metrics UI] Ensure Kubernetes Pod CPU & Memory Usage is consistent across pages

### DIFF
--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/tsvb/pod_overview.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/tsvb/pod_overview.ts
@@ -50,8 +50,22 @@ export const podOverview: TSVBMetricModelCreator = (
       metrics: [
         {
           field: 'kubernetes.pod.memory.usage.node.pct',
-          id: 'avg-memory-usage',
+          id: 'avg-memory-without',
           type: 'avg',
+        },
+        {
+          field: 'kubernetes.pod.memory.usage.limit.pct',
+          id: 'avg-memory-with',
+          type: 'avg',
+        },
+        {
+          id: 'memory-usage',
+          type: 'calculation',
+          variables: [
+            { id: 'memory_with', name: 'with_limit', field: 'avg-memory-with' },
+            { id: 'memory_without', name: 'without_limit', field: 'avg-memory-without' },
+          ],
+          script: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
         },
       ],
     },

--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/tsvb/pod_overview.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/tsvb/pod_overview.ts
@@ -25,8 +25,22 @@ export const podOverview: TSVBMetricModelCreator = (
       metrics: [
         {
           field: 'kubernetes.pod.cpu.usage.node.pct',
-          id: 'avg-cpu-usage',
+          id: 'avg-cpu-without',
           type: 'avg',
+        },
+        {
+          field: 'kubernetes.pod.cpu.usage.limit.pct',
+          id: 'avg-cpu-with',
+          type: 'avg',
+        },
+        {
+          id: 'cpu-usage',
+          type: 'calculation',
+          variables: [
+            { id: 'cpu_with', name: 'with_limit', field: 'avg-cpu-with' },
+            { id: 'cpu_without', name: 'without_limit', field: 'avg-cpu-without' },
+          ],
+          script: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
         },
       ],
     },


### PR DESCRIPTION
## Summary

This PR fixes #115604 by changing the Kubernetes Pod Overview CPU Usage and Kubernetes Pod Overview Memory on the node detail page to use the same fields and buckets script as the charts below it.

![image](https://user-images.githubusercontent.com/41702/138738094-4cac7eba-d57c-476a-9bfd-2b5a80ae4021.png)