### PR TITLE
[Security Solution] Updating fleet action response data naming

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_fleet_actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_fleet_actions.ts
@@ -66,10 +66,11 @@ export const indexFleetActionsForHost = async (
     const actionResponse = fleetActionGenerator.generateResponse({
       action_id: action.action_id,
       agent_id: agentId,
-      action_data: {
-        ...action.data,
-        // add ack to 4/5th of fleet response
-        ack: fleetActionGenerator.randomFloat() < 0.8 ? true : undefined,
+      action_response: {
+        endpoint: {
+          // add ack to 4/5th of fleet response
+          ack: fleetActionGenerator.randomFloat() < 0.8 ? true : undefined,
+        },
       },
     });
 

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -64,7 +64,12 @@ export interface LogsEndpointActionResponse {
 export interface EndpointActionData {
   command: ISOLATION_ACTIONS;
   comment?: string;
-  ack?: boolean;
+}
+
+export interface FleetActionResponseData {
+  endpoint?: {
+    ack?: boolean;
+  };
 }
 
 export interface EndpointAction {
@@ -93,6 +98,8 @@ export interface EndpointActionResponse {
   completed_at: string;
   error?: string;
   action_data: EndpointActionData;
+  /* Response data from the Endpoint process -- only present in 7.16+ */
+  action_response?: FleetActionResponseData;
 }
 
 export interface EndpointActivityLogAction {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions.ts
@@ -148,7 +148,7 @@ const getActivityLog = async ({
 };
 
 const hasAckInResponse = (response: EndpointActionResponse): boolean => {
-  return typeof response.action_data.ack !== 'undefined';
+  return response.action_response?.endpoint?.ack ?? false;
 };
 
 // return TRUE if for given action_id/agent_id


### PR DESCRIPTION
## Summary

Follow the fleet action pattern of `action_response` as the pathway for returning information


Follows changes in https://github.com/elastic/fleet-server/pull/796