### PR TITLE
[Workplace Search] Fix bug where number rendered as date

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/__mocks__/content_sources.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/__mocks__/content_sources.mock.ts
@@ -376,7 +376,7 @@ export const exampleResult = {
       source: 'custom',
     },
   ],
-  schemaFields: {},
+  schemaFields: { cats: 'text', dogs: 'text' },
 };
 
 export const mostRecentIndexJob = {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.test.tsx
@@ -45,11 +45,25 @@ describe('ExampleResultDetailCard', () => {
       ...exampleResult,
       searchResultConfig: { detailFields: [{ fieldName: 'date', label: 'Date' }] },
       exampleDocuments: [{ date }],
+      schemaFields: { date: 'date' },
     });
     const wrapper = shallow(<ExampleResultDetailCard />);
 
     expect(wrapper.find(EuiText).children().text()).toContain(
       new Date(Date.parse(date)).toLocaleString()
     );
+  });
+
+  it('shows non-formatted value when not a date field', () => {
+    const value = '9999';
+    setMockValues({
+      ...exampleResult,
+      searchResultConfig: { detailFields: [{ fieldName: 'value', label: 'Value' }] },
+      exampleDocuments: [{ value }],
+      schemaFields: { value: 'text' },
+    });
+    const wrapper = shallow(<ExampleResultDetailCard />);
+
+    expect(wrapper.find(EuiText).children().text()).toContain(value);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.tsx
@@ -12,6 +12,7 @@ import { useValues } from 'kea';
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
+import { SchemaType } from '../../../../../shared/schema/types';
 import { URL_LABEL } from '../../../../constants';
 import { getAsLocalDateTimeString } from '../../../../utils';
 
@@ -26,6 +27,7 @@ export const ExampleResultDetailCard: React.FC = () => {
     titleFieldHover,
     urlFieldHover,
     exampleDocuments,
+    schemaFields,
   } = useValues(DisplaySettingsLogic);
 
   const result = exampleDocuments[0];
@@ -63,7 +65,8 @@ export const ExampleResultDetailCard: React.FC = () => {
         {detailFields.length > 0 ? (
           detailFields.map(({ fieldName, label }, index) => {
             const value = result[fieldName];
-            const dateValue = getAsLocalDateTimeString(value);
+            const fieldType = (schemaFields as { [key: string]: SchemaType })[fieldName];
+            const dateValue = fieldType === SchemaType.Date && getAsLocalDateTimeString(value);
 
             return (
               <div

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.test.tsx
@@ -47,7 +47,7 @@ import { ExampleResultDetailCard } from './example_result_detail_card';
 import { ResultDetail } from './result_detail';
 
 describe('ResultDetail', () => {
-  const { searchResultConfig, exampleDocuments } = exampleResult;
+  const { searchResultConfig, exampleDocuments, schemaFields } = exampleResult;
   const availableFieldOptions = [
     {
       value: 'foo',
@@ -70,6 +70,7 @@ describe('ResultDetail', () => {
       searchResultConfig,
       availableFieldOptions,
       exampleDocuments,
+      schemaFields,
     });
   });
 
@@ -94,6 +95,7 @@ describe('ResultDetail', () => {
       },
       availableFieldOptions,
       exampleDocuments,
+      schemaFields,
     });
     const wrapper = shallow(<ResultDetail />);
 
@@ -122,6 +124,7 @@ describe('ResultDetail', () => {
       },
       availableFieldOptions,
       exampleDocuments,
+      schemaFields,
     });
     const wrapper = mount(<ResultDetail />);
 


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/2073

## Summary

Fixes a bug where the Detail card for a search result displays as a date a text field when its value is a parseable date.

**Before** (from [SDH](https://github.com/elastic/sdh-enterprise-search/issues/719))
![before](https://user-images.githubusercontent.com/1869731/138777729-5132fb80-ea94-44ad-babe-9335b013fe4e.png)

**After**
![after](https://user-images.githubusercontent.com/1869731/138777784-34e4b3bf-b8b4-4a5d-8886-8c4106423342.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
