### PR TITLE
Change to infra-monitoring-ui for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,15 +95,15 @@
 # Observability Shared
 /x-pack/plugins/observability/ @elastic/observability-ui
 
-# Logs and Metrics (Infra)
-/x-pack/plugins/infra/ @elastic/logs-metrics-ui
-/x-pack/plugins/infra/server/routes/log* @elastic/logs-metrics-ui @elastic/logs-ui
-/x-pack/plugins/infra/public/pages/logs/ @elastic/logs-metrics-ui @elastic/logs-ui
-/x-pack/plugins/infra/server/routes/metrics* @elastic/logs-metrics-ui @elastic/metrics-ui
-/x-pack/plugins/infra/public/pages/metrics/ @elastic/logs-metrics-ui @elastic/metrics-ui
+# Infra Monitoring
+/x-pack/plugins/infra/ @elastic/infra-monitoring-ui
+/x-pack/test/functional/apps/infra @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/infra @elastic/infra-monitoring-ui
 
-# Stack Monitoring
-/x-pack/plugins/monitoring/ @elastic/stack-monitoring-ui @elastic/logs-metrics-ui @elastic/metrics-ui
+# Elastic Stack Monitoring
+/x-pack/plugins/monitoring/ @elastic/infra-monitoring-ui
+/x-pack/test/functional/apps/monitoring @elastic/infra-monitoring-ui
+/x-pack/test/api_integration/apis/monitoring @elastic/infra-monitoring-ui
 
 # Fleet
 /x-pack/plugins/fleet/ @elastic/fleet


### PR DESCRIPTION
The logs-metrics-ui and stack-monitoring ui teams have merged into one infra-monitoring-ui team inside of observability.