### PR TITLE
[Security Solution] Adds cases and timelines plugins to security solution cypress test execution

### DIFF
--- a/vars/tasks.groovy
+++ b/vars/tasks.groovy
@@ -135,6 +135,8 @@ def functionalXpack(Map params = [:]) {
 
     whenChanged([
       'x-pack/plugins/security_solution/',
+      'x-pack/plugins/cases/',
+      'x-pack/plugins/timelines/',
       'x-pack/test/security_solution_cypress/',
       'x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/',
       'x-pack/plugins/triggers_actions_ui/public/application/context/actions_connectors_context.tsx',


### PR DESCRIPTION
## Summary

The Security Solution Cypress tests are executed when there is a change in our code base. Timelines and cases are part of it but now are extracted from the Security Solution folder to its own plugins, hence we need to update also the `tasks` file in order to execute the tests when there is a change on any of that files. 