### PR TITLE
Set level for all registered deprecations

### DIFF
--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -62,23 +62,38 @@ export const config: PluginConfigDescriptor<APMConfig> = {
   deprecations: ({ renameFromRoot, deprecateFromRoot, unusedFromRoot }) => [
     renameFromRoot(
       'apm_oss.transactionIndices',
-      'xpack.apm.indices.transaction'
+      'xpack.apm.indices.transaction',
+      { level: 'warning' }
     ),
-    renameFromRoot('apm_oss.spanIndices', 'xpack.apm.indices.span'),
-    renameFromRoot('apm_oss.errorIndices', 'xpack.apm.indices.error'),
-    renameFromRoot('apm_oss.metricsIndices', 'xpack.apm.indices.metric'),
-    renameFromRoot('apm_oss.sourcemapIndices', 'xpack.apm.indices.sourcemap'),
-    renameFromRoot('apm_oss.onboardingIndices', 'xpack.apm.indices.onboarding'),
-    deprecateFromRoot('apm_oss.enabled', '8.0.0'),
-    unusedFromRoot('apm_oss.fleetMode'),
-    unusedFromRoot('apm_oss.indexPattern'),
+    renameFromRoot('apm_oss.spanIndices', 'xpack.apm.indices.span', {
+      level: 'warning',
+    }),
+    renameFromRoot('apm_oss.errorIndices', 'xpack.apm.indices.error', {
+      level: 'warning',
+    }),
+    renameFromRoot('apm_oss.metricsIndices', 'xpack.apm.indices.metric', {
+      level: 'warning',
+    }),
+    renameFromRoot('apm_oss.sourcemapIndices', 'xpack.apm.indices.sourcemap', {
+      level: 'warning',
+    }),
+    renameFromRoot(
+      'apm_oss.onboardingIndices',
+      'xpack.apm.indices.onboarding',
+      { level: 'warning' }
+    ),
+    deprecateFromRoot('apm_oss.enabled', '8.0.0', { level: 'warning' }),
+    unusedFromRoot('apm_oss.fleetMode', { level: 'warning' }),
+    unusedFromRoot('apm_oss.indexPattern', { level: 'warning' }),
     renameFromRoot(
       'xpack.apm.maxServiceEnvironments',
-      `uiSettings.overrides[${maxSuggestions}]`
+      `uiSettings.overrides[${maxSuggestions}]`,
+      { level: 'warning' }
     ),
     renameFromRoot(
       'xpack.apm.maxServiceSelections',
-      `uiSettings.overrides[${maxSuggestions}]`
+      `uiSettings.overrides[${maxSuggestions}]`,
+      { level: 'warning' }
     ),
   ],
   exposeToBrowser: {


### PR DESCRIPTION
Explicitly set level for the following registered deprecations:

- apm_oss.transactionIndices
- apm_oss.spanIndices
- apm_oss.errorIndices
- apm_oss.metricsIndices
- apm_oss.sourcemapIndices
- apm_oss.onboardingIndices
- apm_oss.enabled
- apm_oss.fleetMode
- apm_oss.indexPattern
- xpack.apm.maxServiceEnvironments
- xpack.apm.maxServiceSelections

Closes #115347