### PR TITLE
[Fleet] Add data-test-subj to featured integration cards

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -231,6 +231,7 @@ export const AvailablePackages: React.FC = memo(() => {
         <EuiFlexItem>
           <TrackApplicationView viewId="integration-card:epr:endpoint:featured">
             <EuiCard
+              data-test-subj="integration-card:epr:endpoint:featured"
               icon={<EuiIcon type="logoSecurity" size="xxl" />}
               href={addBasePath('/app/integrations/detail/endpoint/')}
               title={i18n.translate('xpack.fleet.featuredSecurityTitle', {
@@ -246,6 +247,7 @@ export const AvailablePackages: React.FC = memo(() => {
         <EuiFlexItem>
           <TrackApplicationView viewId="integration-card:epr:apm:featured">
             <EuiCard
+              data-test-subj="integration-card:epr:apm:featured"
               title={i18n.translate('xpack.fleet.featuredObsTitle', {
                 defaultMessage: 'Elastic APM',
               })}
@@ -261,6 +263,7 @@ export const AvailablePackages: React.FC = memo(() => {
         <EuiFlexItem>
           <TrackApplicationView viewId="integration-card:epr:app_search_web_crawler:featured">
             <EuiCard
+              data-test-sub="integration-card:epr:app_search_web_crawler:featured"
               icon={<EuiIcon type="logoAppSearch" size="xxl" />}
               href={addBasePath('/app/enterprise_search/app_search')}
               title={i18n.translate('xpack.fleet.featuredSearchTitle', {


### PR DESCRIPTION
## Summary

Adds the `data-test-subj` attribute to the new featured cards to ensure that it matches the telemetry added to all other cards in https://github.com/elastic/kibana/pull/115413
