### PR TITLE
[Telemetry] Trusted Application policy scope

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/filters.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/filters.ts
@@ -140,6 +140,7 @@ export const exceptionListEventFields: AllowlistFields = {
   name: true,
   os_types: true,
   rule_version: true,
+  scope: true,
 };
 
 /**

--- a/x-pack/plugins/security_solution/server/lib/telemetry/helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/helpers.ts
@@ -108,6 +108,7 @@ export const trustedApplicationToTelemetryEntry = (trustedApplication: TrustedAp
     updated_at: trustedApplication.updated_at,
     entries: trustedApplication.entries,
     os_types: [trustedApplication.os],
+    scope: trustedApplication.effectScope,
   } as ExceptionListItem;
 };
 


### PR DESCRIPTION
## Summary

Extends https://github.com/elastic/kibana/pull/107765 by collecting trusted application scope as part of the lists telemetry. This functionality already includes unit tests - just letting another field through.

### Example: Global Scope

```js
{
	"@timestamp": 1635250812664,
	"trusted_application": {
		"created_at": "2021-10-26T11:43:04.914Z",
		"entries": [{
			"field": "process.hash.*",
			"value": "e044d9f2d0f1260c3f4a543a1e67f33fcac265be114a1b135fd575b860d2b8c6",
			"type": "match",
			"operator": "included"
		}],
		"id": "46d67655-03dd-41de-b4f4-61222ce84c9a",
		"name": "Pete H - DoejoCrypt/DearCry Ransomware ",
		"os_types": ["windows"],
		"scope": {
			"type": "global"
		}
	}
}
```

### Example: Policy Scope

```js
{
	"@timestamp": 1635250812664,
	"trusted_application": {
		"created_at": "2021-10-26T12:19:02.825Z",
		"entries": [{
			"field": "process.hash.*",
			"value": "36e8bb8719a619b78862907fd49445750371f40945fefd55a9862465dc2930f9",
			"type": "match",
			"operator": "included"
		}],
		"id": "1d561e2e-84de-4eda-9692-7472406c92aa",
		"name": "TypeScript party ",
		"os_types": ["linux"],
		"scope": {
			"type": "policy",
			"policies": ["76ccc57a-8ba8-4eff-9e17-429cffe0fafe"]
		}
	}
}
```
