### PR TITLE
Enable APM agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "deep-freeze-strict": "^1.1.1",
     "deepmerge": "^4.2.2",
     "del": "^5.1.0",
-    "elastic-apm-node": "^3.21.1",
+    "elastic-apm-node": "^3.23.0",
     "execa": "^4.0.2",
     "exit-hook": "^2.2.0",
     "expiry-js": "0.1.7",

--- a/packages/kbn-apm-config-loader/src/init_apm.test.ts
+++ b/packages/kbn-apm-config-loader/src/init_apm.test.ts
@@ -11,8 +11,7 @@ import { mockLoadConfiguration } from './init_apm.test.mocks';
 import { initApm } from './init_apm';
 import apm from 'elastic-apm-node';
 
-// TODO: unskip when https://github.com/elastic/kibana/issues/116109 is fixed
-describe.skip('initApm', () => {
+describe('initApm', () => {
   let apmAddFilterSpy: jest.SpyInstance;
   let apmStartSpy: jest.SpyInstance;
   let getConfig: jest.Mock;

--- a/packages/kbn-apm-config-loader/src/init_apm.ts
+++ b/packages/kbn-apm-config-loader/src/init_apm.ts
@@ -14,9 +14,6 @@ export const initApm = (
   isDistributable: boolean,
   serviceName: string
 ) => {
-  // TODO: re-enabled when https://github.com/elastic/kibana/issues/116109 is fixed
-  return;
-
   const apmConfigLoader = loadConfiguration(argv, rootDir, isDistributable);
   const apmConfig = apmConfigLoader.getConfig(serviceName);
 

--- a/x-pack/test/performance/tests/reporting_dashboard.ts
+++ b/x-pack/test/performance/tests/reporting_dashboard.ts
@@ -16,8 +16,7 @@ export default function ({ getService, getPageObject }: FtrProviderContext) {
   const dashboard = getPageObject('dashboard');
   const reporting = getPageObject('reporting');
 
-  // TODO: unskip when https://github.com/elastic/kibana/issues/116109 is fixed
-  describe.skip('reporting dashbaord', () => {
+  describe('reporting dashbaord', () => {
     before(async () => {
       await kibanaServer.importExport.load(
         'x-pack/test/performance/kbn_archives/reporting_dashboard'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,6 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
-"@elastic/apm-synthtrace@link:bazel-bin/packages/elastic-apm-synthtrace":
-  version "0.0.0"
-  uid ""
-
 "@elastic/apm-rum-core@^5.12.1":
   version "5.12.1"
   resolved "https://registry.yarnpkg.com/@elastic/apm-rum-core/-/apm-rum-core-5.12.1.tgz#ad78787876c68b9ce718d1c42b8e7b12b12eaa69"
@@ -2329,6 +2325,10 @@
   integrity sha512-NJAdzxXxf+LeCI0Dz3P+RMVY66C8sAztIg4tvnrhvBqxf8d7se+FpYw3oYjw3BZ8UDycmXEaIqEGcynUUndgqA==
   dependencies:
     "@elastic/apm-rum-core" "^5.12.1"
+
+"@elastic/apm-synthtrace@link:bazel-bin/packages/elastic-apm-synthtrace":
+  version "0.0.0"
+  uid ""
 
 "@elastic/app-search-javascript@^7.13.1":
   version "7.13.1"
@@ -13165,10 +13165,10 @@ ejs@^3.1.2, ejs@^3.1.6:
   dependencies:
     jake "^10.6.1"
 
-elastic-apm-http-client@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/elastic-apm-http-client/-/elastic-apm-http-client-10.0.0.tgz#495651716c13a744544c4dc983107a948418d213"
-  integrity sha512-D0Frzaqo2h6RxrbxkwfTZSu7tKkmmP3UGYLCp2Fq25cGT/3px4hBWvTc+nV7iDwj2rwdQl7CNkcathYNkyHRWQ==
+elastic-apm-http-client@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/elastic-apm-http-client/-/elastic-apm-http-client-10.1.0.tgz#8fbfa3f026f40d82b22b77bf4ed539cc20623edb"
+  integrity sha512-G+UsOQS8+kTyjbZ9PBXgbN8RGgeTe3FfbVljiwuN+eIf0UwpSR8k5Oh+Z2BELTTVwTcit7NCH4+B4MPayYx1mw==
   dependencies:
     breadth-filter "^2.0.0"
     container-info "^1.0.1"
@@ -13179,10 +13179,10 @@ elastic-apm-http-client@^10.0.0:
     readable-stream "^3.4.0"
     stream-chopper "^3.0.1"
 
-elastic-apm-node@^3.21.1:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-3.21.1.tgz#5f79cfc6ba60469e4ec83d176b3d28ddee78b530"
-  integrity sha512-qnYWvWXQx00pS98IFYxkRQ9+T+R8oh0KdsbCU8t1ouSozZI6l5frlwC9CVpsqakPnAuvWP/qIYJEKF3CkYPv0w==
+elastic-apm-node@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-3.23.0.tgz#e842aa505d576003579803e45fe91f572db74a72"
+  integrity sha512-yzdO/MwAcjT+TbcBQBKWbDb4beDVmmrIaFCu9VA+z6Ow9GKlQv7QaD9/cQjuN8/KI6ASiJfQI8cPgqy1SgSUuA==
   dependencies:
     "@elastic/ecs-pino-format" "^1.2.0"
     after-all-results "^2.0.0"
@@ -13191,7 +13191,7 @@ elastic-apm-node@^3.21.1:
     basic-auth "^2.0.1"
     cookie "^0.4.0"
     core-util-is "^1.0.2"
-    elastic-apm-http-client "^10.0.0"
+    elastic-apm-http-client "^10.1.0"
     end-of-stream "^1.4.4"
     error-callsites "^2.0.4"
     error-stack-parser "^2.0.6"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/116109

Update APM node agent to a version compatible with `elasticsearch-js@8.0.0`  version.
Enables APM agent again.
