### PR TITLE
[7.16] retain query language on step edit (#116227)

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
@@ -127,6 +127,7 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
     dependentVariable,
     includes,
     jobConfigQuery,
+    jobConfigQueryLanguage,
     jobConfigQueryString,
     jobType,
     modelMemoryLimit,
@@ -150,14 +151,18 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
 
   const [query, setQuery] = useState<Query>({
     query: jobConfigQueryString ?? '',
-    language: SEARCH_QUERY_LANGUAGE.KUERY,
+    language: jobConfigQueryLanguage ?? SEARCH_QUERY_LANGUAGE.KUERY,
   });
 
   const toastNotifications = getToastNotifications();
 
   const setJobConfigQuery: ExplorationQueryBarProps['setSearchQuery'] = (update) => {
     if (update.query) {
-      setFormState({ jobConfigQuery: update.query, jobConfigQueryString: update.queryString });
+      setFormState({
+        jobConfigQuery: update.query,
+        jobConfigQueryLanguage: update.language,
+        jobConfigQueryString: update.queryString,
+      });
     }
     setQuery({ query: update.queryString, language: update.language });
   };

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/state.ts
@@ -79,6 +79,7 @@ export interface State {
     jobType: AnalyticsJobType;
     jobConfigQuery: any;
     jobConfigQueryString: string | undefined;
+    jobConfigQueryLanguage: string | undefined;
     lambda: number | undefined;
     lossFunction: string | undefined;
     lossFunctionParameter: number | undefined;
@@ -162,6 +163,7 @@ export const getInitialState = (): State => ({
     jobType: undefined,
     jobConfigQuery: defaultSearchQuery,
     jobConfigQueryString: undefined,
+    jobConfigQueryLanguage: undefined,
     lambda: undefined,
     lossFunction: undefined,
     lossFunctionParameter: undefined,


### PR DESCRIPTION
Backports the following commits to 7.16:
 - retain query language on step edit (#116227)