### PR TITLE
APM project automation

### DIFF
--- a/.github/workflows/add-to-apm-project.yml
+++ b/.github/workflows/add-to-apm-project.yml
@@ -1,0 +1,28 @@
+name: Add to APM Project
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        if: |
+          github.event.label.name == 'Team:apm'
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:String!,$contentid:String!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAGc3Zs0VSg"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN_KIBANA }}

--- a/.github/workflows/add-to-apm-project.yml
+++ b/.github/workflows/add-to-apm-project.yml
@@ -25,4 +25,4 @@ jobs:
           contentid: ${{ github.event.issue.node_id }}
         env:
           PROJECT_ID: "PN_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN_KIBANA }}
+          GITHUB_TOKEN: ${{ secrets.KIBANAMACHINE_TOKEN }}


### PR DESCRIPTION
## Summary

Add APM team issues to the APM GH Projects Beta Board.  This unfortunately can't reuse the [existing automation](https://github.com/elastic/kibana/blob/master/.github/workflows/project-assigner.yml) as it uses a separate API.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
