### PR TITLE
[App Search] Update relevance tuning preview whenever precision or query is changed

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/components/precision_slider/precision_slider.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/components/precision_slider/precision_slider.test.tsx
@@ -25,7 +25,7 @@ const MOCK_VALUES = {
 
 const MOCK_ACTIONS = {
   // RelevanceTuningLogic
-  updatePrecision: jest.fn(),
+  setPrecision: jest.fn(),
 };
 
 describe('PrecisionSlider', () => {
@@ -49,12 +49,12 @@ describe('PrecisionSlider', () => {
       expect(wrapper.find('[data-test-subj="PrecisionRange"]').prop('value')).toEqual(2);
     });
 
-    it('calls updatePrecision on change', () => {
+    it('updates the precision on change', () => {
       wrapper
         .find('[data-test-subj="PrecisionRange"]')
         .simulate('change', { target: { value: 10 } });
 
-      expect(MOCK_ACTIONS.updatePrecision).toHaveBeenCalledWith(10);
+      expect(MOCK_ACTIONS.setPrecision).toHaveBeenCalledWith(10);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/components/precision_slider/precision_slider.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/components/precision_slider/precision_slider.tsx
@@ -33,7 +33,7 @@ export const PrecisionSlider: React.FC = () => {
     searchSettings: { precision },
   } = useValues(RelevanceTuningLogic);
 
-  const { updatePrecision } = useActions(RelevanceTuningLogic);
+  const { setPrecision } = useActions(RelevanceTuningLogic);
 
   const stepDescription = STEP_DESCRIPTIONS[precision];
 
@@ -102,7 +102,7 @@ export const PrecisionSlider: React.FC = () => {
         data-test-subj="PrecisionRange"
         value={precision}
         onChange={(e) => {
-          updatePrecision(parseInt((e.target as HTMLInputElement).value, 10));
+          setPrecision(parseInt((e.target as HTMLInputElement).value, 10));
         }}
         min={1}
         max={11}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -228,10 +228,10 @@ describe('RelevanceTuningLogic', () => {
       });
     });
 
-    describe('updatePrecision', () => {
+    describe('setPrecision', () => {
       it('should set precision inside search settings and set unsavedChanges to true', () => {
         mount();
-        RelevanceTuningLogic.actions.updatePrecision(9);
+        RelevanceTuningLogic.actions.setPrecision(9);
 
         expect(RelevanceTuningLogic.values).toEqual({
           ...DEFAULT_VALUES,
@@ -1007,15 +1007,24 @@ describe('RelevanceTuningLogic', () => {
       });
     });
 
-    describe('updateSearchValue', () => {
-      it('should update the query then update search results', () => {
+    describe('setSearchQuery', () => {
+      it('shoulds update search results', () => {
         mount();
-        jest.spyOn(RelevanceTuningLogic.actions, 'setSearchQuery');
         jest.spyOn(RelevanceTuningLogic.actions, 'getSearchResults');
 
-        RelevanceTuningLogic.actions.updateSearchValue('foo');
+        RelevanceTuningLogic.actions.setSearchQuery('foo');
 
-        expect(RelevanceTuningLogic.actions.setSearchQuery).toHaveBeenCalledWith('foo');
+        expect(RelevanceTuningLogic.actions.getSearchResults).toHaveBeenCalled();
+      });
+    });
+
+    describe('setPrecision', () => {
+      it('shoulds update search results', () => {
+        mount();
+        jest.spyOn(RelevanceTuningLogic.actions, 'getSearchResults');
+
+        RelevanceTuningLogic.actions.setPrecision(9);
+
         expect(RelevanceTuningLogic.actions.getSearchResults).toHaveBeenCalled();
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -88,8 +88,7 @@ interface RelevanceTuningActions {
     optionType: keyof Pick<Boost, 'operation' | 'function'>;
     value: string;
   };
-  updatePrecision(precision: number): { precision: number };
-  updateSearchValue(query: string): string;
+  setPrecision(precision: number): { precision: number };
 }
 
 interface RelevanceTuningValues {
@@ -144,8 +143,7 @@ export const RelevanceTuningLogic = kea<
       optionType,
       value,
     }),
-    updatePrecision: (precision) => ({ precision }),
-    updateSearchValue: (query) => query,
+    setPrecision: (precision) => ({ precision }),
   }),
   reducers: () => ({
     searchSettings: [
@@ -158,7 +156,7 @@ export const RelevanceTuningLogic = kea<
         onInitializeRelevanceTuning: (_, { searchSettings }) => searchSettings,
         setSearchSettings: (_, { searchSettings }) => searchSettings,
         setSearchSettingsResponse: (_, { searchSettings }) => searchSettings,
-        updatePrecision: (currentSearchSettings, { precision }) => ({
+        setPrecision: (currentSearchSettings, { precision }) => ({
           ...currentSearchSettings,
           precision,
         }),
@@ -191,7 +189,7 @@ export const RelevanceTuningLogic = kea<
     unsavedChanges: [
       false,
       {
-        updatePrecision: () => true,
+        setPrecision: () => true,
         setSearchSettings: () => true,
         setSearchSettingsResponse: () => false,
       },
@@ -268,7 +266,11 @@ export const RelevanceTuningLogic = kea<
 
       const { engineName } = EngineLogic.values;
       const { http } = HttpLogic.values;
-      const { search_fields: searchFields, boosts } = removeBoostStateProps(values.searchSettings);
+      const {
+        search_fields: searchFields,
+        boosts,
+        precision,
+      } = removeBoostStateProps(values.searchSettings);
       const url = `/internal/app_search/engines/${engineName}/search`;
 
       actions.setResultsLoading(true);
@@ -283,6 +285,7 @@ export const RelevanceTuningLogic = kea<
           body: JSON.stringify({
             boosts: isEmpty(filteredBoosts) ? undefined : filteredBoosts,
             search_fields: isEmpty(searchFields) ? undefined : searchFields,
+            precision,
           }),
         });
 
@@ -472,8 +475,10 @@ export const RelevanceTuningLogic = kea<
         },
       });
     },
-    updateSearchValue: (query) => {
-      actions.setSearchQuery(query);
+    setSearchQuery: () => {
+      actions.getSearchResults();
+    },
+    setPrecision: () => {
       actions.getSearchResults();
     },
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_preview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_preview.test.tsx
@@ -22,7 +22,7 @@ describe('RelevanceTuningPreview', () => {
   const result3 = { id: { raw: 3 } };
 
   const actions = {
-    updateSearchValue: jest.fn(),
+    setSearchQuery: jest.fn(),
   };
 
   const values = {
@@ -79,7 +79,7 @@ describe('RelevanceTuningPreview', () => {
 
     wrapper.find(EuiFieldSearch).simulate('change', { target: { value: 'some search text' } });
 
-    expect(actions.updateSearchValue).toHaveBeenCalledWith('some search text');
+    expect(actions.setSearchQuery).toHaveBeenCalledWith('some search text');
   });
 
   it('will show user a prompt to enter a query if they have not entered one', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_preview.tsx
@@ -44,7 +44,7 @@ const noResultsCallout = (
 );
 
 export const RelevanceTuningPreview: React.FC = () => {
-  const { updateSearchValue } = useActions(RelevanceTuningLogic);
+  const { setSearchQuery } = useActions(RelevanceTuningLogic);
   const { searchResults, schema } = useValues(RelevanceTuningLogic);
   const { engineName, isMetaEngine } = useValues(EngineLogic);
 
@@ -59,7 +59,7 @@ export const RelevanceTuningPreview: React.FC = () => {
       </EuiTitle>
       <EuiSpacer />
       <EuiFieldSearch
-        onChange={(e) => updateSearchValue(e.target.value)}
+        onChange={(e) => setSearchQuery(e.target.value)}
         placeholder={i18n.translate(
           'xpack.enterpriseSearch.appSearch.engine.relevanceTuning.preview.searchPlaceholder',
           {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
@@ -16,7 +16,7 @@ export const filterIfTerm = (array: string[], filterTerm: string): string[] => {
   return filterTerm === '' ? array : array.filter((item) => item.includes(filterTerm));
 };
 
-export const removeBoostStateProps = (searchSettings: SearchSettings) => {
+export const removeBoostStateProps = (searchSettings: SearchSettings): SearchSettings => {
   const updatedSettings = cloneDeep(searchSettings);
   const { boosts } = updatedSettings;
   const keys = Object.keys(boosts);


### PR DESCRIPTION
## Summary

Previous we were not retrieving new search results when the precision value was updated.  

- combined `RelevanceTuningLogic.actions.updateSearchValue` and `RelevanceTuningLogic.actions.setSearchQuery` into a single action `RelevanceTuningLogic.actions.setSearchQuery`, which still sets the query in local state and then calls `RelevanceTuningLogic.actions.getSearchResults`
- Replaced `RelevanceTuningLogic.actions.updatePrecision` with `RelevanceTuningLogic.actions.setPrecision`.  This new action sets the precision in the local state _and now also_ calls `RelevanceTuningLogic.actions.getSearchResults`

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
