### PR TITLE
[docs] Re-add `experimental` label to dashboard import/export API docs.

### DIFF
--- a/docs/api/dashboard-api.asciidoc
+++ b/docs/api/dashboard-api.asciidoc
@@ -1,7 +1,7 @@
 [[dashboard-api]]
 == Import and export dashboard APIs
 
-deprecated::[7.15.0,Both of these APIs have been deprecated in favor of <<saved-objects-api-import>> and <<saved-objects-api-export>>.]
+deprecated::[7.15.0,These experimental APIs have been deprecated in favor of <<saved-objects-api-import>> and <<saved-objects-api-export>>.]
 
 Import and export dashboards with the corresponding saved objects, such as visualizations, saved
 searches, and index patterns.

--- a/docs/api/dashboard/export-dashboard.asciidoc
+++ b/docs/api/dashboard/export-dashboard.asciidoc
@@ -6,7 +6,7 @@
 
 deprecated::[7.15.0,Use <<saved-objects-api-export>> instead.]
 
-Export dashboards and corresponding saved objects.
+experimental[] Export dashboards and corresponding saved objects.
 
 [[dashboard-api-export-request]]
 ==== Request

--- a/docs/api/dashboard/import-dashboard.asciidoc
+++ b/docs/api/dashboard/import-dashboard.asciidoc
@@ -6,7 +6,7 @@
 
 deprecated::[7.15.0,Use <<saved-objects-api-import>> instead.]
 
-Import dashboards and corresponding saved objects.
+experimental[] Import dashboards and corresponding saved objects.
 
 [[dashboard-api-import-request]]
 ==== Request


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/116137

In https://github.com/elastic/kibana/pull/108826, we updated the docs to mark the dashboard import/export APIs as deprecated. In that update, we inadvertently removed the `experimental` label from these APIs, which has caused some confusion among users.

This fixes the issue so that the `experimental` label remains in 7.15 and later.

Docs preview: https://kibana_116348.docs-preview.app.elstc.co/diff 