### PR TITLE
[7.16] [Fleet] Marking API spec as experimental (#116331)

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/README.md
+++ b/x-pack/plugins/fleet/common/openapi/README.md
@@ -1,6 +1,6 @@
-# OpenAPI
+# OpenAPI (Experimental)
 
-The current self-contained spec file is [as JSON](https://raw.githubusercontent.com/elastic/kibana/7.x/x-pack/plugins/fleet/common/openapi/bundled.json) or [as YAML](https://raw.githubusercontent.com/elastic/kibana/7.x/x-pack/plugins/fleet/common/openapi/bundled.yaml) and can be used for online tools like those found at https://openapi.tools/
+The current self-contained spec file is [as JSON](https://raw.githubusercontent.com/elastic/kibana/7.x/x-pack/plugins/fleet/common/openapi/bundled.json) or [as YAML](https://raw.githubusercontent.com/elastic/kibana/7.x/x-pack/plugins/fleet/common/openapi/bundled.yaml) and can be used for online tools like those found at https://openapi.tools/. This spec is experiemental and may be incomplete or change later.
 
 For example, online viewers for the specification like these:
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Fleet] Marking API spec as experimental (#116331)