### PR TITLE
[Canvas] Fixes Reveal Image background is not contained.

### DIFF
--- a/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
@@ -118,11 +118,11 @@ function RevealImageComponent({
     return imgStyles;
   }
 
-  const additionaAlignerStyles: AlignerStyles = {};
+  const additionalAlignerStyles: AlignerStyles = {};
 
   if (isValidUrl(emptyImage ?? '')) {
     // only use empty image if one is provided
-    additionaAlignerStyles.backgroundImage = `url(${emptyImage})`;
+    additionalAlignerStyles.backgroundImage = `url(${emptyImage})`;
   }
 
   let additionalImgStyles: ImageStyles = {};
@@ -136,10 +136,10 @@ function RevealImageComponent({
   return (
     <div
       className="revealImageAligner"
-      css={css({
+      style={{
         ...revealImageAlignerStyle,
-        ...additionaAlignerStyles,
-      })}
+        ...additionalAlignerStyles,
+      }}
     >
       <img
         ref={imgRef}

--- a/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
+++ b/src/plugins/expression_reveal_image/public/components/reveal_image_component.tsx
@@ -136,7 +136,7 @@ function RevealImageComponent({
   return (
     <div
       className="revealImageAligner"
-      style={{
+      css={{
         ...revealImageAlignerStyle,
         ...additionalAlignerStyles,
       }}


### PR DESCRIPTION
#### Fixes: https://github.com/elastic/kibana/issues/116350

The current bug has been caused by the emotion/css behavior. The `css` function was producing the right styles, but the `css` prop of the `div` was excluding one of the attributes of the style, `background-repeat` or `background-size`.
The replacement of `emotion/css` with the usual `style` attribute or `css` attribute without using `css` function from `emotion/css` fixed the problem.

#### Screenshots
##### Before:
![Screenshot 2021-10-27 at 11 31 00](https://user-images.githubusercontent.com/22456368/139029615-a9a8c715-e1f8-4c20-be3a-e521203f4e2f.png)

##### After: 
![Screenshot 2021-10-27 at 11 32 45](https://user-images.githubusercontent.com/22456368/139029881-fc8def6c-d5d6-4f4f-9736-b1a8a6a52a80.png)


