### PR TITLE
[Vega] Replace static messages with callouts

### DIFF
--- a/src/plugins/vis_types/vega/public/vega_view/vega_messages_list.tsx
+++ b/src/plugins/vis_types/vega/public/vega_view/vega_messages_list.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiIcon,
+} from '@elastic/eui';
+import React from 'react';
+
+interface VegaMessagesListProps {
+  messages: Array<{ type: 'err' | 'warning'; text: string }>;
+  removeMessage: (text: string) => void;
+}
+
+export const VegaMessagesList = ({ messages, removeMessage }: VegaMessagesListProps) => {
+  return messages.map(({ type, text }) => {
+    const color = type === 'err' ? 'danger' : 'warning';
+
+    return (
+      <li className="vgaVis__message vgaVis__message--${type}">
+        <EuiCallOut color={color} size="s">
+          <EuiFlexGroup direction="row" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="alert" color={color} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="s" color={color}>
+                {text}
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon
+                aria-label="close"
+                iconType="cross"
+                color={color}
+                onClick={() => removeMessage(text)}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiCallOut>
+      </li>
+    );
+  });
+};


### PR DESCRIPTION
## Summary

Replaced Vega static error and warning messages with callouts that could be dismissed.

![image](https://user-images.githubusercontent.com/54894989/139030263-a94afd16-629c-421e-886f-bac1d73ad2f7.png)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
