### PR TITLE
[7.15] Ignore security disabled HTTP response header (#115945)

### DIFF
--- a/src/plugins/data/public/search/fetch/handle_response.tsx
+++ b/src/plugins/data/public/search/fetch/handle_response.tsx
@@ -17,7 +17,7 @@ import { SearchRequest } from '..';
 
 export function handleResponse(request: SearchRequest, response: IKibanaSearchResponse) {
   const { rawResponse, warning } = response;
-  if (warning) {
+  if (warning && !shouldIgnoreWarning(warning)) {
     getNotifications().toasts.addWarning({
       title: i18n.translate('data.search.searchSource.fetch.warningMessage', {
         defaultMessage: 'Warning: {warning}',
@@ -63,4 +63,11 @@ export function handleResponse(request: SearchRequest, response: IKibanaSearchRe
   }
 
   return response;
+}
+
+function shouldIgnoreWarning(warning: string): boolean {
+  // https://github.com/elastic/kibana/issues/115632
+  if (warning.includes('Elasticsearch built-in security features are not enabled')) return true;
+
+  return false;
 }


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Ignore security disabled HTTP response header (#115945)