### PR TITLE
[7.16] [Reporting / Dashboard] Use Unsaved State in Report URL (#114331)

### DIFF
--- a/src/plugins/dashboard/public/application/lib/convert_dashboard_panels.ts
+++ b/src/plugins/dashboard/public/application/lib/convert_dashboard_panels.ts
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { convertSavedDashboardPanelToPanelState } from '../../../common/embeddable/embeddable_saved_object_converters';
+import {
+  convertSavedDashboardPanelToPanelState,
+  convertPanelStateToSavedDashboardPanel,
+} from '../../../common/embeddable/embeddable_saved_object_converters';
 import type { SavedDashboardPanel, DashboardPanelMap } from '../../types';
 
 export const convertSavedPanelsToPanelMap = (panels?: SavedDashboardPanel[]): DashboardPanelMap => {
@@ -15,4 +18,10 @@ export const convertSavedPanelsToPanelMap = (panels?: SavedDashboardPanel[]): Da
     panelsMap![panel.panelIndex ?? String(idx)] = convertSavedDashboardPanelToPanelState(panel);
   });
   return panelsMap;
+};
+
+export const convertPanelMapToSavedPanels = (panels: DashboardPanelMap, version: string) => {
+  return Object.values(panels).map((panel) =>
+    convertPanelStateToSavedDashboardPanel(panel, version)
+  );
 };

--- a/src/plugins/dashboard/public/application/lib/convert_dashboard_state.ts
+++ b/src/plugins/dashboard/public/application/lib/convert_dashboard_state.ts
@@ -19,7 +19,7 @@ import {
   DashboardContainerInput,
   DashboardBuildContext,
 } from '../../types';
-import { convertSavedPanelsToPanelMap } from './convert_saved_panels_to_panel_map';
+import { convertSavedPanelsToPanelMap } from './convert_dashboard_panels';
 
 interface SavedObjectToDashboardStateProps {
   version: string;

--- a/src/plugins/dashboard/public/application/lib/load_dashboard_history_location_state.ts
+++ b/src/plugins/dashboard/public/application/lib/load_dashboard_history_location_state.ts
@@ -8,7 +8,7 @@
 
 import { ForwardedDashboardState } from '../../locator';
 import { DashboardState } from '../../types';
-import { convertSavedPanelsToPanelMap } from './convert_saved_panels_to_panel_map';
+import { convertSavedPanelsToPanelMap } from './convert_dashboard_panels';
 
 export const loadDashboardHistoryLocationState = (
   state?: ForwardedDashboardState

--- a/src/plugins/dashboard/public/application/lib/sync_dashboard_url_state.ts
+++ b/src/plugins/dashboard/public/application/lib/sync_dashboard_url_state.ts
@@ -21,7 +21,7 @@ import type {
   DashboardState,
   RawDashboardState,
 } from '../../types';
-import { convertSavedPanelsToPanelMap } from './convert_saved_panels_to_panel_map';
+import { convertSavedPanelsToPanelMap } from './convert_dashboard_panels';
 
 type SyncDashboardUrlStateProps = DashboardBuildContext & { savedDashboard: DashboardSavedObject };
 

--- a/src/plugins/dashboard/public/application/top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/dashboard_top_nav.tsx
@@ -407,16 +407,24 @@ export function DashboardTopNav({
       const timeRange = timefilter.getTime();
       ShowShareModal({
         share,
+        timeRange,
         kibanaVersion,
         anchorElement,
         dashboardCapabilities,
+        dashboardSessionStorage,
         currentDashboardState: currentState,
         savedDashboard: dashboardAppState.savedDashboard,
         isDirty: Boolean(dashboardAppState.hasUnsavedChanges),
-        timeRange,
       });
     },
-    [dashboardAppState, dashboardCapabilities, share, kibanaVersion, timefilter]
+    [
+      share,
+      timefilter,
+      kibanaVersion,
+      dashboardAppState,
+      dashboardCapabilities,
+      dashboardSessionStorage,
+    ]
   );
 
   const dashboardTopNavActions = useMemo(() => {

--- a/src/plugins/dashboard/public/application/top_nav/show_share_modal.test.tsx
+++ b/src/plugins/dashboard/public/application/top_nav/show_share_modal.test.tsx
@@ -6,8 +6,13 @@
  * Side Public License, v 1.
  */
 
-import { Capabilities } from 'src/core/public';
-import { showPublicUrlSwitch } from './show_share_modal';
+import { DashboardState } from '../../types';
+import { DashboardAppLocatorParams } from '../..';
+import { Capabilities } from '../../services/core';
+import { SharePluginStart } from '../../services/share';
+import { stateToRawDashboardState } from '../lib/convert_dashboard_state';
+import { getSavedDashboardMock, makeDefaultServices } from '../test_helpers';
+import { showPublicUrlSwitch, ShowShareModal, ShowShareModalProps } from './show_share_modal';
 
 describe('showPublicUrlSwitch', () => {
   test('returns false if "dashboard" app is not available', () => {
@@ -47,5 +52,102 @@ describe('showPublicUrlSwitch', () => {
     const result = showPublicUrlSwitch(anonymousUserCapabilities);
 
     expect(result).toBe(true);
+  });
+});
+
+describe('ShowShareModal', () => {
+  const unsavedStateKeys = ['query', 'filters', 'options', 'savedQuery', 'panels'] as Array<
+    keyof DashboardAppLocatorParams
+  >;
+
+  const getPropsAndShare = (
+    unsavedState?: Partial<DashboardState>
+  ): { share: SharePluginStart; showModalProps: ShowShareModalProps } => {
+    const services = makeDefaultServices();
+    const share = {} as unknown as SharePluginStart;
+    share.toggleShareContextMenu = jest.fn();
+    services.dashboardSessionStorage.getState = jest.fn().mockReturnValue(unsavedState);
+    return {
+      showModalProps: {
+        share,
+        isDirty: true,
+        kibanaVersion: 'testKibanaVersion',
+        savedDashboard: getSavedDashboardMock(),
+        anchorElement: document.createElement('div'),
+        dashboardCapabilities: services.dashboardCapabilities,
+        currentDashboardState: { panels: {} } as unknown as DashboardState,
+        dashboardSessionStorage: services.dashboardSessionStorage,
+        timeRange: {
+          from: '2021-10-07T00:00:00.000Z',
+          to: '2021-10-10T00:00:00.000Z',
+        },
+      },
+      share,
+    };
+  };
+
+  it('locatorParams is missing all unsaved state when none is given', () => {
+    const { share, showModalProps } = getPropsAndShare();
+    const toggleShareMenuSpy = jest.spyOn(share, 'toggleShareContextMenu');
+    ShowShareModal(showModalProps);
+    expect(share.toggleShareContextMenu).toHaveBeenCalledTimes(1);
+    const shareLocatorParams = (
+      toggleShareMenuSpy.mock.calls[0][0].sharingData as {
+        locatorParams: { params: DashboardAppLocatorParams };
+      }
+    ).locatorParams.params;
+    unsavedStateKeys.forEach((key) => {
+      expect(shareLocatorParams[key]).toBeUndefined();
+    });
+  });
+
+  it('locatorParams unsaved state is properly propagated to locator', () => {
+    const unsavedDashboardState: DashboardState = {
+      panels: {
+        panel_1: {
+          type: 'panel_type',
+          gridData: { w: 0, h: 0, x: 0, y: 0, i: '0' },
+          panelRefName: 'superPanel',
+          explicitInput: {
+            id: 'superPanel',
+          },
+        },
+      },
+      options: {
+        hidePanelTitles: true,
+        useMargins: true,
+        syncColors: true,
+      },
+      filters: [
+        {
+          meta: {
+            alias: null,
+            disabled: false,
+            negate: false,
+          },
+          query: { query: 'hi' },
+        },
+      ],
+      query: { query: 'bye', language: 'kuery' },
+      savedQuery: 'amazingSavedQuery',
+    } as unknown as DashboardState;
+    const { share, showModalProps } = getPropsAndShare(unsavedDashboardState);
+    const toggleShareMenuSpy = jest.spyOn(share, 'toggleShareContextMenu');
+    ShowShareModal(showModalProps);
+    expect(share.toggleShareContextMenu).toHaveBeenCalledTimes(1);
+    const shareLocatorParams = (
+      toggleShareMenuSpy.mock.calls[0][0].sharingData as {
+        locatorParams: { params: DashboardAppLocatorParams };
+      }
+    ).locatorParams.params;
+    const rawDashboardState = stateToRawDashboardState({
+      state: unsavedDashboardState,
+      version: 'testKibanaVersion',
+    });
+    unsavedStateKeys.forEach((key) => {
+      expect(shareLocatorParams[key]).toStrictEqual(
+        (rawDashboardState as Partial<DashboardAppLocatorParams>)[key]
+      );
+    });
   });
 });

--- a/src/plugins/dashboard/public/services/core.ts
+++ b/src/plugins/dashboard/public/services/core.ts
@@ -9,6 +9,7 @@
 export {
   AppMountParameters,
   CoreSetup,
+  Capabilities,
   PluginInitializerContext,
   ScopedHistory,
   NotificationsStart,


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Reporting / Dashboard] Use Unsaved State in Report URL (#114331)