### PR TITLE
[7.16] [APM] Rename `traceData` to `synthtraceEsClient` (#116215)

### DIFF
--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -15,7 +15,7 @@ import { createApmUser, APM_TEST_PASSWORD, ApmUser } from './authentication';
 import { APMFtrConfigName } from '../configs';
 import { createApmApiClient } from './apm_api_supertest';
 import { registry } from './registry';
-import { traceData } from './trace_data';
+import { synthtraceEsClient } from './synthtrace_es_client';
 
 interface Config {
   name: APMFtrConfigName;
@@ -77,7 +77,7 @@ export function createTestConfig(config: Config) {
       servers,
       services: {
         ...services,
-        traceData,
+        synthtraceEsClient,
         apmApiClient: async (context: InheritedFtrProviderContext) => {
           const security = context.getService('security');
           await security.init();

--- a/x-pack/test/apm_api_integration/common/synthtrace_es_client.ts
+++ b/x-pack/test/apm_api_integration/common/synthtrace_es_client.ts
@@ -16,7 +16,7 @@ import pLimit from 'p-limit';
 import { inspect } from 'util';
 import { InheritedFtrProviderContext } from './ftr_provider_context';
 
-export async function traceData(context: InheritedFtrProviderContext) {
+export async function synthtraceEsClient(context: InheritedFtrProviderContext) {
   const es = context.getService('es');
   return {
     index: (events: any[]) => {

--- a/x-pack/test/apm_api_integration/tests/error_rate/service_apis.ts
+++ b/x-pack/test/apm_api_integration/tests/error_rate/service_apis.ts
@@ -15,7 +15,7 @@ import { registry } from '../../common/registry';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const serviceName = 'synth-go';
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
@@ -128,7 +128,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const transactionNameProductList = 'GET /api/product/list';
         const transactionNameProductId = 'GET /api/product/:id';
 
-        await traceData.index([
+        await synthtraceEsClient.index([
           ...timerange(start, end)
             .interval('1m')
             .rate(GO_PROD_LIST_RATE)
@@ -176,7 +176,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      after(() => traceData.clean());
+      after(() => synthtraceEsClient.clean());
 
       describe('compare error rate value between service inventory, error rate chart, service inventory and transactions apis', () => {
         before(async () => {

--- a/x-pack/test/apm_api_integration/tests/latency/service_apis.ts
+++ b/x-pack/test/apm_api_integration/tests/latency/service_apis.ts
@@ -15,7 +15,7 @@ import { registry } from '../../common/registry';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const serviceName = 'synth-go';
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
@@ -129,7 +129,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const serviceGoDevInstance = service(serviceName, 'development', 'go').instance(
           'instance-b'
         );
-        await traceData.index([
+        await synthtraceEsClient.index([
           ...timerange(start, end)
             .interval('1m')
             .rate(GO_PROD_RATE)
@@ -153,7 +153,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      after(() => traceData.clean());
+      after(() => synthtraceEsClient.clean());
 
       describe('compare latency value between service inventory, latency chart, service inventory and transactions apis', () => {
         before(async () => {

--- a/x-pack/test/apm_api_integration/tests/observability_overview/observability_overview.ts
+++ b/x-pack/test/apm_api_integration/tests/observability_overview/observability_overview.ts
@@ -15,7 +15,7 @@ import { roundNumber } from '../../utils';
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
 
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
   const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
@@ -99,7 +99,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           'instance-c'
         );
 
-        await traceData.index([
+        await synthtraceEsClient.index([
           ...timerange(start, end)
             .interval('1m')
             .rate(GO_PROD_RATE)
@@ -133,7 +133,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      after(() => traceData.clean());
+      after(() => synthtraceEsClient.clean());
 
       describe('compare throughput values', () => {
         let throughputValues: PromiseReturnType<typeof getThroughputValues>;

--- a/x-pack/test/apm_api_integration/tests/service_overview/instances_main_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/service_overview/instances_main_statistics.ts
@@ -21,7 +21,7 @@ import { SERVICE_NODE_NAME_MISSING } from '../../../../plugins/apm/common/servic
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const archiveName = 'apm_8.0.0';
   const { start, end } = archives[archiveName];
@@ -320,7 +320,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             );
           }
 
-          return traceData.index([
+          return synthtraceEsClient.index([
             ...interval.rate(GO_A_INSTANCE_RATE_SUCCESS).flatMap((timestamp) =>
               goInstanceA
                 .transaction('GET /api/product/list')
@@ -361,7 +361,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         after(async () => {
-          return traceData.clean();
+          return synthtraceEsClient.clean();
         });
 
         describe('for the go service', () => {

--- a/x-pack/test/apm_api_integration/tests/services/throughput.ts
+++ b/x-pack/test/apm_api_integration/tests/services/throughput.ts
@@ -23,7 +23,7 @@ type ThroughputReturn = APIReturnType<'GET /internal/apm/services/{serviceName}/
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const serviceName = 'synth-go';
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
@@ -81,7 +81,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           'instance-c'
         );
 
-        await traceData.index([
+        await synthtraceEsClient.index([
           ...timerange(start, end)
             .interval('1m')
             .rate(GO_PROD_RATE)
@@ -115,7 +115,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      after(() => traceData.clean());
+      after(() => synthtraceEsClient.clean());
 
       describe('compare transactions and metrics based throughput', () => {
         let throughputMetrics: ThroughputReturn;

--- a/x-pack/test/apm_api_integration/tests/throughput/dependencies_apis.ts
+++ b/x-pack/test/apm_api_integration/tests/throughput/dependencies_apis.ts
@@ -15,7 +15,7 @@ import { roundNumber } from '../../utils';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
   const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
@@ -101,7 +101,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             'instance-c'
           );
 
-          await traceData.index([
+          await synthtraceEsClient.index([
             ...timerange(start, end)
               .interval('1m')
               .rate(GO_PROD_RATE)
@@ -159,7 +159,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           ]);
         });
 
-        after(() => traceData.clean());
+        after(() => synthtraceEsClient.clean());
 
         describe('verify top dependencies', () => {
           before(async () => {

--- a/x-pack/test/apm_api_integration/tests/throughput/service_apis.ts
+++ b/x-pack/test/apm_api_integration/tests/throughput/service_apis.ts
@@ -15,7 +15,7 @@ import { roundNumber } from '../../utils';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const serviceName = 'synth-go';
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
@@ -115,7 +115,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const serviceGoDevInstance = service(serviceName, 'development', 'go').instance(
           'instance-b'
         );
-        await traceData.index([
+        await synthtraceEsClient.index([
           ...timerange(start, end)
             .interval('1m')
             .rate(GO_PROD_RATE)
@@ -139,7 +139,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      after(() => traceData.clean());
+      after(() => synthtraceEsClient.clean());
 
       describe('compare throughput value between service inventory, throughput chart, service inventory and transactions apis', () => {
         before(async () => {

--- a/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_detailed_statistics.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/transactions_groups_detailed_statistics.ts
@@ -20,7 +20,7 @@ type TransactionsGroupsDetailedStatistics =
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const apmApiClient = getService('apmApiClient');
-  const traceData = getService('traceData');
+  const synthtraceEsClient = getService('synthtraceEsClient');
 
   const serviceName = 'synth-go';
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
@@ -87,7 +87,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         const transactionName = 'GET /api/product/list';
 
-        await traceData.index([
+        await synthtraceEsClient.index([
           ...timerange(start, end)
             .interval('1m')
             .rate(GO_PROD_RATE)
@@ -113,7 +113,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         ]);
       });
 
-      after(() => traceData.clean());
+      after(() => synthtraceEsClient.clean());
 
       describe('without comparisons', () => {
         let transactionsStatistics: TransactionsGroupsDetailedStatistics;


### PR DESCRIPTION
Backports the following commits to 7.16:
 - #116215