### PR TITLE
Replace noHits variable

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview.test.tsx
@@ -130,13 +130,11 @@ describe('ServiceOverview', () => {
       'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate':
         {
           currentPeriod: {
-            transactionErrorRate: [],
-            noHits: true,
+            timeseries: [],
             average: null,
           },
           previousPeriod: {
-            transactionErrorRate: [],
-            noHits: true,
+            timeseries: [],
             average: null,
           },
         },

--- a/x-pack/plugins/apm/public/components/shared/charts/failed_transaction_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/failed_transaction_rate_chart/index.tsx
@@ -40,13 +40,11 @@ type ErrorRate =
 
 const INITIAL_STATE: ErrorRate = {
   currentPeriod: {
-    noHits: true,
-    transactionErrorRate: [],
+    timeseries: [],
     average: null,
   },
   previousPeriod: {
-    noHits: true,
-    transactionErrorRate: [],
+    timeseries: [],
     average: null,
   },
 };
@@ -116,7 +114,7 @@ export function FailedTransactionRateChart({
 
   const timeseries = [
     {
-      data: data.currentPeriod.transactionErrorRate,
+      data: data.currentPeriod.timeseries,
       type: 'linemark',
       color: theme.eui.euiColorVis7,
       title: i18n.translate('xpack.apm.errorRate.chart.errorRate', {
@@ -126,7 +124,7 @@ export function FailedTransactionRateChart({
     ...(comparisonEnabled
       ? [
           {
-            data: data.previousPeriod.transactionErrorRate,
+            data: data.previousPeriod.timeseries,
             type: 'area',
             color: theme.eui.euiColorMediumShade,
             title: i18n.translate(

--- a/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
@@ -17,7 +17,6 @@ export interface TraceSample {
 }
 
 const INITIAL_DATA = {
-  noHits: true,
   traceSamples: [] as TraceSample[],
 };
 
@@ -71,14 +70,13 @@ export function useTransactionTraceSamplesFetcher({
           },
         });
 
-        if (response.noHits) {
+        if (response.traceSamples.length === 0) {
           return response;
         }
 
         const { traceSamples } = response;
 
         return {
-          noHits: false,
           traceSamples,
         };
       }

--- a/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_trace_samples_fetcher.ts
@@ -70,15 +70,7 @@ export function useTransactionTraceSamplesFetcher({
           },
         });
 
-        if (response.traceSamples.length === 0) {
-          return response;
-        }
-
-        const { traceSamples } = response;
-
-        return {
-          traceSamples,
-        };
+        return response;
       }
     },
     // the samples should not be refetched if the transactionId or traceId changes

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
@@ -123,7 +123,6 @@ export async function fetchAndTransformGcMetrics({
   if (!aggregations) {
     return {
       ...chartBase,
-      noHits: true,
       series: [],
     };
   }
@@ -170,7 +169,6 @@ export async function fetchAndTransformGcMetrics({
 
   return {
     ...chartBase,
-    noHits: response.hits.total.value === 0,
     series,
   };
 }

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/index.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/index.ts
@@ -107,7 +107,7 @@ export async function getMemoryChartData({
       operationName: 'get_cgroup_memory_metrics_charts',
     });
 
-    if (cgroupResponse.noHits) {
+    if (cgroupResponse.series.length === 0) {
       return await fetchAndTransformMetrics({
         environment,
         kuery,

--- a/x-pack/plugins/apm/server/lib/metrics/transform_metrics_chart.test.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/transform_metrics_chart.test.ts
@@ -60,7 +60,6 @@ test('transformDataToMetricsChart should transform an ES result into a chart obj
   expect(chart).toMatchInlineSnapshot(`
 Object {
   "key": "test_chart_key",
-  "noHits": false,
   "series": Array [
     Object {
       "color": "red",

--- a/x-pack/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
@@ -19,14 +19,13 @@ export function transformDataToMetricsChart(
   result: ESSearchResponse<unknown, GenericMetricsRequest>,
   chartBase: ChartBase
 ) {
-  const { aggregations, hits } = result;
+  const { aggregations } = result;
   const timeseriesData = aggregations?.timeseriesData;
 
   return {
     title: chartBase.title,
     key: chartBase.key,
     yUnit: chartBase.yUnit,
-    noHits: hits.total.value === 0,
     series: Object.keys(chartBase.series).map((seriesKey, i) => {
       const overallValue = aggregations?.[seriesKey]?.value;
 

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.test.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.test.ts
@@ -49,8 +49,7 @@ describe('getServiceMapServiceNodeInfo', () => {
     it('returns data', async () => {
       jest.spyOn(getErrorRateModule, 'getErrorRate').mockResolvedValueOnce({
         average: 0.5,
-        transactionErrorRate: [],
-        noHits: false,
+        timeseries: [{ x: 1634808240000, y: 0 }],
       });
 
       const setup = {

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.ts
@@ -104,7 +104,7 @@ async function getErrorStats({
   end,
 }: Options) {
   return withApmSpan('get_error_rate_for_service_map_node', async () => {
-    const { timeseries, average } = await getErrorRate({
+    const { average } = await getErrorRate({
       environment,
       setup,
       serviceName,
@@ -113,7 +113,7 @@ async function getErrorStats({
       end,
       kuery: '',
     });
-    return { avgErrorRate: timeseries.length === 0 ? null : average };
+    return { avgErrorRate: average };
   });
 }
 

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.ts
@@ -104,7 +104,7 @@ async function getErrorStats({
   end,
 }: Options) {
   return withApmSpan('get_error_rate_for_service_map_node', async () => {
-    const { noHits, average } = await getErrorRate({
+    const { timeseries, average } = await getErrorRate({
       environment,
       setup,
       serviceName,
@@ -113,8 +113,7 @@ async function getErrorStats({
       end,
       kuery: '',
     });
-
-    return { avgErrorRate: noHits ? null : average };
+    return { avgErrorRate: timeseries.length === 0 ? null : average };
   });
 }
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
@@ -49,8 +49,7 @@ export async function getErrorRate({
   start: number;
   end: number;
 }): Promise<{
-  noHits: boolean;
-  transactionErrorRate: Coordinate[];
+  timeseries: Coordinate[];
   average: number | null;
 }> {
   const { apmEventClient } = setup;
@@ -111,20 +110,16 @@ export async function getErrorRate({
     'get_transaction_group_error_rate',
     params
   );
-
-  const noHits = resp.hits.total.value === 0;
-
   if (!resp.aggregations) {
-    return { noHits, transactionErrorRate: [], average: null };
+    return { timeseries: [], average: null };
   }
 
-  const transactionErrorRate = getFailedTransactionRateTimeSeries(
+  const timeseries = getFailedTransactionRateTimeSeries(
     resp.aggregations.timeseries.buckets
   );
-
   const average = calculateFailedTransactionRate(resp.aggregations.outcomes);
 
-  return { noHits, transactionErrorRate, average };
+  return { timeseries, average };
 }
 
 export async function getErrorRatePeriods({
@@ -171,22 +166,22 @@ export async function getErrorRatePeriods({
           start: comparisonStart,
           end: comparisonEnd,
         })
-      : { noHits: true, transactionErrorRate: [], average: null };
+      : { timeseries: [], average: null };
 
   const [currentPeriod, previousPeriod] = await Promise.all([
     currentPeriodPromise,
     previousPeriodPromise,
   ]);
 
-  const firstCurrentPeriod = currentPeriod.transactionErrorRate;
+  const firstCurrentPeriod = currentPeriod.timeseries;
 
   return {
     currentPeriod,
     previousPeriod: {
       ...previousPeriod,
-      transactionErrorRate: offsetPreviousPeriodCoordinates({
+      timeseries: offsetPreviousPeriodCoordinates({
         currentPeriodTimeseries: firstCurrentPeriod,
-        previousPeriodTimeseries: previousPeriod.transactionErrorRate,
+        previousPeriodTimeseries: previousPeriod.timeseries,
       }),
     },
   };

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
@@ -173,14 +173,14 @@ export async function getErrorRatePeriods({
     previousPeriodPromise,
   ]);
 
-  const firstCurrentPeriod = currentPeriod.timeseries;
+  const currentPeriodTimeseries = currentPeriod.timeseries;
 
   return {
     currentPeriod,
     previousPeriod: {
       ...previousPeriod,
       timeseries: offsetPreviousPeriodCoordinates({
-        currentPeriodTimeseries: firstCurrentPeriod,
+        currentPeriodTimeseries,
         previousPeriodTimeseries: previousPeriod.timeseries,
       }),
     },

--- a/x-pack/plugins/apm/server/lib/transactions/trace_samples/get_trace_samples/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/trace_samples/get_trace_samples/index.ts
@@ -93,19 +93,14 @@ export async function getTraceSamples({
         },
       });
 
-      return response.hits.hits;
+      return response.hits.hits.map((hit) => ({
+        transactionId: hit._source.transaction.id,
+        traceId: hit._source.trace.id,
+      }));
     }
 
-    const samplesForDistributionHits = await getTraceSamplesHits();
-
-    const traceSamples = samplesForDistributionHits.map((hit) => ({
-      transactionId: hit._source.transaction.id,
-      traceId: hit._source.trace.id,
-    }));
-
     return {
-      samplesForDistributionHits,
-      traceSamples,
+      traceSamples: await getTraceSamplesHits(),
     };
   });
 }

--- a/x-pack/plugins/apm/server/lib/transactions/trace_samples/get_trace_samples/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/trace_samples/get_trace_samples/index.ts
@@ -104,7 +104,7 @@ export async function getTraceSamples({
     }));
 
     return {
-      noHits: samplesForDistributionHits.length === 0,
+      samplesForDistributionHits,
       traceSamples,
     };
   });

--- a/x-pack/test/apm_api_integration/tests/error_rate/service_apis.ts
+++ b/x-pack/test/apm_api_integration/tests/error_rate/service_apis.ts
@@ -87,7 +87,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       serviceInventoryAPIResponse.body.items[0].transactionErrorRate;
 
     const errorRateChartApiMean = meanBy(
-      transactionsErrorRateChartAPIResponse.body.currentPeriod.transactionErrorRate.filter(
+      transactionsErrorRateChartAPIResponse.body.currentPeriod.timeseries.filter(
         (item) => isFiniteNumber(item.y) && item.y > 0
       ),
       'y'

--- a/x-pack/test/apm_api_integration/tests/transactions/error_rate.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/error_rate.ts
@@ -38,8 +38,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       const body = response.body as ErrorRate;
       expect(body).to.be.eql({
-        currentPeriod: { noHits: true, transactionErrorRate: [], average: null },
-        previousPeriod: { noHits: true, transactionErrorRate: [], average: null },
+        currentPeriod: { timeseries: [], average: null },
+        previousPeriod: { timeseries: [], average: null },
       });
     });
 
@@ -62,8 +62,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       const body = response.body as ErrorRate;
       expect(body).to.be.eql({
-        currentPeriod: { noHits: true, transactionErrorRate: [], average: null },
-        previousPeriod: { noHits: true, transactionErrorRate: [], average: null },
+        currentPeriod: { timeseries: [], average: null },
+        previousPeriod: { timeseries: [], average: null },
       });
     });
   });
@@ -89,10 +89,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           expect(errorRateResponse.currentPeriod.average).to.be.greaterThan(0);
           expect(errorRateResponse.previousPeriod.average).to.be(null);
 
-          expect(errorRateResponse.currentPeriod.transactionErrorRate.length).to.be.greaterThan(0);
-          expect(errorRateResponse.previousPeriod.transactionErrorRate).to.empty();
+          expect(errorRateResponse.currentPeriod.timeseries.length).to.be.greaterThan(0);
+          expect(errorRateResponse.previousPeriod.timeseries).to.empty();
 
-          const nonNullDataPoints = errorRateResponse.currentPeriod.transactionErrorRate.filter(
+          const nonNullDataPoints = errorRateResponse.currentPeriod.timeseries.filter(
             ({ y }) => y !== null
           );
 
@@ -101,24 +101,18 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         it('has the correct start date', () => {
           expectSnapshot(
-            new Date(
-              first(errorRateResponse.currentPeriod.transactionErrorRate)?.x ?? NaN
-            ).toISOString()
+            new Date(first(errorRateResponse.currentPeriod.timeseries)?.x ?? NaN).toISOString()
           ).toMatchInline(`"2021-08-03T06:50:00.000Z"`);
         });
 
         it('has the correct end date', () => {
           expectSnapshot(
-            new Date(
-              last(errorRateResponse.currentPeriod.transactionErrorRate)?.x ?? NaN
-            ).toISOString()
+            new Date(last(errorRateResponse.currentPeriod.timeseries)?.x ?? NaN).toISOString()
           ).toMatchInline(`"2021-08-03T07:20:00.000Z"`);
         });
 
         it('has the correct number of buckets', () => {
-          expectSnapshot(errorRateResponse.currentPeriod.transactionErrorRate.length).toMatchInline(
-            `61`
-          );
+          expectSnapshot(errorRateResponse.currentPeriod.timeseries.length).toMatchInline(`61`);
         });
 
         it('has the correct calculation for average', () => {
@@ -128,7 +122,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         it('has the correct error rate', () => {
-          expectSnapshot(errorRateResponse.currentPeriod.transactionErrorRate).toMatch();
+          expectSnapshot(errorRateResponse.currentPeriod.timeseries).toMatch();
         });
       });
 
@@ -157,14 +151,15 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           expect(errorRateResponse.currentPeriod.average).to.be.greaterThan(0);
           expect(errorRateResponse.previousPeriod.average).to.be.greaterThan(0);
 
-          expect(errorRateResponse.currentPeriod.transactionErrorRate.length).to.be.greaterThan(0);
-          expect(errorRateResponse.previousPeriod.transactionErrorRate.length).to.be.greaterThan(0);
+          expect(errorRateResponse.currentPeriod.timeseries.length).to.be.greaterThan(0);
+          expect(errorRateResponse.previousPeriod.timeseries.length).to.be.greaterThan(0);
 
-          const currentPeriodNonNullDataPoints =
-            errorRateResponse.currentPeriod.transactionErrorRate.filter(({ y }) => y !== null);
+          const currentPeriodNonNullDataPoints = errorRateResponse.currentPeriod.timeseries.filter(
+            ({ y }) => y !== null
+          );
 
           const previousPeriodNonNullDataPoints =
-            errorRateResponse.previousPeriod.transactionErrorRate.filter(({ y }) => y !== null);
+            errorRateResponse.previousPeriod.timeseries.filter(({ y }) => y !== null);
 
           expect(currentPeriodNonNullDataPoints.length).to.be.greaterThan(0);
           expect(previousPeriodNonNullDataPoints.length).to.be.greaterThan(0);
@@ -172,37 +167,25 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
         it('has the correct start date', () => {
           expectSnapshot(
-            new Date(
-              first(errorRateResponse.currentPeriod.transactionErrorRate)?.x ?? NaN
-            ).toISOString()
+            new Date(first(errorRateResponse.currentPeriod.timeseries)?.x ?? NaN).toISOString()
           ).toMatchInline(`"2021-08-03T07:05:10.000Z"`);
           expectSnapshot(
-            new Date(
-              first(errorRateResponse.previousPeriod.transactionErrorRate)?.x ?? NaN
-            ).toISOString()
+            new Date(first(errorRateResponse.previousPeriod.timeseries)?.x ?? NaN).toISOString()
           ).toMatchInline(`"2021-08-03T07:05:10.000Z"`);
         });
 
         it('has the correct end date', () => {
           expectSnapshot(
-            new Date(
-              last(errorRateResponse.currentPeriod.transactionErrorRate)?.x ?? NaN
-            ).toISOString()
+            new Date(last(errorRateResponse.currentPeriod.timeseries)?.x ?? NaN).toISOString()
           ).toMatchInline(`"2021-08-03T07:20:10.000Z"`);
           expectSnapshot(
-            new Date(
-              last(errorRateResponse.previousPeriod.transactionErrorRate)?.x ?? NaN
-            ).toISOString()
+            new Date(last(errorRateResponse.previousPeriod.timeseries)?.x ?? NaN).toISOString()
           ).toMatchInline(`"2021-08-03T07:20:10.000Z"`);
         });
 
         it('has the correct number of buckets', () => {
-          expectSnapshot(errorRateResponse.currentPeriod.transactionErrorRate.length).toMatchInline(
-            `91`
-          );
-          expectSnapshot(
-            errorRateResponse.previousPeriod.transactionErrorRate.length
-          ).toMatchInline(`91`);
+          expectSnapshot(errorRateResponse.currentPeriod.timeseries.length).toMatchInline(`91`);
+          expectSnapshot(errorRateResponse.previousPeriod.timeseries.length).toMatchInline(`91`);
         });
 
         it('has the correct calculation for average', () => {
@@ -215,13 +198,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         it('has the correct error rate', () => {
-          expectSnapshot(errorRateResponse.currentPeriod.transactionErrorRate).toMatch();
-          expectSnapshot(errorRateResponse.previousPeriod.transactionErrorRate).toMatch();
+          expectSnapshot(errorRateResponse.currentPeriod.timeseries).toMatch();
+          expectSnapshot(errorRateResponse.previousPeriod.timeseries).toMatch();
         });
 
         it('matches x-axis on current period and previous period', () => {
-          expect(errorRateResponse.currentPeriod.transactionErrorRate.map(({ x }) => x)).to.be.eql(
-            errorRateResponse.previousPeriod.transactionErrorRate.map(({ x }) => x)
+          expect(errorRateResponse.currentPeriod.timeseries.map(({ x }) => x)).to.be.eql(
+            errorRateResponse.previousPeriod.timeseries.map(({ x }) => x)
           );
         });
       });


### PR DESCRIPTION
## Summary

`noHits` is misleading and in some places is passed as a request result but not used.

### What was done

- Replace `noHits` everywhere for `[data].length === 0 ` and fix tests.
- Rename `transactionErrorRate` to `timeseries`

