### PR TITLE
[APM] Synthtrace for e2e tests

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/integration/read_only_user/service_overview/service_overview.spec.ts
@@ -6,9 +6,18 @@
  */
 
 import url from 'url';
-import archives_metadata from '../../../fixtures/es_archiver/archives_metadata';
+import { service, timerange } from '@elastic/apm-synthtrace';
+import { getSynthtraceEsClient } from '../../../../synthtrace_es_client';
 
-const { start, end } = archives_metadata['apm_8.0.0'];
+const esTarget = Cypress.env('ES_TARGET');
+const synthtraceEsClient = getSynthtraceEsClient(esTarget);
+const serviceName = 'synth-go';
+const start = new Date('2021-01-01T00:00:00.000Z').getTime();
+const end = new Date('2021-01-01T00:15:00.000Z').getTime();
+const GO_PROD_RATE = 80;
+const GO_PROD_DURATION = 1000;
+
+console.log({ esTarget });
 
 const serviceOverviewPath = '/app/apm/services/opbeans-node/overview';
 const baseUrl = url.format({
@@ -20,6 +29,29 @@ describe('Service Overview', () => {
   beforeEach(() => {
     cy.loginAsReadOnlyUser();
   });
+
+  before(async () => {
+    const serviceGoProdInstance = service(
+      serviceName,
+      'production',
+      'go'
+    ).instance('instance-a');
+
+    await synthtraceEsClient.index([
+      ...timerange(start, end)
+        .interval('1m')
+        .rate(GO_PROD_RATE)
+        .flatMap((timestamp) =>
+          serviceGoProdInstance
+            .transaction('GET /api/product/list')
+            .duration(GO_PROD_DURATION)
+            .timestamp(timestamp)
+            .serialize()
+        ),
+    ]);
+  });
+
+  after(() => synthtraceEsClient.clean());
 
   it('persists transaction type selected when clicking on Transactions tab', () => {
     cy.visit(baseUrl);

--- a/x-pack/plugins/apm/ftr_e2e/cypress_run.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress_run.ts
@@ -8,7 +8,9 @@ import { argv } from 'yargs';
 import { FtrConfigProviderContext } from '@kbn/test';
 import { cypressRunTests } from './cypress_start';
 
-const specArg = argv.spec as string | undefined;
+const specArg = (argv.spec ?? argv.grep) as string | undefined;
+
+console.log({ specArg });
 
 async function runE2ETests({ readConfigFile }: FtrConfigProviderContext) {
   const kibanaConfig = await readConfigFile(require.resolve('./config.ts'));

--- a/x-pack/plugins/apm/ftr_e2e/cypress_start.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress_start.ts
@@ -36,7 +36,6 @@ async function cypressStart(
   const config = getService('config');
 
   const archiveName = 'apm_8.0.0';
-  const { start, end } = archives_metadata[archiveName];
 
   const kibanaUrl = Url.format({
     protocol: config.get('servers.kibana.protocol'),
@@ -56,21 +55,30 @@ async function cypressStart(
     },
   });
 
+  // TODO: Remove archive in favor of synthtrace
   console.log('Loading esArchiver...');
-  await esArchiverLoad('apm_8.0.0');
+  // await esArchiverLoad('apm_8.0.0');
 
   const res = await cypressExecution({
     ...(spec !== undefined ? { spec } : {}),
     config: { baseUrl: kibanaUrl },
+
     env: {
-      START_DATE: start,
-      END_DATE: end,
+      ES_TARGET: Url.format({
+        protocol: config.get('servers.elasticsearch.protocol'),
+        host: config.get('servers.elasticsearch.hostname'),
+        port: config.get('servers.elasticsearch.port'),
+        auth: `${config.get('servers.elasticsearch.username')}:${config.get(
+          'servers.elasticsearch.password'
+        )}`,
+      }),
       KIBANA_URL: kibanaUrl,
     },
   });
 
+  // TODO: Remove archive in favor of synthtrace
   console.log('Removing esArchiver...');
-  await esArchiverUnload('apm_8.0.0');
+  // await esArchiverUnload('apm_8.0.0');
 
   return res;
 }

--- a/x-pack/plugins/apm/ftr_e2e/synthtrace_es_client.ts
+++ b/x-pack/plugins/apm/ftr_e2e/synthtrace_es_client.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getBreakdownMetrics,
+  getSpanDestinationMetrics,
+  getTransactionMetrics,
+  toElasticsearchOutput,
+} from '@elastic/apm-synthtrace';
+import { chunk } from 'lodash';
+import pLimit from 'p-limit';
+import { inspect } from 'util';
+import { Client } from '@elastic/elasticsearch';
+
+// TODO: duplicate of x-pack/test/apm_api_integration/common/synthtrace_es_client.ts
+// The two clients should be merged and preferably moved into @elastic/apm-synthtrace
+export function getSynthtraceEsClient(esTarget: string) {
+  const client = new Client({ node: String(esTarget) });
+
+  return {
+    index: (events: any[]) => {
+      const esEvents = toElasticsearchOutput({
+        events: [
+          ...events,
+          ...getTransactionMetrics(events),
+          ...getSpanDestinationMetrics(events),
+          ...getBreakdownMetrics(events),
+        ],
+        writeTargets: {
+          transaction: 'apm-7.14.0-transaction',
+          span: 'apm-7.14.0-span',
+          error: 'apm-7.14.0-error',
+          metric: 'apm-7.14.0-metric',
+        },
+      });
+
+      const batches = chunk(esEvents, 1000);
+      const limiter = pLimit(1);
+
+      return Promise.all(
+        batches.map((batch) =>
+          limiter(() => {
+            return client.bulk({
+              body: batch.flatMap(({ _index, _source }) => [
+                { index: { _index } },
+                _source,
+              ]),
+              require_alias: true,
+              refresh: true,
+            });
+          })
+        )
+      ).then((results) => {
+        const errors = results
+          .flatMap((result) => result.body.items)
+          .filter((item) => !!item.index?.error)
+          .map((item) => item.index?.error);
+
+        if (errors.length) {
+          // eslint-disable-next-line no-console
+          console.log(inspect(errors.slice(0, 10), { depth: null }));
+          throw new Error('Failed to upload some events');
+        }
+        return results;
+      });
+    },
+    clean: () => {
+      return client.deleteByQuery({
+        index: 'apm-*',
+        body: {
+          query: {
+            match_all: {},
+          },
+        },
+      });
+    },
+  };
+}


### PR DESCRIPTION
WIP

Run the service overview test:
```
 node ../../../../scripts/functional_test_runner --config cypress_run.ts --grep '**/*service_overview*'
``` 

Currently seeing a webpack error:
```
Error: Webpack Compilation Error
./synthtrace_es_client.ts 50:51
Module parse failed: Unexpected token (50:51)
File was processed with these loaders:
 * ../../../../../../Library/Caches/Cypress/8.5.0/Cypress.app/Contents/Resources/app/packages/server/node_modules/ts-loader/index.js
You may need an additional loader to handle the result of these loaders.
```