### PR TITLE
[Security Solution] Skips EQL test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/detection_rules/event_correlation_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_rules/event_correlation_rule.spec.ts
@@ -70,7 +70,7 @@ import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 
 import { ALERTS_URL } from '../../urls/navigation';
 
-describe('Detection rules, EQL', () => {
+describe.skip('Detection rules, EQL', () => {
   const expectedUrls = getEqlRule().referenceUrls.join('');
   const expectedFalsePositives = getEqlRule().falsePositivesExamples.join('');
   const expectedTags = getEqlRule().tags.join('');
@@ -169,7 +169,7 @@ describe('Detection rules, EQL', () => {
   });
 });
 
-describe('Detection rules, sequence EQL', () => {
+describe.skip('Detection rules, sequence EQL', () => {
   const expectedNumberOfRules = 1;
   const expectedNumberOfSequenceAlerts = '1 alert';
 


### PR DESCRIPTION
## Summary

After the merge of https://github.com/elastic/kibana/pull/112113 a lot of bugs and issues are happening. One of them is the duplication of alerts making the EQL test fail. 

This is why in this PR we are skipping the test until all the bugs and issues are fixed.