### PR TITLE
Fix flaky Hosts test

### DIFF
--- a/x-pack/test/api_integration/apis/security_solution/hosts.ts
+++ b/x-pack/test/api_integration/apis/security_solution/hosts.ts
@@ -28,7 +28,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
 
   // Failing: See https://github.com/elastic/kibana/issues/104260
-  describe.skip('hosts', () => {
+  describe('hosts', () => {
     before(() => esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts'));
     after(() => esArchiver.unload('x-pack/test/functional/es_archives/auditbeat/hosts'));
 
@@ -184,7 +184,7 @@ export default function ({ getService }: FtrProviderContext) {
         .set('kbn-xsrf', 'true')
         .send({
           factoryQueryType: HostsQueries.firstOrLastSeen,
-          defaultIndex: ['auditbeat-*', 'filebeat-*', 'packetbeat-*', 'winlogbeat-*'],
+          defaultIndex: ['auditbeat-*'],
           docValueFields: [{ field: '@timestamp', format: 'epoch_millis' }],
           hostName: 'zeek-sensor-san-francisco',
           order: 'asc',
@@ -200,7 +200,7 @@ export default function ({ getService }: FtrProviderContext) {
         .set('kbn-xsrf', 'true')
         .send({
           factoryQueryType: HostsQueries.firstOrLastSeen,
-          defaultIndex: ['auditbeat-*', 'filebeat-*', 'packetbeat-*', 'winlogbeat-*'],
+          defaultIndex: ['auditbeat-*'],
           docValueFields: [{ field: '@timestamp', format: 'epoch_millis' }],
           hostName: 'zeek-sensor-san-francisco',
           order: 'desc',


### PR DESCRIPTION
## Summary

# How to reproduce it
1. run  `node scripts/functional_tests_server --config x-pack/test/api_integration/config.ts`
2. Surround the test with:
```
for(let i=0; i < 1000; i++) {
   it('passes this test',() => {})
} 
```
3. just after the previous command is ready, run `node scripts/functional_test_runner --config x-pack/test/api_integration/config.ts --grep "Make sure that we get First Seen for a Host with docValueFields"`
4. Approximately 3 tests should fail.


After this PR change, It didn't fail for me. even after running it 5000 times.

