### PR TITLE
[ci] bump timeout for cigroups until we figure out the slowdown

### DIFF
--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -21,7 +21,7 @@ steps:
     agents:
       queue: ci-group-6
     depends_on: build
-    timeout_in_minutes: 150
+    timeout_in_minutes: 250
     key: default-cigroup
     retry:
       automatic:


### PR DESCRIPTION
We've got a major slowdown occurring that we are trying to diagnose, but now ciGroup6 is regularly timing out so we need to bump the timeout to keep ci green.