### PR TITLE
[Security Solutions] Adds console logging and relaxes the 200 checks in a 2 areas of the e2e tests

### DIFF
--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -962,7 +962,9 @@ export const deleteRule = async (
   if (response.status !== 200) {
     // eslint-disable-next-line no-console
     console.log(
-      'Did not get an expected 200 "ok" when deleting the rule. CI issues could happen. Suspect this line if you are seeing CI issues.'
+      `Did not get an expected 200 "ok" when deleting the rule. CI issues could happen. Suspect this line if you are seeing CI issues. body: ${JSON.stringify(
+        response.body
+      )}, status: ${JSON.stringify(response.status)}`
     );
   }
 
@@ -1126,7 +1128,9 @@ export const deleteExceptionList = async (
   if (response.status !== 200) {
     // eslint-disable-next-line no-console
     console.log(
-      'Did not get an expected 200 "ok" when deleting an exception list. CI issues could happen. Suspect this line if you are seeing CI issues.'
+      `Did not get an expected 200 "ok" when deleting an exception list. CI issues could happen. Suspect this line if you are seeing CI issues. body: ${JSON.stringify(
+        response.body
+      )}, status: ${JSON.stringify(response.status)}`
     );
   }
 
@@ -1151,9 +1155,9 @@ export const createExceptionListItem = async (
   if (response.status !== 200) {
     // eslint-disable-next-line no-console
     console.log(
-      `Did not get an expected 200 "ok" when creating an exception list item. CI issues could happen. Suspect this line if you are seeing CI issues. ${JSON.stringify(
+      `Did not get an expected 200 "ok" when creating an exception list item. CI issues could happen. Suspect this line if you are seeing CI issues. body: ${JSON.stringify(
         response.body
-      )}`
+      )}, status: ${JSON.stringify(response.status)}`
     );
   }
   return response.body;

--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -1111,7 +1111,7 @@ export const createExceptionList = async (
 };
 
 /**
- * Helper to cut down on the noise in some of the tests. Does a delete of a rule.
+ * Helper to cut down on the noise in some of the tests. Does a delete of an exception list.
  * It does not check for a 200 "ok" on this.
  * @param supertest The supertest deps
  * @param id The rule id to delete
@@ -1143,12 +1143,45 @@ export const createExceptionListItem = async (
   supertest: SuperTest.SuperTest<SuperTest.Test>,
   exceptionListItem: CreateExceptionListItemSchema
 ): Promise<ExceptionListItemSchema> => {
-  const { body } = await supertest
+  const response = await supertest
     .post(EXCEPTION_LIST_ITEM_URL)
     .set('kbn-xsrf', 'true')
-    .send(exceptionListItem)
-    .expect(200);
-  return body;
+    .send(exceptionListItem);
+
+  if (response.status !== 200) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Did not get an expected 200 "ok" when creating an exception list item. CI issues could happen. Suspect this line if you are seeing CI issues. ${JSON.stringify(
+        response.body
+      )}`
+    );
+  }
+  return response.body;
+};
+
+/**
+ * Helper to cut down on the noise in some of the tests. Does a delete of an exception list item.
+ * It does not check for a 200 "ok" on this.
+ * @param supertest The supertest deps
+ * @param id The rule id to delete
+ */
+export const deleteExceptionListItem = async (
+  supertest: SuperTest.SuperTest<SuperTest.Test>,
+  listId: string
+): Promise<FullResponseSchema> => {
+  const response = await supertest
+    .delete(`${EXCEPTION_LIST_ITEM_URL}?list_id=${listId}`)
+    .set('kbn-xsrf', 'true');
+  if (response.status !== 200) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Did not get an expected 200 "ok" when deleting an exception list. CI issues could happen. Suspect this line if you are seeing CI issues.${JSON.stringify(
+        response.body
+      )}`
+    );
+  }
+
+  return response.body;
 };
 
 /**

--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -1160,31 +1160,6 @@ export const createExceptionListItem = async (
 };
 
 /**
- * Helper to cut down on the noise in some of the tests. Does a delete of an exception list item.
- * It does not check for a 200 "ok" on this.
- * @param supertest The supertest deps
- * @param id The rule id to delete
- */
-export const deleteExceptionListItem = async (
-  supertest: SuperTest.SuperTest<SuperTest.Test>,
-  listId: string
-): Promise<FullResponseSchema> => {
-  const response = await supertest
-    .delete(`${EXCEPTION_LIST_ITEM_URL}?list_id=${listId}`)
-    .set('kbn-xsrf', 'true');
-  if (response.status !== 200) {
-    // eslint-disable-next-line no-console
-    console.log(
-      `Did not get an expected 200 "ok" when deleting an exception list. CI issues could happen. Suspect this line if you are seeing CI issues.${JSON.stringify(
-        response.body
-      )}`
-    );
-  }
-
-  return response.body;
-};
-
-/**
  * Helper to cut down on the noise in some of the tests. This gets
  * a particular rule.
  * @param supertest The supertest deps

--- a/x-pack/test/lists_api_integration/utils.ts
+++ b/x-pack/test/lists_api_integration/utils.ts
@@ -219,9 +219,9 @@ export const importFile = async (
   if (response.status !== 200) {
     // eslint-disable-next-line no-console
     console.log(
-      `When importing a file found an unexpected non-200 response code. If you see errors in CI suspect this line. ${JSON.stringify(
+      `Did not get an expected 200 "ok" When importing a file. CI issues could happen. Suspect this line if you are seeing CI issues. body: ${JSON.stringify(
         response.body
-      )}`
+      )}, status: ${JSON.stringify(response.status)}`
     );
   }
 

--- a/x-pack/test/lists_api_integration/utils.ts
+++ b/x-pack/test/lists_api_integration/utils.ts
@@ -210,12 +210,20 @@ export const importFile = async (
   fileName: string,
   testValues?: string[]
 ): Promise<void> => {
-  await supertest
+  const response = await supertest
     .post(`${LIST_ITEM_URL}/_import?type=${type}`)
     .set('kbn-xsrf', 'true')
     .attach('file', getImportListItemAsBuffer(contents), fileName)
-    .expect('Content-Type', 'application/json; charset=utf-8')
-    .expect(200);
+    .expect('Content-Type', 'application/json; charset=utf-8');
+
+  if (response.status !== 200) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `When importing a file found an unexpected non-200 response code. If you see errors in CI suspect this line. ${JSON.stringify(
+        response.body
+      )}`
+    );
+  }
 
   // although we have pushed the list and its items, it is async so we
   // have to wait for the contents before continuing


### PR DESCRIPTION
## Summary

Adds console logging and relaxes a few 200 checks in the end to end tests in two areas of:
* createExceptionListItem
* importFile

As recently the tests are failing around these parts and possibly we can get information on the next failures if it is from these two areas or if it's from somewhere else we are not expecting.

Also outputs the body message so if it fails in these areas we can see the message with the conflict that might help us see where the issue is arising.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
