### PR TITLE
[Security Solution] Skips failing tests

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/from_alert.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/from_alert.spec.ts
@@ -35,7 +35,7 @@ import {
 import { ALERTS_URL } from '../../urls/navigation';
 import { cleanKibana } from '../../tasks/common';
 
-describe('From alert', () => {
+describe.skip('From alert', () => {
   const NUMBER_OF_AUDITBEAT_EXCEPTIONS_ALERTS = '1 alert';
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/cypress/integration/exceptions/from_rule.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/exceptions/from_rule.spec.ts
@@ -35,7 +35,7 @@ import { refreshPage } from '../../tasks/security_header';
 import { ALERTS_URL } from '../../urls/navigation';
 import { cleanKibana } from '../../tasks/common';
 
-describe('From rule', () => {
+describe.skip('From rule', () => {
   const NUMBER_OF_AUDITBEAT_EXCEPTIONS_ALERTS = '1';
   beforeEach(() => {
     cleanKibana();


### PR DESCRIPTION
## Summary

After the merge of #112113 a lot of bugs and issues are happening. One of them is the duplication of alerts making the exceptions tests fail.

This is why in this PR we are skipping the test until all the bugs and issues are fixed.