### PR TITLE
[ML] Functional tests - remove monitor cluster privilege from test role

### DIFF
--- a/x-pack/test/functional/services/ml/security_common.ts
+++ b/x-pack/test/functional/services/ml/security_common.ts
@@ -58,7 +58,7 @@ export function MachineLearningSecurityCommonProvider({ getService }: FtrProvide
     {
       name: 'ft_ml_ui_extras',
       elasticsearch: {
-        cluster: ['manage_ingest_pipelines', 'monitor'],
+        cluster: ['manage_ingest_pipelines'],
       },
       kibana: [],
     },


### PR DESCRIPTION
## Summary

This PR removes the `monitor` cluster privilege from the `ft_ml_ui_extras` test role as it's no longer required by the categorization wizard and we want to stay close to the minimum set of required privileges for our test users.
