### PR TITLE
Add API tests for dependencies metadata

### DIFF
--- a/x-pack/test/apm_api_integration/tests/dependencies/generate_data.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/generate_data.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { service, timerange } from '@elastic/apm-synthtrace';
+import type { SynthtraceEsClient } from '../../common/synthtrace_es_client';
+
+export const dataConfig = {
+  spanType: 'db',
+};
+
+export async function generateData({
+  synthtraceEsClient,
+  backendName,
+  start,
+  end,
+}: {
+  synthtraceEsClient: SynthtraceEsClient;
+  backendName: string;
+  start: number;
+  end: number;
+}) {
+  const instance = service('synth-go', 'production', 'go').instance('instance-a');
+  const transactionName = 'GET /api/product/list';
+  const spanName = 'GET apm-*/_search';
+
+  await synthtraceEsClient.index(
+    timerange(start, end)
+      .interval('1m')
+      .rate(10)
+      .flatMap((timestamp) =>
+        instance
+          .transaction(transactionName)
+          .timestamp(timestamp)
+          .duration(1000)
+          .success()
+          .children(
+            instance
+              .span(spanName, dataConfig.spanType, backendName)
+              .duration(1000)
+              .success()
+              .destination(backendName)
+              .timestamp(timestamp)
+          )
+          .serialize()
+      )
+  );
+}

--- a/x-pack/test/apm_api_integration/tests/dependencies/metadata.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/metadata.ts
@@ -45,7 +45,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when(
     'Dependency metadata when data is loaded',
-    { config: 'basic', archives: ['apm_8.0.0_empty'] },
+    { config: 'basic', archives: ['apm_mappings_only_8.0.0'] },
     () => {
       it('returns correct metadata for the dependency', async () => {
         await generateData({ synthtraceEsClient, backendName, start, end });

--- a/x-pack/test/apm_api_integration/tests/dependencies/metadata.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/metadata.ts
@@ -15,7 +15,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   const start = new Date('2021-01-01T00:00:00.000Z').getTime();
   const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
-  const backendName = 'elasticsearh';
+  const backendName = 'elasticsearch';
 
   async function callApi() {
     return await apmApiClient.readUser({

--- a/x-pack/test/apm_api_integration/tests/dependencies/metadata.ts
+++ b/x-pack/test/apm_api_integration/tests/dependencies/metadata.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+import { APIReturnType } from '../../../../plugins/apm/public/services/rest/createCallApmApi';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { registry } from '../../common/registry';
+import { dataConfig, generateData } from './generate_data';
+
+type DependenciesMetadata = APIReturnType<'GET /internal/apm/backends/metadata'>;
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const apmApiClient = getService('apmApiClient');
+  const synthtraceEsClient = getService('synthtraceEsClient');
+
+  const start = new Date('2021-01-01T00:00:00.000Z').getTime();
+  const end = new Date('2021-01-01T00:15:00.000Z').getTime() - 1;
+  const backendName = 'elasticsearh';
+
+  async function callApi() {
+    return await apmApiClient.readUser({
+      endpoint: `GET /internal/apm/backends/metadata`,
+      params: {
+        query: {
+          backendName,
+          start: new Date(start).toISOString(),
+          end: new Date(end).toISOString(),
+        },
+      },
+    });
+  }
+
+  registry.when('Dependencies when data is not loaded', { config: 'basic', archives: [] }, () => {
+    it('handles empty state', async () => {
+      const response = await callApi();
+      expect(response.status).to.be(200);
+      expect(response.body.metadata).to.empty();
+    });
+  });
+
+  registry.when('Dependencies metadata', { config: 'basic', archives: ['apm_8.0.0_empty'] }, () => {
+    describe('when data is loaded', () => {
+      before(async () => {
+        await generateData({ synthtraceEsClient, backendName, start, end });
+      });
+
+      after(() => synthtraceEsClient.clean());
+
+      describe('returns the correct data', () => {
+        let dependencyMetadata: DependenciesMetadata;
+
+        before(async () => {
+          const response = await callApi();
+          dependencyMetadata = response.body;
+        });
+
+        it('returns correct metadata for the dependency', () => {
+          expect(dependencyMetadata.metadata.spanType).to.equal(dataConfig.spanType);
+          expect(dependencyMetadata.metadata.spanSubtype).to.equal(backendName);
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/apm_api_integration/tests/event_metadata/event_metadata.ts
+++ b/x-pack/test/apm_api_integration/tests/event_metadata/event_metadata.ts
@@ -36,7 +36,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   }
 
   registry.when('Event metadata', { config: 'basic', archives: ['apm_8.0.0'] }, () => {
-    it('fetches transaction metadata', async () => {
+    it('fetches transaction event metadata', async () => {
       const id = await getLastDocId(ProcessorEvent.transaction);
 
       const { body } = await apmApiClient.readUser({
@@ -66,7 +66,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       );
     });
 
-    it('fetches error metadata', async () => {
+    it('fetches error event metadata', async () => {
       const id = await getLastDocId(ProcessorEvent.error);
 
       const { body } = await apmApiClient.readUser({
@@ -96,7 +96,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       );
     });
 
-    it('fetches span metadata', async () => {
+    it('fetches span event metadata', async () => {
       const id = await getLastDocId(ProcessorEvent.span);
 
       const { body } = await apmApiClient.readUser({

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -14,7 +14,7 @@ export default function apmApiIntegrationTests(providerContext: FtrProviderConte
   describe('APM API tests', function () {
     this.tags('ciGroup1');
 
-    // // inspect feature
+    // inspect feature
     describe('inspect/inspect', function () {
       loadTestFile(require.resolve('./inspect/inspect'));
     });

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -37,8 +37,8 @@ export default function apmApiIntegrationTests(providerContext: FtrProviderConte
       loadTestFile(require.resolve('./correlations/latency'));
     });
 
-    describe('metadata/event_metadata', function () {
-      loadTestFile(require.resolve('./metadata/event_metadata'));
+    describe('event_metadata/event_metadata', function () {
+      loadTestFile(require.resolve('./event_metadata/event_metadata'));
     });
 
     describe('metrics_charts/metrics_charts', function () {

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -14,7 +14,7 @@ export default function apmApiIntegrationTests(providerContext: FtrProviderConte
   describe('APM API tests', function () {
     this.tags('ciGroup1');
 
-    // inspect feature
+    // // inspect feature
     describe('inspect/inspect', function () {
       loadTestFile(require.resolve('./inspect/inspect'));
     });
@@ -243,6 +243,11 @@ export default function apmApiIntegrationTests(providerContext: FtrProviderConte
 
     describe('errors/distribution', function () {
       loadTestFile(require.resolve('./errors/distribution'));
+    });
+
+    // Dependencies
+    describe('dependencies/metadata', function () {
+      loadTestFile(require.resolve('./dependencies/metadata'));
     });
 
     registry.run(providerContext);


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/116290

Adding tests for:
- `GET /internal/apm/backends/metadata`