### PR TITLE
[ML] APM Correlations: Fix log-log plot y axis ticks when maximum bucket count is only 1.

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
@@ -132,7 +132,7 @@ export function TransactionDistributionChart({
     Math.max(
       ...flatten(data.map((d) => d.histogram)).map((d) => d.doc_count)
     ) ?? 0;
-  const yTicks = Math.ceil(Math.log10(yMax));
+  const yTicks = Math.max(1, Math.ceil(Math.log10(yMax)));
   const yAxisDomain = {
     min: 0.5,
     max: Math.pow(10, yTicks),


### PR DESCRIPTION
## Summary

Fixes #116457.

Fixes the y axis ticks for chart variants where the maximum transaction count for overall buckets is only 1.

Before fix:

![image](https://user-images.githubusercontent.com/230104/139286015-0ecbd113-c61b-402e-a884-7f6442a11bad.png)

After fix:

![image](https://user-images.githubusercontent.com/230104/139285933-2b71e63e-5fdd-4e7a-b96d-cf3eccb1c4a0.png)

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
