### PR TITLE
[Security Solution] Fix edit not working due to state management overwrite in Host isolation exceptions

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/service.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/service.ts
@@ -42,8 +42,8 @@ export async function getHostIsolationExceptionItems({
   http,
   perPage,
   page,
-  sortField,
-  sortOrder,
+  sortField = 'created_at',
+  sortOrder = 'desc',
   filter,
 }: {
   http: HttpStart;

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/middleware.ts
@@ -239,9 +239,17 @@ async function updateHostIsolationExceptionsItem(
       http,
       entry
     );
+
+    // notify the update was correct
     dispatch({
       type: 'hostIsolationExceptionsFormStateChanged',
       payload: createLoadedResourceState(response),
+    });
+
+    // clear the form
+    dispatch({
+      type: 'hostIsolationExceptionsFormEntryChanged',
+      payload: undefined,
     });
   } catch (error) {
     dispatch({

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form_flyout.tsx
@@ -94,7 +94,7 @@ export const HostIsolationExceptionsFormFlyout: React.FC<{}> = memo(() => {
           type: 'hostIsolationExceptionsMarkToEdit',
           payload: { id: location.id },
         });
-      } else {
+      } else if (exception === undefined) {
         setException(exceptionToEdit);
       }
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/116565 - edit not working due to state management overwrite in Host isolation exceptions

It also fixes a secondary edge case where the form was not updated from the previous info if attempted to update the same item twice.