### PR TITLE
Upgrade EUI to v39.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.16.0-canary.4",
     "@elastic/ems-client": "7.16.0",
-    "@elastic/eui": "39.1.1",
+    "@elastic/eui": "39.1.2",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "^9.0.1-kibana3",
     "@elastic/maki": "6.3.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -75,6 +75,6 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@7.16.0': ['Elastic License 2.0'],
-  '@elastic/eui@39.1.1': ['SSPL-1.0 OR Elastic License 2.0'],
+  '@elastic/eui@39.1.2': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
 };

--- a/src/plugins/vis_types/table/public/components/__snapshots__/table_vis_basic.test.tsx.snap
+++ b/src/plugins/vis_types/table/public/components/__snapshots__/table_vis_basic.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`TableVisBasic should init data grid 1`] = `
         "header": "underline",
       }
     }
-    key="0"
     minSizeForControls={1}
     onColumnResize={[Function]}
     renderCellValue={[Function]}
@@ -56,7 +55,6 @@ exports[`TableVisBasic should init data grid with title provided - for split mod
         "header": "underline",
       }
     }
-    key="0"
     minSizeForControls={1}
     onColumnResize={[Function]}
     renderCellValue={[Function]}
@@ -88,7 +86,6 @@ exports[`TableVisBasic should render the toolbar 1`] = `
         "header": "underline",
       }
     }
-    key="0"
     minSizeForControls={1}
     onColumnResize={[Function]}
     renderCellValue={[Function]}

--- a/src/plugins/vis_types/table/public/components/table_vis_basic.tsx
+++ b/src/plugins/vis_types/table/public/components/table_vis_basic.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { memo, useCallback, useMemo, useEffect, useState, useRef } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { EuiDataGrid, EuiDataGridProps, EuiDataGridSorting, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { orderBy } from 'lodash';
@@ -111,26 +111,6 @@ export const TableVisBasic = memo(
       [columns, setColumnsWidth]
     );
 
-    const firstRender = useRef(true);
-    const [dataGridUpdateCounter, setDataGridUpdateCounter] = useState(0);
-
-    // key was added as temporary solution to force re-render if we change autoFitRowToContent or we get new data
-    // cause we have problem with correct updating height cache in EUI datagrid when we use auto-height
-    // will be removed as soon as fix problem on EUI side
-    useEffect(() => {
-      // skip first render
-      if (firstRender.current) {
-        firstRender.current = false;
-        return;
-      }
-      // skip if auto height was turned off
-      if (!visConfig.autoFitRowToContent) {
-        return;
-      }
-      // update counter to remount grid from scratch
-      setDataGridUpdateCounter((counter) => counter + 1);
-    }, [visConfig.autoFitRowToContent, table, sort, pagination, columnsWidth]);
-
     return (
       <>
         {title && (
@@ -139,7 +119,6 @@ export const TableVisBasic = memo(
           </EuiTitle>
         )}
         <EuiDataGrid
-          key={String(dataGridUpdateCounter)}
           aria-label={dataGridAriaLabel}
           columns={gridColumns}
           gridStyle={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,6 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
-"@elastic/apm-synthtrace@link:bazel-bin/packages/elastic-apm-synthtrace":
-  version "0.0.0"
-  uid ""
-
 "@elastic/apm-rum-core@^5.12.1":
   version "5.12.1"
   resolved "https://registry.yarnpkg.com/@elastic/apm-rum-core/-/apm-rum-core-5.12.1.tgz#ad78787876c68b9ce718d1c42b8e7b12b12eaa69"
@@ -2329,6 +2325,10 @@
   integrity sha512-NJAdzxXxf+LeCI0Dz3P+RMVY66C8sAztIg4tvnrhvBqxf8d7se+FpYw3oYjw3BZ8UDycmXEaIqEGcynUUndgqA==
   dependencies:
     "@elastic/apm-rum-core" "^5.12.1"
+
+"@elastic/apm-synthtrace@link:bazel-bin/packages/elastic-apm-synthtrace":
+  version "0.0.0"
+  uid ""
 
 "@elastic/app-search-javascript@^7.13.1":
   version "7.13.1"
@@ -2412,10 +2412,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@39.1.1":
-  version "39.1.1"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-39.1.1.tgz#52e59f1dd6448b2e80047259ca60c6c87e9873f0"
-  integrity sha512-zYCNitpp6Ds7U6eaa9QkJqc20ZMo2wjpZokNtd1WalFV22vdfiVizFg7DMtDjJrCDLmoXcLOOCMasKlmmJ1cRg==
+"@elastic/eui@39.1.2":
+  version "39.1.2"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-39.1.2.tgz#8eb1684a7a406bc13b8514a366d450e964dbf56f"
+  integrity sha512-R3MqXcLOYMe/nlm+KG0TGrAjTCmpuwNkh7iKGUxVXZIRkzkgp2wyGmoX1qZnKTogN3OSEf7kKEq1JeivPYWBOA==
   dependencies:
     "@types/chroma-js" "^2.0.0"
     "@types/lodash" "^4.14.160"


### PR DESCRIPTION
## Summary

`eui@39.1.1` ⏩ `eui@39.1.2`

## [`39.1.2`](https://github.com/elastic/eui/tree/v39.1.2)

**Note: this release is a backport containing changes originally made in `40.1.0`**
 
**Bug fixes**

- Fixed `EuiDataGrid` to dynamically update row heights when set to `auto` ([#5281](https://github.com/elastic/eui/pull/5281))
