### PR TITLE
[Fleet] Fix pipeline with id [*] does not exists

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/storage.ts
@@ -264,7 +264,7 @@ export const getEsPackage = async (
       dataStreams.push({
         dataset: dataset || `${pkgName}.${dataStreamPath}`,
         package: pkgName,
-        ingest_pipeline: ingestPipeline || 'default',
+        ingest_pipeline: ingestPipeline,
         path: dataStreamPath,
         streams,
         ...dataStreamManifestProps,

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -217,7 +217,6 @@ export function parseAndVerifyDataStreams(
     }
     const streams = parseAndVerifyStreams(manifestStreams, dataStreamPath);
 
-    // default ingest pipeline name see https://github.com/elastic/package-registry/blob/master/util/dataset.go#L26
     dataStreams.push(
       Object.entries(restOfProps).reduce(
         (validatedDataStream, [key, value]) => {
@@ -233,7 +232,7 @@ export function parseAndVerifyDataStreams(
           type,
           package: pkgName,
           dataset: dataset || `${pkgName}.${dataStreamPath}`,
-          ingest_pipeline: ingestPipeline || 'default',
+          ingest_pipeline: ingestPipeline,
           path: dataStreamPath,
           streams,
         }

--- a/x-pack/test/fleet_api_integration/apis/epm/__snapshots__/install_by_upload.snap
+++ b/x-pack/test/fleet_api_integration/apis/epm/__snapshots__/install_by_upload.snap
@@ -167,7 +167,6 @@ Object {
   "data_streams": Array [
     Object {
       "dataset": "apache.access",
-      "ingest_pipeline": "default",
       "package": "apache",
       "path": "access",
       "release": "experimental",
@@ -199,7 +198,6 @@ Object {
     },
     Object {
       "dataset": "apache.status",
-      "ingest_pipeline": "default",
       "package": "apache",
       "path": "status",
       "release": "experimental",
@@ -236,7 +234,6 @@ Object {
     },
     Object {
       "dataset": "apache.error",
-      "ingest_pipeline": "default",
       "package": "apache",
       "path": "error",
       "release": "experimental",
@@ -331,11 +328,11 @@ Object {
       "install_version": "0.1.4",
       "installed_es": Array [
         Object {
-          "id": "logs-apache.access-0.1.4",
+          "id": "logs-apache.access-0.1.4-default",
           "type": "ingest_pipeline",
         },
         Object {
-          "id": "logs-apache.error-0.1.4",
+          "id": "logs-apache.error-0.1.4-default",
           "type": "ingest_pipeline",
         },
         Object {

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -74,7 +74,7 @@ export default function (providerContext: FtrProviderContext) {
         .type('application/gzip')
         .send(buf)
         .expect(200);
-      expect(res.body.response.length).to.be(29);
+      expect(res.body.response.length).to.be(27);
     });
 
     it('should install a zip archive correctly and package info should return correctly after validation', async function () {
@@ -85,7 +85,7 @@ export default function (providerContext: FtrProviderContext) {
         .type('application/zip')
         .send(buf)
         .expect(200);
-      expect(res.body.response.length).to.be(29);
+      expect(res.body.response.length).to.be(27);
 
       const packageInfoRes = await supertest
         .get(`/api/fleet/epm/packages/${testPkgKey}`)


### PR DESCRIPTION
## Summary

Resolve #116343 

Avoid to create index template with default ingest pipeline  that does not exists, when you force reinstall a package and no cache is present.

This solution fix the bug, but I think we should in the future work on adding more robustness to that part of the code maybe on stopping relying on that cache that seems error proof to me.


Should we backport this to 7.16? I think we should the bug is complex enough to debug or fix so if we can avoid some issues.

