### PR TITLE
Reverts client URLs in doc link service

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -498,7 +498,7 @@ export class DocLinksService {
           javaIndex: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/java-api-client/${DOC_LINK_VERSION}/index.html`,
           jsIntro: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/javascript-api/${DOC_LINK_VERSION}/introduction.html`,
           netGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/net-api/${DOC_LINK_VERSION}/index.html`,
-          perlGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/perl-api/master/index.html`,
+          perlGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/perl-api/${DOC_LINK_VERSION}/index.html`,
           phpGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/php-api/${DOC_LINK_VERSION}/index.html`,
           pythonGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/python-api/${DOC_LINK_VERSION}/index.html`,
           rubyOverview: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/client/ruby-api/${DOC_LINK_VERSION}/ruby_client.html`,

--- a/src/plugins/custom_integrations/server/language_clients/index.ts
+++ b/src/plugins/custom_integrations/server/language_clients/index.ts
@@ -87,7 +87,7 @@ export const integrations: LanguageIntegration[] = [
     description: i18n.translate('customIntegrations.languageclients.PerlDescription', {
       defaultMessage: 'Index data to Elasticsearch with the Perl client.',
     }),
-    docUrlTemplate: `${ELASTICSEARCH_CLIENT_URL}/perl-api/master/index.html`,
+    docUrlTemplate: `${ELASTICSEARCH_CLIENT_URL}/perl-api/{branch}/index.html`,
   },
   {
     id: 'python',

--- a/src/plugins/custom_integrations/server/plugin.test.ts
+++ b/src/plugins/custom_integrations/server/plugin.test.ts
@@ -98,7 +98,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/perl-api/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/perl-api/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],


### PR DESCRIPTION
## Summary

This PR reverts https://github.com/elastic/kibana/pull/116525, since there is now a 8.0 branch for the Elasticsearch Perl client docs.