### PR TITLE
Revert "Update CTI ECS 1.11 fields (#113404)"

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -63,10 +63,10 @@ export const DEFAULT_SPACE_ID = 'default';
 
 // Document path where threat indicator fields are expected. Fields are used
 // to enrich signals, and are copied to threat.enrichments.
-export const DEFAULT_INDICATOR_SOURCE_PATH = 'threat.indicator';
+export const DEFAULT_INDICATOR_SOURCE_PATH = 'threatintel.indicator';
 export const ENRICHMENT_DESTINATION_PATH = 'threat.enrichments';
 export const DEFAULT_THREAT_INDEX_KEY = 'securitySolution:defaultThreatIndex';
-export const DEFAULT_THREAT_INDEX_VALUE = ['logs-ti_*'];
+export const DEFAULT_THREAT_INDEX_VALUE = ['filebeat-*'];
 export const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d"';
 
 export enum SecurityPageName {

--- a/x-pack/plugins/security_solution/common/cti/constants.ts
+++ b/x-pack/plugins/security_solution/common/cti/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ENRICHMENT_DESTINATION_PATH, DEFAULT_INDICATOR_SOURCE_PATH } from '../constants';
+import { ENRICHMENT_DESTINATION_PATH } from '../constants';
 
 export const MATCHED_ATOMIC = 'matched.atomic';
 export const MATCHED_FIELD = 'matched.field';
@@ -43,29 +43,27 @@ export enum ENRICHMENT_TYPES {
 }
 
 export const EVENT_ENRICHMENT_INDICATOR_FIELD_MAP = {
-  'file.hash.md5': `${DEFAULT_INDICATOR_SOURCE_PATH}.file.hash.md5`,
-  'file.hash.sha1': `${DEFAULT_INDICATOR_SOURCE_PATH}.file.hash.sha1`,
-  'file.hash.sha256': `${DEFAULT_INDICATOR_SOURCE_PATH}.file.hash.sha256`,
-  'file.pe.imphash': `${DEFAULT_INDICATOR_SOURCE_PATH}.file.pe.imphash`,
-  'file.elf.telfhash': `${DEFAULT_INDICATOR_SOURCE_PATH}.file.elf.telfhash`,
-  'file.hash.ssdeep': `${DEFAULT_INDICATOR_SOURCE_PATH}.file.hash.ssdeep`,
-  'source.ip': `${DEFAULT_INDICATOR_SOURCE_PATH}.ip`,
-  'destination.ip': `${DEFAULT_INDICATOR_SOURCE_PATH}.ip`,
-  'url.full': `${DEFAULT_INDICATOR_SOURCE_PATH}.url.full`,
-  'registry.path': `${DEFAULT_INDICATOR_SOURCE_PATH}.registry.path`,
+  'file.hash.md5': 'threatintel.indicator.file.hash.md5',
+  'file.hash.sha1': 'threatintel.indicator.file.hash.sha1',
+  'file.hash.sha256': 'threatintel.indicator.file.hash.sha256',
+  'file.pe.imphash': 'threatintel.indicator.file.pe.imphash',
+  'file.elf.telfhash': 'threatintel.indicator.file.elf.telfhash',
+  'file.hash.ssdeep': 'threatintel.indicator.file.hash.ssdeep',
+  'source.ip': 'threatintel.indicator.ip',
+  'destination.ip': 'threatintel.indicator.ip',
+  'url.full': 'threatintel.indicator.url.full',
+  'registry.path': 'threatintel.indicator.registry.path',
 };
 
 export const DEFAULT_EVENT_ENRICHMENT_FROM = 'now-30d';
 export const DEFAULT_EVENT_ENRICHMENT_TO = 'now';
 
 export const CTI_DATASET_KEY_MAP: { [key: string]: string } = {
-  'AbuseCH URL': 'ti_abusech.url',
-  'AbuseCH Malware': 'ti_abusech.malware',
-  'AbuseCH MalwareBazaar': 'ti_abusech.malwarebazaar',
-  'AlienVault OTX': 'ti_otx.threat',
-  'Anomali Limo': 'ti_anomali.limo',
-  'Anomali Threatstream': 'ti_anomali.threatstream',
-  MISP: 'ti_misp.threat',
-  ThreatQuotient: 'ti_threatq.threat',
-  Cybersixgill: 'ti_cybersixgill.threat',
+  'Abuse URL': 'threatintel.abuseurl',
+  'Abuse Malware': 'threatintel.abusemalware',
+  'AlienVault OTX': 'threatintel.otx',
+  Anomali: 'threatintel.anomali',
+  'Malware Bazaar': 'threatintel.malwarebazaar',
+  MISP: 'threatintel.misp',
+  'Recorded Future': 'threatintel.recordedfuture',
 };

--- a/x-pack/plugins/security_solution/common/search_strategy/security_solution/cti/index.mock.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/security_solution/cti/index.mock.ts
@@ -52,29 +52,29 @@ export const buildEventEnrichmentRawResponseMock = (): IEsSearchResponse => ({
           _score: 6.0637846,
           fields: {
             'event.category': ['threat'],
-            'threat.indicator.file.type': ['html'],
+            'threatintel.indicator.file.type': ['html'],
             'related.hash': [
               '5529de7b60601aeb36f57824ed0e1ae8',
               '15b012e6f626d0f88c2926d2bf4ca394d7b8ee07cc06d2ec05ea76bed3e8a05e',
               '768:NXSFGJ/ooP6FawrB7Bo1MWnF/jRmhJImp:1SFXIqBo1Mwj2p',
             ],
-            'threat.indicator.first_seen': ['2021-05-28T18:33:29.000Z'],
-            'threat.indicator.file.hash.tlsh': [
+            'threatintel.indicator.first_seen': ['2021-05-28T18:33:29.000Z'],
+            'threatintel.indicator.file.hash.tlsh': [
               'FFB20B82F6617061C32784E2712F7A46B179B04FD1EA54A0F28CD8E9CFE4CAA1617F1C',
             ],
             'service.type': ['threatintel'],
-            'threat.indicator.file.hash.ssdeep': [
+            'threatintel.indicator.file.hash.ssdeep': [
               '768:NXSFGJ/ooP6FawrB7Bo1MWnF/jRmhJImp:1SFXIqBo1Mwj2p',
             ],
             'agent.type': ['filebeat'],
             'event.module': ['threatintel'],
-            'threat.indicator.type': ['file'],
+            'threatintel.indicator.type': ['file'],
             'agent.name': ['rylastic.local'],
-            'threat.indicator.file.hash.sha256': [
+            'threatintel.indicator.file.hash.sha256': [
               '15b012e6f626d0f88c2926d2bf4ca394d7b8ee07cc06d2ec05ea76bed3e8a05e',
             ],
             'event.kind': ['enrichment'],
-            'threat.indicator.file.hash.md5': ['5529de7b60601aeb36f57824ed0e1ae8'],
+            'threatintel.indicator.file.hash.md5': ['5529de7b60601aeb36f57824ed0e1ae8'],
             'fileset.name': ['abusemalware'],
             'input.type': ['httpjson'],
             'agent.hostname': ['rylastic.local'],
@@ -89,9 +89,9 @@ export const buildEventEnrichmentRawResponseMock = (): IEsSearchResponse => ({
             'event.type': ['indicator'],
             'event.created': ['2021-05-28T18:33:52.993Z'],
             'agent.ephemeral_id': ['d6b14f65-5bf3-430d-8315-7b5613685979'],
-            'threat.indicator.file.size': [24738],
+            'threatintel.indicator.file.size': [24738],
             'agent.version': ['8.0.0'],
-            'event.dataset': ['ti_abusech.malware'],
+            'event.dataset': ['threatintel.abusemalware'],
           },
           matched_queries: ['file.hash.md5'],
         },
@@ -113,7 +113,7 @@ export const buildEventEnrichmentMock = (
   'ecs.version': ['1.6.0'],
   'event.category': ['threat'],
   'event.created': ['2021-05-28T18:33:52.993Z'],
-  'event.dataset': ['ti_abusech.malware'],
+  'event.dataset': ['threatintel.abusemalware'],
   'event.ingested': ['2021-05-28T18:33:55.086Z'],
   'event.kind': ['enrichment'],
   'event.module': ['threatintel'],
@@ -135,18 +135,20 @@ export const buildEventEnrichmentMock = (
   ],
   'service.type': ['threatintel'],
   tags: ['threatintel-abusemalware', 'forwarded'],
-  'threat.indicator.file.hash.md5': ['5529de7b60601aeb36f57824ed0e1ae8'],
-  'threat.indicator.file.hash.sha256': [
+  'threatintel.indicator.file.hash.md5': ['5529de7b60601aeb36f57824ed0e1ae8'],
+  'threatintel.indicator.file.hash.sha256': [
     '15b012e6f626d0f88c2926d2bf4ca394d7b8ee07cc06d2ec05ea76bed3e8a05e',
   ],
-  'threat.indicator.file.hash.ssdeep': ['768:NXSFGJ/ooP6FawrB7Bo1MWnF/jRmhJImp:1SFXIqBo1Mwj2p'],
-  'threat.indicator.file.hash.tlsh': [
+  'threatintel.indicator.file.hash.ssdeep': [
+    '768:NXSFGJ/ooP6FawrB7Bo1MWnF/jRmhJImp:1SFXIqBo1Mwj2p',
+  ],
+  'threatintel.indicator.file.hash.tlsh': [
     'FFB20B82F6617061C32784E2712F7A46B179B04FD1EA54A0F28CD8E9CFE4CAA1617F1C',
   ],
-  'threat.indicator.file.size': [24738],
-  'threat.indicator.file.type': ['html'],
-  'threat.indicator.first_seen': ['2021-05-28T18:33:29.000Z'],
-  'threat.indicator.type': ['file'],
+  'threatintel.indicator.file.size': [24738],
+  'threatintel.indicator.file.type': ['html'],
+  'threatintel.indicator.first_seen': ['2021-05-28T18:33:29.000Z'],
+  'threatintel.indicator.type': ['file'],
   ...overrides,
 });
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/cti_enrichments.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/cti_enrichments.spec.ts
@@ -10,7 +10,7 @@ import { cleanKibana, reload } from '../../tasks/common';
 import { esArchiverLoad, esArchiverUnload } from '../../tasks/es_archiver';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 import {
-  JSON_LINES,
+  JSON_TEXT,
   TABLE_CELL,
   TABLE_ROWS,
   THREAT_DETAILS_VIEW,
@@ -28,11 +28,7 @@ import {
   viewThreatIntelTab,
 } from '../../tasks/alerts';
 import { createCustomIndicatorRule } from '../../tasks/api_calls/rules';
-import {
-  openJsonView,
-  openThreatIndicatorDetails,
-  scrollJsonViewToBottom,
-} from '../../tasks/alerts_details';
+import { openJsonView, openThreatIndicatorDetails } from '../../tasks/alerts_details';
 
 import { ALERTS_URL } from '../../urls/navigation';
 import { addsFieldsToTimeline } from '../../tasks/rule_details';
@@ -76,26 +72,39 @@ describe('CTI Enrichment', () => {
 
   it('Displays persisted enrichments on the JSON view', () => {
     const expectedEnrichment = [
-      { line: 4, text: '  "threat": {' },
       {
-        line: 3,
-        text: '    "enrichments": "{\\"indicator\\":{\\"first_seen\\":\\"2021-03-10T08:02:14.000Z\\",\\"file\\":{\\"size\\":80280,\\"pe\\":{},\\"type\\":\\"elf\\",\\"hash\\":{\\"sha256\\":\\"a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3\\",\\"tlsh\\":\\"6D7312E017B517CC1371A8353BED205E9128223972AE35302E97528DF957703BAB2DBE\\",\\"ssdeep\\":\\"1536:87vbq1lGAXSEYQjbChaAU2yU23M51DjZgSQAvcYkFtZTjzBht5:8D+CAXFYQChaAUk5ljnQssL\\",\\"md5\\":\\"9b6c3518a91d23ed77504b5416bfb5b3\\"}},\\"type\\":\\"file\\"},\\"matched\\":{\\"atomic\\":\\"a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3\\",\\"field\\":\\"myhash.mysha256\\",\\"id\\":\\"84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f\\",\\"index\\":\\"filebeat-7.12.0-2021.03.10-000001\\",\\"type\\":\\"indicator_match_rule\\"}}"',
+        indicator: {
+          first_seen: '2021-03-10T08:02:14.000Z',
+          file: {
+            size: 80280,
+            pe: {},
+            type: 'elf',
+            hash: {
+              sha256: 'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
+              tlsh: '6D7312E017B517CC1371A8353BED205E9128223972AE35302E97528DF957703BAB2DBE',
+              ssdeep:
+                '1536:87vbq1lGAXSEYQjbChaAU2yU23M51DjZgSQAvcYkFtZTjzBht5:8D+CAXFYQChaAUk5ljnQssL',
+              md5: '9b6c3518a91d23ed77504b5416bfb5b3',
+            },
+          },
+          type: 'file',
+        },
+        matched: {
+          atomic: 'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
+          field: 'myhash.mysha256',
+          id: '84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f',
+          index: 'filebeat-7.12.0-2021.03.10-000001',
+          type: 'indicator_match_rule',
+        },
       },
-      { line: 2, text: '  }' },
     ];
 
     expandFirstAlert();
     openJsonView();
-    scrollJsonViewToBottom();
 
-    cy.get(JSON_LINES).then((elements) => {
-      const length = elements.length;
-      expectedEnrichment.forEach((enrichment) => {
-        cy.wrap(elements)
-          .eq(length - enrichment.line)
-          .invoke('text')
-          .should('include', enrichment.text);
-      });
+    cy.get(JSON_TEXT).then((x) => {
+      const parsed = JSON.parse(x.text());
+      expect(parsed._source.threat.enrichments).to.deep.equal(expectedEnrichment);
     });
   });
 

--- a/x-pack/plugins/security_solution/cypress/integration/detection_alerts/cti_enrichments.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/detection_alerts/cti_enrichments.spec.ts
@@ -10,7 +10,7 @@ import { cleanKibana, reload } from '../../tasks/common';
 import { esArchiverLoad, esArchiverUnload } from '../../tasks/es_archiver';
 import { loginAndWaitForPageWithoutDateRange } from '../../tasks/login';
 import {
-  JSON_TEXT,
+  JSON_LINES,
   TABLE_CELL,
   TABLE_ROWS,
   THREAT_DETAILS_VIEW,
@@ -28,7 +28,11 @@ import {
   viewThreatIntelTab,
 } from '../../tasks/alerts';
 import { createCustomIndicatorRule } from '../../tasks/api_calls/rules';
-import { openJsonView, openThreatIndicatorDetails } from '../../tasks/alerts_details';
+import {
+  openJsonView,
+  openThreatIndicatorDetails,
+  scrollJsonViewToBottom,
+} from '../../tasks/alerts_details';
 
 import { ALERTS_URL } from '../../urls/navigation';
 import { addsFieldsToTimeline } from '../../tasks/rule_details';
@@ -72,39 +76,26 @@ describe('CTI Enrichment', () => {
 
   it('Displays persisted enrichments on the JSON view', () => {
     const expectedEnrichment = [
+      { line: 4, text: '  "threat": {' },
       {
-        indicator: {
-          first_seen: '2021-03-10T08:02:14.000Z',
-          file: {
-            size: 80280,
-            pe: {},
-            type: 'elf',
-            hash: {
-              sha256: 'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
-              tlsh: '6D7312E017B517CC1371A8353BED205E9128223972AE35302E97528DF957703BAB2DBE',
-              ssdeep:
-                '1536:87vbq1lGAXSEYQjbChaAU2yU23M51DjZgSQAvcYkFtZTjzBht5:8D+CAXFYQChaAUk5ljnQssL',
-              md5: '9b6c3518a91d23ed77504b5416bfb5b3',
-            },
-          },
-          type: 'file',
-        },
-        matched: {
-          atomic: 'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
-          field: 'myhash.mysha256',
-          id: '84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f',
-          index: 'logs-ti_abusech.malware',
-          type: 'indicator_match_rule',
-        },
+        line: 3,
+        text: '    "enrichments": "{\\"indicator\\":{\\"first_seen\\":\\"2021-03-10T08:02:14.000Z\\",\\"file\\":{\\"size\\":80280,\\"pe\\":{},\\"type\\":\\"elf\\",\\"hash\\":{\\"sha256\\":\\"a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3\\",\\"tlsh\\":\\"6D7312E017B517CC1371A8353BED205E9128223972AE35302E97528DF957703BAB2DBE\\",\\"ssdeep\\":\\"1536:87vbq1lGAXSEYQjbChaAU2yU23M51DjZgSQAvcYkFtZTjzBht5:8D+CAXFYQChaAUk5ljnQssL\\",\\"md5\\":\\"9b6c3518a91d23ed77504b5416bfb5b3\\"}},\\"type\\":\\"file\\"},\\"matched\\":{\\"atomic\\":\\"a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3\\",\\"field\\":\\"myhash.mysha256\\",\\"id\\":\\"84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f\\",\\"index\\":\\"filebeat-7.12.0-2021.03.10-000001\\",\\"type\\":\\"indicator_match_rule\\"}}"',
       },
+      { line: 2, text: '  }' },
     ];
 
     expandFirstAlert();
     openJsonView();
+    scrollJsonViewToBottom();
 
-    cy.get(JSON_TEXT).then((x) => {
-      const parsed = JSON.parse(x.text());
-      expect(parsed._source.threat.enrichments).to.deep.equal(expectedEnrichment);
+    cy.get(JSON_LINES).then((elements) => {
+      const length = elements.length;
+      expectedEnrichment.forEach((enrichment) => {
+        cy.wrap(elements)
+          .eq(length - enrichment.line)
+          .invoke('text')
+          .should('include', enrichment.text);
+      });
     });
   });
 
@@ -136,7 +127,7 @@ describe('CTI Enrichment', () => {
         field: 'matched.id',
         value: '84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f',
       },
-      { field: 'matched.index', value: 'logs-ti_abusech.malware' },
+      { field: 'matched.index', value: 'filebeat-7.12.0-2021.03.10-000001' },
       { field: 'matched.type', value: 'indicator_match_rule' },
     ];
 

--- a/x-pack/plugins/security_solution/cypress/objects/rule.ts
+++ b/x-pack/plugins/security_solution/cypress/objects/rule.ts
@@ -109,7 +109,7 @@ export const getIndexPatterns = (): string[] => [
   'winlogbeat-*',
 ];
 
-export const getThreatIndexPatterns = (): string[] => ['logs-ti_*'];
+export const getThreatIndexPatterns = (): string[] => ['filebeat-*'];
 
 const getMitre1 = (): Mitre => ({
   tactic: `${getMockThreatData().tactic.name} (${getMockThreatData().tactic.id})`,
@@ -400,7 +400,7 @@ export const getNewThreatIndicatorRule = (): ThreatIndicatorRule => ({
   lookBack: getLookBack(),
   indicatorIndexPattern: ['filebeat-*'],
   indicatorMappingField: 'myhash.mysha256',
-  indicatorIndexField: 'threat.indicator.file.hash.sha256',
+  indicatorIndexField: 'threatintel.indicator.file.hash.sha256',
   type: 'file',
   atomic: 'a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3',
   timeline: getIndicatorMatchTimelineTemplate(),

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_details_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_details_view.test.tsx
@@ -37,7 +37,7 @@ describe('ThreatDetailsView', () => {
   it('renders an anchor link for indicator.reference', () => {
     const enrichments = [
       buildEventEnrichmentMock({
-        'threat.indicator.reference': ['http://foo.baz'],
+        'threatintel.indicator.reference': ['http://foo.baz'],
       }),
     ];
     const wrapper = mount(
@@ -60,10 +60,10 @@ describe('ThreatDetailsView', () => {
     const existingEnrichment = buildEventEnrichmentMock({
       'indicator.first_seen': [mostRecentDate],
     });
-    delete existingEnrichment['threat.indicator.first_seen'];
+    delete existingEnrichment['threatintel.indicator.first_seen'];
     const newEnrichment = buildEventEnrichmentMock({
       'matched.id': ['other.id'],
-      'threat.indicator.first_seen': [olderDate],
+      'threatintel.indicator.first_seen': [olderDate],
     });
     const enrichments = [existingEnrichment, newEnrichment];
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/field_maps/cti.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/field_maps/cti.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ctiFieldMap = {
+  'threat.indicator': {
+    type: 'nested',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.as.number': {
+    type: 'long',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.as.organization.name': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.confidence': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.dataset': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.description': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.domain': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.email.address': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.first_seen': {
+    type: 'date',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.city_name': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.continent_name': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.country_iso_code': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.country_name': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.location': {
+    type: 'geo_point',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.name': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.region_iso_code': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.geo.region_name': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.ip': {
+    type: 'ip',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.last_seen': {
+    type: 'date',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.marking.tlp': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.matched.atomic': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.matched.field': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.matched.type': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.module': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.port': {
+    type: 'long',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.provider': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.scanner_stats': {
+    type: 'long',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.sightings': {
+    type: 'long',
+    array: false,
+    required: false,
+  },
+  'threat.indicator.type': {
+    type: 'keyword',
+    array: false,
+    required: false,
+  },
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/create_indicator_match_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/create_indicator_match_alert_type.test.ts
@@ -42,7 +42,7 @@ describe('Indicator Match Alerts', () => {
           {
             field: 'file.hash.md5',
             type: 'mapping',
-            value: 'threat.indicator.file.hash.md5',
+            value: 'threatintel.indicator.file.hash.md5',
           },
         ],
       },
@@ -156,11 +156,11 @@ describe('Indicator Match Alerts', () => {
               ...sampleDocNoSortId(v4()),
               _source: {
                 ...sampleDocNoSortId(v4())._source,
-                'threat.indicator.file.hash.md5': 'a1b2c3',
+                'threatintel.indicator.file.hash.md5': 'a1b2c3',
               },
               fields: {
                 ...sampleDocNoSortId(v4()).fields,
-                'threat.indicator.file.hash.md5': ['a1b2c3'],
+                'threatintel.indicator.file.hash.md5': ['a1b2c3'],
               },
             },
           ],

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/scripts/create_rule_indicator_match.sh
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/scripts/create_rule_indicator_match.sh
@@ -46,7 +46,7 @@ curl -X POST ${KIBANA_URL}${SPACE_URL}/api/alerts/alert \
             {
               "field":"file.hash.md5",
               "type":"mapping",
-              "value":"threat.indicator.file.hash.md5"
+              "value":"threatintel.indicator.file.hash.md5"
             }
           ]
         }

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -68,6 +68,7 @@ import { registerEventLogProvider } from './lib/detection_engine/rule_execution_
 import { getKibanaPrivilegesFeaturePrivileges } from './features';
 import { EndpointMetadataService } from './endpoint/services/metadata';
 import { CreateRuleOptions } from './lib/detection_engine/rule_types/types';
+import { ctiFieldMap } from './lib/detection_engine/rule_types/field_maps/cti';
 import { registerPrivilegeDeprecations } from './deprecation_privileges';
 // eslint-disable-next-line no-restricted-imports
 import { legacyRulesNotificationAlertType } from './lib/detection_engine/notifications/legacy_rules_notification_alert_type';
@@ -198,7 +199,10 @@ export class Plugin implements ISecuritySolutionPlugin {
         componentTemplates: [
           {
             name: 'mappings',
-            mappings: mappingFromFieldMap({ ...alertsFieldMap, ...rulesFieldMap }, false),
+            mappings: mappingFromFieldMap(
+              { ...alertsFieldMap, ...rulesFieldMap, ...ctiFieldMap },
+              false
+            ),
           },
         ],
         secondaryAlias: config.signalsIndex,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/helpers.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/helpers.test.ts
@@ -32,7 +32,7 @@ describe('buildIndicatorShouldClauses', () => {
 
     expect(buildIndicatorShouldClauses(eventFields)).toContainEqual({
       match: {
-        'threat.indicator.file.hash.md5': {
+        'threatintel.indicator.file.hash.md5': {
           _name: 'file.hash.md5',
           query: '1eee2bf3f56d8abed72da2bc523e7431',
         },
@@ -44,8 +44,8 @@ describe('buildIndicatorShouldClauses', () => {
     const eventFields = { 'source.ip': '127.0.0.1', 'url.full': 'elastic.co' };
     expect(buildIndicatorShouldClauses(eventFields)).toEqual(
       expect.arrayContaining([
-        { match: { 'threat.indicator.ip': { _name: 'source.ip', query: '127.0.0.1' } } },
-        { match: { 'threat.indicator.url.full': { _name: 'url.full', query: 'elastic.co' } } },
+        { match: { 'threatintel.indicator.ip': { _name: 'source.ip', query: '127.0.0.1' } } },
+        { match: { 'threatintel.indicator.url.full': { _name: 'url.full', query: 'elastic.co' } } },
       ])
     );
   });
@@ -83,7 +83,7 @@ describe('buildIndicatorEnrichments', () => {
         _index: '_index',
         matched_queries: ['file.hash.md5'],
         fields: {
-          'threat.indicator.file.hash.md5': ['indicator_value'],
+          'threatintel.indicator.file.hash.md5': ['indicator_value'],
         },
       },
     ];
@@ -94,7 +94,7 @@ describe('buildIndicatorEnrichments', () => {
         'matched.field': ['file.hash.md5'],
         'matched.id': ['_id'],
         'matched.index': ['_index'],
-        'threat.indicator.file.hash.md5': ['indicator_value'],
+        'threatintel.indicator.file.hash.md5': ['indicator_value'],
       }),
     ]);
   });
@@ -106,8 +106,8 @@ describe('buildIndicatorEnrichments', () => {
         _index: '_index',
         matched_queries: ['file.hash.md5', 'source.ip'],
         fields: {
-          'threat.indicator.file.hash.md5': ['indicator_value'],
-          'threat.indicator.ip': ['127.0.0.1'],
+          'threatintel.indicator.file.hash.md5': ['indicator_value'],
+          'threatintel.indicator.ip': ['127.0.0.1'],
         },
       },
     ];
@@ -118,16 +118,16 @@ describe('buildIndicatorEnrichments', () => {
         'matched.field': ['file.hash.md5'],
         'matched.id': ['_id'],
         'matched.index': ['_index'],
-        'threat.indicator.file.hash.md5': ['indicator_value'],
-        'threat.indicator.ip': ['127.0.0.1'],
+        'threatintel.indicator.file.hash.md5': ['indicator_value'],
+        'threatintel.indicator.ip': ['127.0.0.1'],
       }),
       expect.objectContaining({
         'matched.atomic': ['127.0.0.1'],
         'matched.field': ['source.ip'],
         'matched.id': ['_id'],
         'matched.index': ['_index'],
-        'threat.indicator.file.hash.md5': ['indicator_value'],
-        'threat.indicator.ip': ['127.0.0.1'],
+        'threatintel.indicator.file.hash.md5': ['indicator_value'],
+        'threatintel.indicator.ip': ['127.0.0.1'],
       }),
     ]);
   });
@@ -139,7 +139,7 @@ describe('buildIndicatorEnrichments', () => {
         _index: '_index',
         matched_queries: ['file.hash.md5'],
         fields: {
-          'threat.indicator.file.hash.md5': ['indicator_value'],
+          'threatintel.indicator.file.hash.md5': ['indicator_value'],
         },
       },
       {
@@ -147,7 +147,7 @@ describe('buildIndicatorEnrichments', () => {
         _index: '_index2',
         matched_queries: ['source.ip'],
         fields: {
-          'threat.indicator.ip': ['127.0.0.1'],
+          'threatintel.indicator.ip': ['127.0.0.1'],
         },
       },
     ];
@@ -158,14 +158,14 @@ describe('buildIndicatorEnrichments', () => {
         'matched.field': ['file.hash.md5'],
         'matched.id': ['_id'],
         'matched.index': ['_index'],
-        'threat.indicator.file.hash.md5': ['indicator_value'],
+        'threatintel.indicator.file.hash.md5': ['indicator_value'],
       }),
       expect.objectContaining({
         'matched.atomic': ['127.0.0.1'],
         'matched.field': ['source.ip'],
         'matched.id': ['_id2'],
         'matched.index': ['_index2'],
-        'threat.indicator.ip': ['127.0.0.1'],
+        'threatintel.indicator.ip': ['127.0.0.1'],
       }),
     ]);
   });

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/query.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/query.test.ts
@@ -16,14 +16,14 @@ describe('buildEventEnrichmentQuery', () => {
       expect.arrayContaining([
         {
           match: {
-            'threat.indicator.file.hash.md5': {
+            'threatintel.indicator.file.hash.md5': {
               _name: 'file.hash.md5',
               query: '1eee2bf3f56d8abed72da2bc523e7431',
             },
           },
         },
-        { match: { 'threat.indicator.ip': { _name: 'source.ip', query: '127.0.0.1' } } },
-        { match: { 'threat.indicator.url.full': { _name: 'url.full', query: 'elastic.co' } } },
+        { match: { 'threatintel.indicator.ip': { _name: 'source.ip', query: '127.0.0.1' } } },
+        { match: { 'threatintel.indicator.url.full': { _name: 'url.full', query: 'elastic.co' } } },
       ])
     );
   });

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
@@ -41,16 +41,16 @@ describe('parseEventEnrichmentResponse', () => {
             should: [
               {
                 match: {
-                  'threat.indicator.file.hash.md5': {
+                  'threatintel.indicator.file.hash.md5': {
                     _name: 'file.hash.md5',
                     query: '1eee2bf3f56d8abed72da2bc523e7431',
                   },
                 },
               },
-              { match: { 'threat.indicator.ip': { _name: 'source.ip', query: '127.0.0.1' } } },
+              { match: { 'threatintel.indicator.ip': { _name: 'source.ip', query: '127.0.0.1' } } },
               {
                 match: {
-                  'threat.indicator.url.full': { _name: 'url.full', query: 'elastic.co' },
+                  'threatintel.indicator.url.full': { _name: 'url.full', query: 'elastic.co' },
                 },
               },
             ],

--- a/x-pack/test/functional/es_archives/filebeat/threat_intel/data.json
+++ b/x-pack/test/functional/es_archives/filebeat/threat_intel/data.json
@@ -18,7 +18,7 @@
       "event": {
         "category": "threat",
         "created": "2021-01-26T11:09:05.529Z",
-        "dataset": "ti_abusech.malware",
+        "dataset": "threatintel.abuseurl",
         "ingested": "2021-01-26T11:09:06.595350Z",
         "kind": "enrichment",
         "module": "threatintel",
@@ -87,7 +87,7 @@
       "event": {
         "category": "threat",
         "created": "2021-01-26T11:09:05.529Z",
-        "dataset": "ti_abusech.malware",
+        "dataset": "threatintel.abuseurl",
         "ingested": "2021-01-26T11:09:06.616763Z",
         "kind": "enrichment",
         "module": "threatintel",
@@ -156,7 +156,7 @@
       "event": {
         "category": "threat",
         "created": "2021-01-26T11:09:05.529Z",
-        "dataset": "ti_abusech.malware",
+        "dataset": "threatintel.abuseurl",
         "ingested": "2021-01-26T11:09:06.616763Z",
         "kind": "enrichment",
         "module": "threatintel",
@@ -226,7 +226,7 @@
       "event": {
         "category": "threat",
         "created": "2021-01-26T11:09:05.529Z",
-        "dataset": "ti_abusech.malware",
+        "dataset": "threatintel.abuseurl",
         "ingested": "2021-01-26T11:09:06.616763Z",
         "kind": "enrichment",
         "module": "threatintel",

--- a/x-pack/test/functional/es_archives/security_solution/legacy_cti_signals/data.json
+++ b/x-pack/test/functional/es_archives/security_solution/legacy_cti_signals/data.json
@@ -168,12 +168,12 @@
                 {
                   "field": "host.name",
                   "type": "mapping",
-                  "value": "threat.indicator.domain"
+                  "value": "threatintel.indicator.domain"
                 }
               ]
             }
           ],
-          "threat_query": "threat.indicator.type : \"url\"",
+          "threat_query": "threatintel.indicator.type : \"url\"",
           "throttle": null,
           "to": "now",
           "type": "threat_match",
@@ -190,7 +190,7 @@
             "event": {
               "category": "threat",
               "created": "2021-08-04T03:53:30.761Z",
-              "dataset": "ti_abusech.malware",
+              "dataset": "threatintel.abuseurl",
               "ingested": "2021-08-04T03:53:37.514040Z",
               "kind": "enrichment",
               "module": "threatintel",
@@ -412,12 +412,12 @@
                 {
                   "field": "host.name",
                   "type": "mapping",
-                  "value": "threat.indicator.domain"
+                  "value": "threatintel.indicator.domain"
                 }
               ]
             }
           ],
-          "threat_query": "threat.indicator.type : \"url\"",
+          "threat_query": "threatintel.indicator.type : \"url\"",
           "throttle": null,
           "to": "now",
           "type": "threat_match",
@@ -434,7 +434,7 @@
             "event": {
               "category": "threat",
               "created": "2021-08-04T03:53:30.761Z",
-              "dataset": "ti_abusech.malware",
+              "dataset": "threatintel.abuseurl",
               "ingested": "2021-08-04T03:53:37.514040Z",
               "kind": "enrichment",
               "module": "threatintel",

--- a/x-pack/test/security_solution_cypress/es_archives/threat_indicator/data.json
+++ b/x-pack/test/security_solution_cypress/es_archives/threat_indicator/data.json
@@ -2,7 +2,7 @@
   "type": "doc",
   "value": {
     "id": "84cf452c1e0375c3d4412cb550bd1783358468a3b3b777da4829d72c7d6fb74f",
-    "index": "logs-ti_abusech.malware",
+    "index": "filebeat-7.12.0-2021.03.10-000001",
     "source": {
       "@timestamp": "2021-03-10T14:51:05.766Z",
       "agent": {
@@ -16,7 +16,7 @@
       "fileset": {
         "name": "abusemalware"
       },
-      "threat": {
+      "threatintel": {
         "indicator": {
           "first_seen": "2021-03-10T08:02:14.000Z",
           "file": {
@@ -31,13 +31,13 @@
             }
           },
           "type": "file"
-        }
-      },
-      "abusemalware": {
-        "virustotal": {
-          "result": "38 / 61",
-          "link": "https://www.virustotal.com/gui/file/a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3/detection/f-a04ac6d",
-          "percent": "62.30"
+        },
+        "abusemalware": {
+          "virustotal": {
+            "result": "38 / 61",
+            "link": "https://www.virustotal.com/gui/file/a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3/detection/f-a04ac6d",
+            "percent": "62.30"
+          }
         }
       },
       "tags": [
@@ -68,7 +68,7 @@
         "module": "threatintel",
         "category": "threat",
         "type": "indicator",
-        "dataset": "ti_abusech.malware"
+        "dataset": "threatintel.abusemalware"
       }
     }
   }

--- a/x-pack/test/security_solution_cypress/es_archives/threat_indicator/mappings.json
+++ b/x-pack/test/security_solution_cypress/es_archives/threat_indicator/mappings.json
@@ -6,7 +6,7 @@
         "is_write_index": true
       }
     },
-    "index": "logs-ti_abusech.malware",
+    "index": "filebeat-7.12.0-2021.03.10-000001",
     "mappings": {
       "_meta": {
         "beat": "filebeat",
@@ -194,7 +194,7 @@
             }
           }
         },
-        "threat": {
+        "threatintel": {
           "properties": {
             "abusemalware": {
               "properties": {

--- a/x-pack/test/security_solution_cypress/es_archives/threat_indicator2/data.json
+++ b/x-pack/test/security_solution_cypress/es_archives/threat_indicator2/data.json
@@ -2,7 +2,7 @@
   "type": "doc",
   "value": {
     "id": "a04ac6d98ad989312783d4fe3456c53730b212c79a426fb215708b6c6daa3de3",
-    "index": "logs-ti_abusech.malware",
+    "index": "filebeat-7.12.0-2021.03.11-000001",
     "source": {
       "@timestamp": "2021-06-27T14:51:05.766Z",
       "agent": {
@@ -16,7 +16,7 @@
       "fileset": {
         "name": "abusemalware"
       },
-      "threat": {
+      "threatintel": {
         "indicator": {
           "first_seen": "2021-03-11T08:02:14.000Z",
           "ip": "192.168.1.1",
@@ -56,7 +56,7 @@
         "module": "threatintel",
         "category": "threat",
         "type": "indicator",
-        "dataset": "ti_abusech.malware"
+        "dataset": "threatintel.abusemalware"
       }
     }
   }

--- a/x-pack/test/security_solution_cypress/es_archives/threat_indicator2/mappings.json
+++ b/x-pack/test/security_solution_cypress/es_archives/threat_indicator2/mappings.json
@@ -2,11 +2,11 @@
   "type": "index",
   "value": {
     "aliases": {
-      "logs-ti": {
+      "filebeat-7.12.0": {
         "is_write_index": false
       }
     },
-    "index": "logs-ti_abusech.malware",
+    "index": "filebeat-7.12.0-2021.03.11-000001",
     "mappings": {
       "_meta": {
         "beat": "filebeat",
@@ -194,7 +194,7 @@
             }
           }
         },
-        "threat": {
+        "threatintel": {
           "properties": {
             "abusemalware": {
               "properties": {


### PR DESCRIPTION
This reverts commit e4a30af3ce03fcba1066eb0f9269f1ff4be8fa31.

note: this change also contains the reversion of changes in `x-pack/plugins/security_solution/common/cti/constants.ts`, which were modified as part of #116175

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
