### PR TITLE
[alerting] disable status reporting for now

### DIFF
--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -6,10 +6,9 @@
  */
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
-import { first, map, share } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { BehaviorSubject } from 'rxjs';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
-import { combineLatest } from 'rxjs';
 import { SecurityPluginSetup, SecurityPluginStart } from '../../security/server';
 import {
   EncryptedSavedObjectsPluginSetup,
@@ -61,11 +60,7 @@ import {
   initializeApiKeyInvalidator,
   scheduleApiKeyInvalidatorTask,
 } from './invalidate_pending_api_keys/task';
-import {
-  getHealthStatusStream,
-  scheduleAlertingHealthCheck,
-  initializeAlertingHealth,
-} from './health';
+import { scheduleAlertingHealthCheck, initializeAlertingHealth } from './health';
 import { AlertsConfig } from './config';
 import { getHealth } from './health/get_health';
 import { AlertingAuthorizationClientFactory } from './alerting_authorization_client_factory';
@@ -236,8 +231,8 @@ export class AlertingPlugin {
     );
 
     const serviceStatus$ = new BehaviorSubject<ServiceStatus>({
-      level: ServiceStatusLevels.degraded,
-      summary: 'Alerting is initializing',
+      level: ServiceStatusLevels.available,
+      summary: 'Alerting is (probably) ready',
     });
     core.status.set(serviceStatus$);
 

--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -241,28 +241,28 @@ export class AlertingPlugin {
     });
     core.status.set(serviceStatus$);
 
-    core.getStartServices().then(async ([coreStart, startPlugins]) => {
-      combineLatest([
-        core.status.derivedStatus$,
-        getHealthStatusStream(
-          startPlugins.taskManager,
-          this.logger,
-          coreStart.savedObjects,
-          this.config
-        ),
-      ])
-        .pipe(
-          map(([derivedStatus, healthStatus]) => {
-            if (healthStatus.level > derivedStatus.level) {
-              return healthStatus as ServiceStatus;
-            } else {
-              return derivedStatus;
-            }
-          }),
-          share()
-        )
-        .subscribe(serviceStatus$);
-    });
+    // core.getStartServices().then(async ([coreStart, startPlugins]) => {
+    //   combineLatest([
+    //     core.status.derivedStatus$,
+    //     getHealthStatusStream(
+    //       startPlugins.taskManager,
+    //       this.logger,
+    //       coreStart.savedObjects,
+    //       this.config
+    //     ),
+    //   ])
+    //     .pipe(
+    //       map(([derivedStatus, healthStatus]) => {
+    //         if (healthStatus.level > derivedStatus.level) {
+    //           return healthStatus as ServiceStatus;
+    //         } else {
+    //           return derivedStatus;
+    //         }
+    //       }),
+    //       share()
+    //     )
+    //     .subscribe(serviceStatus$);
+    // });
 
     initializeAlertingHealth(this.logger, plugins.taskManager, core.getStartServices());
 


### PR DESCRIPTION
Temporary mitigation for https://github.com/elastic/kibana/issues/116714

From what we can tell the alerting status isn't actually necessary for the plugin to operation successfully, and is only harming DX/UX as described in https://github.com/elastic/kibana/issues/116714, so this is an attempt to disable status reporting for now until a better long term solution can be determined with the Alerting team.