### PR TITLE
Revert "[Logs UI][Metrics UI] Remove deprecated config fields from APIs and SavedObjects"

### DIFF
--- a/x-pack/plugins/infra/common/constants.ts
+++ b/x-pack/plugins/infra/common/constants.ts
@@ -8,6 +8,7 @@
 export const DEFAULT_SOURCE_ID = 'default';
 export const METRICS_INDEX_PATTERN = 'metrics-*,metricbeat-*';
 export const LOGS_INDEX_PATTERN = 'logs-*,filebeat-*,kibana_sample_data_logs*';
+export const TIMESTAMP_FIELD = '@timestamp';
 export const METRICS_APP = 'metrics';
 export const LOGS_APP = 'logs';
 
@@ -15,9 +16,3 @@ export const METRICS_FEATURE_ID = 'infrastructure';
 export const LOGS_FEATURE_ID = 'logs';
 
 export type InfraFeatureId = typeof METRICS_FEATURE_ID | typeof LOGS_FEATURE_ID;
-
-export const TIMESTAMP_FIELD = '@timestamp';
-export const TIEBREAKER_FIELD = '_doc';
-export const HOST_FIELD = 'host.name';
-export const CONTAINER_FIELD = 'container.id';
-export const POD_FIELD = 'kubernetes.pod.uid';

--- a/x-pack/plugins/infra/common/http_api/host_details/process_list.ts
+++ b/x-pack/plugins/infra/common/http_api/host_details/process_list.ts
@@ -14,6 +14,7 @@ const AggValueRT = rt.type({
 
 export const ProcessListAPIRequestRT = rt.type({
   hostTerm: rt.record(rt.string, rt.string),
+  timefield: rt.string,
   indexPattern: rt.string,
   to: rt.number,
   sortBy: rt.type({
@@ -101,6 +102,7 @@ export type ProcessListAPIResponse = rt.TypeOf<typeof ProcessListAPIResponseRT>;
 
 export const ProcessListAPIChartRequestRT = rt.type({
   hostTerm: rt.record(rt.string, rt.string),
+  timefield: rt.string,
   indexPattern: rt.string,
   to: rt.number,
   command: rt.string,

--- a/x-pack/plugins/infra/common/http_api/metrics_api.ts
+++ b/x-pack/plugins/infra/common/http_api/metrics_api.ts
@@ -10,6 +10,7 @@ import { MetricsUIAggregationRT } from '../inventory_models/types';
 import { afterKeyObjectRT } from './metrics_explorer';
 
 export const MetricsAPITimerangeRT = rt.type({
+  field: rt.string,
   from: rt.number,
   to: rt.number,
   interval: rt.string,

--- a/x-pack/plugins/infra/common/http_api/metrics_explorer.ts
+++ b/x-pack/plugins/infra/common/http_api/metrics_explorer.ts
@@ -41,6 +41,7 @@ export const metricsExplorerMetricRT = rt.intersection([
 ]);
 
 export const timeRangeRT = rt.type({
+  field: rt.string,
   from: rt.number,
   to: rt.number,
   interval: rt.string,

--- a/x-pack/plugins/infra/common/inventory_models/index.ts
+++ b/x-pack/plugins/infra/common/inventory_models/index.ts
@@ -6,7 +6,6 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { POD_FIELD, HOST_FIELD, CONTAINER_FIELD } from '../constants';
 import { host } from './host';
 import { pod } from './pod';
 import { awsEC2 } from './aws_ec2';
@@ -31,23 +30,31 @@ export const findInventoryModel = (type: InventoryItemType) => {
   return model;
 };
 
+interface InventoryFields {
+  host: string;
+  pod: string;
+  container: string;
+  timestamp: string;
+  tiebreaker: string;
+}
+
 const LEGACY_TYPES = ['host', 'pod', 'container'];
 
-export const getFieldByType = (type: InventoryItemType) => {
+const getFieldByType = (type: InventoryItemType, fields: InventoryFields) => {
   switch (type) {
     case 'pod':
-      return POD_FIELD;
+      return fields.pod;
     case 'host':
-      return HOST_FIELD;
+      return fields.host;
     case 'container':
-      return CONTAINER_FIELD;
+      return fields.container;
   }
 };
 
-export const findInventoryFields = (type: InventoryItemType) => {
+export const findInventoryFields = (type: InventoryItemType, fields?: InventoryFields) => {
   const inventoryModel = findInventoryModel(type);
-  if (LEGACY_TYPES.includes(type)) {
-    const id = getFieldByType(type) || inventoryModel.fields.id;
+  if (fields && LEGACY_TYPES.includes(type)) {
+    const id = getFieldByType(type, fields) || inventoryModel.fields.id;
     return {
       ...inventoryModel.fields,
       id,

--- a/x-pack/plugins/infra/common/log_sources/log_source_configuration.ts
+++ b/x-pack/plugins/infra/common/log_sources/log_source_configuration.ts
@@ -16,6 +16,11 @@ export const logSourceConfigurationOriginRT = rt.keyof({
 export type LogSourceConfigurationOrigin = rt.TypeOf<typeof logSourceConfigurationOriginRT>;
 
 const logSourceFieldsConfigurationRT = rt.strict({
+  container: rt.string,
+  host: rt.string,
+  pod: rt.string,
+  timestamp: rt.string,
+  tiebreaker: rt.string,
   message: rt.array(rt.string),
 });
 

--- a/x-pack/plugins/infra/common/log_sources/resolved_log_source_configuration.ts
+++ b/x-pack/plugins/infra/common/log_sources/resolved_log_source_configuration.ts
@@ -8,7 +8,6 @@
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { DataView, DataViewsContract } from '../../../../../src/plugins/data_views/common';
 import { ObjectEntries } from '../utility_types';
-import { TIMESTAMP_FIELD, TIEBREAKER_FIELD } from '../constants';
 import { ResolveLogSourceConfigurationError } from './errors';
 import {
   LogSourceColumnConfiguration,
@@ -62,8 +61,8 @@ const resolveLegacyReference = async (
 
   return {
     indices: sourceConfiguration.logIndices.indexName,
-    timestampField: TIMESTAMP_FIELD,
-    tiebreakerField: TIEBREAKER_FIELD,
+    timestampField: sourceConfiguration.fields.timestamp,
+    tiebreakerField: sourceConfiguration.fields.tiebreaker,
     messageField: sourceConfiguration.fields.message,
     fields,
     runtimeMappings: {},
@@ -92,8 +91,8 @@ const resolveKibanaIndexPatternReference = async (
 
   return {
     indices: indexPattern.title,
-    timestampField: TIMESTAMP_FIELD,
-    tiebreakerField: TIEBREAKER_FIELD,
+    timestampField: indexPattern.timeFieldName ?? '@timestamp',
+    tiebreakerField: '_doc',
     messageField: ['message'],
     fields: indexPattern.fields,
     runtimeMappings: resolveRuntimeMappings(indexPattern),

--- a/x-pack/plugins/infra/common/metrics_sources/index.ts
+++ b/x-pack/plugins/infra/common/metrics_sources/index.ts
@@ -6,6 +6,7 @@
  */
 
 import * as rt from 'io-ts';
+import { omit } from 'lodash';
 import {
   SourceConfigurationRT,
   SourceStatusRuntimeType,
@@ -21,6 +22,7 @@ export const metricsSourceConfigurationPropertiesRT = rt.strict({
   metricAlias: SourceConfigurationRT.props.metricAlias,
   inventoryDefaultView: SourceConfigurationRT.props.inventoryDefaultView,
   metricsExplorerDefaultView: SourceConfigurationRT.props.metricsExplorerDefaultView,
+  fields: rt.strict(omit(SourceConfigurationRT.props.fields.props, 'message')),
   anomalyThreshold: rt.number,
 });
 
@@ -30,6 +32,9 @@ export type MetricsSourceConfigurationProperties = rt.TypeOf<
 
 export const partialMetricsSourceConfigurationPropertiesRT = rt.partial({
   ...metricsSourceConfigurationPropertiesRT.type.props,
+  fields: rt.partial({
+    ...metricsSourceConfigurationPropertiesRT.type.props.fields.type.props,
+  }),
 });
 
 export type PartialMetricsSourceConfigurationProperties = rt.TypeOf<

--- a/x-pack/plugins/infra/common/source_configuration/source_configuration.ts
+++ b/x-pack/plugins/infra/common/source_configuration/source_configuration.ts
@@ -50,7 +50,12 @@ export const sourceConfigurationConfigFilePropertiesRT = rt.type({
   sources: rt.type({
     default: rt.partial({
       fields: rt.partial({
+        timestamp: rt.string,
         message: rt.array(rt.string),
+        tiebreaker: rt.string,
+        host: rt.string,
+        container: rt.string,
+        pod: rt.string,
       }),
     }),
   }),
@@ -108,6 +113,11 @@ export type InfraSourceConfigurationColumn = rt.TypeOf<typeof SourceConfiguratio
  */
 
 const SourceConfigurationFieldsRT = rt.type({
+  container: rt.string,
+  host: rt.string,
+  pod: rt.string,
+  tiebreaker: rt.string,
+  timestamp: rt.string,
   message: rt.array(rt.string),
 });
 

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.test.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.test.tsx
@@ -54,6 +54,14 @@ describe('ExpressionChart', () => {
         metricAlias: 'metricbeat-*',
         inventoryDefaultView: 'host',
         metricsExplorerDefaultView: 'host',
+        // @ts-ignore
+        fields: {
+          timestamp: '@timestamp',
+          container: 'container.id',
+          host: 'host.name',
+          pod: 'kubernetes.pod.uid',
+          tiebreaker: '_doc',
+        },
         anomalyThreshold: 20,
       },
     };

--- a/x-pack/plugins/infra/public/containers/logs/log_source/log_source.mock.ts
+++ b/x-pack/plugins/infra/public/containers/logs/log_source/log_source.mock.ts
@@ -73,6 +73,11 @@ export const createBasicSourceConfiguration = (sourceId: string): LogSourceConfi
     },
     logColumns: [],
     fields: {
+      container: 'CONTAINER_FIELD',
+      host: 'HOST_FIELD',
+      pod: 'POD_FIELD',
+      tiebreaker: 'TIEBREAKER_FIELD',
+      timestamp: 'TIMESTAMP_FIELD',
       message: ['MESSAGE_FIELD'],
     },
     name: sourceId,

--- a/x-pack/plugins/infra/public/containers/ml/infra_ml_module.tsx
+++ b/x-pack/plugins/infra/public/containers/ml/infra_ml_module.tsx
@@ -19,7 +19,7 @@ export const useInfraMLModule = <JobType extends string>({
   moduleDescriptor: ModuleDescriptor<JobType>;
 }) => {
   const { services } = useKibanaContextForPlugin();
-  const { spaceId, sourceId } = sourceConfiguration;
+  const { spaceId, sourceId, timestampField } = sourceConfiguration;
   const [moduleStatus, dispatchModuleStatus] = useModuleStatus(moduleDescriptor.jobTypes);
 
   const [, fetchJobStatus] = useTrackedPromise(
@@ -64,6 +64,7 @@ export const useInfraMLModule = <JobType extends string>({
               indices: selectedIndices,
               sourceId,
               spaceId,
+              timestampField,
             },
             partitionField,
           },
@@ -90,7 +91,7 @@ export const useInfraMLModule = <JobType extends string>({
         dispatchModuleStatus({ type: 'failedSetup' });
       },
     },
-    [moduleDescriptor.setUpModule, spaceId, sourceId]
+    [moduleDescriptor.setUpModule, spaceId, sourceId, timestampField]
   );
 
   const [cleanUpModuleRequest, cleanUpModule] = useTrackedPromise(

--- a/x-pack/plugins/infra/public/containers/ml/infra_ml_module_configuration.ts
+++ b/x-pack/plugins/infra/public/containers/ml/infra_ml_module_configuration.ts
@@ -45,7 +45,8 @@ export const isJobConfigurationOutdated =
       isSubset(
         new Set(jobConfiguration.indexPattern.split(',')),
         new Set(currentSourceConfiguration.indices)
-      )
+      ) &&
+      jobConfiguration.timestampField === currentSourceConfiguration.timestampField
     );
   };
 

--- a/x-pack/plugins/infra/public/containers/ml/infra_ml_module_types.ts
+++ b/x-pack/plugins/infra/public/containers/ml/infra_ml_module_types.ts
@@ -49,10 +49,12 @@ export interface ModuleDescriptor<JobType extends string> {
   ) => Promise<DeleteJobsResponsePayload>;
   validateSetupIndices?: (
     indices: string[],
+    timestampField: string,
     fetch: HttpHandler
   ) => Promise<ValidationIndicesResponsePayload>;
   validateSetupDatasets?: (
     indices: string[],
+    timestampField: string,
     startTime: number,
     endTime: number,
     fetch: HttpHandler
@@ -63,6 +65,7 @@ export interface ModuleSourceConfiguration {
   indices: string[];
   sourceId: string;
   spaceId: string;
+  timestampField: string;
 }
 
 interface ManyCategoriesWarningReason {

--- a/x-pack/plugins/infra/public/containers/ml/modules/metrics_hosts/module.tsx
+++ b/x-pack/plugins/infra/public/containers/ml/modules/metrics_hosts/module.tsx
@@ -17,18 +17,21 @@ export const useMetricHostsModule = ({
   indexPattern,
   sourceId,
   spaceId,
+  timestampField,
 }: {
   indexPattern: string;
   sourceId: string;
   spaceId: string;
+  timestampField: string;
 }) => {
   const sourceConfiguration: ModuleSourceConfiguration = useMemo(
     () => ({
       indices: indexPattern.split(','),
       sourceId,
       spaceId,
+      timestampField,
     }),
-    [indexPattern, sourceId, spaceId]
+    [indexPattern, sourceId, spaceId, timestampField]
   );
 
   const infraMLModule = useInfraMLModule({

--- a/x-pack/plugins/infra/public/containers/ml/modules/metrics_hosts/module_descriptor.ts
+++ b/x-pack/plugins/infra/public/containers/ml/modules/metrics_hosts/module_descriptor.ts
@@ -18,7 +18,6 @@ import {
   MetricsHostsJobType,
   bucketSpan,
 } from '../../../../../common/infra_ml';
-import { TIMESTAMP_FIELD } from '../../../../../common/constants';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import MemoryJob from '../../../../../../ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/hosts_memory_usage.json';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
@@ -69,7 +68,7 @@ const setUpModule = async (setUpModuleArgs: SetUpModuleArgs, fetch: HttpHandler)
     start,
     end,
     filter,
-    moduleSourceConfiguration: { spaceId, sourceId, indices },
+    moduleSourceConfiguration: { spaceId, sourceId, indices, timestampField },
     partitionField,
   } = setUpModuleArgs;
 
@@ -94,13 +93,13 @@ const setUpModule = async (setUpModuleArgs: SetUpModuleArgs, fetch: HttpHandler)
     return {
       job_id: id,
       data_description: {
-        time_field: TIMESTAMP_FIELD,
+        time_field: timestampField,
       },
       analysis_config,
       custom_settings: {
         metrics_source_config: {
           indexPattern: indexNamePattern,
-          timestampField: TIMESTAMP_FIELD,
+          timestampField,
           bucketSpan,
         },
       },

--- a/x-pack/plugins/infra/public/containers/ml/modules/metrics_k8s/module.tsx
+++ b/x-pack/plugins/infra/public/containers/ml/modules/metrics_k8s/module.tsx
@@ -17,18 +17,21 @@ export const useMetricK8sModule = ({
   indexPattern,
   sourceId,
   spaceId,
+  timestampField,
 }: {
   indexPattern: string;
   sourceId: string;
   spaceId: string;
+  timestampField: string;
 }) => {
   const sourceConfiguration: ModuleSourceConfiguration = useMemo(
     () => ({
       indices: indexPattern.split(','),
       sourceId,
       spaceId,
+      timestampField,
     }),
-    [indexPattern, sourceId, spaceId]
+    [indexPattern, sourceId, spaceId, timestampField]
   );
 
   const infraMLModule = useInfraMLModule({

--- a/x-pack/plugins/infra/public/containers/ml/modules/metrics_k8s/module_descriptor.ts
+++ b/x-pack/plugins/infra/public/containers/ml/modules/metrics_k8s/module_descriptor.ts
@@ -18,7 +18,6 @@ import {
   MetricK8sJobType,
   bucketSpan,
 } from '../../../../../common/infra_ml';
-import { TIMESTAMP_FIELD } from '../../../../../common/constants';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import MemoryJob from '../../../../../../ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/k8s_memory_usage.json';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
@@ -70,7 +69,7 @@ const setUpModule = async (setUpModuleArgs: SetUpModuleArgs, fetch: HttpHandler)
     start,
     end,
     filter,
-    moduleSourceConfiguration: { spaceId, sourceId, indices },
+    moduleSourceConfiguration: { spaceId, sourceId, indices, timestampField },
     partitionField,
   } = setUpModuleArgs;
 
@@ -94,13 +93,13 @@ const setUpModule = async (setUpModuleArgs: SetUpModuleArgs, fetch: HttpHandler)
     return {
       job_id: id,
       data_description: {
-        time_field: TIMESTAMP_FIELD,
+        time_field: timestampField,
       },
       analysis_config,
       custom_settings: {
         metrics_source_config: {
           indexPattern: indexNamePattern,
-          timestampField: TIMESTAMP_FIELD,
+          timestampField,
           bucketSpan,
         },
       },

--- a/x-pack/plugins/infra/public/lib/lib.ts
+++ b/x-pack/plugins/infra/public/lib/lib.ts
@@ -14,6 +14,7 @@ import {
   SnapshotNodeMetric,
   SnapshotNodePath,
 } from '../../common/http_api/snapshot_api';
+import { MetricsSourceConfigurationProperties } from '../../common/metrics_sources';
 import { WaffleSortOption } from '../pages/metrics/inventory_view/hooks/use_waffle_options';
 
 export interface InfraWaffleMapNode {
@@ -123,6 +124,7 @@ export enum InfraWaffleMapRuleOperator {
 }
 
 export interface InfraWaffleMapOptions {
+  fields?: Omit<MetricsSourceConfigurationProperties['fields'], 'message'> | null;
   formatter: InfraFormatterType;
   formatTemplate: string;
   metric: SnapshotMetricInput;

--- a/x-pack/plugins/infra/public/pages/link_to/link_to_logs.test.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/link_to_logs.test.tsx
@@ -151,7 +151,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('default');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'host.name: HOST_NAME')"`
+        `"(language:kuery,query:'HOST_FIELD: HOST_NAME')"`
       );
       expect(searchParams.get('logPosition')).toEqual(null);
     });
@@ -172,7 +172,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('default');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'(host.name: HOST_NAME) and (FILTER_FIELD:FILTER_VALUE)')"`
+        `"(language:kuery,query:'(HOST_FIELD: HOST_NAME) and (FILTER_FIELD:FILTER_VALUE)')"`
       );
       expect(searchParams.get('logPosition')).toMatchInlineSnapshot(
         `"(end:'2019-02-20T14:58:09.404Z',position:(tiebreaker:0,time:1550671089404),start:'2019-02-20T12:58:09.404Z',streamLive:!f)"`
@@ -193,7 +193,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('OTHER_SOURCE');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'host.name: HOST_NAME')"`
+        `"(language:kuery,query:'HOST_FIELD: HOST_NAME')"`
       );
       expect(searchParams.get('logPosition')).toEqual(null);
     });
@@ -229,7 +229,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('default');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'container.id: CONTAINER_ID')"`
+        `"(language:kuery,query:'CONTAINER_FIELD: CONTAINER_ID')"`
       );
       expect(searchParams.get('logPosition')).toEqual(null);
     });
@@ -250,7 +250,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('default');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'(container.id: CONTAINER_ID) and (FILTER_FIELD:FILTER_VALUE)')"`
+        `"(language:kuery,query:'(CONTAINER_FIELD: CONTAINER_ID) and (FILTER_FIELD:FILTER_VALUE)')"`
       );
       expect(searchParams.get('logPosition')).toMatchInlineSnapshot(
         `"(end:'2019-02-20T14:58:09.404Z',position:(tiebreaker:0,time:1550671089404),start:'2019-02-20T12:58:09.404Z',streamLive:!f)"`
@@ -287,7 +287,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('default');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'kubernetes.pod.uid: POD_UID')"`
+        `"(language:kuery,query:'POD_FIELD: POD_UID')"`
       );
       expect(searchParams.get('logPosition')).toEqual(null);
     });
@@ -306,7 +306,7 @@ describe('LinkToLogsPage component', () => {
       const searchParams = new URLSearchParams(history.location.search);
       expect(searchParams.get('sourceId')).toEqual('default');
       expect(searchParams.get('logFilter')).toMatchInlineSnapshot(
-        `"(language:kuery,query:'(kubernetes.pod.uid: POD_UID) and (FILTER_FIELD:FILTER_VALUE)')"`
+        `"(language:kuery,query:'(POD_FIELD: POD_UID) and (FILTER_FIELD:FILTER_VALUE)')"`
       );
       expect(searchParams.get('logPosition')).toMatchInlineSnapshot(
         `"(end:'2019-02-20T14:58:09.404Z',position:(tiebreaker:0,time:1550671089404),start:'2019-02-20T12:58:09.404Z',streamLive:!f)"`

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_node_logs.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_node_logs.tsx
@@ -34,11 +34,12 @@ export const RedirectToNodeLogs = ({
   location,
 }: RedirectToNodeLogsType) => {
   const { services } = useKibanaContextForPlugin();
-  const { isLoading, loadSource } = useLogSource({
+  const { isLoading, loadSource, sourceConfiguration } = useLogSource({
     fetch: services.http.fetch,
     sourceId,
     indexPatternsService: services.data.indexPatterns,
   });
+  const fields = sourceConfiguration?.configuration.fields;
 
   useMount(() => {
     loadSource();
@@ -56,9 +57,11 @@ export const RedirectToNodeLogs = ({
         })}
       />
     );
+  } else if (fields == null) {
+    return null;
   }
 
-  const nodeFilter = `${findInventoryFields(nodeType).id}: ${nodeId}`;
+  const nodeFilter = `${findInventoryFields(nodeType, fields).id}: ${nodeId}`;
   const userFilter = getFilterFromLocation(location);
   const filter = userFilter ? `(${nodeFilter}) and (${userFilter})` : nodeFilter;
 

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/layout.tsx
@@ -18,6 +18,7 @@ import { PageContent } from '../../../../components/page';
 import { useWaffleTimeContext } from '../hooks/use_waffle_time';
 import { useWaffleFiltersContext } from '../hooks/use_waffle_filters';
 import { DEFAULT_LEGEND, useWaffleOptionsContext } from '../hooks/use_waffle_options';
+import { useSourceContext } from '../../../../containers/metrics_source';
 import { InfraFormatterType } from '../../../../lib/lib';
 import { euiStyled } from '../../../../../../../../src/plugins/kibana_react/common';
 import { Toolbar } from './toolbars/toolbar';
@@ -40,6 +41,7 @@ interface Props {
 export const Layout = React.memo(
   ({ shouldLoadDefault, currentView, reload, interval, nodes, loading }: Props) => {
     const [showLoading, setShowLoading] = useState(true);
+    const { source } = useSourceContext();
     const {
       metric,
       groupBy,
@@ -63,6 +65,7 @@ export const Layout = React.memo(
       legend: createLegend(legendPalette, legendSteps, legendReverseColors),
       metric,
       sort,
+      fields: source?.configuration?.fields,
       groupBy,
     };
 

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/ml/anomaly_detection/anomaly_detection_flyout.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/ml/anomaly_detection/anomaly_detection_flyout.tsx
@@ -67,11 +67,13 @@ export const AnomalyDetectionFlyout = () => {
           indexPattern={source?.configuration.metricAlias ?? ''}
           sourceId={'default'}
           spaceId={space.id}
+          timestampField={source?.configuration.fields.timestamp ?? ''}
         >
           <MetricK8sModuleProvider
             indexPattern={source?.configuration.metricAlias ?? ''}
             sourceId={'default'}
             spaceId={space.id}
+            timestampField={source?.configuration.fields.timestamp ?? ''}
           >
             <EuiFlyout onClose={closeFlyout} data-test-subj="loadMLFlyout">
               {screenName === 'home' && (

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/logs.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/logs.tsx
@@ -25,13 +25,15 @@ const TabComponent = (props: TabProps) => {
   const endTimestamp = props.currentTime;
   const startTimestamp = endTimestamp - 60 * 60 * 1000; // 60 minutes
   const { nodeType } = useWaffleOptionsContext();
-  const { node } = props;
+  const { options, node } = props;
 
   const throttledTextQuery = useThrottle(textQuery, textQueryThrottleInterval);
 
   const filter = useMemo(() => {
     const query = [
-      `${findInventoryFields(nodeType).id}: "${node.id}"`,
+      ...(options.fields != null
+        ? [`${findInventoryFields(nodeType, options.fields).id}: "${node.id}"`]
+        : []),
       ...(throttledTextQuery !== '' ? [throttledTextQuery] : []),
     ].join(' and ');
 
@@ -39,7 +41,7 @@ const TabComponent = (props: TabProps) => {
       language: 'kuery',
       query,
     };
-  }, [nodeType, node.id, throttledTextQuery]);
+  }, [options.fields, nodeType, node.id, throttledTextQuery]);
 
   const onQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setTextQuery(e.target.value);

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/metrics/metrics.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/metrics/metrics.tsx
@@ -71,12 +71,14 @@ const TabComponent = (props: TabProps) => {
   ]);
   const { sourceId, createDerivedIndexPattern } = useSourceContext();
   const { nodeType, accountId, region, customMetrics } = useWaffleOptionsContext();
-  const { currentTime, node } = props;
+  const { currentTime, options, node } = props;
   const derivedIndexPattern = useMemo(
     () => createDerivedIndexPattern('metrics'),
     [createDerivedIndexPattern]
   );
-  let filter = `${findInventoryFields(nodeType).id}: "${node.id}"`;
+  let filter = options.fields
+    ? `${findInventoryFields(nodeType, options.fields).id}: "${node.id}"`
+    : '';
 
   if (filter) {
     filter = convertKueryToElasticSearchQuery(filter, derivedIndexPattern);

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/node_details/tabs/processes/index.tsx
@@ -17,7 +17,6 @@ import {
   EuiIconTip,
   Query,
 } from '@elastic/eui';
-import { getFieldByType } from '../../../../../../../../common/inventory_models';
 import {
   useProcessList,
   SortBy,
@@ -29,7 +28,7 @@ import { SummaryTable } from './summary_table';
 import { ProcessesTable } from './processes_table';
 import { parseSearchString } from './parse_search_string';
 
-const TabComponent = ({ currentTime, node, nodeType }: TabProps) => {
+const TabComponent = ({ currentTime, node, nodeType, options }: TabProps) => {
   const [searchBarState, setSearchBarState] = useState<Query>(Query.MATCH_ALL);
   const [searchFilter, setSearchFilter] = useState<string>('');
   const [sortBy, setSortBy] = useState<SortBy>({
@@ -37,17 +36,22 @@ const TabComponent = ({ currentTime, node, nodeType }: TabProps) => {
     isAscending: false,
   });
 
+  const timefield = options.fields!.timestamp;
+
   const hostTerm = useMemo(() => {
-    const field = getFieldByType(nodeType) ?? nodeType;
+    const field =
+      options.fields && Reflect.has(options.fields, nodeType)
+        ? Reflect.get(options.fields, nodeType)
+        : nodeType;
     return { [field]: node.name };
-  }, [node, nodeType]);
+  }, [options, node, nodeType]);
 
   const {
     loading,
     error,
     response,
     makeRequest: reload,
-  } = useProcessList(hostTerm, currentTime, sortBy, parseSearchString(searchFilter));
+  } = useProcessList(hostTerm, timefield, currentTime, sortBy, parseSearchString(searchFilter));
 
   const debouncedSearchOnChange = useMemo(
     () => debounce<(queryText: string) => void>((queryText) => setSearchFilter(queryText), 500),
@@ -69,7 +73,7 @@ const TabComponent = ({ currentTime, node, nodeType }: TabProps) => {
 
   return (
     <TabContent>
-      <ProcessListContextProvider hostTerm={hostTerm} to={currentTime}>
+      <ProcessListContextProvider hostTerm={hostTerm} to={currentTime} timefield={timefield}>
         <SummaryTable
           isLoading={loading}
           processSummary={(!error ? response?.summary : null) ?? { total: 0 }}

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node.tsx
@@ -124,7 +124,11 @@ export class Node extends React.PureComponent<Props, State> {
 
         {isAlertFlyoutVisible && (
           <AlertFlyout
-            filter={`${findInventoryFields(nodeType).id}: "${node.id}"`}
+            filter={
+              options.fields
+                ? `${findInventoryFields(nodeType, options.fields).id}: "${node.id}"`
+                : ''
+            }
             options={options}
             nodeType={nodeType}
             setVisible={this.setAlertFlyoutVisible}

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
@@ -64,14 +64,16 @@ export const NodeContextMenu: React.FC<Props & { theme?: EuiTheme }> = withTheme
           return { label: <EuiCode>host.ip</EuiCode>, value: node.ip };
         }
       } else {
-        const { id } = findInventoryFields(nodeType);
-        return {
-          label: <EuiCode>{id}</EuiCode>,
-          value: node.id,
-        };
+        if (options.fields) {
+          const { id } = findInventoryFields(nodeType, options.fields);
+          return {
+            label: <EuiCode>{id}</EuiCode>,
+            value: node.id,
+          };
+        }
       }
       return { label: '', value: '' };
-    }, [nodeType, node.ip, node.id]);
+    }, [nodeType, node.ip, node.id, options.fields]);
 
     const nodeLogsMenuItemLinkProps = useLinkProps(
       getNodeLogsUrl({
@@ -182,7 +184,11 @@ export const NodeContextMenu: React.FC<Props & { theme?: EuiTheme }> = withTheme
 
         {flyoutVisible && (
           <AlertFlyout
-            filter={`${findInventoryFields(nodeType).id}: "${node.id}"`}
+            filter={
+              options.fields
+                ? `${findInventoryFields(nodeType, options.fields).id}: "${node.id}"`
+                : ''
+            }
             options={options}
             nodeType={nodeType}
             setVisible={setFlyoutVisible}

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_process_list.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_process_list.ts
@@ -22,6 +22,7 @@ export interface SortBy {
 
 export function useProcessList(
   hostTerm: Record<string, string>,
+  timefield: string,
   to: number,
   sortBy: SortBy,
   searchFilter: object
@@ -50,6 +51,7 @@ export function useProcessList(
     'POST',
     JSON.stringify({
       hostTerm,
+      timefield,
       indexPattern,
       to,
       sortBy: parsedSortBy,
@@ -73,11 +75,15 @@ export function useProcessList(
   };
 }
 
-function useProcessListParams(props: { hostTerm: Record<string, string>; to: number }) {
-  const { hostTerm, to } = props;
+function useProcessListParams(props: {
+  hostTerm: Record<string, string>;
+  timefield: string;
+  to: number;
+}) {
+  const { hostTerm, timefield, to } = props;
   const { createDerivedIndexPattern } = useSourceContext();
   const indexPattern = createDerivedIndexPattern('metrics').title;
-  return { hostTerm, indexPattern, to };
+  return { hostTerm, indexPattern, timefield, to };
 }
 const ProcessListContext = createContainter(useProcessListParams);
 export const [ProcessListContextProvider, useProcessListContext] = ProcessListContext;

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_process_list_row_chart.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/hooks/use_process_list_row_chart.ts
@@ -25,13 +25,14 @@ export function useProcessListRowChart(command: string) {
       fold(throwErrors(createPlainError), identity)
     );
   };
-  const { hostTerm, indexPattern, to } = useProcessListContext();
+  const { hostTerm, timefield, indexPattern, to } = useProcessListContext();
 
   const { error, loading, response, makeRequest } = useHTTPRequest<ProcessListAPIChartResponse>(
     '/api/metrics/process_list/chart',
     'POST',
     JSON.stringify({
       hostTerm,
+      timefield,
       indexPattern,
       to,
       command,

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/lib/create_uptime_link.test.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/lib/create_uptime_link.test.ts
@@ -10,6 +10,13 @@ import { InfraWaffleMapOptions, InfraFormatterType } from '../../../../lib/lib';
 import { SnapshotMetricType } from '../../../../../common/inventory_models/types';
 
 const options: InfraWaffleMapOptions = {
+  fields: {
+    container: 'container.id',
+    pod: 'kubernetes.pod.uid',
+    host: 'host.name',
+    timestamp: '@timestanp',
+    tiebreaker: '@timestamp',
+  },
   formatter: InfraFormatterType.percent,
   formatTemplate: '{{value}}',
   metric: { type: 'cpu' },

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/lib/create_uptime_link.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/lib/create_uptime_link.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
+import { get } from 'lodash';
 import { InfraWaffleMapNode, InfraWaffleMapOptions } from '../../../../lib/lib';
 import { InventoryItemType } from '../../../../../common/inventory_models/types';
-import { getFieldByType } from '../../../../../common/inventory_models';
 import { LinkDescriptor } from '../../../../hooks/use_link_props';
 
 export const createUptimeLink = (
@@ -24,7 +24,7 @@ export const createUptimeLink = (
       },
     };
   }
-  const field = getFieldByType(nodeType);
+  const field = get(options, ['fields', nodeType], '');
   return {
     app: 'uptime',
     hash: '/',

--- a/x-pack/plugins/infra/public/pages/metrics/metric_detail/lib/get_filtered_metrics.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metric_detail/lib/get_filtered_metrics.ts
@@ -8,7 +8,6 @@
 import { InfraMetadataFeature } from '../../../../../common/http_api/metadata_api';
 import { InventoryMetric } from '../../../../../common/inventory_models/types';
 import { metrics } from '../../../../../common/inventory_models/metrics';
-import { TIMESTAMP_FIELD } from '../../../../../common/constants';
 
 export const getFilteredMetrics = (
   requiredMetrics: InventoryMetric[],
@@ -21,7 +20,7 @@ export const getFilteredMetrics = (
     const metricModelCreator = metrics.tsvb[metric];
     // We just need to get a dummy version of the model so we can filter
     // using the `requires` attribute.
-    const metricModel = metricModelCreator(TIMESTAMP_FIELD, 'test', '>=1m');
+    const metricModel = metricModelCreator('@timestamp', 'test', '>=1m');
     return metricMetadata.some((m) => m && metricModel.requires.includes(m));
   });
 };

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_context_menu.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_context_menu.tsx
@@ -27,7 +27,6 @@ import {
 import { createTSVBLink } from './helpers/create_tsvb_link';
 import { getNodeDetailUrl } from '../../../link_to/redirect_to_node_detail';
 import { InventoryItemType } from '../../../../../common/inventory_models/types';
-import { HOST_FIELD, POD_FIELD, CONTAINER_FIELD } from '../../../../../common/constants';
 import { useLinkProps } from '../../../../hooks/use_link_props';
 
 export interface Props {
@@ -45,13 +44,13 @@ const fieldToNodeType = (
   groupBy: string | string[]
 ): InventoryItemType | undefined => {
   const fields = Array.isArray(groupBy) ? groupBy : [groupBy];
-  if (fields.includes(HOST_FIELD)) {
+  if (fields.includes(source.fields.host)) {
     return 'host';
   }
-  if (fields.includes(POD_FIELD)) {
+  if (fields.includes(source.fields.pod)) {
     return 'pod';
   }
-  if (fields.includes(CONTAINER_FIELD)) {
+  if (fields.includes(source.fields.container)) {
     return 'container';
   }
 };

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.test.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.test.ts
@@ -79,7 +79,7 @@ describe('createTSVBLink()', () => {
       app: 'visualize',
       hash: '/create',
       search: {
-        _a: "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))",
+        _a: "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))",
         _g: '(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))',
         type: 'metrics',
       },
@@ -97,7 +97,7 @@ describe('createTSVBLink()', () => {
       app: 'visualize',
       hash: '/create',
       search: {
-        _a: "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:(language:kuery,query:'system.network.name:lo* and host.name : \"example-01\"'),id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))",
+        _a: "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:(language:kuery,query:'system.network.name:lo* and host.name : \"example-01\"'),id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))",
         _g: '(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))',
         type: 'metrics',
       },
@@ -161,7 +161,7 @@ describe('createTSVBLink()', () => {
       app: 'visualize',
       hash: '/create',
       search: {
-        _a: "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'metric*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'metric*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))",
+        _a: "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'metric*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'metric*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))",
         _g: '(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))',
         type: 'metrics',
       },

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
@@ -8,7 +8,6 @@
 import { encode } from 'rison-node';
 import uuid from 'uuid';
 import { set } from '@elastic/safer-lodash-set';
-import { TIMESTAMP_FIELD } from '../../../../../../common/constants';
 import { MetricsSourceConfigurationProperties } from '../../../../../../common/metrics_sources';
 import { colorTransformer, Color } from '../../../../../../common/color_palette';
 import { MetricsExplorerSeries } from '../../../../../../common/http_api/metrics_explorer';
@@ -170,7 +169,7 @@ export const createTSVBLink = (
         series: options.metrics.map(mapMetricToSeries(chartOptions)),
         show_grid: 1,
         show_legend: 1,
-        time_field: TIMESTAMP_FIELD,
+        time_field: (source && source.fields.timestamp) || '@timestamp',
         type: 'timeseries',
         filter: createFilterFromOptions(options, series),
       },

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
@@ -84,6 +84,7 @@ export function useMetricsExplorerData(
               void 0,
             timerange: {
               ...timerange,
+              field: source.fields.timestamp,
               from: from.valueOf(),
               to: to.valueOf(),
             },

--- a/x-pack/plugins/infra/public/utils/logs_overview_fetches.test.ts
+++ b/x-pack/plugins/infra/public/utils/logs_overview_fetches.test.ts
@@ -150,6 +150,7 @@ describe('Logs UI Observability Homepage Functions', () => {
               type: 'index_pattern',
               indexPatternId: 'test-index-pattern',
             },
+            fields: { timestamp: '@timestamp', tiebreaker: '_doc' },
           },
         },
       } as GetLogSourceConfigurationSuccessResponsePayload);

--- a/x-pack/plugins/infra/server/deprecations.ts
+++ b/x-pack/plugins/infra/server/deprecations.ts
@@ -13,13 +13,6 @@ import {
   DeprecationsDetails,
   GetDeprecationsContext,
 } from 'src/core/server';
-import {
-  TIMESTAMP_FIELD,
-  TIEBREAKER_FIELD,
-  CONTAINER_FIELD,
-  HOST_FIELD,
-  POD_FIELD,
-} from '../common/constants';
 import { InfraSources } from './lib/sources';
 
 const deprecatedFieldMessage = (fieldName: string, defaultValue: string, configNames: string[]) =>
@@ -35,11 +28,11 @@ const deprecatedFieldMessage = (fieldName: string, defaultValue: string, configN
   });
 
 const DEFAULT_VALUES = {
-  timestamp: TIMESTAMP_FIELD,
-  tiebreaker: TIEBREAKER_FIELD,
-  container: CONTAINER_FIELD,
-  host: HOST_FIELD,
-  pod: POD_FIELD,
+  timestamp: '@timestamp',
+  tiebreaker: '_doc',
+  container: 'container.id',
+  host: 'host.name',
+  pod: 'kubernetes.pod.uid',
 };
 
 const FIELD_DEPRECATION_FACTORIES: Record<string, (configNames: string[]) => DeprecationsDetails> =

--- a/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
@@ -24,7 +24,6 @@ import {
 import { SortedSearchHit } from '../framework';
 import { KibanaFramework } from '../framework/kibana_framework_adapter';
 import { ResolvedLogSourceConfiguration } from '../../../../common/log_sources';
-import { TIMESTAMP_FIELD, TIEBREAKER_FIELD } from '../../../../common/constants';
 
 const TIMESTAMP_FORMAT = 'epoch_millis';
 
@@ -65,8 +64,8 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
       : {};
 
     const sort = {
-      [TIMESTAMP_FIELD]: sortDirection,
-      [TIEBREAKER_FIELD]: sortDirection,
+      [resolvedLogSourceConfiguration.timestampField]: sortDirection,
+      [resolvedLogSourceConfiguration.tiebreakerField]: sortDirection,
     };
 
     const esQuery = {
@@ -84,7 +83,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
               ...createFilterClauses(query, highlightQuery),
               {
                 range: {
-                  [TIMESTAMP_FIELD]: {
+                  [resolvedLogSourceConfiguration.timestampField]: {
                     gte: startTimestamp,
                     lte: endTimestamp,
                     format: TIMESTAMP_FORMAT,
@@ -147,7 +146,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
         aggregations: {
           count_by_date: {
             date_range: {
-              field: TIMESTAMP_FIELD,
+              field: resolvedLogSourceConfiguration.timestampField,
               format: TIMESTAMP_FORMAT,
               ranges: bucketIntervalStarts.map((bucketIntervalStart) => ({
                 from: bucketIntervalStart.getTime(),
@@ -158,7 +157,10 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
               top_hits_by_key: {
                 top_hits: {
                   size: 1,
-                  sort: [{ [TIMESTAMP_FIELD]: 'asc' }, { [TIEBREAKER_FIELD]: 'asc' }],
+                  sort: [
+                    { [resolvedLogSourceConfiguration.timestampField]: 'asc' },
+                    { [resolvedLogSourceConfiguration.tiebreakerField]: 'asc' },
+                  ],
                   _source: false,
                 },
               },
@@ -171,7 +173,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
               ...createQueryFilterClauses(filterQuery),
               {
                 range: {
-                  [TIMESTAMP_FIELD]: {
+                  [resolvedLogSourceConfiguration.timestampField]: {
                     gte: startTimestamp,
                     lte: endTimestamp,
                     format: TIMESTAMP_FORMAT,

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/kibana_metrics_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/kibana_metrics_adapter.ts
@@ -8,7 +8,6 @@
 import { i18n } from '@kbn/i18n';
 import { flatten, get } from 'lodash';
 import { KibanaRequest } from 'src/core/server';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 import { NodeDetailsMetricData } from '../../../../common/http_api/node_details_api';
 import { KibanaFramework } from '../framework/kibana_framework_adapter';
 import { InfraMetricsAdapter, InfraMetricsRequestOptions } from './adapter_types';
@@ -37,7 +36,7 @@ export class KibanaMetricsAdapter implements InfraMetricsAdapter {
     rawRequest: KibanaRequest
   ): Promise<NodeDetailsMetricData[]> {
     const indexPattern = `${options.sourceConfiguration.metricAlias}`;
-    const fields = findInventoryFields(options.nodeType);
+    const fields = findInventoryFields(options.nodeType, options.sourceConfiguration.fields);
     const nodeField = fields.id;
 
     const search = <Aggregation>(searchOptions: object) =>
@@ -123,7 +122,11 @@ export class KibanaMetricsAdapter implements InfraMetricsAdapter {
       max: options.timerange.to,
     };
 
-    const model = createTSVBModel(TIMESTAMP_FIELD, indexPattern, options.timerange.interval);
+    const model = createTSVBModel(
+      options.sourceConfiguration.fields.timestamp,
+      indexPattern,
+      options.timerange.interval
+    );
 
     const client = <Hit = {}, Aggregation = undefined>(
       opts: CallWithRequestParams
@@ -134,6 +137,7 @@ export class KibanaMetricsAdapter implements InfraMetricsAdapter {
       client,
       {
         indexPattern: `${options.sourceConfiguration.metricAlias}`,
+        timestampField: options.sourceConfiguration.fields.timestamp,
         timerange: options.timerange,
       },
       model.requires

--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/mocks/index.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/mocks/index.ts
@@ -17,6 +17,7 @@ export const libsMock = {
             type: 'index_pattern',
             indexPatternId: 'some-id',
           },
+          fields: { timestamp: '@timestamp' },
         },
       });
     },

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/evaluate_alert.ts
@@ -74,6 +74,7 @@ export const evaluateAlert = <Params extends EvaluatedAlertParams = EvaluatedAle
         esClient,
         criterion,
         config.metricAlias,
+        config.fields.timestamp,
         groupBy,
         filterQuery,
         timeframe,
@@ -146,6 +147,7 @@ const getMetric: (
   esClient: ElasticsearchClient,
   params: MetricExpressionParams,
   index: string,
+  timefield: string,
   groupBy: string | undefined | string[],
   filterQuery: string | undefined,
   timeframe?: { start?: number; end: number },
@@ -154,6 +156,7 @@ const getMetric: (
   esClient,
   params,
   index,
+  timefield,
   groupBy,
   filterQuery,
   timeframe,
@@ -169,6 +172,7 @@ const getMetric: (
 
   const searchBody = getElasticsearchMetricQuery(
     params,
+    timefield,
     calculatedTimerange,
     hasGroupBy ? groupBy : undefined,
     filterQuery

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.test.ts
@@ -17,6 +17,7 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
     timeSize: 1,
   } as MetricExpressionParams;
 
+  const timefield = '@timestamp';
   const groupBy = 'host.doggoname';
   const timeframe = {
     start: moment().subtract(5, 'minutes').valueOf(),
@@ -24,7 +25,7 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
   };
 
   describe('when passed no filterQuery', () => {
-    const searchBody = getElasticsearchMetricQuery(expressionParams, timeframe, groupBy);
+    const searchBody = getElasticsearchMetricQuery(expressionParams, timefield, timeframe, groupBy);
     test('includes a range filter', () => {
       expect(
         searchBody.query.bool.filter.find((filter) => filter.hasOwnProperty('range'))
@@ -46,6 +47,7 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
 
     const searchBody = getElasticsearchMetricQuery(
       expressionParams,
+      timefield,
       timeframe,
       groupBy,
       filterQuery

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/lib/metric_query.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TIMESTAMP_FIELD } from '../../../../../common/constants';
 import { networkTraffic } from '../../../../../common/inventory_models/shared/metrics/snapshot/network_traffic';
 import { MetricExpressionParams, Aggregators } from '../types';
 import { createPercentileAggregation } from './create_percentile_aggregation';
@@ -22,6 +21,7 @@ const getParsedFilterQuery: (filterQuery: string | undefined) => Record<string, 
 
 export const getElasticsearchMetricQuery = (
   { metric, aggType, timeUnit, timeSize }: MetricExpressionParams,
+  timefield: string,
   timeframe: { start: number; end: number },
   groupBy?: string | string[],
   filterQuery?: string
@@ -56,9 +56,9 @@ export const getElasticsearchMetricQuery = (
       ? {
           aggregatedIntervals: {
             date_histogram: {
-              field: TIMESTAMP_FIELD,
+              field: timefield,
               fixed_interval: interval,
-              offset: calculateDateHistogramOffset({ from, to, interval }),
+              offset: calculateDateHistogramOffset({ from, to, interval, field: timefield }),
               extended_bounds: {
                 min: from,
                 max: to,

--- a/x-pack/plugins/infra/server/lib/host_details/process_list.ts
+++ b/x-pack/plugins/infra/server/lib/host_details/process_list.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TIMESTAMP_FIELD } from '../../../common/constants';
 import { ProcessListAPIRequest, ProcessListAPIQueryAggregation } from '../../../common/http_api';
 import { ESSearchClient } from '../metrics/types';
 import { CMDLINE_FIELD } from './common';
@@ -14,7 +13,7 @@ const TOP_N = 10;
 
 export const getProcessList = async (
   search: ESSearchClient,
-  { hostTerm, indexPattern, to, sortBy, searchFilter }: ProcessListAPIRequest
+  { hostTerm, timefield, indexPattern, to, sortBy, searchFilter }: ProcessListAPIRequest
 ) => {
   const body = {
     size: 0,
@@ -23,7 +22,7 @@ export const getProcessList = async (
         filter: [
           {
             range: {
-              [TIMESTAMP_FIELD]: {
+              [timefield]: {
                 gte: to - 60 * 1000, // 1 minute
                 lte: to,
               },
@@ -48,7 +47,7 @@ export const getProcessList = async (
               size: 1,
               sort: [
                 {
-                  [TIMESTAMP_FIELD]: {
+                  [timefield]: {
                     order: 'desc',
                   },
                 },
@@ -94,7 +93,7 @@ export const getProcessList = async (
                   size: 1,
                   sort: [
                     {
-                      [TIMESTAMP_FIELD]: {
+                      [timefield]: {
                         order: 'desc',
                       },
                     },

--- a/x-pack/plugins/infra/server/lib/host_details/process_list_chart.ts
+++ b/x-pack/plugins/infra/server/lib/host_details/process_list_chart.ts
@@ -6,7 +6,6 @@
  */
 
 import { first } from 'lodash';
-import { TIMESTAMP_FIELD } from '../../../common/constants';
 import {
   ProcessListAPIChartRequest,
   ProcessListAPIChartQueryAggregation,
@@ -18,7 +17,7 @@ import { CMDLINE_FIELD } from './common';
 
 export const getProcessListChart = async (
   search: ESSearchClient,
-  { hostTerm, indexPattern, to, command }: ProcessListAPIChartRequest
+  { hostTerm, timefield, indexPattern, to, command }: ProcessListAPIChartRequest
 ) => {
   const body = {
     size: 0,
@@ -27,7 +26,7 @@ export const getProcessListChart = async (
         filter: [
           {
             range: {
-              [TIMESTAMP_FIELD]: {
+              [timefield]: {
                 gte: to - 60 * 1000, // 1 minute
                 lte: to,
               },
@@ -61,7 +60,7 @@ export const getProcessListChart = async (
             aggs: {
               timeseries: {
                 date_histogram: {
-                  field: TIMESTAMP_FIELD,
+                  field: timefield,
                   fixed_interval: '1m',
                   extended_bounds: {
                     min: to - 60 * 15 * 1000, // 15 minutes,

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_hosts_anomalies.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_hosts_anomalies.ts
@@ -6,7 +6,6 @@
  */
 
 import * as rt from 'io-ts';
-import { TIEBREAKER_FIELD } from '../../../../common/constants';
 import { ANOMALY_THRESHOLD } from '../../../../common/infra_ml';
 import { commonSearchSuccessResponseFieldsRT } from '../../../utils/elasticsearch_runtime_types';
 import {
@@ -20,6 +19,9 @@ import {
 } from './common';
 import { InfluencerFilter } from '../common';
 import { Sort, Pagination } from '../../../../common/http_api/infra_ml';
+
+// TODO: Reassess validity of this against ML docs
+const TIEBREAKER_FIELD = '_doc';
 
 const sortToMlFieldMap = {
   dataset: 'partition_field_value',

--- a/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.ts
+++ b/x-pack/plugins/infra/server/lib/infra_ml/queries/metrics_k8s_anomalies.ts
@@ -6,7 +6,6 @@
  */
 
 import * as rt from 'io-ts';
-import { TIEBREAKER_FIELD } from '../../../../common/constants';
 import { ANOMALY_THRESHOLD } from '../../../../common/infra_ml';
 import { commonSearchSuccessResponseFieldsRT } from '../../../utils/elasticsearch_runtime_types';
 import {
@@ -20,6 +19,9 @@ import {
 } from './common';
 import { InfluencerFilter } from '../common';
 import { Sort, Pagination } from '../../../../common/http_api/infra_ml';
+
+// TODO: Reassess validity of this against ML docs
+const TIEBREAKER_FIELD = '_doc';
 
 const sortToMlFieldMap = {
   dataset: 'partition_field_value',

--- a/x-pack/plugins/infra/server/lib/metrics/index.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/index.ts
@@ -7,7 +7,6 @@
 
 import { set } from '@elastic/safer-lodash-set';
 import { ThrowReporter } from 'io-ts/lib/ThrowReporter';
-import { TIMESTAMP_FIELD } from '../../../common/constants';
 import { MetricsAPIRequest, MetricsAPIResponse, afterKeyObjectRT } from '../../../common/http_api';
 import {
   ESSearchClient,
@@ -37,7 +36,7 @@ export const query = async (
   const filter: Array<Record<string, any>> = [
     {
       range: {
-        [TIMESTAMP_FIELD]: {
+        [options.timerange.field]: {
           gte: options.timerange.from,
           lte: options.timerange.to,
           format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/lib/metrics/lib/calculate_interval.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/calculate_interval.ts
@@ -21,6 +21,7 @@ export const calculatedInterval = async (search: ESSearchClient, options: Metric
         search,
         {
           indexPattern: options.indexPattern,
+          timestampField: options.timerange.field,
           timerange: { from: options.timerange.from, to: options.timerange.to },
         },
         options.modules

--- a/x-pack/plugins/infra/server/lib/metrics/lib/convert_histogram_buckets_to_timeseries.test.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/convert_histogram_buckets_to_timeseries.test.ts
@@ -13,6 +13,7 @@ const keys = ['example-0'];
 
 const options: MetricsAPIRequest = {
   timerange: {
+    field: '@timestamp',
     from: moment('2020-01-01T00:00:00Z').valueOf(),
     to: moment('2020-01-01T00:00:00Z').add(5, 'minute').valueOf(),
     interval: '1m',

--- a/x-pack/plugins/infra/server/lib/metrics/lib/create_aggregations.test.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/create_aggregations.test.ts
@@ -11,6 +11,7 @@ import { MetricsAPIRequest } from '../../../../common/http_api';
 
 const options: MetricsAPIRequest = {
   timerange: {
+    field: '@timestamp',
     from: moment('2020-01-01T00:00:00Z').valueOf(),
     to: moment('2020-01-01T01:00:00Z').valueOf(),
     interval: '>=1m',

--- a/x-pack/plugins/infra/server/lib/metrics/lib/create_aggregations.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/create_aggregations.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 import { MetricsAPIRequest } from '../../../../common/http_api/metrics_api';
 import { calculateDateHistogramOffset } from './calculate_date_histogram_offset';
 import { createMetricsAggregations } from './create_metrics_aggregations';
@@ -16,7 +15,7 @@ export const createAggregations = (options: MetricsAPIRequest) => {
   const histogramAggregation = {
     histogram: {
       date_histogram: {
-        field: TIMESTAMP_FIELD,
+        field: options.timerange.field,
         fixed_interval: intervalString,
         offset: options.alignDataToEnd ? calculateDateHistogramOffset(options.timerange) : '0s',
         extended_bounds: {

--- a/x-pack/plugins/infra/server/lib/metrics/lib/create_metrics_aggregations.test.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/lib/create_metrics_aggregations.test.ts
@@ -11,6 +11,7 @@ import { createMetricsAggregations } from './create_metrics_aggregations';
 
 const options: MetricsAPIRequest = {
   timerange: {
+    field: '@timestamp',
     from: moment('2020-01-01T00:00:00Z').valueOf(),
     to: moment('2020-01-01T01:00:00Z').valueOf(),
     interval: '>=1m',

--- a/x-pack/plugins/infra/server/lib/sources/defaults.ts
+++ b/x-pack/plugins/infra/server/lib/sources/defaults.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { METRICS_INDEX_PATTERN, LOGS_INDEX_PATTERN } from '../../../common/constants';
+import {
+  METRICS_INDEX_PATTERN,
+  LOGS_INDEX_PATTERN,
+  TIMESTAMP_FIELD,
+} from '../../../common/constants';
 import { InfraSourceConfiguration } from '../../../common/source_configuration/source_configuration';
 
 export const defaultSourceConfiguration: InfraSourceConfiguration = {
@@ -17,7 +21,12 @@ export const defaultSourceConfiguration: InfraSourceConfiguration = {
     indexName: LOGS_INDEX_PATTERN,
   },
   fields: {
+    container: 'container.id',
+    host: 'host.name',
     message: ['message', '@message'],
+    pod: 'kubernetes.pod.uid',
+    tiebreaker: '_doc',
+    timestamp: TIMESTAMP_FIELD,
   },
   inventoryDefaultView: '0',
   metricsExplorerDefaultView: '0',

--- a/x-pack/plugins/infra/server/lib/sources/saved_object_references.test.ts
+++ b/x-pack/plugins/infra/server/lib/sources/saved_object_references.test.ts
@@ -101,7 +101,12 @@ const sourceConfigurationWithIndexPatternReference: InfraSourceConfiguration = {
   name: 'NAME',
   description: 'DESCRIPTION',
   fields: {
+    container: 'CONTAINER_FIELD',
+    host: 'HOST_FIELD',
     message: ['MESSAGE_FIELD'],
+    pod: 'POD_FIELD',
+    tiebreaker: 'TIEBREAKER_FIELD',
+    timestamp: 'TIMESTAMP_FIELD',
   },
   logColumns: [],
   logIndices: {

--- a/x-pack/plugins/infra/server/lib/sources/sources.test.ts
+++ b/x-pack/plugins/infra/server/lib/sources/sources.test.ts
@@ -24,6 +24,13 @@ describe('the InfraSources lib', () => {
         attributes: {
           metricAlias: 'METRIC_ALIAS',
           logIndices: { type: 'index_pattern', indexPatternId: 'log_index_pattern_0' },
+          fields: {
+            container: 'CONTAINER',
+            host: 'HOST',
+            pod: 'POD',
+            tiebreaker: 'TIEBREAKER',
+            timestamp: 'TIMESTAMP',
+          },
         },
         references: [
           {
@@ -43,6 +50,13 @@ describe('the InfraSources lib', () => {
         configuration: {
           metricAlias: 'METRIC_ALIAS',
           logIndices: { type: 'index_pattern', indexPatternId: 'LOG_INDEX_PATTERN' },
+          fields: {
+            container: 'CONTAINER',
+            host: 'HOST',
+            pod: 'POD',
+            tiebreaker: 'TIEBREAKER',
+            timestamp: 'TIMESTAMP',
+          },
         },
       });
     });
@@ -53,6 +67,12 @@ describe('the InfraSources lib', () => {
           default: {
             metricAlias: 'METRIC_ALIAS',
             logIndices: { type: 'index_pattern', indexPatternId: 'LOG_ALIAS' },
+            fields: {
+              host: 'HOST',
+              pod: 'POD',
+              tiebreaker: 'TIEBREAKER',
+              timestamp: 'TIMESTAMP',
+            },
           },
         }),
       });
@@ -62,7 +82,11 @@ describe('the InfraSources lib', () => {
         version: 'foo',
         type: infraSourceConfigurationSavedObjectName,
         updated_at: '2000-01-01T00:00:00.000Z',
-        attributes: {},
+        attributes: {
+          fields: {
+            container: 'CONTAINER',
+          },
+        },
         references: [],
       });
 
@@ -75,6 +99,13 @@ describe('the InfraSources lib', () => {
         configuration: {
           metricAlias: 'METRIC_ALIAS',
           logIndices: { type: 'index_pattern', indexPatternId: 'LOG_ALIAS' },
+          fields: {
+            container: 'CONTAINER',
+            host: 'HOST',
+            pod: 'POD',
+            tiebreaker: 'TIEBREAKER',
+            timestamp: 'TIMESTAMP',
+          },
         },
       });
     });
@@ -102,6 +133,13 @@ describe('the InfraSources lib', () => {
         configuration: {
           metricAlias: expect.any(String),
           logIndices: expect.any(Object),
+          fields: {
+            container: expect.any(String),
+            host: expect.any(String),
+            pod: expect.any(String),
+            tiebreaker: expect.any(String),
+            timestamp: expect.any(String),
+          },
         },
       });
     });

--- a/x-pack/plugins/infra/server/plugin.ts
+++ b/x-pack/plugins/infra/server/plugin.ts
@@ -53,7 +53,12 @@ export const config: PluginConfigDescriptor = {
           schema.object({
             fields: schema.maybe(
               schema.object({
+                timestamp: schema.maybe(schema.string()),
                 message: schema.maybe(schema.arrayOf(schema.string())),
+                tiebreaker: schema.maybe(schema.string()),
+                host: schema.maybe(schema.string()),
+                container: schema.maybe(schema.string()),
+                pod: schema.maybe(schema.string()),
               })
             ),
           })

--- a/x-pack/plugins/infra/server/routes/inventory_metadata/lib/get_cloud_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/inventory_metadata/lib/get_cloud_metadata.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 import { InventoryCloudAccount } from '../../../../common/http_api/inventory_meta_api';
 import {
   InfraMetadataAggregationResponse,
@@ -50,7 +49,7 @@ export const getCloudMetadata = async (
           must: [
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [sourceConfiguration.fields.timestamp]: {
                   gte: currentTime - 86400000, // 24 hours ago
                   lte: currentTime,
                   format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_cloud_metric_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_cloud_metric_metadata.ts
@@ -13,7 +13,6 @@ import {
 import { KibanaFramework } from '../../../lib/adapters/framework/kibana_framework_adapter';
 import { InfraSourceConfiguration } from '../../../lib/sources';
 import { CLOUD_METRICS_MODULES } from '../../../lib/constants';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
 export interface InfraCloudMetricsAdapterResponse {
   buckets: InfraMetadataAggregationBucket[];
@@ -37,7 +36,7 @@ export const getCloudMetricsMetadata = async (
             { match: { 'cloud.instance.id': instanceId } },
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [sourceConfiguration.fields.timestamp]: {
                   gte: timeRange.from,
                   lte: timeRange.to,
                   format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_metric_metadata.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_metric_metadata.ts
@@ -15,7 +15,6 @@ import { KibanaFramework } from '../../../lib/adapters/framework/kibana_framewor
 import { InfraSourceConfiguration } from '../../../lib/sources';
 import { findInventoryFields } from '../../../../common/inventory_models';
 import { InventoryItemType } from '../../../../common/inventory_models/types';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
 export interface InfraMetricsAdapterResponse {
   id: string;
@@ -31,7 +30,7 @@ export const getMetricMetadata = async (
   nodeType: InventoryItemType,
   timeRange: { from: number; to: number }
 ): Promise<InfraMetricsAdapterResponse> => {
-  const fields = findInventoryFields(nodeType);
+  const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
   const metricQuery = {
     allow_no_indices: true,
     ignore_unavailable: true,
@@ -46,7 +45,7 @@ export const getMetricMetadata = async (
             },
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [sourceConfiguration.fields.timestamp]: {
                   gte: timeRange.from,
                   lte: timeRange.to,
                   format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
@@ -15,7 +15,6 @@ import { getPodNodeName } from './get_pod_node_name';
 import { CLOUD_METRICS_MODULES } from '../../../lib/constants';
 import { findInventoryFields } from '../../../../common/inventory_models';
 import { InventoryItemType } from '../../../../common/inventory_models/types';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
 export const getNodeInfo = async (
   framework: KibanaFramework,
@@ -51,7 +50,8 @@ export const getNodeInfo = async (
     }
     return {};
   }
-  const fields = findInventoryFields(nodeType);
+  const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
+  const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
     allow_no_indices: true,
     ignore_unavailable: true,
@@ -60,14 +60,14 @@ export const getNodeInfo = async (
     body: {
       size: 1,
       _source: ['host.*', 'cloud.*', 'agent.*'],
-      sort: [{ [TIMESTAMP_FIELD]: 'desc' }],
+      sort: [{ [timestampField]: 'desc' }],
       query: {
         bool: {
           filter: [
             { match: { [fields.id]: nodeId } },
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [timestampField]: {
                   gte: timeRange.from,
                   lte: timeRange.to,
                   format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_pod_node_name.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_pod_node_name.ts
@@ -10,7 +10,6 @@ import { KibanaFramework } from '../../../lib/adapters/framework/kibana_framewor
 import { InfraSourceConfiguration } from '../../../lib/sources';
 import { findInventoryFields } from '../../../../common/inventory_models';
 import type { InfraPluginRequestHandlerContext } from '../../../types';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
 export const getPodNodeName = async (
   framework: KibanaFramework,
@@ -20,7 +19,8 @@ export const getPodNodeName = async (
   nodeType: 'host' | 'pod' | 'container',
   timeRange: { from: number; to: number }
 ): Promise<string | undefined> => {
-  const fields = findInventoryFields(nodeType);
+  const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
+  const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
     allow_no_indices: true,
     ignore_unavailable: true,
@@ -29,7 +29,7 @@ export const getPodNodeName = async (
     body: {
       size: 1,
       _source: ['kubernetes.node.name'],
-      sort: [{ [TIMESTAMP_FIELD]: 'desc' }],
+      sort: [{ [timestampField]: 'desc' }],
       query: {
         bool: {
           filter: [
@@ -37,7 +37,7 @@ export const getPodNodeName = async (
             { exists: { field: `kubernetes.node.name` } },
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [timestampField]: {
                   gte: timeRange.from,
                   lte: timeRange.to,
                   format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_request_to_metrics_api_options.test.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_request_to_metrics_api_options.test.ts
@@ -10,6 +10,7 @@ import { convertRequestToMetricsAPIOptions } from './convert_request_to_metrics_
 
 const BASE_REQUEST: MetricsExplorerRequestBody = {
   timerange: {
+    field: '@timestamp',
     from: new Date('2020-01-01T00:00:00Z').getTime(),
     to: new Date('2020-01-01T01:00:00Z').getTime(),
     interval: '1m',
@@ -21,6 +22,7 @@ const BASE_REQUEST: MetricsExplorerRequestBody = {
 
 const BASE_METRICS_UI_OPTIONS: MetricsAPIRequest = {
   timerange: {
+    field: '@timestamp',
     from: new Date('2020-01-01T00:00:00Z').getTime(),
     to: new Date('2020-01-01T01:00:00Z').getTime(),
     interval: '1m',

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/find_interval_for_metrics.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/find_interval_for_metrics.ts
@@ -44,6 +44,7 @@ export const findIntervalForMetrics = async (
     client,
     {
       indexPattern: options.indexPattern,
+      timestampField: options.timerange.field,
       timerange: options.timerange,
     },
     modules.filter(Boolean) as string[]

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 import { ESSearchClient } from '../../../lib/metrics/types';
 
 interface EventDatasetHit {
@@ -20,7 +19,7 @@ export const getDatasetForField = async (
   client: ESSearchClient,
   field: string,
   indexPattern: string,
-  timerange: { to: number; from: number }
+  timerange: { field: string; to: number; from: number }
 ) => {
   const params = {
     allow_no_indices: true,
@@ -34,7 +33,7 @@ export const getDatasetForField = async (
             { exists: { field } },
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [timerange.field]: {
                   gte: timerange.from,
                   lte: timerange.to,
                   format: 'epoch_millis',
@@ -46,7 +45,7 @@ export const getDatasetForField = async (
       },
       size: 1,
       _source: ['event.dataset'],
-      sort: [{ [TIMESTAMP_FIELD]: { order: 'desc' } }],
+      sort: [{ [timerange.field]: { order: 'desc' } }],
     },
   };
 

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/query_total_groupings.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/query_total_groupings.ts
@@ -6,7 +6,6 @@
  */
 
 import { isArray } from 'lodash';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 import { MetricsAPIRequest } from '../../../../common/http_api';
 import { ESSearchClient } from '../../../lib/metrics/types';
 
@@ -27,7 +26,7 @@ export const queryTotalGroupings = async (
   let filters: Array<Record<string, any>> = [
     {
       range: {
-        [TIMESTAMP_FIELD]: {
+        [options.timerange.field]: {
           gte: options.timerange.from,
           lte: options.timerange.to,
           format: 'epoch_millis',

--- a/x-pack/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
+++ b/x-pack/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
@@ -7,7 +7,6 @@
 
 import { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
 import { TopNodesRequest } from '../../../../common/http_api/overview_api';
-import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
 export const createTopNodesQuery = (
   options: TopNodesRequest,
@@ -23,7 +22,7 @@ export const createTopNodesQuery = (
         filter: [
           {
             range: {
-              [TIMESTAMP_FIELD]: {
+              [source.configuration.fields.timestamp]: {
                 gte: options.timerange.from,
                 lte: options.timerange.to,
               },
@@ -50,7 +49,7 @@ export const createTopNodesQuery = (
                 { field: 'host.name' },
                 { field: 'cloud.provider' },
               ],
-              sort: { [TIMESTAMP_FIELD]: 'desc' },
+              sort: { '@timestamp': 'desc' },
               size: 1,
             },
           },

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/apply_metadata_to_last_path.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/apply_metadata_to_last_path.ts
@@ -42,7 +42,10 @@ export const applyMetadataToLastPath = (
     if (firstMetaDoc && lastPath) {
       // We will need the inventory fields so we can use the field paths to get
       // the values from the metadata document
-      const inventoryFields = findInventoryFields(snapshotRequest.nodeType);
+      const inventoryFields = findInventoryFields(
+        snapshotRequest.nodeType,
+        source.configuration.fields
+      );
       // Set the label as the name and fallback to the id OR path.value
       lastPath.label = (firstMetaDoc[inventoryFields.name] ?? lastPath.value) as string;
       // If the inventory fields contain an ip address, we need to try and set that

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
@@ -25,6 +25,7 @@ const createInterval = async (client: ESSearchClient, options: InfraSnapshotRequ
       client,
       {
         indexPattern: options.sourceConfiguration.metricAlias,
+        timestampField: options.sourceConfiguration.fields.timestamp,
         timerange: { from: timerange.from, to: timerange.to },
       },
       modules,
@@ -80,6 +81,7 @@ const aggregationsToModules = async (
       async (field) =>
         await getDatasetForField(client, field as string, options.sourceConfiguration.metricAlias, {
           ...options.timerange,
+          field: options.sourceConfiguration.fields.timestamp,
         })
     )
   );

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/get_nodes.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/get_nodes.ts
@@ -16,6 +16,7 @@ import { LogQueryFields } from '../../../services/log_queries/get_log_query_fiel
 
 export interface SourceOverrides {
   indexPattern: string;
+  timestamp: string;
 }
 
 const transformAndQueryData = async ({

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/transform_request_to_metrics_api_request.test.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/transform_request_to_metrics_api_request.test.ts
@@ -47,7 +47,12 @@ const source: InfraSource = {
       indexPatternId: 'kibana_index_pattern',
     },
     fields: {
+      container: 'container.id',
+      host: 'host.name',
       message: ['message', '@message'],
+      pod: 'kubernetes.pod.uid',
+      tiebreaker: '_doc',
+      timestamp: '@timestamp',
     },
     inventoryDefaultView: '0',
     metricsExplorerDefaultView: '0',
@@ -75,7 +80,7 @@ const snapshotRequest: SnapshotRequest = {
 
 const metricsApiRequest = {
   indexPattern: 'metrics-*,metricbeat-*',
-  timerange: { from: 1605705900000, to: 1605706200000, interval: '60s' },
+  timerange: { field: '@timestamp', from: 1605705900000, to: 1605706200000, interval: '60s' },
   metrics: [
     {
       id: 'cpu',

--- a/x-pack/plugins/infra/server/services/log_entries/log_entries_search_strategy.test.ts
+++ b/x-pack/plugins/infra/server/services/log_entries/log_entries_search_strategy.test.ts
@@ -289,7 +289,12 @@ const createSourceConfigurationMock = (): InfraSource => ({
       },
     ],
     fields: {
+      pod: 'POD_FIELD',
+      host: 'HOST_FIELD',
+      container: 'CONTAINER_FIELD',
       message: ['MESSAGE_FIELD'],
+      timestamp: 'TIMESTAMP_FIELD',
+      tiebreaker: 'TIEBREAKER_FIELD',
     },
     anomalyThreshold: 20,
   },

--- a/x-pack/plugins/infra/server/services/log_entries/log_entry_search_strategy.test.ts
+++ b/x-pack/plugins/infra/server/services/log_entries/log_entry_search_strategy.test.ts
@@ -244,7 +244,12 @@ const createSourceConfigurationMock = (): InfraSource => ({
     metricsExplorerDefaultView: 'DEFAULT_VIEW',
     logColumns: [],
     fields: {
+      pod: 'POD_FIELD',
+      host: 'HOST_FIELD',
+      container: 'CONTAINER_FIELD',
       message: ['MESSAGE_FIELD'],
+      timestamp: 'TIMESTAMP_FIELD',
+      tiebreaker: 'TIEBREAKER_FIELD',
     },
     anomalyThreshold: 20,
   },

--- a/x-pack/plugins/infra/server/services/log_queries/get_log_query_fields.ts
+++ b/x-pack/plugins/infra/server/services/log_queries/get_log_query_fields.ts
@@ -12,6 +12,7 @@ import { KibanaFramework } from '../../lib/adapters/framework/kibana_framework_a
 
 export interface LogQueryFields {
   indexPattern: string;
+  timestamp: string;
 }
 
 export const createGetLogQueryFields = (sources: InfraSources, framework: KibanaFramework) => {
@@ -28,6 +29,7 @@ export const createGetLogQueryFields = (sources: InfraSources, framework: Kibana
 
     return {
       indexPattern: resolvedLogSourceConfiguration.indices,
+      timestamp: resolvedLogSourceConfiguration.timestampField,
     };
   };
 };

--- a/x-pack/plugins/infra/server/utils/calculate_metric_interval.ts
+++ b/x-pack/plugins/infra/server/utils/calculate_metric_interval.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { TIMESTAMP_FIELD } from '../../common/constants';
 import { findInventoryModel } from '../../common/inventory_models';
 // import { KibanaFramework } from '../lib/adapters/framework/kibana_framework_adapter';
 import { InventoryItemType } from '../../common/inventory_models/types';
@@ -13,6 +12,7 @@ import { ESSearchClient } from '../lib/metrics/types';
 
 interface Options {
   indexPattern: string;
+  timestampField: string;
   timerange: {
     from: number;
     to: number;
@@ -44,7 +44,7 @@ export const calculateMetricInterval = async (
           filter: [
             {
               range: {
-                [TIMESTAMP_FIELD]: {
+                [options.timestampField]: {
                   gte: from,
                   lte: options.timerange.to,
                   format: 'epoch_millis',

--- a/x-pack/test/api_integration/apis/metrics_ui/http_source.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/http_source.ts
@@ -42,6 +42,13 @@ export default function ({ getService }: FtrProviderContext) {
           return resp.then((data) => {
             expect(data).to.have.property('source');
             expect(data?.source.configuration.metricAlias).to.equal('metrics-*,metricbeat-*');
+            expect(data?.source.configuration.fields).to.eql({
+              container: 'container.id',
+              host: 'host.name',
+              pod: 'kubernetes.pod.uid',
+              tiebreaker: '_doc',
+              timestamp: '@timestamp',
+            });
             expect(data?.source).to.have.property('status');
             expect(data?.source.status?.metricIndicesExist).to.equal(true);
           });

--- a/x-pack/test/api_integration/apis/metrics_ui/log_sources.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/log_sources.ts
@@ -40,6 +40,8 @@ export default function ({ getService }: FtrProviderContext) {
           type: 'index_name',
           indexName: 'logs-*,filebeat-*,kibana_sample_data_logs*',
         });
+        expect(configuration.fields.timestamp).to.be('@timestamp');
+        expect(configuration.fields.tiebreaker).to.be('_doc');
         expect(configuration.logColumns[0]).to.have.key('timestampColumn');
         expect(configuration.logColumns[1]).to.have.key('fieldColumn');
         expect(configuration.logColumns[2]).to.have.key('messageColumn');
@@ -55,6 +57,10 @@ export default function ({ getService }: FtrProviderContext) {
             logIndices: {
               type: 'index_pattern',
               indexPatternId: 'kip-id',
+            },
+            fields: {
+              tiebreaker: 'TIEBREAKER',
+              timestamp: 'TIMESTAMP',
             },
             logColumns: [
               {
@@ -77,6 +83,8 @@ export default function ({ getService }: FtrProviderContext) {
           type: 'index_pattern',
           indexPatternId: 'kip-id',
         });
+        expect(configuration.fields.timestamp).to.be('TIMESTAMP');
+        expect(configuration.fields.tiebreaker).to.be('TIEBREAKER');
         expect(configuration.logColumns).to.have.length(1);
         expect(configuration.logColumns[0]).to.have.key('messageColumn');
 
@@ -103,6 +111,8 @@ export default function ({ getService }: FtrProviderContext) {
           type: 'index_name',
           indexName: 'logs-*,filebeat-*,kibana_sample_data_logs*',
         });
+        expect(configuration.fields.timestamp).to.be('@timestamp');
+        expect(configuration.fields.tiebreaker).to.be('_doc');
         expect(configuration.logColumns).to.have.length(3);
         expect(configuration.logColumns[0]).to.have.key('timestampColumn');
         expect(configuration.logColumns[1]).to.have.key('fieldColumn');
@@ -132,6 +142,10 @@ export default function ({ getService }: FtrProviderContext) {
               type: 'index_pattern',
               indexPatternId: 'kip-id',
             },
+            fields: {
+              tiebreaker: 'TIEBREAKER',
+              timestamp: 'TIMESTAMP',
+            },
             logColumns: [
               {
                 messageColumn: {
@@ -152,6 +166,8 @@ export default function ({ getService }: FtrProviderContext) {
           type: 'index_pattern',
           indexPatternId: 'kip-id',
         });
+        expect(configuration.fields.timestamp).to.be('TIMESTAMP');
+        expect(configuration.fields.tiebreaker).to.be('TIEBREAKER');
         expect(configuration.logColumns).to.have.length(1);
         expect(configuration.logColumns[0]).to.have.key('messageColumn');
       });
@@ -173,6 +189,8 @@ export default function ({ getService }: FtrProviderContext) {
           type: 'index_name',
           indexName: 'logs-*,filebeat-*,kibana_sample_data_logs*',
         });
+        expect(configuration.fields.timestamp).to.be('@timestamp');
+        expect(configuration.fields.tiebreaker).to.be('_doc');
         expect(configuration.logColumns).to.have.length(3);
         expect(configuration.logColumns[0]).to.have.key('timestampColumn');
         expect(configuration.logColumns[1]).to.have.key('fieldColumn');

--- a/x-pack/test/api_integration/apis/metrics_ui/metric_threshold_alert.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/metric_threshold_alert.ts
@@ -54,6 +54,11 @@ export default function ({ getService }: FtrProviderContext) {
     metricsExplorerDefaultView: 'default',
     anomalyThreshold: 70,
     fields: {
+      container: 'container.id',
+      host: 'host.name',
+      pod: 'kubernetes.od.uid',
+      tiebreaker: '_doc',
+      timestamp: '@timestamp',
       message: ['message'],
     },
     logColumns: [

--- a/x-pack/test/api_integration/apis/metrics_ui/metrics_alerting.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/metrics_alerting.ts
@@ -37,7 +37,11 @@ export default function ({ getService }: FtrProviderContext) {
             start: moment().subtract(25, 'minutes').valueOf(),
             end: moment().valueOf(),
           };
-          const searchBody = getElasticsearchMetricQuery(getSearchParams(aggType), timeframe);
+          const searchBody = getElasticsearchMetricQuery(
+            getSearchParams(aggType),
+            '@timestamp',
+            timeframe
+          );
           const result = await client.search({
             index,
             // @ts-expect-error @elastic/elasticsearch AggregationsBucketsPath is not valid
@@ -57,6 +61,7 @@ export default function ({ getService }: FtrProviderContext) {
         };
         const searchBody = getElasticsearchMetricQuery(
           getSearchParams('avg'),
+          '@timestamp',
           timeframe,
           undefined,
           '{"bool":{"should":[{"match_phrase":{"agent.hostname":"foo"}}],"minimum_should_match":1}}'
@@ -80,6 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
           };
           const searchBody = getElasticsearchMetricQuery(
             getSearchParams(aggType),
+            '@timestamp',
             timeframe,
             'agent.id'
           );
@@ -100,6 +106,7 @@ export default function ({ getService }: FtrProviderContext) {
         };
         const searchBody = getElasticsearchMetricQuery(
           getSearchParams('avg'),
+          '@timestamp',
           timeframe,
           'agent.id',
           '{"bool":{"should":[{"match_phrase":{"agent.hostname":"foo"}}],"minimum_should_match":1}}'

--- a/x-pack/test/api_integration/apis/metrics_ui/sources.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/sources.ts
@@ -66,6 +66,11 @@ export default function ({ getService }: FtrProviderContext) {
         expect(configuration?.name).to.be('UPDATED_NAME');
         expect(configuration?.description).to.be('UPDATED_DESCRIPTION');
         expect(configuration?.metricAlias).to.be('metricbeat-**');
+        expect(configuration?.fields.host).to.be('host.name');
+        expect(configuration?.fields.pod).to.be('kubernetes.pod.uid');
+        expect(configuration?.fields.tiebreaker).to.be('_doc');
+        expect(configuration?.fields.timestamp).to.be('@timestamp');
+        expect(configuration?.fields.container).to.be('container.id');
         expect(configuration?.anomalyThreshold).to.be(50);
         expect(status?.metricIndicesExist).to.be(true);
       });
@@ -97,6 +102,40 @@ export default function ({ getService }: FtrProviderContext) {
         expect(updatedAt).to.be.greaterThan(createdAt || 0);
         expect(configuration?.metricAlias).to.be('metricbeat-**');
         expect(status?.metricIndicesExist).to.be(true);
+      });
+
+      it('applies a single nested field update to an existing source', async () => {
+        const creationResponse = await patchRequest({
+          name: 'NAME',
+          fields: {
+            host: 'HOST',
+          },
+        });
+
+        const initialVersion = creationResponse?.source.version;
+        const createdAt = creationResponse?.source.updatedAt;
+
+        expect(initialVersion).to.be.a('string');
+        expect(createdAt).to.be.greaterThan(0);
+
+        const updateResponse = await patchRequest({
+          fields: {
+            container: 'UPDATED_CONTAINER',
+          },
+        });
+
+        const version = updateResponse?.source.version;
+        const updatedAt = updateResponse?.source.updatedAt;
+        const configuration = updateResponse?.source.configuration;
+
+        expect(version).to.be.a('string');
+        expect(version).to.not.be(initialVersion);
+        expect(updatedAt).to.be.greaterThan(createdAt || 0);
+        expect(configuration?.fields.container).to.be('UPDATED_CONTAINER');
+        expect(configuration?.fields.host).to.be('HOST');
+        expect(configuration?.fields.pod).to.be('kubernetes.pod.uid');
+        expect(configuration?.fields.tiebreaker).to.be('_doc');
+        expect(configuration?.fields.timestamp).to.be('@timestamp');
       });
 
       it('validates anomalyThreshold is between range 1-100', async () => {


### PR DESCRIPTION
Reverts elastic/kibana#115874

`main` is not yet protected from auto-merge