### PR TITLE
Revert "[Metrics UI] Fix OR logic on redundant groupBy detection"

### DIFF
--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression.tsx
@@ -260,9 +260,6 @@ export const Expressions: React.FC<Props> = (props) => {
     [alertParams.groupBy]
   );
 
-  // Test to see if any of the group fields in groupBy are already filtered down to a single
-  // group by the filterQuery. If this is the case, then a groupBy is unnecessary, as it would only
-  // ever produce one group instance
   const groupByFilterTestPatterns = useMemo(() => {
     if (!alertParams.groupBy) return null;
     const groups = !Array.isArray(alertParams.groupBy)
@@ -270,7 +267,7 @@ export const Expressions: React.FC<Props> = (props) => {
       : alertParams.groupBy;
     return groups.map((group: string) => ({
       groupName: group,
-      pattern: new RegExp(`{"match(_phrase)?":{"${group}":"(.*?)"}}`, 'g'),
+      pattern: new RegExp(`{"match(_phrase)?":{"${group}":"(.*?)"}}`),
     }));
   }, [alertParams.groupBy]);
 
@@ -278,11 +275,7 @@ export const Expressions: React.FC<Props> = (props) => {
     if (!alertParams.filterQuery || !groupByFilterTestPatterns) return [];
     return groupByFilterTestPatterns
       .map(({ groupName, pattern }) => {
-        // Test to see if there is ONLY ONE match for this group in the query
-        // If there are 0 matches, then this query isn't filtering out any groups at all
-        // If there are 2+ matches, the query is using OR logic (e.g. group:a OR group:b) and will
-        // still allow for more than one groupBy alert instance.
-        if (alertParams.filterQuery!.match(pattern)?.length === 1) {
+        if (pattern.test(alertParams.filterQuery!)) {
           return groupName;
         }
       })


### PR DESCRIPTION
Reverts elastic/kibana#116695

`main` is not yet protected from auto-merge