### PR TITLE
[7.16] [saved objects] Strip version qualifier in SO service to fix unknown type deprecations. (#116480)

### DIFF
--- a/src/core/server/saved_objects/migrations/kibana/kibana_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/kibana/kibana_migrator.test.ts
@@ -45,15 +45,6 @@ describe('KibanaMigrator', () => {
   beforeEach(() => {
     (DocumentMigrator as jest.Mock).mockClear();
   });
-  describe('constructor', () => {
-    it('coerces the current Kibana version if it has a hyphen', () => {
-      const options = mockOptions();
-      options.kibanaVersion = '3.2.1-SNAPSHOT';
-      const migrator = new KibanaMigrator(options);
-      expect(migrator.kibanaVersion).toEqual('3.2.1');
-      expect((DocumentMigrator as jest.Mock).mock.calls[0][0].kibanaVersion).toEqual('3.2.1');
-    });
-  });
   describe('getActiveMappings', () => {
     it('returns full index mappings w/ core properties', () => {
       const options = mockOptions();

--- a/src/core/server/saved_objects/migrations/kibana/kibana_migrator.ts
+++ b/src/core/server/saved_objects/migrations/kibana/kibana_migrator.ts
@@ -89,7 +89,7 @@ export class KibanaMigrator {
     this.serializer = new SavedObjectsSerializer(this.typeRegistry);
     this.mappingProperties = mergeTypes(this.typeRegistry.getAllTypes());
     this.log = logger;
-    this.kibanaVersion = kibanaVersion.split('-')[0]; // coerce a semver-like string (x.y.z-SNAPSHOT) or prerelease version (x.y.z-alpha) to a regular semver (x.y.z);
+    this.kibanaVersion = kibanaVersion;
     this.documentMigrator = new DocumentMigrator({
       kibanaVersion: this.kibanaVersion,
       typeRegistry,

--- a/src/core/server/saved_objects/saved_objects_service.test.mocks.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.mocks.ts
@@ -25,3 +25,8 @@ export const typeRegistryInstanceMock = typeRegistryMock.create();
 jest.doMock('./saved_objects_type_registry', () => ({
   SavedObjectTypeRegistry: jest.fn().mockImplementation(() => typeRegistryInstanceMock),
 }));
+
+export const registerRoutesMock = jest.fn();
+jest.doMock('./routes', () => ({
+  registerRoutes: registerRoutesMock,
+}));

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -6,17 +6,25 @@
  * Side Public License, v 1.
  */
 
+import { join } from 'path';
+import loadJsonFile from 'load-json-file';
+
 import {
-  migratorInstanceMock,
   clientProviderInstanceMock,
+  KibanaMigratorMock,
+  migratorInstanceMock,
+  registerRoutesMock,
   typeRegistryInstanceMock,
 } from './saved_objects_service.test.mocks';
 import { BehaviorSubject } from 'rxjs';
+import { RawPackageInfo } from '@kbn/config';
 import { ByteSizeValue } from '@kbn/config-schema';
+import { REPO_ROOT } from '@kbn/dev-utils';
 
 import { SavedObjectsService } from './saved_objects_service';
 import { mockCoreContext } from '../core_context.mock';
 import { Env } from '../config';
+import { getEnvOptions } from '../config/mocks';
 import { configServiceMock } from '../mocks';
 import { elasticsearchServiceMock } from '../elasticsearch/elasticsearch_service.mock';
 import { coreUsageDataServiceMock } from '../core_usage_data/core_usage_data_service.mock';
@@ -106,6 +114,42 @@ describe('SavedObjectsService', () => {
       expect(deprecationsSetup.getRegistry).toHaveBeenCalledWith('savedObjects');
       expect(mockRegistry.registerDeprecations).toHaveBeenCalledTimes(1);
       expect(mockRegistry.registerDeprecations).toHaveBeenCalledWith(deprecations);
+    });
+
+    it('registers the deprecation provider with the correct kibanaVersion', async () => {
+      const pkg = loadJsonFile.sync(join(REPO_ROOT, 'package.json')) as RawPackageInfo;
+      const kibanaVersion = pkg.version;
+
+      const coreContext = createCoreContext({
+        env: Env.createDefault(REPO_ROOT, getEnvOptions(), {
+          ...pkg,
+          version: `${kibanaVersion}-beta1`, // test behavior when release has a version qualifier
+        }),
+      });
+
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+
+      expect(getSavedObjectsDeprecationsProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ kibanaVersion })
+      );
+    });
+
+    it('calls registerRoutes with the correct kibanaVersion', async () => {
+      const pkg = loadJsonFile.sync(join(REPO_ROOT, 'package.json')) as RawPackageInfo;
+      const kibanaVersion = pkg.version;
+
+      const coreContext = createCoreContext({
+        env: Env.createDefault(REPO_ROOT, getEnvOptions(), {
+          ...pkg,
+          version: `${kibanaVersion}-beta1`, // test behavior when release has a version qualifier
+        }),
+      });
+
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+
+      expect(registerRoutesMock).toHaveBeenCalledWith(expect.objectContaining({ kibanaVersion }));
     });
 
     describe('#setClientFactoryProvider', () => {
@@ -216,6 +260,24 @@ describe('SavedObjectsService', () => {
       await soService.setup(createSetupDeps());
       await soService.start(createStartDeps());
       expect(migratorInstanceMock.runMigrations).not.toHaveBeenCalled();
+    });
+
+    it('calls KibanaMigrator with correct version', async () => {
+      const pkg = loadJsonFile.sync(join(REPO_ROOT, 'package.json')) as RawPackageInfo;
+      const kibanaVersion = pkg.version;
+
+      const coreContext = createCoreContext({
+        env: Env.createDefault(REPO_ROOT, getEnvOptions(), {
+          ...pkg,
+          version: `${kibanaVersion}-beta1`, // test behavior when release has a version qualifier
+        }),
+      });
+
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+      await soService.start(createStartDeps());
+
+      expect(KibanaMigratorMock).toHaveBeenCalledWith(expect.objectContaining({ kibanaVersion }));
     });
 
     it('waits for all es nodes to be compatible before running migrations', async (done) => {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [saved objects] Strip version qualifier in SO service to fix unknown type deprecations. (#116480)