### PR TITLE
[Security Solution] unskip endpoint functional tests

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/setup.ts
@@ -24,8 +24,10 @@ export default function (providerContext: FtrProviderContext) {
     describe('setup performs upgrades', async () => {
       const oldEndpointVersion = '0.13.0';
       beforeEach(async () => {
+        const url = '/api/fleet/epm/packages/endpoint';
+        await supertest.delete(url).set('kbn-xsrf', 'xxxx').send({ force: true }).expect(200);
         await supertest
-          .post(`/api/fleet/epm/packages/endpoint-${oldEndpointVersion}`)
+          .post(`${url}-${oldEndpointVersion}`)
           .set('kbn-xsrf', 'xxxx')
           .send({ force: true })
           .expect(200);

--- a/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/create.ts
@@ -199,7 +199,8 @@ export default function (providerContext: FtrProviderContext) {
         .expect(400);
     });
 
-    it('should not allow multiple limited packages on the same agent policy', async function () {
+    // https://github.com/elastic/kibana/issues/118257
+    it.skip('should not allow multiple limited packages on the same agent policy', async function () {
       await supertest
         .post(`/api/fleet/package_policies`)
         .set('kbn-xsrf', 'xxxx')

--- a/x-pack/test/fleet_api_integration/config.ts
+++ b/x-pack/test/fleet_api_integration/config.ts
@@ -15,7 +15,7 @@ import { defineDockerServersConfig } from '@kbn/test';
 // example: https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fpackage-storage/detail/snapshot/74/pipeline/257#step-302-log-1.
 // It should be updated any time there is a new Docker image published for the Snapshot Distribution of the Package Registry.
 export const dockerImage =
-  'docker.elastic.co/package-registry/distribution@sha256:42dbdbb7fbc7ea61d0c38c0df6dad977ca2ad9cf01e247543054377aef33d377';
+  'docker.elastic.co/package-registry/distribution@sha256:13d9996dd24161624784704e080f5f5b7f0ef34ff0d9259f8f05010ccae00058';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -15,8 +15,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService } = providerContext;
 
-  // FAILING: https://github.com/elastic/kibana/issues/72874
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');


### PR DESCRIPTION
## Summary

* bump package registry hash for endpoint 1.3.0 (8.0.0 kibana support)
* unskip endpoint tests.
* ~requires https://github.com/elastic/kibana/pull/118248~ merged
* resolves https://github.com/elastic/kibana/issues/72874


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
