### PR TITLE
[ci] Temporarily stop writing to Bazel remote cache

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -10,8 +10,6 @@ steps:
 
   - command: .buildkite/scripts/steps/on_merge_build_and_metrics.sh
     label: Default Build and Metrics
-    env:
-      BAZEL_CACHE_MODE: read-write
     agents:
       queue: c2-8
     timeout_in_minutes: 60


### PR DESCRIPTION
We have disabled the read cache for now, so we don't need to be writing to it.