### PR TITLE
[7.16] Removes isUuid and tests as they're not used anymore (#116848)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/schema.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/schema.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { validateSingleAction, validateRuleActionsField } from './schema';
-import { isUuid, getActionTypeName, validateMustache, validateActionParams } from './utils';
+import { getActionTypeName, validateMustache, validateActionParams } from './utils';
 import { actionTypeRegistryMock } from '../../../../../../triggers_actions_ui/public/application/action_type_registry.mock';
 import { FormHook } from '../../../../shared_imports';
 jest.mock('./utils');
@@ -86,9 +86,7 @@ describe('stepRuleActions schema', () => {
     });
 
     it('should validate multiple incorrect rule actions field', async () => {
-      (isUuid as jest.Mock).mockReturnValueOnce(false);
       (getActionTypeName as jest.Mock).mockReturnValueOnce('Slack');
-      (isUuid as jest.Mock).mockReturnValueOnce(true);
       (getActionTypeName as jest.Mock).mockReturnValueOnce('Pagerduty');
       (validateActionParams as jest.Mock).mockReturnValue(['Summary is required']);
       (validateMustache as jest.Mock).mockReturnValue(['Component is not valid mustache template']);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/utils.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/utils.test.ts
@@ -6,19 +6,9 @@
  */
 
 import { actionTypeRegistryMock } from '../../../../../../triggers_actions_ui/public/application/action_type_registry.mock';
-import { isUuid, getActionTypeName, validateMustache, validateActionParams } from './utils';
+import { getActionTypeName, validateMustache, validateActionParams } from './utils';
 
 describe('stepRuleActions utils', () => {
-  describe('isUuidv4', () => {
-    it('should validate proper uuid v4 value', () => {
-      expect(isUuid('817b8bca-91d1-4729-8ee1-3a83aaafd9d4')).toEqual(true);
-    });
-
-    it('should validate incorrect uuid v4 value', () => {
-      expect(isUuid('ad9d4')).toEqual(false);
-    });
-  });
-
   describe('getActionTypeName', () => {
     it('should return capitalized action type name', () => {
       expect(getActionTypeName('.slack')).toEqual('Slack');

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/utils.ts
@@ -14,10 +14,6 @@ import {
 } from '../../../../../../triggers_actions_ui/public';
 import * as I18n from './translations';
 
-const UUID_REGEX = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
-
-export const isUuid = (id: AlertAction['id']) => !!id.match(UUID_REGEX);
-
 export const getActionTypeName = (actionTypeId: AlertAction['actionTypeId']) => {
   if (!actionTypeId) return '';
   const actionType = actionTypeId.split('.')[1];


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Removes isUuid and tests as they're not used anymore (#116848)