### PR TITLE
remove unused public code from share plugin

### DIFF
--- a/src/plugins/share/public/index.ts
+++ b/src/plugins/share/public/index.ts
@@ -37,7 +37,6 @@ export { useLocatorUrl } from '../common/url_service/locators/use_locator_url';
 
 import { SharePlugin } from './plugin';
 
-export { KibanaURL } from './kibana_url';
 export { downloadMultipleAs, downloadFileAs } from './lib/download_as';
 export type { DownloadableContent } from './lib/download_as';
 


### PR DESCRIPTION
`KibanaURL` class is unused externally and so doesn't need to be exported as part of the Share plugins public API.