### PR TITLE
[Actions][Docs] Rename isLegacy to usesTableApi

### DIFF
--- a/docs/management/connectors/action-types/servicenow-sir.asciidoc
+++ b/docs/management/connectors/action-types/servicenow-sir.asciidoc
@@ -37,7 +37,7 @@ Use the <<action-settings, Action configuration settings>> to customize connecto
    actionTypeId: .servicenow-sir
    config:
      apiUrl: https://example.service-now.com/
-     isLegacy: false
+     usesTableApi: false
    secrets:
      username: testuser
      password: passwordkeystorevalue
@@ -46,9 +46,9 @@ Use the <<action-settings, Action configuration settings>> to customize connecto
 Config defines information for the connector type.
 
 `apiUrl`:: An address that corresponds to *URL*.
-`isLegacy`:: A boolean that indicates if the connector should use the Table API (legacy) or the Import Set API.
+`usesTableApi`:: A boolean that indicates if the connector uses the Table API or the Import Set API.
 
-Note: If `isLegacy` is set to false the Elastic application should be installed in ServiceNow.
+Note: If `usesTableApi` is set to false the Elastic application should be installed in ServiceNow.
 
 Secrets defines sensitive information for the connector type.
 

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -37,7 +37,7 @@ Use the <<action-settings, Action configuration settings>> to customize connecto
    actionTypeId: .servicenow
    config:
      apiUrl: https://example.service-now.com/
-     isLegacy: false
+     usesTableApi: false
    secrets:
      username: testuser
      password: passwordkeystorevalue
@@ -46,9 +46,9 @@ Use the <<action-settings, Action configuration settings>> to customize connecto
 Config defines information for the connector type.
 
 `apiUrl`:: An address that corresponds to *URL*.
-`isLegacy`:: A boolean that indicates if the connector should use the Table API (legacy) or the Import Set API.
+`usesTableApi`:: A boolean that indicates if the connector uses the Table API or the Import Set API.
 
-Note: If `isLegacy` is set to false the Elastic application should be installed in ServiceNow.
+Note: If `usesTableApi` is set to false the Elastic application should be installed in ServiceNow.
 
 Secrets defines sensitive information for the connector type.
 


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/115028 renamed the `isLegacy` to `usesTableApi`. This PR fixes the docs to reflect the changes.

Docs Preview: 

- https://kibana_116922.docs-preview.app.elstc.co/guide/en/kibana/master/servicenow-action-type.html
- https://kibana_116922.docs-preview.app.elstc.co/guide/en/kibana/master/servicenow-sir-action-type.html


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
