### PR TITLE
Remove unused public APIs in share plugin

### DIFF
--- a/src/plugins/share/common/index.ts
+++ b/src/plugins/share/common/index.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export { LocatorDefinition, LocatorPublic, useLocatorUrl, formatSearchParams } from './url_service';
+export { LocatorDefinition, LocatorPublic, useLocatorUrl } from './url_service';
 export type { AnonymousAccessServiceContract, AnonymousAccessState } from './anonymous_access';

--- a/src/plugins/share/public/index.ts
+++ b/src/plugins/share/public/index.ts
@@ -12,11 +12,11 @@ export { CSV_QUOTE_VALUES_SETTING, CSV_SEPARATOR_SETTING } from '../common/const
 
 export { LocatorDefinition, LocatorPublic, KibanaLocation } from '../common/url_service';
 
-export { UrlGeneratorStateMapping } from './url_generators/url_generator_definition';
+export type { UrlGeneratorStateMapping } from './url_generators/url_generator_definition';
 
-export { SharePluginSetup, SharePluginStart } from './plugin';
+export type { SharePluginSetup, SharePluginStart } from './plugin';
 
-export {
+export type {
   ShareContext,
   ShareMenuProvider,
   ShareMenuItem,

--- a/src/plugins/share/public/url_generators/url_generator_contract.ts
+++ b/src/plugins/share/public/url_generators/url_generator_contract.ts
@@ -12,8 +12,4 @@ export interface UrlGeneratorContract<Id extends UrlGeneratorId> {
   id: Id;
   createUrl(state: UrlGeneratorStateMapping[Id]['State']): Promise<string>;
   isDeprecated: boolean;
-  migrate(state: UrlGeneratorStateMapping[Id]['State']): Promise<{
-    state: UrlGeneratorStateMapping[Id]['MigratedState'];
-    id: UrlGeneratorStateMapping[Id]['MigratedId'];
-  }>;
 }

--- a/src/plugins/share/public/url_generators/url_generator_internal.ts
+++ b/src/plugins/share/public/url_generators/url_generator_internal.ts
@@ -72,17 +72,6 @@ export class UrlGeneratorInternal<Id extends UrlGeneratorId> {
         return this.spec.createUrl!(state);
       },
       isDeprecated: !!this.spec.isDeprecated,
-      migrate: async (state: UrlGeneratorStateMapping[Id]['State']) => {
-        if (!this.spec.isDeprecated) {
-          throw new Error(
-            i18n.translate('share.urlGenerators.error.migrateCalledNotDeprecated', {
-              defaultMessage: 'You cannot call migrate on a non-deprecated generator.',
-            })
-          );
-        }
-
-        return this.spec.migrate!(state);
-      },
     };
   }
 }

--- a/src/plugins/share/public/url_generators/url_generator_service.test.ts
+++ b/src/plugins/share/public/url_generators/url_generator_service.test.ts
@@ -32,9 +32,6 @@ test('Registering and retrieving a generator', async () => {
       "migrate": [Function],
     }
   `);
-  await expect(generator.migrate({})).rejects.toEqual(
-    new Error('You cannot call migrate on a non-deprecated generator.')
-  );
   expect(await generator.createUrl({})).toBe('myurl');
 
   const retrievedGenerator = start.getUrlGenerator('TEST_GENERATOR');
@@ -46,9 +43,6 @@ test('Registering and retrieving a generator', async () => {
       "migrate": [Function],
     }
   `);
-  await expect(generator.migrate({})).rejects.toEqual(
-    new Error('You cannot call migrate on a non-deprecated generator.')
-  );
   expect(await generator.createUrl({})).toBe('myurl');
 });
 
@@ -124,6 +118,5 @@ test('Generator returns migrated url', async () => {
 
   const generator = start.getUrlGenerator('v1');
   expect(generator.isDeprecated).toBe(true);
-  expect(await generator.migrate({ bar: 'hi' })).toEqual({ id: 'v2', state: { foo: 'hi' } });
   expect(await generator.createUrl({ bar: 'hi' })).toEqual('www.hi.com');
 });

--- a/src/plugins/share/public/url_generators/url_generator_service.test.ts
+++ b/src/plugins/share/public/url_generators/url_generator_service.test.ts
@@ -29,7 +29,6 @@ test('Registering and retrieving a generator', async () => {
       "createUrl": [Function],
       "id": "TEST_GENERATOR",
       "isDeprecated": false,
-      "migrate": [Function],
     }
   `);
   expect(await generator.createUrl({})).toBe('myurl');
@@ -40,7 +39,6 @@ test('Registering and retrieving a generator', async () => {
       "createUrl": [Function],
       "id": "TEST_GENERATOR",
       "isDeprecated": false,
-      "migrate": [Function],
     }
   `);
   expect(await generator.createUrl({})).toBe('myurl');

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4395,7 +4395,6 @@
     "share.contextMenu.permalinksLabel": "パーマリンク",
     "share.contextMenuTitle": "この {objectType} を共有",
     "share.urlGenerators.error.createUrlFnProvided": "このジェネレーターは非推奨とマークされています。createUrl fn を付けないでください。",
-    "share.urlGenerators.error.migrateCalledNotDeprecated": "非推奨以外のジェネレーターで migrate を呼び出すことはできません。",
     "share.urlGenerators.error.migrationFnGivenNotDeprecated": "移行機能を提供する場合、このジェネレーターに非推奨マークを付ける必要があります",
     "share.urlGenerators.error.noCreateUrlFnProvided": "このジェネレーターには非推奨のマークがありません。createUrl fn を付けてください。",
     "share.urlGenerators.error.noMigrationFnProvided": "アクセスリンクジェネレーターに非推奨マークが付いている場合、移行機能を提供する必要があります。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4438,7 +4438,6 @@
     "share.contextMenu.permalinksLabel": "固定链接",
     "share.contextMenuTitle": "共享此 {objectType}",
     "share.urlGenerators.error.createUrlFnProvided": "此生成器标记为已过时。切勿提供 createUrl 函数。",
-    "share.urlGenerators.error.migrateCalledNotDeprecated": "无法在非过时的生成器上调用迁移。",
     "share.urlGenerators.error.migrationFnGivenNotDeprecated": "如果提供了迁移函数，则必须将此生成器标记为已过时",
     "share.urlGenerators.error.noCreateUrlFnProvided": "此生成器未标记为已过时。请提供 createUrl 函数。",
     "share.urlGenerators.error.noMigrationFnProvided": "如果访问链接生成器标记为已过时，则必须提供迁移函数。",


### PR DESCRIPTION
Removes more unused public APIs from the Share plugin. The public migrate function was never used and that class is deprecated anyhow.