### PR TITLE
[ML] Fix logging in the trained models endpoint to prevent Kibana server from crashing

### DIFF
--- a/x-pack/plugins/ml/server/lib/log.ts
+++ b/x-pack/plugins/ml/server/lib/log.ts
@@ -25,7 +25,7 @@ export let mlLog: MlLog;
 export function initMlServerLog(logInitialization: LogInitialization) {
   mlLog = {
     fatal: (message: string) => logInitialization.log.fatal(message),
-    error: (message: string) => logInitialization.log.error(message),
+    error: (message: string | Error) => logInitialization.log.error(message),
     warn: (message: string) => logInitialization.log.warn(message),
     info: (message: string) => logInitialization.log.info(message),
     debug: (message: string) => logInitialization.log.debug(message),

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
@@ -49,7 +49,11 @@ export function modelsProvider(
         modelIds.map((id: string) => [id, null])
       );
 
-      const { body } = await client.asCurrentUser.ingest.getPipeline();
+      const { body, statusCode } = await client.asCurrentUser.ingest.getPipeline();
+
+      if (statusCode !== 200) {
+        return modelIdsMap;
+      }
 
       for (const [pipelineName, pipelineDefinition] of Object.entries(body)) {
         const { processors } = pipelineDefinition as { processors: Array<Record<string, any>> };

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -15,6 +15,7 @@ import {
 import { modelsProvider } from '../models/data_frame_analytics';
 import { TrainedModelConfigResponse } from '../../common/types/trained_models';
 import { memoryOverviewServiceProvider } from '../models/memory_overview';
+import { mlLog } from '../lib/log';
 
 export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization) {
   /**
@@ -77,8 +78,7 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
           }
         } catch (e) {
           // the user might not have required permissions to fetch pipelines
-          // eslint-disable-next-line no-console
-          console.log(e);
+          mlLog.error(e);
         }
 
         return response.ok({


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/116765

Kibana was crashing in non-standard deployments with muffled `stderr` stream.
Replaces the `console` statement with the Kibana logger to fix it.
