### PR TITLE
[Reporting] Stabilize ILM test for Cloud

### DIFF
--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -24,6 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/reporting/logs');
       await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
+      await reportingAPI.migrateReportingIndices(); // ensure that the ILM policy exists for the first test
     });
 
     after(async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/109456

## Summary

ESTF-Cloud testing runs our test suites in a different order than the PR-build job. This means tests could fail if they are not stable enough to run in an unexpected order.

A Reporting test seems to fail in the ESTF-Cloud runner because the test expects the cluster to have the Reporting ILM policy installed by default. This expectation is broken if a previous test deleted the ILM policies in the cluster, which is what seems to be happening.

This fixes the problem by explicitly setting up the Reporting ILM policy that is expected.


