### PR TITLE
remove unused enrollment path

### DIFF
--- a/api_docs/fleet.json
+++ b/api_docs/fleet.json
@@ -19698,16 +19698,6 @@
           },
           {
             "parentPluginId": "fleet",
-            "id": "def-common.AGENT_API_ROUTES.ENROLL_PATTERN",
-            "type": "string",
-            "tags": [],
-            "label": "ENROLL_PATTERN",
-            "description": [],
-            "path": "x-pack/plugins/fleet/common/constants/routes.ts",
-            "deprecated": false
-          },
-          {
-            "parentPluginId": "fleet",
             "id": "def-common.AGENT_API_ROUTES.UNENROLL_PATTERN",
             "type": "string",
             "tags": [],

--- a/x-pack/plugins/fleet/common/constants/routes.ts
+++ b/x-pack/plugins/fleet/common/constants/routes.ts
@@ -89,7 +89,6 @@ export const AGENT_API_ROUTES = {
   CHECKIN_PATTERN: `${API_ROOT}/agents/{agentId}/checkin`,
   ACKS_PATTERN: `${API_ROOT}/agents/{agentId}/acks`,
   ACTIONS_PATTERN: `${API_ROOT}/agents/{agentId}/actions`,
-  ENROLL_PATTERN: `${API_ROOT}/agents/enroll`,
   UNENROLL_PATTERN: `${API_ROOT}/agents/{agentId}/unenroll`,
   BULK_UNENROLL_PATTERN: `${API_ROOT}/agents/bulk_unenroll`,
   REASSIGN_PATTERN: `${API_ROOT}/agents/{agentId}/reassign`,


### PR DESCRIPTION
## Summary
Found this seemingly unused path while tracing through the enrollment code used by the agent. This PR removes the potential red herring.