### PR TITLE
[Fleet] Fix add agent help not closing when button clicked

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_agents_cell.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/components/package_policy_agents_cell.tsx
@@ -22,8 +22,12 @@ const AddAgentButton = ({ onAddAgent }: { onAddAgent: () => void }) => (
 );
 
 const AddAgentButtonWithPopover = ({ onAddAgent }: { onAddAgent: () => void }) => {
-  const button = <AddAgentButton onAddAgent={onAddAgent} />;
   const [isHelpOpen, setIsHelpOpen] = useState<boolean>(true);
+  const onAddAgentCloseHelp = () => {
+    setIsHelpOpen(false);
+    onAddAgent();
+  };
+  const button = <AddAgentButton onAddAgent={onAddAgentCloseHelp} />;
   return (
     <AddAgentHelpPopover
       button={button}

--- a/x-pack/plugins/fleet/public/components/add_agent_help_popover.tsx
+++ b/x-pack/plugins/fleet/public/components/add_agent_help_popover.tsx
@@ -11,6 +11,9 @@ import { FormattedMessage } from '@kbn/i18n/react';
 
 import type { NoArgCallback } from '@elastic/eui';
 import { EuiTourStep, EuiLink, EuiText } from '@elastic/eui';
+import { useTheme } from 'styled-components';
+
+import type { EuiTheme } from '../../../../../src/plugins/kibana_react/common';
 
 import { useStartServices } from '../hooks';
 
@@ -26,7 +29,7 @@ export const AddAgentHelpPopover = ({
   closePopover: NoArgCallback<void>;
 }) => {
   const { docLinks } = useStartServices();
-
+  const theme = useTheme() as EuiTheme;
   const optionalProps: { offset?: number } = {};
 
   if (offset !== undefined) {
@@ -55,6 +58,7 @@ export const AddAgentHelpPopover = ({
           />
         </EuiText>
       }
+      zIndex={theme.eui.euiZLevel1 - 1} // put popover behind any modals that happen to be open
       isStepOpen={isOpen}
       minWidth={300}
       onFinish={() => {}}


### PR DESCRIPTION
## Summary

Fixes #117044 

- close help popover on button click
- reduce popover z-index to be behind any open modals e.g if a user happened to navigate to `/app/fleet/policies/<policy ID>?showAddAgentHelp=true&openEnrollmentFlyout=true`
