### PR TITLE
[7.16] [Security Solution][Endpoint] Add tooltip to Name and Description on the `ArtifactEntryCollapsableCard` when collapsed (#116839)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/artifact_entry_collapsible_card.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/artifact_entry_collapsible_card.test.tsx
@@ -75,6 +75,25 @@ describe.each([
     expect(renderResult.getByTestId('testCard-criteriaConditions')).not.toBeNull();
   });
 
+  it('should display tooltip if collapsed', () => {
+    render();
+
+    expect(renderResult.baseElement.querySelectorAll('.euiToolTipAnchor')).toHaveLength(2);
+  });
+
+  it('should display tooltip when collapsed but only if not empty', () => {
+    item.description = '';
+    render();
+
+    expect(renderResult.baseElement.querySelectorAll('.euiToolTipAnchor')).toHaveLength(1);
+  });
+
+  it('should NOT display a tooltip if expanded', () => {
+    render({ expanded: true });
+
+    expect(renderResult.baseElement.querySelectorAll('.euiToolTipAnchor')).toHaveLength(0);
+  });
+
   it('should call `onExpandCollapse` callback when button is clicked', () => {
     render();
     act(() => {

--- a/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/components/card_compressed_header.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/components/card_compressed_header.tsx
@@ -56,12 +56,14 @@ export const CardCompressedHeader = memo<CardCompressedHeaderProps>(
           />
         }
         name={
-          <TextValueDisplay bold truncate={!expanded}>
+          <TextValueDisplay bold truncate={!expanded} withTooltip={!expanded}>
             {artifact.name}
           </TextValueDisplay>
         }
         description={
-          <DescriptionField truncate={!expanded}>{artifact.description}</DescriptionField>
+          <DescriptionField truncate={!expanded} withTooltip={!expanded}>
+            {artifact.description}
+          </DescriptionField>
         }
         effectScope={
           <EffectScope policies={policyNavLinks} data-test-subj={getTestId('effectScope')} />

--- a/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/components/description_field.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/components/description_field.tsx
@@ -12,12 +12,17 @@ import { TextValueDisplay, TextValueDisplayProps } from './text_value_display';
 
 export type DescriptionFieldProps = PropsWithChildren<{}> &
   Pick<CommonProps, 'data-test-subj'> &
-  Pick<TextValueDisplayProps, 'truncate'>;
+  Pick<TextValueDisplayProps, 'truncate' | 'withTooltip'>;
 
 export const DescriptionField = memo<DescriptionFieldProps>(
-  ({ truncate, children, 'data-test-subj': dataTestSubj }) => {
+  ({ truncate, children, 'data-test-subj': dataTestSubj, withTooltip }) => {
     return (
-      <TextValueDisplay size="m" truncate={truncate} data-test-subj={dataTestSubj}>
+      <TextValueDisplay
+        size="m"
+        truncate={truncate}
+        data-test-subj={dataTestSubj}
+        withTooltip={withTooltip}
+      >
         {children || getEmptyValue()}
       </TextValueDisplay>
     );

--- a/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/components/text_value_display.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_entry_card/components/text_value_display.tsx
@@ -6,14 +6,16 @@
  */
 
 import React, { memo, PropsWithChildren, useMemo } from 'react';
-import { CommonProps, EuiText } from '@elastic/eui';
+import { CommonProps, EuiText, EuiToolTip } from '@elastic/eui';
 import classNames from 'classnames';
+import { getEmptyValue } from '../../../../common/components/empty_value';
 
 export type TextValueDisplayProps = Pick<CommonProps, 'data-test-subj'> &
   PropsWithChildren<{
     bold?: boolean;
     truncate?: boolean;
     size?: 'xs' | 's' | 'm' | 'relative';
+    withTooltip?: boolean;
   }>;
 
 /**
@@ -21,7 +23,14 @@ export type TextValueDisplayProps = Pick<CommonProps, 'data-test-subj'> &
  * display of values on the card
  */
 export const TextValueDisplay = memo<TextValueDisplayProps>(
-  ({ bold, truncate, size = 's', 'data-test-subj': dataTestSubj, children }) => {
+  ({
+    bold,
+    truncate,
+    size = 's',
+    withTooltip = false,
+    'data-test-subj': dataTestSubj,
+    children,
+  }) => {
     const cssClassNames = useMemo(() => {
       return classNames({
         'eui-textTruncate': truncate,
@@ -29,9 +38,22 @@ export const TextValueDisplay = memo<TextValueDisplayProps>(
       });
     }, [truncate]);
 
+    const textContent = useMemo(() => {
+      return bold ? <strong>{children}</strong> : children;
+    }, [bold, children]);
+
     return (
       <EuiText size={size} className={cssClassNames} data-test-subj={dataTestSubj}>
-        {bold ? <strong>{children}</strong> : children}
+        {withTooltip &&
+        'string' === typeof children &&
+        children.length > 0 &&
+        children !== getEmptyValue() ? (
+          <EuiToolTip content={children} position="top">
+            <>{textContent}</>
+          </EuiToolTip>
+        ) : (
+          textContent
+        )}
       </EuiText>
     );
   }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Security Solution][Endpoint] Add tooltip to Name and Description on the `ArtifactEntryCollapsableCard` when collapsed (#116839)