### PR TITLE
[Home] Adding upload data link to home page

### DIFF
--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -87,13 +87,13 @@ exports[`AddData render 1`] = `
             grow={false}
           >
             <EuiButtonEmpty
-              data-test-subj="uploadData"
+              data-test-subj="uploadFile"
               href="#/tutorial_directory/fileDataViz"
               iconType="importAction"
             >
               <FormattedMessage
-                defaultMessage="Upload data"
-                id="home.addData.uploadDataButtonLabel"
+                defaultMessage="Upload a file"
+                id="home.addData.uploadFileButtonLabel"
                 values={Object {}}
               />
             </EuiButtonEmpty>

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -83,6 +83,21 @@ exports[`AddData render 1`] = `
               />
             </EuiButtonEmpty>
           </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiButtonEmpty
+              data-test-subj="uploadData"
+              href="#/tutorial_directory/fileDataViz"
+              iconType="importAction"
+            >
+              <FormattedMessage
+                defaultMessage="Upload data"
+                id="home.addData.uploadDataButtonLabel"
+                values={Object {}}
+              />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -96,6 +96,19 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode }) => 
                     />
                   </EuiButtonEmpty>
                 </EuiFlexItem>
+
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    data-test-subj="uploadData"
+                    href={addBasePath('#/tutorial_directory/fileDataViz')}
+                    iconType="importAction"
+                  >
+                    <FormattedMessage
+                      id="home.addData.uploadDataButtonLabel"
+                      defaultMessage="Upload data"
+                    />
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>
 

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -99,13 +99,13 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode }) => 
 
                 <EuiFlexItem grow={false}>
                   <EuiButtonEmpty
-                    data-test-subj="uploadData"
+                    data-test-subj="uploadFile"
                     href={addBasePath('#/tutorial_directory/fileDataViz')}
                     iconType="importAction"
                   >
                     <FormattedMessage
-                      id="home.addData.uploadDataButtonLabel"
-                      defaultMessage="Upload data"
+                      id="home.addData.uploadFileButtonLabel"
+                      defaultMessage="Upload a file"
                     />
                   </EuiButtonEmpty>
                 </EuiFlexItem>


### PR DESCRIPTION
Pending decision on https://github.com/elastic/kibana/issues/117018

Adds a link to the file upload page from the kibana home page.

<img width="634" alt="image" src="https://user-images.githubusercontent.com/22172091/139920000-b341157b-811a-4eda-bdb1-bfc01f8b866c.png">


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
