### PR TITLE
[bazel] Set cache for build, not common

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -13,10 +13,10 @@ test --experimental_guard_against_concurrent_changes
 query --experimental_guard_against_concurrent_changes
 
 ## Cache action outputs on disk so they persist across output_base and bazel shutdown (eg. changing branches)
-common --disk_cache=~/.bazel-cache/disk-cache
+build --disk_cache=~/.bazel-cache/disk-cache
 
 ## Bazel repo cache settings
-common --repository_cache=~/.bazel-cache/repository-cache
+build --repository_cache=~/.bazel-cache/repository-cache
 
 # Bazel will create symlinks from the workspace directory to output artifacts.
 # Build results will be placed in a directory called "bazel-bin"


### PR DESCRIPTION
These settings are not valid outside build, and cause commands like shutdown to fail.