### PR TITLE
[7.16] [App Search] Update API namespace and routes for Search Relevance Suggestions/Adaptive Relevance (#116994)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_logic.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_logic.test.tsx
@@ -122,7 +122,7 @@ describe('SuggestionsLogic', () => {
         await nextTick();
 
         expect(http.post).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify({
               page: {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_logic.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_logic.tsx
@@ -74,8 +74,8 @@ export const SuggestionsLogic = kea<MakeLogicType<SuggestionsValues, SuggestionA
       const { engineName } = EngineLogic.values;
 
       try {
-        const response = await http.post(
-          `/internal/app_search/engines/${engineName}/search_relevance_suggestions`,
+        const response = await http.post<SuggestionsAPIResponse>(
+          `/internal/app_search/engines/${engineName}/adaptive_relevance/suggestions`,
           {
             body: JSON.stringify({
               page: {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
@@ -295,7 +295,7 @@ describe('CurationLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify([
               {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -194,15 +194,18 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
       const { engineName } = EngineLogic.values;
 
       try {
-        await http.put(`/internal/app_search/engines/${engineName}/search_relevance_suggestions`, {
-          body: JSON.stringify([
-            {
-              query: values.activeQuery,
-              type: 'curation',
-              status: 'applied',
-            },
-          ]),
-        });
+        await http.put(
+          `/internal/app_search/engines/${engineName}/adaptive_relevance/suggestions`,
+          {
+            body: JSON.stringify([
+              {
+                query: values.activeQuery,
+                type: 'curation',
+                status: 'applied',
+              },
+            ]),
+          }
+        );
         actions.loadCuration();
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.test.ts
@@ -241,7 +241,7 @@ describe('CurationSuggestionLogic', () => {
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions/foo-query',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions/foo-query',
           {
             query: {
               type: 'curation',
@@ -297,7 +297,7 @@ describe('CurationSuggestionLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify([
               {
@@ -380,7 +380,7 @@ describe('CurationSuggestionLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify([
               {
@@ -463,7 +463,7 @@ describe('CurationSuggestionLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify([
               {
@@ -508,7 +508,7 @@ describe('CurationSuggestionLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify([
               {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curation_suggestion/curation_suggestion_logic.ts
@@ -79,8 +79,9 @@ export const CurationSuggestionLogic = kea<
       const { engineName } = EngineLogic.values;
 
       try {
-        const suggestionResponse = await http.get(
-          `/internal/app_search/engines/${engineName}/search_relevance_suggestions/${props.query}`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const suggestionResponse = await http.get<any>(
+          `/internal/app_search/engines/${engineName}/adaptive_relevance/suggestions/${props.query}`,
           {
             query: {
               type: 'curation',
@@ -250,7 +251,7 @@ const updateSuggestion = async (
   status: string
 ) => {
   const response = await http.put<{ results: Array<CurationSuggestion | Error> }>(
-    `/internal/app_search/engines/${engineName}/search_relevance_suggestions`,
+    `/internal/app_search/engines/${engineName}/adaptive_relevance/suggestions`,
     {
       body: JSON.stringify([
         {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/ignored_queries_panel/ignored_queries_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/ignored_queries_panel/ignored_queries_logic.test.ts
@@ -114,7 +114,7 @@ describe('IgnoredQueriesLogic', () => {
         await nextTick();
 
         expect(http.post).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify({
               page: {
@@ -170,7 +170,7 @@ describe('IgnoredQueriesLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/suggestions',
           {
             body: JSON.stringify([
               {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/ignored_queries_panel/ignored_queries_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_history/components/ignored_queries_panel/ignored_queries_logic.ts
@@ -89,7 +89,7 @@ export const IgnoredQueriesLogic = kea<MakeLogicType<IgnoredQueriesValues, Ignor
 
       try {
         const response: { results: CurationSuggestion[]; meta: Meta } = await http.post(
-          `/internal/app_search/engines/${engineName}/search_relevance_suggestions`,
+          `/internal/app_search/engines/${engineName}/adaptive_relevance/suggestions`,
           {
             body: JSON.stringify({
               page: {
@@ -116,7 +116,7 @@ export const IgnoredQueriesLogic = kea<MakeLogicType<IgnoredQueriesValues, Ignor
       try {
         const response = await http.put<{
           results: Array<CurationSuggestion | SuggestionUpdateError>;
-        }>(`/internal/app_search/engines/${engineName}/search_relevance_suggestions`, {
+        }>(`/internal/app_search/engines/${engineName}/adaptive_relevance/suggestions`, {
           body: JSON.stringify([
             {
               query: ignoredQuery,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings_logic.test.ts
@@ -97,7 +97,7 @@ describe('CurationsSettingsLogic', () => {
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions/settings'
+          '/internal/app_search/engines/some-engine/adaptive_relevance/settings'
         );
         expect(CurationsSettingsLogic.actions.onCurationsSettingsLoad).toHaveBeenCalledWith({
           enabled: true,
@@ -204,7 +204,7 @@ describe('CurationsSettingsLogic', () => {
         await nextTick();
 
         expect(http.put).toHaveBeenCalledWith(
-          '/internal/app_search/engines/some-engine/search_relevance_suggestions/settings',
+          '/internal/app_search/engines/some-engine/adaptive_relevance/settings',
           {
             body: JSON.stringify({
               curation: {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_settings/curations_settings_logic.ts
@@ -71,8 +71,8 @@ export const CurationsSettingsLogic = kea<
       const { engineName } = EngineLogic.values;
 
       try {
-        const response = await http.get(
-          `/internal/app_search/engines/${engineName}/search_relevance_suggestions/settings`
+        const response = await http.get<{ curation: CurationsSettings }>(
+          `/internal/app_search/engines/${engineName}/adaptive_relevance/settings`
         );
         actions.onCurationsSettingsLoad(response.curation);
       } catch (e) {
@@ -95,8 +95,8 @@ export const CurationsSettingsLogic = kea<
       const { http } = HttpLogic.values;
       const { engineName } = EngineLogic.values;
       try {
-        const response = await http.put(
-          `/internal/app_search/engines/${engineName}/search_relevance_suggestions/settings`,
+        const response = await http.put<{ curation: CurationsSettings }>(
+          `/internal/app_search/engines/${engineName}/adaptive_relevance/settings`,
           {
             body: JSON.stringify({ curation: currationsSetting }),
           }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/adaptive_relevance.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/adaptive_relevance.test.ts
@@ -7,17 +7,17 @@
 
 import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
 
-import { registerSearchRelevanceSuggestionsRoutes } from './search_relevance_suggestions';
+import { registerSearchRelevanceSuggestionsRoutes } from './adaptive_relevance';
 
 describe('search relevance insights routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('POST /internal/app_search/engines/{name}/search_relevance_suggestions', () => {
+  describe('POST /internal/app_search/engines/{name}/adaptive_relevance/suggestions', () => {
     const mockRouter = new MockRouter({
       method: 'post',
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/suggestions',
     });
 
     beforeEach(() => {
@@ -33,15 +33,15 @@ describe('search relevance insights routes', () => {
       });
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/api/as/v0/engines/:engineName/search_relevance_suggestions',
+        path: '/api/as/v0/engines/:engineName/adaptive_relevance/suggestions',
       });
     });
   });
 
-  describe('PUT /internal/app_search/engines/{name}/search_relevance_suggestions', () => {
+  describe('PUT /internal/app_search/engines/{name}/adaptive_relevance/suggestions', () => {
     const mockRouter = new MockRouter({
       method: 'put',
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/suggestions',
     });
 
     beforeEach(() => {
@@ -62,15 +62,15 @@ describe('search relevance insights routes', () => {
       });
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/api/as/v0/engines/:engineName/search_relevance_suggestions',
+        path: '/api/as/v0/engines/:engineName/adaptive_relevance/suggestions',
       });
     });
   });
 
-  describe('GET /internal/app_search/engines/{name}/search_relevance_suggestions/settings', () => {
+  describe('GET /internal/app_search/engines/{name}/adaptive_relevance/settings', () => {
     const mockRouter = new MockRouter({
       method: 'get',
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/settings',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/settings',
     });
 
     beforeEach(() => {
@@ -86,15 +86,15 @@ describe('search relevance insights routes', () => {
       });
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/settings',
+        path: '/api/as/v0/engines/:engineName/adaptive_relevance/settings',
       });
     });
   });
 
-  describe('PUT /internal/app_search/engines/{name}/search_relevance_suggestions/settings', () => {
+  describe('PUT /internal/app_search/engines/{name}/adaptive_relevance/settings', () => {
     const mockRouter = new MockRouter({
       method: 'put',
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/settings',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/settings',
     });
 
     beforeEach(() => {
@@ -111,15 +111,15 @@ describe('search relevance insights routes', () => {
       });
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/settings',
+        path: '/api/as/v0/engines/:engineName/adaptive_relevance/settings',
       });
     });
   });
 
-  describe('GET /internal/app_search/engines/{engineName}/search_relevance_suggestions/{query}', () => {
+  describe('GET /internal/app_search/engines/{engineName}/adaptive_relevance/suggestions/{query}', () => {
     const mockRouter = new MockRouter({
       method: 'get',
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/{query}',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/suggestions/{query}',
     });
 
     beforeEach(() => {
@@ -136,7 +136,7 @@ describe('search relevance insights routes', () => {
       });
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/as/engines/:engineName/search_relevance_suggestions/:query',
+        path: '/as/engines/:engineName/adaptive_relevance/suggestions/:query',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/adaptive_relevance.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/adaptive_relevance.ts
@@ -17,7 +17,7 @@ export function registerSearchRelevanceSuggestionsRoutes({
 }: RouteDependencies) {
   router.post(
     {
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/suggestions',
       validate: {
         params: schema.object({
           engineName: schema.string(),
@@ -35,13 +35,13 @@ export function registerSearchRelevanceSuggestionsRoutes({
       },
     },
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v0/engines/:engineName/search_relevance_suggestions',
+      path: '/api/as/v0/engines/:engineName/adaptive_relevance/suggestions',
     })
   );
 
   router.put(
     skipBodyValidation({
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/suggestions',
       validate: {
         params: schema.object({
           engineName: schema.string(),
@@ -49,13 +49,13 @@ export function registerSearchRelevanceSuggestionsRoutes({
       },
     }),
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v0/engines/:engineName/search_relevance_suggestions',
+      path: '/api/as/v0/engines/:engineName/adaptive_relevance/suggestions',
     })
   );
 
   router.get(
     {
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/settings',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/settings',
       validate: {
         params: schema.object({
           engineName: schema.string(),
@@ -63,13 +63,13 @@ export function registerSearchRelevanceSuggestionsRoutes({
       },
     },
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/settings',
+      path: '/api/as/v0/engines/:engineName/adaptive_relevance/settings',
     })
   );
 
   router.put(
     skipBodyValidation({
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/settings',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/settings',
       validate: {
         params: schema.object({
           engineName: schema.string(),
@@ -77,13 +77,13 @@ export function registerSearchRelevanceSuggestionsRoutes({
       },
     }),
     enterpriseSearchRequestHandler.createRequest({
-      path: '/api/as/v0/engines/:engineName/search_relevance_suggestions/settings',
+      path: '/api/as/v0/engines/:engineName/adaptive_relevance/settings',
     })
   );
 
   router.get(
     {
-      path: '/internal/app_search/engines/{engineName}/search_relevance_suggestions/{query}',
+      path: '/internal/app_search/engines/{engineName}/adaptive_relevance/suggestions/{query}',
       validate: {
         params: schema.object({
           engineName: schema.string(),
@@ -95,7 +95,7 @@ export function registerSearchRelevanceSuggestionsRoutes({
       },
     },
     enterpriseSearchRequestHandler.createRequest({
-      path: '/as/engines/:engineName/search_relevance_suggestions/:query',
+      path: '/as/engines/:engineName/adaptive_relevance/suggestions/:query',
     })
   );
 }

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
@@ -7,6 +7,7 @@
 
 import { RouteDependencies } from '../../plugin';
 
+import { registerSearchRelevanceSuggestionsRoutes } from './adaptive_relevance';
 import { registerAnalyticsRoutes } from './analytics';
 import { registerApiLogsRoutes } from './api_logs';
 import { registerCrawlerRoutes } from './crawler';
@@ -22,7 +23,6 @@ import { registerResultSettingsRoutes } from './result_settings';
 import { registerRoleMappingsRoutes } from './role_mappings';
 import { registerSchemaRoutes } from './schema';
 import { registerSearchRoutes } from './search';
-import { registerSearchRelevanceSuggestionsRoutes } from './search_relevance_suggestions';
 import { registerSearchSettingsRoutes } from './search_settings';
 import { registerSearchUIRoutes } from './search_ui';
 import { registerSettingsRoutes } from './settings';


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [App Search] Update API namespace and routes for Search Relevance Suggestions/Adaptive Relevance (#116994)