### PR TITLE
[8.0] Remove analytics event (#116995)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
@@ -412,6 +412,7 @@ describe('CurationLogic', () => {
         expect(http.put).toHaveBeenCalledWith(
           '/internal/app_search/engines/some-engine/curations/cur-123456789',
           {
+            query: { skip_record_analytics: 'true' },
             body: '{"queries":["a","b","c"],"query":"b","promoted":["d","e","f"],"hidden":["g"]}', // Uses state currently in CurationLogic
           }
         );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -251,6 +251,7 @@ export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, 
         const response = await http.put(
           `/internal/app_search/engines/${engineName}/curations/${props.curationId}`,
           {
+            query: { skip_record_analytics: 'true' },
             body: JSON.stringify({
               queries: values.queries,
               query: values.activeQuery,

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
@@ -85,6 +85,9 @@ export function registerCurationsRoutes({
     {
       path: '/internal/app_search/engines/{engineName}/curations/{curationId}',
       validate: {
+        query: schema.object({
+          skip_record_analytics: schema.string(),
+        }),
         params: schema.object({
           engineName: schema.string(),
           curationId: schema.string(),


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Remove analytics event (#116995)