### PR TITLE
[Enterprise Search] Update Role mappings modal copy

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -382,7 +382,7 @@ export const INVITATION_PENDING_LABEL = i18n.translate(
 
 export const ROLE_MODAL_TEXT = i18n.translate('xpack.enterpriseSearch.roleMapping.roleModalText', {
   defaultMessage:
-    'Removing a role mapping revokes access to any user corresponding to the mapping attributes, but may not take effect immediately for SAML-governed roles. Users with an active SAML session will retain access until it expires.',
+    'Removing a role mapping could revoke access to the currently logged-in user. Before proceeding, verify that the currently logged-in user has the appropriate access level via a different role mapping to avoid undesired behavior. This action may not take effect immediately for SAML-governed roles. Users with an active SAML session will retain access until it expires.',
 });
 
 export const USER_MODAL_TITLE = (username: string) =>


### PR DESCRIPTION
closes https://github.com/elastic/enterprise-search-team/issues/712

## Summary

Update Role mappings modal copy to help prevent edge case bug where users can lock themselves out.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
