### PR TITLE
[ML] Set data recognizer to ignore frozen indices

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/data_recognizer.ts
+++ b/x-pack/plugins/ml/server/models/data_recognizer/data_recognizer.ts
@@ -293,6 +293,8 @@ export class DataRecognizer {
       index,
       size,
       body: searchBody,
+      // Ignored indices that are frozen
+      ignore_throttled: true,
     });
 
     // @ts-expect-error incorrect search response type


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/116696. Currently, it will take a long time to get results from /api/ml/modules/recognize especially if the index pattern includes indices that are frozen. This PR sets `ignore_throttled` to true as we would not need to search for frozen. This should speed up the request.
