### PR TITLE
[8.0] [Reporting] Log TM health and drift stats prior to reporting tests (#117013)

### DIFF
--- a/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/index.ts
@@ -14,6 +14,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
     before(async () => {
       const reportingAPI = getService('reportingAPI');
+      await reportingAPI.logTaskManagerHealth();
       await reportingAPI.createDataAnalystRole();
       await reportingAPI.createTestReportingUserRole();
       await reportingAPI.createDataAnalyst();

--- a/x-pack/test/reporting_api_integration/reporting_without_security/index.ts
+++ b/x-pack/test/reporting_api_integration/reporting_without_security/index.ts
@@ -8,8 +8,12 @@
 import { FtrProviderContext } from '../ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
-export default function ({ loadTestFile }: FtrProviderContext) {
+export default function ({ loadTestFile, getService }: FtrProviderContext) {
   describe('Reporting API Integration Tests with Security disabled', function () {
+    before(async () => {
+      const reportingAPI = getService('reportingAPI');
+      await reportingAPI.logTaskManagerHealth();
+    });
     this.tags('ciGroup13');
     loadTestFile(require.resolve('./job_apis_csv'));
     loadTestFile(require.resolve('./job_apis_csv_deprecated'));

--- a/x-pack/test/reporting_api_integration/services/scenarios.ts
+++ b/x-pack/test/reporting_api_integration/services/scenarios.ts
@@ -36,6 +36,20 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
   const REPORTING_USER_USERNAME = 'reporting_user';
   const REPORTING_USER_PASSWORD = 'reporting_user-password';
 
+  const logTaskManagerHealth = async () => {
+    // Check task manager health for analyzing test failures. See https://github.com/elastic/kibana/issues/114946
+    const tmHealth = await supertest.get(`/api/task_manager/_health`);
+    const driftValues = tmHealth.body?.stats?.runtime?.value;
+
+    log.info(`Task Manager status: "${tmHealth.body?.status}"`);
+    log.info(`Task Manager overall drift rankings: "${JSON.stringify(driftValues?.drift)}"`);
+    log.info(
+      `Task Manager drift rankings for "report:execute": "${JSON.stringify(
+        driftValues?.drift_by_type?.['report:execute']
+      )}"`
+    );
+  };
+
   const initEcommerce = async () => {
     await esArchiver.load('x-pack/test/functional/es_archives/reporting/ecommerce');
     await kibanaServer.importExport.load(ecommerceSOPath);
@@ -205,6 +219,7 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
   };
 
   return {
+    logTaskManagerHealth,
     initEcommerce,
     teardownEcommerce,
     DATA_ANALYST_USERNAME,

--- a/x-pack/test/reporting_functional/reporting_and_deprecated_security/index.ts
+++ b/x-pack/test/reporting_functional/reporting_and_deprecated_security/index.ts
@@ -46,6 +46,8 @@ export default function (context: FtrProviderContext) {
     this.tags('ciGroup2');
 
     before(async () => {
+      const reportingAPI = context.getService('reportingAPI');
+      await reportingAPI.logTaskManagerHealth();
       await createDataAnalystRole();
       await createDataAnalyst();
       await createReportingUser();

--- a/x-pack/test/reporting_functional/reporting_and_security/index.ts
+++ b/x-pack/test/reporting_functional/reporting_and_security/index.ts
@@ -14,6 +14,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
     before(async () => {
       const reportingFunctional = getService('reportingFunctional');
+      await reportingFunctional.logTaskManagerHealth();
       await reportingFunctional.createDataAnalystRole();
       await reportingFunctional.createDataAnalyst();
       await reportingFunctional.createTestReportingUserRole();

--- a/x-pack/test/reporting_functional/reporting_without_security/index.ts
+++ b/x-pack/test/reporting_functional/reporting_without_security/index.ts
@@ -11,6 +11,12 @@ import { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ loadTestFile, getService }: FtrProviderContext) {
   describe('Reporting Functional Tests with Security disabled', function () {
     this.tags('ciGroup2');
+
+    before(async () => {
+      const reportingAPI = getService('reportingAPI');
+      await reportingAPI.logTaskManagerHealth();
+    });
+
     loadTestFile(require.resolve('./management'));
   });
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Reporting] Log TM health and drift stats prior to reporting tests (#117013)