### PR TITLE
[Security Solution][Prepackaged rules] Add late updates for filebeat threat match rule

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/threat_intel_module_match.json
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/threat_intel_module_match.json
@@ -3,7 +3,7 @@
     "Elastic"
   ],
   "description": "This rule is triggered when indicators from the Threat Intel Filebeat module has a match against local file or network observations.",
-  "from": "now-10m",
+  "from": "now-65m",
   "index": [
     "auditbeat-*",
     "endgame-*",
@@ -12,7 +12,7 @@
     "packetbeat-*",
     "winlogbeat-*"
   ],
-  "interval": "9m",
+  "interval": "1h",
   "language": "kuery",
   "license": "Elastic License v2",
   "name": "Threat Intel Filebeat Module Indicator Match",
@@ -194,5 +194,5 @@
   "timeline_id": "495ad7a7-316e-4544-8a0f-9c098daee76e",
   "timeline_title": "Generic Threat Match Timeline",
   "type": "threat_match",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
## Summary

These changes were merged upstream in https://github.com/elastic/detection-rules/pull/1596, but that happened after rules were released into kibana for 7.16 (https://github.com/elastic/kibana/pull/114939). This PR adds those missed changes.



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
