### PR TITLE
[7.16] make sure string mode popover is actually closed (#116585)

### DIFF
--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -508,15 +508,15 @@ export class VisualBuilderPageObject extends FtrService {
   public async toggleIndexPatternSelectionModePopover(shouldOpen: boolean) {
     await this.retry.try(async () => {
       const isPopoverOpened = await this.testSubjects.exists(
-        'switchIndexPatternSelectionModePopoverContent'
+        'switchIndexPatternSelectionMode'
       );
       if ((shouldOpen && !isPopoverOpened) || (!shouldOpen && isPopoverOpened)) {
-        await this.testSubjects.click('switchIndexPatternSelectionModePopoverButton');
+        await this.testSubjects.click('switchIndexPatternSelectionModePopover');
       }
       if (shouldOpen) {
-        await this.testSubjects.existOrFail('switchIndexPatternSelectionModePopoverContent');
+        await this.testSubjects.existOrFail('switchIndexPatternSelectionMode');
       } else {
-        await this.testSubjects.missingOrFail('switchIndexPatternSelectionModePopoverContent');
+        await this.testSubjects.missingOrFail('switchIndexPatternSelectionMode');
       }
     });
   }

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -507,9 +507,7 @@ export class VisualBuilderPageObject extends FtrService {
 
   public async toggleIndexPatternSelectionModePopover(shouldOpen: boolean) {
     await this.retry.try(async () => {
-      const isPopoverOpened = await this.testSubjects.exists(
-        'switchIndexPatternSelectionMode'
-      );
+      const isPopoverOpened = await this.testSubjects.exists('switchIndexPatternSelectionMode');
       if ((shouldOpen && !isPopoverOpened) || (!shouldOpen && isPopoverOpened)) {
         await this.testSubjects.click('switchIndexPatternSelectionModePopover');
       }

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -505,12 +505,29 @@ export class VisualBuilderPageObject extends FtrService {
     return await annotationTooltipDetails.getVisibleText();
   }
 
+  public async toggleIndexPatternSelectionModePopover(shouldOpen: boolean) {
+    await this.retry.try(async () => {
+      const isPopoverOpened = await this.testSubjects.exists(
+        'switchIndexPatternSelectionModePopoverContent'
+      );
+      if ((shouldOpen && !isPopoverOpened) || (!shouldOpen && isPopoverOpened)) {
+        await this.testSubjects.click('switchIndexPatternSelectionModePopoverButton');
+      }
+      if (shouldOpen) {
+        await this.testSubjects.existOrFail('switchIndexPatternSelectionModePopoverContent');
+      } else {
+        await this.testSubjects.missingOrFail('switchIndexPatternSelectionModePopoverContent');
+      }
+    });
+  }
+
   public async switchIndexPatternSelectionMode(useKibanaIndices: boolean) {
-    await this.testSubjects.click('switchIndexPatternSelectionModePopover');
+    await this.toggleIndexPatternSelectionModePopover(true);
     await this.testSubjects.setEuiSwitch(
       'switchIndexPatternSelectionMode',
       useKibanaIndices ? 'check' : 'uncheck'
     );
+    await this.toggleIndexPatternSelectionModePopover(false);
   }
 
   public async setIndexPatternValue(value: string, useKibanaIndices?: boolean) {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - make sure string mode popover is actually closed (#116585)