### PR TITLE
[8.0] use more robust way of entering value (#116566)

### DIFF
--- a/test/functional/apps/visualize/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/_tsvb_time_series.ts
@@ -193,8 +193,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/115529
-      describe.skip('Elastic charts', () => {
+      describe('Elastic charts', () => {
         beforeEach(async () => {
           await visualBuilder.toggleNewChartsLibraryWithDebug(true);
           await visualBuilder.clickPanelOptions('timeSeries');

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -664,7 +664,10 @@ export class VisualBuilderPageObject extends FtrService {
   public async setBackgroundColor(colorHex: string): Promise<void> {
     await this.clickColorPicker();
     await this.checkColorPickerPopUpIsPresent();
-    await this.find.setValue('.euiColorPicker input', colorHex);
+    await this.testSubjects.setValue('euiColorPickerInput_top', colorHex, {
+      clearWithKeyboard: true,
+      typeCharByChar: true,
+    });
     await this.clickColorPicker();
     await this.visChart.waitForVisualizationRenderingStabilized();
   }
@@ -677,7 +680,10 @@ export class VisualBuilderPageObject extends FtrService {
   public async setColorPickerValue(colorHex: string, nth: number = 0): Promise<void> {
     await this.clickColorPicker(nth);
     await this.checkColorPickerPopUpIsPresent();
-    await this.find.setValue('.euiColorPicker input', colorHex);
+    await this.testSubjects.setValue('euiColorPickerInput_top', colorHex, {
+      clearWithKeyboard: true,
+      typeCharByChar: true,
+    });
     await this.clickColorPicker(nth);
     await this.visChart.waitForVisualizationRenderingStabilized();
   }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - use more robust way of entering value (#116566)