### PR TITLE
[ML] Removing log error statements when no ingest pipelines exist

### DIFF
--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
@@ -49,26 +49,35 @@ export function modelsProvider(
         modelIds.map((id: string) => [id, null])
       );
 
-      const { body, statusCode } = await client.asCurrentUser.ingest.getPipeline();
+      try {
+        const { body, statusCode } = await client.asCurrentUser.ingest.getPipeline();
 
-      if (statusCode !== 200) {
-        return modelIdsMap;
-      }
+        if (statusCode !== 200) {
+          return modelIdsMap;
+        }
 
-      for (const [pipelineName, pipelineDefinition] of Object.entries(body)) {
-        const { processors } = pipelineDefinition as { processors: Array<Record<string, any>> };
+        for (const [pipelineName, pipelineDefinition] of Object.entries(body)) {
+          const { processors } = pipelineDefinition as { processors: Array<Record<string, any>> };
 
-        for (const processor of processors) {
-          const id = processor.inference?.model_id;
-          if (modelIdsMap.has(id)) {
-            const obj = modelIdsMap.get(id);
-            if (obj === null) {
-              modelIdsMap.set(id, { [pipelineName]: pipelineDefinition });
-            } else {
-              obj![pipelineName] = pipelineDefinition;
+          for (const processor of processors) {
+            const id = processor.inference?.model_id;
+            if (modelIdsMap.has(id)) {
+              const obj = modelIdsMap.get(id);
+              if (obj === null) {
+                modelIdsMap.set(id, { [pipelineName]: pipelineDefinition });
+              } else {
+                obj![pipelineName] = pipelineDefinition;
+              }
             }
           }
         }
+      } catch (error) {
+        if (error.statusCode === 404) {
+          // ES returns 404 when there are no pipelines
+          // Instead, we should return the modelIdsMap and a 200
+          return modelIdsMap;
+        }
+        throw error;
       }
 
       return modelIdsMap;

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts
@@ -50,11 +50,7 @@ export function modelsProvider(
       );
 
       try {
-        const { body, statusCode } = await client.asCurrentUser.ingest.getPipeline();
-
-        if (statusCode !== 200) {
-          return modelIdsMap;
-        }
+        const { body } = await client.asCurrentUser.ingest.getPipeline();
 
         for (const [pipelineName, pipelineDefinition] of Object.entries(body)) {
           const { processors } = pipelineDefinition as { processors: Array<Record<string, any>> };


### PR DESCRIPTION
Follows on from https://github.com/elastic/kibana/pull/116999

If no ingest pipelines exist, es will return a `404` when asking for all pipelines.
The change made in https://github.com/elastic/kibana/pull/116999 now means we are flooding kibana's log with errors, when really we should be ignoring the 404s and assuming an empty pipeline list.

Example error:
```
[2021-11-03T10:20:46.499+00:00][ERROR][plugins.ml] ResponseError: {}
    at KibanaTransport.request (/Users/james/dev/kibana/node_modules/@elastic/transport/src/Transport.ts:520:17)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Ingest.getPipeline (/Users/james/dev/kibana/node_modules/@elastic/elasticsearch/src/api/api/ingest.ts:118:12)
    at Object.getModelsPipelines (/Users/james/dev/kibana/x-pack/plugins/ml/server/models/data_frame_analytics/models_provider.ts:52:36)
    at /Users/james/dev/kibana/x-pack/plugins/ml/server/routes/trained_models.ts:64:39
    at Router.handle (/Users/james/dev/kibana/src/core/server/http/router/router.ts:275:30)
    at handler (/Users/james/dev/kibana/src/core/server/http/router/router.ts:230:13)
    at exports.Manager.execute (/Users/james/dev/kibana/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at Object.internals.handler (/Users/james/dev/kibana/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at exports.execute (/Users/james/dev/kibana/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at Request._lifecycle (/Users/james/dev/kibana/node_modules/@hapi/hapi/lib/request.js:371:32)
    at Request._execute (/Users/james/dev/kibana/node_modules/@hapi/hapi/lib/request.js:281:9)
```


This is how the ingest pipeline UI handles it: https://github.com/elastic/kibana/blob/ee63830072a5d5a248b5514a32687e70da8ed2bd/x-pack/plugins/ingest_pipelines/server/routes/api/get.ts#L29
