### PR TITLE
[Fleet] Fix agent logs not reading query from URL

### DIFF
--- a/src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts
+++ b/src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts
@@ -63,7 +63,7 @@ export const createKbnUrlStateStorage = (
     onGetError,
     onSetError,
   }: {
-    useHash?: boolean;
+    useHash: boolean;
     useHashQuery?: boolean;
     history?: History;
     onGetError?: (error: Error) => void;

--- a/src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts
+++ b/src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts
@@ -63,7 +63,7 @@ export const createKbnUrlStateStorage = (
     onGetError,
     onSetError,
   }: {
-    useHash: boolean;
+    useHash?: boolean;
     useHashQuery?: boolean;
     history?: History;
     onGetError?: (error: Error) => void;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
@@ -56,7 +56,7 @@ export const AgentLogs: React.FunctionComponent<Pick<AgentLogsProps, 'agent' | '
     const [isSyncReady, setIsSyncReady] = useState<boolean>(false);
 
     useEffect(() => {
-      const stateStorage = createKbnUrlStateStorage({ useHashQuery: false });
+      const stateStorage = createKbnUrlStateStorage({ useHashQuery: false, useHash: false });
       const { start, stop } = syncState({
         storageKey: STATE_STORAGE_KEY,
         stateContainer: stateContainer as INullableBaseStateContainer<AgentLogsState>,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
@@ -56,7 +56,7 @@ export const AgentLogs: React.FunctionComponent<Pick<AgentLogsProps, 'agent' | '
     const [isSyncReady, setIsSyncReady] = useState<boolean>(false);
 
     useEffect(() => {
-      const stateStorage = createKbnUrlStateStorage();
+      const stateStorage = createKbnUrlStateStorage({ useHashQuery: false });
       const { start, stop } = syncState({
         storageKey: STATE_STORAGE_KEY,
         stateContainer: stateContainer as INullableBaseStateContainer<AgentLogsState>,


### PR DESCRIPTION
## Summary

Fixes #112412

In #106267 we converted Fleet routing to not use hashes. We then moved to not reading the agent logs state from the URL hash in #109982 but the URL state storage connector was still storing the query using the hash, causing a mismatch.  

