### PR TITLE
[Task Manager] Removing perf_hooks from task manager

### DIFF
--- a/x-pack/plugins/task_manager/server/task_pool.ts
+++ b/x-pack/plugins/task_manager/server/task_pool.ts
@@ -11,7 +11,6 @@
  */
 import { Observable, Subject } from 'rxjs';
 import moment, { Duration } from 'moment';
-import { performance } from 'perf_hooks';
 import { padStart } from 'lodash';
 import { Logger } from '../../../../src/core/server';
 import { TaskRunner } from './task_running';
@@ -111,7 +110,6 @@ export class TaskPool {
   public run = async (tasks: TaskRunner[]): Promise<TaskPoolRunResult> => {
     const [tasksToRun, leftOverTasks] = partitionListByCount(tasks, this.availableWorkers);
     if (tasksToRun.length) {
-      performance.mark('attemptToRun_start');
       await Promise.all(
         tasksToRun
           .filter((taskRunner) => !this.tasksInPool.has(taskRunner.id))
@@ -130,9 +128,6 @@ export class TaskPool {
               .catch((err) => this.handleFailureOfMarkAsRunning(taskRunner, err));
           })
       );
-
-      performance.mark('attemptToRun_stop');
-      performance.measure('taskPool.attemptToRun', 'attemptToRun_start', 'attemptToRun_stop');
     }
 
     if (leftOverTasks.length) {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/116636

## Summary

Removed `perf_hooks` from task manager. There were not used for anything and, as of Node 16.7, were potentially causing a memory leak because they were not being cleared.


