### PR TITLE
[App Search] Fixed content not displayed for automatic curations

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.test.tsx
@@ -28,7 +28,7 @@ const MOCK_VALUES = {
   },
   // EngineLogic
   engine: {
-    search_relevance_suggestions_active: true,
+    adaptive_relevance_suggestions_active: true,
   },
 };
 
@@ -53,7 +53,7 @@ describe('SuggestedDocumentsCallout', () => {
   });
 
   it('is empty when suggestions are not active', () => {
-    const values = set('engine.search_relevance_suggestions_active', false, MOCK_VALUES);
+    const values = set('engine.adaptive_relevance_suggestions_active', false, MOCK_VALUES);
     setMockValues(values);
 
     const wrapper = shallow(<SuggestedDocumentsCallout />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.tsx
@@ -22,13 +22,13 @@ export const SuggestedDocumentsCallout: React.FC = () => {
     curation: { suggestion, queries },
   } = useValues(CurationLogic);
   const {
-    engine: { search_relevance_suggestions_active: searchRelevanceSuggestionsActive },
+    engine: { adaptive_relevance_suggestions_active: adaptiveRelevanceSuggestionsActive },
   } = useValues(EngineLogic);
 
   if (
     typeof suggestion === 'undefined' ||
     suggestion.status !== 'pending' ||
-    searchRelevanceSuggestionsActive === false
+    adaptiveRelevanceSuggestionsActive === false
   ) {
     return null;
   }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
@@ -55,7 +55,7 @@ describe('Curations', () => {
     },
     // EngineLogic
     engine: {
-      search_relevance_suggestions_active: true,
+      adaptive_relevance_suggestions_active: true,
     },
   };
 
@@ -89,7 +89,7 @@ describe('Curations', () => {
   });
 
   it('renders less tabs when suggestions are not active', () => {
-    setMockValues(set('engine.search_relevance_suggestions_active', false, values));
+    setMockValues(set('engine.adaptive_relevance_suggestions_active', false, values));
     const wrapper = shallow(<Curations />);
 
     expect(getPageTitle(wrapper)).toEqual('Curated results');
@@ -99,7 +99,7 @@ describe('Curations', () => {
   });
 
   it('renders a New! badge  when suggestions are not active', () => {
-    setMockValues(set('engine.search_relevance_suggestions_active', false, values));
+    setMockValues(set('engine.adaptive_relevance_suggestions_active', false, values));
     const wrapper = shallow(<Curations />);
 
     expect(getPageTitle(wrapper)).toEqual('Curated results');
@@ -109,7 +109,7 @@ describe('Curations', () => {
   });
 
   it('hides the badge when suggestions are active', () => {
-    setMockValues(set('engine.search_relevance_suggestions_active', true, values));
+    setMockValues(set('engine.adaptive_relevance_suggestions_active', true, values));
     const wrapper = shallow(<Curations />);
 
     expect(getPageTitle(wrapper)).toEqual('Curated results');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
@@ -30,10 +30,10 @@ export const Curations: React.FC = () => {
   const { dataLoading, meta, selectedPageTab } = useValues(CurationsLogic);
   const { loadCurations, onSelectPageTab } = useActions(CurationsLogic);
   const {
-    engine: { search_relevance_suggestions_active: searchRelevanceSuggestionsActive },
+    engine: { adaptive_relevance_suggestions_active: adaptiveRelevanceSuggestionsActive },
   } = useValues(EngineLogic);
 
-  const suggestionsEnabled = searchRelevanceSuggestionsActive;
+  const suggestionsEnabled = adaptiveRelevanceSuggestionsActive;
 
   const OVERVIEW_TAB = {
     label: i18n.translate(
@@ -72,7 +72,7 @@ export const Curations: React.FC = () => {
     ),
   };
 
-  const pageTabs = searchRelevanceSuggestionsActive
+  const pageTabs = adaptiveRelevanceSuggestionsActive
     ? [OVERVIEW_TAB, HISTORY_TAB, SETTINGS_TAB]
     : [OVERVIEW_TAB, SETTINGS_TAB];
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_overview.test.tsx
@@ -36,7 +36,7 @@ const MOCK_VALUES = {
   ],
   // EngineLogic
   engine: {
-    search_relevance_suggestions_active: true,
+    adaptive_relevance_suggestions_active: true,
   },
 };
 
@@ -71,14 +71,14 @@ describe('CurationsOverview', () => {
   });
 
   it('renders a suggestions table when suggestions are active', () => {
-    setMockValues(set('engine.search_relevance_suggestions_active', true, MOCK_VALUES));
+    setMockValues(set('engine.adaptive_relevance_suggestions_active', true, MOCK_VALUES));
     const wrapper = shallow(<CurationsOverview />);
 
     expect(wrapper.find(SuggestionsTable).exists()).toBe(true);
   });
 
   it('doesn\t render a suggestions table when suggestions are not active', () => {
-    setMockValues(set('engine.search_relevance_suggestions_active', false, MOCK_VALUES));
+    setMockValues(set('engine.adaptive_relevance_suggestions_active', false, MOCK_VALUES));
     const wrapper = shallow(<CurationsOverview />);
 
     expect(wrapper.find(SuggestionsTable).exists()).toBe(false);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations_overview.tsx
@@ -19,10 +19,10 @@ import { CurationsLogic } from '../curations_logic';
 export const CurationsOverview: React.FC = () => {
   const { curations } = useValues(CurationsLogic);
   const {
-    engine: { search_relevance_suggestions_active: searchRelevanceSuggestionsActive },
+    engine: { adaptive_relevance_suggestions_active: adaptiveRelevanceSuggestionsActive },
   } = useValues(EngineLogic);
 
-  const shouldShowSuggestions = searchRelevanceSuggestionsActive;
+  const shouldShowSuggestions = adaptiveRelevanceSuggestionsActive;
 
   return (
     <>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -43,7 +43,7 @@ describe('EngineLogic', () => {
     schema: { test: SchemaType.Text },
     apiTokens: [],
     apiKey: 'some-key',
-    search_relevance_suggestions_active: true,
+    adaptive_relevance_suggestions_active: true,
   };
 
   const DEFAULT_VALUES = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -53,8 +53,8 @@ export interface EngineDetails extends Engine {
   isMeta: boolean;
   engine_count?: number;
   includedEngines?: EngineDetails[];
-  search_relevance_suggestions?: SearchRelevanceSuggestionDetails;
-  search_relevance_suggestions_active: boolean;
+  adaptive_relevance_suggestions?: SearchRelevanceSuggestionDetails;
+  adaptive_relevance_suggestions_active: boolean;
 }
 
 interface ResultField {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.test.tsx
@@ -19,12 +19,12 @@ import { SuggestedCurationsCallout } from './suggested_curations_callout';
 
 const MOCK_VALUES = {
   engine: {
-    search_relevance_suggestions: {
+    adaptive_relevance_suggestions: {
       curation: {
         pending: 1,
       },
     },
-    search_relevance_suggestions_active: true,
+    adaptive_relevance_suggestions_active: true,
   },
 };
 
@@ -44,7 +44,7 @@ describe('SuggestedCurationsCallout', () => {
     setMockValues({
       ...MOCK_VALUES,
       engine: {
-        search_relevance_suggestions_active: true,
+        adaptive_relevance_suggestions_active: true,
       },
     });
 
@@ -54,7 +54,7 @@ describe('SuggestedCurationsCallout', () => {
   });
 
   it('is empty when suggestions are not active', () => {
-    const values = set('engine.search_relevance_suggestions_active', false, MOCK_VALUES);
+    const values = set('engine.adaptive_relevance_suggestions_active', false, MOCK_VALUES);
     setMockValues(values);
 
     const wrapper = shallow(<SuggestedCurationsCallout />);
@@ -63,7 +63,7 @@ describe('SuggestedCurationsCallout', () => {
   });
 
   it('is empty when no pending curations', () => {
-    const values = set('engine.search_relevance_suggestions.curation.pending', 0, MOCK_VALUES);
+    const values = set('engine.adaptive_relevance_suggestions.curation.pending', 0, MOCK_VALUES);
     setMockValues(values);
 
     const wrapper = shallow(<SuggestedCurationsCallout />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.tsx
@@ -17,17 +17,17 @@ import { EngineLogic, generateEnginePath } from '../../engine';
 export const SuggestedCurationsCallout: React.FC = () => {
   const {
     engine: {
-      search_relevance_suggestions: searchRelevanceSuggestions,
-      search_relevance_suggestions_active: searchRelevanceSuggestionsActive,
+      adaptive_relevance_suggestions: adaptiveRelevanceSuggestions,
+      adaptive_relevance_suggestions_active: adaptiveRelevanceSuggestionsActive,
     },
   } = useValues(EngineLogic);
 
-  const pendingCount = searchRelevanceSuggestions?.curation.pending;
+  const pendingCount = adaptiveRelevanceSuggestions?.curation.pending;
 
   if (
-    typeof searchRelevanceSuggestions === 'undefined' ||
+    typeof adaptiveRelevanceSuggestions === 'undefined' ||
     pendingCount === 0 ||
-    searchRelevanceSuggestionsActive === false
+    adaptiveRelevanceSuggestionsActive === false
   ) {
     return null;
   }
@@ -46,7 +46,7 @@ export const SuggestedCurationsCallout: React.FC = () => {
         }
       )}
       buttonTo={generateEnginePath(ENGINE_CURATIONS_PATH)}
-      lastUpdatedTimestamp={searchRelevanceSuggestions.curation.last_updated}
+      lastUpdatedTimestamp={adaptiveRelevanceSuggestions.curation.last_updated}
     />
   );
 };


### PR DESCRIPTION
## Summary

This fixes https://github.com/elastic/app-search-team/issues/2190

The bug was "Suggestions table and History tab not displayed in Curations".

The backend property name changed, and we weren't looking for the updated property name on the front end.