### PR TITLE
[8.0] [Share] The redirect app path should not appear in the browser history (#117155)

### DIFF
--- a/src/plugins/share/public/url_service/redirect/redirect_manager.test.ts
+++ b/src/plugins/share/public/url_service/redirect/redirect_manager.test.ts
@@ -57,9 +57,12 @@ describe('on page mount', () => {
         })
       )}`
     );
-    expect(spy).toHaveBeenCalledWith({
-      foo: 'bar',
-    });
+    expect(spy).toHaveBeenCalledWith(
+      {
+        foo: 'bar',
+      },
+      { replace: true }
+    );
   });
 
   test('migrates parameters on-the-fly to the latest version', async () => {
@@ -73,9 +76,12 @@ describe('on page mount', () => {
         })
       )}`
     );
-    expect(spy).toHaveBeenCalledWith({
-      num: 2,
-    });
+    expect(spy).toHaveBeenCalledWith(
+      {
+        num: 2,
+      },
+      { replace: true }
+    );
   });
 
   test('throws if locator does not exist', async () => {

--- a/src/plugins/share/public/url_service/redirect/redirect_manager.ts
+++ b/src/plugins/share/public/url_service/redirect/redirect_manager.ts
@@ -66,7 +66,9 @@ export class RedirectManager {
     });
 
     locator
-      .navigate(migratedParams)
+      .navigate(migratedParams, {
+        replace: true, // We do not want the redirect app URL to appear in browser navigation history
+      })
       .then()
       .catch((error) => {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Share] The redirect app path should not appear in the browser history (#117155)