### PR TITLE
[Uptime] adjust the synthetics journey type

### DIFF
--- a/x-pack/plugins/uptime/common/runtime_types/ping/synthetics.ts
+++ b/x-pack/plugins/uptime/common/runtime_types/ping/synthetics.ts
@@ -27,7 +27,7 @@ export const JourneyStepType = t.intersection([
         lt: t.string,
       }),
     }),
-    observer: t.type({
+    observer: t.partial({
       geo: t.type({
         name: t.string,
       }),


### PR DESCRIPTION
## Summary

APIs used by the step details page were throwing API response errors when steps did not have the `observer.geo.name` key. This PR adjusts the type to account for journeys without a location name.

Previously this type of error message was displayed.

<img width="555" alt="Screen Shot 2021-11-03 at 9 48 14 AM" src="https://user-images.githubusercontent.com/11356435/140072555-8ed55cda-b9a0-40ae-a8f5-a3b420bc184c.png">

Now no error messages should be displayed.

### Testing
Navigate to the step details page of a browser monitor in the Uptime App
Open the console, ensure there are no API console errors.