### PR TITLE
[Fleet] Add deprecation level to all fleet deprecations

### DIFF
--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -45,42 +45,59 @@ export const config: PluginConfigDescriptor = {
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
     // Fleet plugin was named ingestManager before
-    renameFromRoot('xpack.ingestManager.enabled', 'xpack.fleet.enabled'),
-    renameFromRoot('xpack.ingestManager.registryUrl', 'xpack.fleet.registryUrl'),
-    renameFromRoot('xpack.ingestManager.registryProxyUrl', 'xpack.fleet.registryProxyUrl'),
-    renameFromRoot('xpack.ingestManager.fleet', 'xpack.ingestManager.agents'),
-    renameFromRoot('xpack.ingestManager.agents.enabled', 'xpack.fleet.agents.enabled'),
-    renameFromRoot('xpack.ingestManager.agents.elasticsearch', 'xpack.fleet.agents.elasticsearch'),
+    renameFromRoot('xpack.ingestManager.enabled', 'xpack.fleet.enabled', { level: 'critical' }),
+    renameFromRoot('xpack.ingestManager.registryUrl', 'xpack.fleet.registryUrl', {
+      level: 'critical',
+    }),
+    renameFromRoot('xpack.ingestManager.registryProxyUrl', 'xpack.fleet.registryProxyUrl', {
+      level: 'critical',
+    }),
+    renameFromRoot('xpack.ingestManager.fleet', 'xpack.ingestManager.agents', {
+      level: 'critical',
+    }),
+    renameFromRoot('xpack.ingestManager.agents.enabled', 'xpack.fleet.agents.enabled', {
+      level: 'critical',
+    }),
+    renameFromRoot('xpack.ingestManager.agents.elasticsearch', 'xpack.fleet.agents.elasticsearch', {
+      level: 'critical',
+    }),
     renameFromRoot(
       'xpack.ingestManager.agents.tlsCheckDisabled',
-      'xpack.fleet.agents.tlsCheckDisabled'
+      'xpack.fleet.agents.tlsCheckDisabled',
+      { level: 'critical' }
     ),
     renameFromRoot(
       'xpack.ingestManager.agents.pollingRequestTimeout',
-      'xpack.fleet.agents.pollingRequestTimeout'
+      'xpack.fleet.agents.pollingRequestTimeout',
+      { level: 'critical' }
     ),
     renameFromRoot(
       'xpack.ingestManager.agents.maxConcurrentConnections',
-      'xpack.fleet.agents.maxConcurrentConnections'
+      'xpack.fleet.agents.maxConcurrentConnections',
+      { level: 'critical' }
     ),
-    renameFromRoot('xpack.ingestManager.agents.kibana', 'xpack.fleet.agents.kibana'),
+    renameFromRoot('xpack.ingestManager.agents.kibana', 'xpack.fleet.agents.kibana', {
+      level: 'critical',
+    }),
     renameFromRoot(
       'xpack.ingestManager.agents.agentPolicyRolloutRateLimitIntervalMs',
-      'xpack.fleet.agents.agentPolicyRolloutRateLimitIntervalMs'
+      'xpack.fleet.agents.agentPolicyRolloutRateLimitIntervalMs',
+      { level: 'critical' }
     ),
     renameFromRoot(
       'xpack.ingestManager.agents.agentPolicyRolloutRateLimitRequestPerInterval',
-      'xpack.fleet.agents.agentPolicyRolloutRateLimitRequestPerInterval'
+      'xpack.fleet.agents.agentPolicyRolloutRateLimitRequestPerInterval',
+      { level: 'critical' }
     ),
-    unusedFromRoot('xpack.ingestManager'),
+    unusedFromRoot('xpack.ingestManager', { level: 'critical' }),
     // Unused settings before Fleet server exists
-    unused('agents.kibana'),
-    unused('agents.maxConcurrentConnections'),
-    unused('agents.agentPolicyRolloutRateLimitIntervalMs'),
-    unused('agents.agentPolicyRolloutRateLimitRequestPerInterval'),
-    unused('agents.pollingRequestTimeout'),
-    unused('agents.tlsCheckDisabled'),
-    unused('agents.fleetServerEnabled'),
+    unused('agents.kibana', { level: 'critical' }),
+    unused('agents.maxConcurrentConnections', { level: 'critical' }),
+    unused('agents.agentPolicyRolloutRateLimitIntervalMs', { level: 'critical' }),
+    unused('agents.agentPolicyRolloutRateLimitRequestPerInterval', { level: 'critical' }),
+    unused('agents.pollingRequestTimeout', { level: 'critical' }),
+    unused('agents.tlsCheckDisabled', { level: 'critical' }),
+    unused('agents.fleetServerEnabled', { level: 'critical' }),
     // Renaming elasticsearch.host => elasticsearch.hosts
     (fullConfig, fromPath, addDeprecation) => {
       const oldValue = fullConfig?.xpack?.fleet?.agents?.elasticsearch?.host;
@@ -95,6 +112,7 @@ export const config: PluginConfigDescriptor = {
               `Use [xpack.fleet.agents.elasticsearch.hosts] with an array of host instead.`,
             ],
           },
+          level: 'critical',
         });
       }
 


### PR DESCRIPTION
## Summary

Part of #115344, we need to set the log level for all of our deprecations. `critical` is the default which we have been using up until now so I am continuing with that level. 

