### PR TITLE
[Uptime] increase timeout and clear mocks for UptimeDatePicker flaky test

### DIFF
--- a/x-pack/plugins/uptime/public/components/common/uptime_date_picker.test.tsx
+++ b/x-pack/plugins/uptime/public/components/common/uptime_date_picker.test.tsx
@@ -12,8 +12,13 @@ import { createMemoryHistory } from 'history';
 import { render } from '../../lib/helper/rtl_helpers';
 import { fireEvent } from '@testing-library/dom';
 
-// FLAKY: https://github.com/elastic/kibana/issues/114396
-describe.skip('UptimeDatePicker component', () => {
+describe('UptimeDatePicker component', () => {
+  jest.setTimeout(10_000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders properly with mock data', async () => {
     const { findByText } = render(<UptimeDatePicker />);
     expect(await findByText('Last 15 minutes')).toBeInTheDocument();
@@ -86,7 +91,7 @@ describe.skip('UptimeDatePicker component', () => {
 
     // it should update shared state
 
-    expect(startPlugins.data.query.timefilter.timefilter.setTime).toHaveBeenCalledTimes(3);
+    expect(startPlugins.data.query.timefilter.timefilter.setTime).toHaveBeenCalledTimes(2);
 
     expect(startPlugins.data.query.timefilter.timefilter.setTime).toHaveBeenCalledWith({
       from: 'now-10m',


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/114396

Increase timeout of flaky UptimeDatePicker test.

This change also clears mocks for this tests, and adjusts the expected values based on the now cleared mocks.

This test has been checked for flakyness by running in a loop for 200 iterations locally.