### PR TITLE
[File data visualizer] Disabling create data view based on capabilities

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/common/components/results_links/results_links.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/results_links/results_links.tsx
@@ -58,7 +58,13 @@ export const ResultsLinks: FC<Props> = ({
   additionalLinks,
 }) => {
   const {
-    services: { fileUpload },
+    services: {
+      fileUpload,
+      application: { getUrlForApp, capabilities },
+      share: {
+        urlGenerators: { getUrlGenerator },
+      },
+    },
   } = useDataVisualizerKibana();
 
   const [duration, setDuration] = useState({
@@ -71,15 +77,6 @@ export const ResultsLinks: FC<Props> = ({
   const [indexManagementLink, setIndexManagementLink] = useState('');
   const [indexPatternManagementLink, setIndexPatternManagementLink] = useState('');
   const [generatedLinks, setGeneratedLinks] = useState<Record<string, string>>({});
-
-  const {
-    services: {
-      application: { getUrlForApp, capabilities },
-      share: {
-        urlGenerators: { getUrlGenerator },
-      },
-    },
-  } = useDataVisualizerKibana();
 
   useEffect(() => {
     let unmounted = false;
@@ -137,11 +134,14 @@ export const ResultsLinks: FC<Props> = ({
       setIndexManagementLink(
         getUrlForApp('management', { path: '/data/index_management/indices' })
       );
-      setIndexPatternManagementLink(
-        getUrlForApp('management', {
-          path: `/kibana/indexPatterns${createIndexPattern ? `/patterns/${indexPatternId}` : ''}`,
-        })
-      );
+
+      if (capabilities.indexPatterns.save === true) {
+        setIndexPatternManagementLink(
+          getUrlForApp('management', {
+            path: `/kibana/indexPatterns${createIndexPattern ? `/patterns/${indexPatternId}` : ''}`,
+          })
+        );
+      }
     }
 
     return () => {

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/file_data_visualizer_view/file_data_visualizer_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/file_data_visualizer_view/file_data_visualizer_view.js
@@ -295,12 +295,7 @@ export class FileDataVisualizerView extends Component {
       <div>
         {mode === MODE.READ && (
           <>
-            {!loading && !loaded && (
-              <AboutPanel
-                onFilePickerChange={this.onFilePickerChange}
-                disabled={!fileCouldNotBeReadPermissionError}
-              />
-            )}
+            {!loading && !loaded && <AboutPanel onFilePickerChange={this.onFilePickerChange} />}
 
             {loading && <LoadingPanel />}
 
@@ -373,6 +368,7 @@ export class FileDataVisualizerView extends Component {
               savedObjectsClient={this.savedObjectsClient}
               fileUpload={this.props.fileUpload}
               resultsLinks={this.props.resultsLinks}
+              capabilities={this.props.capabilities}
             />
 
             {bottomBarVisible && (

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/advanced.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/advanced.tsx
@@ -21,7 +21,7 @@ import {
 import { CombinedField, CombinedFieldsForm } from '../../../common/components/combined_fields';
 import { JsonEditor, EDITOR_MODE } from '../json_editor';
 import { FindFileStructureResponse } from '../../../../../../file_upload/common';
-import { DataViewToolTip } from './data_view_tooltip';
+import { CreateDataViewToolTip } from './create_data_view_tooltip';
 const EDITOR_HEIGHT = '300px';
 
 interface Props {
@@ -101,7 +101,7 @@ export const AdvancedSettings: FC<Props> = ({
 
       <EuiSpacer size="m" />
 
-      <DataViewToolTip showTooltip={canCreateDataView === false}>
+      <CreateDataViewToolTip showTooltip={canCreateDataView === false}>
         <EuiCheckbox
           id="createIndexPattern"
           label={
@@ -114,7 +114,7 @@ export const AdvancedSettings: FC<Props> = ({
           disabled={initialized === true || canCreateDataView === false}
           onChange={onCreateIndexPatternChange}
         />
-      </DataViewToolTip>
+      </CreateDataViewToolTip>
 
       <EuiSpacer size="s" />
 

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/advanced.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/advanced.tsx
@@ -21,6 +21,7 @@ import {
 import { CombinedField, CombinedFieldsForm } from '../../../common/components/combined_fields';
 import { JsonEditor, EDITOR_MODE } from '../json_editor';
 import { FindFileStructureResponse } from '../../../../../../file_upload/common';
+import { DataViewToolTip } from './data_view_tooltip';
 const EDITOR_HEIGHT = '300px';
 
 interface Props {
@@ -42,6 +43,7 @@ interface Props {
   combinedFields: CombinedField[];
   onCombinedFieldsChange(combinedFields: CombinedField[]): void;
   results: FindFileStructureResponse;
+  canCreateDataView: boolean;
 }
 
 export const AdvancedSettings: FC<Props> = ({
@@ -63,6 +65,7 @@ export const AdvancedSettings: FC<Props> = ({
   combinedFields,
   onCombinedFieldsChange,
   results,
+  canCreateDataView,
 }) => {
   return (
     <React.Fragment>
@@ -98,18 +101,20 @@ export const AdvancedSettings: FC<Props> = ({
 
       <EuiSpacer size="m" />
 
-      <EuiCheckbox
-        id="createIndexPattern"
-        label={
-          <FormattedMessage
-            id="xpack.dataVisualizer.file.advancedImportSettings.createDataViewLabel"
-            defaultMessage="Create data view"
-          />
-        }
-        checked={createIndexPattern === true}
-        disabled={initialized === true}
-        onChange={onCreateIndexPatternChange}
-      />
+      <DataViewToolTip showTooltip={canCreateDataView === false}>
+        <EuiCheckbox
+          id="createIndexPattern"
+          label={
+            <FormattedMessage
+              id="xpack.dataVisualizer.file.advancedImportSettings.createDataViewLabel"
+              defaultMessage="Create data view"
+            />
+          }
+          checked={createIndexPattern === true}
+          disabled={initialized === true || canCreateDataView === false}
+          onChange={onCreateIndexPatternChange}
+        />
+      </DataViewToolTip>
 
       <EuiSpacer size="s" />
 

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/create_data_view_tooltip.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/create_data_view_tooltip.tsx
@@ -14,7 +14,7 @@ interface Props {
   showTooltip: boolean;
 }
 
-export const DataViewToolTip: FC<Props> = ({ children, showTooltip }) => {
+export const CreateDataViewToolTip: FC<Props> = ({ children, showTooltip }) => {
   return (
     <EuiToolTip
       position="top"
@@ -22,7 +22,7 @@ export const DataViewToolTip: FC<Props> = ({ children, showTooltip }) => {
         showTooltip ? (
           <FormattedMessage
             id="xpack.dataVisualizer.file.cannotCreateDataView.tooltip"
-            defaultMessage="You require permission to create data views"
+            defaultMessage="You need permission to create data views."
           />
         ) : null
       }

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/data_view_tooltip.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/data_view_tooltip.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { EuiToolTip } from '@elastic/eui';
+
+interface Props {
+  children?: React.ReactElement;
+  showTooltip: boolean;
+}
+
+export const DataViewToolTip: FC<Props> = ({ children, showTooltip }) => {
+  return (
+    <EuiToolTip
+      position="top"
+      content={
+        showTooltip ? (
+          <FormattedMessage
+            id="xpack.dataVisualizer.file.cannotCreateDataView.tooltip"
+            defaultMessage="You require permission to create data views"
+          />
+        ) : null
+      }
+    >
+      {children}
+    </EuiToolTip>
+  );
+};

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/import_settings.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/import_settings.tsx
@@ -14,6 +14,7 @@ import { SimpleSettings } from './simple';
 import { AdvancedSettings } from './advanced';
 import { CombinedField } from '../../../common/components/combined_fields';
 import { FindFileStructureResponse } from '../../../../../../file_upload/common';
+import { useDataVisualizerKibana } from '../../../kibana_context';
 
 interface Props {
   index: string;
@@ -56,6 +57,14 @@ export const ImportSettings: FC<Props> = ({
   onCombinedFieldsChange,
   results,
 }) => {
+  const {
+    services: {
+      application: { capabilities },
+    },
+  } = useDataVisualizerKibana();
+
+  const canCreateDataView = capabilities.savedObjectsManagement.edit as boolean;
+
   const tabs = [
     {
       id: 'simple-settings',
@@ -74,6 +83,7 @@ export const ImportSettings: FC<Props> = ({
             onCreateIndexPatternChange={onCreateIndexPatternChange}
             indexNameError={indexNameError}
             combinedFields={combinedFields}
+            canCreateDataView={canCreateDataView}
           />
         </React.Fragment>
       ),
@@ -106,6 +116,7 @@ export const ImportSettings: FC<Props> = ({
             combinedFields={combinedFields}
             onCombinedFieldsChange={onCombinedFieldsChange}
             results={results}
+            canCreateDataView={canCreateDataView}
           />
         </React.Fragment>
       ),

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/import_settings.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/import_settings.tsx
@@ -63,7 +63,8 @@ export const ImportSettings: FC<Props> = ({
     },
   } = useDataVisualizerKibana();
 
-  const canCreateDataView = capabilities.savedObjectsManagement.edit as boolean;
+  const canCreateDataView =
+    capabilities.savedObjectsManagement.edit === true || capabilities.indexPatterns.save === true;
 
   const tabs = [
     {

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/simple.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/simple.tsx
@@ -14,7 +14,7 @@ import {
   CombinedField,
   CombinedFieldsReadOnlyForm,
 } from '../../../common/components/combined_fields';
-import { DataViewToolTip } from './data_view_tooltip';
+import { CreateDataViewToolTip } from './create_data_view_tooltip';
 
 interface Props {
   index: string;
@@ -72,7 +72,7 @@ export const SimpleSettings: FC<Props> = ({
 
       <EuiSpacer size="m" />
 
-      <DataViewToolTip showTooltip={canCreateDataView === false}>
+      <CreateDataViewToolTip showTooltip={canCreateDataView === false}>
         <EuiCheckbox
           id="createIndexPattern"
           label={
@@ -86,7 +86,7 @@ export const SimpleSettings: FC<Props> = ({
           onChange={onCreateIndexPatternChange}
           data-test-subj="dataVisualizerFileCreateIndexPatternCheckbox"
         />
-      </DataViewToolTip>
+      </CreateDataViewToolTip>
 
       <EuiSpacer size="m" />
 

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/simple.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_settings/simple.tsx
@@ -14,6 +14,7 @@ import {
   CombinedField,
   CombinedFieldsReadOnlyForm,
 } from '../../../common/components/combined_fields';
+import { DataViewToolTip } from './data_view_tooltip';
 
 interface Props {
   index: string;
@@ -23,6 +24,7 @@ interface Props {
   onCreateIndexPatternChange(): void;
   indexNameError: string;
   combinedFields: CombinedField[];
+  canCreateDataView: boolean;
 }
 
 export const SimpleSettings: FC<Props> = ({
@@ -33,6 +35,7 @@ export const SimpleSettings: FC<Props> = ({
   onCreateIndexPatternChange,
   indexNameError,
   combinedFields,
+  canCreateDataView,
 }) => {
   return (
     <React.Fragment>
@@ -69,19 +72,21 @@ export const SimpleSettings: FC<Props> = ({
 
       <EuiSpacer size="m" />
 
-      <EuiCheckbox
-        id="createIndexPattern"
-        label={
-          <FormattedMessage
-            id="xpack.dataVisualizer.file.simpleImportSettings.createDataViewLabel"
-            defaultMessage="Create data view"
-          />
-        }
-        checked={createIndexPattern === true}
-        disabled={initialized === true}
-        onChange={onCreateIndexPatternChange}
-        data-test-subj="dataVisualizerFileCreateIndexPatternCheckbox"
-      />
+      <DataViewToolTip showTooltip={canCreateDataView === false}>
+        <EuiCheckbox
+          id="createIndexPattern"
+          label={
+            <FormattedMessage
+              id="xpack.dataVisualizer.file.simpleImportSettings.createDataViewLabel"
+              defaultMessage="Create data view"
+            />
+          }
+          checked={createIndexPattern === true}
+          disabled={initialized === true || canCreateDataView === false}
+          onChange={onCreateIndexPatternChange}
+          data-test-subj="dataVisualizerFileCreateIndexPatternCheckbox"
+        />
+      </DataViewToolTip>
 
       <EuiSpacer size="m" />
 

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
@@ -85,7 +85,7 @@ export class ImportView extends Component {
   }
 
   clickReset = () => {
-    const state = getDefaultState(this.state, this.props.results);
+    const state = getDefaultState(this.state, this.props.results, this.props.capabilities);
     this.setState(state, () => {
       this.loadIndexPatternNames();
     });

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
@@ -76,7 +76,7 @@ export class ImportView extends Component {
   constructor(props) {
     super(props);
 
-    this.state = getDefaultState(DEFAULT_STATE, this.props.results);
+    this.state = getDefaultState(DEFAULT_STATE, this.props.results, this.props.capabilities);
     this.savedObjectsClient = props.savedObjectsClient;
   }
 
@@ -640,7 +640,7 @@ async function createKibanaIndexPattern(indexPatternName, indexPatterns, timeFie
   }
 }
 
-function getDefaultState(state, results) {
+function getDefaultState(state, results, capabilities) {
   const indexSettingsString =
     state.indexSettingsString === ''
       ? JSON.stringify(DEFAULT_INDEX_SETTINGS, null, 2)
@@ -666,6 +666,9 @@ function getDefaultState(state, results) {
 
   const timeFieldName = results.timestamp_field;
 
+  const createIndexPattern =
+    capabilities.savedObjectsManagement.edit === false ? false : state.createIndexPattern;
+
   return {
     ...DEFAULT_STATE,
     indexSettingsString,
@@ -673,6 +676,7 @@ function getDefaultState(state, results) {
     pipelineString,
     timeFieldName,
     combinedFields,
+    createIndexPattern,
   };
 }
 

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
@@ -667,7 +667,9 @@ function getDefaultState(state, results, capabilities) {
   const timeFieldName = results.timestamp_field;
 
   const createIndexPattern =
-    capabilities.savedObjectsManagement.edit === false ? false : state.createIndexPattern;
+    capabilities.savedObjectsManagement.edit === false && capabilities.indexPatterns.save === false
+      ? false
+      : state.createIndexPattern;
 
   return {
     ...DEFAULT_STATE,

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx
@@ -39,6 +39,7 @@ export const FileDataVisualizer: FC<Props> = ({ additionalLinks }) => {
         http={coreStart.http}
         fileUpload={fileUpload}
         resultsLinks={additionalLinks}
+        capabilities={coreStart.application.capabilities}
       />
     </KibanaContextProvider>
   );

--- a/x-pack/plugins/ml/public/application/datavisualizer/file_based/file_datavisualizer.tsx
+++ b/x-pack/plugins/ml/public/application/datavisualizer/file_based/file_datavisualizer.tsx
@@ -89,7 +89,7 @@ export const FileDataVisualizerPage: FC = () => {
             },
           });
         },
-        canDisplay: async () => true,
+        canDisplay: async ({ indexPatternId }) => indexPatternId !== '',
       },
     ],
     []


### PR DESCRIPTION
If the user does not have permission to create index patterns, we should disable the option in the UI.

![image](https://user-images.githubusercontent.com/22172091/140090133-a79dcc13-1028-492a-b835-0576bbd9fda3.png)

Also removes the link to manage data views if the user does not have permission. 
Also removes link to the index data visualizer if the index pattern hasn't been created. (ML only)

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

