### PR TITLE
[Workplace Search] Fix a bug where error not displaying when connector misconfigured

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -546,8 +546,8 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
           navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
         }
       } catch (e) {
-        flashAPIErrors(e);
         navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
+        flashAPIErrors(e);
       }
     },
     createContentSource: async ({ serviceType, successCallback, errorCallback }) => {


### PR DESCRIPTION
closes https://github.com/elastic/workplace-search-team/issues/1926

## Summary

This PR fixes a bug where the error was not displaying when misconfigured connector was connected and redirected back. The issue was that the redirect was occuring after the flash message was set and the fix was to redirect and then show the flash message

**Before**
![before](https://user-images.githubusercontent.com/1869731/140091361-8744aa89-b7d6-40e4-b543-38f8570bf238.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/140091410-86b690b3-fafe-4b94-be1f-929a22b09cd6.gif)

