### PR TITLE
add Core team as owner for global "typings" folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -232,6 +232,7 @@
 /src/core/  @elastic/kibana-core
 /src/plugins/saved_objects_tagging_oss  @elastic/kibana-core
 /config/kibana.yml @elastic/kibana-core
+/typings/ @elastic/kibana-core
 /x-pack/plugins/banners/  @elastic/kibana-core
 /x-pack/plugins/features/  @elastic/kibana-core
 /x-pack/plugins/licensing/  @elastic/kibana-core


### PR DESCRIPTION
## Summary

As per a discussion with @stacey-gammon and @spalger.