### PR TITLE
Remove Fleet setup call from Integrations app

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/app.tsx
@@ -5,21 +5,14 @@
  * 2.0.
  */
 
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo } from 'react';
 import type { AppMountParameters } from 'kibana/public';
 import { EuiErrorBoundary, EuiPortal } from '@elastic/eui';
 import type { History } from 'history';
 import { Router, Redirect, Route, Switch } from 'react-router-dom';
-import { FormattedMessage } from '@kbn/i18n/react';
 import useObservable from 'react-use/lib/useObservable';
 
-import {
-  ConfigContext,
-  FleetStatusProvider,
-  KibanaVersionContext,
-  sendGetPermissionsCheck,
-  sendSetup,
-} from '../../hooks';
+import { ConfigContext, FleetStatusProvider, KibanaVersionContext } from '../../hooks';
 
 import type { FleetConfigType, FleetStartServices } from '../../plugin';
 
@@ -32,90 +25,13 @@ import { EuiThemeProvider } from '../../../../../../src/plugins/kibana_react/com
 import { AgentPolicyContextProvider, useUrlModal } from './hooks';
 import { INTEGRATIONS_ROUTING_PATHS, pagePathGetters } from './constants';
 
-import { Error, Loading, SettingFlyout } from './components';
+import { SettingFlyout } from './components';
 
 import type { UIExtensionsStorage } from './types';
 
 import { EPMApp } from './sections/epm';
-import { DefaultLayout } from './layouts';
-import { PackageInstallProvider } from './hooks';
-import { useBreadcrumbs, UIExtensionsContext } from './hooks';
+import { PackageInstallProvider, UIExtensionsContext } from './hooks';
 import { IntegrationsHeader } from './components/header';
-
-const ErrorLayout = ({ children }: { children: JSX.Element }) => (
-  <EuiErrorBoundary>
-    <DefaultLayout>{children}</DefaultLayout>
-  </EuiErrorBoundary>
-);
-
-export const WithPermissionsAndSetup: React.FC = memo(({ children }) => {
-  useBreadcrumbs('integrations');
-
-  const [isPermissionsLoading, setIsPermissionsLoading] = useState<boolean>(false);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [initializationError, setInitializationError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    (async () => {
-      setIsInitialized(false);
-      setInitializationError(null);
-      try {
-        // Attempt Fleet Setup if user has permissions, otherwise skip
-        setIsPermissionsLoading(true);
-        const permissionsResponse = await sendGetPermissionsCheck();
-        setIsPermissionsLoading(false);
-
-        if (permissionsResponse.data?.success) {
-          try {
-            const setupResponse = await sendSetup();
-            if (setupResponse.error) {
-              setInitializationError(setupResponse.error);
-            }
-          } catch (err) {
-            setInitializationError(err);
-          }
-          setIsInitialized(true);
-        } else {
-          setIsInitialized(true);
-        }
-      } catch {
-        // If there's an error checking permissions, default to proceeding without running setup
-        // User will only have access to EPM endpoints if they actually have permission
-        setIsInitialized(true);
-      }
-    })();
-  }, []);
-
-  if (isPermissionsLoading) {
-    return (
-      <ErrorLayout>
-        <Loading />
-      </ErrorLayout>
-    );
-  }
-
-  if (!isInitialized || initializationError) {
-    return (
-      <ErrorLayout>
-        {initializationError ? (
-          <Error
-            title={
-              <FormattedMessage
-                id="xpack.fleet.initializationErrorMessageTitle"
-                defaultMessage="Unable to initialize Fleet"
-              />
-            }
-            error={initializationError}
-          />
-        ) : (
-          <Loading />
-        )}
-      </ErrorLayout>
-    );
-  }
-
-  return <>{children}</>;
-});
 
 /**
  * Fleet Application context all the way down to the Router, but with no permissions or setup checks

--- a/x-pack/plugins/fleet/public/applications/integrations/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/index.tsx
@@ -15,7 +15,7 @@ import type { FleetConfigType, FleetStartServices } from '../../plugin';
 import { licenseService } from '../../hooks';
 import type { UIExtensionsStorage } from '../../types';
 
-import { AppRoutes, IntegrationsAppContext, WithPermissionsAndSetup } from './app';
+import { AppRoutes, IntegrationsAppContext } from './app';
 
 export interface ProtectedRouteProps extends RouteProps {
   isAllowed?: boolean;
@@ -58,9 +58,7 @@ const IntegrationsApp = ({
       extensions={extensions}
       setHeaderActionMenu={setHeaderActionMenu}
     >
-      <WithPermissionsAndSetup>
-        <AppRoutes />
-      </WithPermissionsAndSetup>
+      <AppRoutes />
     </IntegrationsAppContext>
   );
 };


### PR DESCRIPTION
## Summary

This improves the experience when Fleet setup fails for some reason by still allowing the user to view the other integrations. Instead, setup is called when the user starts adding their first Fleet integration and are redirected to the Fleet app.

It also greatly improves the load time for the Integrations app for on-prem users who have not yet run the Fleet setup process.