### PR TITLE
[Dashboard] Fix Flaky Tests

### DIFF
--- a/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_security.ts
@@ -499,8 +499,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/116881
-    describe.skip('no dashboard privileges', () => {
+    describe('no dashboard privileges', () => {
       before(async () => {
         await security.role.create('no_dashboard_privileges_role', {
           elasticsearch: {


### PR DESCRIPTION
Unskips a flaky set of tests in dashboard_security.  

Flaky test runner results, could not reproduce the flakiness.  https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/227

Closes #116881