### PR TITLE
[Security Solution][Investigations] - Update timeline host and ip fields to be clickable

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/stateful_cell.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/data_driven_columns/stateful_cell.tsx
@@ -51,6 +51,7 @@ const StatefulCellComponent = ({
         isExpandable: true,
         isExpanded: false,
         isDetails: false,
+        isTimeline: true,
         linkValues,
         rowIndex: ariaRowindex - 1,
         setCellProps,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/cell_rendering/default_cell_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/cell_rendering/default_cell_renderer.tsx
@@ -32,6 +32,7 @@ export const DefaultCellRenderer: React.FC<CellValueElementProps> = ({
   header,
   isDetails,
   isDraggable,
+  isTimeline,
   linkValues,
   rowRenderers,
   setCellProps,
@@ -49,7 +50,7 @@ export const DefaultCellRenderer: React.FC<CellValueElementProps> = ({
     <>
       <StyledContent className={styledContentClassName} $isDetails={isDetails}>
         {getColumnRenderer(header.id, columnRenderers, data).renderColumn({
-          asPlainText: !!getLink(header.id, header.type), // we want to render value with links as plain text but keep other formatters like badge.
+          asPlainText: !!getLink(header.id, header.type) && !isTimeline, // we want to render value with links as plain text but keep other formatters like badge.
           browserFields,
           columnName: header.id,
           ecsData,

--- a/x-pack/plugins/timelines/common/types/timeline/cells/index.ts
+++ b/x-pack/plugins/timelines/common/types/timeline/cells/index.ts
@@ -23,6 +23,7 @@ export type CellValueElementProps = EuiDataGridCellValueElementProps & {
   globalFilters?: Filter[];
   header: ColumnHeaderOptions;
   isDraggable: boolean;
+  isTimeline?: boolean; // Default cell renderer is used for both the alert table and timeline. This allows us to cheaply separate concerns
   linkValues: string[] | undefined;
   rowRenderers?: RowRenderer[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/kibana/issues/116558 . 

A bug was introduced by accident that removed functionality from timeline as the `DefaultCellRenderer` component is shared by both the alert table and timeline. This PR introduces a boolean flag `isTimeline` to allow for differentiating the two. With this flag, we can now separate functionality between the alert table and timeline such as allowing the host and ip fields to be clickable (and show hover actions) in the timeline versus the fly in actions in the alert table: 

**Test:ing**
- Verify clicking the host.name field opens the side panel in the timeline flyout (query and pinned tabs)
- Verify clicking the ip fields (source.ip, destination.ip) opens the side panel in the timeline flyout (query and pinned tabs)
- Verify the hover actions are functioning again in the timeline flyout for host.name and ip fields
- Verify that the host.name and ip fields are not clickable in the alert table or hosts table

The fix:

![image](https://user-images.githubusercontent.com/17211684/140173719-3289d8d7-ced9-4af3-b99f-a879c9181617.png)
