### PR TITLE
[Security Solution][Endpoint] Show correct completed response message on activity log

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/log_entry.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/log_entry.tsx
@@ -129,9 +129,9 @@ const useLogEntryUIProps = (
       if (isIsolateAction) {
         if (isCompleted) {
           if (isSuccessful) {
-            return i18.ACTIVITY_LOG.LogEntry.response.unisolationCompletedAndSuccessful;
+            return i18.ACTIVITY_LOG.LogEntry.response.isolationCompletedAndSuccessful;
           }
-          return i18.ACTIVITY_LOG.LogEntry.response.unisolationCompletedAndUnsuccessful;
+          return i18.ACTIVITY_LOG.LogEntry.response.isolationCompletedAndUnsuccessful;
         } else if (isSuccessful) {
           return i18.ACTIVITY_LOG.LogEntry.response.isolationSuccessful;
         } else {


### PR DESCRIPTION
## Summary

Fixes an earlier [commit](https://github.com/elastic/kibana/pull/114905/files#diff-41a74ad41665921620230a0729728f3bf6e27a6f9dc302fb37b0d2061637c212R131-R135) with incorrect messages for isolation response, which showed the same message on completion of isolate/unisolate action.



The screenshot below shows the correct message for `isolation` action response
**screenshot (this change)**
![image](https://user-images.githubusercontent.com/1849116/140175303-41578862-4fa6-49b8-a57b-630e31eacb16.png)
