### PR TITLE
[Security Solution][Investigations] - Default enable copy icon tooltip

### DIFF
--- a/x-pack/plugins/timelines/public/components/clipboard/with_copy_to_clipboard.tsx
+++ b/x-pack/plugins/timelines/public/components/clipboard/with_copy_to_clipboard.tsx
@@ -26,7 +26,7 @@ export const WithCopyToClipboard = React.memo<{
   showTooltip?: boolean;
   text: string;
   titleSummary?: string;
-}>(({ isHoverAction, keyboardShortcut = '', showTooltip = false, text, titleSummary }) => {
+}>(({ isHoverAction, keyboardShortcut = '', showTooltip = true, text, titleSummary }) => {
   return showTooltip ? (
     <EuiToolTip
       content={


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/kibana/issues/115534

We now default enable the tooltip for the copy button. This copy button is only visible / used in the hover actions and the only place where it's actually visible as a hover action is within the draggables.

![image](https://user-images.githubusercontent.com/17211684/140177037-e752cd8c-ef47-4486-b662-5121144dabff.png)