### PR TITLE
[7.15] [APM] Don't use transaction metrics if set to never (#117370)

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/aggregated_transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/aggregated_transactions/index.ts
@@ -66,16 +66,21 @@ export async function getSearchAggregatedTransactions({
   const searchAggregatedTransactions =
     config['xpack.apm.searchAggregatedTransactions'];
 
-  if (
-    kuery ||
-    searchAggregatedTransactions === SearchAggregatedTransactionSetting.auto
-  ) {
-    return getHasAggregatedTransactions({ start, end, apmEventClient, kuery });
+  switch (searchAggregatedTransactions) {
+    case SearchAggregatedTransactionSetting.always:
+      return kuery
+        ? getHasAggregatedTransactions({ start, end, apmEventClient, kuery })
+        : true;
+    case SearchAggregatedTransactionSetting.auto:
+      return getHasAggregatedTransactions({
+        start,
+        end,
+        apmEventClient,
+        kuery,
+      });
+    case SearchAggregatedTransactionSetting.never:
+      return false;
   }
-
-  return (
-    searchAggregatedTransactions === SearchAggregatedTransactionSetting.always
-  );
 }
 
 export function getTransactionDurationFieldForAggregatedTransactions(


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [APM] Don't use transaction metrics if set to never (#117370)