### PR TITLE
[Maps][7.16] set deprecation level

### DIFF
--- a/x-pack/plugins/maps/server/index.ts
+++ b/x-pack/plugins/maps/server/index.ts
@@ -24,7 +24,7 @@ export const config: PluginConfigDescriptor<MapsXPackConfig> = {
   },
   schema: configSchema,
   deprecations: ({ deprecate }) => [
-    deprecate('enabled', '8.0.0', { level: 'critical'}),
+    deprecate('enabled', '8.0.0', { level: 'critical' }),
     (
       completeConfig: Record<string, any>,
       rootPath: string,

--- a/x-pack/plugins/maps/server/index.ts
+++ b/x-pack/plugins/maps/server/index.ts
@@ -24,7 +24,7 @@ export const config: PluginConfigDescriptor<MapsXPackConfig> = {
   },
   schema: configSchema,
   deprecations: ({ deprecate }) => [
-    deprecate('enabled', '8.0.0'),
+    deprecate('enabled', '8.0.0', { level: 'critical'}),
     (
       completeConfig: Record<string, any>,
       rootPath: string,
@@ -35,6 +35,7 @@ export const config: PluginConfigDescriptor<MapsXPackConfig> = {
       }
       addDeprecation({
         configPath: 'xpack.maps.showMapVisualizationTypes',
+        level: 'critical',
         message: i18n.translate('xpack.maps.deprecation.showMapVisualizationTypes.message', {
           defaultMessage:
             'xpack.maps.showMapVisualizationTypes is deprecated and is no longer used',
@@ -61,6 +62,7 @@ export const config: PluginConfigDescriptor<MapsXPackConfig> = {
       }
       addDeprecation({
         configPath: 'map.proxyElasticMapsServiceInMaps',
+        level: 'critical',
         documentationUrl: `https://www.elastic.co/guide/en/kibana/${branch}/maps-connect-to-ems.html#elastic-maps-server`,
         message: i18n.translate('xpack.maps.deprecation.proxyEMS.message', {
           defaultMessage: 'map.proxyElasticMapsServiceInMaps is deprecated and is no longer used',
@@ -89,6 +91,7 @@ export const config: PluginConfigDescriptor<MapsXPackConfig> = {
       }
       addDeprecation({
         configPath: 'map.regionmap',
+        level: 'critical',
         message: i18n.translate('xpack.maps.deprecation.regionmap.message', {
           defaultMessage: 'map.regionmap is deprecated and is no longer used',
         }),


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/115344

Set level for map deprecations. All levels set to "critical" because each depreciation removed an item from kibana.yml and kibana will not start with unknown kibana.yml settings.