### PR TITLE
[ML] Hide anomaly entity filter button tooltips when clicked

### DIFF
--- a/x-pack/plugins/ml/public/application/components/anomalies_table/influencers_cell.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/influencers_cell.js
@@ -59,13 +59,14 @@ export class InfluencersCell extends Component {
               <EuiButtonIcon
                 size="s"
                 className="filter-button"
-                onClick={() =>
+                onClick={(e) => {
+                  e.target.blur(); // Remove focus from button so tooltip is hidden on click
                   influencerFilter(
                     influencer.influencerFieldName,
                     influencer.influencerFieldValue,
                     '+'
-                  )
-                }
+                  );
+                }}
                 iconType="plusInCircle"
                 aria-label={i18n.translate(
                   'xpack.ml.anomaliesTable.influencersCell.addFilterAriaLabel',
@@ -86,13 +87,14 @@ export class InfluencersCell extends Component {
               <EuiButtonIcon
                 size="s"
                 className="filter-button"
-                onClick={() =>
+                onClick={(e) => {
+                  e.target.blur(); // Remove focus from button so tooltip is hidden on click
                   influencerFilter(
                     influencer.influencerFieldName,
                     influencer.influencerFieldValue,
                     '-'
-                  )
-                }
+                  );
+                }}
                 iconType="minusInCircle"
                 aria-label={i18n.translate(
                   'xpack.ml.anomaliesTable.influencersCell.removeFilterAriaLabel',

--- a/x-pack/plugins/ml/public/application/components/anomalies_table/influencers_cell.js
+++ b/x-pack/plugins/ml/public/application/components/anomalies_table/influencers_cell.js
@@ -12,6 +12,7 @@ import React, { Component } from 'react';
 import { EuiLink, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
+import { blurButtonOnClick } from '../../util/component_utils';
 
 /*
  * Component for rendering a list of record influencers inside a cell in the anomalies table.
@@ -59,14 +60,13 @@ export class InfluencersCell extends Component {
               <EuiButtonIcon
                 size="s"
                 className="filter-button"
-                onClick={(e) => {
-                  e.target.blur(); // Remove focus from button so tooltip is hidden on click
+                onClick={blurButtonOnClick(() => {
                   influencerFilter(
                     influencer.influencerFieldName,
                     influencer.influencerFieldValue,
                     '+'
                   );
-                }}
+                })}
                 iconType="plusInCircle"
                 aria-label={i18n.translate(
                   'xpack.ml.anomaliesTable.influencersCell.addFilterAriaLabel',
@@ -87,14 +87,13 @@ export class InfluencersCell extends Component {
               <EuiButtonIcon
                 size="s"
                 className="filter-button"
-                onClick={(e) => {
-                  e.target.blur(); // Remove focus from button so tooltip is hidden on click
+                onClick={blurButtonOnClick(() => {
                   influencerFilter(
                     influencer.influencerFieldName,
                     influencer.influencerFieldValue,
                     '-'
                   );
-                }}
+                })}
                 iconType="minusInCircle"
                 aria-label={i18n.translate(
                   'xpack.ml.anomaliesTable.influencersCell.removeFilterAriaLabel',

--- a/x-pack/plugins/ml/public/application/components/entity_cell/entity_cell.tsx
+++ b/x-pack/plugins/ml/public/application/components/entity_cell/entity_cell.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC } from 'react';
+import React, { FC, MouseEvent } from 'react';
 
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -41,7 +41,10 @@ function getAddFilter({ entityName, entityValue, filter }: EntityCellProps) {
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={() => filter(entityName, entityValue, ENTITY_FIELD_OPERATIONS.ADD)}
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
+            filter(entityName, entityValue, ENTITY_FIELD_OPERATIONS.ADD);
+          }}
           iconType="plusInCircle"
           aria-label={i18n.translate('xpack.ml.anomaliesTable.entityCell.addFilterAriaLabel', {
             defaultMessage: 'Add filter',
@@ -66,7 +69,10 @@ function getRemoveFilter({ entityName, entityValue, filter }: EntityCellProps) {
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={() => filter(entityName, entityValue, ENTITY_FIELD_OPERATIONS.REMOVE)}
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
+            filter(entityName, entityValue, ENTITY_FIELD_OPERATIONS.REMOVE);
+          }}
           iconType="minusInCircle"
           aria-label={i18n.translate('xpack.ml.anomaliesTable.entityCell.removeFilterAriaLabel', {
             defaultMessage: 'Remove filter',

--- a/x-pack/plugins/ml/public/application/components/entity_cell/entity_cell.tsx
+++ b/x-pack/plugins/ml/public/application/components/entity_cell/entity_cell.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FC, MouseEvent } from 'react';
+import React, { FC } from 'react';
 
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiText, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -13,6 +13,7 @@ import { i18n } from '@kbn/i18n';
 import { EMPTY_FIELD_VALUE_LABEL } from '../../timeseriesexplorer/components/entity_control/entity_control';
 import { MLCATEGORY } from '../../../../common/constants/field_types';
 import { ENTITY_FIELD_OPERATIONS } from '../../../../common/util/anomaly_utils';
+import { blurButtonOnClick } from '../../util/component_utils';
 
 export type EntityCellFilter = (
   entityName: string,
@@ -41,10 +42,9 @@ function getAddFilter({ entityName, entityValue, filter }: EntityCellProps) {
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={(event: MouseEvent<HTMLButtonElement>) => {
-            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
+          onClick={blurButtonOnClick(() => {
             filter(entityName, entityValue, ENTITY_FIELD_OPERATIONS.ADD);
-          }}
+          })}
           iconType="plusInCircle"
           aria-label={i18n.translate('xpack.ml.anomaliesTable.entityCell.addFilterAriaLabel', {
             defaultMessage: 'Add filter',
@@ -69,10 +69,9 @@ function getRemoveFilter({ entityName, entityValue, filter }: EntityCellProps) {
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={(event: MouseEvent<HTMLButtonElement>) => {
-            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
+          onClick={blurButtonOnClick(() => {
             filter(entityName, entityValue, ENTITY_FIELD_OPERATIONS.REMOVE);
-          }}
+          })}
           iconType="minusInCircle"
           aria-label={i18n.translate('xpack.ml.anomaliesTable.entityCell.removeFilterAriaLabel', {
             defaultMessage: 'Remove filter',

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/components/explorer_chart_label/entity_filter/entity_filter.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/components/explorer_chart_label/entity_filter/entity_filter.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { FC, MouseEvent } from 'react';
+import React, { FC } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
@@ -12,6 +12,7 @@ import {
   ENTITY_FIELD_OPERATIONS,
   EntityFieldOperation,
 } from '../../../../../../../common/util/anomaly_utils';
+import { blurButtonOnClick } from '../../../../../util/component_utils';
 import './_entity_filter.scss';
 
 interface EntityFilterProps {
@@ -41,14 +42,13 @@ export const EntityFilter: FC<EntityFilterProps> = ({
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={(event: MouseEvent<HTMLButtonElement>) => {
-            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
+          onClick={blurButtonOnClick(() => {
             onFilter({
               influencerFieldName,
               influencerFieldValue,
               action: ENTITY_FIELD_OPERATIONS.ADD,
             });
-          }}
+          })}
           iconType="plusInCircle"
           aria-label={i18n.translate('xpack.ml.entityFilter.addFilterAriaLabel', {
             defaultMessage: 'Add filter for {influencerFieldName} {influencerFieldValue}',
@@ -67,14 +67,13 @@ export const EntityFilter: FC<EntityFilterProps> = ({
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={(event: MouseEvent<HTMLButtonElement>) => {
-            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
+          onClick={blurButtonOnClick(() => {
             onFilter({
               influencerFieldName,
               influencerFieldValue,
               action: ENTITY_FIELD_OPERATIONS.REMOVE,
             });
-          }}
+          })}
           iconType="minusInCircle"
           aria-label={i18n.translate('xpack.ml.entityFilter.removeFilterAriaLabel', {
             defaultMessage: 'Remove filter for {influencerFieldName} {influencerFieldValue}',

--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/components/explorer_chart_label/entity_filter/entity_filter.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/components/explorer_chart_label/entity_filter/entity_filter.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { FC } from 'react';
+import React, { FC, MouseEvent } from 'react';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
@@ -41,13 +41,14 @@ export const EntityFilter: FC<EntityFilterProps> = ({
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={() =>
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
             onFilter({
               influencerFieldName,
               influencerFieldValue,
               action: ENTITY_FIELD_OPERATIONS.ADD,
-            })
-          }
+            });
+          }}
           iconType="plusInCircle"
           aria-label={i18n.translate('xpack.ml.entityFilter.addFilterAriaLabel', {
             defaultMessage: 'Add filter for {influencerFieldName} {influencerFieldValue}',
@@ -66,13 +67,14 @@ export const EntityFilter: FC<EntityFilterProps> = ({
         <EuiButtonIcon
           size="s"
           className="filter-button"
-          onClick={() =>
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            (event.target as HTMLButtonElement).blur(); // Remove focus from button so tooltip is hidden on click
             onFilter({
               influencerFieldName,
               influencerFieldValue,
               action: ENTITY_FIELD_OPERATIONS.REMOVE,
-            })
-          }
+            });
+          }}
           iconType="minusInCircle"
           aria-label={i18n.translate('xpack.ml.entityFilter.removeFilterAriaLabel', {
             defaultMessage: 'Remove filter for {influencerFieldName} {influencerFieldValue}',

--- a/x-pack/plugins/ml/public/application/util/component_utils.ts
+++ b/x-pack/plugins/ml/public/application/util/component_utils.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MouseEvent } from 'react';
+
+/**
+ * Removes focus from a button element when clicked, for example to
+ * ensure a wrapping tooltip is hidden on click.
+ */
+export const blurButtonOnClick = (callback: Function) => (event: MouseEvent<HTMLButtonElement>) => {
+  (event.target as HTMLButtonElement).blur();
+  callback();
+};


### PR DESCRIPTION
## Summary

Fixes the behavior of the tooltip on the influencer filter buttons used in the Anomaly Explorer and Single Metric Viewer, so that the tooltip is hidden when the button is clicked and the view is refreshed. Previously, as shown in #116758, the tooltip would remain visible until another element was given focus.

Before:

![filter_tooltip_before](https://user-images.githubusercontent.com/7405507/140308327-5a59e1d0-6ade-41e5-a500-375d229661c3.gif)

After:

![filter_tooltip_hide](https://user-images.githubusercontent.com/7405507/140308350-30bc0cee-b615-41e6-a524-1b40c06ecb2d.gif)


### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

Fixes #116758
