### PR TITLE
Refines hasAnyData check for alerts

### DIFF
--- a/x-pack/plugins/observability/public/context/has_data_context.test.tsx
+++ b/x-pack/plugins/observability/public/context/has_data_context.test.tsx
@@ -556,7 +556,7 @@ describe('HasDataContextProvider', () => {
             status: 'success',
           },
         },
-        hasAnyData: false,
+        hasAnyData: true,
         isAllRequestsComplete: true,
         forceUpdate: expect.any(String),
         onRefreshTimeRange: expect.any(Function),

--- a/x-pack/plugins/observability/public/context/has_data_context.tsx
+++ b/x-pack/plugins/observability/public/context/has_data_context.tsx
@@ -147,7 +147,9 @@ export function HasDataContextProvider({ children }: { children: React.ReactNode
   });
 
   const hasAnyData = (Object.keys(hasDataMap) as ObservabilityFetchDataPlugins[]).some(
-    (app) => hasDataMap[app]?.hasData === true
+    (app) =>
+      hasDataMap[app]?.hasData === true ||
+      (Array.isArray(hasDataMap[app]?.hasData) && hasDataMap[app]?.hasData.length > 0)
   );
 
   return (

--- a/x-pack/plugins/observability/public/context/has_data_context.tsx
+++ b/x-pack/plugins/observability/public/context/has_data_context.tsx
@@ -147,8 +147,10 @@ export function HasDataContextProvider({ children }: { children: React.ReactNode
   });
 
   const hasAnyData = (Object.keys(hasDataMap) as ObservabilityFetchDataPlugins[]).some((app) => {
-    const hasData = hasDataMap[app]?.hasData;
-    return hasData === true || (Array.isArray(hasData) && (hasData as Alert[])?.length > 0);
+    const appHasData = hasDataMap[app]?.hasData;
+    return (
+      appHasData === true || (Array.isArray(appHasData) && (appHasData as Alert[])?.length > 0)
+    );
   });
 
   return (

--- a/x-pack/plugins/observability/public/context/has_data_context.tsx
+++ b/x-pack/plugins/observability/public/context/has_data_context.tsx
@@ -146,11 +146,10 @@ export function HasDataContextProvider({ children }: { children: React.ReactNode
     return appStatus !== undefined && appStatus !== FETCH_STATUS.LOADING;
   });
 
-  const hasAnyData = (Object.keys(hasDataMap) as ObservabilityFetchDataPlugins[]).some(
-    (app) =>
-      hasDataMap[app]?.hasData === true ||
-      (Array.isArray(hasDataMap[app]?.hasData) && (hasDataMap[app]?.hasData as Alert[])?.length > 0)
-  );
+  const hasAnyData = (Object.keys(hasDataMap) as ObservabilityFetchDataPlugins[]).some((app) => {
+    const hasData = hasDataMap[app]?.hasData;
+    return hasData === true || (Array.isArray(hasData) && (hasData as Alert[])?.length > 0);
+  });
 
   return (
     <HasDataContext.Provider

--- a/x-pack/plugins/observability/public/context/has_data_context.tsx
+++ b/x-pack/plugins/observability/public/context/has_data_context.tsx
@@ -149,7 +149,7 @@ export function HasDataContextProvider({ children }: { children: React.ReactNode
   const hasAnyData = (Object.keys(hasDataMap) as ObservabilityFetchDataPlugins[]).some(
     (app) =>
       hasDataMap[app]?.hasData === true ||
-      (Array.isArray(hasDataMap[app]?.hasData) && hasDataMap[app]?.hasData.length > 0)
+      (Array.isArray(hasDataMap[app]?.hasData) && (hasDataMap[app]?.hasData as Alert[])?.length > 0)
   );
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes #116759 by refining the condition that determines `hasAnyData` to accommodate for the case when `app === 'alerts'` whose `hasData` field is always set to an `Array`, eventually empty:

<img width="600" alt="Screenshot 2021-11-04 at 12 26 39" src="https://user-images.githubusercontent.com/860099/140311076-670dbc67-a3fc-4ad6-896c-c53d0943e1f4.png">

Once applied this change, the Alerts page renders fine for a user in a role with the matrix of permissions described in #116759.

### Before

<img width="1008" alt="Screenshot 2021-11-04 at 13 12 34" src="https://user-images.githubusercontent.com/860099/140311494-bbc5df72-44f6-4581-95a4-d5cdca3bdbbf.png">


### After
<img width="1008" alt="Screenshot 2021-11-04 at 12 43 44" src="https://user-images.githubusercontent.com/860099/140311340-9fa89a2b-e98b-4ca4-b0e9-4b6ae10f4c7f.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)