### PR TITLE
[ML] Functional tests - stabilize and re-enable feature importance tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/feature_importance.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/feature_importance.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/116078
-  describe.skip('total feature importance panel and decision path popover', function () {
+  describe('total feature importance panel and decision path popover', function () {
     const testDataList: Array<{
       suiteTitle: string;
       archive: string;
@@ -64,6 +63,7 @@ export default function ({ getService }: FtrProviderContext) {
                 training_percent: 35,
                 prediction_field_name: 'CentralAir_prediction',
                 num_top_classes: -1,
+                max_trees: 10,
               },
             },
             model_memory_limit: '60mb',
@@ -109,6 +109,7 @@ export default function ({ getService }: FtrProviderContext) {
                 training_percent: 35,
                 prediction_field_name: 'heatingqc',
                 num_top_classes: -1,
+                max_trees: 10,
               },
             },
             model_memory_limit: '60mb',
@@ -140,6 +141,7 @@ export default function ({ getService }: FtrProviderContext) {
                 dependent_variable: 'stab',
                 num_top_feature_importance_values: 5,
                 training_percent: 35,
+                max_trees: 10,
               },
             },
             analyzed_fields: {

--- a/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_results.ts
@@ -73,6 +73,7 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
 
     async assertTotalFeatureImportanceEvaluatePanelExists() {
       await testSubjects.existOrFail('mlDFExpandableSection-FeatureImportanceSummary');
+      await this.scrollFeatureImportanceIntoView();
       await testSubjects.existOrFail('mlTotalFeatureImportanceChart', { timeout: 30 * 1000 });
     },
 
@@ -212,6 +213,34 @@ export function MachineLearningDataFrameAnalyticsResultsProvider(
         const buttonVisible = await interactionButton.isDisplayed();
         expect(buttonVisible).to.equal(true, 'Expected data grid cell button to be visible');
       });
+    },
+
+    async scrollContentSectionIntoView(sectionId: string) {
+      await testSubjects.scrollIntoView(`mlDFExpandableSection-${sectionId}`);
+    },
+
+    async scrollAnalysisIntoView() {
+      await this.scrollContentSectionIntoView('analysis');
+    },
+
+    async scrollRegressionEvaluationIntoView() {
+      await this.scrollContentSectionIntoView('RegressionEvaluation');
+    },
+
+    async scrollClassificationEvaluationIntoView() {
+      await this.scrollContentSectionIntoView('ClassificationEvaluation');
+    },
+
+    async scrollFeatureImportanceIntoView() {
+      await this.scrollContentSectionIntoView('FeatureImportanceSummary');
+    },
+
+    async scrollScatterplotMatrixIntoView() {
+      await this.scrollContentSectionIntoView('splom');
+    },
+
+    async scrollResultsIntoView() {
+      await this.scrollContentSectionIntoView('results');
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR re-activates and stabilizes the data frame analytics feature importance tests by reducing the job run time. It also scrolls the feature importance section into view during validation so in case of a failure the screenshot shows the relevant part of the screen.

Closes #116078