### PR TITLE
[8.0] [ML] Functional tests - re-activate module test suite

### DIFF
--- a/x-pack/test/api_integration/apis/ml/modules/index.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/index.ts
@@ -14,8 +14,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
   const fleetPackages = ['apache', 'nginx'];
 
-  // failing: https://github.com/elastic/kibana/issues/102283
-  describe.skip('modules', function () {
+  describe('modules', function () {
     before(async () => {
       // use empty_kibana to make sure the fleet setup is removed correctly after the tests
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');


### PR DESCRIPTION
## Summary

This PR re-enabled the ML modules API test suite.

### Details

When 8.0 was cut, there was an issue with the Fleet package repository not being available for that version so all test using it have been temporarily skipped (see https://github.com/elastic/kibana/pull/116530#issuecomment-954049774). The issue is resolved so the module tests can be re-enabled.

Note: the tests have only been skipped in the 8.0 branch, so this PR also targets 8.0 only.

Closes #102283
