### PR TITLE
[7.16] [Fleet] Default to APM tutorial (#117421)

### DIFF
--- a/test/api_integration/apis/custom_integration/integrations.ts
+++ b/test/api_integration/apis/custom_integration/integrations.ts
@@ -22,7 +22,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(resp.body).to.be.an('array');
 
-        expect(resp.body.length).to.be(12);
+        expect(resp.body.length).to.be(13);
 
         // Test for sample data card
         expect(resp.body.findIndex((c: { id: string }) => c.id === 'sample_data_all')).to.be.above(
@@ -40,7 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(resp.body).to.be.an('array');
 
-        expect(resp.body.length).to.be.above(109); // at least the beats + apm
+        expect(resp.body.length).to.be(109); // the beats
       });
     });
   });

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/RumHome.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/RumHome.tsx
@@ -48,7 +48,7 @@ export function RumHome() {
                     'Enable RUM with the APM agent to collect user experience data.',
                 }
               ),
-              href: core.http.basePath.prepend(`integrations/detail/apm`),
+              href: core.http.basePath.prepend(`/app/home#/tutorial/apm`),
             },
           },
           docsLink: core.docLinks.links.observability.guide,

--- a/x-pack/plugins/apm/server/tutorial/index.ts
+++ b/x-pack/plugins/apm/server/tutorial/index.ts
@@ -103,7 +103,6 @@ It allows you to monitor the performance of thousands of applications in real ti
         }
       ),
       euiIconType: 'apmApp',
-      eprPackageOverlap: 'apm',
       integrationBrowserCategories: ['web'],
       artifacts,
       customStatusCheckName: 'apm_fleet_server_status_check',

--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_merge_epr_with_replacements.test.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_merge_epr_with_replacements.test.ts
@@ -120,6 +120,17 @@ describe('useMergeEprWithReplacements', () => {
     ]);
   });
 
+  test('should filter out apm from package list', () => {
+    const eprPackages: PackageListItem[] = mockEprPackages([
+      {
+        name: 'apm',
+        release: 'beta',
+      },
+    ]);
+
+    expect(useMergeEprPackagesWithReplacements(eprPackages, [])).toEqual([]);
+  });
+
   test('should consists of all 3 types (ga eprs, replacements for non-ga eprs, replacements without epr equivalent', () => {
     const eprPackages: PackageListItem[] = mockEprPackages([
       {
@@ -135,6 +146,10 @@ describe('useMergeEprWithReplacements', () => {
       {
         name: 'activemq',
         release: 'beta',
+      },
+      {
+        name: 'apm',
+        release: 'ga',
       },
     ]);
     const replacements: CustomIntegration[] = mockIntegrations([

--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_merge_epr_with_replacements.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_merge_epr_with_replacements.ts
@@ -8,6 +8,7 @@
 import type { PackageListItem } from '../../../../common/types/models';
 import type { CustomIntegration } from '../../../../../../../src/plugins/custom_integrations/common';
 import { filterCustomIntegrations } from '../../../../../../../src/plugins/custom_integrations/public';
+import { FLEET_APM_PACKAGE } from '../../../../common/constants';
 
 // Export this as a utility to find replacements for a package (e.g. in the overview-page for an EPR package)
 function findReplacementsForEprPackage(
@@ -22,11 +23,16 @@ function findReplacementsForEprPackage(
 }
 
 export function useMergeEprPackagesWithReplacements(
-  eprPackages: PackageListItem[],
+  rawEprPackages: PackageListItem[],
   replacements: CustomIntegration[]
 ): Array<PackageListItem | CustomIntegration> {
   const merged: Array<PackageListItem | CustomIntegration> = [];
   const filteredReplacements = replacements;
+
+  // APM EPR-packages should _never_ show. They have special handling.
+  const eprPackages = rawEprPackages.filter((p) => {
+    return p.name !== FLEET_APM_PACKAGE;
+  });
 
   // Either select replacement or select beat
   eprPackages.forEach((eprPackage: PackageListItem) => {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -221,6 +221,7 @@ export const AvailablePackages: React.FC = memo(() => {
     if (selectedCategory === '') {
       return true;
     }
+
     return c.categories.includes(selectedCategory);
   });
 
@@ -255,7 +256,7 @@ export const AvailablePackages: React.FC = memo(() => {
                 defaultMessage:
                   'Monitor, detect and diagnose complex performance issues from your application.',
               })}
-              href={addBasePath('/app/integrations/detail/apm')}
+              href={addBasePath('/app/home#/tutorial/apm')}
               icon={<EuiIcon type="logoObservability" size="xxl" />}
             />
           </TrackApplicationView>

--- a/x-pack/plugins/fleet/public/components/home_integration/tutorial_module_notice.tsx
+++ b/x-pack/plugins/fleet/public/components/home_integration/tutorial_module_notice.tsx
@@ -13,6 +13,7 @@ import type { TutorialModuleNoticeComponent } from 'src/plugins/home/public';
 
 import { useGetPackages, useLink, useCapabilities } from '../../hooks';
 import { pkgKeyFromPackageInfo } from '../../services';
+import { FLEET_APM_PACKAGE } from '../../../common/constants';
 
 const TutorialModuleNotice: TutorialModuleNoticeComponent = memo(({ moduleName }) => {
   const { getHref } = useLink();
@@ -22,7 +23,7 @@ const TutorialModuleNotice: TutorialModuleNoticeComponent = memo(({ moduleName }
   const pkgInfo =
     !isLoading &&
     packagesData?.response &&
-    packagesData.response.find((pkg) => pkg.name === moduleName);
+    packagesData.response.find((pkg) => pkg.name === moduleName && pkg.name !== FLEET_APM_PACKAGE); // APM needs special handling
 
   if (hasIngestManager && pkgInfo) {
     return (


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Fleet] Default to APM tutorial (#117421)