### PR TITLE
[CI] Delete node_modules in between bootstrap attempts

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -6,7 +6,17 @@ source .buildkite/scripts/common/util.sh
 source .buildkite/scripts/common/setup_bazel.sh
 
 echo "--- yarn install and bootstrap"
-retry 2 15 yarn kbn bootstrap
+if ! yarn kbn bootstrap; then
+  echo "bootstrap failed, trying again in 15 seconds"
+  sleep 15
+
+  # Most bootstrap failures will result in a problem inside node_modules that does not get fixed on the next bootstrap
+  # So, we should just delete node_modules in between attempts
+  rm -rf node_modules
+
+  echo "--- yarn install and bootstrap, attempt 2"
+  yarn kbn bootstrap
+fi
 
 ###
 ### upload ts-refs-cache artifacts as quickly as possible so they are available for download


### PR DESCRIPTION
When bootstrap fails, it usually results in a problem inside `node_modules` that is not corrected on the next bootstrap. This is likely because of `postinstall` scripts that don't run.

See here for an example: https://buildkite.com/elastic/kibana-on-merge/builds/7291#37f2ecc1-4dc5-4789-bac2-99e7dac1d560

We have lots of random failures in CI because of this. Deleting `node_modules` before the retry should fix the problem.