### PR TITLE
Welcome to Analytics!

### DIFF
--- a/src/plugins/kibana_overview/public/components/overview/overview.tsx
+++ b/src/plugins/kibana_overview/public/components/overview/overview.tsx
@@ -84,6 +84,9 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
     solution: i18n.translate('kibanaOverview.noDataConfig.solutionName', {
       defaultMessage: `Analytics`,
     }),
+    pageTitle: i18n.translate('kibanaOverview.noDataConfig.pageTitle', {
+      defaultMessage: `Welcome to Analytics!`,
+    }),
     logo: 'logoKibana',
     actions: {
       elasticAgent: {


### PR DESCRIPTION
Fixes #117570

## Summary
Per the issue, drops 'Elastic' from the title of the Analytics Overview no-data page.

<img width="727" alt="Screen Shot 2021-11-04 at 4 29 08 PM" src="https://user-images.githubusercontent.com/446285/140422747-a3308ef6-3012-428b-89b8-05c937fda9d1.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
