### PR TITLE
[heatmap] Fix x time scale with calendar intervals

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@elastic/apm-rum": "^5.9.1",
     "@elastic/apm-rum-react": "^1.3.1",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "38.1.3",
+    "@elastic/charts": "39.0.0",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.35",
     "@elastic/ems-client": "8.0.0",

--- a/x-pack/plugins/lens/public/heatmap_visualization/chart_component.tsx
+++ b/x-pack/plugins/lens/public/heatmap_visualization/chart_component.tsx
@@ -16,6 +16,8 @@ import {
   HeatmapSpec,
   ScaleType,
   Settings,
+  ESFixedIntervalUnit,
+  ESCalendarIntervalUnit,
 } from '@elastic/charts';
 import type { CustomPaletteState } from 'src/plugins/charts/public';
 import { VisualizationContainer } from '../visualization_container';
@@ -172,7 +174,18 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = ({
     if (esInterval) {
       xScale = {
         type: ScaleType.Time,
-        interval: { type: esInterval.type, unit: esInterval.unit, value: esInterval.value },
+        interval:
+          esInterval.type === 'fixed'
+            ? {
+                type: 'fixed',
+                unit: esInterval.unit as ESFixedIntervalUnit,
+                value: esInterval.value,
+              }
+            : {
+                type: 'calendar',
+                unit: esInterval.unit as ESCalendarIntervalUnit,
+                value: esInterval.value,
+              },
         timeZone,
       };
     }
@@ -334,7 +347,6 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = ({
     brushArea: {
       stroke: isDarkTheme ? 'rgb(255, 255, 255)' : 'rgb(105, 112, 125)',
     },
-    timeZone,
   };
 
   if (!chartData || !chartData.length) {

--- a/x-pack/plugins/lens/public/heatmap_visualization/chart_component.tsx
+++ b/x-pack/plugins/lens/public/heatmap_visualization/chart_component.tsx
@@ -186,7 +186,6 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = ({
                 unit: esInterval.unit as ESCalendarIntervalUnit,
                 value: esInterval.value,
               },
-        timeZone,
       };
     }
   }
@@ -347,6 +346,7 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = ({
     brushArea: {
       stroke: isDarkTheme ? 'rgb(255, 255, 255)' : 'rgb(105, 112, 125)',
     },
+    timeZone,
   };
 
   if (!chartData || !chartData.length) {

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -337,6 +337,7 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
         stroke: isDarkTheme ? 'rgb(255, 255, 255)' : 'rgb(105, 112, 125)',
       },
       ...(showLegend ? { maxLegendHeight: LEGEND_HEIGHT } : {}),
+      timeZone: 'UTC',
     };
 
     return config;
@@ -478,7 +479,6 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
                             // adding a fallback to 1m bucket
                             value: xDomain?.minInterval ?? 1000 * 60,
                           },
-                          timeZone: 'UTC',
                         }}
                         ySortPredicate="dataIndex"
                         config={swimLaneConfig}

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -337,7 +337,6 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
         stroke: isDarkTheme ? 'rgb(255, 255, 255)' : 'rgb(105, 112, 125)',
       },
       ...(showLegend ? { maxLegendHeight: LEGEND_HEIGHT } : {}),
-      timeZone: 'UTC',
     };
 
     return config;
@@ -470,12 +469,13 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
                         valueAccessor="value"
                         highlightedData={highlightedData}
                         valueFormatter={getFormattedSeverityScore}
-                        // the xDomain.minInterval should always be available at rendering time, just falling back to 1m bucket just in case
                         xScale={{
                           type: ScaleType.Time,
                           interval: {
                             type: 'fixed',
                             unit: 'ms',
+                            // the xDomain.minInterval should always be available at rendering time
+                            // adding a fallback to 1m bucket
                             value: xDomain?.minInterval ?? 1000 * 60,
                           },
                           timeZone: 'UTC',

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -470,7 +470,16 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
                         valueAccessor="value"
                         highlightedData={highlightedData}
                         valueFormatter={getFormattedSeverityScore}
-                        xScaleType={ScaleType.Time}
+                        // the xDomain.minInterval should always be available at rendering time, just falling back to 1m bucket just in case
+                        xScale={{
+                          type: ScaleType.Time,
+                          interval: {
+                            type: 'fixed',
+                            unit: 'ms',
+                            value: xDomain?.minInterval ?? 1000 * 60,
+                          },
+                          timeZone: 'UTC',
+                        }}
                         ySortPredicate="dataIndex"
                         config={swimLaneConfig}
                       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,10 +2337,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@38.1.3":
-  version "38.1.3"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-38.1.3.tgz#0bf27021c54176e87d38269613205f3d6219da96"
-  integrity sha512-p6bJQWmfJ5SLkcgAoAMB3eTah/2a3/r3uo3ZskEN/xdPiqU8P+GANF8+6F4dWNfejbrpSUyCUldl7S4nWFGg3Q==
+"@elastic/charts@39.0.0":
+  version "39.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-39.0.0.tgz#85e615f550d03d8fb880bf44e891452b4341706b"
+  integrity sha512-EnmOXFAN5u9rkcwM4L2AksxoWpOpZRXbjX2HYAxgj8WcBb14zYoYeyENMQyG/qu2Rm6PnUni0dgy+mPOTEnGmw==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

The PR will introduce a fix from `elastic-charts` add the ability to use both calendars and fixed intervals as described in Elasticserach [date_histogram aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html)


This fix was required to cover the Lens usage when calendar intervals are used in conjunction with the date_histogram aggs.

In ML Swimlane, the fix only covers the API changes in elastic-charts but doesn't cause any differences in the chart behaviour.

To do:
- [x] update elastic/charts with the merged PR https://github.com/elastic/elastic-charts/pull/1462


