### PR TITLE
[Cases] Fix cases navigation after attaching an alert to a case.

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -235,12 +235,14 @@ function ObservabilityActions({
               event,
               casePermissions,
               appId: observabilityFeatureId,
+              owner: observabilityFeatureId,
               onClose: afterCaseSelection,
             }),
             timelines.getAddToNewCaseButton({
               event,
               casePermissions,
               appId: observabilityFeatureId,
+              owner: observabilityFeatureId,
               onClose: afterCaseSelection,
             }),
           ]
@@ -390,6 +392,7 @@ export function AlertsTableTGrid(props: AlertsTableTGridProps) {
     const sortDirection: SortDirection = 'desc';
     return {
       appId: observabilityFeatureId,
+      appIdUI: observabilityFeatureId,
       casePermissions,
       type,
       columns,

--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -392,7 +392,7 @@ export function AlertsTableTGrid(props: AlertsTableTGridProps) {
     const sortDirection: SortDirection = 'desc';
     return {
       appId: observabilityFeatureId,
-      appIdUI: observabilityFeatureId,
+      casesOwner: observabilityFeatureId,
       casePermissions,
       type,
       columns,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import { useGetUserCasesPermissions, useKibana } from '../../../../common/lib/kibana';
 import { TimelineId, TimelineNonEcsData } from '../../../../../common';
-import { APP_ID } from '../../../../../common/constants';
+import { APP_ID, APP_UI_ID } from '../../../../../common/constants';
 import { useInsertTimeline } from '../../../../cases/components/use_insert_timeline';
 import { Ecs } from '../../../../../common/ecs';
 
@@ -39,7 +39,8 @@ export const useAddToCaseActions = ({
             event: { data: nonEcsData ?? [], ecs: ecsData, _id: ecsData?._id },
             useInsertTimeline: insertTimelineHook,
             casePermissions,
-            appId: APP_ID,
+            appId: APP_UI_ID,
+            owner: APP_ID,
             onClose: afterCaseSelection,
           }
         : null,

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.test.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.test.tsx
@@ -35,7 +35,8 @@ describe('AddToCaseAction', () => {
       crud: true,
       read: true,
     },
-    appId: 'securitySolution',
+    appId: 'securitySolutionUI',
+    owner: 'securitySolution',
     onClose: () => null,
   };
 

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.tsx
@@ -25,6 +25,7 @@ export interface AddToCaseActionProps {
     read: boolean;
   } | null;
   appId: string;
+  owner: string;
   onClose?: Function;
   disableAlerts?: boolean;
 }
@@ -35,6 +36,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
   useInsertTimeline,
   casePermissions,
   appId,
+  owner,
   onClose,
   disableAlerts,
 }) => {
@@ -50,7 +52,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
     createCaseUrl,
     isAllCaseModalOpen,
     isCreateCaseFlyoutOpen,
-  } = useAddToCase({ event, useInsertTimeline, casePermissions, appId, onClose });
+  } = useAddToCase({ event, useInsertTimeline, casePermissions, appId, owner, onClose });
 
   const getAllCasesSelectorModalProps = useMemo(() => {
     const { ruleId, ruleName } = normalizedEventFields(event);
@@ -62,7 +64,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
           id: ruleId,
           name: ruleName,
         },
-        owner: appId,
+        owner,
       },
       createCaseNavigation: {
         href: createCaseUrl,
@@ -75,7 +77,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
       onRowClick: onCaseClicked,
       updateCase: onCaseSuccess,
       userCanCrud: casePermissions?.crud ?? false,
-      owner: [appId],
+      owner: [owner],
       onClose: () =>
         dispatch(tGridActions.setOpenAddToExistingCase({ id: eventId, isOpen: false })),
     };
@@ -87,8 +89,8 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
     goToCreateCase,
     eventId,
     eventIndex,
-    appId,
     dispatch,
+    owner,
     useInsertTimeline,
     event,
   ]);
@@ -105,7 +107,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
           onCloseFlyout={closeCaseFlyoutOpen}
           onSuccess={onCaseSuccess}
           useInsertTimeline={useInsertTimeline}
-          appId={appId}
+          owner={owner}
           disableAlerts={disableAlerts}
         />
       )}

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action_button.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action_button.tsx
@@ -25,6 +25,7 @@ const AddToCaseActionButtonComponent: React.FC<AddToCaseActionProps> = ({
   useInsertTimeline,
   casePermissions,
   appId,
+  owner,
   onClose,
 }) => {
   const {
@@ -36,7 +37,7 @@ const AddToCaseActionButtonComponent: React.FC<AddToCaseActionProps> = ({
     openPopover,
     closePopover,
     isPopoverOpen,
-  } = useAddToCase({ event, useInsertTimeline, casePermissions, appId, onClose });
+  } = useAddToCase({ event, useInsertTimeline, casePermissions, appId, owner, onClose });
   const tooltipContext = userCanCrud
     ? isEventSupported
       ? i18n.ACTION_ADD_TO_CASE_TOOLTIP

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_existing_case_button.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_existing_case_button.tsx
@@ -18,6 +18,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
   useInsertTimeline,
   casePermissions,
   appId,
+  owner,
   onClose,
 }) => {
   const { addExistingCaseClick, isDisabled, userCanCrud } = useAddToCase({
@@ -25,6 +26,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
     useInsertTimeline,
     casePermissions,
     appId,
+    owner,
     onClose,
   });
   return (

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_new_case_button.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_new_case_button.tsx
@@ -18,6 +18,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
   useInsertTimeline,
   casePermissions,
   appId,
+  owner,
   onClose,
 }) => {
   const { addNewCaseClick, isDisabled, userCanCrud } = useAddToCase({
@@ -25,6 +26,7 @@ const AddToCaseActionComponent: React.FC<AddToCaseActionProps> = ({
     useInsertTimeline,
     casePermissions,
     appId,
+    owner,
     onClose,
   });
 

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.test.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.test.tsx
@@ -16,7 +16,7 @@ const onSuccess = jest.fn();
 const defaultProps = {
   onCloseFlyout,
   onSuccess,
-  appId: 'securitySolution',
+  owner: 'securitySolution',
 };
 
 describe('CreateCaseFlyout', () => {

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/create/flyout.tsx
@@ -19,7 +19,7 @@ export interface CreateCaseModalProps {
   onCloseFlyout: () => void;
   onSuccess: (theCase: Case) => Promise<void>;
   useInsertTimeline?: Function;
-  appId: string;
+  owner: string;
   disableAlerts?: boolean;
 }
 
@@ -70,7 +70,7 @@ const CreateCaseFlyoutComponent: React.FC<CreateCaseModalProps> = ({
   afterCaseCreated,
   onCloseFlyout,
   onSuccess,
-  appId,
+  owner,
   disableAlerts,
 }) => {
   const { cases } = useKibana<TimelinesStartServices>().services;
@@ -80,10 +80,10 @@ const CreateCaseFlyoutComponent: React.FC<CreateCaseModalProps> = ({
       onCancel: onCloseFlyout,
       onSuccess,
       withSteps: false,
-      owner: [appId],
+      owner: [owner],
       disableAlerts,
     };
-  }, [afterCaseCreated, onCloseFlyout, onSuccess, appId, disableAlerts]);
+  }, [afterCaseCreated, onCloseFlyout, onSuccess, owner, disableAlerts]);
   return (
     <>
       <GlobalStyle />

--- a/x-pack/plugins/timelines/public/components/t_grid/standalone/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/standalone/index.tsx
@@ -80,7 +80,7 @@ const ScrollableFlexItem = styled(EuiFlexItem)`
 
 export interface TGridStandaloneProps {
   appId: string;
-  appIdUI: string;
+  casesOwner: string;
   casePermissions: {
     crud: boolean;
     read: boolean;
@@ -124,7 +124,7 @@ export interface TGridStandaloneProps {
 const TGridStandaloneComponent: React.FC<TGridStandaloneProps> = ({
   afterCaseSelection,
   appId,
-  appIdUI,
+  casesOwner,
   casePermissions,
   columns,
   defaultCellActions,
@@ -277,10 +277,10 @@ const TGridStandaloneComponent: React.FC<TGridStandaloneProps> = ({
       event: selectedEvent,
       casePermissions: casePermissions ?? null,
       appId,
-      owner: appIdUI,
+      owner: casesOwner,
       onClose: afterCaseSelection,
     };
-  }, [appId, casePermissions, afterCaseSelection, selectedEvent, appIdUI]);
+  }, [appId, casePermissions, afterCaseSelection, selectedEvent, casesOwner]);
 
   const nonDeletedEvents = useMemo(
     () => events.filter((e) => !deletedEventIds.includes(e._id)),

--- a/x-pack/plugins/timelines/public/components/t_grid/standalone/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/standalone/index.tsx
@@ -80,6 +80,7 @@ const ScrollableFlexItem = styled(EuiFlexItem)`
 
 export interface TGridStandaloneProps {
   appId: string;
+  appIdUI: string;
   casePermissions: {
     crud: boolean;
     read: boolean;
@@ -123,6 +124,7 @@ export interface TGridStandaloneProps {
 const TGridStandaloneComponent: React.FC<TGridStandaloneProps> = ({
   afterCaseSelection,
   appId,
+  appIdUI,
   casePermissions,
   columns,
   defaultCellActions,
@@ -275,9 +277,10 @@ const TGridStandaloneComponent: React.FC<TGridStandaloneProps> = ({
       event: selectedEvent,
       casePermissions: casePermissions ?? null,
       appId,
+      owner: appIdUI,
       onClose: afterCaseSelection,
     };
-  }, [appId, casePermissions, afterCaseSelection, selectedEvent]);
+  }, [appId, casePermissions, afterCaseSelection, selectedEvent, appIdUI]);
 
   const nonDeletedEvents = useMemo(
     () => events.filter((e) => !deletedEventIds.includes(e._id)),

--- a/x-pack/plugins/timelines/public/hooks/use_add_to_case.ts
+++ b/x-pack/plugins/timelines/public/hooks/use_add_to_case.ts
@@ -81,6 +81,7 @@ export const useAddToCase = ({
   useInsertTimeline,
   casePermissions,
   appId,
+  owner,
   onClose,
 }: AddToCaseActionProps): UseAddToCase => {
   const eventId = event?.ecs._id ?? '';
@@ -167,13 +168,13 @@ export const useAddToCase = ({
               id: ruleId,
               name: ruleName,
             },
-            owner: appId,
+            owner,
           },
           updateCase,
         });
       }
     },
-    [eventId, eventIndex, appId, dispatch, event]
+    [eventId, eventIndex, owner, dispatch, event]
   );
   const onCaseSuccess = useCallback(
     async (theCase: Case) => {
@@ -187,7 +188,7 @@ export const useAddToCase = ({
     async (ev) => {
       ev.preventDefault();
       return navigateToApp(appId, {
-        deepLinkId: appId === 'securitySolution' ? 'case' : 'cases',
+        deepLinkId: appId === 'securitySolutionUI' ? 'case' : 'cases',
         path: getCreateCaseUrl(urlSearch),
       });
     },

--- a/x-pack/test/plugin_functional/plugins/timelines_test/public/applications/timelines_test/index.tsx
+++ b/x-pack/test/plugin_functional/plugins/timelines_test/public/applications/timelines_test/index.tsx
@@ -66,6 +66,7 @@ const AppRoot = React.memo(
                 timelinesPluginSetup.getTGrid &&
                 timelinesPluginSetup.getTGrid<'standalone'>({
                   appId: 'securitySolution',
+                  appIdUI: 'securitySolutionUI',
                   type: 'standalone',
                   casePermissions: {
                     read: true,

--- a/x-pack/test/plugin_functional/plugins/timelines_test/public/applications/timelines_test/index.tsx
+++ b/x-pack/test/plugin_functional/plugins/timelines_test/public/applications/timelines_test/index.tsx
@@ -66,7 +66,7 @@ const AppRoot = React.memo(
                 timelinesPluginSetup.getTGrid &&
                 timelinesPluginSetup.getTGrid<'standalone'>({
                   appId: 'securitySolution',
-                  appIdUI: 'securitySolutionUI',
+                  casesOwner: 'securitySolutionUI',
                   type: 'standalone',
                   casePermissions: {
                     read: true,


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/116793

This will be fixed in https://github.com/elastic/kibana/pull/117582:

> I don't believe this code is ever called. The goToCreateCase is passed to here: main/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.tsx#L69
>
> Which is used in the cases plugin modal code here: main/x-pack/plugins/cases/public/components/all_cases/selector_modal/index.tsx#L71
>
>That code also defines:
>
> ```
> isSelectorView={true}
> onRowClick={onClick}
> ```
>
>Which means that those code: main/x-pack/plugins/cases/public/components/all_cases/all_cases_generic.tsx#L143 will be called instead of the goToCreateCase callback defined in timeline.
>
>Needing to specifically check for securitySolution in timeline could lead to additional bugs in the future if we need to change the appId again and I think we can avoid it by not requiring goToCreateCase when using the modal.
### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
