### PR TITLE
[Reporting] Remove `pdf-to-img`

### DIFF
--- a/package.json
+++ b/package.json
@@ -771,7 +771,6 @@
     "oboe": "^2.1.4",
     "parse-link-header": "^1.0.1",
     "pbf": "3.2.1",
-    "pdf-to-img": "^1.1.1",
     "pirates": "^4.0.1",
     "pixelmatch": "^5.1.0",
     "postcss": "^7.0.32",

--- a/x-pack/test/examples/reporting_examples/capture_test.ts
+++ b/x-pack/test/examples/reporting_examples/capture_test.ts
@@ -44,48 +44,5 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await compareImages.checkIfPngsMatch(pngSessionFilePath, fixtures.baselineAPng)
       ).to.be.lessThan(0.09);
     });
-
-    it('PDF that matches the baseline', async () => {
-      await PageObjects.common.navigateToApp(appId);
-
-      await (await testSubjects.find('shareButton')).click();
-      await (await testSubjects.find('captureTestPanel')).click();
-      await (await testSubjects.find('captureTestPDF')).click();
-
-      await PageObjects.reporting.clickGenerateReportButton();
-      const url = await PageObjects.reporting.getReportURL(60000);
-      const captureData = await PageObjects.reporting.getRawPdfReportData(url);
-
-      const pdfSessionFilePath = await compareImages.writeToSessionFile(
-        'capture_test_baseline_a',
-        captureData
-      );
-
-      expect(
-        await compareImages.checkIfPdfsMatch(pdfSessionFilePath, fixtures.baselineAPdf)
-      ).to.be.lessThan(0.001);
-    });
-
-    it('print-optimized PDF that matches the baseline', async () => {
-      await PageObjects.common.navigateToApp(appId);
-
-      await (await testSubjects.find('shareButton')).click();
-      await (await testSubjects.find('captureTestPanel')).click();
-      await (await testSubjects.find('captureTestPDFPrint')).click();
-
-      await PageObjects.reporting.checkUsePrintLayout();
-      await PageObjects.reporting.clickGenerateReportButton();
-      const url = await PageObjects.reporting.getReportURL(60000);
-      const captureData = await PageObjects.reporting.getRawPdfReportData(url);
-
-      const pdfSessionFilePath = await compareImages.writeToSessionFile(
-        'capture_test_baseline_a',
-        captureData
-      );
-
-      expect(
-        await compareImages.checkIfPdfsMatch(pdfSessionFilePath, fixtures.baselineAPdfPrint)
-      ).to.be.lessThan(0.001);
-    });
   });
 }

--- a/x-pack/test/functional/services/compare_images.ts
+++ b/x-pack/test/functional/services/compare_images.ts
@@ -7,7 +7,6 @@
 
 import path from 'path';
 import { promises as fs } from 'fs';
-import { pdf as pdfToPng } from 'pdf-to-img';
 import { comparePngs } from '../../../../test/functional/services/lib/compare_pngs';
 import { FtrProviderContext } from '../ftr_provider_context';
 
@@ -72,76 +71,6 @@ export function CompareImagesProvider({ getService }: FtrProviderContext) {
         sessionDirectoryPath,
         log
       );
-
-      return diffTotal;
-    },
-    async checkIfPdfsMatch(
-      actualPdfPath: string,
-      baselinePdfPath: string,
-      screenshotsDirectory = screenshotsDir
-    ) {
-      log.debug(`checkIfPdfsMatch: ${actualPdfPath} vs ${baselinePdfPath}`);
-      // Copy the pdfs into the screenshot session directory, as that's where the generated pngs will automatically be
-      // stored.
-      const sessionDirectoryPath = path.resolve(screenshotsDirectory, 'session');
-      const failureDirectoryPath = path.resolve(screenshotsDirectory, 'failure');
-
-      await fs.mkdir(sessionDirectoryPath, { recursive: true });
-      await fs.mkdir(failureDirectoryPath, { recursive: true });
-
-      const actualPdfFileName = path.basename(actualPdfPath, '.pdf');
-      const baselinePdfFileName = path.basename(baselinePdfPath, '.pdf');
-
-      const baselineCopyPath = path.resolve(
-        sessionDirectoryPath,
-        `${baselinePdfFileName}_baseline.pdf`
-      );
-      const actualCopyPath = path.resolve(sessionDirectoryPath, `${actualPdfFileName}_actual.pdf`);
-
-      // Don't cause a test failure if the baseline snapshot doesn't exist - we don't have all OS's covered and we
-      // don't want to start causing failures for other devs working on OS's which are lacking snapshots.  We have
-      // mac and linux covered which is better than nothing for now.
-      try {
-        log.debug(`writeFileSync: ${baselineCopyPath}`);
-        await fs.writeFile(baselineCopyPath, await fs.readFile(baselinePdfPath));
-      } catch (error) {
-        log.error(`No baseline pdf found at ${baselinePdfPath}`);
-        return 0;
-      }
-      log.debug(`writeFileSync: ${actualCopyPath}`);
-      await fs.writeFile(actualCopyPath, await fs.readFile(actualPdfPath));
-
-      const actualPdf = await pdfToPng(actualCopyPath);
-      const baselinePdf = await pdfToPng(baselineCopyPath);
-
-      log.debug(`Checking number of pages`);
-
-      if (actualPdf.length !== baselinePdf.length) {
-        throw new Error(
-          `Expected ${baselinePdf.length} pages but got ${actualPdf.length} in PDFs expected: "${baselineCopyPath}" actual: "${actualCopyPath}".`
-        );
-      }
-
-      let diffTotal = 0;
-      let pageNum = 1;
-
-      for await (const actualPage of actualPdf) {
-        for await (const baselinePage of baselinePdf) {
-          const diffPngPath = path.resolve(
-            failureDirectoryPath,
-            `${baselinePdfFileName}-${pageNum}.png`
-          );
-          diffTotal += await comparePngs(
-            { path: path.resolve(screenshotsDirectory, '_actual.png'), buffer: actualPage },
-            { path: path.resolve(screenshotsDirectory, '_baseline.png'), buffer: baselinePage },
-            diffPngPath,
-            sessionDirectoryPath,
-            log
-          );
-          ++pageNum;
-          break;
-        }
-      }
 
       return diffTotal;
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,21 +4129,6 @@
   resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz#f60b6a55a5d8e5ee908347d2ce4250b15103dc8e"
   integrity sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==
 
-"@mapbox/node-pre-gyp@^1.0.0":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
-  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
-  dependencies:
-    detect-libc "^1.0.3"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.1.0"
-    node-fetch "^2.6.1"
-    nopt "^5.0.0"
-    npmlog "^4.1.2"
-    rimraf "^3.0.2"
-    semver "^7.3.4"
-    tar "^6.1.0"
-
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
@@ -10184,15 +10169,6 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001109, can
   version "1.0.30001261"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz#96d89813c076ea061209a4e040d8dcf0c66a1d01"
   integrity sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==
-
-canvas@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.8.0.tgz#f99ca7f25e6e26686661ffa4fec1239bbef74461"
-  integrity sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==
-  dependencies:
-    "@mapbox/node-pre-gyp" "^1.0.0"
-    nan "^2.14.0"
-    simple-get "^3.0.3"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -22399,19 +22375,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdf-to-img@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pdf-to-img/-/pdf-to-img-1.1.1.tgz#1918738477c3cc95a6786877bb1e36de81909400"
-  integrity sha512-e+4BpKSDhU+BZt34yo2P5OAqO0CRRy8xSNGDP7HhpT2FMEo5H7mzNcXdymYKRcj7xIr0eK1gYFhyjpWwHGp46Q==
-  dependencies:
-    canvas "2.8.0"
-    pdfjs-dist "2.9.359"
-
-pdfjs-dist@2.9.359:
-  version "2.9.359"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.9.359.tgz#e67bafebf20e50fc41f1a5c189155ad008ac4f81"
-  integrity sha512-P2nYtkacdlZaNNwrBLw1ZyMm0oE2yY/5S/GDCAmMJ7U4+ciL/D0mrlEC/o4HZZc/LNE3w8lEVzBEyVgEQlPVKQ==
-
 pdfkit@>=0.8.1, pdfkit@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/pdfkit/-/pdfkit-0.11.0.tgz#9cdb2fc42bd2913587fe3ddf48cc5bbb3c36f7de"
@@ -27655,7 +27618,7 @@ tar@6.1.9:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@^6.0.2, tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
+tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==


### PR DESCRIPTION
## Summary

See https://github.com/elastic/kibana/issues/116708.

This PR removes `pdf-to-img` until the underlying `canvas` dependency supports all platforms with pre-built.

We should be able to revert this PR at a future date, this work was originally introduced here: https://github.com/elastic/kibana/pull/113910. This is a partial revert.