### PR TITLE
Create missing directories in file logging appenders

### DIFF
--- a/src/core/server/logging/appenders/file/file_appender.test.mocks.ts
+++ b/src/core/server/logging/appenders/file/file_appender.test.mocks.ts
@@ -19,4 +19,5 @@ jest.mock('../../layouts/layouts', () => {
 });
 
 export const mockCreateWriteStream = jest.fn();
-jest.mock('fs', () => ({ createWriteStream: mockCreateWriteStream }));
+export const mockMkdirSync = jest.fn();
+jest.mock('fs', () => ({ createWriteStream: mockCreateWriteStream, mkdirSync: mockMkdirSync }));

--- a/src/core/server/logging/appenders/file/file_appender.ts
+++ b/src/core/server/logging/appenders/file/file_appender.ts
@@ -8,7 +8,8 @@
 
 import { schema } from '@kbn/config-schema';
 import { LogRecord, Layout, DisposableAppender } from '@kbn/logging';
-import { createWriteStream, WriteStream } from 'fs';
+import { createWriteStream, WriteStream, mkdirSync } from 'fs';
+import { dirname } from 'path';
 
 import { Layouts, LayoutConfigType } from '../../layouts/layouts';
 
@@ -47,6 +48,7 @@ export class FileAppender implements DisposableAppender {
    */
   public append(record: LogRecord) {
     if (this.outputStream === undefined) {
+      this.ensureDirectory(this.path);
       this.outputStream = createWriteStream(this.path, {
         encoding: 'utf8',
         flags: 'a',
@@ -72,5 +74,9 @@ export class FileAppender implements DisposableAppender {
         resolve();
       });
     });
+  }
+
+  private ensureDirectory(path: string) {
+    mkdirSync(dirname(path), { recursive: true });
   }
 }

--- a/src/core/server/logging/appenders/rolling_file/rolling_file_manager.ts
+++ b/src/core/server/logging/appenders/rolling_file/rolling_file_manager.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { createWriteStream, WriteStream } from 'fs';
+import { createWriteStream, WriteStream, mkdirSync } from 'fs';
+import { dirname } from 'path';
 import { RollingFileContext } from './rolling_file_context';
 
 /**
@@ -40,6 +41,7 @@ export class RollingFileManager {
 
   private ensureStreamOpen() {
     if (this.outputStream === undefined) {
+      this.ensureDirectory(this.filePath);
       this.outputStream = createWriteStream(this.filePath, {
         encoding: 'utf8',
         flags: 'a',
@@ -48,5 +50,9 @@ export class RollingFileManager {
       this.context.refreshFileInfo();
     }
     return this.outputStream!;
+  }
+
+  private ensureDirectory(path: string) {
+    mkdirSync(dirname(path), { recursive: true });
   }
 }


### PR DESCRIPTION
When using either the `FileAppender` or the `RollingFileAppender` with a path to a logfile where the directories doesn't exist, they are now created automatically the first time anything is written to the path.

## Release note

Improves the file logging capabilities of Kibana, so that missing directories in the configured file path now are created before Kibana attempts to write to the file.