### PR TITLE
[ML] Revert set ignore_throttled for data_recognizer module

### DIFF
--- a/x-pack/plugins/ml/server/models/data_recognizer/data_recognizer.ts
+++ b/x-pack/plugins/ml/server/models/data_recognizer/data_recognizer.ts
@@ -293,8 +293,6 @@ export class DataRecognizer {
       index,
       size,
       body: searchBody,
-      // Ignored indices that are frozen
-      ignore_throttled: true,
     });
 
     // @ts-expect-error incorrect search response type


### PR DESCRIPTION
This PR reverts https://github.com/elastic/kibana/pull/117208 because frozen indices are now deprecated