### PR TITLE
[Security Solution][Investigations] - Change context menu text and add test

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/cell_rendering/default_cell_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/cell_rendering/default_cell_renderer.test.tsx
@@ -161,3 +161,116 @@ describe('DefaultCellRenderer', () => {
     ).toBeTruthy();
   });
 });
+
+describe('host link rendering', () => {
+  const data = cloneDeep(mockTimelineData[0].data);
+  const hostNameHeader = cloneDeep(defaultHeaders[4]);
+
+  beforeEach(() => {
+    const { getColumnRenderer: realGetColumnRenderer } = jest.requireActual(
+      '../body/renderers/get_column_renderer'
+    );
+
+    getColumnRendererMock.mockImplementation(realGetColumnRenderer); // link rendering tests must use the real renderer
+  });
+
+  test('it renders a link button for `host.name` when `isTimeline` is true', () => {
+    const id = 'host.name';
+    const isTimeline = true;
+
+    const wrapper = mount(
+      <TestProviders>
+        <DragDropContextWrapper browserFields={mockBrowserFields}>
+          <DroppableWrapper droppableId="testing">
+            <DefaultCellRenderer
+              browserFields={undefined}
+              columnId={id}
+              ecsData={undefined}
+              data={data}
+              eventId="_id-123"
+              header={hostNameHeader}
+              isDetails={false}
+              isDraggable={true}
+              isExpandable={false}
+              isExpanded={false}
+              isTimeline={isTimeline}
+              linkValues={[]}
+              rowIndex={3}
+              setCellProps={jest.fn()}
+              timelineId={'timeline-1-query'}
+            />
+          </DroppableWrapper>
+        </DragDropContextWrapper>
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="host-details-button"]').first().text()).toEqual('apache');
+  });
+
+  test('it does NOT render a link button for `host.name` when `isTimeline` is false', () => {
+    const id = 'host.name';
+    const isTimeline = false;
+
+    const wrapper = mount(
+      <TestProviders>
+        <DragDropContextWrapper browserFields={mockBrowserFields}>
+          <DroppableWrapper droppableId="testing">
+            <DefaultCellRenderer
+              browserFields={undefined}
+              columnId={id}
+              ecsData={undefined}
+              data={data}
+              eventId="_id-123"
+              header={hostNameHeader}
+              isDetails={false}
+              isDraggable={true}
+              isExpandable={false}
+              isExpanded={false}
+              isTimeline={isTimeline}
+              linkValues={[]}
+              rowIndex={3}
+              setCellProps={jest.fn()}
+              timelineId={'timeline-1-query'}
+            />
+          </DroppableWrapper>
+        </DragDropContextWrapper>
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="host-details-button"]').exists()).toBe(false);
+  });
+
+  test('it does NOT render a link button for non-host fields when `isTimeline` is true', () => {
+    const id = '@timestamp'; // a non-host field
+    const isTimeline = true;
+    const timestampHeader = cloneDeep(defaultHeaders[0]);
+
+    const wrapper = mount(
+      <TestProviders>
+        <DragDropContextWrapper browserFields={mockBrowserFields}>
+          <DroppableWrapper droppableId="testing">
+            <DefaultCellRenderer
+              browserFields={undefined}
+              columnId={id}
+              ecsData={undefined}
+              data={data}
+              eventId="_id-123"
+              header={timestampHeader}
+              isDetails={false}
+              isDraggable={true}
+              isExpandable={false}
+              isExpanded={false}
+              isTimeline={isTimeline}
+              linkValues={[]}
+              rowIndex={3}
+              setCellProps={jest.fn()}
+              timelineId={'timeline-1-query'}
+            />
+          </DroppableWrapper>
+        </DragDropContextWrapper>
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="host-details-button"]').exists()).toBe(false);
+  });
+});

--- a/x-pack/plugins/timelines/public/components/t_grid/translations.ts
+++ b/x-pack/plugins/timelines/public/components/t_grid/translations.ts
@@ -22,7 +22,7 @@ export const EVENTS_TABLE_ARIA_LABEL = ({
 export const BULK_ACTION_OPEN_SELECTED = i18n.translate(
   'xpack.timelines.timeline.openSelectedTitle',
   {
-    defaultMessage: 'Open selected',
+    defaultMessage: 'Mark as open',
   }
 );
 


### PR DESCRIPTION
## Summary

Original bug: https://github.com/elastic/kibana/issues/114965

This PR changes the text of `Open Selected` to `Mark as open` in the alert table context menu. It also introduces a test for the host and ip links that was absent in this PR: https://github.com/elastic/kibana/pull/117403

Screenshot:

![image](https://user-images.githubusercontent.com/17211684/140539766-0a702841-6ef3-40d4-baa3-b491ae81aca3.png)

