### PR TITLE
[Uptime] Add callout to ML jobs flyout when users don't have the necessary permissions

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor/ml/ml_flyout.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/ml/ml_flyout.tsx
@@ -19,6 +19,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiCallOut,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useSelector } from 'react-redux';
@@ -69,6 +70,20 @@ export function MLFlyoutView({ isCreatingJob, onClickCreate, onClose, canCreateM
           </p>
         </EuiText>
         <EuiSpacer />
+        {!canCreateMLJob && (
+          <EuiCallOut
+            title={labels.ADD_JOB_PERMISSIONS_NEEDED}
+            color="primary"
+            iconType="iInCircle"
+          >
+            <p>
+              <FormattedMessage
+                id="xpack.uptime.ml.enableAnomalyDetectionPanel.insufficient_permissions_add_job"
+                defaultMessage="You must have the Kibana privileges for Machine Learning to use this feature."
+              />
+            </p>
+          </EuiCallOut>
+        )}
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">

--- a/x-pack/plugins/uptime/public/components/monitor/ml/translations.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/ml/translations.tsx
@@ -179,3 +179,10 @@ export const ENABLE_MANAGE_JOB = i18n.translate(
       'You can enable anomaly detection job or if job is already there you can manage the job or alert.',
   }
 );
+
+export const ADD_JOB_PERMISSIONS_NEEDED = i18n.translate(
+  'xpack.uptime.ml.enableAnomalyDetectionPanel.add_job_permissions_needed',
+  {
+    defaultMessage: 'Permissions needed',
+  }
+);

--- a/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
+++ b/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
@@ -8,7 +8,12 @@
 import React, { ReactElement } from 'react';
 import { of } from 'rxjs';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { render as reactTestLibRender, RenderOptions } from '@testing-library/react';
+import {
+  render as reactTestLibRender,
+  MatcherFunction,
+  RenderOptions,
+  Nullish,
+} from '@testing-library/react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
 import { CoreStart } from 'kibana/public';
@@ -209,3 +214,18 @@ const getHistoryFromUrl = (url: Url) => {
     initialEntries: [url.path + stringifyUrlParams(url.queryParams)],
   });
 };
+
+// This function allows us to query for the nearest button with test
+// no matter whether it has nested tags or not (as EuiButton elements do).
+export const forNearestButton =
+  (getByText: (f: MatcherFunction) => HTMLElement | null) =>
+  (text: string): HTMLElement | null =>
+    getByText((_content: string, node: Nullish<Element>) => {
+      if (!node) return false;
+      const noOtherButtonHasText = Array.from(node.children).every(
+        (child) => child && (child.textContent !== text || child.tagName.toLowerCase() !== 'button')
+      );
+      return (
+        noOtherButtonHasText && node.textContent === text && node.tagName.toLowerCase() === 'button'
+      );
+    });


### PR DESCRIPTION
> For post-FF testing:
> ⚠️ On v8.1.0 I believe we now don't even open the flyout if the user doesn't have ML permissions, so this PR must be tested both on v8.0.0 and v8.1.0.

## Summary

This PR closes #107994. It adds a callout to the fly-out which appears when users try to create ML jobs but do not have the necessary role or privileges to do so.

Please notice that the fly-out informing users when they lack a license already existed.

One thing to note is that EUI's writing guidelines state that one shouldn't use unnecessary introductory phrases, as in:

> Don't: In order to use Kibana, you must configure at least one index pattern.
> Do: Configure at least one index pattern.

However, considering that this is a fly-out, I decided to follow a writing style similar to the original issue (#107994) as I think otherwise it would still not be clear _why_ certain privileges/roles are required. Please let me know what you think about this.

**Further input on the copy would be much appreciated.**

### Before this change

![no-privileges-before](https://user-images.githubusercontent.com/6868147/140515405-f5a119cc-c8d0-4e45-bb14-c79fe155b578.gif)

### After this change

![Screenshot 2021-12-02 at 13 28 05](https://user-images.githubusercontent.com/6868147/144431512-e8e4db75-7e1e-439e-bc0a-4fed3b5c10ce.png)

### Testing instructions

#### Test case 1: Verifying the callout does _not_ appear when users have permissions

1. As a superuser, create a monitor and wait for it to send some data.
2. Access the Uptime > Monitors page, and go into the details of your monitor
3. In the monitor duration panel, click on "Enable anomaly detection"
4. Verify that the fly-out does **not** contain the new callout which explains what are the necessary permissions.
5. Ensure the ML Job creation button is enabled, and that you can use it.


#### Test case 2: Verifying the callout does appear when users do not have permissions

1. As a superuser, create a monitor and wait for it to send some data.
2. As a superuser, access Stack Management > Users, and create a new user whose only role is the builtin `viewer` role.
3. Login as the user you just created
4. Access the Uptime > Monitors page, and go into the details of a monitor
5. In the monitor duration panel, click on "Enable anomaly detection"
6. Verify that the fly-out does contains the new callout which explains what are the necessary permissions.
7. Ensure the ML Job creation button is disabled.

### Checklist

Delete any items that are not applicable to this PR.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

I don't believe this is applicable for this PR, but please do let me know if you think otherwise.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Release note

Adds a callout to inform users of when they do not have permissions to create ML jobs for Uptime monitors.