### PR TITLE
[CI] Prep for the transition to build bot for github commit statuses

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -42,7 +42,11 @@ if is_pr; then
     export ELASTIC_APM_ACTIVE=false
   fi
 
-  export CHECKS_REPORTER_ACTIVE=true
+  if [[ "${GITHUB_STEP_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
+    export CHECKS_REPORTER_ACTIVE=true
+  else
+    export CHECKS_REPORTER_ACTIVE=false
+  fi
 
   # These can be removed once we're not supporting Jenkins and Buildkite at the same time
   # These are primarily used by github checks reporter and can be configured via /github_checks_api.json

--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 BUILD_SUCCESSFUL=$(node "$(dirname "${0}")/build_status.js")
 export BUILD_SUCCESSFUL
 
-"$(dirname "${0}")/commit_status_complete.sh"
+if [[ "${GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
+  "$(dirname "${0}")/commit_status_complete.sh"
+fi
 
 node "$(dirname "${0}")/ci_stats_complete.js"
 

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-"$(dirname "${0}")/commit_status_start.sh"
+if [[ "${GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
+  "$(dirname "${0}")/commit_status_start.sh"
+fi
 
 export CI_STATS_TOKEN="$(retry 5 5 vault read -field=api_token secret/kibana-issues/dev/kibana_ci_stats)"
 export CI_STATS_HOST="$(retry 5 5 vault read -field=api_host secret/kibana-issues/dev/kibana_ci_stats)"


### PR DESCRIPTION
We are moving Github commit statuses out of pre-/post-build steps and the checks-reporter, and into our Buildkite build bot.

The configurations for this (`GITHUB_BUILD|STEP_COMMIT_STATUS_ENABLED`) have to be set at the root pipeline level, outside of the repo, which means it's enabled for all PRs at the same time.

So, we need to make sure the changes in this PR are propagated to most PRs before we flip the switch, in order to not have any lost or duplicate commit statuses.

After that, a separate PR will remove the code for these completely.