### PR TITLE
fix typo in fleet instructions page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
@@ -368,7 +368,7 @@ const AgentPolicySelectionStep = ({
         <EuiText>
           <FormattedMessage
             id="xpack.fleet.fleetServerSetup.selectAgentPolicyDescriptionText"
-            defaultMessage="Agent policies allow you to configure and mange your agents remotely. We recommend using the “Default Fleet Server policy” which includes the necessary configuration to run a Fleet Server."
+            defaultMessage="Agent policies allow you to configure and manage your agents remotely. We recommend using the “Default Fleet Server policy” which includes the necessary configuration to run a Fleet Server."
           />
         </EuiText>
         <EuiSpacer size="m" />


### PR DESCRIPTION
## Summary
s/mange/manage

Was playing around with fleet and noticed this small typo


