### PR TITLE
chore(NA): creates wrapper macro for pkg_npm rule

### DIFF
--- a/src/dev/bazel/index.bzl
+++ b/src/dev/bazel/index.bzl
@@ -12,6 +12,8 @@ Please do not import from any other files when looking to use a custom rule
 
 load("//src/dev/bazel:jsts_transpiler.bzl", _jsts_transpiler = "jsts_transpiler")
 load("//src/dev/bazel:ts_project.bzl", _ts_project = "ts_project")
+load("//src/dev/bazel:pkg_npm.bzl", _pkg_npm = "pkg_npm")
 
 jsts_transpiler = _jsts_transpiler
+pkg_npm = _pkg_npm
 ts_project = _ts_project

--- a/src/dev/bazel/pkg_npm.bzl
+++ b/src/dev/bazel/pkg_npm.bzl
@@ -1,0 +1,16 @@
+"Simple wrapper over the general pkg_npm rule from rules_nodejs so we can override some configs"
+
+load("@build_bazel_rules_nodejs//internal/pkg_npm:pkg_npm.bzl", _pkg_npm = "pkg_npm_macro")
+
+def pkg_npm(validate = False, **kwargs):
+  """A macro around the upstream pkg_npm rule.
+
+  Args:
+    validate: boolean; Whether to check that the attributes match the package.json. Defaults to false
+    **kwargs: the rest
+  """
+
+  _pkg_npm(
+    validate = validate,
+    **kwargs
+  )


### PR DESCRIPTION
This PR creates a wrapper macro for the upstream pkg_npm rule. The goal here is to make it easier to override some defaults overtime without have the work of going through each single pkg rule.