### PR TITLE
[Alerting UI] Fixed bug Search is not reset in Create rule flyout

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_form/alert_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alert_form/alert_form.tsx
@@ -764,7 +764,12 @@ export const AlertForm = ({
                 <EuiFieldSearch
                   fullWidth
                   data-test-subj="alertSearchField"
-                  onChange={(e) => setInputText(e.target.value)}
+                  onChange={(e) => {
+                    setInputText(e.target.value);
+                    if (e.target.value === '') {
+                      setSearchText('');
+                    }
+                  }}
                   onKeyUp={(e) => {
                     if (e.keyCode === ENTER_KEY) {
                       setSearchText(inputText);

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -18,6 +18,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const find = getService('find');
   const retry = getService('retry');
   const comboBox = getService('comboBox');
+  const browser = getService('browser');
 
   async function getAlertsByName(name: string) {
     const {
@@ -290,6 +291,25 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.click('testQuery');
       await testSubjects.missingOrFail('testQuerySuccess');
       await testSubjects.existOrFail('testQueryError');
+    });
+
+    it('should show all rule types on click euiFormControlLayoutClearButton', async () => {
+      await pageObjects.triggersActionsUI.clickCreateAlertButton();
+      await testSubjects.setValue('alertNameInput', 'alertName');
+      const ruleTypeSearchBox = await find.byCssSelector('.alertSearchField');
+      await ruleTypeSearchBox.type('notexisting rule type');
+      await ruleTypeSearchBox.pressKeys(browser.keys.ENTER);
+
+      const ruleTypes = await find.allByCssSelector('.triggersActionsUI__alertTypeNodeHeading');
+      expect(ruleTypes).to.have.length(0);
+
+      const searchClearButton = await find.byCssSelector('.euiFormControlLayoutClearButton');
+      await searchClearButton.click();
+
+      const ruleTypesClearFilter = await find.allByCssSelector(
+        '.triggersActionsUI__alertTypeNodeHeading'
+      );
+      expect(ruleTypes.length).to.above(0);
     });
   });
 };

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -309,7 +309,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       const ruleTypesClearFilter = await find.allByCssSelector(
         '.triggersActionsUI__alertTypeNodeHeading'
       );
-      expect(ruleTypes.length).to.above(0);
+      expect(ruleTypesClearFilter.length).to.above(0);
     });
   });
 };


### PR DESCRIPTION
## Summary

Resolves #117127
Added handler for onChange empty search string to run the filter query if clear button was clicked
