### PR TITLE
[Lens] Unskips heatmap test suite & stabilizes the dimensionConfiguration helper

### DIFF
--- a/x-pack/test/functional/apps/lens/heatmap.ts
+++ b/x-pack/test/functional/apps/lens/heatmap.ts
@@ -12,10 +12,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['visualize', 'lens', 'common', 'header']);
   const elasticChart = getService('elasticChart');
   const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/117404
-  // FLAKY: https://github.com/elastic/kibana/issues/113043
-  describe.skip('lens heatmap', () => {
+  describe('lens heatmap', () => {
     before(async () => {
       await PageObjects.visualize.navigateToNewVisualization();
       await PageObjects.visualize.clickVisType('lens');
@@ -73,9 +72,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('should reflect stop colors change on the chart', async () => {
       await PageObjects.lens.openDimensionEditor('lnsHeatmap_cellPanel > lns-dimensionTrigger');
       await PageObjects.lens.openPalettePanel('lnsHeatmap');
-      await testSubjects.setValue('lnsPalettePanel_dynamicColoring_stop_value_0', '10', {
-        clearWithKeyboard: true,
-        typeCharByChar: true,
+      await retry.try(async () => {
+        await testSubjects.setValue('lnsPalettePanel_dynamicColoring_stop_value_0', '10', {
+          clearWithKeyboard: true,
+          typeCharByChar: true,
+        });
       });
       await PageObjects.lens.waitForVisualization();
 

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -126,10 +126,11 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       if (opts.operation === 'formula') {
         await this.switchToFormula();
       } else {
+        const operationSelector = opts.isPreviousIncompatible
+          ? `lns-indexPatternDimension-${opts.operation} incompatible`
+          : `lns-indexPatternDimension-${opts.operation}`;
         await retry.try(async () => {
-          const operationSelector = opts.isPreviousIncompatible
-            ? `lns-indexPatternDimension-${opts.operation} incompatible`
-            : `lns-indexPatternDimension-${opts.operation}`;
+          await testSubjects.exists(operationSelector);
           await testSubjects.click(operationSelector);
         });
       }

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -126,12 +126,13 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       if (opts.operation === 'formula') {
         await this.switchToFormula();
       } else {
-        const operationSelector = opts.isPreviousIncompatible
-          ? `lns-indexPatternDimension-${opts.operation} incompatible`
-          : `lns-indexPatternDimension-${opts.operation}`;
-        await testSubjects.click(operationSelector);
+        await retry.try(async () => {
+          const operationSelector = opts.isPreviousIncompatible
+            ? `lns-indexPatternDimension-${opts.operation} incompatible`
+            : `lns-indexPatternDimension-${opts.operation}`;
+          await testSubjects.click(operationSelector);
+        });
       }
-
       if (opts.field) {
         const target = await testSubjects.find('indexPattern-dimension-field');
         await comboBox.openOptionsList(target);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/117404
Closes https://github.com/elastic/kibana/issues/113043
Closes https://github.com/elastic/kibana/issues/117491
Closes https://github.com/elastic/kibana/issues/117479

There are 2 points of flakiness here.
- The first one fails because although we have set up the dimension to be the average, the median is selected instead.
![image](https://user-images.githubusercontent.com/17003240/140702612-349a8750-73f7-4498-8041-ef807c258eff.png)

- Instead of altering the color stop, it changes the color instead.
![image](https://user-images.githubusercontent.com/17003240/140702713-0eefc846-6595-4540-9e48-983a222767fd.png)

For both of them, I have added the flaky code into a retry. I think that it will stabilize the flakiness.


Other tests that fail because Median is selected instead of Average are:
 - https://github.com/elastic/kibana/issues/117491
 - https://github.com/elastic/kibana/issues/117479
 I think that the retry will also stabilize them.