### PR TITLE
[7.16] [Fleet] Fix copy and add back button to Beats tutorial pages (#117657)

### DIFF
--- a/src/plugins/home/public/application/components/tutorial/__snapshots__/introduction.test.js.snap
+++ b/src/plugins/home/public/application/components/tutorial/__snapshots__/introduction.test.js.snap
@@ -1,118 +1,198 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`props exportedFieldsUrl 1`] = `
-<EuiPageHeader
-  description={
-    <React.Fragment>
-      <Content
-        text="this is a great tutorial about..."
+<Fragment>
+  <div>
+    <EuiButtonEmpty
+      flush="left"
+      iconType="arrowLeft"
+      size="xs"
+    >
+      <FormattedMessage
+        defaultMessage="Browse all integrations"
+        id="home.tutorial.introduction.browseAllIntegrationsButton"
+        values={Object {}}
       />
+    </EuiButtonEmpty>
+  </div>
+  <EuiSpacer />
+  <EuiPageHeader
+    description={
       <React.Fragment>
-        <br />
-        <EuiLink
-          href="exported_fields_url"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <FormattedMessage
-            defaultMessage="View exported fields"
-            id="home.tutorial.introduction.viewButtonLabel"
-            values={Object {}}
-          />
-        </EuiLink>
+        <Content
+          text="this is a great tutorial about..."
+        />
+        <React.Fragment>
+          <br />
+          <EuiLink
+            href="exported_fields_url"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              defaultMessage="View exported fields"
+              id="home.tutorial.introduction.viewButtonLabel"
+              values={Object {}}
+            />
+          </EuiLink>
+        </React.Fragment>
       </React.Fragment>
-    </React.Fragment>
-  }
-  pageTitle={
-    <React.Fragment>
-      Great tutorial
-    </React.Fragment>
-  }
-/>
+    }
+    pageTitle={
+      <React.Fragment>
+        Great tutorial
+      </React.Fragment>
+    }
+  />
+</Fragment>
 `;
 
 exports[`props iconType 1`] = `
-<EuiPageHeader
-  description={
-    <React.Fragment>
-      <Content
-        text="this is a great tutorial about..."
+<Fragment>
+  <div>
+    <EuiButtonEmpty
+      flush="left"
+      iconType="arrowLeft"
+      size="xs"
+    >
+      <FormattedMessage
+        defaultMessage="Browse all integrations"
+        id="home.tutorial.introduction.browseAllIntegrationsButton"
+        values={Object {}}
       />
-    </React.Fragment>
-  }
-  iconType="logoElastic"
-  pageTitle={
-    <React.Fragment>
-      Great tutorial
-    </React.Fragment>
-  }
-/>
+    </EuiButtonEmpty>
+  </div>
+  <EuiSpacer />
+  <EuiPageHeader
+    description={
+      <React.Fragment>
+        <Content
+          text="this is a great tutorial about..."
+        />
+      </React.Fragment>
+    }
+    iconType="logoElastic"
+    pageTitle={
+      <React.Fragment>
+        Great tutorial
+      </React.Fragment>
+    }
+  />
+</Fragment>
 `;
 
 exports[`props isBeta 1`] = `
-<EuiPageHeader
-  description={
-    <React.Fragment>
-      <Content
-        text="this is a great tutorial about..."
+<Fragment>
+  <div>
+    <EuiButtonEmpty
+      flush="left"
+      iconType="arrowLeft"
+      size="xs"
+    >
+      <FormattedMessage
+        defaultMessage="Browse all integrations"
+        id="home.tutorial.introduction.browseAllIntegrationsButton"
+        values={Object {}}
       />
-    </React.Fragment>
-  }
-  pageTitle={
-    <React.Fragment>
-      Great tutorial
+    </EuiButtonEmpty>
+  </div>
+  <EuiSpacer />
+  <EuiPageHeader
+    description={
       <React.Fragment>
-         
-        <EuiBetaBadge
-          label="Beta"
+        <Content
+          text="this is a great tutorial about..."
         />
       </React.Fragment>
-    </React.Fragment>
-  }
-/>
+    }
+    pageTitle={
+      <React.Fragment>
+        Great tutorial
+        <React.Fragment>
+           
+          <EuiBetaBadge
+            label="Beta"
+          />
+        </React.Fragment>
+      </React.Fragment>
+    }
+  />
+</Fragment>
 `;
 
 exports[`props previewUrl 1`] = `
-<EuiPageHeader
-  description={
-    <React.Fragment>
-      <Content
-        text="this is a great tutorial about..."
+<Fragment>
+  <div>
+    <EuiButtonEmpty
+      flush="left"
+      iconType="arrowLeft"
+      size="xs"
+    >
+      <FormattedMessage
+        defaultMessage="Browse all integrations"
+        id="home.tutorial.introduction.browseAllIntegrationsButton"
+        values={Object {}}
       />
-    </React.Fragment>
-  }
-  pageTitle={
-    <React.Fragment>
-      Great tutorial
-    </React.Fragment>
-  }
-  rightSideItems={
-    Array [
-      <EuiImage
-        allowFullScreen={true}
-        alt="screenshot of primary dashboard."
-        fullScreenIconColor="dark"
-        size="l"
-        url="preview_image_url"
-      />,
-    ]
-  }
-/>
+    </EuiButtonEmpty>
+  </div>
+  <EuiSpacer />
+  <EuiPageHeader
+    description={
+      <React.Fragment>
+        <Content
+          text="this is a great tutorial about..."
+        />
+      </React.Fragment>
+    }
+    pageTitle={
+      <React.Fragment>
+        Great tutorial
+      </React.Fragment>
+    }
+    rightSideItems={
+      Array [
+        <EuiImage
+          allowFullScreen={true}
+          alt="screenshot of primary dashboard."
+          fullScreenIconColor="dark"
+          size="l"
+          url="preview_image_url"
+        />,
+      ]
+    }
+  />
+</Fragment>
 `;
 
 exports[`render 1`] = `
-<EuiPageHeader
-  description={
-    <React.Fragment>
-      <Content
-        text="this is a great tutorial about..."
+<Fragment>
+  <div>
+    <EuiButtonEmpty
+      flush="left"
+      iconType="arrowLeft"
+      size="xs"
+    >
+      <FormattedMessage
+        defaultMessage="Browse all integrations"
+        id="home.tutorial.introduction.browseAllIntegrationsButton"
+        values={Object {}}
       />
-    </React.Fragment>
-  }
-  pageTitle={
-    <React.Fragment>
-      Great tutorial
-    </React.Fragment>
-  }
-/>
+    </EuiButtonEmpty>
+  </div>
+  <EuiSpacer />
+  <EuiPageHeader
+    description={
+      <React.Fragment>
+        <Content
+          text="this is a great tutorial about..."
+        />
+      </React.Fragment>
+    }
+    pageTitle={
+      <React.Fragment>
+        Great tutorial
+      </React.Fragment>
+    }
+  />
+</Fragment>
 `;

--- a/src/plugins/home/public/application/components/tutorial/__snapshots__/tutorial.test.js.snap
+++ b/src/plugins/home/public/application/components/tutorial/__snapshots__/tutorial.test.js.snap
@@ -6,6 +6,11 @@ exports[`isCloudEnabled is false should not render instruction toggle when ON_PR
 >
   <div>
     <InjectIntl(IntroductionUI)
+      basePath={
+        Object {
+          "prepend": [Function],
+        }
+      }
       description="tutorial used to drive jest tests"
       notices={null}
       title="jest test tutorial"
@@ -43,6 +48,11 @@ exports[`isCloudEnabled is false should render ON_PREM instructions with instruc
 >
   <div>
     <InjectIntl(IntroductionUI)
+      basePath={
+        Object {
+          "prepend": [Function],
+        }
+      }
       description="tutorial used to drive jest tests"
       iconType="logoApache"
       notices={null}
@@ -113,6 +123,11 @@ exports[`should render ELASTIC_CLOUD instructions when isCloudEnabled is true 1`
 >
   <div>
     <InjectIntl(IntroductionUI)
+      basePath={
+        Object {
+          "prepend": [Function],
+        }
+      }
       description="tutorial used to drive jest tests"
       iconType="logoApache"
       notices={null}

--- a/src/plugins/home/public/application/components/tutorial/introduction.js
+++ b/src/plugins/home/public/application/components/tutorial/introduction.js
@@ -9,7 +9,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Content } from './content';
-import { EuiImage, EuiLink, EuiBetaBadge, EuiPageHeader } from '@elastic/eui';
+import {
+  EuiImage,
+  EuiLink,
+  EuiBetaBadge,
+  EuiPageHeader,
+  EuiButtonEmpty,
+  EuiSpacer,
+} from '@elastic/eui';
 
 import { FormattedMessage, injectI18n } from '@kbn/i18n/react';
 
@@ -22,6 +29,7 @@ function IntroductionUI({
   isBeta,
   intl,
   notices,
+  basePath,
 }) {
   let rightSideItems;
   if (previewUrl) {
@@ -64,28 +72,44 @@ function IntroductionUI({
     );
   }
   return (
-    <EuiPageHeader
-      iconType={iconType}
-      pageTitle={
-        <>
-          {title}
-          {betaBadge && (
-            <>
-              &nbsp;
-              {betaBadge}
-            </>
-          )}
-        </>
-      }
-      description={
-        <>
-          <Content text={description} />
-          {exportedFields}
-          {notices}
-        </>
-      }
-      rightSideItems={rightSideItems}
-    />
+    <>
+      <div>
+        <EuiButtonEmpty
+          iconType="arrowLeft"
+          size="xs"
+          flush="left"
+          href={basePath.prepend(`/app/integrations`)}
+        >
+          <FormattedMessage
+            id="home.tutorial.introduction.browseAllIntegrationsButton"
+            defaultMessage="Browse all integrations"
+          />
+        </EuiButtonEmpty>
+      </div>
+      <EuiSpacer />
+      <EuiPageHeader
+        iconType={iconType}
+        pageTitle={
+          <>
+            {title}
+            {betaBadge && (
+              <>
+                &nbsp;
+                {betaBadge}
+              </>
+            )}
+          </>
+        }
+        description={
+          <>
+            <Content text={description} />
+            {exportedFields}
+            {notices}
+          </>
+        }
+        rightSideItems={rightSideItems}
+      />
+    </>
   );
 }
 

--- a/src/plugins/home/public/application/components/tutorial/introduction.test.js
+++ b/src/plugins/home/public/application/components/tutorial/introduction.test.js
@@ -10,12 +10,16 @@ import React from 'react';
 import { shallowWithIntl } from '@kbn/test/jest';
 
 import { Introduction } from './introduction';
+import { httpServiceMock } from '../../../../../../core/public/mocks';
+
+const basePathMock = httpServiceMock.createBasePath();
 
 test('render', () => {
   const component = shallowWithIntl(
     <Introduction.WrappedComponent
       description="this is a great tutorial about..."
       title="Great tutorial"
+      basePath={basePathMock}
     />
   );
   expect(component).toMatchSnapshot(); // eslint-disable-line
@@ -27,6 +31,7 @@ describe('props', () => {
       <Introduction.WrappedComponent
         description="this is a great tutorial about..."
         title="Great tutorial"
+        basePath={basePathMock}
         iconType="logoElastic"
       />
     );
@@ -38,6 +43,7 @@ describe('props', () => {
       <Introduction.WrappedComponent
         description="this is a great tutorial about..."
         title="Great tutorial"
+        basePath={basePathMock}
         exportedFieldsUrl="exported_fields_url"
       />
     );
@@ -49,6 +55,7 @@ describe('props', () => {
       <Introduction.WrappedComponent
         description="this is a great tutorial about..."
         title="Great tutorial"
+        basePath={basePathMock}
         previewUrl="preview_image_url"
       />
     );
@@ -60,6 +67,7 @@ describe('props', () => {
       <Introduction.WrappedComponent
         description="this is a great tutorial about..."
         title="Great tutorial"
+        basePath={basePathMock}
         isBeta={true}
       />
     );

--- a/src/plugins/home/public/application/components/tutorial/tutorial.js
+++ b/src/plugins/home/public/application/components/tutorial/tutorial.js
@@ -421,6 +421,7 @@ class TutorialUi extends React.Component {
             iconType={icon}
             isBeta={this.state.tutorial.isBeta}
             notices={this.renderModuleNotices()}
+            basePath={getServices().http.basePath}
           />
 
           {this.renderInstructionSetsToggle()}

--- a/src/plugins/home/public/application/components/tutorial/tutorial.test.js
+++ b/src/plugins/home/public/application/components/tutorial/tutorial.test.js
@@ -15,6 +15,7 @@ jest.mock('../../kibana_services', () => ({
   getServices: () => ({
     http: {
       post: jest.fn().mockImplementation(async () => ({ count: 1 })),
+      basePath: { prepend: (path) => `/foo/${path}` },
     },
     getBasePath: jest.fn(() => 'path'),
     chrome: {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid.tsx
@@ -235,7 +235,7 @@ function MissingIntegrationContent({
       <p>
         <FormattedMessage
           id="xpack.fleet.integrations.missing"
-          defaultMessage="Don't see an integration? Collect any logs or metrics using our {customInputsLink}. Request new integrations using our {discussForumLink}."
+          defaultMessage="Don't see an integration? Collect any logs or metrics using our {customInputsLink}. Request new integrations in our {forumLink}."
           values={{
             customInputsLink: (
               <EuiLink onClick={handleCustomInputsLinkClick}>
@@ -245,11 +245,11 @@ function MissingIntegrationContent({
                 />
               </EuiLink>
             ),
-            discussForumLink: (
+            forumLink: (
               <EuiLink href="https://discuss.elastic.co/tag/integrations" external target="_blank">
                 <FormattedMessage
                   id="xpack.fleet.integrations.discussForumLink"
-                  defaultMessage="discuss forum"
+                  defaultMessage="forum"
                 />
               </EuiLink>
             ),

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -370,12 +370,12 @@ export function Detail() {
                             content: missingSecurityConfiguration ? (
                               <FormattedMessage
                                 id="xpack.fleet.epm.addPackagePolicyButtonSecurityRequiredTooltip"
-                                defaultMessage="To add Elastic Agent Integrations, you must have security enabled and have the minimum required privileges. Contact your administrator."
+                                defaultMessage="To add Elastic Agent Integrations, you must have security enabled and have the superuser role. Contact your administrator."
                               />
                             ) : (
                               <FormattedMessage
                                 id="xpack.fleet.epm.addPackagePolicyButtonPrivilegesRequiredTooltip"
-                                defaultMessage="To add Elastic Agent integrations, you must have the minimum required privileges. Contact your adminstrator."
+                                defaultMessage="To add Elastic Agent integrations, you must have the superuser role. Contact your adminstrator."
                               />
                             ),
                           }


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Fleet] Fix copy and add back button to Beats tutorial pages (#117657)