### PR TITLE
[User Experience] add title to UX data view

### DIFF
--- a/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/use_data_view.test.js
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/use_data_view.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import * as dynamicDataView from '../../../../hooks/use_dynamic_data_view';
+import { useDataView } from './use_data_view';
+import { MockApmPluginContextWrapper } from '../../../../context/apm_plugin/mock_apm_plugin_context';
+import { KibanaContextProvider } from '../../../../../../../../src/plugins/kibana_react/public';
+
+describe('useDataView', () => {
+  const create = jest.fn();
+  const mockDataService = {
+    data: {
+      dataViews: {
+        create,
+      },
+    },
+  };
+
+  const title = 'apm-*';
+  jest
+    .spyOn(dynamicDataView, 'useDynamicDataViewFetcher')
+    .mockReturnValue({ dataView: { title } });
+
+  it('returns result as expected', async () => {
+    const { waitForNextUpdate } = renderHook(() => useDataView(), {
+      wrapper: ({ children }) => (
+        <MockApmPluginContextWrapper>
+          <KibanaContextProvider services={mockDataService}>
+            {children}
+          </KibanaContextProvider>
+        </MockApmPluginContextWrapper>
+      ),
+    });
+
+    await waitForNextUpdate();
+
+    expect(create).toBeCalledWith({ title });
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/use_data_view.ts
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/use_data_view.ts
@@ -6,10 +6,7 @@
  */
 
 import { useDynamicDataViewFetcher } from '../../../../hooks/use_dynamic_data_view';
-import {
-  DataView,
-  DataViewSpec,
-} from '../../../../../../../../src/plugins/data/common';
+import { DataView } from '../../../../../../../../src/plugins/data/common';
 import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { DataPublicPluginStart } from '../../../../../../../../src/plugins/data/public';
@@ -26,9 +23,8 @@ export function useDataView() {
   const { data } = useFetcher<Promise<DataView | undefined>>(async () => {
     if (dataView?.title) {
       return dataViews.create({
-        pattern: dataView?.title,
         title: dataView?.title,
-      } as DataViewSpec);
+      });
     }
   }, [dataView?.title, dataViews]);
 

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/use_data_view.ts
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/LocalUIFilters/use_data_view.ts
@@ -27,6 +27,7 @@ export function useDataView() {
     if (dataView?.title) {
       return dataViews.create({
         pattern: dataView?.title,
+        title: dataView?.title,
       } as DataViewSpec);
     }
   }, [dataView?.title, dataViews]);


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/116226

Adds title to UX Data View, allowing the Data View pattern to be appropriately created based off the apm pattern.

The previous Data View configuration would cause the filters to break. This has been resolved with the updated Data View creation logic.

![chrome-capture (24)](https://user-images.githubusercontent.com/11356435/140764249-aa4b00a8-ebdc-48c5-a58a-67cdd647d3d6.gif)

### Testing
Connect Kibana to a cross-cluster search enabled ES cluster using the `oblt-cli` tool
Navigate to the User Experience app
Attempt to use the UX filters, for example the location filter
The page should load appropriately after the filter is selected

