### PR TITLE
chore(NA): removes invalid ui_actions docs links

### DIFF
--- a/src/plugins/ui_actions/README.asciidoc
+++ b/src/plugins/ui_actions/README.asciidoc
@@ -71,13 +71,3 @@ action to execute.
 
 https://github.com/elastic/kibana/blob/main/examples/ui_action_examples/README.md[ui_action examples]
 
-=== API Docs
-
-==== Server API
-https://github.com/elastic/kibana/blob/main/docs/development/plugins/ui_actions/server/kibana-plugin-plugins-ui_actions-server.uiactionssetup.md[Browser Setup contract]
-https://github.com/elastic/kibana/blob/main/docs/development/plugins/ui_actions/server/kibana-plugin-plugins-ui_actions-server.uiactionsstart.md[Browser Start contract]
-
-==== Browser API
-https://github.com/elastic/kibana/blob/main/docs/development/plugins/ui_actions/public/kibana-plugin-plugins-ui_actions-public.uiactionssetup.md[Browser Setup contract]
-https://github.com/elastic/kibana/blob/main/docs/development/plugins/ui_actions/public/kibana-plugin-plugins-ui_actions-public.uiactionsstart.md[Browser Start contract]
-


### PR DESCRIPTION
After https://github.com/elastic/kibana/pull/109927 those linked docs stopped being valid so I'm removing those here.