### PR TITLE
[7.16] migrations: handle 200 response code from _cluster/health API on timeout (#117879)

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/actions/clone_index.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/clone_index.ts
@@ -127,11 +127,11 @@ export const cloneIndex = ({
         // If the cluster state was updated and all shards ackd we're done
         return TaskEither.right(res);
       } else {
-        // Otherwise, wait until the target index has a 'green' status.
+        // Otherwise, wait until the target index has a 'yellow' status.
         return pipe(
           waitForIndexStatusYellow({ client, index: target, timeout }),
           TaskEither.map((value) => {
-            /** When the index status is 'green' we know that all shards were started */
+            /** When the index status is 'yellow' we know that all shards were started */
             return { acknowledged: true, shardsAcknowledged: true };
           })
         );

--- a/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
@@ -409,14 +409,15 @@ describe('migration actions', () => {
         timeout: '0s',
       })();
 
-      await expect(cloneIndexPromise).resolves.toMatchObject({
-        _tag: 'Left',
-        left: {
-          error: expect.any(ResponseError),
-          message: expect.stringMatching(/\"timed_out\":true/),
-          type: 'retryable_es_client_error',
-        },
-      });
+      await expect(cloneIndexPromise).resolves.toMatchInlineSnapshot(`
+        Object {
+          "_tag": "Left",
+          "left": Object {
+            "message": "Timeout waiting for the status of the [clone_red_index] index to become 'yellow'",
+            "type": "retryable_es_client_error",
+          },
+        }
+      `);
     });
   });
 

--- a/src/core/server/saved_objects/migrationsv2/actions/wait_for_index_status_yellow.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/wait_for_index_status_yellow.ts
@@ -45,7 +45,7 @@ export const waitForIndexStatusYellow =
         wait_for_status: 'yellow',
         timeout,
         // @ts-expect-error
-        return_200_for_cluster_health_timeout: true // opt-in to the 8.0 breaking behaviour to prevent a deprecation log
+        return_200_for_cluster_health_timeout: true, // opt-in to the 8.0 breaking behaviour to prevent a deprecation log
       })
       .then((res) => {
         if (res.body.timed_out === true) {

--- a/src/core/server/saved_objects/migrationsv2/actions/wait_for_index_status_yellow.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/wait_for_index_status_yellow.ts
@@ -40,8 +40,20 @@ export const waitForIndexStatusYellow =
   }: WaitForIndexStatusYellowParams): TaskEither.TaskEither<RetryableEsClientError, {}> =>
   () => {
     return client.cluster
-      .health({ index, wait_for_status: 'yellow', timeout })
-      .then(() => {
+      .health({
+        index,
+        wait_for_status: 'yellow',
+        timeout,
+        // @ts-expect-error
+        return_200_for_cluster_health_timeout: true // opt-in to the 8.0 breaking behaviour to prevent a deprecation log
+      })
+      .then((res) => {
+        if (res.body.timed_out === true) {
+          return Either.left({
+            type: 'retryable_es_client_error' as const,
+            message: `Timeout waiting for the status of the [${index}] index to become 'yellow'`,
+          });
+        }
         return Either.right({});
       })
       .catch(catchRetryableEsClientErrors);


### PR DESCRIPTION
Backports the following commits to 7.16:
 - migrations: handle 200 response code from _cluster/health API on timeout (#117879)