### PR TITLE
[7.16] [Charts] fix legend breaking on words (#117681)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
     "@elastic/apm-rum": "^5.9.1",
     "@elastic/apm-rum-react": "^1.3.1",
-    "@elastic/charts": "38.0.2",
+    "@elastic/charts": "38.0.3",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^7.16.0-canary.7",
     "@elastic/ems-client": "7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,10 +2337,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@38.0.2":
-  version "38.0.2"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-38.0.2.tgz#70eff5f97bca60a10cb2b376175618ee4309d351"
-  integrity sha512-8CfLxXHtbAVz2K6HejS05Mg7oolIRamgC1pvhMNLHhI4PClY03Icymap/RoWSiuzR0FhX6Hqkeu7uD0HIR/bWg==
+"@elastic/charts@38.0.3":
+  version "38.0.3"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-38.0.3.tgz#0c52dd59abc9b2591348d162f5a8ff4544d1d301"
+  integrity sha512-BRCVCtOqIJ8L6sOEeeqcQIj4MIzyst1M7cwUMd3QjThd3ZC2iPfTBjxb7lJGqITU79p4zbVkU5w4jtGTQ3sKgw==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Charts] fix legend breaking on words (#117681)