### PR TITLE
[basePathProxy] fix bypass route, request to server shouldn't have basePath

### DIFF
--- a/packages/kbn-cli-dev-mode/src/base_path_proxy_server.ts
+++ b/packages/kbn-cli-dev-mode/src/base_path_proxy_server.ts
@@ -177,7 +177,7 @@ export class BasePathProxyServer {
               hostname: request.server.info.host,
               port: this.devConfig.basePathProxyTargetPort,
               protocol: request.server.info.protocol,
-              pathname: `${this.httpConfig.basePath}/${request.params.kbnPath}`,
+              pathname: request.params.kbnPath,
               query: request.query,
             }),
             headers: request.headers,


### PR DESCRIPTION
At some point we dropped the basePath from the requests being sent from the basePathProxy to the Kibana server, but the `__UNSAFE_bypassBasePathProxy` route was not updated to do the same. This takes care of that change restoring the functionality that allows users to bypass the basePathProxy for local development scripts.