### PR TITLE
[Security Solution] Fixes upgrade assistant info for rule preview warnings

### DIFF
--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
@@ -109,6 +109,24 @@ describe('rule preview privileges deprecation', () => {
       expect(result).toEqual([]);
     });
 
+    it('returns no deprecation when a role also has read access to the previews index', async () => {
+      mockDependencies.getKibanaRoles.mockResolvedValue({
+        roles: [
+          getRoleMock(
+            [
+              {
+                names: ['other-index', '.siem-signals-*', '.preview.alerts-security.alerts-*'],
+                privileges: ['all'],
+              },
+            ],
+            'roleWithCorrectAccess'
+          ),
+        ],
+      });
+      const result = await deprecationHandler.getDeprecations(mockContext);
+      expect(result).toEqual([]);
+    });
+
     it('returns no deprecation if all roles found are internal', async () => {
       const internalRoleMock = {
         ...getRoleMock(
@@ -142,6 +160,15 @@ describe('rule preview privileges deprecation', () => {
               },
             ],
             'irrelevantRole'
+          ),
+          getRoleMock(
+            [
+              {
+                names: ['other-index', '.siem-signals-*', '.preview.alerts-security.alerts-*'],
+                privileges: ['all'],
+              },
+            ],
+            'roleWithCorrectAccess'
           ),
           getRoleMock(
             [

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
@@ -101,28 +101,12 @@ describe('rule preview privileges deprecation', () => {
       ]);
     });
 
-    it('returns an appropriate deprecation if no roles are found', async () => {
+    it('returns no deprecation if no roles are found', async () => {
       mockDependencies.getKibanaRoles.mockResolvedValue({
         roles: [],
       });
       const result = await deprecationHandler.getDeprecations(mockContext);
-      expect(result).toEqual([
-        {
-          correctiveActions: {
-            manualSteps: [
-              'Update your roles to include read privileges for the detection alerts preview indices appropriate for that role and space(s).',
-              'In 8.0, users will be unable to view preview results until those permissions are added.',
-            ],
-          },
-          deprecationType: 'feature',
-          documentationUrl:
-            'https://www.elastic.co/guide/en/security/some-branch/rules-ui-create.html#preview-rules',
-          level: 'warning',
-          message:
-            'In order to enable a more robust preview, users will need read privileges to new detection alerts preview indices (.alerts-security.preview.alert-<KIBANA_SPACE>), analogous to existing detection alerts indices (.siem-signals-<KIBANA_SPACE>).',
-          title: 'The Detections Rule Preview feature is changing',
-        },
-      ]);
+      expect(result).toEqual([]);
     });
 
     it('returns an appropriate deprecation if roles are found', async () => {

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
@@ -14,7 +14,7 @@ import { RegisterDeprecationsConfig } from 'src/core/server';
 import { Role } from '../../../security/common/model';
 import {
   registerRulePreviewPrivilegeDeprecations,
-  roleHasSignalsReadAccess,
+  roleHasReadAccess,
 } from './rule_preview_privileges';
 
 const emptyRole: Role = {
@@ -171,7 +171,7 @@ describe('rule preview privileges deprecation', () => {
   });
 
   describe('utilities', () => {
-    describe('roleHasSignalsReadAccess', () => {
+    describe('roleHasReadAccess', () => {
       it('returns true if the role has read privilege to all signals indexes', () => {
         const role = getRoleMock([
           {
@@ -179,7 +179,7 @@ describe('rule preview privileges deprecation', () => {
             privileges: ['read'],
           },
         ]);
-        expect(roleHasSignalsReadAccess(role)).toEqual(true);
+        expect(roleHasReadAccess(role)).toEqual(true);
       });
 
       it('returns true if the role has read privilege to a single signals index', () => {
@@ -189,7 +189,7 @@ describe('rule preview privileges deprecation', () => {
             privileges: ['read'],
           },
         ]);
-        expect(roleHasSignalsReadAccess(role)).toEqual(true);
+        expect(roleHasReadAccess(role)).toEqual(true);
       });
 
       it('returns true if the role has all privilege to a single signals index', () => {
@@ -199,7 +199,7 @@ describe('rule preview privileges deprecation', () => {
             privileges: ['all'],
           },
         ]);
-        expect(roleHasSignalsReadAccess(role)).toEqual(true);
+        expect(roleHasReadAccess(role)).toEqual(true);
       });
 
       it('returns false if the role has read privilege to other indices', () => {
@@ -209,7 +209,7 @@ describe('rule preview privileges deprecation', () => {
             privileges: ['read'],
           },
         ]);
-        expect(roleHasSignalsReadAccess(role)).toEqual(false);
+        expect(roleHasReadAccess(role)).toEqual(false);
       });
 
       it('returns false if the role has all privilege to other indices', () => {
@@ -219,12 +219,12 @@ describe('rule preview privileges deprecation', () => {
             privileges: ['all'],
           },
         ]);
-        expect(roleHasSignalsReadAccess(role)).toEqual(false);
+        expect(roleHasReadAccess(role)).toEqual(false);
       });
 
       it('returns false if the role has no specific privileges', () => {
         const role = getRoleMock();
-        expect(roleHasSignalsReadAccess(role)).toEqual(false);
+        expect(roleHasReadAccess(role)).toEqual(false);
       });
     });
   });

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
@@ -109,6 +109,28 @@ describe('rule preview privileges deprecation', () => {
       expect(result).toEqual([]);
     });
 
+    it('returns no deprecation if all roles found are internal', async () => {
+      const internalRoleMock = {
+        ...getRoleMock(
+          [
+            {
+              names: ['other-index', '.siem-signals-*'],
+              privileges: ['all'],
+            },
+          ],
+          'internalRole'
+        ),
+        metadata: {
+          _reserved: true,
+        },
+      };
+      mockDependencies.getKibanaRoles.mockResolvedValue({
+        roles: [internalRoleMock],
+      });
+      const result = await deprecationHandler.getDeprecations(mockContext);
+      expect(result).toEqual([]);
+    });
+
     it('returns an appropriate deprecation if roles are found', async () => {
       mockDependencies.getKibanaRoles.mockResolvedValue({
         roles: [

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.test.ts
@@ -147,7 +147,7 @@ describe('rule preview privileges deprecation', () => {
             'https://www.elastic.co/guide/en/security/some-branch/rules-ui-create.html#preview-rules',
           level: 'warning',
           message:
-            'In order to enable a more robust preview, users will need read privileges to new detection alerts preview indices (.alerts-security.preview.alert-<KIBANA_SPACE>), analogous to existing detection alerts indices (.siem-signals-<KIBANA_SPACE>).',
+            'In order to enable a more robust preview in 8.0+, users will need read privileges to new detection alerts preview indices (.preview.alerts-security.alerts-<KIBANA_SPACE>), analogous to existing detection alerts indices (.siem-signals-<KIBANA_SPACE>).',
           title: 'The Detections Rule Preview feature is changing',
         },
       ]);

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
@@ -74,6 +74,10 @@ export const registerRulePreviewPrivilegeDeprecations = ({
         rolesWhichReadSignals = roles?.filter((role) => roleHasReadAccess(role)) ?? [];
       }
 
+      if (rolesWhichReadSignals.length === 0) {
+        return [];
+      }
+
       const roleNamesWhichReadSignals = rolesWhichReadSignals.map((role) => role.name);
 
       return [

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
@@ -21,6 +21,8 @@ export const roleHasReadAccess = (role: Role, indexPrefix = DEFAULT_SIGNALS_INDE
       index.privileges.some((indexPrivilege) => READ_PRIVILEGES.includes(indexPrivilege))
   );
 
+export const roleIsExternal = (role: Role): boolean => role.metadata?._reserved !== true;
+
 const buildManualSteps = (roleNames: string[]): string[] => {
   const baseSteps = [
     i18n.translate('xpack.securitySolution.deprecations.rulePreviewPrivileges.manualStep1', {
@@ -71,7 +73,8 @@ export const registerRulePreviewPrivilegeDeprecations = ({
           return errors;
         }
 
-        rolesWhichReadSignals = roles?.filter((role) => roleHasReadAccess(role)) ?? [];
+        rolesWhichReadSignals =
+          roles?.filter((role) => roleIsExternal(role) && roleHasReadAccess(role)) ?? [];
       }
 
       if (rolesWhichReadSignals.length === 0) {

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
@@ -75,11 +75,11 @@ export const registerRulePreviewPrivilegeDeprecations = ({
             'xpack.securitySolution.deprecations.rulePreviewPrivileges.message',
             {
               values: {
-                previewIndexPrefix: '.alerts-security.preview.alert',
+                previewIndexPrefix: '.preview.alerts-security.alerts',
                 signalsIndexPrefix: DEFAULT_SIGNALS_INDEX,
               },
               defaultMessage:
-                'In order to enable a more robust preview, users will need read privileges to new detection alerts preview indices ({previewIndexPrefix}-<KIBANA_SPACE>), analogous to existing detection alerts indices ({signalsIndexPrefix}-<KIBANA_SPACE>).',
+                'In order to enable a more robust preview in 8.0+, users will need read privileges to new detection alerts preview indices ({previewIndexPrefix}-<KIBANA_SPACE>), analogous to existing detection alerts indices ({signalsIndexPrefix}-<KIBANA_SPACE>).',
             }
           ),
           level: 'warning',

--- a/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
+++ b/x-pack/plugins/security_solution/server/deprecations/rule_preview_privileges.ts
@@ -74,7 +74,12 @@ export const registerRulePreviewPrivilegeDeprecations = ({
         }
 
         rolesWhichReadSignals =
-          roles?.filter((role) => roleIsExternal(role) && roleHasReadAccess(role)) ?? [];
+          roles?.filter(
+            (role) =>
+              roleIsExternal(role) &&
+              roleHasReadAccess(role) &&
+              !roleHasReadAccess(role, PREVIEW_INDEX_PREFIX)
+          ) ?? [];
       }
 
       if (rolesWhichReadSignals.length === 0) {


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/117903

Updates index name to approved nomenclature and adds `8.0` specific text

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
