### PR TITLE
[7.16] [maps] fix layer flashes when query is updated in query bar for mvt layers (#117590)

### DIFF
--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -212,12 +212,10 @@ export class MapApp extends React.Component<Props, State> {
     filters,
     query,
     time,
-    forceRefresh = false,
   }: {
     filters?: Filter[];
     query?: Query;
     time?: TimeRange;
-    forceRefresh?: boolean;
   }) => {
     const { filterManager } = getData().query;
 
@@ -226,7 +224,7 @@ export class MapApp extends React.Component<Props, State> {
     }
 
     this.props.setQuery({
-      forceRefresh,
+      forceRefresh: false,
       filters: filterManager.getFilters(),
       query,
       timeFilters: time,
@@ -400,11 +398,16 @@ export class MapApp extends React.Component<Props, State> {
         filters={this.props.filters}
         query={this.props.query}
         onQuerySubmit={({ dateRange, query }) => {
-          this._onQueryChange({
-            query,
-            time: dateRange,
-            forceRefresh: true,
-          });
+          const isUpdate =
+            !_.isEqual(dateRange, this.props.timeFilters) || !_.isEqual(query, this.props.query);
+          if (isUpdate) {
+            this._onQueryChange({
+              query,
+              time: dateRange,
+            });
+          } else {
+            this.props.setQuery({ forceRefresh: true });
+          }
         }}
         onFiltersUpdated={this._onFiltersChange}
         dateRangeFrom={this.props.timeFilters.from}


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [maps] fix layer flashes when query is updated in query bar for mvt layers (#117590)