### PR TITLE
[Security Solution] Clarify SN roles needed when setting up SN ITSM and SecOps connectors

### DIFF
--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -10,7 +10,7 @@ The ServiceNow connector uses the https://docs.servicenow.com/bundle/orlando-app
 [float]
 [[servicenow-connector-prerequisites]]
 ==== Prerequisites
-Create a {sn} integration user and assign it the following roles.
+Create a {sn} integration user and assign it the following roles:
 
 * `incident_manager`: Allows the user read, create, and update access to the Incident table.
 * `personalize_choices`: Allows the user to retrieve Choice element options, such as Severity.

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -10,7 +10,7 @@ The ServiceNow connector uses the https://docs.servicenow.com/bundle/orlando-app
 [float]
 [[servicenow-connector-prerequisites]]
 ==== Prerequisites
-Create an integration user in ServiceNow and assign it the following roles.
+Create a {sn} integration user and assign it the following roles.
 
 * `incident_manager`: Allows the user read, create, and update access to the Incident table.
 * `personalize_choices`: Allows the user to retrieve Choice element options, such as Severity.

--- a/docs/management/connectors/action-types/servicenow.asciidoc
+++ b/docs/management/connectors/action-types/servicenow.asciidoc
@@ -8,6 +8,14 @@
 The ServiceNow connector uses the https://docs.servicenow.com/bundle/orlando-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html[V2 Table API] to create ServiceNow incidents.
 
 [float]
+[[servicenow-connector-prerequisites]]
+==== Prerequisites
+Create an integration user in ServiceNow and assign it the following roles.
+
+* `incident_manager`: Allows the user read, create, and update access to the Incident table.
+* `personalize_choices`: Allows the user to retrieve Choice element options, such as Severity.
+
+[float]
 [[servicenow-connector-configuration]]
 ==== Connector configuration
 
@@ -17,8 +25,6 @@ Name::      The name of the connector. The name is used to identify a  connector
 URL::       ServiceNow instance URL.
 Username::  Username for HTTP Basic authentication.
 Password::  Password for HTTP Basic authentication.
-
-The ServiceNow user requires at minimum read, create, and update access to the Incident table and read access to the https://docs.servicenow.com/bundle/paris-platform-administration/page/administer/localization/reference/r_ChoicesTable.html[sys_choice]. If you don't provide access to sys_choice, then the choices will not render.
 
 [float]
 [[servicenow-connector-networking-configuration]]


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/117726.

Preview:
- [ServiceNow connector and action](https://kibana_117951.docs-preview.app.elstc.co/guide/en/kibana/7.15/servicenow-action-type.html)
