### PR TITLE
[SecuritySolution][Detections] Fixes rule status migration when alertId is not a string

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.test.ts
@@ -136,7 +136,6 @@ describe.each([
 
   describe('mergeStatuses', () => {
     it('merges statuses and converts from camelCase saved object to snake_case HTTP response', () => {
-      //
       const statusOne = exampleRuleStatus();
       statusOne.attributes.status = RuleExecutionStatus.failed;
       const statusTwo = exampleRuleStatus();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_execution_log/saved_objects_adapter/rule_status_saved_objects_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_execution_log/saved_objects_adapter/rule_status_saved_objects_client.ts
@@ -67,6 +67,9 @@ export const ruleStatusSavedObjectsClientFactory = (
       type: 'alert',
     }));
     const order: 'desc' = 'desc';
+    // NOTE: Once https://github.com/elastic/kibana/issues/115153 is resolved
+    // ${legacyRuleStatusSavedObjectType}.statusDate will need to be updated to
+    // ${legacyRuleStatusSavedObjectType}.attributes.statusDate
     const aggs = {
       references: {
         nested: {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/legacy_rule_status/legacy_migrations.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/legacy_rule_status/legacy_migrations.ts
@@ -50,9 +50,13 @@ export const legacyMigrateRuleAlertIdSOReferences = (
   const { alertId, ...otherAttributes } = doc.attributes;
   const existingReferences = doc.references ?? [];
 
-  // early return if alertId is not a string as expected
+  // early return if alertId is not a string as expected, still removing alertId as the mapping no longer exists
   if (!isString(alertId)) {
-    return { ...doc, references: existingReferences };
+    return {
+      ...doc,
+      attributes: otherAttributes,
+      references: existingReferences,
+    };
   }
 
   const alertReferences = legacyMigrateAlertId({

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/migrations.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/migrations.ts
@@ -154,6 +154,37 @@ export default ({ getService }: FtrProviderContext): void => {
           lastLookBackDate: null,
         });
       });
+
+      // If alertId is not a string/null ensure it is removed as the mapping was removed and so the migration would fail.
+      // Specific test for this as e2e tests will not catch the mismatch and we can't use the migration test harness
+      // since this SO is not importable/exportable via the SOM.
+      // For details see: https://github.com/elastic/kibana/issues/116423
+      it('migrates legacy siem-detection-engine-rule-status and removes alertId when not a string', async () => {
+        const response = await es.get<{
+          'siem-detection-engine-rule-status': IRuleStatusSOAttributes;
+        }>(
+          {
+            index: '.kibana',
+            id: 'siem-detection-engine-rule-status:d62d2980-27c4-11ec-92b0-f7b47106bb36',
+          },
+          { meta: true }
+        );
+        expect(response.statusCode).to.eql(200);
+
+        expect(response.body._source?.['siem-detection-engine-rule-status']).to.eql({
+          statusDate: '2021-10-11T20:51:26.622Z',
+          status: 'succeeded',
+          lastFailureAt: '2021-10-11T18:10:08.982Z',
+          lastSuccessAt: '2021-10-11T20:51:26.622Z',
+          lastFailureMessage:
+            '4 days (323690920ms) were not queried between this rule execution and the last execution, so signals may have been missed. Consider increasing your look behind time or adding more Kibana instances. name: "Threshy" id: "fb1046a0-0452-11ec-9b15-d13d79d162f3" rule id: "b789c80f-f6d8-41f1-8b4f-b4a23342cde2" signals index: ".siem-signals-spong-default"',
+          lastSuccessMessage: 'succeeded',
+          gap: '4 days',
+          bulkCreateTimeDurations: ['34.49'],
+          searchAfterTimeDurations: ['62.58'],
+          lastLookBackDate: null,
+        });
+      });
     });
   });
 };

--- a/x-pack/test/functional/es_archives/security_solution/migrations/data.json
+++ b/x-pack/test/functional/es_archives/security_solution/migrations/data.json
@@ -61,3 +61,34 @@
   }
 }
 
+{
+  "type": "doc",
+  "value": {
+    "id": "siem-detection-engine-rule-status:d62d2980-27c4-11ec-92b0-f7b47106bb36",
+    "index": ".kibana_1",
+    "source": {
+      "siem-detection-engine-rule-status": {
+        "alertId": 1337,
+        "statusDate": "2021-10-11T20:51:26.622Z",
+        "status": "succeeded",
+        "lastFailureAt": "2021-10-11T18:10:08.982Z",
+        "lastSuccessAt": "2021-10-11T20:51:26.622Z",
+        "lastFailureMessage": "4 days (323690920ms) were not queried between this rule execution and the last execution, so signals may have been missed. Consider increasing your look behind time or adding more Kibana instances. name: \"Threshy\" id: \"fb1046a0-0452-11ec-9b15-d13d79d162f3\" rule id: \"b789c80f-f6d8-41f1-8b4f-b4a23342cde2\" signals index: \".siem-signals-spong-default\"",
+        "lastSuccessMessage": "succeeded",
+        "gap": "4 days",
+        "bulkCreateTimeDurations": [
+          "34.49"
+        ],
+        "searchAfterTimeDurations": [
+          "62.58"
+        ],
+        "lastLookBackDate": null
+      },
+      "type": "siem-detection-engine-rule-status",
+      "references": [],
+      "coreMigrationVersion": "7.14.0",
+      "updated_at": "2021-10-11T20:51:26.657Z"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/116423, and adds an e2e test catching this behavior as we can't test via the migration test harness since the `siem-detection-engine-rule-status` SO isn't exposed within the SO Manager UI.

Also adds note with regards to changes necessary once core issue https://github.com/elastic/kibana/issues/115153 is resolved. See https://github.com/elastic/kibana/pull/114585/files#r729620927. Note: existing `find_statuses`/`find_rules` integration tests will fail once fixed, so no additional tests necessary. 



### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
