### PR TITLE
[7.16] Always call `forceLogout` first in the test cleanup code. (#117555)

### DIFF
--- a/x-pack/test/accessibility/apps/login_page.ts
+++ b/x-pack/test/accessibility/apps/login_page.ts
@@ -27,6 +27,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       afterEach(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
       });
 

--- a/x-pack/test/accessibility/apps/ml.ts
+++ b/x-pack/test/accessibility/apps/ml.ts
@@ -33,6 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await ml.securityUI.logout();
       });
 

--- a/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts
+++ b/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts
@@ -72,10 +72,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await ml.securityUI.logout();
+
       await ml.securityCommon.cleanMlUsers();
       await ml.securityCommon.cleanMlRoles();
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.securityUI.logout();
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/accessibility/apps/transform.ts
+++ b/x-pack/test/accessibility/apps/transform.ts
@@ -30,6 +30,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await transform.securityUI.logout();
       });
 

--- a/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_security.ts
+++ b/x-pack/test/functional/apps/advanced_settings/feature_controls/advanced_settings_security.ts
@@ -52,6 +52,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_advanced_settings_all_role'),

--- a/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
+++ b/x-pack/test/functional/apps/apm/feature_controls/apm_security.ts
@@ -23,6 +23,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     after(async () => {
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/functional/apps/canvas/feature_controls/canvas_security.ts
+++ b/x-pack/test/functional/apps/canvas/feature_controls/canvas_security.ts
@@ -58,6 +58,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_canvas_all_role'),

--- a/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/dashboard_security.ts
@@ -43,12 +43,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await PageObjects.security.forceLogout();
+
       await esArchiver.unload(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-
-      // logout, so the other tests don't accidentally run as the custom users we're testing below
-      await PageObjects.security.forceLogout();
     });
 
     describe('global dashboard all privileges, no embeddable application privileges', () => {

--- a/x-pack/test/functional/apps/dashboard/feature_controls/time_to_visualize_security.ts
+++ b/x-pack/test/functional/apps/dashboard/feature_controls/time_to_visualize_security.ts
@@ -70,15 +70,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await PageObjects.security.forceLogout();
+
       await security.role.delete('dashboard_write_vis_read');
       await security.user.delete('dashboard_write_vis_read_user');
 
       await esArchiver.unload(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-
-      // logout, so the other tests don't accidentally run as the custom users we're testing below
-      await PageObjects.security.forceLogout();
     });
 
     describe('lens by value works without library save permissions', () => {

--- a/x-pack/test/functional/apps/dev_tools/feature_controls/dev_tools_security.ts
+++ b/x-pack/test/functional/apps/dev_tools/feature_controls/dev_tools_security.ts
@@ -27,6 +27,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     after(async () => {
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/functional/apps/discover/feature_controls/discover_security.ts
+++ b/x-pack/test/functional/apps/discover/feature_controls/discover_security.ts
@@ -43,12 +43,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await PageObjects.security.forceLogout();
+
       await kibanaServer.importExport.unload(
         'x-pack/test/functional/fixtures/kbn_archiver/discover/feature_controls/security'
       );
-
-      // logout, so the other tests don't accidentally run as the custom users we're testing below
-      await PageObjects.security.forceLogout();
     });
 
     describe('global discover all privileges', () => {

--- a/x-pack/test/functional/apps/graph/feature_controls/graph_security.ts
+++ b/x-pack/test/functional/apps/graph/feature_controls/graph_security.ts
@@ -26,6 +26,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     after(async () => {
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/functional/apps/home/feature_controls/home_security.ts
+++ b/x-pack/test/functional/apps/home/feature_controls/home_security.ts
@@ -26,12 +26,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await PageObjects.security.forceLogout();
+
       await esArchiver.unload(
         'x-pack/test/functional/es_archives/dashboard/feature_controls/security'
       );
-
-      // logout, so the other tests don't accidentally run as the custom users we're testing below
-      await PageObjects.security.forceLogout();
     });
 
     describe('global all privileges', () => {

--- a/x-pack/test/functional/apps/index_patterns/feature_controls/index_patterns_security.ts
+++ b/x-pack/test/functional/apps/index_patterns/feature_controls/index_patterns_security.ts
@@ -64,6 +64,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_index_patterns_all_role'),

--- a/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -53,6 +53,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_infrastructure_all_role'),
@@ -150,6 +151,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_infrastructure_read_role'),

--- a/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/logs_security.ts
@@ -50,6 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_logs_all_role'),
@@ -112,6 +113,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_logs_read_role'),
@@ -174,6 +176,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_logs_no_privileges_role'),

--- a/x-pack/test/functional/apps/maps/feature_controls/maps_security.ts
+++ b/x-pack/test/functional/apps/maps/feature_controls/maps_security.ts
@@ -20,6 +20,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   describe('maps security feature controls', () => {
     after(async () => {
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 
@@ -53,6 +54,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_maps_all_role'),

--- a/x-pack/test/functional/apps/maps/feature_controls/maps_spaces.ts
+++ b/x-pack/test/functional/apps/maps/feature_controls/maps_spaces.ts
@@ -21,6 +21,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
       PageObjects.maps.setBasePath('');
     });

--- a/x-pack/test/functional/apps/ml/feature_controls/ml_security.ts
+++ b/x-pack/test/functional/apps/ml/feature_controls/ml_security.ts
@@ -32,10 +32,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await security.role.delete('global_all_role');
-
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
+
+      await security.role.delete('global_all_role');
     });
 
     describe('machine_learning_user', () => {

--- a/x-pack/test/functional/apps/ml/index.ts
+++ b/x-pack/test/functional/apps/ml/index.ts
@@ -21,6 +21,9 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await ml.securityUI.logout();
+
         await ml.securityCommon.cleanMlUsers();
         await ml.securityCommon.cleanMlRoles();
         await ml.testResources.deleteSavedSearches();
@@ -42,7 +45,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
         await esArchiver.unload('x-pack/test/functional/es_archives/ml/egs_regression');
         await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');
         await ml.testResources.resetKibanaTimeZone();
-        await ml.securityUI.logout();
       });
 
       loadTestFile(require.resolve('./permissions'));
@@ -61,6 +63,9 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await ml.securityUI.logout();
+
         await ml.securityCommon.cleanMlUsers();
         await ml.securityCommon.cleanMlRoles();
         await ml.testResources.deleteSavedSearches();
@@ -82,7 +87,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
         await esArchiver.unload('x-pack/test/functional/es_archives/ml/egs_regression');
         await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');
         await ml.testResources.resetKibanaTimeZone();
-        await ml.securityUI.logout();
       });
 
       loadTestFile(require.resolve('./feature_controls'));

--- a/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
@@ -32,6 +32,7 @@ export default function ({ getService }: FtrProviderContext) {
           });
 
           after(async () => {
+            // NOTE: Logout needs to happen before anything else to avoid flaky behavior
             await ml.securityUI.logout();
           });
 
@@ -156,6 +157,7 @@ export default function ({ getService }: FtrProviderContext) {
           });
 
           after(async () => {
+            // NOTE: Logout needs to happen before anything else to avoid flaky behavior
             await ml.securityUI.logout();
           });
 

--- a/x-pack/test/functional/apps/ml/permissions/no_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/no_ml_access.ts
@@ -28,6 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
 
         after(async () => {
+          // NOTE: Logout needs to happen before anything else to avoid flaky behavior
           await ml.securityUI.logout();
         });
 

--- a/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
@@ -32,6 +32,7 @@ export default function ({ getService }: FtrProviderContext) {
           });
 
           after(async () => {
+            // NOTE: Logout needs to happen before anything else to avoid flaky behavior
             await ml.securityUI.logout();
           });
 
@@ -157,6 +158,7 @@ export default function ({ getService }: FtrProviderContext) {
           });
 
           after(async () => {
+            // NOTE: Logout needs to happen before anything else to avoid flaky behavior
             await ml.securityUI.logout();
           });
 

--- a/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_security.ts
+++ b/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_security.ts
@@ -36,11 +36,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await PageObjects.security.forceLogout();
+
       await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
       await security.role.delete('global_all_role');
-
-      // logout, so the other tests don't accidentally run as the custom users we're testing below
-      await PageObjects.security.forceLogout();
     });
 
     describe('monitoring_user', () => {

--- a/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_spaces.ts
+++ b/x-pack/test/functional/apps/monitoring/feature_controls/monitoring_spaces.ts
@@ -21,9 +21,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
-      await PageObjects.common.navigateToApp('home');
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
+      await esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana');
     });
 
     describe('space with no features disabled', () => {

--- a/x-pack/test/functional/apps/saved_objects_management/feature_controls/saved_objects_management_security.ts
+++ b/x-pack/test/functional/apps/saved_objects_management/feature_controls/saved_objects_management_security.ts
@@ -57,6 +57,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_all_role'),
@@ -171,6 +172,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_som_read_role'),
@@ -290,6 +292,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_visualize_all_role'),

--- a/x-pack/test/functional/apps/security/doc_level_security_roles.ts
+++ b/x-pack/test/functional/apps/security/doc_level_security_roles.ts
@@ -7,8 +7,9 @@
 
 import expect from '@kbn/expect';
 import { keyBy } from 'lodash';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }) {
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const browser = getService('browser');
   const retry = getService('retry');
@@ -45,15 +46,12 @@ export default function ({ getService, getPageObjects }) {
             },
           ],
         },
-        kibana: {
-          global: ['all'],
-        },
       });
       const roles = keyBy(await PageObjects.security.getElasticsearchRoles(), 'rolename');
       log.debug('actualRoles = %j', roles);
       expect(roles).to.have.key('myroleEast');
       expect(roles.myroleEast.reserved).to.be(false);
-      screenshot.take('Security_Roles');
+      await screenshot.take('Security_Roles');
     });
 
     it('should add new user userEAST ', async function () {
@@ -83,6 +81,7 @@ export default function ({ getService, getPageObjects }) {
       expect(rowData).to.contain('EAST');
     });
     after('logout', async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
   });

--- a/x-pack/test/functional/apps/security/field_level_security.ts
+++ b/x-pack/test/functional/apps/security/field_level_security.ts
@@ -7,8 +7,9 @@
 
 import expect from '@kbn/expect';
 import { keyBy } from 'lodash';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }) {
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const browser = getService('browser');
   const retry = getService('retry');
@@ -18,7 +19,7 @@ export default function ({ getService, getPageObjects }) {
 
   describe('field_level_security', () => {
     before('initialize tests', async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/security/flstest/data'); //( data)
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/security/flstest/data'); // ( data)
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/security/flstest/index_pattern'
       );
@@ -43,9 +44,6 @@ export default function ({ getService, getPageObjects }) {
             },
           ],
         },
-        kibana: {
-          global: ['all'],
-        },
       });
 
       await PageObjects.common.sleep(1000);
@@ -65,9 +63,6 @@ export default function ({ getService, getPageObjects }) {
               field_security: { grant: ['customer_name', 'customer_region', 'customer_type'] },
             },
           ],
-        },
-        kibana: {
-          global: ['all'],
         },
       });
       await PageObjects.common.sleep(1000);
@@ -130,6 +125,7 @@ export default function ({ getService, getPageObjects }) {
     });
 
     after(async function () {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
       await kibanaServer.importExport.unload(
         'x-pack/test/functional/fixtures/kbn_archiver/security/flstest/index_pattern'

--- a/x-pack/test/functional/apps/security/index.ts
+++ b/x-pack/test/functional/apps/security/index.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-export default function ({ loadTestFile }) {
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
   describe('security app', function () {
     this.tags('ciGroup4');
 

--- a/x-pack/test/functional/apps/security/management.ts
+++ b/x-pack/test/functional/apps/security/management.ts
@@ -6,8 +6,9 @@
  */
 
 import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }) {
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
@@ -45,9 +46,11 @@ export default function ({ getService, getPageObjects }) {
     });
 
     after(async () => {
-      await security.role.delete('logstash-readonly');
-      await security.user.delete('dashuser', 'new-user');
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
+      await security.role.delete('logstash-readonly');
+      await security.user.delete('dashuser');
+      await security.user.delete('new-user');
     });
 
     describe('Security', () => {

--- a/x-pack/test/functional/apps/security/secure_roles_perm.ts
+++ b/x-pack/test/functional/apps/security/secure_roles_perm.ts
@@ -7,8 +7,9 @@
 
 import expect from '@kbn/expect';
 import { keyBy } from 'lodash';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }) {
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects([
     'security',
     'settings',
@@ -48,9 +49,6 @@ export default function ({ getService, getPageObjects }) {
             },
           ],
         },
-        kibana: {
-          global: ['all'],
-        },
       });
     });
 
@@ -89,6 +87,7 @@ export default function ({ getService, getPageObjects }) {
     });
 
     after(async function () {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
       await kibanaServer.importExport.unload(
         'x-pack/test/functional/fixtures/kbn_archiver/security/discover'

--- a/x-pack/test/functional/apps/security/security.ts
+++ b/x-pack/test/functional/apps/security/security.ts
@@ -29,6 +29,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       afterEach(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
       });
 

--- a/x-pack/test/functional/apps/security/user_email.ts
+++ b/x-pack/test/functional/apps/security/user_email.ts
@@ -7,8 +7,9 @@
 
 import expect from '@kbn/expect';
 import { keyBy } from 'lodash';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }) {
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['security', 'settings', 'common', 'accountSetting']);
   const log = getService('log');
   const kibanaServer = getService('kibanaServer');
@@ -57,6 +58,7 @@ export default function ({ getService, getPageObjects }) {
     });
 
     after(async function () {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
       await kibanaServer.importExport.unload(
         'x-pack/test/functional/fixtures/kbn_archiver/security/discover'

--- a/x-pack/test/functional/apps/spaces/enter_space.ts
+++ b/x-pack/test/functional/apps/spaces/enter_space.ts
@@ -26,6 +26,7 @@ export default function enterSpaceFunctonalTests({
     );
 
     afterEach(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/functional/apps/spaces/feature_controls/spaces_security.ts
+++ b/x-pack/test/functional/apps/spaces/feature_controls/spaces_security.ts
@@ -57,10 +57,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('global_all_role'),
           security.user.delete('global_all_user'),
-          PageObjects.security.forceLogout(),
         ]);
       });
 
@@ -134,10 +135,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
         await Promise.all([
           security.role.delete('default_space_all_role'),
           security.user.delete('default_space_all_user'),
-          PageObjects.security.forceLogout(),
         ]);
       });
 
@@ -213,10 +215,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await Promise.all([
           security.role.delete('nondefault_space_specific_role'),
           security.user.delete('nondefault_space_specific_user'),
-          PageObjects.security.forceLogout(),
         ]);
       });
 

--- a/x-pack/test/functional/apps/spaces/spaces_selection.ts
+++ b/x-pack/test/functional/apps/spaces/spaces_selection.ts
@@ -34,6 +34,7 @@ export default function spaceSelectorFunctionalTests({
       );
 
       afterEach(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
       });
 

--- a/x-pack/test/functional/apps/transform/index.ts
+++ b/x-pack/test/functional/apps/transform/index.ts
@@ -24,6 +24,9 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     });
 
     after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await transform.securityUI.logout();
+
       await transform.securityCommon.cleanTransformUsers();
       await transform.securityCommon.cleanTransformRoles();
 
@@ -36,7 +39,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
 
       await transform.testResources.resetKibanaTimeZone();
-      await transform.securityUI.logout();
     });
 
     loadTestFile(require.resolve('./permissions'));

--- a/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
@@ -20,6 +20,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await transform.securityUI.logout();
       });
 

--- a/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
@@ -20,6 +20,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await transform.securityUI.logout();
       });
 

--- a/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
+++ b/x-pack/test/functional/apps/uptime/feature_controls/uptime_security.ts
@@ -25,6 +25,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     after(async () => {
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/functional/apps/visualize/feature_controls/visualize_security.ts
+++ b/x-pack/test/functional/apps/visualize/feature_controls/visualize_security.ts
@@ -37,9 +37,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await esArchiver.unload('x-pack/test/functional/es_archives/visualize/default');
       // logout, so the other tests don't accidentally run as the custom users we're testing below
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
+
+      await esArchiver.unload('x-pack/test/functional/es_archives/visualize/default');
     });
 
     describe('global visualize all privileges', () => {
@@ -76,6 +78,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await security.role.delete('global_visualize_all_role');
         await security.user.delete('global_visualize_all_user');
@@ -207,6 +210,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await security.role.delete('global_visualize_read_role');
         await security.user.delete('global_visualize_read_user');
@@ -322,6 +326,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await security.role.delete('global_visualize_read_url_create_role');
         await security.user.delete('global_visualize_read_url_create_user');
@@ -427,6 +432,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
         await security.role.delete('no_visualize_privileges_role');
         await security.user.delete('no_visualize_privileges_user');

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -470,7 +470,10 @@ export class SecurityPageObject extends FtrService {
     await this.submitCreateUserForm();
   }
 
-  async addRole(roleName: string, roleObj: Role) {
+  async addRole(
+    roleName: string,
+    roleObj: { elasticsearch: Pick<Role['elasticsearch'], 'indices'> }
+  ) {
     const self = this;
 
     await this.clickCreateNewRole();
@@ -488,21 +491,14 @@ export class SecurityPageObject extends FtrService {
       await this.monacoEditor.setCodeEditorValue(roleObj.elasticsearch.indices[0].query);
     }
 
-    const globalPrivileges = (roleObj.kibana as any).global;
-    if (globalPrivileges) {
-      for (const privilegeName of globalPrivileges) {
-        await this.testSubjects.click('addSpacePrivilegeButton');
+    await this.testSubjects.click('addSpacePrivilegeButton');
+    await this.testSubjects.click('spaceSelectorComboBox');
 
-        await this.testSubjects.click('spaceSelectorComboBox');
+    const globalSpaceOption = await this.find.byCssSelector(`#spaceOption_\\*`);
+    await globalSpaceOption.click();
 
-        const globalSpaceOption = await this.find.byCssSelector(`#spaceOption_\\*`);
-        await globalSpaceOption.click();
-
-        await this.testSubjects.click(`basePrivilege_${privilegeName}`);
-
-        await this.testSubjects.click('createSpacePrivilegeButton');
-      }
-    }
+    await this.testSubjects.click('basePrivilege_all');
+    await this.testSubjects.click('createSpacePrivilegeButton');
 
     const addPrivilege = (privileges: string[]) => {
       return privileges.reduce((promise: Promise<any>, privilegeName: string) => {

--- a/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
@@ -53,6 +53,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         after(async () => {
+          // NOTE: Logout needs to happen before anything else to avoid flaky behavior
           await ml.securityUI.logout();
         });
 

--- a/x-pack/test/functional_basic/apps/ml/permissions/no_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/no_ml_access.ts
@@ -26,6 +26,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
 
         after(async () => {
+          // NOTE: Logout needs to happen before anything else to avoid flaky behavior
           await ml.securityUI.logout();
         });
 

--- a/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
@@ -53,6 +53,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         after(async () => {
+          // NOTE: Logout needs to happen before anything else to avoid flaky behavior
           await ml.securityUI.logout();
         });
 

--- a/x-pack/test/functional_with_es_ssl/apps/ml/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/ml/index.ts
@@ -20,12 +20,14 @@ export default ({ loadTestFile, getService }: FtrProviderContext) => {
     });
 
     after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await ml.securityUI.logout();
+
       await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
       await ml.securityCommon.cleanMlUsers();
       await ml.securityCommon.cleanMlRoles();
       await ml.testResources.resetKibanaTimeZone();
-      await ml.securityUI.logout();
     });
 
     loadTestFile(require.resolve('./alert_flyout'));

--- a/x-pack/test/saved_object_tagging/functional/tests/feature_control.ts
+++ b/x-pack/test/saved_object_tagging/functional/tests/feature_control.ts
@@ -53,6 +53,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
       });
 

--- a/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/dashboard/async_search/sessions_in_space.ts
@@ -57,11 +57,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await security.role.delete('data_analyst');
         await security.user.delete('analyst');
 
         await esArchiver.unload('x-pack/test/functional/es_archives/dashboard/session_in_space');
-        await PageObjects.security.forceLogout();
       });
 
       it('Saves and restores a session', async () => {
@@ -127,11 +129,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await security.role.delete('data_analyst');
         await security.user.delete('analyst');
 
         await esArchiver.unload('x-pack/test/functional/es_archives/dashboard/session_in_space');
-        await PageObjects.security.forceLogout();
       });
 
       it("Doesn't allow to store a session", async () => {

--- a/x-pack/test/search_sessions_integration/tests/apps/discover/sessions_in_space.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/discover/sessions_in_space.ts
@@ -57,11 +57,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await security.role.delete('data_analyst');
         await security.user.delete('analyst');
 
         await esArchiver.unload('x-pack/test/functional/es_archives/dashboard/session_in_space');
-        await PageObjects.security.forceLogout();
       });
 
       it('Saves and restores a session', async () => {
@@ -130,11 +132,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await security.role.delete('data_analyst');
         await security.user.delete('analyst');
 
         await esArchiver.unload('x-pack/test/functional/es_archives/dashboard/session_in_space');
-        await PageObjects.security.forceLogout();
       });
 
       it("Doesn't allow to store a session", async () => {

--- a/x-pack/test/search_sessions_integration/tests/apps/management/search_sessions/sessions_management_permissions.ts
+++ b/x-pack/test/search_sessions_integration/tests/apps/management/search_sessions/sessions_management_permissions.ts
@@ -51,9 +51,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await security.role.delete('data_analyst');
         await security.user.delete('analyst');
-        await PageObjects.security.forceLogout();
       });
 
       it('if no apps enable search sessions', async () => {
@@ -90,9 +92,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       after(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+        await PageObjects.security.forceLogout();
+
         await security.role.delete('data_analyst');
         await security.user.delete('analyst');
-        await PageObjects.security.forceLogout();
       });
 
       it('if one app enables search sessions', async () => {

--- a/x-pack/test/security_functional/tests/login_selector/auth_provider_hint.ts
+++ b/x-pack/test/security_functional/tests/login_selector/auth_provider_hint.ts
@@ -47,6 +47,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     afterEach(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
+++ b/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
@@ -48,6 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     afterEach(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await PageObjects.security.forceLogout();
     });
 

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_permissions.ts
@@ -50,6 +50,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         after(async () => {
           // Log the user back out
+          // NOTE: Logout needs to happen before anything else to avoid flaky behavior
           await PageObjects.security.forceLogout();
 
           // delete role/user

--- a/x-pack/test/visual_regression/tests/login_page.ts
+++ b/x-pack/test/visual_regression/tests/login_page.ts
@@ -26,6 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       afterEach(async () => {
+        // NOTE: Logout needs to happen before anything else to avoid flaky behavior
         await PageObjects.security.forceLogout();
       });
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Always call `forceLogout` first in the test cleanup code. (#117555)