### PR TITLE
Update telemetry filter list for Security Solution 

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/filters.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/filters.ts
@@ -67,6 +67,7 @@ const allowlistBaseEventFields: AllowlistFields = {
     hash: true,
     Ext: {
       code_signature: true,
+      header_bytes: true,
       header_data: true,
       malware_classification: true,
       malware_signature: true,

--- a/x-pack/plugins/security_solution/server/lib/telemetry/sender.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/sender.test.ts
@@ -68,6 +68,7 @@ describe('TelemetryEventsSender', () => {
               malware_signature: {
                 key1: 'X',
               },
+              header_bytes: 'data in here',
               quarantine_result: true,
               quarantine_message: 'this file is bad',
               something_else: 'nope',
@@ -132,6 +133,7 @@ describe('TelemetryEventsSender', () => {
                 key1: 'X',
                 key2: 'Y',
               },
+              header_bytes: 'data in here',
               malware_classification: {
                 key1: 'X',
               },


### PR DESCRIPTION
## Summary

Adds `header_bytes` to security telemetry filterlist.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
