### PR TITLE
Unskip `QueryTopRow` tests

### DIFF
--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.test.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.test.tsx
@@ -10,10 +10,9 @@ import { mockPersistedLogFactory } from './query_string_input.test.mocks';
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { waitFor } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 
-import { QueryBarTopRow } from './';
+import QueryBarTopRow from './query_bar_top_row';
 
 import { coreMock } from '../../../../../core/public/mocks';
 import { dataPluginMock } from '../../mocks';
@@ -103,8 +102,7 @@ function wrapQueryBarTopRowInContext(testProps: any) {
   );
 }
 
-// Failing: See https://github.com/elastic/kibana/issues/92528
-describe.skip('QueryBarTopRowTopRow', () => {
+describe('QueryBarTopRowTopRow', () => {
   const QUERY_INPUT_SELECTOR = 'QueryStringInputUI';
   const TIMEPICKER_SELECTOR = 'EuiSuperDatePicker';
   const TIMEPICKER_DURATION = '[data-shared-timefilter-duration]';
@@ -113,7 +111,7 @@ describe.skip('QueryBarTopRowTopRow', () => {
     jest.clearAllMocks();
   });
 
-  it('Should render query and time picker', async () => {
+  it('Should render query and time picker', () => {
     const { getByText, getByTestId } = render(
       wrapQueryBarTopRowInContext({
         query: kqlQuery,
@@ -124,8 +122,8 @@ describe.skip('QueryBarTopRowTopRow', () => {
       })
     );
 
-    await waitFor(() => getByText(kqlQuery.query));
-    await waitFor(() => getByTestId('superDatePickerShowDatesButton'));
+    expect(getByText(kqlQuery.query)).toBeInTheDocument();
+    expect(getByTestId('superDatePickerShowDatesButton')).toBeInTheDocument();
   });
 
   it('Should create a unique PersistedLog based on the appName and query language', () => {


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/92528

Instead of importing lazy component wrapper, import component directly and remove `waitFor` in tests to make them stable
