### PR TITLE
[8.0] [DOCS] Removes coming tag from 8.0.0-beta1 release notes (#117045)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -18,8 +18,6 @@ Review important information about the {kib} 8.0.0 releases.
 [[release-notes-8.0.0-beta1]]
 == {kib} 8.0.0-beta1
 
-coming::[8.0.0-beta1]
-
 Review the {kib} 8.0.0-beta1 changes, then use the <<upgrade-assistant,Upgrade Assistant>> to complete the upgrade.
 
 [float]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Removes coming tag from 8.0.0-beta1 release notes (#117045)