### PR TITLE
[Timelion ]Remove usage of ignore_throttled unless targeting frozen indices to avoid deprecation warning

### DIFF
--- a/src/plugins/vis_types/timelion/server/series_functions/es/es.test.js
+++ b/src/plugins/vis_types/timelion/server/series_functions/es/es.test.js
@@ -256,12 +256,20 @@ describe('es', () => {
         sandbox.restore();
       });
 
-      test('sets ignore_throttled=true on the request', () => {
+      test('sets ignore_throttled=false on the request', () => {
+        config.index = 'beer';
+        tlConfig.settings[UI_SETTINGS.SEARCH_INCLUDE_FROZEN] = true;
+        const request = fn(config, tlConfig, emptyScriptFields);
+
+        expect(request.params.ignore_throttled).toEqual(false);
+      });
+
+      test('sets no ignore_throttled if SEARCH_INCLUDE_FROZEN is false', () => {
         config.index = 'beer';
         tlConfig.settings[UI_SETTINGS.SEARCH_INCLUDE_FROZEN] = false;
         const request = fn(config, tlConfig, emptyScriptFields);
 
-        expect(request.params.ignore_throttled).toEqual(true);
+        expect(request.params).not.toHaveProperty('ignore_throttled');
       });
 
       test('sets no timeout if elasticsearch.shardTimeout is set to 0', () => {

--- a/src/plugins/vis_types/timelion/server/series_functions/es/lib/build_request.js
+++ b/src/plugins/vis_types/timelion/server/series_functions/es/lib/build_request.js
@@ -66,9 +66,10 @@ export default function buildRequest(config, tlConfig, scriptFields, runtimeFiel
 
   _.assign(aggCursor, createDateAgg(config, tlConfig, scriptFields));
 
+  const includeFrozen = Boolean(tlConfig.settings[UI_SETTINGS.SEARCH_INCLUDE_FROZEN]);
   const request = {
     index: config.index,
-    ignore_throttled: !tlConfig.settings[UI_SETTINGS.SEARCH_INCLUDE_FROZEN],
+    ...(includeFrozen ? { ignore_throttled: false } : {}),
     body: {
       query: {
         bool: bool,


### PR DESCRIPTION
Part of: #117980

## Summary

`ignore_throttled` was deprecated on ES side. For this reason, we will only pass `ignore_throttled` only if searching over frozen indices

The following code

```
{
  ignore_throttled: !tlConfig.settings[UI_SETTINGS.SEARCH_INCLUDE_FROZEN],
}
```

was replaced with
```
{
 ...(includeFrozen ? { ignore_throttled: false } : {}),
}
```