### PR TITLE
[8.0] [Alerting][Telemetry] Reverted type changes for throttle_time and schedule_time with adding a proper new number fields (#117805)

### DIFF
--- a/x-pack/plugins/alerting/server/usage/alerts_telemetry.test.ts
+++ b/x-pack/plugins/alerting/server/usage/alerts_telemetry.test.ts
@@ -106,11 +106,21 @@ Object {
   "count_rules_namespaces": 0,
   "count_total": 4,
   "schedule_time": Object {
+    "avg": "4.5s",
+    "max": "10s",
+    "min": "1s",
+  },
+  "schedule_time_number_s": Object {
     "avg": 4.5,
     "max": 10,
     "min": 1,
   },
   "throttle_time": Object {
+    "avg": "30s",
+    "max": "60s",
+    "min": "0s",
+  },
+  "throttle_time_number_s": Object {
     "avg": 30,
     "max": 60,
     "min": 0,

--- a/x-pack/plugins/alerting/server/usage/alerts_telemetry.ts
+++ b/x-pack/plugins/alerting/server/usage/alerts_telemetry.ts
@@ -13,7 +13,7 @@ const alertTypeMetric = {
     init_script: 'state.ruleTypes = [:]; state.namespaces = [:]',
     map_script: `
       String alertType = doc['alert.alertTypeId'].value;
-      String namespace = doc['namespaces'] !== null ? doc['namespaces'].value : 'default';
+      String namespace = doc['namespaces'] !== null && doc['namespaces'].size() > 0 ? doc['namespaces'].value : 'default';
       state.ruleTypes.put(alertType, state.ruleTypes.containsKey(alertType) ? state.ruleTypes.get(alertType) + 1 : 1);
       if (state.namespaces.containsKey(namespace) === false) {
         state.namespaces.put(namespace, 1);
@@ -107,6 +107,8 @@ export async function getTotalCountAggregations(
     | 'count_by_type'
     | 'throttle_time'
     | 'schedule_time'
+    | 'throttle_time_number_s'
+    | 'schedule_time_number_s'
     | 'connectors_per_alert'
     | 'count_rules_namespaces'
   >
@@ -253,11 +255,21 @@ export async function getTotalCountAggregations(
       {}
     ),
     throttle_time: {
+      min: `${aggregations.min_throttle_time.value}s`,
+      avg: `${aggregations.avg_throttle_time.value}s`,
+      max: `${aggregations.max_throttle_time.value}s`,
+    },
+    schedule_time: {
+      min: `${aggregations.min_interval_time.value}s`,
+      avg: `${aggregations.avg_interval_time.value}s`,
+      max: `${aggregations.max_interval_time.value}s`,
+    },
+    throttle_time_number_s: {
       min: aggregations.min_throttle_time.value,
       avg: aggregations.avg_throttle_time.value,
       max: aggregations.max_throttle_time.value,
     },
-    schedule_time: {
+    schedule_time_number_s: {
       min: aggregations.min_interval_time.value,
       avg: aggregations.avg_interval_time.value,
       max: aggregations.max_interval_time.value,

--- a/x-pack/plugins/alerting/server/usage/alerts_usage_collector.ts
+++ b/x-pack/plugins/alerting/server/usage/alerts_usage_collector.ts
@@ -95,11 +95,21 @@ export function createAlertsUsageCollector(
           count_active_total: 0,
           count_disabled_total: 0,
           throttle_time: {
+            min: '0s',
+            avg: '0s',
+            max: '0s',
+          },
+          schedule_time: {
+            min: '0s',
+            avg: '0s',
+            max: '0s',
+          },
+          throttle_time_number_s: {
             min: 0,
             avg: 0,
             max: 0,
           },
-          schedule_time: {
+          schedule_time_number_s: {
             min: 0,
             avg: 0,
             max: 0,
@@ -127,11 +137,21 @@ export function createAlertsUsageCollector(
       count_active_total: { type: 'long' },
       count_disabled_total: { type: 'long' },
       throttle_time: {
+        min: { type: 'keyword' },
+        avg: { type: 'keyword' },
+        max: { type: 'keyword' },
+      },
+      schedule_time: {
+        min: { type: 'keyword' },
+        avg: { type: 'keyword' },
+        max: { type: 'keyword' },
+      },
+      throttle_time_number_s: {
         min: { type: 'long' },
         avg: { type: 'float' },
         max: { type: 'long' },
       },
-      schedule_time: {
+      schedule_time_number_s: {
         min: { type: 'long' },
         avg: { type: 'float' },
         max: { type: 'long' },

--- a/x-pack/plugins/alerting/server/usage/types.ts
+++ b/x-pack/plugins/alerting/server/usage/types.ts
@@ -20,11 +20,21 @@ export interface AlertsUsage {
   avg_execution_time_per_day: number;
   avg_execution_time_by_type_per_day: Record<string, number>;
   throttle_time: {
+    min: string;
+    avg: string;
+    max: string;
+  };
+  schedule_time: {
+    min: string;
+    avg: string;
+    max: string;
+  };
+  throttle_time_number_s: {
     min: number;
     avg: number;
     max: number;
   };
-  schedule_time: {
+  schedule_time_number_s: {
     min: number;
     avg: number;
     max: number;

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -273,6 +273,19 @@
         "throttle_time": {
           "properties": {
             "min": {
+              "type": "keyword"
+            },
+            "avg": {
+              "type": "keyword"
+            },
+            "max": {
+              "type": "keyword"
+            }
+          }
+        },
+        "throttle_time_number_s": {
+          "properties": {
+            "min": {
               "type": "long"
             },
             "avg": {
@@ -284,6 +297,19 @@
           }
         },
         "schedule_time": {
+          "properties": {
+            "min": {
+              "type": "keyword"
+            },
+            "avg": {
+              "type": "keyword"
+            },
+            "max": {
+              "type": "keyword"
+            }
+          }
+        },
+        "schedule_time_number_s": {
           "properties": {
             "min": {
               "type": "long"


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Alerting][Telemetry] Reverted type changes for throttle_time and schedule_time with adding a proper new number fields (#117805)