### PR TITLE
[Alerting UI] Removing focusable element in tags badge

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_list/components/alerts_list.tsx
@@ -438,6 +438,7 @@ export const AlertsList: React.FunctionComponent = () => {
                 color="hollow"
                 iconType="tag"
                 iconSide="left"
+                tabIndex={-1}
                 onClick={() => setTagPopoverOpenIndex(item.index)}
                 onClickAriaLabel="Tags"
                 iconOnClick={() => setTagPopoverOpenIndex(item.index)}


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/117334

## Summary

As shown in the issue, tags had 2 focusable elements. Updated so it now only has 1 focusable element:
![Nov-09-2021 13-04-02](https://user-images.githubusercontent.com/13104637/140979742-18c6216b-284a-49a2-af3b-7895f60c8759.gif)
