### PR TITLE
[DOCS] Removes coming tag from 7.15.2 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -69,8 +69,6 @@ Review important information about the {kib} 7.x releases.
 [[release-notes-7.15.2]]
 == {kib} 7.15.2
 
-coming::[7.15.2]
-
 Review the following information about the 7.15.2 release.
 
 [float]


### PR DESCRIPTION
## Summary

Removes the `coming` tag from the 7.15.2 release notes.