### PR TITLE
[Observability] [Exploratory View] prevent chart from rerendering on report type changes

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_lens_attributes.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_lens_attributes.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { allSeriesKey, reportTypeKey, UrlStorageContextProvider } from './use_series_storage';
+import { renderHook } from '@testing-library/react-hooks';
+import { useLensAttributes } from './use_lens_attributes';
+import { ReportTypes } from '../configurations/constants';
+import { mockIndexPattern } from '../rtl_helpers';
+import { createKbnUrlStateStorage } from '../../../../../../../../src/plugins/kibana_utils/public';
+import { TRANSACTION_DURATION } from '../configurations/constants/elasticsearch_fieldnames';
+import * as lensAttributes from '../configurations/lens_attributes';
+import * as indexPattern from './use_app_index_pattern';
+import * as theme from '../../../../hooks/use_theme';
+
+const mockSingleSeries = [
+  {
+    name: 'performance-distribution',
+    dataType: 'ux',
+    breakdown: 'user_agent.name',
+    time: { from: 'now-15m', to: 'now' },
+    selectedMetricField: TRANSACTION_DURATION,
+    reportDefinitions: { 'service.name': ['elastic-co'] },
+  },
+];
+
+describe('useExpViewTimeRange', function () {
+  const storage = createKbnUrlStateStorage({ useHash: false });
+  // @ts-ignore
+  jest.spyOn(indexPattern, 'useAppIndexPatternContext').mockReturnValue({
+    indexPatterns: {
+      ux: mockIndexPattern,
+      apm: mockIndexPattern,
+      mobile: mockIndexPattern,
+      infra_logs: mockIndexPattern,
+      infra_metrics: mockIndexPattern,
+      synthetics: mockIndexPattern,
+    },
+  });
+  jest.spyOn(theme, 'useTheme').mockReturnValue({
+    // @ts-ignore
+    eui: {
+      euiColorVis1: '#111111',
+    },
+  });
+  const lensAttributesSpy = jest.spyOn(lensAttributes, 'LensAttributes');
+
+  function Wrapper({ children }: { children: JSX.Element }) {
+    return <UrlStorageContextProvider storage={storage}>{children}</UrlStorageContextProvider>;
+  }
+
+  it('updates lens attributes with report type from storage', async function () {
+    await storage.set(allSeriesKey, mockSingleSeries);
+    await storage.set(reportTypeKey, ReportTypes.KPI);
+
+    renderHook(() => useLensAttributes(), {
+      wrapper: Wrapper,
+    });
+
+    expect(lensAttributesSpy).toBeCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          seriesConfig: expect.objectContaining({ reportType: ReportTypes.KPI }),
+        }),
+      ])
+    );
+  });
+});

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_lens_attributes.ts
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_lens_attributes.ts
@@ -13,6 +13,7 @@ import {
   AllSeries,
   allSeriesKey,
   convertAllShortSeries,
+  reportTypeKey,
   useSeriesStorage,
 } from './use_series_storage';
 import { getDefaultConfigs } from '../configurations/default_configs';
@@ -93,11 +94,12 @@ export const useLensAttributes = (): TypedLensByValueInput['attributes'] | null 
   return useMemo(() => {
     // we only use the data from url to apply, since that gets updated to apply changes
     const allSeriesT: AllSeries = convertAllShortSeries(storage.get(allSeriesKey) ?? []);
+    const reportTypeT: ReportViewType = storage.get(reportTypeKey) as ReportViewType;
 
-    if (isEmpty(indexPatterns) || isEmpty(allSeriesT) || !reportType) {
+    if (isEmpty(indexPatterns) || isEmpty(allSeriesT) || !reportTypeT) {
       return null;
     }
-    const layerConfigs = getLayerConfigs(allSeriesT, reportType, theme, indexPatterns);
+    const layerConfigs = getLayerConfigs(allSeriesT, reportTypeT, theme, indexPatterns);
 
     if (layerConfigs.length < 1) {
       return null;

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/hooks/use_series_storage.tsx
@@ -32,7 +32,7 @@ export interface SeriesContextValue {
   setSeries: (seriesIndex: number, newValue: SeriesUrl) => void;
   getSeries: (seriesIndex: number) => SeriesUrl | undefined;
   removeSeries: (seriesIndex: number) => void;
-  setReportType: (reportType: string) => void;
+  setReportType: (reportType: ReportViewType) => void;
   storage: IKbnUrlStateStorage | ISessionStorageStateStorage;
   reportType: ReportViewType;
 }
@@ -59,8 +59,8 @@ export function UrlStorageContextProvider({
 
   const [lastRefresh, setLastRefresh] = useState<number>(() => Date.now());
 
-  const [reportType, setReportType] = useState<string>(
-    () => (storage as IKbnUrlStateStorage).get(reportTypeKey) ?? ''
+  const [reportType, setReportType] = useState<ReportViewType>(
+    () => ((storage as IKbnUrlStateStorage).get(reportTypeKey) ?? '') as ReportViewType
   );
 
   const [firstSeries, setFirstSeries] = useState<SeriesUrl>();
@@ -97,10 +97,6 @@ export function UrlStorageContextProvider({
     });
   }, []);
 
-  useEffect(() => {
-    (storage as IKbnUrlStateStorage).set(reportTypeKey, reportType);
-  }, [reportType, storage]);
-
   const removeSeries = useCallback((seriesIndex: number) => {
     setAllSeries((prevAllSeries) =>
       prevAllSeries.filter((seriesT, index) => index !== seriesIndex)
@@ -117,6 +113,7 @@ export function UrlStorageContextProvider({
   const applyChanges = useCallback(
     (onApply?: () => void) => {
       const allShortSeries = allSeries.map((series) => convertToShortUrl(series));
+      (storage as IKbnUrlStateStorage).set(reportTypeKey, reportType);
 
       (storage as IKbnUrlStateStorage).set(allSeriesKey, allShortSeries);
       setLastRefresh(Date.now());
@@ -140,7 +137,7 @@ export function UrlStorageContextProvider({
     lastRefresh,
     setLastRefresh,
     setReportType,
-    reportType: storage.get(reportTypeKey) as ReportViewType,
+    reportType,
     firstSeries: firstSeries!,
   };
   return <UrlStorageContext.Provider value={value}>{children}</UrlStorageContext.Provider>;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/117268

Prevents the exploratory view chart from rendering on changes to the DataType. This is critical to prevent the chart from attempting to render using old data from the URL parameters. The apply button should be the only way for changes to populate on the chart. 

![chrome-capture (26)](https://user-images.githubusercontent.com/11356435/140999413-ab42a486-6a5e-4222-b5a9-22dbc665bc11.gif)

### Testing
1. Navigate to exploratory view via Uptime or User Experience.
2. Remove the existing series using the reset button the trash can icon next to the series
3. Select a different report type
4. Ensure that the chart is not rendered when a different report type is selected.