### PR TITLE
[Fleet] Remove force flag from agent instruction

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.test.ts
@@ -17,9 +17,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "sudo ./elastic-agent install  -f \\\\
-         --fleet-server-es=http://elasticsearch:9200 \\\\
-         --fleet-server-service-token=service-token-1"
+        "sudo ./elastic-agent install   \\\\
+          --fleet-server-es=http://elasticsearch:9200 \\\\
+          --fleet-server-service-token=service-token-1"
       `);
     });
 
@@ -31,9 +31,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        ".\\\\elastic-agent.exe install  -f \`
-         --fleet-server-es=http://elasticsearch:9200 \`
-         --fleet-server-service-token=service-token-1"
+        ".\\\\elastic-agent.exe install   \`
+          --fleet-server-es=http://elasticsearch:9200 \`
+          --fleet-server-service-token=service-token-1"
       `);
     });
 
@@ -45,9 +45,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "sudo elastic-agent enroll  -f \\\\
-         --fleet-server-es=http://elasticsearch:9200 \\\\
-         --fleet-server-service-token=service-token-1"
+        "sudo elastic-agent enroll   \\\\
+          --fleet-server-es=http://elasticsearch:9200 \\\\
+          --fleet-server-service-token=service-token-1"
       `);
     });
   });
@@ -62,9 +62,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "sudo ./elastic-agent install  -f \\\\
-         --fleet-server-es=http://elasticsearch:9200 \\\\
-         --fleet-server-service-token=service-token-1 \\\\
+        "sudo ./elastic-agent install   \\\\
+          --fleet-server-es=http://elasticsearch:9200 \\\\
+          --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1"
       `);
     });
@@ -78,9 +78,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        ".\\\\elastic-agent.exe install  -f \`
-         --fleet-server-es=http://elasticsearch:9200 \`
-         --fleet-server-service-token=service-token-1 \`
+        ".\\\\elastic-agent.exe install   \`
+          --fleet-server-es=http://elasticsearch:9200 \`
+          --fleet-server-service-token=service-token-1 \`
           --fleet-server-policy=policy-1"
       `);
     });
@@ -94,9 +94,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "sudo elastic-agent enroll  -f \\\\
-         --fleet-server-es=http://elasticsearch:9200 \\\\
-         --fleet-server-service-token=service-token-1 \\\\
+        "sudo elastic-agent enroll   \\\\
+          --fleet-server-es=http://elasticsearch:9200 \\\\
+          --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1"
       `);
     });
@@ -115,9 +115,8 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "sudo ./elastic-agent install --url=http://fleetserver:8220 \\\\
-         -f \\\\
-         --fleet-server-es=http://elasticsearch:9200 \\\\
-         --fleet-server-service-token=service-token-1 \\\\
+          --fleet-server-es=http://elasticsearch:9200 \\\\
+          --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
           --certificate-authorities=<PATH_TO_CA> \\\\
           --fleet-server-es-ca=<PATH_TO_ES_CERT> \\\\
@@ -138,9 +137,8 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         ".\\\\elastic-agent.exe install --url=http://fleetserver:8220 \`
-         -f \`
-         --fleet-server-es=http://elasticsearch:9200 \`
-         --fleet-server-service-token=service-token-1 \`
+          --fleet-server-es=http://elasticsearch:9200 \`
+          --fleet-server-service-token=service-token-1 \`
           --fleet-server-policy=policy-1 \`
           --certificate-authorities=<PATH_TO_CA> \`
           --fleet-server-es-ca=<PATH_TO_ES_CERT> \`
@@ -161,9 +159,8 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "sudo elastic-agent enroll --url=http://fleetserver:8220 \\\\
-         -f \\\\
-         --fleet-server-es=http://elasticsearch:9200 \\\\
-         --fleet-server-service-token=service-token-1 \\\\
+          --fleet-server-es=http://elasticsearch:9200 \\\\
+          --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
           --certificate-authorities=<PATH_TO_CA> \\\\
           --fleet-server-es-ca=<PATH_TO_ES_CERT> \\\\
@@ -181,9 +178,9 @@ describe('getInstallCommandForPlatform', () => {
     );
 
     expect(res).toMatchInlineSnapshot(`
-      "sudo elastic-agent enroll  -f \\\\
-       --fleet-server-es=http://elasticsearch:9200 \\\\
-       --fleet-server-service-token=service-token-1"
+      "sudo elastic-agent enroll   \\\\
+        --fleet-server-es=http://elasticsearch:9200 \\\\
+        --fleet-server-service-token=service-token-1"
     `);
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/install_command_utils.ts
@@ -20,10 +20,12 @@ export function getInstallCommandForPlatform(
 
   if (isProductionDeployment && fleetServerHost) {
     commandArguments += `--url=${fleetServerHost} ${newLineSeparator}\n`;
+  } else {
+    commandArguments += `  ${newLineSeparator}\n`;
   }
 
-  commandArguments += ` -f ${newLineSeparator}\n --fleet-server-es=${esHost}`;
-  commandArguments += ` ${newLineSeparator}\n --fleet-server-service-token=${serviceToken}`;
+  commandArguments += `  --fleet-server-es=${esHost}`;
+  commandArguments += ` ${newLineSeparator}\n  --fleet-server-service-token=${serviceToken}`;
   if (policyId) {
     commandArguments += ` ${newLineSeparator}\n  --fleet-server-policy=${policyId}`;
   }

--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -38,9 +38,9 @@ export const ManualInstructions: React.FunctionComponent<Props> = ({
 
   const enrollArgs = getfleetServerHostsEnrollArgs(apiKey, fleetServerHosts);
 
-  const linuxMacCommand = `sudo ./elastic-agent install -f ${enrollArgs}`;
+  const linuxMacCommand = `sudo ./elastic-agent install ${enrollArgs}`;
 
-  const windowsCommand = `.\\elastic-agent.exe install -f ${enrollArgs}`;
+  const windowsCommand = `.\\elastic-agent.exe install ${enrollArgs}`;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Resolve #117730

Remove `-f` force flag from agent install instructions. (Fleet server requirement and add agent flyout)
## UI Changes


<img width="1224" alt="Screen Shot 2021-11-09 at 3 33 52 PM" src="https://user-images.githubusercontent.com/1336873/141000299-72db4eaa-e3c2-41ee-b9bf-8be48acbdbaf.png">

<img width="880" alt="Screen Shot 2021-11-09 at 3 12 01 PM" src="https://user-images.githubusercontent.com/1336873/140998160-220a2286-41ae-4a82-8d68-0e6c138ba096.png">
