### PR TITLE
[docs] Use inspect-brk instead of debug-brk

### DIFF
--- a/docs/developer/contributing/development-functional-tests.asciidoc
+++ b/docs/developer/contributing/development-functional-tests.asciidoc
@@ -490,7 +490,7 @@ From the command line run:
 
 ["source","shell"]
 -----------
-node --debug-brk --inspect scripts/functional_test_runner
+node --inspect-brk scripts/functional_test_runner
 -----------
 
 This prints out a URL that you can visit in Chrome and debug your functional tests in the browser.

--- a/docs/developer/contributing/development-unit-tests.asciidoc
+++ b/docs/developer/contributing/development-unit-tests.asciidoc
@@ -75,7 +75,7 @@ In order to ease the pain specialized tasks provide alternate methods
 for running the tests.
 
 You could also add the `--debug` option so that `node` is run using
-the `--debug-brk` flag. You’ll need to connect a remote debugger such
+the `--inspect-brk` flag. You’ll need to connect a remote debugger such
 as https://github.com/node-inspector/node-inspector[`node-inspector`]
 to proceed in this mode.
 


### PR DESCRIPTION
Node removed these some time ago. We should update the docs.