### PR TITLE
[Fleet, Enterprise Search] Update web crawler link to lead directly to the crawler page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -266,7 +266,7 @@ export const AvailablePackages: React.FC = memo(() => {
             <EuiCard
               data-test-sub="integration-card:epr:app_search_web_crawler:featured"
               icon={<EuiIcon type="logoAppSearch" size="xxl" />}
-              href={addBasePath('/app/enterprise_search/app_search')}
+              href={addBasePath('/app/enterprise_search/app_search/engines/new?method=crawler')}
               title={i18n.translate('xpack.fleet.featuredSearchTitle', {
                 defaultMessage: 'Web site crawler',
               })}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/117765

This PR updates the link in the pinned web crawler card to lead directly to the crawler page, instead of the generic "Create your first engine" page.

Before (see the first half of the video):

https://user-images.githubusercontent.com/11838280/140588635-2e44c6a3-d019-4af5-997e-a5db81a76c8a.mp4

After:

https://user-images.githubusercontent.com/11838280/141010368-d9b6b086-72df-441d-b1c7-de45230249bc.mp4

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
