### PR TITLE
[SecuritySolution] Fixes deprecated use of Spaces API

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -25,7 +25,6 @@ import {
   getPackagePolicyDeleteCallback,
 } from '../fleet_integration/fleet_integration';
 import { ManifestManager } from './services/artifacts';
-import { AppClientFactory } from '../client';
 import { ConfigType } from '../config';
 import { IRequestContextFactory } from '../request_context_factory';
 import { LicenseService } from '../../common/license';
@@ -49,7 +48,6 @@ export type EndpointAppContextServiceStartContract = Partial<
   logger: Logger;
   endpointMetadataService: EndpointMetadataService;
   manifestManager?: ManifestManager;
-  appClientFactory: AppClientFactory;
   security: SecurityPluginStart;
   alerting: AlertsPluginStartContract;
   config: ConfigType;

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -18,7 +18,6 @@ import {
   createMockAgentService,
   createArtifactsClientMock,
 } from '../../../fleet/server/mocks';
-import { AppClientFactory } from '../client';
 import { createMockConfig } from '../lib/detection_engine/routes/__mocks__';
 import {
   EndpointAppContextService,
@@ -87,8 +86,6 @@ export const createMockEndpointAppContextServiceSetupContract =
 export const createMockEndpointAppContextServiceStartContract =
   (): jest.Mocked<EndpointAppContextServiceStartContract> => {
     const config = createMockConfig();
-    const factory = new AppClientFactory();
-    factory.setup({ getSpaceId: () => 'mockSpace', config });
 
     const casesClientMock = createCasesClientMock();
     const savedObjectsStart = savedObjectsServiceMock.createStartContract();
@@ -107,7 +104,6 @@ export const createMockEndpointAppContextServiceStartContract =
       packageService: createMockPackageService(),
       logger: loggingSystemMock.create().get('mock_endpoint_app_context'),
       manifestManager: getManifestManagerMock(),
-      appClientFactory: factory,
       security: securityMock.createStart(),
       alerting: alertsMock.createStart(),
       config,

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -130,7 +130,7 @@ export class Plugin implements ISecuritySolutionPlugin {
   ): SecuritySolutionPluginSetup {
     this.logger.debug('plugin setup');
 
-    const { pluginContext, config, logger } = this;
+    const { appClientFactory, pluginContext, config, logger } = this;
     const experimentalFeatures = config.experimentalFeatures;
     this.kibanaIndex = core.savedObjects.getKibanaIndex();
 
@@ -303,6 +303,11 @@ export class Plugin implements ISecuritySolutionPlugin {
     }
 
     core.getStartServices().then(([_, depsStart]) => {
+      appClientFactory.setup({
+        getSpaceId: depsStart.spaces?.spacesService?.getSpaceId,
+        config,
+      });
+
       const securitySolutionSearchStrategy = securitySolutionSearchStrategyProvider(
         depsStart.data,
         endpointContext
@@ -335,11 +340,6 @@ export class Plugin implements ISecuritySolutionPlugin {
     plugins: SecuritySolutionPluginStartDependencies
   ): SecuritySolutionPluginStart {
     const { config, logger, appClientFactory } = this;
-
-    appClientFactory.setup({
-      getSpaceId: plugins.spaces?.spacesService?.getSpaceId,
-      config,
-    });
 
     const savedObjectsClient = new SavedObjectsClient(core.savedObjects.createInternalRepository());
     const registerIngestCallback = plugins.fleet?.registerExternalCallback;

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -130,14 +130,9 @@ export class Plugin implements ISecuritySolutionPlugin {
   ): SecuritySolutionPluginSetup {
     this.logger.debug('plugin setup');
 
-    const { pluginContext, config, logger, appClientFactory } = this;
+    const { pluginContext, config, logger } = this;
     const experimentalFeatures = config.experimentalFeatures;
     this.kibanaIndex = core.savedObjects.getKibanaIndex();
-
-    appClientFactory.setup({
-      getSpaceId: plugins.spaces?.spacesService?.getSpaceId,
-      config,
-    });
 
     initSavedObjects(core.savedObjects);
     initUiSettings(core.uiSettings, experimentalFeatures);
@@ -340,6 +335,11 @@ export class Plugin implements ISecuritySolutionPlugin {
     plugins: SecuritySolutionPluginStartDependencies
   ): SecuritySolutionPluginStart {
     const { config, logger, appClientFactory } = this;
+
+    appClientFactory.setup({
+      getSpaceId: plugins.spaces?.spacesService?.getSpaceId,
+      config,
+    });
 
     const savedObjectsClient = new SavedObjectsClient(core.savedObjects.createInternalRepository());
     const registerIngestCallback = plugins.fleet?.registerExternalCallback;

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -339,7 +339,7 @@ export class Plugin implements ISecuritySolutionPlugin {
     core: SecuritySolutionPluginCoreStartDependencies,
     plugins: SecuritySolutionPluginStartDependencies
   ): SecuritySolutionPluginStart {
-    const { config, logger, appClientFactory } = this;
+    const { config, logger } = this;
 
     const savedObjectsClient = new SavedObjectsClient(core.savedObjects.createInternalRepository());
     const registerIngestCallback = plugins.fleet?.registerExternalCallback;
@@ -407,7 +407,6 @@ export class Plugin implements ISecuritySolutionPlugin {
         plugins.fleet?.agentPolicyService!,
         logger
       ),
-      appClientFactory,
       security: plugins.security,
       alerting: plugins.alerting,
       config: this.config,

--- a/x-pack/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/plugins/security_solution/server/plugin_contract.ts
@@ -33,7 +33,7 @@ import {
   RuleRegistryPluginStartContract as RuleRegistryPluginStart,
 } from '../../rule_registry/server';
 import { SecurityPluginSetup, SecurityPluginStart } from '../../security/server';
-import { SpacesPluginSetup } from '../../spaces/server';
+import { SpacesPluginSetup, SpacesPluginStart } from '../../spaces/server';
 import {
   TaskManagerSetupContract as TaskManagerPluginSetup,
   TaskManagerStartContract as TaskManagerPluginStart,
@@ -68,6 +68,7 @@ export interface SecuritySolutionPluginStartDependencies {
   licensing: LicensingPluginStart;
   ruleRegistry: RuleRegistryPluginStart;
   security: SecurityPluginStart;
+  spaces?: SpacesPluginStart;
   taskManager?: TaskManagerPluginStart;
   telemetry?: TelemetryPluginStart;
 }


### PR DESCRIPTION
## Summary

Spaces' `getSpaceId` moved from being available in the `setup` phase to the `start` phase as part of the Saved Objects shareability work. The variant in `setup` was deprecated, and we need it gone in 7.16 as per [dev docs](https://docs.elastic.dev/kibana-dev-docs/api-meta/deprecated-api-list-by-plugin#securitysolution). 

The changes here are relatively straightforward, as the distinction between `setup` and `start` on the server is minor.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
