### PR TITLE
[jest] Support meta project configs

### DIFF
--- a/packages/kbn-test/src/jest/run.ts
+++ b/packages/kbn-test/src/jest/run.ts
@@ -44,6 +44,7 @@ declare global {
 
 export function runJest(configName = 'jest.config.js') {
   const argv = buildArgv(process.argv);
+  const devConfigName = 'jest.config.dev.js';
 
   const log = new ToolingLog({
     level: argv.verbose ? 'verbose' : 'info',
@@ -67,16 +68,23 @@ export function runJest(configName = 'jest.config.js') {
     log.verbose('commonTestFiles:', commonTestFiles);
 
     let configPath;
+    let devConfigPath;
 
     // sets the working directory to the cwd or the common
     // base directory of the provided test files
     let wd = testFilesProvided ? commonTestFiles : cwd;
 
+    devConfigPath = resolve(wd, devConfigName);
     configPath = resolve(wd, configName);
 
-    while (!existsSync(configPath)) {
+    while (!existsSync(configPath) && !existsSync(devConfigPath)) {
       wd = resolve(wd, '..');
+      devConfigPath = resolve(wd, devConfigName);
       configPath = resolve(wd, configName);
+    }
+
+    if (existsSync(devConfigPath)) {
+      configPath = devConfigPath;
     }
 
     log.verbose(`no config provided, found ${configPath}`);

--- a/x-pack/plugins/security_solution/jest.config.dev.js
+++ b/x-pack/plugins/security_solution/jest.config.dev.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../',
+  projects: [
+    '<rootDir>/x-pack/plugins/security_solution/*/jest.config.js',
+
+    '<rootDir>/x-pack/plugins/security_solution/server/*/jest.config.js',
+    '<rootDir>/x-pack/plugins/security_solution/public/*/jest.config.js',
+  ],
+};


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/117188 we had to split up the security solution Jest configs quite a bit until we work out the memory leaks and are able to shard configs based on history build times. 

One problem raised is there is no longer an easy way to run all tests under the security solution plugin. This PR should address that by adding a dev Jest config.

You can run it manually with `node ./node_modules/.bin/jest --config x-pack/plugins/security_solution/jest.config.dev.js`

Or, with `yarn test:jest x-pack/plugins/security_solution`