### PR TITLE
[7.16] [Reporting] Allow POST URL in Canvas to be copied (#117954)

### DIFF
--- a/x-pack/plugins/canvas/public/components/workpad_header/share_menu/share_menu.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/share_menu/share_menu.tsx
@@ -49,6 +49,7 @@ export const ShareMenu = () => {
             getJobParams={() => getPdfJobParams(sharingData, platformService.getKibanaVersion())}
             layoutOption="canvas"
             onClose={onClose}
+            objectId={workpad.id}
           />
         )
       : null;

--- a/x-pack/plugins/reporting/public/share_context_menu/screen_capture_panel_content.test.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/screen_capture_panel_content.test.tsx
@@ -63,6 +63,43 @@ test('ScreenCapturePanelContent properly renders a view with "canvas" layout opt
   expect(component.text()).toMatch('Full page layout');
 });
 
+test('ScreenCapturePanelContent allows POST URL to be copied when objectId is provided', () => {
+  const component = mount(
+    <IntlProvider locale="en">
+      <ScreenCapturePanelContent
+        layoutOption="canvas"
+        reportType="Analytical App"
+        requiresSavedState={false}
+        apiClient={apiClient}
+        uiSettings={uiSettings}
+        toasts={coreSetup.notifications.toasts}
+        getJobParams={getJobParamsDefault}
+        objectId={'1234-5'}
+      />
+    </IntlProvider>
+  );
+  expect(component.text()).toMatch('Copy POST URL');
+  expect(component.text()).not.toMatch('Unsaved work');
+});
+
+test('ScreenCapturePanelContent does not allow POST URL to be copied when objectId is not provided', () => {
+  const component = mount(
+    <IntlProvider locale="en">
+      <ScreenCapturePanelContent
+        layoutOption="canvas"
+        reportType="Analytical App"
+        requiresSavedState={false}
+        apiClient={apiClient}
+        uiSettings={uiSettings}
+        toasts={coreSetup.notifications.toasts}
+        getJobParams={getJobParamsDefault}
+      />
+    </IntlProvider>
+  );
+  expect(component.text()).not.toMatch('Copy POST URL');
+  expect(component.text()).toMatch('Unsaved work');
+});
+
 test('ScreenCapturePanelContent properly renders a view with "print" layout option', () => {
   const component = mount(
     <IntlProvider locale="en">

--- a/x-pack/plugins/reporting/public/shared/get_shared_components.tsx
+++ b/x-pack/plugins/reporting/public/shared/get_shared_components.tsx
@@ -16,7 +16,8 @@ interface IncludeOnCloseFn {
   onClose: () => void;
 }
 
-type Props = Pick<PanelPropsScreenCapture, 'getJobParams' | 'layoutOption'> & IncludeOnCloseFn;
+type Props = Pick<PanelPropsScreenCapture, 'getJobParams' | 'layoutOption' | 'objectId'> &
+  IncludeOnCloseFn;
 
 /*
  * As of 7.14, the only shared component is a PDF report that is suited for Canvas integration.


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Reporting] Allow POST URL in Canvas to be copied (#117954)