### PR TITLE
[8.0] Fix FSREQCALLBACK open handles in Jest tests (#117984)

### DIFF
--- a/package.json
+++ b/package.json
@@ -757,7 +757,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mochawesome": "^6.2.1",
     "mochawesome-merge": "^4.2.0",
-    "mock-fs": "^5.1.1",
+    "mock-fs": "^5.1.2",
     "mock-http-server": "1.3.0",
     "ms-chromium-edge-driver": "^0.4.2",
     "multimatch": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20593,10 +20593,10 @@ mochawesome@^6.2.1:
     strip-ansi "^6.0.0"
     uuid "^7.0.3"
 
-mock-fs@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.1.1.tgz#d4c95e916abf400664197079d7e399d133bb6048"
-  integrity sha512-p/8oZ3qvfKGPw+4wdVCyjDxa6wn2tP0TCf3WXC1UyUBAevezPn1TtOoxtMYVbZu/S/iExg+Ghed1busItj2CEw==
+mock-fs@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.1.2.tgz#6fa486e06d00f8793a8d2228de980eff93ce6db7"
+  integrity sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==
 
 mock-http-server@1.3.0:
   version "1.3.0"


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Fix FSREQCALLBACK open handles in Jest tests (#117984)