### PR TITLE
Refine CODEOWNERS for the observability plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,7 +94,19 @@
 ### Observability Plugins
 
 # Observability Shared
-/x-pack/plugins/observability/ @elastic/unified-observability
+/x-pack/plugins/observability/ @elastic/observability-ui
+
+# Unified Observability
+/x-pack/plugins/observability/public/pages/overview @elastic/unified-observability
+/x-pack/plugins/observability/public/pages/home @elastic/unified-observability
+/x-pack/plugins/observability/public/pages/landing @elastic/unified-observability
+/x-pack/plugins/observability/public/context @elastic/unified-observability
+
+# Actionable Observability
+/x-pack/plugins/observability/common/rules @elastic/actionable-observability
+/x-pack/plugins/observability/public/rules @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/alerts @elastic/actionable-observability
+/x-pack/plugins/observability/public/pages/cases  @elastic/actionable-observability
 
 # Infra Monitoring
 /x-pack/plugins/infra/ @elastic/infra-monitoring-ui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,7 +94,7 @@
 ### Observability Plugins
 
 # Observability Shared
-/x-pack/plugins/observability/ @elastic/observability-ui
+/x-pack/plugins/observability/ @elastic/unified-observability
 
 # Infra Monitoring
 /x-pack/plugins/infra/ @elastic/infra-monitoring-ui


### PR DESCRIPTION
Make @elastic/unified-observability the owner of the observability plugin