### PR TITLE
[Security Solution][Detections] Fix race condition on execution logs write

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_execution_log/event_log_adapter/event_log_adapter.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_execution_log/event_log_adapter/event_log_adapter.ts
@@ -104,7 +104,7 @@ export class EventLogAdapter implements IRuleExecutionLogClient {
     await this.savedObjectsAdapter.logStatusChange(args);
 
     if (args.metrics) {
-      this.logExecutionMetrics({
+      await this.logExecutionMetrics({
         ruleId: args.ruleId,
         ruleName: args.ruleName,
         ruleType: args.ruleType,


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/117900

This PR fixes a race condition when two consecutive `RuleExecutionLog.logStatusChange` calls containing metric fields occur.