### PR TITLE
[Graph] Only set ignored_throttled when required

### DIFF
--- a/x-pack/plugins/graph/server/routes/search.ts
+++ b/x-pack/plugins/graph/server/routes/search.ts
@@ -49,7 +49,7 @@ export function registerSearchRoute({
                   index: request.body.index,
                   body: request.body.body,
                   track_total_hits: true,
-                  ignore_throttled: !includeFrozen,
+                  ...(includeFrozen ? { ignore_throttled: false } : {}),
                 })
               ).body,
             },


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/117980

This will make sure `ignored_throttled: true` won't be set and thus not log into the deprecation log for using the flag.

The request that uses this parameter is triggered when using the "Add links" feature in Graph:

![screenshot-20211110-153301](https://user-images.githubusercontent.com/877229/141133127-ca3e68a5-e8b2-48af-8df3-5ebaba495a7e.png)

I've tested looking at the deprecation log of ES (`.es/8.1.0/logs/elasticsearch_deprecation.json`) that now a deprecation is only logged when the `search:includeFrozen` advanced setting is turned on, but not when it's turned off.