### PR TITLE
[Reporting] Fix timeouts handling in the screenshotting observable handler

### DIFF
--- a/x-pack/plugins/reporting/server/lib/screenshots/observable.test.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/observable.test.ts
@@ -353,7 +353,7 @@ describe('Screenshot Observable Pipeline', () => {
                       },
                     },
                   ],
-                  "error": [Error: An error occurred when trying to read the page for visualization panel info: Error: Mock error!],
+                  "error": [Error: The "wait for elements" phase encountered an error: Error: An error occurred when trying to read the page for visualization panel info: Error: Mock error!],
                   "screenshots": Array [
                     Object {
                       "data": Object {

--- a/x-pack/plugins/reporting/server/lib/screenshots/observable.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/observable.ts
@@ -58,9 +58,8 @@ export function getScreenshots$(
       const screen = new ScreenshotObservableHandler(driver, opts, getTimeouts(captureConfig));
 
       return Rx.from(opts.urlsOrUrlLocatorTuples).pipe(
-        concatMap((urlOrUrlLocatorTuple, index) => {
-          return Rx.of(1).pipe(
-            screen.setupPage(index, urlOrUrlLocatorTuple, apmTrans),
+        concatMap((urlOrUrlLocatorTuple, index) =>
+          screen.setupPage(index, urlOrUrlLocatorTuple, apmTrans).pipe(
             catchError((err) => {
               screen.checkPageIsOpen(); // this fails the job if the browser has closed
 
@@ -69,8 +68,8 @@ export function getScreenshots$(
             }),
             takeUntil(exit$),
             screen.getScreenshots()
-          );
-        }),
+          )
+        ),
         take(opts.urlsOrUrlLocatorTuples.length),
         toArray()
       );

--- a/x-pack/plugins/reporting/server/lib/screenshots/observable_handler.test.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/observable_handler.test.ts
@@ -95,7 +95,7 @@ describe('ScreenshotObservableHandler', () => {
 
       const testPipeline = () => test$.toPromise();
       await expect(testPipeline).rejects.toMatchInlineSnapshot(
-        `[Error: The "Test Config" phase took longer than 0.2 seconds. You may need to increase "test.config.value": TimeoutError: Timeout has occurred]`
+        `[Error: The "Test Config" phase took longer than 0.2 seconds. You may need to increase "test.config.value"]`
       );
     });
 


### PR DESCRIPTION
## Summary

Resolves #117432.

The problem was with the `timeout` operator being used on the same source. As a result, a timeout with the least value has been thrown.
In this PR, the `setupPage` stage has been refactored to apply the timeout operator on an inner observable.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
