### PR TITLE
update app services code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /examples/demo_search/ @elastic/kibana-app-services
 /examples/developer_examples/ @elastic/kibana-app-services
 /examples/embeddable_examples/ @elastic/kibana-app-services
+/examples/embeddable_explorer/ @elastic/kibana-app-services
 /examples/state_containers_examples/ @elastic/kibana-app-services
 /examples/ui_action_examples/ @elastic/kibana-app-services
 /examples/ui_actions_explorer/ @elastic/kibana-app-services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,6 @@
 /packages/elastic-datemath/ @elastic/kibana-app-services
 /packages/kbn-interpreter/ @elastic/kibana-app-services
 /packages/kbn-react-field/ @elastic/kibana-app-services
-/packages/kbn-interpreter/ @elastic/kibana-app-services
 /src/plugins/bfetch/ @elastic/kibana-app-services
 /src/plugins/data/ @elastic/kibana-app-services
 /src/plugins/data_views/ @elastic/kibana-app-services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,6 @@
 /examples/demo_search/ @elastic/kibana-app-services
 /examples/developer_examples/ @elastic/kibana-app-services
 /examples/embeddable_examples/ @elastic/kibana-app-services
-/examples/embeddable_explorer/ @elastic/kibana-app-services
 /examples/state_containers_examples/ @elastic/kibana-app-services
 /examples/ui_action_examples/ @elastic/kibana-app-services
 /examples/ui_actions_explorer/ @elastic/kibana-app-services
@@ -59,9 +58,11 @@
 /examples/url_generators_explorer/ @elastic/kibana-app-services
 /examples/field_formats_example/ @elastic/kibana-app-services
 /examples/partial_results_example/ @elastic/kibana-app-services
+/examples/search_examples/ @elastic/kibana-app-services
 /packages/elastic-datemath/ @elastic/kibana-app-services
 /packages/kbn-interpreter/ @elastic/kibana-app-services
 /packages/kbn-react-field/ @elastic/kibana-app-services
+/packages/kbn-interpreter/ @elastic/kibana-app-services
 /src/plugins/bfetch/ @elastic/kibana-app-services
 /src/plugins/data/ @elastic/kibana-app-services
 /src/plugins/data_views/ @elastic/kibana-app-services
@@ -78,18 +79,15 @@
 /src/plugins/ui_actions/ @elastic/kibana-app-services
 /src/plugins/index_pattern_field_editor @elastic/kibana-app-services
 /src/plugins/screenshot_mode @elastic/kibana-app-services
+/src/plugins/bfetch/ @elastic/kibana-app-services
+/src/plugins/index_pattern_management/ @elastic/kibana-app-services
+/src/plugins/inspector/ @elastic/kibana-app-services
 /x-pack/examples/ui_actions_enhanced_examples/ @elastic/kibana-app-services
 /x-pack/plugins/data_enhanced/ @elastic/kibana-app-services
 /x-pack/plugins/embeddable_enhanced/ @elastic/kibana-app-services
 /x-pack/plugins/ui_actions_enhanced/ @elastic/kibana-app-services
 /x-pack/plugins/runtime_fields @elastic/kibana-app-services
 /x-pack/test/search_sessions_integration/ @elastic/kibana-app-services
-#CC# /src/plugins/bfetch/ @elastic/kibana-app-services
-#CC# /src/plugins/index_pattern_management/ @elastic/kibana-app-services
-#CC# /src/plugins/inspector/ @elastic/kibana-app-services
-#CC# /src/plugins/share/ @elastic/kibana-app-services
-#CC# /x-pack/plugins/drilldowns/ @elastic/kibana-app-services
-#CC# /packages/kbn-interpreter/ @elastic/kibana-app-services
 
 ### Observability Plugins
 


### PR DESCRIPTION
* Be regular code-owner for previously `CC` directories
* Remove `/x-pack/plugins/drilldowns` as there is no such path anymore
* Add `/examples/search_examples/` as CO