### PR TITLE
[App Search] Fix margins suggestion callout on Curation Detail view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/suggestions_callout.tsx
@@ -28,6 +28,7 @@ interface SuggestionsCalloutProps {
   description: string;
   buttonTo: string;
   lastUpdatedTimestamp: string; // ISO string like '2021-10-04T18:53:02.784Z'
+  style?: React.CSSProperties;
 }
 
 export const SuggestionsCallout: React.FC<SuggestionsCalloutProps> = ({
@@ -35,6 +36,7 @@ export const SuggestionsCallout: React.FC<SuggestionsCalloutProps> = ({
   description,
   buttonTo,
   lastUpdatedTimestamp,
+  style,
 }) => {
   const { pathname } = useLocation();
 
@@ -49,7 +51,7 @@ export const SuggestionsCallout: React.FC<SuggestionsCalloutProps> = ({
 
   return (
     <>
-      <EuiCallOut color="success" iconType={LightbulbIcon} title={title}>
+      <EuiCallOut style={style} color="success" iconType={LightbulbIcon} title={title}>
         <EuiText size="s">
           <p>{description}</p>
         </EuiText>
@@ -80,7 +82,6 @@ export const SuggestionsCallout: React.FC<SuggestionsCalloutProps> = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiCallOut>
-      <EuiSpacer />
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/suggested_documents_callout.tsx
@@ -35,6 +35,7 @@ export const SuggestedDocumentsCallout: React.FC = () => {
 
   return (
     <SuggestionsCallout
+      style={{ marginTop: '24px' }}
       title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.curation.suggestedDocumentsCallout.title',
         { defaultMessage: 'New suggested documents for this query' }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/suggested_curations_callout.tsx
@@ -34,6 +34,7 @@ export const SuggestedCurationsCallout: React.FC = () => {
 
   return (
     <SuggestionsCallout
+      style={{ marginBottom: '24px' }}
       title={i18n.translate(
         'xpack.enterpriseSearch.appSearch.engine.suggestedCurationsCallout.title',
         { defaultMessage: 'New suggested curations to review' }


### PR DESCRIPTION
## Summary

This moves the margin from below the callout to above it on the Curation Detail view.  For the callouts on the Engine Overview and Analytics Overview pages, we keep the margin on the bottom of the callout.


## Screenshots

**Curation Detail - No callout**
![Screen Shot 2021-11-10 at 12 51 40 PM](https://user-images.githubusercontent.com/2479295/141167425-62ce2c6a-e1ee-4c55-8a6b-3efcaf089f9b.png)

**Curation Detail - With callout**
![Screen Shot 2021-11-10 at 12 50 50 PM](https://user-images.githubusercontent.com/2479295/141167480-ddb7ae8a-bbc9-4979-9afa-a703adb31332.png)

**Engine Overview - With callout**
![Screen Shot 2021-11-10 at 12 50 57 PM](https://user-images.githubusercontent.com/2479295/141167575-5d06828a-9a5b-44a1-976b-e8fa757e1af6.png)

**Analytics Overview - With callout**
![Screen Shot 2021-11-10 at 12 51 06 PM](https://user-images.githubusercontent.com/2479295/141167561-12967203-6078-4bbc-b6a5-5a2be32ec9d7.png)

### Checklist
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

