### PR TITLE
[Security Solution][Detections] Fixes description of Import rules modal

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -551,7 +551,8 @@ export const IMPORT_RULE_BTN_TITLE = i18n.translate(
 export const SELECT_RULE = i18n.translate(
   'xpack.securitySolution.detectionEngine.components.importRuleModal.selectRuleDescription',
   {
-    defaultMessage: 'Select Security rules (as exported from the Detection Rules page) to import',
+    defaultMessage:
+      'Select rules and actions (as exported from the Security > Rules page) to import',
   }
 );
 


### PR DESCRIPTION
Issue https://github.com/elastic/kibana/issues/115537
## Summary

Changing outdate description on Import rules modal to "Select rules and actions (as exported from the Security > Rules page) to import"

### Screenshots

#### Before
<img width="1287" alt="Screenshot 2021-11-10 at 18 50 42" src="https://user-images.githubusercontent.com/92328789/141175007-bf5c6f36-8c5a-4137-89ab-4e1588643f05.png">

#### After
<img width="1285" alt="Screenshot 2021-11-10 at 18 49 13" src="https://user-images.githubusercontent.com/92328789/141174835-41baec9c-2c0f-4015-a08f-ffbd9b870a9b.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
