### PR TITLE
[Exploratory View] Make series editor header sticky

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
@@ -102,11 +102,7 @@ export function ExploratoryView({
             chartTimeRange={chartTimeRangeContext}
           />
           <LensWrapper ref={wrapperRef} height={height}>
-            <EuiResizableContainer
-              style={{ height: '100%' }}
-              direction="vertical"
-              onToggleCollapsed={onCollapse}
-            >
+            <ResizableContainer direction="vertical" onToggleCollapsed={onCollapse}>
               {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => {
                 collapseFn.current = (id, direction) => togglePanel?.(id, { direction });
 
@@ -134,6 +130,7 @@ export function ExploratoryView({
                       mode={'main'}
                       id="seriesPanel"
                       color="subdued"
+                      className="paddingTopSmall"
                     >
                       <ChartToggle
                         isCollapsed={hiddenPanel === 'chartPanel'}
@@ -148,7 +145,7 @@ export function ExploratoryView({
                   </>
                 );
               }}
-            </EuiResizableContainer>
+            </ResizableContainer>
             {hiddenPanel === 'seriesPanel' && (
               <ShowPreview onClick={() => onChange('seriesPanel')} iconType="arrowUp">
                 {PREVIEW_LABEL}
@@ -172,6 +169,14 @@ const LensWrapper = styled.div<{ height: string }>`
     height: 100%;
   }
 `;
+
+const ResizableContainer = styled(EuiResizableContainer)`
+  height: 100%;
+  &&& .paddingTopSmall {
+    padding-top: 8px;
+  }
+`;
+
 const Wrapper = styled(EuiPanel)`
   max-width: 1800px;
   min-width: 800px;

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/exploratory_view.tsx
@@ -135,19 +135,11 @@ export function ExploratoryView({
                       id="seriesPanel"
                       color="subdued"
                     >
-                      {hiddenPanel === 'chartPanel' ? (
-                        <ShowChart onClick={() => onChange('chartPanel')} iconType="arrowDown">
-                          {SHOW_CHART_LABEL}
-                        </ShowChart>
-                      ) : (
-                        <HideChart
-                          onClick={() => onChange('chartPanel')}
-                          iconType="arrowUp"
-                          color="text"
-                        >
-                          {HIDE_CHART_LABEL}
-                        </HideChart>
-                      )}
+                      <ChartToggle
+                        isCollapsed={hiddenPanel === 'chartPanel'}
+                        onClick={() => onChange('chartPanel')}
+                      />
+
                       <SeriesViews
                         seriesBuilderRef={seriesBuilderRef}
                         onSeriesPanelCollapse={onChange}
@@ -197,15 +189,22 @@ const ShowPreview = styled(EuiButtonEmpty)`
   position: absolute;
   bottom: 34px;
 `;
-const HideChart = styled(EuiButtonEmpty)`
+
+const ChartToggle = styled(({ isCollapsed, ...rest }) => (
+  <EuiButtonEmpty
+    {...(isCollapsed ? { iconType: 'arrowDown' } : { iconType: 'arrowUp', color: 'text' })}
+    {...rest}
+  >
+    {isCollapsed ? SHOW_CHART_LABEL : HIDE_CHART_LABEL}
+  </EuiButtonEmpty>
+))`
+  &:focus,
+  &:focus:enabled {
+    background: none;
+  }
   position: absolute;
-  top: -35px;
-  right: 50px;
-`;
-const ShowChart = styled(EuiButtonEmpty)`
-  position: absolute;
-  top: -10px;
-  right: 50px;
+  top: -30px;
+  right: 0;
 `;
 
 const HIDE_CHART_LABEL = i18n.translate('xpack.observability.overview.exploratoryView.hideChart', {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -115,6 +115,7 @@ export const SeriesEditor = React.memo(function () {
 
   return (
     <Wrapper>
+      <SectionHeaderBackground />
       <StickyFlexGroup gutterSize="none">
         <ReportTypeFormFlexItem grow={false}>
           <EuiFormRow
@@ -185,13 +186,22 @@ const Wrapper = euiStyled.div`
   }
 `;
 
+const SectionHeaderBackground = euiStyled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 56px;
+  background-color: ${({ theme }) => theme.eui.euiPageBackgroundColor};
+  border-bottom: 1px solid ${({ theme }) => theme.eui.euiColorLightShade};
+  z-index: 90;
+`;
+
 const StickyFlexGroup = euiStyled(EuiFlexGroup)`
   position: sticky;
-  top: -${({ theme }) => theme.eui.paddingSizes.m};
-  background-color: ${({ theme }) => theme.eui.euiPageBackgroundColor};
+  top: 0;
   z-index: 100;
-  padding: ${({ theme }) => theme.eui.paddingSizes.s} 0;
-  border-bottom: 2px solid ${({ theme }) => theme.eui.euiColorLightShade};
+  padding: 0;
 `;
 
 const EditorRowsWrapper = euiStyled.div`

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -117,7 +117,7 @@ export const SeriesEditor = React.memo(function () {
     <Wrapper>
       <SectionHeaderBackground />
       <StickyFlexGroup gutterSize="none">
-        <ReportTypeFormFlexItem grow={false}>
+        <EuiFlexItem grow={false}>
           <EuiFormRow
             css={{ alignItems: 'center' }}
             aria-label={REPORT_TYPE_ARIA_LABEL}
@@ -126,7 +126,7 @@ export const SeriesEditor = React.memo(function () {
           >
             <ReportTypesSelect prepend={REPORT_TYPE_LABEL} />
           </EuiFormRow>
-        </ReportTypeFormFlexItem>
+        </EuiFlexItem>
 
         <EuiFlexItem>
           <ViewActions onApply={() => setItemIdToExpandedRowMap({})} />
@@ -206,16 +206,6 @@ const StickyFlexGroup = euiStyled(EuiFlexGroup)`
 
 const EditorRowsWrapper = euiStyled.div`
   margin: ${({ theme }) => theme.eui.paddingSizes.m} 0;
-`;
-
-const ReportTypeFormFlexItem = euiStyled(EuiFlexItem)`
-  margin-right: ${({ theme }) => theme.eui.paddingSizes.m};
-  &&& {
-    .euiFormLabel {
-      font-size: ${({ theme }) => theme.eui.euiFontSize};
-      font-weight: ${({ theme }) => theme.eui.euiFontWeightMedium};
-    }
-  }
 `;
 
 export const LOADING_VIEW = i18n.translate(

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -222,10 +222,6 @@ export const SELECT_REPORT_TYPE = i18n.translate(
   }
 );
 
-export const RESET_LABEL = i18n.translate('xpack.observability.expView.seriesBuilder.reset', {
-  defaultMessage: 'Reset',
-});
-
 export const REPORT_TYPE_LABEL = i18n.translate(
   'xpack.observability.expView.seriesBuilder.reportType',
   {

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -7,9 +7,9 @@
 
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiSpacer, EuiFormRow, EuiFlexItem, EuiFlexGroup, EuiHorizontalRule } from '@elastic/eui';
+import { EuiSpacer, EuiFormRow, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { rgba } from 'polished';
-import { euiStyled } from './../../../../../../../../src/plugins/kibana_react/common';
+import { euiStyled } from '../../../../../../../../src/plugins/kibana_react/common';
 import { AppDataType, ReportViewType, BuilderItem } from '../types';
 import { SeriesContextValue, useSeriesStorage } from '../hooks/use_series_storage';
 import { IndexPatternState, useAppIndexPatternContext } from '../hooks/use_app_index_pattern';
@@ -115,23 +115,24 @@ export const SeriesEditor = React.memo(function () {
 
   return (
     <Wrapper>
-      <div>
-        <EuiFlexGroup>
-          <EuiFlexItem grow={false}>
-            <EuiFormRow
-              aria-label={REPORT_TYPE_ARIA_LABEL}
-              id="report-type-label"
-              isDisabled={true}
-            >
-              <ReportTypesSelect prepend={REPORT_TYPE_LABEL} />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <ViewActions onApply={() => setItemIdToExpandedRowMap({})} />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+      <StickyFlexGroup gutterSize="none">
+        <ReportTypeFormFlexItem grow={false}>
+          <EuiFormRow
+            css={{ alignItems: 'center' }}
+            aria-label={REPORT_TYPE_ARIA_LABEL}
+            id="report-type-label"
+            isDisabled={true}
+          >
+            <ReportTypesSelect prepend={REPORT_TYPE_LABEL} />
+          </EuiFormRow>
+        </ReportTypeFormFlexItem>
 
-        <EuiHorizontalRule margin="s" />
+        <EuiFlexItem>
+          <ViewActions onApply={() => setItemIdToExpandedRowMap({})} />
+        </EuiFlexItem>
+      </StickyFlexGroup>
+
+      <EditorRowsWrapper>
         {editorItems.map((item) => (
           <div key={item.id}>
             <Series
@@ -142,8 +143,7 @@ export const SeriesEditor = React.memo(function () {
             <EuiSpacer size="s" />
           </div>
         ))}
-        <EuiSpacer size="s" />
-      </div>
+      </EditorRowsWrapper>
     </Wrapper>
   );
 });
@@ -181,6 +181,29 @@ const Wrapper = euiStyled.div`
     }
     .isIncomplete .euiTableRowCell {
       background-color: rgba(254, 197, 20, 0.1);
+    }
+  }
+`;
+
+const StickyFlexGroup = euiStyled(EuiFlexGroup)`
+  position: sticky;
+  top: -${({ theme }) => theme.eui.paddingSizes.m};
+  background-color: ${({ theme }) => theme.eui.euiPageBackgroundColor};
+  z-index: 100;
+  padding: ${({ theme }) => theme.eui.paddingSizes.s} 0;
+  border-bottom: 2px solid ${({ theme }) => theme.eui.euiColorLightShade};
+`;
+
+const EditorRowsWrapper = euiStyled.div`
+  margin: ${({ theme }) => theme.eui.paddingSizes.m} 0;
+`;
+
+const ReportTypeFormFlexItem = euiStyled(EuiFlexItem)`
+  margin-right: ${({ theme }) => theme.eui.paddingSizes.m};
+  &&& {
+    .euiFormLabel {
+      font-size: ${({ theme }) => theme.eui.euiFontSize};
+      font-weight: ${({ theme }) => theme.eui.euiFontWeightMedium};
     }
   }
 `;


### PR DESCRIPTION
Fixes #117131

## Summary

Make the header actions header on series editor on Exploratory View sticky, because the Apply Changes button scrolls off the container.

**Before**
https://user-images.githubusercontent.com/2748376/141177629-c859f669-04e6-45f9-b41d-2ccbb295ddf0.mp4

 **After**
https://user-images.githubusercontent.com/2748376/141177679-1c9315f9-06c4-40de-876a-87691836add9.mp4

**Screenshots**
| Light | Dark |
| :---: | :---: |
|<img width="1770" alt="Screenshot 2021-11-10 at 16 53 11" src="https://user-images.githubusercontent.com/2748376/141158529-49b01606-afcc-4ec4-b0d9-a3fc3193a4cb.png">|<img width="1771" alt="Screenshot 2021-11-10 at 16 55 02" src="https://user-images.githubusercontent.com/2748376/141158542-6f7ebcb0-4001-411f-9af3-a431c783ecdf.png">|



### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
