### PR TITLE
[Exploratory View] Remove exploratory view reset button

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/series_editor/series_editor.tsx
@@ -7,14 +7,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import {
-  EuiSpacer,
-  EuiFormRow,
-  EuiFlexItem,
-  EuiFlexGroup,
-  EuiButtonEmpty,
-  EuiHorizontalRule,
-} from '@elastic/eui';
+import { EuiSpacer, EuiFormRow, EuiFlexItem, EuiFlexGroup, EuiHorizontalRule } from '@elastic/eui';
 import { rgba } from 'polished';
 import { euiStyled } from './../../../../../../../../src/plugins/kibana_react/common';
 import { AppDataType, ReportViewType, BuilderItem } from '../types';
@@ -62,7 +55,7 @@ export const getSeriesToEdit = ({
 export const SeriesEditor = React.memo(function () {
   const [editorItems, setEditorItems] = useState<BuilderItem[]>([]);
 
-  const { getSeries, allSeries, reportType, removeSeries } = useSeriesStorage();
+  const { getSeries, allSeries, reportType } = useSeriesStorage();
 
   const { loading, indexPatterns } = useAppIndexPatternContext();
 
@@ -120,15 +113,6 @@ export const SeriesEditor = React.memo(function () {
     setItemIdToExpandedRowMap(itemIdToExpandedRowMapValues);
   };
 
-  const resetView = () => {
-    const totalSeries = allSeries.length;
-    for (let i = totalSeries; i >= 0; i--) {
-      removeSeries(i);
-    }
-    setEditorItems([]);
-    setItemIdToExpandedRowMap({});
-  };
-
   return (
     <Wrapper>
       <div>
@@ -138,13 +122,6 @@ export const SeriesEditor = React.memo(function () {
               <ReportTypesSelect />
             </EuiFormRow>
           </EuiFlexItem>
-          {reportType && (
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty onClick={() => resetView()} color="text">
-                {RESET_LABEL}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          )}
           <EuiFlexItem>
             <ViewActions onApply={() => setItemIdToExpandedRowMap({})} />
           </EuiFlexItem>


### PR DESCRIPTION
## Summary

Resolves #118095.

Removes the exp. view reset button for the reasons explained in the linked issue.


### Checklist

Delete any items that are not applicable to this PR.

- I simply removed one element, so no real bearing on accessibility, docs, etc.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
