### PR TITLE
[Security Solution] fix tests for unique policy names

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_endpoint_hosts.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_loaders/index_endpoint_hosts.ts
@@ -8,6 +8,7 @@
 import { Client } from '@elastic/elasticsearch';
 import { cloneDeep, merge } from 'lodash';
 import { AxiosResponse } from 'axios';
+import uuid from 'uuid';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { KbnClient } from '@kbn/test';
 import { DeleteByQueryResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
@@ -139,12 +140,13 @@ export async function indexEndpointHostDocs({
 
     if (enrollFleet) {
       const { id: appliedPolicyId, name: appliedPolicyName } = hostMetadata.Endpoint.policy.applied;
+      const uniqueAppliedPolicyName = `${appliedPolicyName}-${uuid.v4()}`;
 
       // If we don't yet have a "real" policy record, then create it now in ingest (package config)
       if (!realPolicies[appliedPolicyId]) {
         const createdPolicies = await indexFleetEndpointPolicy(
           kbnClient,
-          appliedPolicyName,
+          uniqueAppliedPolicyName,
           epmEndpointPackage.version
         );
 

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -401,6 +401,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(agentFullPolicy.inputs).to.eql([
           getExpectedAgentPolicyEndpointInput({
             id: policyInfo.packagePolicy.id,
+            name: policyInfo.packagePolicy.name,
             meta: {
               package: {
                 version: policyInfo.packageInfo.version,
@@ -447,6 +448,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(agentFullPolicy.inputs).to.eql([
           getExpectedAgentPolicyEndpointInput({
             id: policyInfo.packagePolicy.id,
+            name: policyInfo.packagePolicy.name,
             meta: {
               package: {
                 version: policyInfo.packageInfo.version,
@@ -485,6 +487,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         expect(agentFullPolicyUpdated.inputs).to.eql([
           getExpectedAgentPolicyEndpointInput({
             id: policyInfo.packagePolicy.id,
+            name: policyInfo.packagePolicy.name,
             revision: 3,
             meta: {
               package: {

--- a/x-pack/test/security_solution_endpoint/services/endpoint_policy.ts
+++ b/x-pack/test/security_solution_endpoint/services/endpoint_policy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import uuid from 'uuid';
 import { FtrProviderContext } from '../ftr_provider_context';
 import {
   CreateAgentPolicyRequest,
@@ -161,7 +162,7 @@ export function EndpointPolicyTestResourcesProvider({ getService }: FtrProviderC
       let agentPolicy: CreateAgentPolicyResponse['item'];
       try {
         const newAgentPolicyData: CreateAgentPolicyRequest['body'] = {
-          name: 'East Coast',
+          name: `East Coast ${uuid.v4()}`,
           description: 'East Coast call center',
           namespace: 'default',
         };
@@ -182,7 +183,7 @@ export function EndpointPolicyTestResourcesProvider({ getService }: FtrProviderC
       let packagePolicy: CreatePackagePolicyResponse['item'];
       try {
         const newPackagePolicyData: CreatePackagePolicyRequest['body'] = {
-          name: 'Protect East Coast',
+          name: `Protect East Coast ${uuid.v4()}`,
           description: 'Protect the worlds data - but in the East Coast',
           policy_id: agentPolicy!.id,
           enabled: true,


### PR DESCRIPTION
## Summary

fixes endpoint tests that were failing due to policy names not being unique. unique policies names were introduced in https://github.com/elastic/kibana/pull/115212. needs to be back-ported into `7.16` for https://github.com/elastic/kibana/pull/117380.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
