### PR TITLE
[7.16] [Reporting] Fix timeouts handling in the screenshotting observable handler (#118186)

### DIFF
--- a/x-pack/plugins/reporting/server/lib/screenshots/observable.test.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/observable.test.ts
@@ -353,7 +353,7 @@ describe('Screenshot Observable Pipeline', () => {
                       },
                     },
                   ],
-                  "error": [Error: An error occurred when trying to read the page for visualization panel info: Error: Mock error!],
+                  "error": [Error: The "wait for elements" phase encountered an error: Error: An error occurred when trying to read the page for visualization panel info: Error: Mock error!],
                   "screenshots": Array [
                     Object {
                       "data": Object {

--- a/x-pack/plugins/reporting/server/lib/screenshots/observable.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/observable.ts
@@ -58,9 +58,8 @@ export function getScreenshots$(
       const screen = new ScreenshotObservableHandler(driver, opts, getTimeouts(captureConfig));
 
       return Rx.from(opts.urlsOrUrlLocatorTuples).pipe(
-        concatMap((urlOrUrlLocatorTuple, index) => {
-          return Rx.of(1).pipe(
-            screen.setupPage(index, urlOrUrlLocatorTuple, apmTrans),
+        concatMap((urlOrUrlLocatorTuple, index) =>
+          screen.setupPage(index, urlOrUrlLocatorTuple, apmTrans).pipe(
             catchError((err) => {
               screen.checkPageIsOpen(); // this fails the job if the browser has closed
 
@@ -69,8 +68,8 @@ export function getScreenshots$(
             }),
             takeUntil(exit$),
             screen.getScreenshots()
-          );
-        }),
+          )
+        ),
         take(opts.urlsOrUrlLocatorTuples.length),
         toArray()
       );

--- a/x-pack/plugins/reporting/server/lib/screenshots/observable_handler.test.ts
+++ b/x-pack/plugins/reporting/server/lib/screenshots/observable_handler.test.ts
@@ -95,7 +95,7 @@ describe('ScreenshotObservableHandler', () => {
 
       const testPipeline = () => test$.toPromise();
       await expect(testPipeline).rejects.toMatchInlineSnapshot(
-        `[Error: The "Test Config" phase took longer than 0.2 seconds. You may need to increase "test.config.value": TimeoutError: Timeout has occurred]`
+        `[Error: The "Test Config" phase took longer than 0.2 seconds. You may need to increase "test.config.value"]`
       );
     });
 


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Reporting] Fix timeouts handling in the screenshotting observable handler (#118186)