### PR TITLE
[Global Search] Integrate with ScreenshotMode service

### DIFF
--- a/x-pack/plugins/global_search/kibana.json
+++ b/x-pack/plugins/global_search/kibana.json
@@ -8,7 +8,7 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["licensing"],
+  "requiredPlugins": ["licensing", "screenshotMode"],
   "optionalPlugins": [],
   "configPath": ["xpack", "global_search"]
 }

--- a/x-pack/plugins/global_search/public/plugin.ts
+++ b/x-pack/plugins/global_search/public/plugin.ts
@@ -6,16 +6,18 @@
  */
 
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from 'src/core/public';
+import type { ScreenshotModePluginStart } from '../../../../src/plugins/screenshot_mode/public';
 import { LicensingPluginStart } from '../../licensing/public';
-import { LicenseChecker, ILicenseChecker } from '../common/license_checker';
-import { GlobalSearchPluginSetup, GlobalSearchPluginStart } from './types';
+import { ILicenseChecker, LicenseChecker } from '../common/license_checker';
 import { GlobalSearchClientConfigType } from './config';
 import { SearchService } from './services';
+import { GlobalSearchPluginSetup, GlobalSearchPluginStart } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface GlobalSearchPluginSetupDeps {}
 export interface GlobalSearchPluginStartDeps {
   licensing: LicensingPluginStart;
+  screenshotMode: ScreenshotModePluginStart;
 }
 
 export class GlobalSearchPlugin
@@ -45,11 +47,12 @@ export class GlobalSearchPlugin
     };
   }
 
-  start({ http }: CoreStart, { licensing }: GlobalSearchPluginStartDeps) {
+  start({ http }: CoreStart, { licensing, screenshotMode }: GlobalSearchPluginStartDeps) {
     this.licenseChecker = new LicenseChecker(licensing.license$);
     const { find, getSearchableTypes } = this.searchService.start({
       http,
       licenseChecker: this.licenseChecker,
+      isScreenshotMode: screenshotMode.isScreenshotMode(),
     });
 
     return {

--- a/x-pack/plugins/global_search/public/services/search_service.test.ts
+++ b/x-pack/plugins/global_search/public/services/search_service.test.ts
@@ -39,9 +39,12 @@ describe('SearchService', () => {
     };
   };
 
+  let isScreenshotMode = false;
+
   const startDeps = () => ({
     http: httpStart,
     licenseChecker,
+    isScreenshotMode,
   });
 
   const createProvider = (
@@ -102,6 +105,8 @@ describe('SearchService', () => {
 
     getDefaultPreferenceMock.mockClear();
     getDefaultPreferenceMock.mockReturnValue('default_pref');
+
+    isScreenshotMode = false;
   });
 
   describe('#setup()', () => {
@@ -158,6 +163,19 @@ describe('SearchService', () => {
           { term: 'foobar', types: ['dashboard', 'map'], tags: ['tag-id'] },
           expect.objectContaining({ preference: 'pref', aborted$: expect.any(Object) })
         );
+      });
+
+      it('has `fetchServerResults` avoid HTTP calls when isScreenshotMode = true', () => {
+        service.setup({ config: createConfig() });
+
+        isScreenshotMode = true;
+        const { find } = service.start(startDeps());
+        find(
+          { term: 'foobar', types: ['dashboard', 'map'], tags: ['tag-id'] },
+          { preference: 'pref' }
+        );
+
+        expect(fetchServerResultsMock).toHaveBeenCalledTimes(0);
       });
 
       it('calls `getDefaultPreference` when `preference` is not specified', () => {

--- a/x-pack/plugins/global_search/public/services/types.ts
+++ b/x-pack/plugins/global_search/public/services/types.ts
@@ -25,4 +25,8 @@ export interface GlobalSearchFindOptions {
    * If/when provided and emitting, the result observable will be completed and no further result emission will be performed.
    */
   aborted$?: Observable<void>;
+  /**
+   * When a screenshot capture service has opened Kibana, the page needs to avoid automatically calling APIs
+   */
+  isScreenshotMode?: boolean;
 }

--- a/x-pack/plugins/global_search/tsconfig.json
+++ b/x-pack/plugins/global_search/tsconfig.json
@@ -14,6 +14,7 @@
   ],
   "references": [
     { "path": "../../../src/core/tsconfig.json" },
+    { "path": "../../../src/plugins/screenshot_mode/tsconfig.json" },
     { "path": "../licensing/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/117880

### Testing
1. Set Reporting plugin logs to `trace` level
2. Execute a PDF or PNG report
3. Search for `using custom headers` in the logs
4. The user should not see `using custom headers for '/internal/global_search/find'` in the logs


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios