### PR TITLE
[8.0] [Reporting] Fix task manager not to run tasks before Kibana is available (#118206)

### DIFF
--- a/x-pack/plugins/reporting/server/core.ts
+++ b/x-pack/plugins/reporting/server/core.ts
@@ -7,7 +7,7 @@
 
 import Hapi from '@hapi/hapi';
 import * as Rx from 'rxjs';
-import { first, map, take } from 'rxjs/operators';
+import { filter, first, map, take } from 'rxjs/operators';
 import { ScreenshotModePluginSetup } from 'src/plugins/screenshot_mode/server';
 import {
   BasePath,
@@ -17,6 +17,8 @@ import {
   PluginInitializerContext,
   SavedObjectsClientContract,
   SavedObjectsServiceStart,
+  ServiceStatusLevels,
+  StatusServiceSetup,
   UiSettingsServiceStart,
 } from '../../../../src/core/server';
 import { PluginStart as DataPluginStart } from '../../../../src/plugins/data/server';
@@ -44,6 +46,7 @@ export interface ReportingInternalSetup {
   taskManager: TaskManagerSetupContract;
   screenshotMode: ScreenshotModePluginSetup;
   logger: LevelLogger;
+  status: StatusServiceSetup;
 }
 
 export interface ReportingInternalStart {
@@ -111,10 +114,23 @@ export class ReportingCore {
     this.pluginStart$.next(startDeps); // trigger the observer
     this.pluginStartDeps = startDeps; // cache
 
+    await this.assertKibanaIsAvailable();
+
     const { taskManager } = startDeps;
     const { executeTask, monitorTask } = this;
     // enable this instance to generate reports and to monitor for pending reports
     await Promise.all([executeTask.init(taskManager), monitorTask.init(taskManager)]);
+  }
+
+  private async assertKibanaIsAvailable(): Promise<void> {
+    const { status } = this.getPluginSetupDeps();
+
+    await status.overall$
+      .pipe(
+        filter((current) => current.level === ServiceStatusLevels.available),
+        first()
+      )
+      .toPromise();
   }
 
   /*

--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -52,7 +52,6 @@ export class ReportingPlugin
 
     const router = http.createRouter<ReportingRequestHandlerContext>();
     const basePath = http.basePath;
-
     reportingCore.pluginSetup({
       screenshotMode,
       features,
@@ -63,6 +62,7 @@ export class ReportingPlugin
       spaces,
       taskManager,
       logger: this.logger,
+      status: core.status,
     });
 
     registerUiSettings(core);

--- a/x-pack/plugins/reporting/server/test_helpers/create_mock_reportingplugin.ts
+++ b/x-pack/plugins/reporting/server/test_helpers/create_mock_reportingplugin.ts
@@ -11,7 +11,7 @@ jest.mock('../browsers');
 
 import _ from 'lodash';
 import * as Rx from 'rxjs';
-import { coreMock, elasticsearchServiceMock } from 'src/core/server/mocks';
+import { coreMock, elasticsearchServiceMock, statusServiceMock } from 'src/core/server/mocks';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { dataPluginMock } from 'src/plugins/data/server/mocks';
 import { FieldFormatsRegistry } from 'src/plugins/field_formats/common';
@@ -45,6 +45,7 @@ export const createMockPluginSetup = (setupMock?: any): ReportingInternalSetup =
     licensing: { license$: Rx.of({ isAvailable: true, isActive: true, type: 'basic' }) } as any,
     taskManager: taskManagerMock.createSetup(),
     logger: createMockLevelLogger(),
+    status: statusServiceMock.createSetupContract(),
     ...setupMock,
   };
 };


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Reporting] Fix task manager not to run tasks before Kibana is available (#118206)