### PR TITLE
[APM] Removes warning about Stack Monitoring in Fleet migration

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Settings/schema/confirm_switch_modal.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/schema/confirm_switch_modal.tsx
@@ -58,12 +58,6 @@ export function ConfirmSwitchModal({
       }}
       confirmButtonDisabled={!isConfirmChecked}
     >
-      <p>
-        {i18n.translate('xpack.apm.settings.schema.confirm.descriptionText', {
-          defaultMessage:
-            'Please note Stack monitoring is not currently supported with Fleet-managed APM.',
-        })}
-      </p>
       {!hasUnsupportedConfigs && (
         <p>
           {i18n.translate(

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -6619,7 +6619,6 @@
     "xpack.apm.settings.schema.confirm.apmServerSettingsCloudLinkText": "クラウドでAPMサーバー設定に移動",
     "xpack.apm.settings.schema.confirm.cancelText": "キャンセル",
     "xpack.apm.settings.schema.confirm.checkboxLabel": "データストリームに切り替えることを確認する",
-    "xpack.apm.settings.schema.confirm.descriptionText": "現在、スタック監視はFleetで管理されたAPMではサポートされていません。",
     "xpack.apm.settings.schema.confirm.irreversibleWarning.message": "移行中には一時的にAPMデータ収集に影響する可能性があります。移行プロセスは数分で完了します。",
     "xpack.apm.settings.schema.confirm.irreversibleWarning.title": "データストリームへの切り替えは元に戻せません。",
     "xpack.apm.settings.schema.confirm.switchButtonText": "データストリームに切り替える",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -6672,7 +6672,6 @@
     "xpack.apm.settings.schema.confirm.apmServerSettingsCloudLinkText": "前往 Cloud 中的 APM Server 设置",
     "xpack.apm.settings.schema.confirm.cancelText": "取消",
     "xpack.apm.settings.schema.confirm.checkboxLabel": "我确认我想切换到数据流",
-    "xpack.apm.settings.schema.confirm.descriptionText": "请注意 Fleet 托管的 APM 当前不支持堆栈监测。",
     "xpack.apm.settings.schema.confirm.irreversibleWarning.message": "迁移在进行中时，可能会暂时影响 APM 数据收集。迁移的过程应只需花费几分钟。",
     "xpack.apm.settings.schema.confirm.irreversibleWarning.title": "切换到数据流是不可逆的操作",
     "xpack.apm.settings.schema.confirm.switchButtonText": "切换到数据流",


### PR DESCRIPTION
Closes #117086.
![Screen Shot 2021-11-11 at 1 51 28 AM](https://user-images.githubusercontent.com/1967266/141251567-ae36d563-2a53-4199-bfa0-0ccc289b7dce.png)


