### PR TITLE
Lens runtime field tests: Backport stabilization fix

### DIFF
--- a/test/functional/services/field_editor.ts
+++ b/test/functional/services/field_editor.ts
@@ -37,7 +37,12 @@ export class FieldEditorService extends FtrService {
     const textarea = await editor.findByClassName('monaco-mouse-cursor-text');
 
     await textarea.click();
-    await this.browser.pressKeys(script);
+    // To avoid issue with the timing needed for Selenium to write the script and the monaco editor
+    // syntax validation kicking in, we loop through all the chars of the script and enter
+    // them one by one (instead of calling "await this.browser.pressKeys(script);").
+    for (const letter of script.split('')) {
+      await this.browser.pressKeys(letter);
+    }
   }
   public async save() {
     await this.testSubjects.click('fieldSaveButton');


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/107854
Fixes https://github.com/elastic/kibana/issues/112515

https://github.com/elastic/kibana/pull/109233 stabilizes this on 8.1, this PR is backporting the crucial bit to 8.0 and 7.16 to stabilize it there as well.
