### PR TITLE
Adjust user management functional tests to work in Cloud.

### DIFF
--- a/x-pack/test/functional/apps/security/users.ts
+++ b/x-pack/test/functional/apps/security/users.ts
@@ -19,6 +19,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const toasts = getService('toasts');
   const browser = getService('browser');
 
+  function isCloudEnvironment() {
+    return config.get('servers.elasticsearch.hostname') !== 'localhost';
+  }
+
   describe('users', function () {
     const optionalUser: UserFormValues = {
       username: 'OptionalUser',
@@ -37,7 +41,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       const users = keyBy(await PageObjects.security.getElasticsearchUsers(), 'username');
       log.info('actualUsers = %j', users);
       log.info('config = %j', config.get('servers.elasticsearch.hostname'));
-      if (config.get('servers.elasticsearch.hostname') === 'localhost') {
+
+      // In Cloud default users are defined in file realm, such users aren't exposed through the Users API.
+      if (isCloudEnvironment()) {
+        expect(Object.keys(users)).to.eql(['test_user']);
+      } else {
         expect(users.elastic.roles).to.eql(['superuser']);
         expect(users.elastic.reserved).to.be(true);
         expect(users.elastic.deprecated).to.be(false);
@@ -49,9 +57,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(users.kibana.roles).to.eql(['kibana_system']);
         expect(users.kibana.reserved).to.be(true);
         expect(users.kibana.deprecated).to.be(true);
-      } else {
-        expect(users.anonymous.roles).to.eql(['anonymous']);
-        expect(users.anonymous.reserved).to.be(true);
       }
     });
 


### PR DESCRIPTION
## Summary

Some of our user management functional tests are failing when run against Cloud deployment. The reason is that default users in Cloud are defined in the file realm and hence not returned from the users APIs.

It turned out that we already tried to fix this test to work in Cloud using the workaround (`config.get('servers.elasticsearch.hostname') !== 'localhost'`), but the test broke again when the Cloud disabled anonymous access by default.

In this PR I'm reusing the same Cloud-detection workaround and updating the test.

~~__Blocked:__ We cannot verify fix at the moment, 8.1.0-SHANPSHOT is failing in Cloud and latest 7.16.0-SNAPSHOT doesn't include https://github.com/elastic/kibana/pull/118413 yet.~~ The tests with [the same fix](https://github.com/elastic/kibana/pull/118376) have passed on 7.16 branch (link is internal, ping me and I'll share the link),

__Fixes: https://github.com/elastic/kibana/issues/63276__