### PR TITLE
Lens functional test: Avoid triggering below-the-fold issue

### DIFF
--- a/x-pack/test/functional/apps/lens/formula.ts
+++ b/x-pack/test/functional/apps/lens/formula.ts
@@ -26,7 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await PageObjects.lens.configureDimension({
         dimension: 'lnsXY_yDimensionPanel > lns-dimensionTrigger',
-        operation: 'sum',
+        operation: 'average',
         field: 'bytes',
         keepOpen: true,
       });

--- a/x-pack/test/functional/apps/lens/formula.ts
+++ b/x-pack/test/functional/apps/lens/formula.ts
@@ -26,7 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await PageObjects.lens.configureDimension({
         dimension: 'lnsXY_yDimensionPanel > lns-dimensionTrigger',
-        operation: 'average',
+        operation: 'sum',
         field: 'bytes',
         keepOpen: true,
       });

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -20,6 +20,8 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
   const browser = getService('browser');
   const dashboardAddPanel = getService('dashboardAddPanel');
 
+  const FORMULA_TAB_HEIGHT = 40;
+
   const PageObjects = getPageObjects([
     'common',
     'header',
@@ -131,7 +133,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           : `lns-indexPatternDimension-${opts.operation}`;
         await retry.try(async () => {
           await testSubjects.exists(operationSelector);
-          await testSubjects.click(operationSelector);
+          await testSubjects.click(operationSelector, undefined, FORMULA_TAB_HEIGHT);
         });
       }
       if (opts.field) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/117769

The `scrollIntoViewIfNecessary` helper we are using can't deal with sticky elements like the one used by the formula/quick function tabs:
<img width="540" alt="Screenshot 2021-11-11 at 12 09 01" src="https://user-images.githubusercontent.com/1508364/141288657-e5b404ab-fe6a-433c-bb43-57e8a830c52b.png">

We have to pass in the `topHeight` to the click (~40px)