### PR TITLE
Use eui overflow for spaces scroll menu

### DIFF
--- a/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.scss
+++ b/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.scss
@@ -5,7 +5,6 @@
 .spcMenu__spacesList {
   @include euiYScrollWithShadows;
   max-height: $euiSizeXL * 10;
-
 }
 
 .spcMenu__searchFieldWrapper {

--- a/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.scss
+++ b/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.scss
@@ -3,8 +3,9 @@
 }
 
 .spcMenu__spacesList {
+  @include euiYScrollWithShadows;
   max-height: $euiSizeXL * 10;
-  overflow-y: auto;
+
 }
 
 .spcMenu__searchFieldWrapper {


### PR DESCRIPTION
## Summary

Small fix to make the scroller for spaces a little cleaner.

## BEFORE

![image](https://user-images.githubusercontent.com/324519/141308408-3211d68f-4cd5-4e39-ae24-47b9013a4596.png)


## AFTER

![image](https://user-images.githubusercontent.com/324519/141308211-1da3ffb0-2a2e-4c04-8fd6-7d9978434873.png)
