### PR TITLE
[8.0] [TSVB] Filter with scripted field doesn't work after migration to 7.13.1 (#115762)

### DIFF
--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/get_series_data.ts
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/get_series_data.ts
@@ -36,7 +36,10 @@ export async function getSeriesData(
     fieldFormatService,
   } = services;
 
-  const panelIndex = await cachedIndexPatternFetcher(panel.index_pattern);
+  const panelIndex = await cachedIndexPatternFetcher(
+    panel.index_pattern,
+    !panel.use_kibana_indexes
+  );
 
   const strategy = await searchStrategyRegistry.getViableStrategy(requestContext, req, panelIndex);
 

--- a/src/plugins/vis_types/timeseries/server/lib/vis_data/get_table_data.ts
+++ b/src/plugins/vis_types/timeseries/server/lib/vis_data/get_table_data.ts
@@ -31,7 +31,10 @@ export async function getTableData(
   panel: Panel,
   services: VisTypeTimeseriesRequestServices
 ) {
-  const panelIndex = await services.cachedIndexPatternFetcher(panel.index_pattern);
+  const panelIndex = await services.cachedIndexPatternFetcher(
+    panel.index_pattern,
+    !panel.use_kibana_indexes
+  );
 
   const strategy = await services.searchStrategyRegistry.getViableStrategy(
     requestContext,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [TSVB] Filter with scripted field doesn't work after migration to 7.13.1 (#115762)