### PR TITLE
use an ordinary es client in task_manager

### DIFF
--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -159,7 +159,7 @@ export class TaskManagerPlugin
     const taskStore = new TaskStore({
       serializer,
       savedObjectsRepository,
-      esClient: elasticsearch.createClient('taskManager').asInternalUser,
+      esClient: elasticsearch.client.asInternalUser,
       index: TASK_MANAGER_INDEX,
       definitions: this.definitions,
       taskManagerId: `kibana:${this.taskManagerId!}`,


### PR DESCRIPTION
## Summary

Do not use a custom ES client to re-use the common connection pool of the standard ES client.