### PR TITLE
[APM] Remove usage of ignore_throttled unless targeting frozen indices

### DIFF
--- a/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.test.ts
@@ -25,20 +25,5 @@ describe('correlations', () => {
         ignore_unavailable: true,
       });
     });
-
-    it('defaults ignore_throttled to true', () => {
-      const requestBase = getRequestBase({
-        index: 'apm-*',
-        environment: ENVIRONMENT_ALL.value,
-        kuery: '',
-        start: 1577836800000,
-        end: 1609459200000,
-      });
-      expect(requestBase).toEqual({
-        index: 'apm-*',
-        ignore_throttled: true,
-        ignore_unavailable: true,
-      });
-    });
   });
 });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.test.ts
@@ -18,10 +18,7 @@ describe('correlations', () => {
         start: 1577836800000,
         end: 1609459200000,
       });
-      expect(requestBase).toEqual({
-        index: 'apm-*',
-        ignore_unavailable: true,
-      });
+      expect(requestBase.ignore_throttled).toEqual(undefined);
     });
 
     it('adds `ignore_throttled=false` when `includeFrozen=true`', () => {
@@ -33,11 +30,7 @@ describe('correlations', () => {
         start: 1577836800000,
         end: 1609459200000,
       });
-      expect(requestBase).toEqual({
-        index: 'apm-*',
-        ignore_throttled: false,
-        ignore_unavailable: true,
-      });
+      expect(requestBase.ignore_throttled).toEqual(false);
     });
   });
 });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.test.ts
@@ -10,7 +10,21 @@ import { getRequestBase } from './get_request_base';
 
 describe('correlations', () => {
   describe('getRequestBase', () => {
-    it('returns the request base parameters', () => {
+    it('defaults to not setting `ignore_throttled`', () => {
+      const requestBase = getRequestBase({
+        index: 'apm-*',
+        environment: ENVIRONMENT_ALL.value,
+        kuery: '',
+        start: 1577836800000,
+        end: 1609459200000,
+      });
+      expect(requestBase).toEqual({
+        index: 'apm-*',
+        ignore_unavailable: true,
+      });
+    });
+
+    it('adds `ignore_throttled=false` when `includeFrozen=true`', () => {
       const requestBase = getRequestBase({
         index: 'apm-*',
         includeFrozen: true,

--- a/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/get_request_base.ts
@@ -13,6 +13,6 @@ export const getRequestBase = ({
 }: CorrelationsParams) => ({
   index,
   // matches APM's event client settings
-  ignore_throttled: includeFrozen === undefined ? true : !includeFrozen,
+  ...(includeFrozen ? { ignore_throttled: false } : {}),
   ignore_unavailable: true,
 });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/query_field_candidates.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/query_field_candidates.test.ts
@@ -88,7 +88,7 @@ describe('query_field_candidates', () => {
           size: 1000,
         },
         index: params.index,
-        ignore_throttled: !params.includeFrozen,
+        ignore_throttled: params.includeFrozen ? false : undefined,
         ignore_unavailable: true,
       });
     });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/query_histogram.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/query_histogram.test.ts
@@ -63,7 +63,7 @@ describe('query_histogram', () => {
           size: 0,
         },
         index: params.index,
-        ignore_throttled: !params.includeFrozen,
+        ignore_throttled: params.includeFrozen ? false : undefined,
         ignore_unavailable: true,
       });
     });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/query_histogram_range_steps.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/query_histogram_range_steps.test.ts
@@ -66,7 +66,7 @@ describe('query_histogram_range_steps', () => {
           size: 0,
         },
         index: params.index,
-        ignore_throttled: !params.includeFrozen,
+        ignore_throttled: params.includeFrozen ? false : undefined,
         ignore_unavailable: true,
       });
     });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/query_percentiles.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/query_percentiles.test.ts
@@ -65,7 +65,7 @@ describe('query_percentiles', () => {
           track_total_hits: true,
         },
         index: params.index,
-        ignore_throttled: !params.includeFrozen,
+        ignore_throttled: params.includeFrozen ? false : undefined,
         ignore_unavailable: true,
       });
     });

--- a/x-pack/plugins/apm/server/lib/correlations/queries/query_ranges.test.ts
+++ b/x-pack/plugins/apm/server/lib/correlations/queries/query_ranges.test.ts
@@ -82,7 +82,7 @@ describe('query_ranges', () => {
           size: 0,
         },
         index: params.index,
-        ignore_throttled: !params.includeFrozen,
+        ignore_throttled: params.includeFrozen ? false : undefined,
         ignore_unavailable: true,
       });
     });

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
@@ -100,7 +100,7 @@ export function createApmEventClient({
 
       const searchParams = {
         ...withPossibleLegacyDataFilter,
-        ignore_throttled: !includeFrozen,
+        ...(includeFrozen ? { ignore_throttled: false } : {}),
         ignore_unavailable: true,
         preference: 'any',
       };

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
@@ -132,7 +132,6 @@ describe('setupRequest', () => {
             },
           },
           ignore_unavailable: true,
-          ignore_throttled: true,
           preference: 'any',
         },
         {
@@ -251,7 +250,7 @@ describe('without a bool filter', () => {
 });
 
 describe('with includeFrozen=false', () => {
-  it('sets `ignore_throttled=true`', async () => {
+  it('should NOT send "ignore_throttled:true" in the request', async () => {
     const mockResources = getMockResources();
 
     // mock includeFrozen to return false
@@ -268,7 +267,7 @@ describe('with includeFrozen=false', () => {
     const params =
       mockResources.context.core.elasticsearch.client.asCurrentUser.search.mock
         .calls[0][0];
-    expect(params.ignore_throttled).toBe(true);
+    expect(params.ignore_throttled).toBe(undefined);
   });
 });
 


### PR DESCRIPTION
Related to #117980
Closes https://github.com/elastic/kibana/issues/117991



