### PR TITLE
[Fleet] Fix - Increment system package name when adding agent policy with monitoring

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1195,3 +1195,30 @@ function deepMergeVars(original: any, override: any): any {
 
   return result;
 }
+
+export async function incrementPackageName(
+  soClient: SavedObjectsClientContract,
+  packageName: string
+) {
+  // Fetch all packagePolicies having the package name
+  const packagePolicyData = await packagePolicyService.list(soClient, {
+    perPage: 1,
+    kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: "${packageName}"`,
+  });
+
+  // Retrieve highest number appended to package policy name and increment it by one
+  const pkgPoliciesNamePattern = new RegExp(`${packageName}-(\\d+)`);
+
+  const pkgPoliciesWithMatchingNames = packagePolicyData?.items
+    ? packagePolicyData.items
+        .filter((ds) => Boolean(ds.name.match(pkgPoliciesNamePattern)))
+        .map((ds) => parseInt(ds.name.match(pkgPoliciesNamePattern)![1], 10))
+        .sort()
+    : [];
+
+  return `${packageName}-${
+    pkgPoliciesWithMatchingNames.length
+      ? pkgPoliciesWithMatchingNames[pkgPoliciesWithMatchingNames.length - 1] + 1
+      : 1
+  }`;
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/118357

## Summary
Adding an agent policy with "Collect system logs and metric" checkbox enabled triggers the error `There is already a package with the same name`

This bug was caused by the [unique names PR](https://github.com/elastic/kibana/pull/115212/files): when we add a new agent policy with the system monitoring enabled we automatically install the `system` package, but the name given to the integration was always the same (`system-1`). Since we are now checking that all the integration packages have a unique name, the installation fails with the above error.

In this PR I'm adding a function that fetches all the `system` integrations already installed and increment the name, like it was done in the previous PR.

### Steps to reproduce:

1. Navigate to "add agent policy" fly out
2. If it's the first time you set up the system, add an agent policy with name test , otherwise go to step 3
3. Now add another agent policy with name test2, or any other name as long as is unique with "Collect system logs and metric" checked
4. The agent policy should be created properly and contain the `system` integration with incremental name format (something like `system-1`, `system-2`...)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
