### PR TITLE
[telemetry] remove unused es client

### DIFF
--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -16,7 +16,6 @@ import {
   SavedObjectsClientContract,
   SavedObjectsClient,
   CoreStart,
-  ICustomClusterClient,
 } from '../../../core/server';
 import {
   getTelemetryChannelEndpoint,
@@ -53,7 +52,6 @@ export class FetcherTask {
   private isSending = false;
   private internalRepository?: SavedObjectsClientContract;
   private telemetryCollectionManager?: TelemetryCollectionManagerPluginStart;
-  private elasticsearchClient?: ICustomClusterClient;
 
   constructor(initializerContext: PluginInitializerContext<TelemetryConfigType>) {
     this.config$ = initializerContext.config.create();
@@ -67,7 +65,6 @@ export class FetcherTask {
   ) {
     this.internalRepository = new SavedObjectsClient(savedObjects.createInternalRepository());
     this.telemetryCollectionManager = telemetryCollectionManager;
-    this.elasticsearchClient = elasticsearch.createClient('telemetry-fetcher');
 
     this.intervalId = timer(this.initialCheckDelayMs, this.checkIntervalMs).subscribe(() =>
       this.sendIfDue()
@@ -77,9 +74,6 @@ export class FetcherTask {
   public stop() {
     if (this.intervalId) {
       this.intervalId.unsubscribe();
-    }
-    if (this.elasticsearchClient) {
-      this.elasticsearchClient.close();
     }
   }
 


### PR DESCRIPTION
## Summary

I wanted to switch to the `elasticsearch.client` but it's turned out the client instance is not used 