### PR TITLE
[Discover] Disable flaky nested timefield test

### DIFF
--- a/test/functional/apps/discover/_date_nested.ts
+++ b/test/functional/apps/discover/_date_nested.ts
@@ -14,7 +14,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'timePicker', 'discover']);
   const security = getService('security');
 
-  describe('timefield is a date in a nested field', function () {
+  // Disabled due to unterlying issues with the querying infrastructure in Discover
+  describe.skip('timefield is a date in a nested field', function () {
     before(async function () {
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/date_nested');
       await security.testUser.setRoles(['kibana_admin', 'kibana_date_nested']);


### PR DESCRIPTION
## Summary

This test has passed CI so far, but debugging one backport makes me believe this test might start failing soon on `main` and `8.0` where it's enabled. Thus already preparing a PR for the skip, that we can quicker disable it, in case it turns out to be fail on those branches. On 7.16 this got already skipped as part of the backport PR (#118420).