### PR TITLE
Inline formatMsg helper into monitoring and canvas plugins

### DIFF
--- a/x-pack/plugins/canvas/kibana.json
+++ b/x-pack/plugins/canvas/kibana.json
@@ -33,7 +33,6 @@
   "requiredBundles": [
     "discover",
     "home",
-    "kibanaLegacy",
     "kibanaReact",
     "kibanaUtils",
     "lens",

--- a/x-pack/plugins/canvas/public/lib/format_msg.test.ts
+++ b/x-pack/plugins/canvas/public/lib/format_msg.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { formatMsg, formatESMsg } from './format_msg';
+
+describe('formatMsg', () => {
+  test('should prepend the second argument to result', () => {
+    const actual = formatMsg('error message', 'unit_test');
+
+    expect(actual).to.equal('unit_test: error message');
+  });
+
+  test('should handle a simple string', () => {
+    const actual = formatMsg('error message');
+
+    expect(actual).to.equal('error message');
+  });
+
+  test('should handle a simple Error object', () => {
+    const err = new Error('error message');
+    const actual = formatMsg(err);
+
+    expect(actual).to.equal('error message');
+  });
+
+  test('should handle a simple Angular $http error object', () => {
+    const err = {
+      data: {
+        statusCode: 403,
+        error: 'Forbidden',
+        message:
+          '[security_exception] action [indices:data/read/msearch] is unauthorized for user [user]',
+      },
+      status: 403,
+      config: {},
+      statusText: 'Forbidden',
+    };
+    const actual = formatMsg(err);
+
+    expect(actual).to.equal(
+      'Error 403 Forbidden: [security_exception] action [indices:data/read/msearch] is unauthorized for user [user]'
+    );
+  });
+
+  test('should handle an extended elasticsearch error', () => {
+    const err = {
+      resp: {
+        error: {
+          root_cause: [
+            {
+              reason: 'I am the detailed message',
+            },
+          ],
+        },
+      },
+    };
+
+    const actual = formatMsg(err);
+
+    expect(actual).to.equal('I am the detailed message');
+  });
+
+  describe('formatESMsg', () => {
+    test('should return undefined if passed a basic error', () => {
+      const err = new Error('This is a normal error');
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.be(undefined);
+    });
+
+    test('should return undefined if passed a string', () => {
+      const err = 'This is a error string';
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.be(undefined);
+    });
+
+    test('should return the root_cause if passed an extended elasticsearch', () => {
+      const err: Record<string, any> = new Error('This is an elasticsearch error');
+      err.resp = {
+        error: {
+          root_cause: [
+            {
+              reason: 'I am the detailed message',
+            },
+          ],
+        },
+      };
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.equal('I am the detailed message');
+    });
+
+    test('should combine the reason messages if more than one is returned.', () => {
+      const err: Record<string, any> = new Error('This is an elasticsearch error');
+      err.resp = {
+        error: {
+          root_cause: [
+            {
+              reason: 'I am the detailed message 1',
+            },
+            {
+              reason: 'I am the detailed message 2',
+            },
+          ],
+        },
+      };
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.equal('I am the detailed message 1\nI am the detailed message 2');
+    });
+  });
+});

--- a/x-pack/plugins/canvas/public/lib/format_msg.ts
+++ b/x-pack/plugins/canvas/public/lib/format_msg.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import _ from 'lodash';
+import { i18n } from '@kbn/i18n';
+const has = _.has;
+
+const getRootCause = (err: Record<string, any> | string) => _.get(err, 'resp.error.root_cause');
+
+/**
+ * Utilize the extended error information returned from elasticsearch
+ * @param  {Error|String} err
+ * @returns {string}
+ */
+export const formatESMsg = (err: Record<string, any> | string) => {
+  const rootCause = getRootCause(err);
+
+  if (!Array.isArray(rootCause)) {
+    return;
+  }
+
+  return rootCause.map((cause: Record<string, any>) => cause.reason).join('\n');
+};
+
+/**
+ * Formats the error message from an error object, extended elasticsearch
+ * object or simple string; prepends optional second parameter to the message
+ * @param  {Error|String} err
+ * @param  {String} source - Prefix for message indicating source (optional)
+ * @returns {string}
+ */
+export function formatMsg(err: Record<string, any> | string, source: string = '') {
+  let message = '';
+  if (source) {
+    message += source + ': ';
+  }
+
+  const esMsg = formatESMsg(err);
+
+  if (typeof err === 'string') {
+    message += err;
+  } else if (esMsg) {
+    message += esMsg;
+  } else if (err instanceof Error) {
+    message += formatMsg.describeError(err);
+  } else if (has(err, 'status') && has(err, 'data')) {
+    // is an Angular $http "error object"
+    if (err.status === -1) {
+      // status = -1 indicates that the request was failed to reach the server
+      message += i18n.translate('canvas.formatMsg.toaster.unavailableServerErrorMessage', {
+        defaultMessage:
+          'An HTTP request has failed to connect. ' +
+          'Please check if the Kibana server is running and that your browser has a working connection, ' +
+          'or contact your system administrator.',
+      });
+    } else {
+      message += i18n.translate('canvas.formatMsg.toaster.errorStatusMessage', {
+        defaultMessage: 'Error {errStatus} {errStatusText}: {errMessage}',
+        values: {
+          errStatus: err.status,
+          errStatusText: err.statusText,
+          errMessage: err.data.message,
+        },
+      });
+    }
+  }
+
+  return message;
+}
+
+formatMsg.describeError = function (err: Record<string, any>) {
+  if (!err) return undefined;
+  if (err.shortMessage) return err.shortMessage;
+  if (err.body && err.body.message) return err.body.message;
+  if (err.message) return err.message;
+  return '' + err;
+};

--- a/x-pack/plugins/canvas/public/lib/format_msg.ts
+++ b/x-pack/plugins/canvas/public/lib/format_msg.ts
@@ -51,14 +51,14 @@ export function formatMsg(err: Record<string, any> | string, source: string = ''
     // is an Angular $http "error object"
     if (err.status === -1) {
       // status = -1 indicates that the request was failed to reach the server
-      message += i18n.translate('canvas.formatMsg.toaster.unavailableServerErrorMessage', {
+      message += i18n.translate('xpack.canvas.formatMsg.toaster.unavailableServerErrorMessage', {
         defaultMessage:
           'An HTTP request has failed to connect. ' +
           'Please check if the Kibana server is running and that your browser has a working connection, ' +
           'or contact your system administrator.',
       });
     } else {
-      message += i18n.translate('canvas.formatMsg.toaster.errorStatusMessage', {
+      message += i18n.translate('xpack.canvas.formatMsg.toaster.errorStatusMessage', {
         defaultMessage: 'Error {errStatus} {errStatusText}: {errMessage}',
         values: {
           errStatus: err.status,

--- a/x-pack/plugins/canvas/public/services/kibana/notify.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/notify.ts
@@ -8,7 +8,7 @@
 import { get } from 'lodash';
 import { KibanaPluginServiceFactory } from '../../../../../../src/plugins/presentation_util/public';
 
-import { formatMsg } from '../../../../../../src/plugins/kibana_legacy/public';
+import { formatMsg } from '../../lib/format_msg';
 import { ToastInputFields } from '../../../../../../src/core/public';
 import { CanvasStartDeps } from '../../plugin';
 import { CanvasNotifyService } from '../notify';

--- a/x-pack/plugins/monitoring/kibana.json
+++ b/x-pack/plugins/monitoring/kibana.json
@@ -24,7 +24,6 @@
     "kibanaUtils",
     "home",
     "alerting",
-    "kibanaReact",
-    "kibanaLegacy"
+    "kibanaReact"
   ]
 }

--- a/x-pack/plugins/monitoring/public/application/hooks/use_request_error_handler.tsx
+++ b/x-pack/plugins/monitoring/public/application/hooks/use_request_error_handler.tsx
@@ -10,7 +10,7 @@ import { includes } from 'lodash';
 import { IHttpFetchError, ResponseErrorBody } from 'kibana/public';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
-import { formatMsg } from '../../../../../../src/plugins/kibana_legacy/public';
+import { formatMsg } from '../../lib/format_msg';
 import { toMountPoint, useKibana } from '../../../../../../src/plugins/kibana_react/public';
 import { MonitoringStartPluginDependencies } from '../../types';
 

--- a/x-pack/plugins/monitoring/public/lib/ajax_error_handler.tsx
+++ b/x-pack/plugins/monitoring/public/lib/ajax_error_handler.tsx
@@ -10,7 +10,7 @@ import { includes } from 'lodash';
 import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { Legacy } from '../legacy_shims';
-import { formatMsg } from '../../../../../src/plugins/kibana_legacy/public';
+import { formatMsg } from './format_msg';
 import { toMountPoint } from '../../../../../src/plugins/kibana_react/public';
 
 export function formatMonitoringError(err: any) {

--- a/x-pack/plugins/monitoring/public/lib/format_msg.test.ts
+++ b/x-pack/plugins/monitoring/public/lib/format_msg.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { formatMsg, formatESMsg } from './format_msg';
+
+describe('formatMsg', () => {
+  test('should prepend the second argument to result', () => {
+    const actual = formatMsg('error message', 'unit_test');
+
+    expect(actual).to.equal('unit_test: error message');
+  });
+
+  test('should handle a simple string', () => {
+    const actual = formatMsg('error message');
+
+    expect(actual).to.equal('error message');
+  });
+
+  test('should handle a simple Error object', () => {
+    const err = new Error('error message');
+    const actual = formatMsg(err);
+
+    expect(actual).to.equal('error message');
+  });
+
+  test('should handle a simple Angular $http error object', () => {
+    const err = {
+      data: {
+        statusCode: 403,
+        error: 'Forbidden',
+        message:
+          '[security_exception] action [indices:data/read/msearch] is unauthorized for user [user]',
+      },
+      status: 403,
+      config: {},
+      statusText: 'Forbidden',
+    };
+    const actual = formatMsg(err);
+
+    expect(actual).to.equal(
+      'Error 403 Forbidden: [security_exception] action [indices:data/read/msearch] is unauthorized for user [user]'
+    );
+  });
+
+  test('should handle an extended elasticsearch error', () => {
+    const err = {
+      resp: {
+        error: {
+          root_cause: [
+            {
+              reason: 'I am the detailed message',
+            },
+          ],
+        },
+      },
+    };
+
+    const actual = formatMsg(err);
+
+    expect(actual).to.equal('I am the detailed message');
+  });
+
+  describe('formatESMsg', () => {
+    test('should return undefined if passed a basic error', () => {
+      const err = new Error('This is a normal error');
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.be(undefined);
+    });
+
+    test('should return undefined if passed a string', () => {
+      const err = 'This is a error string';
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.be(undefined);
+    });
+
+    test('should return the root_cause if passed an extended elasticsearch', () => {
+      const err: Record<string, any> = new Error('This is an elasticsearch error');
+      err.resp = {
+        error: {
+          root_cause: [
+            {
+              reason: 'I am the detailed message',
+            },
+          ],
+        },
+      };
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.equal('I am the detailed message');
+    });
+
+    test('should combine the reason messages if more than one is returned.', () => {
+      const err: Record<string, any> = new Error('This is an elasticsearch error');
+      err.resp = {
+        error: {
+          root_cause: [
+            {
+              reason: 'I am the detailed message 1',
+            },
+            {
+              reason: 'I am the detailed message 2',
+            },
+          ],
+        },
+      };
+
+      const actual = formatESMsg(err);
+
+      expect(actual).to.equal('I am the detailed message 1\nI am the detailed message 2');
+    });
+  });
+});

--- a/x-pack/plugins/monitoring/public/lib/format_msg.ts
+++ b/x-pack/plugins/monitoring/public/lib/format_msg.ts
@@ -51,14 +51,17 @@ export function formatMsg(err: Record<string, any> | string, source: string = ''
     // is an Angular $http "error object"
     if (err.status === -1) {
       // status = -1 indicates that the request was failed to reach the server
-      message += i18n.translate('monitoring.formatMsg.toaster.unavailableServerErrorMessage', {
-        defaultMessage:
-          'An HTTP request has failed to connect. ' +
-          'Please check if the Kibana server is running and that your browser has a working connection, ' +
-          'or contact your system administrator.',
-      });
+      message += i18n.translate(
+        'xpack.monitoring.formatMsg.toaster.unavailableServerErrorMessage',
+        {
+          defaultMessage:
+            'An HTTP request has failed to connect. ' +
+            'Please check if the Kibana server is running and that your browser has a working connection, ' +
+            'or contact your system administrator.',
+        }
+      );
     } else {
-      message += i18n.translate('monitoring.formatMsg.toaster.errorStatusMessage', {
+      message += i18n.translate('xpack.monitoring.formatMsg.toaster.errorStatusMessage', {
         defaultMessage: 'Error {errStatus} {errStatusText}: {errMessage}',
         values: {
           errStatus: err.status,

--- a/x-pack/plugins/monitoring/public/lib/format_msg.ts
+++ b/x-pack/plugins/monitoring/public/lib/format_msg.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import _ from 'lodash';
+import { i18n } from '@kbn/i18n';
+const has = _.has;
+
+const getRootCause = (err: Record<string, any> | string) => _.get(err, 'resp.error.root_cause');
+
+/**
+ * Utilize the extended error information returned from elasticsearch
+ * @param  {Error|String} err
+ * @returns {string}
+ */
+export const formatESMsg = (err: Record<string, any> | string) => {
+  const rootCause = getRootCause(err);
+
+  if (!Array.isArray(rootCause)) {
+    return;
+  }
+
+  return rootCause.map((cause: Record<string, any>) => cause.reason).join('\n');
+};
+
+/**
+ * Formats the error message from an error object, extended elasticsearch
+ * object or simple string; prepends optional second parameter to the message
+ * @param  {Error|String} err
+ * @param  {String} source - Prefix for message indicating source (optional)
+ * @returns {string}
+ */
+export function formatMsg(err: Record<string, any> | string, source: string = '') {
+  let message = '';
+  if (source) {
+    message += source + ': ';
+  }
+
+  const esMsg = formatESMsg(err);
+
+  if (typeof err === 'string') {
+    message += err;
+  } else if (esMsg) {
+    message += esMsg;
+  } else if (err instanceof Error) {
+    message += formatMsg.describeError(err);
+  } else if (has(err, 'status') && has(err, 'data')) {
+    // is an Angular $http "error object"
+    if (err.status === -1) {
+      // status = -1 indicates that the request was failed to reach the server
+      message += i18n.translate('monitoring.formatMsg.toaster.unavailableServerErrorMessage', {
+        defaultMessage:
+          'An HTTP request has failed to connect. ' +
+          'Please check if the Kibana server is running and that your browser has a working connection, ' +
+          'or contact your system administrator.',
+      });
+    } else {
+      message += i18n.translate('monitoring.formatMsg.toaster.errorStatusMessage', {
+        defaultMessage: 'Error {errStatus} {errStatusText}: {errMessage}',
+        values: {
+          errStatus: err.status,
+          errStatusText: err.statusText,
+          errMessage: err.data.message,
+        },
+      });
+    }
+  }
+
+  return message;
+}
+
+formatMsg.describeError = function (err: Record<string, any>) {
+  if (!err) return undefined;
+  if (err.shortMessage) return err.shortMessage;
+  if (err.body && err.body.message) return err.body.message;
+  if (err.message) return err.message;
+  return '' + err;
+};


### PR DESCRIPTION
## Summary

Inlined code of `src/plugins/kibana_legacy/public/notify/lib/format_msg.ts` to monitoring and canvas plugins.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
