### PR TITLE
[APM] prefer ECS field names for HTTP and URL

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/span_flyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/span_flyout/index.tsx
@@ -101,11 +101,11 @@ export function SpanFlyout({
   const stackframes = span.span.stacktrace;
   const codeLanguage = parentTransaction?.service.language?.name;
   const spanDb = span.span.db;
-  const httpContext = span.span.http;
   const spanTypes = getSpanTypes(span);
-  const spanHttpStatusCode = httpContext?.response?.status_code;
-  const spanHttpUrl = httpContext?.url?.original;
-  const spanHttpMethod = httpContext?.method;
+  const spanHttpStatusCode =
+    span.http?.response?.status_code || span.span?.http?.response?.status_code;
+  const spanHttpUrl = span.url?.original || span.span?.http?.url?.original;
+  const spanHttpMethod = span.http?.request?.method || span.span?.http?.method;
 
   return (
     <EuiPortal>

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/url.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/url.ts
@@ -8,4 +8,5 @@
 export interface Url {
   domain?: string;
   full: string;
+  original?: string;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/span_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/span_raw.ts
@@ -7,8 +7,10 @@
 
 import { APMBaseDoc } from './apm_base_doc';
 import { EventOutcome } from './fields/event_outcome';
+import { Http } from './fields/http';
 import { Stackframe } from './fields/stackframe';
 import { TimestampUs } from './fields/timestamp_us';
+import { Url } from './fields/url';
 
 interface Processor {
   name: 'transaction';
@@ -67,4 +69,6 @@ export interface SpanRaw extends APMBaseDoc {
     id: string;
   };
   child?: { id: string[] };
+  http?: Http;
+  url?: Url;
 }


### PR DESCRIPTION
## Summary

In the span flyout, prefer ECS fields for span HTTP and URL properties. Fall back to the old field names for backwards compatibility with old data.

In 7.14 we started copying `span.http.*` fields to their ECS equivalents: `http.*` and `url*.`
We continued populating the old names for backwards compatibility, but will cease doing so from 8.0 on.

See also https://github.com/elastic/apm-server/issues/5995

### Checklist

~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~ (Are there any?)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)