### PR TITLE
Fix exists or fail check in Lens chart click test

### DIFF
--- a/x-pack/test/functional/apps/lens/dashboard.ts
+++ b/x-pack/test/functional/apps/lens/dashboard.ts
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.goToTimeRange();
       await retry.try(async () => {
         await clickInChart(6, 5); // hardcoded position of bar, depends heavy on data and charts implementation
-        await testSubjects.existOrFail('applyFiltersPopoverButton');
+        await testSubjects.existOrFail('applyFiltersPopoverButton', { timeout: 2500 });
       });
 
       await retry.try(async () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/117770

The previous fix in https://github.com/elastic/kibana/pull/118308 had a problem - the inner `existOrFail` would retry for time itself for too long to actually trigger the outer `retry.try`. This sets the inner `existOrFail` timeout to a more reasonable value.