### PR TITLE
[ML] Functional tests - stabilize and re-enable a11y tests

### DIFF
--- a/x-pack/test/accessibility/apps/ml.ts
+++ b/x-pack/test/accessibility/apps/ml.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const a11y = getService('a11y');
   const ml = getService('ml');
 
-  // FLAKY https://github.com/elastic/kibana/issues/118417
-  describe.skip('ml', () => {
+  describe('ml', () => {
     const esArchiver = getService('esArchiver');
 
     before(async () => {

--- a/x-pack/test/functional/services/ml/data_frame_analytics_table.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_table.ts
@@ -157,9 +157,13 @@ export function MachineLearningDataFrameAnalyticsTableProvider({ getService }: F
     }
 
     public async openResultsView(analyticsId: string) {
-      await this.assertJobRowViewButtonExists(analyticsId);
-      await testSubjects.click(this.rowSelector(analyticsId, 'mlAnalyticsJobViewButton'));
-      await testSubjects.existOrFail('mlPageDataFrameAnalyticsExploration', { timeout: 20 * 1000 });
+      await retry.tryForTime(20 * 1000, async () => {
+        await this.assertJobRowViewButtonExists(analyticsId);
+        await testSubjects.click(this.rowSelector(analyticsId, 'mlAnalyticsJobViewButton'));
+        await testSubjects.existOrFail('mlPageDataFrameAnalyticsExploration', {
+          timeout: 5 * 1000,
+        });
+      });
     }
 
     public async openMapView(analyticsId: string) {


### PR DESCRIPTION
## Summary

This PR stabilizes the data frame analytics job row result link usage in tests and re-enables the a11y ML tests.

This is a follow-up to #117959 where we already stabilized the map view link in the same way.

Closes #118417



