### PR TITLE
[Lens] fixes the flakiness of the configureDimension function

### DIFF
--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -131,9 +131,18 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         const operationSelector = opts.isPreviousIncompatible
           ? `lns-indexPatternDimension-${opts.operation} incompatible`
           : `lns-indexPatternDimension-${opts.operation}`;
-        await retry.try(async () => {
-          await testSubjects.exists(operationSelector);
+        async function getAriaPressed() {
+          const operationSelectorContainer = await testSubjects.find(operationSelector);
           await testSubjects.click(operationSelector, undefined, FORMULA_TAB_HEIGHT);
+          const ariaPressed = await operationSelectorContainer.getAttribute('aria-pressed');
+          return ariaPressed;
+        }
+
+        // adding retry here as it seems that there is a flakiness of the operation click
+        // it seems that the aria-pressed attribute is updated to true when the button is clicked
+        await retry.waitFor('aria pressed to be true', async () => {
+          const ariaPressedStatus = await getAriaPressed();
+          return ariaPressedStatus === 'true';
         });
       }
       if (opts.field) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/117491
Closes https://github.com/elastic/kibana/issues/117465
Closes https://github.com/elastic/kibana/issues/118489

This is my second attempt to stabilize it! It seems that the click on the dimension editor is not always registered. I had tried to add a retry but wasn't configured correctly. I have fixed that by checking the status of the `aria-pressed` attribute. It seems that the status changes to true when the click event is registered and now the retry works correctly.