### PR TITLE
[Alerting][POC][skip-ci] Alerting framework provides static context for each alert

### DIFF
--- a/x-pack/plugins/alerting/common/alert_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_instance.ts
@@ -27,18 +27,19 @@ export type AlertInstanceState = t.TypeOf<typeof stateSchema>;
 const contextSchema = t.record(t.string, t.unknown);
 export type AlertInstanceContext = t.TypeOf<typeof contextSchema>;
 
-export const rawAlertInstance = t.partial({
-  state: stateSchema,
-  meta: metaSchema,
-});
-export type RawAlertInstance = t.TypeOf<typeof rawAlertInstance>;
-
 export const rawAlertStaticContext = t.partial({
   duration: t.number,
-  start: t.number,
-  end: t.number,
+  start: t.string,
+  end: t.string,
   threshold: t.number,
   value: t.number,
   reason: t.string,
 });
 export type RawAlertStaticContext = t.TypeOf<typeof rawAlertStaticContext>;
+
+export const rawAlertInstance = t.partial({
+  state: stateSchema,
+  meta: metaSchema,
+  staticContext: rawAlertStaticContext,
+});
+export type RawAlertInstance = t.TypeOf<typeof rawAlertInstance>;

--- a/x-pack/plugins/alerting/common/alert_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_instance.ts
@@ -32,3 +32,13 @@ export const rawAlertInstance = t.partial({
   meta: metaSchema,
 });
 export type RawAlertInstance = t.TypeOf<typeof rawAlertInstance>;
+
+export const rawAlertStaticContext = t.partial({
+  duration: t.number,
+  start: t.number,
+  end: t.number,
+  threshold: t.number,
+  value: t.number,
+  reason: t.string,
+});
+export type RawAlertStaticContext = t.TypeOf<typeof rawAlertStaticContext>;

--- a/x-pack/plugins/alerting/common/alert_task_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_task_instance.ts
@@ -6,11 +6,12 @@
  */
 
 import * as t from 'io-ts';
-import { rawAlertInstance } from './alert_instance';
+import { rawAlertInstance, rawAlertStaticContext } from './alert_instance';
 import { DateFromString } from './date_from_string';
 
 export const alertStateSchema = t.partial({
   alertTypeState: t.record(t.string, t.unknown),
+  alertStaticContext: t.record(t.string, rawAlertStaticContext),
   alertInstances: t.record(t.string, rawAlertInstance),
   previousStartedAt: t.union([t.null, DateFromString]),
 });

--- a/x-pack/plugins/alerting/server/alert_instance/alert_instance.ts
+++ b/x-pack/plugins/alerting/server/alert_instance/alert_instance.ts
@@ -12,6 +12,7 @@ import {
   rawAlertInstance,
   AlertInstanceContext,
   DefaultActionGroupId,
+  RawAlertStaticContext,
 } from '../../common';
 
 import { parseDuration } from '../lib';
@@ -25,6 +26,7 @@ interface ScheduledExecutionOptions<
   subgroup?: string;
   context: Context;
   state: State;
+  staticContext: RawAlertStaticContext;
 }
 
 export type PublicAlertInstance<
@@ -134,11 +136,16 @@ export class AlertInstance<
     return this.state;
   }
 
-  scheduleActions(actionGroup: ActionGroupIds, context: Context = {} as Context) {
+  scheduleActions(
+    actionGroup: ActionGroupIds,
+    context: Context = {} as Context,
+    staticContext: RawAlertStaticContext = {}
+  ) {
     this.ensureHasNoScheduledActions();
     this.scheduledExecutionOptions = {
       actionGroup,
       context,
+      staticContext,
       state: this.state,
     };
     return this;
@@ -147,13 +154,15 @@ export class AlertInstance<
   scheduleActionsWithSubGroup(
     actionGroup: ActionGroupIds,
     subgroup: string,
-    context: Context = {} as Context
+    context: Context = {} as Context,
+    staticContext: RawAlertStaticContext = {}
   ) {
     this.ensureHasNoScheduledActions();
     this.scheduledExecutionOptions = {
       actionGroup,
       subgroup,
       context,
+      staticContext,
       state: this.state,
     };
     return this;

--- a/x-pack/plugins/alerting/server/alert_instance/alert_instance.ts
+++ b/x-pack/plugins/alerting/server/alert_instance/alert_instance.ts
@@ -26,7 +26,6 @@ interface ScheduledExecutionOptions<
   subgroup?: string;
   context: Context;
   state: State;
-  staticContext: RawAlertStaticContext;
 }
 
 export type PublicAlertInstance<
@@ -46,10 +45,12 @@ export class AlertInstance<
   private scheduledExecutionOptions?: ScheduledExecutionOptions<State, Context, ActionGroupIds>;
   private meta: AlertInstanceMeta;
   private state: State;
+  private staticContext: RawAlertStaticContext;
 
-  constructor({ state, meta = {} }: RawAlertInstance = {}) {
+  constructor({ state, meta = {}, staticContext = {} }: RawAlertInstance = {}) {
     this.state = (state || {}) as State;
     this.meta = meta;
+    this.staticContext = staticContext || {};
   }
 
   hasScheduledActions() {
@@ -136,16 +137,20 @@ export class AlertInstance<
     return this.state;
   }
 
+  getStaticContext() {
+    return this.staticContext;
+  }
+
   scheduleActions(
     actionGroup: ActionGroupIds,
     context: Context = {} as Context,
     staticContext: RawAlertStaticContext = {}
   ) {
     this.ensureHasNoScheduledActions();
+    this.replaceStaticContext(staticContext);
     this.scheduledExecutionOptions = {
       actionGroup,
       context,
-      staticContext,
       state: this.state,
     };
     return this;
@@ -158,11 +163,11 @@ export class AlertInstance<
     staticContext: RawAlertStaticContext = {}
   ) {
     this.ensureHasNoScheduledActions();
+    this.replaceStaticContext(staticContext);
     this.scheduledExecutionOptions = {
       actionGroup,
       subgroup,
       context,
-      staticContext,
       state: this.state,
     };
     return this;
@@ -176,6 +181,11 @@ export class AlertInstance<
 
   replaceState(state: State) {
     this.state = state;
+    return this;
+  }
+
+  replaceStaticContext(staticContext: RawAlertStaticContext) {
+    this.staticContext = staticContext;
     return this;
   }
 
@@ -194,6 +204,7 @@ export class AlertInstance<
     return {
       state: this.state,
       meta: this.meta,
+      staticContext: this.staticContext,
     };
   }
 }

--- a/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
+++ b/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { Logger, KibanaRequest } from '../../../../../src/core/server';
-import { transformActionParams } from './transform_action_params';
+import { transformActionParams, AlertMetadata } from './transform_action_params';
 import {
   asSavedObjectExecutionSource,
   PluginStartContract as ActionsPluginStartContract,
@@ -24,7 +24,6 @@ import {
 import { NormalizedAlertType, UntypedNormalizedAlertType } from '../rule_type_registry';
 import { isEphemeralTaskRejectedDueToCapacityError } from '../../../task_manager/server';
 import { createAlertEventLogRecordObject } from '../lib/create_alert_event_log_record_object';
-
 export interface CreateExecutionHandlerOptions<
   Params extends AlertTypeParams,
   ExtractedParams extends AlertTypeParams,
@@ -65,6 +64,7 @@ interface ExecutionHandlerOptions<ActionGroupIds extends string> {
   alertInstanceId: string;
   context: AlertInstanceContext;
   state: AlertInstanceState;
+  alertMetadata: AlertMetadata;
 }
 
 export type ExecutionHandler<ActionGroupIds extends string> = (
@@ -113,6 +113,7 @@ export function createExecutionHandler<
     context,
     state,
     alertInstanceId,
+    alertMetadata,
   }: ExecutionHandlerOptions<ActionGroupIds | RecoveryActionGroupId>) => {
     if (!alertTypeActionGroups.has(actionGroup)) {
       logger.error(`Invalid action group "${actionGroup}" for alert "${alertType.id}".`);
@@ -141,6 +142,7 @@ export function createExecutionHandler<
             state,
             kibanaBaseUrl,
             alertParams,
+            alertMetadata,
           }),
         };
       })

--- a/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
+++ b/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { Logger, KibanaRequest } from '../../../../../src/core/server';
-import { transformActionParams, AlertMetadata } from './transform_action_params';
+import { transformActionParams } from './transform_action_params';
 import {
   asSavedObjectExecutionSource,
   PluginStartContract as ActionsPluginStartContract,
@@ -20,6 +20,7 @@ import {
   AlertInstanceState,
   AlertInstanceContext,
   RawAlert,
+  RawAlertStaticContext,
 } from '../types';
 import { NormalizedAlertType, UntypedNormalizedAlertType } from '../rule_type_registry';
 import { isEphemeralTaskRejectedDueToCapacityError } from '../../../task_manager/server';
@@ -64,7 +65,7 @@ interface ExecutionHandlerOptions<ActionGroupIds extends string> {
   alertInstanceId: string;
   context: AlertInstanceContext;
   state: AlertInstanceState;
-  alertMetadata: AlertMetadata;
+  staticContext: RawAlertStaticContext;
 }
 
 export type ExecutionHandler<ActionGroupIds extends string> = (
@@ -113,7 +114,7 @@ export function createExecutionHandler<
     context,
     state,
     alertInstanceId,
-    alertMetadata,
+    staticContext,
   }: ExecutionHandlerOptions<ActionGroupIds | RecoveryActionGroupId>) => {
     if (!alertTypeActionGroups.has(actionGroup)) {
       logger.error(`Invalid action group "${actionGroup}" for alert "${alertType.id}".`);
@@ -142,7 +143,7 @@ export function createExecutionHandler<
             state,
             kibanaBaseUrl,
             alertParams,
-            alertMetadata,
+            staticContext,
           }),
         };
       })

--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
@@ -13,6 +13,15 @@ import {
 } from '../types';
 import { PluginStartContract as ActionsPluginStartContract } from '../../../actions/server';
 
+export interface AlertMetadata {
+  start?: number;
+  duration?: number;
+  end?: number;
+  value?: number;
+  threshold?: number;
+  reason?: string;
+}
+
 interface TransformActionParamsOptions {
   actionsPlugin: ActionsPluginStartContract;
   alertId: string;
@@ -20,6 +29,12 @@ interface TransformActionParamsOptions {
   actionId: string;
   actionTypeId: string;
   alertName: string;
+  alertStart?: number;
+  alertDuration?: number;
+  alertEnd?: number;
+  alertValue?: number;
+  alertThreshold?: number;
+  alertReason?: string;
   spaceId: string;
   tags?: string[];
   alertInstanceId: string;
@@ -31,6 +46,7 @@ interface TransformActionParamsOptions {
   state: AlertInstanceState;
   kibanaBaseUrl?: string;
   context: AlertInstanceContext;
+  alertMetadata: AlertMetadata;
 }
 
 export function transformActionParams({
@@ -51,6 +67,7 @@ export function transformActionParams({
   state,
   kibanaBaseUrl,
   alertParams,
+  alertMetadata,
 }: TransformActionParamsOptions): AlertActionParams {
   // when the list of variables we pass in here changes,
   // the UI will need to be updated as well; see:
@@ -81,6 +98,12 @@ export function transformActionParams({
       actionGroup: alertActionGroup,
       actionGroupName: alertActionGroupName,
       actionSubgroup: alertActionSubgroup,
+      ...(alertMetadata.start ? { start: alertMetadata.start } : {}),
+      ...(alertMetadata.duration ? { duration: alertMetadata.duration } : {}),
+      ...(alertMetadata.end ? { end: alertMetadata.end } : {}),
+      ...(alertMetadata.threshold ? { threshold: alertMetadata.threshold } : {}),
+      ...(alertMetadata.value ? { value: alertMetadata.value } : {}),
+      ...(alertMetadata.reason ? { reason: alertMetadata.reason } : {}),
     },
   };
   return actionsPlugin.renderActionParameterTemplates(

--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
@@ -10,17 +10,9 @@ import {
   AlertInstanceState,
   AlertInstanceContext,
   AlertTypeParams,
+  RawAlertStaticContext,
 } from '../types';
 import { PluginStartContract as ActionsPluginStartContract } from '../../../actions/server';
-
-export interface AlertMetadata {
-  start?: number;
-  duration?: number;
-  end?: number;
-  value?: number;
-  threshold?: number;
-  reason?: string;
-}
 
 interface TransformActionParamsOptions {
   actionsPlugin: ActionsPluginStartContract;
@@ -46,7 +38,7 @@ interface TransformActionParamsOptions {
   state: AlertInstanceState;
   kibanaBaseUrl?: string;
   context: AlertInstanceContext;
-  alertMetadata: AlertMetadata;
+  staticContext: RawAlertStaticContext;
 }
 
 export function transformActionParams({
@@ -67,7 +59,7 @@ export function transformActionParams({
   state,
   kibanaBaseUrl,
   alertParams,
-  alertMetadata,
+  staticContext,
 }: TransformActionParamsOptions): AlertActionParams {
   // when the list of variables we pass in here changes,
   // the UI will need to be updated as well; see:
@@ -98,12 +90,12 @@ export function transformActionParams({
       actionGroup: alertActionGroup,
       actionGroupName: alertActionGroupName,
       actionSubgroup: alertActionSubgroup,
-      ...(alertMetadata.start ? { start: alertMetadata.start } : {}),
-      ...(alertMetadata.duration ? { duration: alertMetadata.duration } : {}),
-      ...(alertMetadata.end ? { end: alertMetadata.end } : {}),
-      ...(alertMetadata.threshold ? { threshold: alertMetadata.threshold } : {}),
-      ...(alertMetadata.value ? { value: alertMetadata.value } : {}),
-      ...(alertMetadata.reason ? { reason: alertMetadata.reason } : {}),
+      ...(staticContext.start ? { start: staticContext.start } : {}),
+      ...(null != staticContext.duration ? { duration: staticContext.duration } : {}),
+      ...(staticContext.end ? { end: staticContext.end } : {}),
+      ...(null != staticContext.threshold ? { threshold: staticContext.threshold } : {}),
+      ...(staticContext.value ? { value: staticContext.value } : {}),
+      ...(staticContext.reason ? { reason: staticContext.reason } : {}),
     },
   };
   return actionsPlugin.renderActionParameterTemplates(

--- a/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts
+++ b/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts
@@ -16,6 +16,7 @@ import {
   TimeSeriesQuery,
 } from '../../../../triggers_actions_ui/server';
 import { ComparatorFns, getHumanReadableComparator } from '../lib';
+import { RawAlertStaticContext } from '../../../../alerting/common';
 
 export const ID = '.index-threshold';
 export const ActionGroupId = 'threshold met';
@@ -208,7 +209,13 @@ export function getAlertType(
       };
       const actionContext = addMessages(options, baseContext, params);
       const alertInstance = options.services.alertInstanceFactory(instanceId);
-      alertInstance.scheduleActions(ActionGroupId, actionContext);
+      const staticContext: RawAlertStaticContext = {
+        value,
+        threshold: params.threshold[0],
+        reason: humanFn,
+      };
+
+      alertInstance.scheduleActions(ActionGroupId, actionContext, staticContext);
       logger.debug(`scheduled actionGroup: ${JSON.stringify(actionContext)}`);
     }
   }

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/action_variables.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/action_variables.ts
@@ -32,6 +32,12 @@ export enum AlertProvidedActionVariables {
   alertActionGroup = 'alert.actionGroup',
   alertActionGroupName = 'alert.actionGroupName',
   alertActionSubgroup = 'alert.actionSubgroup',
+  alertStart = 'alert.start',
+  alertDuration = 'alert.duration',
+  alertEnd = 'alert.end',
+  alertValue = 'alert.value',
+  alertThreshold = 'alert.threshold',
+  alertReason = 'alert.reason',
 }
 
 export enum LegacyAlertProvidedActionVariables {
@@ -131,6 +137,48 @@ function getAlwaysProvidedActionVariables(): ActionVariable[] {
           'The human readable name of the action group of the alert that scheduled actions for the rule.',
       }
     ),
+  });
+
+  result.push({
+    name: AlertProvidedActionVariables.alertStart,
+    description: i18n.translate('xpack.triggersActionsUI.actionVariables.alertStartNameLabel', {
+      defaultMessage: 'The date the alert became active, if available.',
+    }),
+  });
+
+  result.push({
+    name: AlertProvidedActionVariables.alertDuration,
+    description: i18n.translate('xpack.triggersActionsUI.actionVariables.alertDurationNameLabel', {
+      defaultMessage: 'The duration of the alert, if available.',
+    }),
+  });
+
+  result.push({
+    name: AlertProvidedActionVariables.alertEnd,
+    description: i18n.translate('xpack.triggersActionsUI.actionVariables.alertEndNameLabel', {
+      defaultMessage: 'The date the alert recovered, if available.',
+    }),
+  });
+
+  result.push({
+    name: AlertProvidedActionVariables.alertValue,
+    description: i18n.translate('xpack.triggersActionsUI.actionVariables.alertValueNameLabel', {
+      defaultMessage: 'The value used to evaluate whether the alert is active.',
+    }),
+  });
+
+  result.push({
+    name: AlertProvidedActionVariables.alertThreshold,
+    description: i18n.translate('xpack.triggersActionsUI.actionVariables.alertThresholdNameLabel', {
+      defaultMessage: 'The threshold used to evaluate whether the alert is active.',
+    }),
+  });
+
+  result.push({
+    name: AlertProvidedActionVariables.alertReason,
+    description: i18n.translate('xpack.triggersActionsUI.actionVariables.alertReasonLabel', {
+      defaultMessage: 'The reason the alert was triggered.',
+    }),
   });
 
   result.push({


### PR DESCRIPTION
With this POC, we are attempting to expand the amount of information provided in recovery contexts by maintaining a limited set of static context variables for each alerts. We are leveraging parts of the alerts-as-data schema converged on during the RAC initiative to determine what context variables to populate.