### PR TITLE
[Metrics UI] Skip failing waffle chart color palette test

### DIFF
--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -105,7 +105,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.infraHome.clearSearchTerm();
       });
 
-      it('change color palette', async () => {
+      // Tracked in https://github.com/elastic/kibana/issues/118481
+      it.skip('change color palette', async () => {
         await pageObjects.infraHome.openLegendControls();
         await pageObjects.infraHome.changePalette('temperature');
         await pageObjects.infraHome.applyLegendControls();


### PR DESCRIPTION
Part of #118481

Disable the test while we figure out what's going on since it seems to be blocking `main` from building.