### PR TITLE
[Exploratory view] Apply fix deep equality check

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/views/view_actions.test.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/views/view_actions.test.tsx
@@ -85,4 +85,58 @@ describe('ViewActions', () => {
 
     await assertApplyIsEnabled();
   });
+  it('apply button is disabled when no filter changes but different orders', async () => {
+    const allSeries: AllSeries = [
+      {
+        seriesType: 'area',
+        breakdown: 'monitor.type',
+        filters: [
+          {
+            values: ['spa-heartbeat', 'nyc-heartbeat', 'au-heartbeat'],
+            field: 'observer.geo.name',
+          },
+        ],
+        time: { from: 'now-15m', to: 'now' },
+        dataType: 'synthetics',
+        reportDefinitions: { 'monitor.name': [], 'url.full': ['ALL_VALUES'] },
+        selectedMetricField: 'monitor.duration.us',
+        name: 'All monitors response duration',
+      },
+    ];
+
+    const urlSeries: AllSeries = [
+      {
+        seriesType: 'area',
+        breakdown: 'monitor.type',
+        filters: [
+          {
+            field: 'observer.geo.name',
+            values: ['spa-heartbeat', 'nyc-heartbeat', 'au-heartbeat'],
+            notValues: undefined,
+            notWildcards: undefined,
+          },
+        ],
+        time: { from: 'now-15m', to: 'now' },
+        reportDefinitions: { 'monitor.name': [], 'url.full': ['ALL_VALUES'] },
+        dataType: 'synthetics',
+        selectedMetricField: 'monitor.duration.us',
+        name: 'All monitors response duration',
+      },
+    ];
+
+    mockSeriesStorage(allSeries, urlSeries);
+
+    render(<ViewActions />);
+    const applyBtn = screen.getByText(/Apply changes/i);
+
+    const btnComponent = screen.getByTestId('seriesChangesApplyButton');
+
+    expect(btnComponent.classList).toContain('euiButton-isDisabled');
+
+    fireEvent.click(applyBtn);
+
+    await waitFor(() => {
+      expect(applyChanges).toBeCalledTimes(0);
+    });
+  });
 });

--- a/x-pack/plugins/observability/public/components/shared/exploratory_view/views/view_actions.tsx
+++ b/x-pack/plugins/observability/public/components/shared/exploratory_view/views/view_actions.tsx
@@ -10,9 +10,21 @@ import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEqual, pickBy } from 'lodash';
 import { allSeriesKey, convertAllShortSeries, useSeriesStorage } from '../hooks/use_series_storage';
+import { SeriesUrl } from '../types';
 
 interface Props {
   onApply?: () => void;
+}
+
+export function removeUndefinedEmptyValues(series: SeriesUrl) {
+  const resultSeries = removeUndefinedProps(series) as SeriesUrl;
+  Object.entries(resultSeries).forEach(([prop, value]) => {
+    if (typeof value === 'object') {
+      // @ts-expect-error
+      resultSeries[prop] = removeUndefinedEmptyValues(value);
+    }
+  });
+  return resultSeries;
 }
 
 export function removeUndefinedProps<T extends object>(obj: T): Partial<T> {
@@ -29,7 +41,10 @@ export function ViewActions({ onApply }: Props) {
   if (noChanges) {
     noChanges = !allSeries.some(
       (series, index) =>
-        !isEqual(removeUndefinedProps(series), removeUndefinedProps(urlAllSeries[index]))
+        !isEqual(
+          removeUndefinedEmptyValues(series),
+          removeUndefinedEmptyValues(urlAllSeries[index])
+        )
     );
   }
 


### PR DESCRIPTION
## Summary
Fixed the deep equality check for apply button.

Apply button would remain enabled in case of filters selection or wildcard urls. This PR fixes that by performing deep equality check.

It makes sure to remove the undefined or empty arrays to make the isEqual check consistent.

