### PR TITLE
[APM] Always set request_cache/body.size

### DIFF
--- a/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_duration.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_duration.ts
@@ -87,6 +87,8 @@ export async function getTransactionDurationChartPreview({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    // don't cache, just a preview
+    request_cache: false,
     body: { size: 0, query, aggs },
   };
   const resp = await apmEventClient.search(

--- a/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_error_count.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_error_count.ts
@@ -47,6 +47,8 @@ export async function getTransactionErrorCountChartPreview({
 
   const params = {
     apm: { events: [ProcessorEvent.error] },
+    // don't cache, just a preview
+    request_cache: false,
     body: { size: 0, query, aggs },
   };
 

--- a/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/chart_preview/get_transaction_error_rate.ts
@@ -47,6 +47,8 @@ export async function getTransactionErrorRateChartPreview({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    // don't cache, just a preview
+    request_cache: false,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_destination_map.ts
@@ -73,6 +73,7 @@ export const getDestinationMap = ({
       apm: {
         events: [ProcessorEvent.span],
       },
+      request_cache: true,
       body: {
         size: 0,
         query: {
@@ -143,6 +144,8 @@ export const getDestinationMap = ({
         apm: {
           events: [ProcessorEvent.transaction],
         },
+        // don't cache, as we set size>0
+        request_cache: false,
         body: {
           query: {
             bool: {

--- a/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_stats.ts
+++ b/x-pack/plugins/apm/server/lib/connections/get_connection_stats/get_stats.ts
@@ -58,6 +58,7 @@ export const getStats = async ({
     apm: {
       events: [ProcessorEvent.metric],
     },
+    request_cache: true,
     body: {
       track_total_hits: true,
       size: 0,

--- a/x-pack/plugins/apm/server/lib/environments/get_all_environments.ts
+++ b/x-pack/plugins/apm/server/lib/environments/get_all_environments.ts
@@ -46,6 +46,7 @@ export async function getAllEnvironments({
         ProcessorEvent.metric,
       ],
     },
+    request_cache: true,
     body: {
       // use timeout + min_doc_count to return as early as possible
       // if filter is not defined to prevent timeouts

--- a/x-pack/plugins/apm/server/lib/environments/get_environments.ts
+++ b/x-pack/plugins/apm/server/lib/environments/get_environments.ts
@@ -48,6 +48,7 @@ export async function getEnvironments({
         ProcessorEvent.error,
       ],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_buckets.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_buckets.ts
@@ -43,6 +43,8 @@ export async function getBuckets({
     apm: {
       events: [ProcessorEvent.error],
     },
+    // only cache the overview, not when a group id or kuery is set
+    request_cache: !groupId && !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/errors/get_error_group_sample.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_group_sample.ts
@@ -40,6 +40,8 @@ export async function getErrorGroupSample({
     apm: {
       events: [ProcessorEvent.error as const],
     },
+    // don't cache, as we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       query: {

--- a/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
@@ -57,6 +57,7 @@ export async function getErrorGroups({
     : { _count: sortDirection };
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       aggs: {

--- a/x-pack/plugins/apm/server/lib/event_metadata/get_event_metadata.ts
+++ b/x-pack/plugins/apm/server/lib/event_metadata/get_event_metadata.ts
@@ -51,6 +51,8 @@ export async function getEventMetadata({
     apm: {
       events: [processorEvent],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       query: {
         bool: { filter },

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.test.ts
@@ -61,6 +61,10 @@ describe('createApmEventClient', () => {
           apm: {
             events: [],
           },
+          request_cache: true,
+          body: {
+            size: 10,
+          },
         });
 
         return res.ok({ body: 'ok' });

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/index.ts
@@ -41,6 +41,10 @@ export type APMEventESSearchRequest = Omit<ESSearchRequest, 'index'> & {
     events: ProcessorEvent[];
     includeLegacyData?: boolean;
   };
+  request_cache: boolean;
+  body: {
+    size: number;
+  };
 };
 
 export type APMEventESTermsEnumRequest = Omit<TermsEnumRequest, 'index'> & {

--- a/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/unpack_processor_events.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/create_es_client/create_apm_event_client/unpack_processor_events.test.ts
@@ -14,7 +14,11 @@ describe('unpackProcessorEvents', () => {
   beforeEach(() => {
     const request = {
       apm: { events: ['transaction', 'error'] },
-      body: { query: { bool: { filter: [{ terms: { foo: 'bar' } }] } } },
+      request_cache: true,
+      body: {
+        size: 0,
+        query: { bool: { filter: [{ terms: { foo: 'bar' } }] } },
+      },
     } as APMEventESSearchRequest;
 
     const indices = {

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
@@ -111,8 +111,9 @@ describe('setupRequest', () => {
       const mockResources = getMockResources();
       const { apmEventClient } = await setupRequest(mockResources);
       await apmEventClient.search('foo', {
+        request_cache: true,
         apm: { events: [ProcessorEvent.transaction] },
-        body: { foo: 'bar' },
+        body: { size: 10 },
       });
 
       expect(
@@ -172,7 +173,9 @@ describe('setupRequest', () => {
         apm: {
           events: [ProcessorEvent.transaction],
         },
+        request_cache: true,
         body: {
+          size: 10,
           query: { bool: { filter: [{ term: { field: 'someTerm' } }] } },
         },
       });
@@ -200,7 +203,9 @@ describe('setupRequest', () => {
           events: [ProcessorEvent.error],
           includeLegacyData: true,
         },
+        request_cache: true,
         body: {
+          size: 10,
           query: { bool: { filter: [{ term: { field: 'someTerm' } }] } },
         },
       });
@@ -233,6 +238,10 @@ describe('without a bool filter', () => {
       apm: {
         events: [ProcessorEvent.error],
       },
+      request_cache: true,
+      body: {
+        size: 0,
+      },
     });
     const params =
       mockResources.context.core.elasticsearch.client.asCurrentUser.search.mock
@@ -263,6 +272,10 @@ describe('with includeFrozen=false', () => {
       apm: {
         events: [],
       },
+      request_cache: true,
+      body: {
+        size: 10,
+      },
     });
 
     const params =
@@ -283,6 +296,10 @@ describe('with includeFrozen=true', () => {
 
     await apmEventClient.search('foo', {
       apm: { events: [] },
+      request_cache: true,
+      body: {
+        size: 10,
+      },
     });
 
     const params =

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/get_is_using_transaction_events.ts
@@ -73,7 +73,9 @@ async function getHasTransactions({
     apm: {
       events: [ProcessorEvent.transaction],
     },
+    request_cache: !kuery,
     body: {
+      size: 0,
       query: {
         bool: {
           filter: [

--- a/x-pack/plugins/apm/server/lib/helpers/transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/transactions/index.ts
@@ -32,7 +32,10 @@ export async function getHasAggregatedTransactions({
       apm: {
         events: [ProcessorEvent.metric],
       },
+      // don't cache as we set size > 0
+      request_cache: false,
       body: {
+        size: 1,
         query: {
           bool: {
             filter: [

--- a/x-pack/plugins/apm/server/lib/latency/get_overall_latency_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/latency/get_overall_latency_distribution.ts
@@ -58,7 +58,11 @@ export async function getOverallLatencyDistribution(
       {
         // TODO: add support for metrics
         apm: { events: [ProcessorEvent.transaction] },
-        body: histogramIntervalRequestBody,
+        request_cache: true,
+        body: {
+          size: 0,
+          ...histogramIntervalRequestBody,
+        },
       }
     )) as {
       aggregations?: {
@@ -95,7 +99,11 @@ export async function getOverallLatencyDistribution(
       {
         // TODO: add support for metrics
         apm: { events: [ProcessorEvent.transaction] },
-        body: transactionDurationRangesRequestBody,
+        request_cache: true,
+        body: {
+          size: 0,
+          ...transactionDurationRangesRequestBody,
+        },
       }
     )) as {
       aggregations?: {

--- a/x-pack/plugins/apm/server/lib/latency/get_percentile_threshold_value.ts
+++ b/x-pack/plugins/apm/server/lib/latency/get_percentile_threshold_value.ts
@@ -33,7 +33,11 @@ export async function getPercentileThresholdValue(
     {
       // TODO: add support for metrics
       apm: { events: [ProcessorEvent.transaction] },
-      body: transactionDurationPercentilesRequestBody,
+      request_cache: false,
+      body: {
+        size: 0,
+        ...transactionDurationPercentilesRequestBody,
+      },
     }
   )) as {
     aggregations?: {

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/gc/fetch_and_transform_gc_metrics.ts
@@ -64,6 +64,7 @@ export async function fetchAndTransformGcMetrics({
   // the delta in an es query. In the future agent might start
   // reporting deltas.
   const params = mergeProjection(projection, {
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/metrics/fetch_and_transform_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/fetch_and_transform_metrics.ts
@@ -27,7 +27,9 @@ type MetricAggs = Record<string, MetricsAggregationMap>;
 export type GenericMetricsRequest = Overwrite<
   APMEventESSearchRequest,
   {
+    request_cache: boolean;
     body: {
+      size: number;
       aggs: {
         timeseriesData: {
           date_histogram: AggregationOptionsByType['date_histogram'];
@@ -87,6 +89,7 @@ export async function fetchAndTransformMetrics<T extends MetricAggs>({
   });
 
   const params: GenericMetricsRequest = mergeProjection(projection, {
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/observability_overview/get_service_count.ts
+++ b/x-pack/plugins/apm/server/lib/observability_overview/get_service_count.ts
@@ -32,6 +32,7 @@ export async function getServiceCount({
         ProcessorEvent.metric,
       ],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/observability_overview/get_transactions_per_minute.ts
+++ b/x-pack/plugins/apm/server/lib/observability_overview/get_transactions_per_minute.ts
@@ -43,6 +43,7 @@ export async function getTransactionsPerMinute({
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
+      request_cache: true,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/observability_overview/has_data.ts
+++ b/x-pack/plugins/apm/server/lib/observability_overview/has_data.ts
@@ -20,6 +20,7 @@ export async function getHasData({ setup }: { setup: Setup }) {
         ],
       },
       terminate_after: 1,
+      request_cache: true,
       body: {
         size: 0,
       },

--- a/x-pack/plugins/apm/server/lib/rum_client/get_client_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_client_metrics.ts
@@ -35,6 +35,7 @@ export async function getClientMetrics({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       track_total_hits: true,

--- a/x-pack/plugins/apm/server/lib/rum_client/get_js_errors.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_js_errors.ts
@@ -40,6 +40,7 @@ export async function getJSErrors({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       track_total_hits: true,

--- a/x-pack/plugins/apm/server/lib/rum_client/get_long_task_metrics.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_long_task_metrics.ts
@@ -34,6 +34,7 @@ export async function getLongTaskMetrics({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       aggs: {

--- a/x-pack/plugins/apm/server/lib/rum_client/get_page_load_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_page_load_distribution.ts
@@ -92,6 +92,7 @@ export async function getPageLoadDistribution({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       aggs: {
@@ -205,6 +206,7 @@ const getPercentilesDistribution = async ({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       aggs: {

--- a/x-pack/plugins/apm/server/lib/rum_client/get_page_view_trends.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_page_view_trends.ts
@@ -36,6 +36,7 @@ export async function getPageViewTrends({
   }
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/rum_client/get_pl_dist_breakdown.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_pl_dist_breakdown.ts
@@ -71,6 +71,7 @@ export const getPageLoadDistBreakdown = async ({
     apm: {
       events: [ProcessorEvent.transaction],
     },
+    request_cache: true,
     body: {
       size: 0,
       aggs: {

--- a/x-pack/plugins/apm/server/lib/rum_client/get_rum_services.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_rum_services.ts
@@ -25,6 +25,7 @@ export async function getRumServices({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/rum_client/get_url_search.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_url_search.ts
@@ -34,6 +34,7 @@ export async function getUrlSearch({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       aggs: {

--- a/x-pack/plugins/apm/server/lib/rum_client/get_visitor_breakdown.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_visitor_breakdown.ts
@@ -32,6 +32,7 @@ export async function getVisitorBreakdown({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       track_total_hits: true,

--- a/x-pack/plugins/apm/server/lib/rum_client/get_web_core_vitals.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/get_web_core_vitals.ts
@@ -37,6 +37,7 @@ export async function getWebCoreVitals({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/rum_client/has_rum_data.ts
+++ b/x-pack/plugins/apm/server/lib/rum_client/has_rum_data.ts
@@ -29,6 +29,7 @@ export async function hasRumData({
       apm: {
         events: [ProcessorEvent.transaction],
       },
+      request_cache: true,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/service_map/fetch_service_paths_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/fetch_service_paths_from_trace_ids.ts
@@ -32,6 +32,7 @@ export async function fetchServicePathsFromTraceIds(
     apm: {
       events: [ProcessorEvent.span, ProcessorEvent.transaction],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map.ts
@@ -103,6 +103,7 @@ async function getServicesData(options: IEnvOptions) {
         ProcessorEvent.error as const,
       ],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map_backend_node_info.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map_backend_node_info.ts
@@ -43,6 +43,7 @@ export function getServiceMapBackendNodeInfo({
         apm: {
           events: [ProcessorEvent.metric],
         },
+        request_cache: true,
         body: {
           size: 0,
           query: {

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map_service_node_info.ts
@@ -132,6 +132,7 @@ async function getTransactionStats({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {
@@ -189,6 +190,7 @@ async function getCpuStats({
       apm: {
         events: [ProcessorEvent.metric],
       },
+      request_cache: true,
       body: {
         size: 0,
         query: {
@@ -229,6 +231,7 @@ function getMemoryStats({
           apm: {
             events: [ProcessorEvent.metric],
           },
+          request_cache: true,
           body: {
             size: 0,
             query: {

--- a/x-pack/plugins/apm/server/lib/service_map/get_trace_sample_ids.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_trace_sample_ids.ts
@@ -71,6 +71,7 @@ export async function getTraceSampleIds({
     apm: {
       events,
     },
+    request_cache: true,
     body: {
       size: 0,
       query,

--- a/x-pack/plugins/apm/server/lib/service_nodes/index.ts
+++ b/x-pack/plugins/apm/server/lib/service_nodes/index.ts
@@ -44,7 +44,9 @@ const getServiceNodes = async ({
   });
 
   const params = mergeProjection(projection, {
+    request_cache: !kuery,
     body: {
+      size: 0,
       aggs: {
         nodes: {
           terms: {

--- a/x-pack/plugins/apm/server/lib/services/annotations/get_derived_service_annotations.ts
+++ b/x-pack/plugins/apm/server/lib/services/annotations/get_derived_service_annotations.ts
@@ -51,6 +51,7 @@ export async function getDerivedServiceAnnotations({
             getProcessorEventForTransactions(searchAggregatedTransactions),
           ],
         },
+        request_cache: true,
         body: {
           size: 0,
           query: {
@@ -82,6 +83,7 @@ export async function getDerivedServiceAnnotations({
               getProcessorEventForTransactions(searchAggregatedTransactions),
             ],
           },
+          request_cache: true,
           body: {
             size: 1,
             query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_agent.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_agent.ts
@@ -47,6 +47,8 @@ export async function getServiceAgent({
         ProcessorEvent.metric,
       ],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       _source: [AGENT_NAME, SERVICE_RUNTIME_NAME],

--- a/x-pack/plugins/apm/server/lib/services/get_service_error_groups/get_service_error_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_error_groups/get_service_error_group_detailed_statistics.ts
@@ -49,6 +49,7 @@ export async function getServiceErrorGroupDetailedStatistics({
       apm: {
         events: [ProcessorEvent.error],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_error_groups/get_service_error_group_main_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_error_groups/get_service_error_group_main_statistics.ts
@@ -43,6 +43,7 @@ export async function getServiceErrorGroupMainStatistics({
       apm: {
         events: [ProcessorEvent.error],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_error_groups/index.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_error_groups/index.ts
@@ -65,6 +65,7 @@ export async function getServiceErrorGroups({
         apm: {
           events: [ProcessorEvent.error],
         },
+        request_cache: !kuery,
         body: {
           size: 0,
           query: {
@@ -144,6 +145,7 @@ export async function getServiceErrorGroups({
         apm: {
           events: [ProcessorEvent.error],
         },
+        request_cache: !kuery,
         body: {
           size: 0,
           query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_infrastructure.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_infrastructure.ts
@@ -36,6 +36,7 @@ export const getServiceInfrastructure = async ({
     apm: {
       events: [ProcessorEvent.metric],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_instance_metadata_details.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_instance_metadata_details.ts
@@ -46,6 +46,8 @@ export async function getServiceInstanceMetadataDetails({
         apm: {
           events: [ProcessorEvent.metric],
         },
+        // don't cache as we set size > 0
+        request_cache: false,
         body: {
           terminate_after: 1,
           size: 1,
@@ -68,6 +70,8 @@ export async function getServiceInstanceMetadataDetails({
         apm: {
           events: [ProcessorEvent.transaction],
         },
+        // don't cache as we set size > 0
+        request_cache: false,
         body: {
           terminate_after: 1,
           size: 1,
@@ -86,6 +90,8 @@ export async function getServiceInstanceMetadataDetails({
         apm: {
           events: [getProcessorEventForTransactions(true)],
         },
+        // don't cache as we set size > 0
+        request_cache: false,
         body: {
           terminate_after: 1,
           size: 1,

--- a/x-pack/plugins/apm/server/lib/services/get_service_instances/get_service_instances_system_metric_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_instances/get_service_instances_system_metric_statistics.ts
@@ -131,6 +131,7 @@ export async function getServiceInstancesSystemMetricStatistics<
       apm: {
         events: [ProcessorEvent.metric],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_instances/get_service_instances_transaction_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_instances/get_service_instances_transaction_statistics.ts
@@ -113,7 +113,6 @@ export async function getServiceInstancesTransactionStatistics<
         ...rangeQuery(start, end),
         ...environmentQuery(environment),
         ...kqlQuery(kuery),
-        ...getDocumentTypeFilterForTransactions(searchAggregatedTransactions),
         ...(isComparisonSearch && serviceNodeIds
           ? [{ terms: { [SERVICE_NODE_NAME]: serviceNodeIds } }]
           : []),
@@ -153,6 +152,7 @@ export async function getServiceInstancesTransactionStatistics<
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
+      request_cache: !kuery,
       body: { size: 0, query, aggs },
     }
   );

--- a/x-pack/plugins/apm/server/lib/services/get_service_metadata_details.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_metadata_details.ts
@@ -86,6 +86,8 @@ export async function getServiceMetadataDetails({
         ProcessorEvent.metric,
       ],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       _source: [SERVICE, AGENT, HOST, CONTAINER_ID, KUBERNETES, CLOUD],

--- a/x-pack/plugins/apm/server/lib/services/get_service_metadata_icons.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_metadata_icons.ts
@@ -68,6 +68,8 @@ export async function getServiceMetadataIcons({
         ProcessorEvent.metric,
       ],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       _source: [KUBERNETES, CLOUD_PROVIDER, CONTAINER_ID, AGENT_NAME],

--- a/x-pack/plugins/apm/server/lib/services/get_service_node_metadata.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_node_metadata.ts
@@ -42,6 +42,7 @@ export async function getServiceNodeMetadata({
       end,
     }),
     {
+      request_cache: !kuery,
       body: {
         size: 0,
         aggs: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_transaction_group_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_transaction_group_detailed_statistics.ts
@@ -84,6 +84,7 @@ export async function getServiceTransactionGroupDetailedStatistics({
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_transaction_groups.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_transaction_groups.ts
@@ -71,6 +71,7 @@ export async function getServiceTransactionGroups({
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_service_transaction_types.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_transaction_types.ts
@@ -35,6 +35,7 @@ export async function getServiceTransactionTypes({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_legacy_data_status.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_legacy_data_status.ts
@@ -24,6 +24,7 @@ export async function getLegacyDataStatus(
       events: [ProcessorEvent.transaction],
       includeLegacyData: true,
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_service_transaction_stats.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_service_transaction_stats.ts
@@ -72,6 +72,7 @@ export async function getServiceTransactionStats({
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_services_from_metric_documents.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_services_from_metric_documents.ts
@@ -39,6 +39,7 @@ export async function getServicesFromMetricDocuments({
       apm: {
         events: [ProcessorEvent.metric],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services_detailed_statistics/get_service_transaction_detailed_statistics.ts
@@ -77,6 +77,7 @@ export async function getServiceTransactionDetailedStatistics({
           getProcessorEventForTransactions(searchAggregatedTransactions),
         ],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/services/get_throughput.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_throughput.ts
@@ -56,6 +56,7 @@ export async function getThroughput({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/services/profiling/get_service_profiling_statistics.ts
+++ b/x-pack/plugins/apm/server/lib/services/profiling/get_service_profiling_statistics.ts
@@ -51,6 +51,7 @@ async function getProfilingStats({
     apm: {
       events: [ProcessorEvent.profile],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {
@@ -104,6 +105,7 @@ function getProfilesWithStacks({
         apm: {
           events: [ProcessorEvent.profile],
         },
+        request_cache: true,
         body: {
           size: 0,
           query: {
@@ -140,7 +142,9 @@ function getProfilesWithStacks({
             apm: {
               events: [ProcessorEvent.profile],
             },
+            request_cache: true,
             body: {
+              size: 0,
               query: {
                 bool: {
                   filter,

--- a/x-pack/plugins/apm/server/lib/services/profiling/get_service_profiling_timeline.ts
+++ b/x-pack/plugins/apm/server/lib/services/profiling/get_service_profiling_timeline.ts
@@ -49,6 +49,7 @@ export async function getServiceProfilingTimeline({
       apm: {
         events: [ProcessorEvent.profile],
       },
+      request_cache: !kuery,
       body: {
         size: 0,
         query: {

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
@@ -28,6 +28,7 @@ export async function getAgentNameByService({
         ProcessorEvent.metric,
       ],
     },
+    request_cache: true,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
@@ -35,6 +35,7 @@ export async function getServiceNames({
         ProcessorEvent.metric,
       ],
     },
+    request_cache: true,
     body: {
       timeout: '1ms',
       size: 0,

--- a/x-pack/plugins/apm/server/lib/settings/custom_link/get_transaction.ts
+++ b/x-pack/plugins/apm/server/lib/settings/custom_link/get_transaction.ts
@@ -36,8 +36,10 @@ export async function getTransaction({
     apm: {
       events: [ProcessorEvent.transaction as const],
     },
-    size: 1,
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
+      size: 1,
       query: {
         bool: {
           filter: esFilters,

--- a/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -31,6 +31,8 @@ export async function getTraceItems(
     apm: {
       events: [ProcessorEvent.error],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: maxTraceItems,
       query: {
@@ -49,6 +51,8 @@ export async function getTraceItems(
     apm: {
       events: [ProcessorEvent.span, ProcessorEvent.transaction],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: maxTraceItems,
       query: {

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -77,6 +77,7 @@ function getRequest(topTraceOptions: TopTraceOptions) {
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/get_error_rate.ts
@@ -79,6 +79,7 @@ export async function getErrorRate({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: { bool: { filter } },

--- a/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -111,6 +111,7 @@ export async function getTransactionBreakdown({
     apm: {
       events: [ProcessorEvent.metric],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/transactions/get_latency_charts/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_latency_charts/index.ts
@@ -72,6 +72,7 @@ function searchLatency({
     apm: {
       events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
@@ -33,6 +33,8 @@ export async function getTransaction({
     apm: {
       events: [ProcessorEvent.transaction],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       query: {

--- a/x-pack/plugins/apm/server/lib/transactions/get_transaction_by_trace/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_transaction_by_trace/index.ts
@@ -22,6 +22,8 @@ export async function getRootTransactionByTraceId(
     apm: {
       events: [ProcessorEvent.transaction as const],
     },
+    // don't cache as we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       query: {

--- a/x-pack/plugins/apm/server/lib/transactions/trace_samples/get_trace_samples/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/trace_samples/get_trace_samples/index.ts
@@ -76,6 +76,8 @@ export async function getTraceSamples({
         apm: {
           events: [ProcessorEvent.transaction],
         },
+        // don't cache because we set size > 0
+        request_cache: false,
         body: {
           query: {
             bool: {

--- a/x-pack/plugins/apm/server/projections/errors.ts
+++ b/x-pack/plugins/apm/server/projections/errors.ts
@@ -30,6 +30,7 @@ export function getErrorGroupsProjection({
     apm: {
       events: [ProcessorEvent.error as const],
     },
+    request_cache: !kuery,
     body: {
       query: {
         bool: {

--- a/x-pack/plugins/apm/server/projections/typings.ts
+++ b/x-pack/plugins/apm/server/projections/typings.ts
@@ -8,11 +8,16 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AggregationOptionsByType } from '../../../../../src/core/types/elasticsearch';
 import { APMEventESSearchRequest } from '../lib/helpers/create_es_client/create_apm_event_client';
 
-export type Projection = Omit<APMEventESSearchRequest, 'body'> & {
+export type Projection = Omit<
+  APMEventESSearchRequest,
+  'body' | 'request_cache'
+> & {
+  request_cache?: boolean;
   body: Omit<
     Required<APMEventESSearchRequest>['body'],
-    'aggs' | 'aggregations'
+    'aggs' | 'aggregations' | 'size'
   > & {
+    size?: number;
     aggs?: {
       [key: string]: {
         terms: AggregationOptionsByType['terms'] & { field: string };

--- a/x-pack/plugins/apm/server/routes/backends/get_error_rate_charts_for_backend.ts
+++ b/x-pack/plugins/apm/server/routes/backends/get_error_rate_charts_for_backend.ts
@@ -46,6 +46,7 @@ export async function getErrorRateChartsForBackend({
     apm: {
       events: [ProcessorEvent.metric],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/routes/backends/get_latency_charts_for_backend.ts
+++ b/x-pack/plugins/apm/server/routes/backends/get_latency_charts_for_backend.ts
@@ -46,6 +46,7 @@ export async function getLatencyChartsForBackend({
     apm: {
       events: [ProcessorEvent.metric],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/routes/backends/get_metadata_for_backend.ts
+++ b/x-pack/plugins/apm/server/routes/backends/get_metadata_for_backend.ts
@@ -28,6 +28,8 @@ export async function getMetadataForBackend({
     apm: {
       events: [ProcessorEvent.span],
     },
+    // don't cache because we set size > 0
+    request_cache: false,
     body: {
       size: 1,
       query: {

--- a/x-pack/plugins/apm/server/routes/backends/get_throughput_charts_for_backend.ts
+++ b/x-pack/plugins/apm/server/routes/backends/get_throughput_charts_for_backend.ts
@@ -51,6 +51,7 @@ export async function getThroughputChartsForBackend({
     apm: {
       events: [ProcessorEvent.metric],
     },
+    request_cache: !kuery,
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/routes/historical_data/has_historical_agent_data.ts
+++ b/x-pack/plugins/apm/server/routes/historical_data/has_historical_agent_data.ts
@@ -21,6 +21,7 @@ export async function hasHistoricalAgentData(setup: Setup) {
         ProcessorEvent.transaction,
       ],
     },
+    request_cache: true,
     body: {
       size: 0,
     },


### PR DESCRIPTION
Explicitly set `request_cache` and `body.size`.

`request_cache` tells ES whether to use the shard request cache for this request. It is e.g. not very useful to cache requests that have a kuery set, as the likeliness of it being reusable is low, but it could evict more useful cache entries as the user moves around the APM app..

Additionally, `body.size` should be set to 0 if hits.hits is not used, for performance reasons.