### PR TITLE
[docs/dev] remove recommendation to use --local

### DIFF
--- a/dev_docs/contributing/how_we_use_github.mdx
+++ b/dev_docs/contributing/how_we_use_github.mdx
@@ -46,7 +46,7 @@ In order to assist with developer tooling we ask that all Elastic engineers use 
  1. Update the git config for your current repository to commit with your `@elastic.co` email:
 
     ```bash
-    git config --local user.email YOUR_ELASTIC_EMAIL@elastic.co
+    git config user.email YOUR_ELASTIC_EMAIL@elastic.co
     ```
 
  1. Create a commit using the new email address

--- a/docs/developer/contributing/development-github.asciidoc
+++ b/docs/developer/contributing/development-github.asciidoc
@@ -53,7 +53,7 @@ In order to assist with developer tooling we ask that all Elastic engineers use 
 +
 ["source","shell"]
 -----------
-git config --local user.email YOUR_ELASTIC_EMAIL@elastic.co
+git config user.email YOUR_ELASTIC_EMAIL@elastic.co
 -----------
  4. Create a commit using the new email address
 +


### PR DESCRIPTION
There's been some confusion about the use of the `--local` flag in these docs, I think it makes sense to remove this from the docs as Elastic contributors should be using dedicated machines and the `--local` flag is well documented elsewhere if people want to learn about it themselves.