### PR TITLE
[Lens] add optional labels to dimensions

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
@@ -59,6 +59,12 @@
   }
 }
 
+.lnsLayerPanel__rowOptional {
+  font-weight: $euiFontWeightLight;
+  font-size: $euiFontSizeXS;
+  color: $euiTextSubduedColor;
+}
+
 .lnsLayerPanel__group {
   margin: (-$euiSizeS) (-$euiSize);
   padding: $euiSizeS $euiSize;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
@@ -59,12 +59,6 @@
   }
 }
 
-.lnsLayerPanel__rowOptional {
-  font-weight: $euiFontWeightLight;
-  font-size: $euiFontSizeXS;
-  color: $euiTextSubduedColor;
-}
-
 .lnsLayerPanel__group {
   margin: (-$euiSizeS) (-$euiSize);
   padding: $euiSizeS $euiSize;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -175,8 +175,8 @@ describe('LayerPanel', () => {
 
       const group = instance.find('.lnsLayerPanel__dimensionContainer[data-test-subj="lnsGroup"]');
       expect(group).toHaveLength(1);
-      const optionalLabel = instance.find('.[data-test-subj="lnsGroup_optional"]');
-      expect(optionalLabel).toHaveLength(1);
+      const optionalLabel = instance.find('[data-test-subj="lnsGroup_optional"]').first();
+      expect(optionalLabel.text()).toEqual('Optional');
     });
 
     it('should render the group with a way to add a new column', async () => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -157,7 +157,7 @@ describe('LayerPanel', () => {
   });
 
   describe('single group', () => {
-    it('should render the non-editable state', async () => {
+    it('should render the non-editable state and optional label', async () => {
       mockVisualization.getConfiguration.mockReturnValue({
         groups: [
           {
@@ -172,8 +172,11 @@ describe('LayerPanel', () => {
       });
 
       const { instance } = await mountWithProvider(<LayerPanel {...getDefaultProps()} />);
+
       const group = instance.find('.lnsLayerPanel__dimensionContainer[data-test-subj="lnsGroup"]');
       expect(group).toHaveLength(1);
+      const optionalLabel = instance.find('.lnsLayerPanel__rowOptional');
+      expect(optionalLabel).toHaveLength(1);
     });
 
     it('should render the group with a way to add a new column', async () => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -175,7 +175,7 @@ describe('LayerPanel', () => {
 
       const group = instance.find('.lnsLayerPanel__dimensionContainer[data-test-subj="lnsGroup"]');
       expect(group).toHaveLength(1);
-      const optionalLabel = instance.find('.lnsLayerPanel__rowOptional');
+      const optionalLabel = instance.find('.[data-test-subj="lnsGroup_optional"]');
       expect(optionalLabel).toHaveLength(1);
     });
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -385,7 +385,7 @@ export function LayerPanel(
 
           {groups.map((group, groupIndex) => {
             const isMissing = !isEmptyLayer && group.required && group.accessors.length === 0;
-
+            const isOptional = !group.required;
             return (
               <EuiFormRow
                 className="lnsLayerPanel__row"
@@ -409,6 +409,15 @@ export function LayerPanel(
                       </>
                     )}
                   </>
+                }
+                labelAppend={
+                  isOptional ? (
+                    <span className="lnsLayerPanel__rowOptional">
+                      {i18n.translate('xpack.lens.editorFrame.optionalDimensionLabel', {
+                        defaultMessage: 'Optional',
+                      })}
+                    </span>
+                  ) : null
                 }
                 labelType="legend"
                 key={group.groupId}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -413,7 +413,7 @@ export function LayerPanel(
                 }
                 labelAppend={
                   isOptional ? (
-                    <EuiText color="subdued" size="xs">
+                    <EuiText color="subdued" size="xs" data-test-subj="lnsGroup_optional">
                       {i18n.translate('xpack.lens.editorFrame.optionalDimensionLabel', {
                         defaultMessage: 'Optional',
                       })}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiText,
   EuiIconTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -412,11 +413,11 @@ export function LayerPanel(
                 }
                 labelAppend={
                   isOptional ? (
-                    <span className="lnsLayerPanel__rowOptional">
+                    <EuiText color="subdued" size="xs">
                       {i18n.translate('xpack.lens.editorFrame.optionalDimensionLabel', {
                         defaultMessage: 'Optional',
                       })}
-                    </span>
+                    </EuiText>
                   ) : null
                 }
                 labelType="legend"

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimensions_editor_helpers.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimensions_editor_helpers.tsx
@@ -161,7 +161,12 @@ export const DimensionEditorTabs = ({ tabs }: { tabs: DimensionEditorTab[] }) =>
     >
       {tabs.map(({ id, enabled, state, onClick, label }) => {
         return enabled ? (
-          <EuiTab isSelected={state} data-test-subj={`lens-dimensionTabs-${id}`} onClick={onClick}>
+          <EuiTab
+            key={id}
+            isSelected={state}
+            data-test-subj={`lens-dimensionTabs-${id}`}
+            onClick={onClick}
+          >
             {label}
           </EuiTab>
         ) : null;

--- a/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/visualization.tsx
@@ -106,6 +106,7 @@ export const metricVisualization: Visualization<MetricState> = {
           accessors: props.state.accessor ? [{ columnId: props.state.accessor }] : [],
           supportsMoreColumns: !props.state.accessor,
           filterOperations: (op: OperationMetadata) => !op.isBucketed && op.dataType === 'number',
+          required: true,
         },
       ],
     };


### PR DESCRIPTION
## Summary

A very small PR according to the changes in the design in preparations for gauges: 

Designs:
<img width="186" alt="Screenshot 2021-11-15 at 18 22 04" src="https://user-images.githubusercontent.com/4283304/141826054-f0581ec0-3008-49b3-b30c-1dc5812741f8.png">
<img width="430" alt="Screenshot 2021-11-15 at 18 22 54" src="https://user-images.githubusercontent.com/4283304/141826187-308852e3-3280-432d-a3a8-8f11a824b6b3.png">

Screenshots:
<img width="328" alt="Screenshot 2021-11-15 at 18 24 55" src="https://user-images.githubusercontent.com/4283304/141826464-7aa9e0f9-0127-4f75-9bc1-cbd172991f4b.png">
<img width="331" alt="Screenshot 2021-11-15 at 18 25 34" src="https://user-images.githubusercontent.com/4283304/141826570-8e396778-ca94-4551-aa88-ea6ea985e695.png">


