### PR TITLE
[Uptime] Add throttling parameters to the Fleet UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_agent_policy.tsx
@@ -229,7 +229,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 <p>
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyFormGroupDescription"
-                    defaultMessage="Agent policies are used to manage a group of integrations across a set of agents"
+                    defaultMessage="Agent policies are used to manage a group of integrations across a set of agents."
                   />
                 </p>
               </EuiText>

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.test.tsx
@@ -6,35 +6,49 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../../lib/helper/rtl_helpers';
 import { BrowserAdvancedFields } from './advanced_fields';
-import { ConfigKeys, IBrowserAdvancedFields, IBrowserSimpleFields } from '../types';
+import {
+  ConfigKeys,
+  DataStream,
+  IBrowserAdvancedFields,
+  IBrowserSimpleFields,
+  Validation,
+} from '../types';
 import {
   BrowserAdvancedFieldsContextProvider,
   BrowserSimpleFieldsContextProvider,
   defaultBrowserAdvancedFields as defaultConfig,
   defaultBrowserSimpleFields,
 } from '../contexts';
+import { validate as centralValidation } from '../validation';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n/react';
 
 jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
   htmlIdGenerator: () => () => `id-${Math.random()}`,
 }));
 
+const defaultValidation = centralValidation[DataStream.BROWSER];
+
 describe('<BrowserAdvancedFields />', () => {
   const WrappedComponent = ({
     defaultValues = defaultConfig,
     defaultSimpleFields = defaultBrowserSimpleFields,
+    validate = defaultValidation,
   }: {
     defaultValues?: IBrowserAdvancedFields;
     defaultSimpleFields?: IBrowserSimpleFields;
+    validate?: Validation;
   }) => {
     return (
-      <BrowserSimpleFieldsContextProvider defaultValues={defaultSimpleFields}>
-        <BrowserAdvancedFieldsContextProvider defaultValues={defaultValues}>
-          <BrowserAdvancedFields />
-        </BrowserAdvancedFieldsContextProvider>
-      </BrowserSimpleFieldsContextProvider>
+      <IntlProvider locale="en">
+        <BrowserSimpleFieldsContextProvider defaultValues={defaultSimpleFields}>
+          <BrowserAdvancedFieldsContextProvider defaultValues={defaultValues}>
+            <BrowserAdvancedFields validate={validate} />
+          </BrowserAdvancedFieldsContextProvider>
+        </BrowserSimpleFieldsContextProvider>
+      </IntlProvider>
     );
   };
 
@@ -43,18 +57,97 @@ describe('<BrowserAdvancedFields />', () => {
 
     const syntheticsArgs = getByLabelText('Synthetics args');
     const screenshots = getByLabelText('Screenshot options') as HTMLInputElement;
+    const downloadSpeed = getByLabelText('Download Speed');
+    const uploadSpeed = getByLabelText('Upload Speed');
+    const latency = getByLabelText('Latency');
+
     expect(screenshots.value).toEqual(defaultConfig[ConfigKeys.SCREENSHOTS]);
     expect(syntheticsArgs).toBeInTheDocument();
+    expect(downloadSpeed).toBeInTheDocument();
+    expect(uploadSpeed).toBeInTheDocument();
+    expect(latency).toBeInTheDocument();
   });
 
-  it('handles changing fields', () => {
-    const { getByLabelText } = render(<WrappedComponent />);
+  describe('handles changing fields', () => {
+    it('for screenshot options', () => {
+      const { getByLabelText } = render(<WrappedComponent />);
 
-    const screenshots = getByLabelText('Screenshot options') as HTMLInputElement;
+      const screenshots = getByLabelText('Screenshot options') as HTMLInputElement;
+      userEvent.selectOptions(screenshots, ['off']);
+      expect(screenshots.value).toEqual('off');
+    });
 
-    fireEvent.change(screenshots, { target: { value: 'off' } });
+    it('for throttling options', () => {
+      const { getByLabelText } = render(<WrappedComponent />);
 
-    expect(screenshots.value).toEqual('off');
+      const downloadSpeed = getByLabelText('Download Speed') as HTMLInputElement;
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '1337');
+      expect(downloadSpeed.value).toEqual('1337');
+
+      const uploadSpeed = getByLabelText('Upload Speed') as HTMLInputElement;
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '1338');
+      expect(uploadSpeed.value).toEqual('1338');
+
+      const latency = getByLabelText('Latency') as HTMLInputElement;
+      userEvent.clear(latency);
+      userEvent.type(latency, '1339');
+      expect(latency.value).toEqual('1339');
+    });
+  });
+
+  describe('validates changing fields', () => {
+    it('disallows negative/zero download speeds', () => {
+      const { getByLabelText, queryByText } = render(<WrappedComponent />);
+
+      const downloadSpeed = getByLabelText('Download Speed') as HTMLInputElement;
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '-1337');
+      expect(queryByText('Download speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '0');
+      expect(queryByText('Download speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '1');
+      expect(queryByText('Download speed must be greater than zero.')).not.toBeInTheDocument();
+    });
+
+    it('disallows negative/zero upload speeds', () => {
+      const { getByLabelText, queryByText } = render(<WrappedComponent />);
+
+      const uploadSpeed = getByLabelText('Upload Speed') as HTMLInputElement;
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '-1337');
+      expect(queryByText('Upload speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '0');
+      expect(queryByText('Upload speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '1');
+      expect(queryByText('Upload speed must be greater than zero.')).not.toBeInTheDocument();
+    });
+
+    it('disallows negative latency values', () => {
+      const { getByLabelText, queryByText } = render(<WrappedComponent />);
+
+      const latency = getByLabelText('Latency') as HTMLInputElement;
+      userEvent.clear(latency);
+      userEvent.type(latency, '-1337');
+      expect(queryByText('Latency must not be negative.')).toBeInTheDocument();
+
+      userEvent.clear(latency);
+      userEvent.type(latency, '0');
+      expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
+
+      userEvent.clear(latency);
+      userEvent.type(latency, '1');
+      expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
+    });
   });
 
   it('only displayed filter options when zip url is truthy', () => {

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.test.tsx
@@ -23,13 +23,14 @@ import {
   defaultBrowserSimpleFields,
 } from '../contexts';
 import { validate as centralValidation } from '../validation';
-import { __IntlProvider as IntlProvider } from '@kbn/i18n/react';
-
-jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
-  htmlIdGenerator: () => () => `id-${Math.random()}`,
-}));
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 
 const defaultValidation = centralValidation[DataStream.BROWSER];
+
+jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
+  ...jest.requireActual('@elastic/eui/lib/services/accessibility/html_id_generator'),
+  htmlIdGenerator: () => () => `id-${Math.random()}`,
+}));
 
 describe('<BrowserAdvancedFields />', () => {
   const WrappedComponent = ({
@@ -57,15 +58,9 @@ describe('<BrowserAdvancedFields />', () => {
 
     const syntheticsArgs = getByLabelText('Synthetics args');
     const screenshots = getByLabelText('Screenshot options') as HTMLInputElement;
-    const downloadSpeed = getByLabelText('Download Speed');
-    const uploadSpeed = getByLabelText('Upload Speed');
-    const latency = getByLabelText('Latency');
 
     expect(screenshots.value).toEqual(defaultConfig[ConfigKeys.SCREENSHOTS]);
     expect(syntheticsArgs).toBeInTheDocument();
-    expect(downloadSpeed).toBeInTheDocument();
-    expect(uploadSpeed).toBeInTheDocument();
-    expect(latency).toBeInTheDocument();
   });
 
   describe('handles changing fields', () => {
@@ -75,78 +70,6 @@ describe('<BrowserAdvancedFields />', () => {
       const screenshots = getByLabelText('Screenshot options') as HTMLInputElement;
       userEvent.selectOptions(screenshots, ['off']);
       expect(screenshots.value).toEqual('off');
-    });
-
-    it('for throttling options', () => {
-      const { getByLabelText } = render(<WrappedComponent />);
-
-      const downloadSpeed = getByLabelText('Download Speed') as HTMLInputElement;
-      userEvent.clear(downloadSpeed);
-      userEvent.type(downloadSpeed, '1337');
-      expect(downloadSpeed.value).toEqual('1337');
-
-      const uploadSpeed = getByLabelText('Upload Speed') as HTMLInputElement;
-      userEvent.clear(uploadSpeed);
-      userEvent.type(uploadSpeed, '1338');
-      expect(uploadSpeed.value).toEqual('1338');
-
-      const latency = getByLabelText('Latency') as HTMLInputElement;
-      userEvent.clear(latency);
-      userEvent.type(latency, '1339');
-      expect(latency.value).toEqual('1339');
-    });
-  });
-
-  describe('validates changing fields', () => {
-    it('disallows negative/zero download speeds', () => {
-      const { getByLabelText, queryByText } = render(<WrappedComponent />);
-
-      const downloadSpeed = getByLabelText('Download Speed') as HTMLInputElement;
-      userEvent.clear(downloadSpeed);
-      userEvent.type(downloadSpeed, '-1337');
-      expect(queryByText('Download speed must be greater than zero.')).toBeInTheDocument();
-
-      userEvent.clear(downloadSpeed);
-      userEvent.type(downloadSpeed, '0');
-      expect(queryByText('Download speed must be greater than zero.')).toBeInTheDocument();
-
-      userEvent.clear(downloadSpeed);
-      userEvent.type(downloadSpeed, '1');
-      expect(queryByText('Download speed must be greater than zero.')).not.toBeInTheDocument();
-    });
-
-    it('disallows negative/zero upload speeds', () => {
-      const { getByLabelText, queryByText } = render(<WrappedComponent />);
-
-      const uploadSpeed = getByLabelText('Upload Speed') as HTMLInputElement;
-      userEvent.clear(uploadSpeed);
-      userEvent.type(uploadSpeed, '-1337');
-      expect(queryByText('Upload speed must be greater than zero.')).toBeInTheDocument();
-
-      userEvent.clear(uploadSpeed);
-      userEvent.type(uploadSpeed, '0');
-      expect(queryByText('Upload speed must be greater than zero.')).toBeInTheDocument();
-
-      userEvent.clear(uploadSpeed);
-      userEvent.type(uploadSpeed, '1');
-      expect(queryByText('Upload speed must be greater than zero.')).not.toBeInTheDocument();
-    });
-
-    it('disallows negative latency values', () => {
-      const { getByLabelText, queryByText } = render(<WrappedComponent />);
-
-      const latency = getByLabelText('Latency') as HTMLInputElement;
-      userEvent.clear(latency);
-      userEvent.type(latency, '-1337');
-      expect(queryByText('Latency must not be negative.')).toBeInTheDocument();
-
-      userEvent.clear(latency);
-      userEvent.type(latency, '0');
-      expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
-
-      userEvent.clear(latency);
-      userEvent.type(latency, '1');
-      expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
-import { FormattedMessage } from '@kbn/i18n-react';
+import React, { memo, useCallback } from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
 import {
   EuiAccordion,
   EuiSelect,
@@ -15,16 +15,22 @@ import {
   EuiFormRow,
   EuiDescribedFormGroup,
   EuiSpacer,
+  EuiFieldNumber,
+  EuiText,
 } from '@elastic/eui';
 import { ComboBox } from '../combo_box';
 
 import { useBrowserAdvancedFieldsContext, useBrowserSimpleFieldsContext } from '../contexts';
 
-import { ConfigKeys, ScreenshotOption } from '../types';
+import { ConfigKeys, Validation, ScreenshotOption } from '../types';
 
 import { OptionalLabel } from '../optional_label';
 
-export const BrowserAdvancedFields = () => {
+interface Props {
+  validate: Validation;
+}
+
+export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
   const { fields, setFields } = useBrowserAdvancedFieldsContext();
   const { fields: simpleFields } = useBrowserSimpleFieldsContext();
 
@@ -159,6 +165,129 @@ export const BrowserAdvancedFields = () => {
         <EuiFormRow
           label={
             <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.label"
+              defaultMessage="Download Speed"
+            />
+          }
+          labelAppend={<OptionalLabel />}
+          isInvalid={!!validate[ConfigKeys.DOWNLOAD_SPEED]?.(fields)}
+          helpText={
+            <>
+              <FormattedMessage
+                id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.helpText"
+                defaultMessage="Set this option to control the monitor's download speed. This is useful for simulating your application's behaviour on slower networks."
+              />
+            </>
+          }
+          error={
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
+              defaultMessage="Download speed must be greater than zero."
+            />
+          }
+        >
+          <EuiFieldNumber
+            min={0}
+            step={0.001}
+            value={fields[ConfigKeys.DOWNLOAD_SPEED]}
+            onChange={(event) => {
+              handleInputChange({
+                value: event.target.value,
+                configKey: ConfigKeys.DOWNLOAD_SPEED,
+              });
+            }}
+            append={
+              <EuiText size="xs">
+                <strong>Mbps</strong>
+              </EuiText>
+            }
+          />
+        </EuiFormRow>
+        <EuiFormRow
+          label={
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.label"
+              defaultMessage="Upload Speed"
+            />
+          }
+          labelAppend={<OptionalLabel />}
+          helpText={
+            <>
+              <FormattedMessage
+                id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.helpText"
+                defaultMessage="Set this option to control the monitor's upload speed. This is useful for simulating your application's behaviour on slower networks."
+              />
+            </>
+          }
+          isInvalid={!!validate[ConfigKeys.UPLOAD_SPEED]?.(fields)}
+          error={
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
+              defaultMessage="Upload speed must be greater than zero."
+            />
+          }
+        >
+          <EuiFieldNumber
+            min={0}
+            step={0.001}
+            value={fields[ConfigKeys.UPLOAD_SPEED]}
+            onChange={(event) =>
+              handleInputChange({
+                value: event.target.value,
+                configKey: ConfigKeys.UPLOAD_SPEED,
+              })
+            }
+            append={
+              <EuiText size="xs">
+                <strong>Mbps</strong>
+              </EuiText>
+            }
+          />
+        </EuiFormRow>
+        <EuiFormRow
+          label={
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.label"
+              defaultMessage="Latency"
+            />
+          }
+          labelAppend={<OptionalLabel />}
+          helpText={
+            <>
+              <FormattedMessage
+                id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.helpText"
+                defaultMessage="Set this option to control the monitor's round-trip time. This is useful for simulating your application's behaviour on laggier networks."
+              />
+            </>
+          }
+          isInvalid={!!validate[ConfigKeys.LATENCY]?.(fields)}
+          error={
+            <FormattedMessage
+              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
+              defaultMessage="Latency must not be negative."
+            />
+          }
+        >
+          <EuiFieldNumber
+            min={0}
+            value={fields[ConfigKeys.LATENCY]}
+            onChange={(event) =>
+              handleInputChange({
+                value: event.target.value,
+                configKey: ConfigKeys.LATENCY,
+              })
+            }
+            append={
+              <EuiText size="xs">
+                <strong>ms</strong>
+              </EuiText>
+            }
+          />
+        </EuiFormRow>
+
+        <EuiFormRow
+          label={
+            <FormattedMessage
               id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.screenshots.label"
               defaultMessage="Screenshot options"
             />
@@ -209,7 +338,7 @@ export const BrowserAdvancedFields = () => {
       </EuiDescribedFormGroup>
     </EuiAccordion>
   );
-};
+});
 
 const requestMethodOptions = Object.values(ScreenshotOption).map((option) => ({
   value: option,

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/advanced_fields.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useCallback } from 'react';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiAccordion,
   EuiSelect,
@@ -15,8 +15,6 @@ import {
   EuiFormRow,
   EuiDescribedFormGroup,
   EuiSpacer,
-  EuiFieldNumber,
-  EuiText,
 } from '@elastic/eui';
 import { ComboBox } from '../combo_box';
 
@@ -25,6 +23,7 @@ import { useBrowserAdvancedFieldsContext, useBrowserSimpleFieldsContext } from '
 import { ConfigKeys, Validation, ScreenshotOption } from '../types';
 
 import { OptionalLabel } from '../optional_label';
+import { ThrottlingFields } from './throttling_fields';
 
 interface Props {
   validate: Validation;
@@ -162,128 +161,6 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
             }
           />
         </EuiFormRow>
-        <EuiFormRow
-          label={
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.label"
-              defaultMessage="Download Speed"
-            />
-          }
-          labelAppend={<OptionalLabel />}
-          isInvalid={!!validate[ConfigKeys.DOWNLOAD_SPEED]?.(fields)}
-          helpText={
-            <>
-              <FormattedMessage
-                id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.helpText"
-                defaultMessage="Set this option to control the monitor's download speed. This is useful for simulating your application's behaviour on slower networks."
-              />
-            </>
-          }
-          error={
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
-              defaultMessage="Download speed must be greater than zero."
-            />
-          }
-        >
-          <EuiFieldNumber
-            min={0}
-            step={0.001}
-            value={fields[ConfigKeys.DOWNLOAD_SPEED]}
-            onChange={(event) => {
-              handleInputChange({
-                value: event.target.value,
-                configKey: ConfigKeys.DOWNLOAD_SPEED,
-              });
-            }}
-            append={
-              <EuiText size="xs">
-                <strong>Mbps</strong>
-              </EuiText>
-            }
-          />
-        </EuiFormRow>
-        <EuiFormRow
-          label={
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.label"
-              defaultMessage="Upload Speed"
-            />
-          }
-          labelAppend={<OptionalLabel />}
-          helpText={
-            <>
-              <FormattedMessage
-                id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.helpText"
-                defaultMessage="Set this option to control the monitor's upload speed. This is useful for simulating your application's behaviour on slower networks."
-              />
-            </>
-          }
-          isInvalid={!!validate[ConfigKeys.UPLOAD_SPEED]?.(fields)}
-          error={
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
-              defaultMessage="Upload speed must be greater than zero."
-            />
-          }
-        >
-          <EuiFieldNumber
-            min={0}
-            step={0.001}
-            value={fields[ConfigKeys.UPLOAD_SPEED]}
-            onChange={(event) =>
-              handleInputChange({
-                value: event.target.value,
-                configKey: ConfigKeys.UPLOAD_SPEED,
-              })
-            }
-            append={
-              <EuiText size="xs">
-                <strong>Mbps</strong>
-              </EuiText>
-            }
-          />
-        </EuiFormRow>
-        <EuiFormRow
-          label={
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.label"
-              defaultMessage="Latency"
-            />
-          }
-          labelAppend={<OptionalLabel />}
-          helpText={
-            <>
-              <FormattedMessage
-                id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.helpText"
-                defaultMessage="Set this option to control the monitor's round-trip time. This is useful for simulating your application's behaviour on laggier networks."
-              />
-            </>
-          }
-          isInvalid={!!validate[ConfigKeys.LATENCY]?.(fields)}
-          error={
-            <FormattedMessage
-              id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
-              defaultMessage="Latency must not be negative."
-            />
-          }
-        >
-          <EuiFieldNumber
-            min={0}
-            value={fields[ConfigKeys.LATENCY]}
-            onChange={(event) =>
-              handleInputChange({
-                value: event.target.value,
-                configKey: ConfigKeys.LATENCY,
-              })
-            }
-            append={
-              <EuiText size="xs">
-                <strong>ms</strong>
-              </EuiText>
-            }
-          />
-        </EuiFormRow>
 
         <EuiFormRow
           label={
@@ -336,6 +213,8 @@ export const BrowserAdvancedFields = memo<Props>(({ validate }) => {
           />
         </EuiFormRow>
       </EuiDescribedFormGroup>
+
+      <ThrottlingFields validate={validate} />
     </EuiAccordion>
   );
 });

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/formatters.ts
@@ -22,6 +22,8 @@ import {
 export type BrowserFormatMap = Record<keyof BrowserFields, Formatter>;
 
 const throttlingFormatter: Formatter = (fields) => {
+  if (!fields[ConfigKeys.IS_THROTTLING_ENABLED]) return 'false';
+
   const getThrottlingValue = (v: string | undefined, suffix: 'd' | 'u' | 'l') =>
     v !== '' && v !== undefined ? `${v}${suffix}` : null;
 
@@ -44,6 +46,7 @@ export const browserFormatters: BrowserFormatMap = {
   [ConfigKeys.SOURCE_INLINE]: (fields) => stringToJsonFormatter(fields[ConfigKeys.SOURCE_INLINE]),
   [ConfigKeys.PARAMS]: null,
   [ConfigKeys.SCREENSHOTS]: null,
+  [ConfigKeys.IS_THROTTLING_ENABLED]: null,
   [ConfigKeys.DOWNLOAD_SPEED]: null,
   [ConfigKeys.UPLOAD_SPEED]: null,
   [ConfigKeys.LATENCY]: null,

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/formatters.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/formatters.ts
@@ -21,6 +21,19 @@ import {
 
 export type BrowserFormatMap = Record<keyof BrowserFields, Formatter>;
 
+const throttlingFormatter: Formatter = (fields) => {
+  const getThrottlingValue = (v: string | undefined, suffix: 'd' | 'u' | 'l') =>
+    v !== '' && v !== undefined ? `${v}${suffix}` : null;
+
+  return [
+    getThrottlingValue(fields[ConfigKeys.DOWNLOAD_SPEED], 'd'),
+    getThrottlingValue(fields[ConfigKeys.UPLOAD_SPEED], 'u'),
+    getThrottlingValue(fields[ConfigKeys.LATENCY], 'l'),
+  ]
+    .filter((v) => v !== null)
+    .join('/');
+};
+
 export const browserFormatters: BrowserFormatMap = {
   [ConfigKeys.METADATA]: (fields) => objectToJsonFormatter(fields[ConfigKeys.METADATA]),
   [ConfigKeys.SOURCE_ZIP_URL]: null,
@@ -31,6 +44,9 @@ export const browserFormatters: BrowserFormatMap = {
   [ConfigKeys.SOURCE_INLINE]: (fields) => stringToJsonFormatter(fields[ConfigKeys.SOURCE_INLINE]),
   [ConfigKeys.PARAMS]: null,
   [ConfigKeys.SCREENSHOTS]: null,
+  [ConfigKeys.DOWNLOAD_SPEED]: null,
+  [ConfigKeys.UPLOAD_SPEED]: null,
+  [ConfigKeys.LATENCY]: null,
   [ConfigKeys.SYNTHETICS_ARGS]: (fields) =>
     arrayToJsonFormatter(fields[ConfigKeys.SYNTHETICS_ARGS]),
   [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: (fields) =>
@@ -49,6 +65,7 @@ export const browserFormatters: BrowserFormatMap = {
     stringToJsonFormatter(fields[ConfigKeys.JOURNEY_FILTERS_MATCH]),
   [ConfigKeys.JOURNEY_FILTERS_TAGS]: (fields) =>
     arrayToJsonFormatter(fields[ConfigKeys.JOURNEY_FILTERS_TAGS]),
+  [ConfigKeys.THROTTLING_CONFIG]: throttlingFormatter,
   [ConfigKeys.IGNORE_HTTPS_ERRORS]: null,
   ...commonFormatters,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.test.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ConfigKeys } from '../types';
+import { getThrottlingParamNormalizer, isThrottlingEnabledNormalizer } from './normalizers';
+import { defaultBrowserAdvancedFields } from '../contexts';
+
+describe('browser normalizers', () => {
+  const makeThrottlingConfig = (value: string) => ({
+    [ConfigKeys.THROTTLING_CONFIG]: { value },
+  });
+
+  describe('throttlingToParameterNormalizer', () => {
+    it('can extract download values', () => {
+      const fields = makeThrottlingConfig('10d/5u/2.5l');
+
+      expect(getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED)(fields)).toEqual('10');
+    });
+
+    it('can extract upload values', () => {
+      const fields = makeThrottlingConfig('10d/5u/2.5l');
+
+      expect(getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED)(fields)).toEqual('5');
+    });
+
+    it('can extract latency values', () => {
+      const fields = makeThrottlingConfig('10d/5u/2.5l');
+
+      expect(getThrottlingParamNormalizer(ConfigKeys.LATENCY)(fields)).toEqual('2.5');
+    });
+
+    it('returns default values when throttling is disabled', () => {
+      const fields = makeThrottlingConfig('false');
+
+      expect(getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED)(fields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKeys.DOWNLOAD_SPEED]
+      );
+      expect(getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED)(fields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKeys.UPLOAD_SPEED]
+      );
+      expect(getThrottlingParamNormalizer(ConfigKeys.LATENCY)(fields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKeys.LATENCY]
+      );
+    });
+
+    it("returns default values when the desired suffix doesn't exist", () => {
+      const noUploadFields = makeThrottlingConfig('10d/2.5l');
+      expect(getThrottlingParamNormalizer(ConfigKeys.UPLOAD_SPEED)(noUploadFields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKeys.UPLOAD_SPEED]
+      );
+
+      const noDownloadFields = makeThrottlingConfig('10u/2.5l');
+      expect(getThrottlingParamNormalizer(ConfigKeys.DOWNLOAD_SPEED)(noDownloadFields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKeys.DOWNLOAD_SPEED]
+      );
+
+      const noLatencyFields = makeThrottlingConfig('10d/5u');
+      expect(getThrottlingParamNormalizer(ConfigKeys.LATENCY)(noLatencyFields)).toEqual(
+        defaultBrowserAdvancedFields[ConfigKeys.LATENCY]
+      );
+    });
+  });
+
+  describe('isThrottlingEnabledNormalizer', () => {
+    it('returns true for any value that is not "false"', () => {
+      expect(isThrottlingEnabledNormalizer(makeThrottlingConfig('10d/2l'))).toEqual(true);
+      expect(isThrottlingEnabledNormalizer(makeThrottlingConfig('test'))).toEqual(true);
+    });
+
+    it('returns false when throttling config is the string "false"', () => {
+      expect(isThrottlingEnabledNormalizer(makeThrottlingConfig('false'))).toEqual(false);
+    });
+  });
+});

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.ts
@@ -41,6 +41,10 @@ export const browserNormalizers: BrowserNormalizerMap = {
   [ConfigKeys.PARAMS]: getBrowserNormalizer(ConfigKeys.PARAMS),
   [ConfigKeys.SCREENSHOTS]: getBrowserNormalizer(ConfigKeys.SCREENSHOTS),
   [ConfigKeys.SYNTHETICS_ARGS]: getBrowserJsonToJavascriptNormalizer(ConfigKeys.SYNTHETICS_ARGS),
+  [ConfigKeys.DOWNLOAD_SPEED]: getBrowserNormalizer(ConfigKeys.DOWNLOAD_SPEED),
+  [ConfigKeys.UPLOAD_SPEED]: getBrowserNormalizer(ConfigKeys.UPLOAD_SPEED),
+  [ConfigKeys.LATENCY]: getBrowserNormalizer(ConfigKeys.LATENCY),
+  [ConfigKeys.THROTTLING_CONFIG]: getBrowserNormalizer(ConfigKeys.THROTTLING_CONFIG),
   [ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES]: getBrowserJsonToJavascriptNormalizer(
     ConfigKeys.ZIP_URL_TLS_CERTIFICATE_AUTHORITIES
   ),

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.ts
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/normalizers.ts
@@ -41,6 +41,7 @@ export const browserNormalizers: BrowserNormalizerMap = {
   [ConfigKeys.PARAMS]: getBrowserNormalizer(ConfigKeys.PARAMS),
   [ConfigKeys.SCREENSHOTS]: getBrowserNormalizer(ConfigKeys.SCREENSHOTS),
   [ConfigKeys.SYNTHETICS_ARGS]: getBrowserJsonToJavascriptNormalizer(ConfigKeys.SYNTHETICS_ARGS),
+  [ConfigKeys.IS_THROTTLING_ENABLED]: getBrowserNormalizer(ConfigKeys.IS_THROTTLING_ENABLED),
   [ConfigKeys.DOWNLOAD_SPEED]: getBrowserNormalizer(ConfigKeys.DOWNLOAD_SPEED),
   [ConfigKeys.UPLOAD_SPEED]: getBrowserNormalizer(ConfigKeys.UPLOAD_SPEED),
   [ConfigKeys.LATENCY]: getBrowserNormalizer(ConfigKeys.LATENCY),

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../lib/helper/rtl_helpers';
+import { ThrottlingFields } from './throttling_fields';
+import { DataStream, IBrowserAdvancedFields, IBrowserSimpleFields, Validation } from '../types';
+import {
+  BrowserAdvancedFieldsContextProvider,
+  BrowserSimpleFieldsContextProvider,
+  defaultBrowserAdvancedFields as defaultConfig,
+  defaultBrowserSimpleFields,
+} from '../contexts';
+import { validate as centralValidation } from '../validation';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+const defaultValidation = centralValidation[DataStream.BROWSER];
+
+jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
+  ...jest.requireActual('@elastic/eui/lib/services/accessibility/html_id_generator'),
+  htmlIdGenerator: () => () => `id-${Math.random()}`,
+}));
+
+describe('<ThrottlingFields />', () => {
+  const WrappedComponent = ({
+    defaultValues = defaultConfig,
+    defaultSimpleFields = defaultBrowserSimpleFields,
+    validate = defaultValidation,
+  }: {
+    defaultValues?: IBrowserAdvancedFields;
+    defaultSimpleFields?: IBrowserSimpleFields;
+    validate?: Validation;
+  }) => {
+    return (
+      <IntlProvider locale="en">
+        <BrowserSimpleFieldsContextProvider defaultValues={defaultSimpleFields}>
+          <BrowserAdvancedFieldsContextProvider defaultValues={defaultValues}>
+            <ThrottlingFields validate={validate} />
+          </BrowserAdvancedFieldsContextProvider>
+        </BrowserSimpleFieldsContextProvider>
+      </IntlProvider>
+    );
+  };
+
+  it('renders ThrottlingFields', () => {
+    const { getByLabelText, getByTestId } = render(<WrappedComponent />);
+
+    const enableSwitch = getByTestId('syntheticsBrowserIsThrottlingEnabled');
+    const downloadSpeed = getByLabelText('Download Speed');
+    const uploadSpeed = getByLabelText('Upload Speed');
+    const latency = getByLabelText('Latency');
+
+    expect(enableSwitch).toBeChecked();
+    expect(downloadSpeed).toBeInTheDocument();
+    expect(uploadSpeed).toBeInTheDocument();
+    expect(latency).toBeInTheDocument();
+  });
+
+  describe('handles changing fields', () => {
+    it('for the enable switch', () => {
+      const { getByTestId } = render(<WrappedComponent />);
+
+      const enableSwitch = getByTestId('syntheticsBrowserIsThrottlingEnabled');
+      userEvent.click(enableSwitch);
+      expect(enableSwitch).not.toBeChecked();
+    });
+
+    it('for the download option', () => {
+      const { getByLabelText } = render(<WrappedComponent />);
+
+      const downloadSpeed = getByLabelText('Download Speed') as HTMLInputElement;
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '1337');
+      expect(downloadSpeed.value).toEqual('1337');
+    });
+
+    it('for the upload option', () => {
+      const { getByLabelText } = render(<WrappedComponent />);
+
+      const uploadSpeed = getByLabelText('Upload Speed') as HTMLInputElement;
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '1338');
+      expect(uploadSpeed.value).toEqual('1338');
+    });
+
+    it('for the latency option', () => {
+      const { getByLabelText } = render(<WrappedComponent />);
+      const latency = getByLabelText('Latency') as HTMLInputElement;
+      userEvent.clear(latency);
+      userEvent.type(latency, '1339');
+      expect(latency.value).toEqual('1339');
+    });
+  });
+
+  describe('validates changing fields', () => {
+    it('disallows negative/zero download speeds', () => {
+      const { getByLabelText, queryByText } = render(<WrappedComponent />);
+
+      const downloadSpeed = getByLabelText('Download Speed') as HTMLInputElement;
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '-1337');
+      expect(queryByText('Download speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '0');
+      expect(queryByText('Download speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(downloadSpeed);
+      userEvent.type(downloadSpeed, '1');
+      expect(queryByText('Download speed must be greater than zero.')).not.toBeInTheDocument();
+    });
+
+    it('disallows negative/zero upload speeds', () => {
+      const { getByLabelText, queryByText } = render(<WrappedComponent />);
+
+      const uploadSpeed = getByLabelText('Upload Speed') as HTMLInputElement;
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '-1337');
+      expect(queryByText('Upload speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '0');
+      expect(queryByText('Upload speed must be greater than zero.')).toBeInTheDocument();
+
+      userEvent.clear(uploadSpeed);
+      userEvent.type(uploadSpeed, '1');
+      expect(queryByText('Upload speed must be greater than zero.')).not.toBeInTheDocument();
+    });
+
+    it('disallows negative latency values', () => {
+      const { getByLabelText, queryByText } = render(<WrappedComponent />);
+
+      const latency = getByLabelText('Latency') as HTMLInputElement;
+      userEvent.clear(latency);
+      userEvent.type(latency, '-1337');
+      expect(queryByText('Latency must not be negative.')).toBeInTheDocument();
+
+      userEvent.clear(latency);
+      userEvent.type(latency, '0');
+      expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
+
+      userEvent.clear(latency);
+      userEvent.type(latency, '1');
+      expect(queryByText('Latency must not be negative.')).not.toBeInTheDocument();
+    });
+  });
+
+  it('only displays download, upload, and latency fields with throttling is on', () => {
+    const { getByLabelText, getByTestId } = render(<WrappedComponent />);
+
+    const enableSwitch = getByTestId('syntheticsBrowserIsThrottlingEnabled');
+    const downloadSpeed = getByLabelText('Download Speed');
+    const uploadSpeed = getByLabelText('Upload Speed');
+    const latency = getByLabelText('Latency');
+
+    expect(downloadSpeed).toBeInTheDocument();
+    expect(uploadSpeed).toBeInTheDocument();
+    expect(latency).toBeInTheDocument();
+
+    userEvent.click(enableSwitch);
+
+    expect(downloadSpeed).not.toBeInTheDocument();
+    expect(uploadSpeed).not.toBeInTheDocument();
+    expect(latency).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/browser/throttling_fields.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiDescribedFormGroup,
+  EuiSwitch,
+  EuiSpacer,
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiText,
+} from '@elastic/eui';
+
+import { OptionalLabel } from '../optional_label';
+import { useBrowserAdvancedFieldsContext } from '../contexts';
+import { Validation, ConfigKeys } from '../types';
+
+interface Props {
+  validate: Validation;
+}
+
+type ThrottlingConfigs =
+  | ConfigKeys.IS_THROTTLING_ENABLED
+  | ConfigKeys.DOWNLOAD_SPEED
+  | ConfigKeys.UPLOAD_SPEED
+  | ConfigKeys.LATENCY;
+
+export const ThrottlingFields = memo<Props>(({ validate }) => {
+  const { fields, setFields } = useBrowserAdvancedFieldsContext();
+
+  const handleInputChange = useCallback(
+    ({ value, configKey }: { value: unknown; configKey: ThrottlingConfigs }) => {
+      setFields((prevFields) => ({ ...prevFields, [configKey]: value }));
+    },
+    [setFields]
+  );
+
+  const throttlingInputs = fields[ConfigKeys.IS_THROTTLING_ENABLED] ? (
+    <>
+      <EuiSpacer size="m" />
+      <EuiFormRow
+        label={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.label"
+            defaultMessage="Download Speed"
+          />
+        }
+        labelAppend={<OptionalLabel />}
+        isInvalid={!!validate[ConfigKeys.DOWNLOAD_SPEED]?.(fields)}
+        error={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.download.error"
+            defaultMessage="Download speed must be greater than zero."
+          />
+        }
+      >
+        <EuiFieldNumber
+          min={0}
+          step={0.001}
+          value={fields[ConfigKeys.DOWNLOAD_SPEED]}
+          onChange={(event) => {
+            handleInputChange({
+              value: event.target.value,
+              configKey: ConfigKeys.DOWNLOAD_SPEED,
+            });
+          }}
+          data-test-subj="syntheticsBrowserDownloadSpeed"
+          append={
+            <EuiText size="xs">
+              <strong>Mbps</strong>
+            </EuiText>
+          }
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.label"
+            defaultMessage="Upload Speed"
+          />
+        }
+        labelAppend={<OptionalLabel />}
+        isInvalid={!!validate[ConfigKeys.UPLOAD_SPEED]?.(fields)}
+        error={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.upload.error"
+            defaultMessage="Upload speed must be greater than zero."
+          />
+        }
+      >
+        <EuiFieldNumber
+          min={0}
+          step={0.001}
+          value={fields[ConfigKeys.UPLOAD_SPEED]}
+          onChange={(event) =>
+            handleInputChange({
+              value: event.target.value,
+              configKey: ConfigKeys.UPLOAD_SPEED,
+            })
+          }
+          data-test-subj="syntheticsBrowserUploadSpeed"
+          append={
+            <EuiText size="xs">
+              <strong>Mbps</strong>
+            </EuiText>
+          }
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.label"
+            defaultMessage="Latency"
+          />
+        }
+        labelAppend={<OptionalLabel />}
+        isInvalid={!!validate[ConfigKeys.LATENCY]?.(fields)}
+        data-test-subj="syntheticsBrowserLatency"
+        error={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.latency.error"
+            defaultMessage="Latency must not be negative."
+          />
+        }
+      >
+        <EuiFieldNumber
+          min={0}
+          value={fields[ConfigKeys.LATENCY]}
+          onChange={(event) =>
+            handleInputChange({
+              value: event.target.value,
+              configKey: ConfigKeys.LATENCY,
+            })
+          }
+          append={
+            <EuiText size="xs">
+              <strong>ms</strong>
+            </EuiText>
+          }
+        />
+      </EuiFormRow>
+    </>
+  ) : null;
+
+  return (
+    <EuiDescribedFormGroup
+      title={
+        <h4>
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.title"
+            defaultMessage="Throttling options"
+          />
+        </h4>
+      }
+      description={
+        <FormattedMessage
+          id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.description"
+          defaultMessage="Control the monitor's download and upload speeds, and its latency to simulate your application's behaviour on slower or laggier networks."
+        />
+      }
+    >
+      <EuiSwitch
+        id={'uptimeFleetIsThrottlingEnabled'}
+        aria-label="enable throttling configuration"
+        data-test-subj="syntheticsBrowserIsThrottlingEnabled"
+        checked={fields[ConfigKeys.IS_THROTTLING_ENABLED]}
+        label={
+          <FormattedMessage
+            id="xpack.uptime.createPackagePolicy.stepConfigure.browserAdvancedSettings.throttling.switch.description"
+            defaultMessage="Enable throttling"
+          />
+        }
+        onChange={(event) =>
+          handleInputChange({
+            value: event.target.checked,
+            configKey: ConfigKeys.IS_THROTTLING_ENABLED,
+          })
+        }
+      />
+      {throttlingInputs}
+    </EuiDescribedFormGroup>
+  );
+});

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context_advanced.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context_advanced.tsx
@@ -25,6 +25,10 @@ export const initialValues: IBrowserAdvancedFields = {
   [ConfigKeys.JOURNEY_FILTERS_MATCH]: '',
   [ConfigKeys.JOURNEY_FILTERS_TAGS]: [],
   [ConfigKeys.IGNORE_HTTPS_ERRORS]: false,
+  [ConfigKeys.DOWNLOAD_SPEED]: '5',
+  [ConfigKeys.UPLOAD_SPEED]: '3',
+  [ConfigKeys.LATENCY]: '20',
+  [ConfigKeys.THROTTLING_CONFIG]: '5d/3u/20l',
 };
 
 const defaultContext: IBrowserAdvancedFieldsContext = {

--- a/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context_advanced.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/contexts/browser_context_advanced.tsx
@@ -25,6 +25,7 @@ export const initialValues: IBrowserAdvancedFields = {
   [ConfigKeys.JOURNEY_FILTERS_MATCH]: '',
   [ConfigKeys.JOURNEY_FILTERS_TAGS]: [],
   [ConfigKeys.IGNORE_HTTPS_ERRORS]: false,
+  [ConfigKeys.IS_THROTTLING_ENABLED]: true,
   [ConfigKeys.DOWNLOAD_SPEED]: '5',
   [ConfigKeys.UPLOAD_SPEED]: '3',
   [ConfigKeys.LATENCY]: '20',

--- a/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.test.tsx
@@ -181,7 +181,7 @@ describe('<CustomFields />', () => {
   });
 
   it('handles switching monitor type', () => {
-    const { getByText, getByLabelText, queryByLabelText, getAllByLabelText } = render(
+    const { getByText, queryByText, getByLabelText, queryByLabelText, getAllByLabelText } = render(
       <WrappedComponent />
     );
     const monitorType = getByLabelText('Monitor Type') as HTMLInputElement;
@@ -200,7 +200,11 @@ describe('<CustomFields />', () => {
     expect(queryByLabelText('Max redirects')).not.toBeInTheDocument();
 
     // expect tls options to be available for TCP
-    expect(queryByLabelText('Enable TLS configuration')).toBeInTheDocument();
+    // here we must getByText because EUI will generate duplicate aria-labelledby
+    // values within the test-env generator used, and that will conflict with other
+    // automatically generated labels. See:
+    // https://github.com/elastic/eui/blob/91b416dcd51e116edb2cb4a2cac4c306512e28c7/src/services/accessibility/html_id_generator.testenv.ts#L12
+    expect(queryByText(/Enable TLS configuration/)).toBeInTheDocument();
 
     // ensure at least one tcp advanced option is present
     let advancedOptionsButton = getByText('Advanced TCP options');
@@ -214,8 +218,8 @@ describe('<CustomFields />', () => {
     // expect ICMP fields to be in the DOM
     expect(getByLabelText('Wait in seconds')).toBeInTheDocument();
 
-    // expect tls options not be available for ICMP
-    expect(queryByLabelText('Enable TLS configuration')).not.toBeInTheDocument();
+    // expect tls options not to be available for ICMP
+    expect(queryByText(/Enable TLS configuration/)).not.toBeInTheDocument();
 
     // expect TCP fields not to be in the DOM
     expect(queryByLabelText('Proxy URL')).not.toBeInTheDocument();
@@ -234,7 +238,7 @@ describe('<CustomFields />', () => {
 
     // expect tls options to be available for browser
     expect(queryByLabelText('Proxy Zip URL')).toBeInTheDocument();
-    expect(queryByLabelText('Enable TLS configuration for Zip URL')).toBeInTheDocument();
+    expect(queryByText(/Enable TLS configuration for Zip URL/)).toBeInTheDocument();
 
     // ensure at least one browser advanced option is present
     advancedOptionsButton = getByText('Advanced Browser options');

--- a/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/custom_fields.tsx
@@ -195,7 +195,7 @@ export const CustomFields = memo<Props>(({ validate, dataStreams = [], children 
       <EuiSpacer size="m" />
       {isHTTP && <HTTPAdvancedFields validate={validate} />}
       {isTCP && <TCPAdvancedFields />}
-      {isBrowser && <BrowserAdvancedFields />}
+      {isBrowser && <BrowserAdvancedFields validate={validate} />}
     </EuiForm>
   );
 });

--- a/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_update_policy.test.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/hooks/use_update_policy.test.tsx
@@ -308,6 +308,22 @@ describe('useBarChartsHooks', () => {
               tags: {
                 type: 'yaml',
               },
+              'throttling.download_speed': {
+                type: 'text',
+                value: '""',
+              },
+              'throttling.upload_speed': {
+                type: 'text',
+                value: '""',
+              },
+              'throttling.latency': {
+                type: 'text',
+                value: '""',
+              },
+              'throttling.config': {
+                type: 'text',
+                value: '""',
+              },
             },
           },
         ],
@@ -599,6 +615,7 @@ describe('useBarChartsHooks', () => {
       validate,
       monitorType: DataStream.BROWSER,
     };
+
     const { result, rerender, waitFor } = renderHook((props) => useUpdatePolicy(props), {
       initialProps,
     });
@@ -619,6 +636,9 @@ describe('useBarChartsHooks', () => {
       [ConfigKeys.SOURCE_ZIP_PASSWORD]: 'password',
       [ConfigKeys.SCREENSHOTS]: 'off',
       [ConfigKeys.SYNTHETICS_ARGS]: ['args'],
+      [ConfigKeys.DOWNLOAD_SPEED]: '13',
+      [ConfigKeys.UPLOAD_SPEED]: '3',
+      [ConfigKeys.LATENCY]: '7',
     };
 
     rerender({
@@ -650,6 +670,11 @@ describe('useBarChartsHooks', () => {
         config[ConfigKeys.APM_SERVICE_NAME]
       );
       expect(vars?.[ConfigKeys.TIMEOUT].value).toEqual(`${config[ConfigKeys.TIMEOUT]}s`);
+      expect(vars?.[ConfigKeys.THROTTLING_CONFIG].value).toEqual(
+        `${config[ConfigKeys.DOWNLOAD_SPEED]}d/${config[ConfigKeys.UPLOAD_SPEED]}u/${
+          config[ConfigKeys.LATENCY]
+        }l`
+      );
 
       expect(onChange).toBeCalledWith({
         isValid: false,

--- a/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
@@ -115,6 +115,10 @@ export enum ConfigKeys {
   TLS_VERSION = 'ssl.supported_protocols',
   TAGS = 'tags',
   TIMEOUT = 'timeout',
+  THROTTLING_CONFIG = 'throttling.config',
+  DOWNLOAD_SPEED = 'throttling.download_speed',
+  UPLOAD_SPEED = 'throttling.upload_speed',
+  LATENCY = 'throttling.latency',
   URLS = 'urls',
   USERNAME = 'username',
   WAIT = 'wait',
@@ -217,6 +221,10 @@ export interface IBrowserAdvancedFields {
   [ConfigKeys.JOURNEY_FILTERS_MATCH]: string;
   [ConfigKeys.JOURNEY_FILTERS_TAGS]: string[];
   [ConfigKeys.IGNORE_HTTPS_ERRORS]: boolean;
+  [ConfigKeys.DOWNLOAD_SPEED]: string;
+  [ConfigKeys.UPLOAD_SPEED]: string;
+  [ConfigKeys.LATENCY]: string;
+  [ConfigKeys.THROTTLING_CONFIG]: string;
 }
 
 export type HTTPFields = IHTTPSimpleFields & IHTTPAdvancedFields & ITLSFields;

--- a/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
@@ -72,6 +72,12 @@ export enum ScreenshotOption {
   ONLY_ON_FAILURE = 'only-on-failure',
 }
 
+export enum ThrottlingSuffix {
+  DOWNLOAD = 'd',
+  UPLOAD = 'u',
+  LATENCY = 'l',
+}
+
 // values must match keys in the integration package
 export enum ConfigKeys {
   APM_SERVICE_NAME = 'service.name',
@@ -257,4 +263,15 @@ export const contentTypesToMode = {
   [ContentType.JSON]: Mode.JSON,
   [ContentType.TEXT]: Mode.PLAINTEXT,
   [ContentType.XML]: Mode.XML,
+};
+
+export type ThrottlingConfigKey =
+  | ConfigKeys.DOWNLOAD_SPEED
+  | ConfigKeys.UPLOAD_SPEED
+  | ConfigKeys.LATENCY;
+
+export const configKeyToThrottlingSuffix: Record<ThrottlingConfigKey, ThrottlingSuffix> = {
+  [ConfigKeys.DOWNLOAD_SPEED]: ThrottlingSuffix.DOWNLOAD,
+  [ConfigKeys.UPLOAD_SPEED]: ThrottlingSuffix.UPLOAD,
+  [ConfigKeys.LATENCY]: ThrottlingSuffix.LATENCY,
 };

--- a/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/types.tsx
@@ -116,6 +116,7 @@ export enum ConfigKeys {
   TAGS = 'tags',
   TIMEOUT = 'timeout',
   THROTTLING_CONFIG = 'throttling.config',
+  IS_THROTTLING_ENABLED = 'throttling.is_enabled',
   DOWNLOAD_SPEED = 'throttling.download_speed',
   UPLOAD_SPEED = 'throttling.upload_speed',
   LATENCY = 'throttling.latency',
@@ -221,6 +222,7 @@ export interface IBrowserAdvancedFields {
   [ConfigKeys.JOURNEY_FILTERS_MATCH]: string;
   [ConfigKeys.JOURNEY_FILTERS_TAGS]: string[];
   [ConfigKeys.IGNORE_HTTPS_ERRORS]: boolean;
+  [ConfigKeys.IS_THROTTLING_ENABLED]: boolean;
   [ConfigKeys.DOWNLOAD_SPEED]: string;
   [ConfigKeys.UPLOAD_SPEED]: string;
   [ConfigKeys.LATENCY]: string;

--- a/x-pack/plugins/uptime/public/components/fleet_package/validation.tsx
+++ b/x-pack/plugins/uptime/public/components/fleet_package/validation.tsx
@@ -113,6 +113,12 @@ const validateICMP: ValidationLibrary = {
   ...validateCommon,
 };
 
+const validateThrottleValue = (speed: string | undefined, allowZero?: boolean) => {
+  if (speed === undefined || speed === '') return false;
+  const throttleValue = parseFloat(speed);
+  return isNaN(throttleValue) || (allowZero ? throttleValue < 0 : throttleValue <= 0);
+};
+
 const validateBrowser: ValidationLibrary = {
   ...validateCommon,
   [ConfigKeys.SOURCE_ZIP_URL]: ({
@@ -123,6 +129,11 @@ const validateBrowser: ValidationLibrary = {
     [ConfigKeys.SOURCE_ZIP_URL]: zipUrl,
     [ConfigKeys.SOURCE_INLINE]: inlineScript,
   }) => !zipUrl && !inlineScript,
+  [ConfigKeys.DOWNLOAD_SPEED]: ({ [ConfigKeys.DOWNLOAD_SPEED]: downloadSpeed }) =>
+    validateThrottleValue(downloadSpeed),
+  [ConfigKeys.UPLOAD_SPEED]: ({ [ConfigKeys.UPLOAD_SPEED]: uploadSpeed }) =>
+    validateThrottleValue(uploadSpeed),
+  [ConfigKeys.LATENCY]: ({ [ConfigKeys.LATENCY]: latency }) => validateThrottleValue(latency, true),
 };
 
 export type ValidateDictionary = Record<DataStream, Validation>;

--- a/x-pack/plugins/uptime/public/components/monitor_management/formatters/browser.ts
+++ b/x-pack/plugins/uptime/public/components/monitor_management/formatters/browser.ts
@@ -26,6 +26,11 @@ export const browserFormatters: BrowserFormatMap = {
   [ConfigKeys.ZIP_URL_TLS_KEY]: null,
   [ConfigKeys.ZIP_URL_TLS_KEY_PASSPHRASE]: null,
   [ConfigKeys.ZIP_URL_TLS_VERIFICATION_MODE]: null,
+  [ConfigKeys.IS_THROTTLING_ENABLED]: null,
+  [ConfigKeys.THROTTLING_CONFIG]: null,
+  [ConfigKeys.DOWNLOAD_SPEED]: null,
+  [ConfigKeys.UPLOAD_SPEED]: null,
+  [ConfigKeys.LATENCY]: null,
   [ConfigKeys.ZIP_URL_TLS_VERSION]: (fields) =>
     arrayFormatter(fields[ConfigKeys.ZIP_URL_TLS_VERSION]),
   [ConfigKeys.JOURNEY_FILTERS_MATCH]: null,

--- a/x-pack/test/functional/apps/uptime/synthetics_integration.ts
+++ b/x-pack/test/functional/apps/uptime/synthetics_integration.ts
@@ -630,9 +630,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           username: 'username',
           password: 'password',
         });
+
         const advancedConfig = {
           screenshots: 'off',
           syntheticsArgs: '-ssBlocks',
+          downloadSpeed: '1337',
+          uploadSpeed: '1338',
+          latency: '1339',
         };
 
         await uptimePage.syntheticsIntegration.createBasicBrowserMonitorDetails(config);
@@ -665,6 +669,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
               'source.zip_url.password': config.password,
               params: JSON.parse(config.params),
               synthetics_args: [advancedConfig.syntheticsArgs],
+              'throttling.download_speed': advancedConfig.downloadSpeed,
+              'throttling.upload_speed': advancedConfig.uploadSpeed,
+              'throttling.latency': advancedConfig.latency,
+              'throttling.config': `${advancedConfig.downloadSpeed}d/${advancedConfig.uploadSpeed}u/${advancedConfig.latency}l`,
               __ui: {
                 is_tls_enabled: false,
                 is_zip_url_tls_enabled: false,

--- a/x-pack/test/functional/apps/uptime/synthetics_integration.ts
+++ b/x-pack/test/functional/apps/uptime/synthetics_integration.ts
@@ -634,6 +634,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const advancedConfig = {
           screenshots: 'off',
           syntheticsArgs: '-ssBlocks',
+          isThrottlingEnabled: true,
           downloadSpeed: '1337',
           uploadSpeed: '1338',
           latency: '1339',
@@ -669,10 +670,79 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
               'source.zip_url.password': config.password,
               params: JSON.parse(config.params),
               synthetics_args: [advancedConfig.syntheticsArgs],
+              'throttling.is_enabled': advancedConfig.isThrottlingEnabled,
               'throttling.download_speed': advancedConfig.downloadSpeed,
               'throttling.upload_speed': advancedConfig.uploadSpeed,
               'throttling.latency': advancedConfig.latency,
               'throttling.config': `${advancedConfig.downloadSpeed}d/${advancedConfig.uploadSpeed}u/${advancedConfig.latency}l`,
+              __ui: {
+                is_tls_enabled: false,
+                is_zip_url_tls_enabled: false,
+                script_source: {
+                  file_name: '',
+                  is_generated_script: false,
+                },
+              },
+            },
+          })
+        );
+      });
+
+      it('allows saving disabling throttling', async () => {
+        // This test ensures that updates made to the Synthetics Policy are carried all the way through
+        // to the generated Agent Policy that is dispatch down to the Elastic Agent.
+        const config = generateBrowserConfig({
+          zipUrl: 'http://test.zip',
+          params: JSON.stringify({ url: 'http://localhost:8080' }),
+          folder: 'folder',
+          username: 'username',
+          password: 'password',
+        });
+
+        const advancedConfig = {
+          screenshots: 'off',
+          syntheticsArgs: '-ssBlocks',
+          isThrottlingEnabled: false,
+          downloadSpeed: '1337',
+          uploadSpeed: '1338',
+          latency: '1339',
+        };
+
+        await uptimePage.syntheticsIntegration.createBasicBrowserMonitorDetails(config);
+        await uptimePage.syntheticsIntegration.configureBrowserAdvancedOptions(advancedConfig);
+        await uptimePage.syntheticsIntegration.confirmAndSave();
+
+        await uptimePage.syntheticsIntegration.isPolicyCreatedSuccessfully();
+
+        const [agentPolicy] = await uptimeService.syntheticsPackage.getAgentPolicyList();
+        const agentPolicyId = agentPolicy.id;
+        const agentFullPolicy = await uptimeService.syntheticsPackage.getFullAgentPolicy(
+          agentPolicyId
+        );
+
+        expect(getSyntheticsPolicy(agentFullPolicy)).to.eql(
+          generatePolicy({
+            agentFullPolicy,
+            version,
+            name: monitorName,
+            monitorType: 'browser',
+            config: {
+              screenshots: advancedConfig.screenshots,
+              schedule: '@every 3m',
+              timeout: '16s',
+              tags: [config.tags],
+              'service.name': config.apmServiceName,
+              'source.zip_url.url': config.zipUrl,
+              'source.zip_url.folder': config.folder,
+              'source.zip_url.username': config.username,
+              'source.zip_url.password': config.password,
+              params: JSON.parse(config.params),
+              synthetics_args: [advancedConfig.syntheticsArgs],
+              'throttling.is_enabled': advancedConfig.isThrottlingEnabled,
+              'throttling.download_speed': advancedConfig.downloadSpeed,
+              'throttling.upload_speed': advancedConfig.uploadSpeed,
+              'throttling.latency': advancedConfig.latency,
+              'throttling.config': 'false',
               __ui: {
                 is_tls_enabled: false,
                 is_zip_url_tls_enabled: false,

--- a/x-pack/test/functional/page_objects/synthetics_integration_page.ts
+++ b/x-pack/test/functional/page_objects/synthetics_integration_page.ts
@@ -115,6 +115,14 @@ export function SyntheticsIntegrationPageProvider({
     },
 
     /**
+     * Finds and returns the enable throttling checkbox
+     */
+    async findThrottleSwitch() {
+      await this.ensureIsOnPackagePage();
+      return await testSubjects.find('syntheticsBrowserIsThrottlingEnabled');
+    },
+
+    /**
      * Finds and returns the enable TLS checkbox
      */
     async findEnableTLSSwitch() {
@@ -428,22 +436,33 @@ export function SyntheticsIntegrationPageProvider({
     async configureBrowserAdvancedOptions({
       screenshots,
       syntheticsArgs,
+      isThrottlingEnabled,
       downloadSpeed,
       uploadSpeed,
       latency,
     }: {
       screenshots: string;
       syntheticsArgs: string;
+      isThrottlingEnabled: boolean;
       downloadSpeed: string;
       uploadSpeed: string;
       latency: string;
     }) {
       await testSubjects.click('syntheticsBrowserAdvancedFieldsAccordion');
+
+      const throttleSwitch = await this.findThrottleSwitch();
+      if ((await throttleSwitch.isSelected()) !== isThrottlingEnabled) {
+        await throttleSwitch.click();
+      }
+
       await testSubjects.selectValue('syntheticsBrowserScreenshots', screenshots);
-      await this.fillTextInputByTestSubj('syntheticsBrowserDownloadSpeed', downloadSpeed);
-      await this.fillTextInputByTestSubj('syntheticsBrowserUploadSpeed', uploadSpeed);
-      await this.fillTextInputByTestSubj('syntheticsBrowserLatency', latency);
       await this.setComboBox('syntheticsBrowserSyntheticsArgs', syntheticsArgs);
+
+      if (isThrottlingEnabled) {
+        await this.fillTextInputByTestSubj('syntheticsBrowserDownloadSpeed', downloadSpeed);
+        await this.fillTextInputByTestSubj('syntheticsBrowserUploadSpeed', uploadSpeed);
+        await this.fillTextInputByTestSubj('syntheticsBrowserLatency', latency);
+      }
     },
   };
 }

--- a/x-pack/test/functional/page_objects/synthetics_integration_page.ts
+++ b/x-pack/test/functional/page_objects/synthetics_integration_page.ts
@@ -425,9 +425,24 @@ export function SyntheticsIntegrationPageProvider({
      * @params name {string} the name of the monitor
      * @params zipUrl {string} the zip url of the synthetics suites
      */
-    async configureBrowserAdvancedOptions({ screenshots, syntheticsArgs }: Record<string, string>) {
+    async configureBrowserAdvancedOptions({
+      screenshots,
+      syntheticsArgs,
+      downloadSpeed,
+      uploadSpeed,
+      latency,
+    }: {
+      screenshots: string;
+      syntheticsArgs: string;
+      downloadSpeed: string;
+      uploadSpeed: string;
+      latency: string;
+    }) {
       await testSubjects.click('syntheticsBrowserAdvancedFieldsAccordion');
       await testSubjects.selectValue('syntheticsBrowserScreenshots', screenshots);
+      await this.fillTextInputByTestSubj('syntheticsBrowserDownloadSpeed', downloadSpeed);
+      await this.fillTextInputByTestSubj('syntheticsBrowserUploadSpeed', uploadSpeed);
+      await this.fillTextInputByTestSubj('syntheticsBrowserLatency', latency);
       await this.setComboBox('syntheticsBrowserSyntheticsArgs', syntheticsArgs);
     },
   };


### PR DESCRIPTION
## Summary

> ⚠️ This PR depends on the integration in elastic/integrations#2161 for its functional tests to pass on CI. Please merge that PR first.

This PR closes elastic/kibana#114155 by adding throttling parameters to the Fleet UI. These parameters are: `download`, `upload`, and `latency`. Furthermore, there's a field which isn't shown called `throttling.config`, which will merge the formatted `download`, `upload`, and `latency` values into one configuration parameter to be passed to the Synthetics runner.

![throttle_toggle](https://user-images.githubusercontent.com/6868147/143488004-7bd83b33-28e5-4d8c-abfb-3beee3783401.gif)

It includes:
* Validating that `download` and `upload` fields are greater than zero (when filled).
* Validating that `latency` is equal to or greater than zero (when filled).


## How to test this PR

**⚠️ NOTE: You'll need to install the `synthetics` integration version in elastic/integrations#2161 to be able to test this. To do so, you can use `elastic-package` to `build` it, and `install` it, as per [the instructions on their repo](https://github.com/elastic/elastic-package).**

This PR is somewhat tricky to test because you'll need to measure the network speed accurately on the agent itself. Therefore, you'll have to access websites which measure network speed, and for, latency, you'll have to use the [`NetworkInformation` API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation) to obtain the `rtt` (round-trip-time).

### Test Case 1 - Download and Upload Speeds:

1. Setup an Elastic Stack which has an Elastic Agent complete enrolled to a policy so that you can run browser monitors
2. Create a new browser monitor which will access `fast.com` and run the speed tests there. Make sure to give at least 30 seconds to run, and set its interval to 45 seconds. For that monitor, you can use the following inline script:
    ```js
    step("load homepage", async () => {
        await page.goto('https://www.fast.com');
    });
    
    step("wait for test", async () => {
      await page.waitForSelector('#show-more-details-link');
      await page.waitForTimeout(10000);
      await page.click("#show-more-details-link");
    });
    
    step("wait for up/lat", async () => {
      await page.waitForSelector(".extra-measurement-value-container.succeeded");
      await page.waitForTimeout(10000);
    });
    ```
    **Before saving the monitor, set the download and upload speeds to values which are smaller than your own upload/download speed, so that you can actually see the capped values in your test.**
3. Access Uptime > Monitors and go to your monitor's details.
4. Verify the monitor's screenshots to confirm that the download and upload speeds match your configured Latency value.
    ![Speed](https://user-images.githubusercontent.com/6868147/142046615-2d8eab21-1744-4e67-aa07-41466ad0756b.png)


### Test Case 2 - Latency:

1. Create a new folder which contains an `index.html` document with the following content:
    ```html
    <!DOCTYPE html>
    <html lang="en">
    <head>
        <meta charset="UTF-8">
        <title>Page Test</title>
    </head>
    <body>

        <h1>RTT: <span id="rtt-value">None</span></h1>

        <script type="application/javascript">
            const update = (id, val ) => document.getElementById(id).innerHTML = val

            const logNetworkInfo = () =>  {
                update('rtt-value', navigator.connection.rtt);
            }

            navigator.connection.addEventListener('change', logNetworkInfo);
            logNetworkInfo();
        </script>
    </body>
    </html>
    ```
2. Serve that `index.html` through a simple HTTP server using `npx http-server ./example_folder` (where `example_folder` is the folder with the `index.html` file from the previous step).
3. Setup an Elastic Stack which has an Elastic Agent complete enrolled to a policy so that you can run browser monitors
4. Create a new browser monitor which will access `host.docker.internal:8081` (that's the name Docker resolves to your `localhost`) so that you can see your `RTT` measurement.
    ```js
    step("load homepage", async () => {
        await page.goto('http://host.docker.internal:8081');
    });

    step("wait for test", async () => {
      await page.waitForTimeout(2000);
    });
    ```
    On that monitor **set the `Latency` field to the value you want to test** (I'd recommend `0`, `250` and `500`).
5. Access Uptime > Monitors and go to your monitor's details.
6. Verify the monitor's screenshots to confirm that RTT matches your configured Latency value.
    **NOTE**: The `rtt` property in the `NetworkInformation` API will round values to the nearest multiple of 25ms, as described [here](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/rtt), so I recommend testing it with values like `0`, `250`, and `500` to see if the value displayed does mach the configured Latency on a 25-50ms range.
    ![rtt](https://user-images.githubusercontent.com/6868147/142046554-ab54479a-9104-4d6e-9cd3-4cf31f841b2c.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials - @dominiqueclarke is there any docs to update in this case? I couldn't find any relevant docs to update and didn't see any on [a similar PR you've done before](https://github.com/elastic/kibana/pull/112454/files).
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

| Risk                                                                          | Probability | Severity | Mitigation/Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
|-------------------------------------------------------------------------------|-------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| The handling of default values changes in the underlying `synthetics` module. | Low         | Medium   | Currently, the underlying `synthetics` module takes a single value with `/` separated fields for each of the throttling values. When one of the fields is not present, it uses default values for it. If we change the formatting of that flag's value or the behaviour of empty values, we will alter the behaviour of the throttling feature. To mitigate this, we should add tests for those flags, or separate them into multiple flags when running the underlying `synthetics` module. **Input on this would be appreciated**. |


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Release Note

Allows users to set Download Speed, Upload Speed, and Latency for their synthetic monitors.