### PR TITLE
[Alerting][POC] Static context variables available in active and recovery context

### DIFF
--- a/x-pack/plugins/alerting/common/alert_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_instance.ts
@@ -30,5 +30,6 @@ export type AlertInstanceContext = t.TypeOf<typeof contextSchema>;
 export const rawAlertInstance = t.partial({
   state: stateSchema,
   meta: metaSchema,
+  staticContext: t.record(t.string, t.unknown),
 });
 export type RawAlertInstance = t.TypeOf<typeof rawAlertInstance>;

--- a/x-pack/plugins/alerting/common/alert_task_instance.ts
+++ b/x-pack/plugins/alerting/common/alert_task_instance.ts
@@ -12,6 +12,7 @@ import { DateFromString } from './date_from_string';
 export const alertStateSchema = t.partial({
   alertTypeState: t.record(t.string, t.unknown),
   alertInstances: t.record(t.string, rawAlertInstance),
+  alertStaticContext: t.record(t.string, t.unknown),
   previousStartedAt: t.union([t.null, DateFromString]),
 });
 

--- a/x-pack/plugins/alerting/server/alert_instance/alert_instance.ts
+++ b/x-pack/plugins/alerting/server/alert_instance/alert_instance.ts
@@ -33,7 +33,11 @@ export type PublicAlertInstance<
   ActionGroupIds extends string = DefaultActionGroupId
 > = Pick<
   AlertInstance<State, Context, ActionGroupIds>,
-  'getState' | 'replaceState' | 'scheduleActions' | 'scheduleActionsWithSubGroup'
+  | 'getState'
+  | 'replaceState'
+  | 'scheduleActions'
+  | 'scheduleActionsWithSubGroup'
+  | 'setStaticContext'
 >;
 
 export class AlertInstance<
@@ -44,10 +48,12 @@ export class AlertInstance<
   private scheduledExecutionOptions?: ScheduledExecutionOptions<State, Context, ActionGroupIds>;
   private meta: AlertInstanceMeta;
   private state: State;
+  private staticContext: Record<string, unknown>;
 
-  constructor({ state, meta = {} }: RawAlertInstance = {}) {
+  constructor({ state, meta = {}, staticContext = {} }: RawAlertInstance = {}) {
     this.state = (state || {}) as State;
     this.meta = meta;
+    this.staticContext = (staticContext || {}) as Record<string, unknown>;
   }
 
   hasScheduledActions() {
@@ -170,6 +176,15 @@ export class AlertInstance<
     return this;
   }
 
+  setStaticContext(metadata: Record<string, unknown>) {
+    this.staticContext = metadata;
+    return this;
+  }
+
+  getStaticContext() {
+    return this.staticContext;
+  }
+
   updateLastScheduledActions(group: ActionGroupIds, subgroup?: string) {
     this.meta.lastScheduledActions = { group, subgroup, date: new Date() };
   }
@@ -185,6 +200,7 @@ export class AlertInstance<
     return {
       state: this.state,
       meta: this.meta,
+      staticContext: this.staticContext,
     };
   }
 }

--- a/x-pack/plugins/alerting/server/alert_instance/create_alert_instance_factory.ts
+++ b/x-pack/plugins/alerting/server/alert_instance/create_alert_instance_factory.ts
@@ -13,9 +13,17 @@ export function createAlertInstanceFactory<
   InstanceContext extends AlertInstanceContext,
   ActionGroupIds extends string
 >(alertInstances: Record<string, AlertInstance<InstanceState, InstanceContext, ActionGroupIds>>) {
-  return (id: string): AlertInstance<InstanceState, InstanceContext, ActionGroupIds> => {
+  return (
+    id: string,
+    staticContext: Record<string, unknown>
+  ): AlertInstance<InstanceState, InstanceContext, ActionGroupIds> => {
     if (!alertInstances[id]) {
       alertInstances[id] = new AlertInstance<InstanceState, InstanceContext, ActionGroupIds>();
+      alertInstances[id].setStaticContext(staticContext ?? {});
+    } else {
+      // Merge existing static context with any new contexts
+      const currentStaticContext = alertInstances[id].getStaticContext();
+      alertInstances[id].setStaticContext({ ...currentStaticContext, ...staticContext });
     }
 
     return alertInstances[id];

--- a/x-pack/plugins/alerting/server/rule_type_registry.ts
+++ b/x-pack/plugins/alerting/server/rule_type_registry.ts
@@ -361,6 +361,7 @@ function normalizedActionVariables(actionVariables: AlertType['actionVariables']
     context: actionVariables?.context ?? [],
     state: actionVariables?.state ?? [],
     params: actionVariables?.params ?? [],
+    staticContext: actionVariables?.staticContext ?? [],
   };
 }
 

--- a/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
+++ b/x-pack/plugins/alerting/server/task_runner/create_execution_handler.ts
@@ -65,6 +65,7 @@ interface ExecutionHandlerOptions<ActionGroupIds extends string> {
   alertInstanceId: string;
   context: AlertInstanceContext;
   state: AlertInstanceState;
+  staticContext: Record<string, unknown>;
 }
 
 export type ExecutionHandler<ActionGroupIds extends string> = (
@@ -113,6 +114,7 @@ export function createExecutionHandler<
     context,
     state,
     alertInstanceId,
+    staticContext,
   }: ExecutionHandlerOptions<ActionGroupIds | RecoveryActionGroupId>) => {
     if (!alertTypeActionGroups.has(actionGroup)) {
       logger.error(`Invalid action group "${actionGroup}" for alert "${alertType.id}".`);
@@ -141,6 +143,7 @@ export function createExecutionHandler<
             state,
             kibanaBaseUrl,
             alertParams,
+            staticContext,
           }),
         };
       })

--- a/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
+++ b/x-pack/plugins/alerting/server/task_runner/transform_action_params.ts
@@ -31,6 +31,7 @@ interface TransformActionParamsOptions {
   state: AlertInstanceState;
   kibanaBaseUrl?: string;
   context: AlertInstanceContext;
+  staticContext: Record<string, unknown>;
 }
 
 export function transformActionParams({
@@ -51,6 +52,7 @@ export function transformActionParams({
   state,
   kibanaBaseUrl,
   alertParams,
+  staticContext,
 }: TransformActionParamsOptions): AlertActionParams {
   // when the list of variables we pass in here changes,
   // the UI will need to be updated as well; see:
@@ -69,6 +71,7 @@ export function transformActionParams({
     state,
     kibanaBaseUrl,
     params: alertParams,
+    staticContext,
     rule: {
       id: alertId,
       name: alertName,

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -73,7 +73,8 @@ export interface AlertServices<
   ActionGroupIds extends string = never
 > extends Services {
   alertInstanceFactory: (
-    id: string
+    id: string,
+    staticContext: Record<string, unknown>
   ) => PublicAlertInstance<InstanceState, InstanceContext, ActionGroupIds>;
 }
 
@@ -150,6 +151,7 @@ export interface AlertType<
     context?: ActionVariable[];
     state?: ActionVariable[];
     params?: ActionVariable[];
+    staticContext?: ActionVariable[];
   };
   minimumLicenseRequired: LicenseType;
   useSavedObjectReferences?: {

--- a/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts
+++ b/x-pack/plugins/stack_alerts/server/alert_types/index_threshold/alert_type.ts
@@ -123,6 +123,10 @@ export function getAlertType(
         { name: 'thresholdComparator', description: actionVariableContextThresholdComparatorLabel },
         ...alertParamsVariables,
       ],
+      staticContext: [
+        { name: 'something', description: 'something about this alert' },
+        { name: 'this', description: 'something else about this alert' },
+      ],
     },
     minimumLicenseRequired: 'basic',
     isExportable: true,
@@ -207,7 +211,10 @@ export function getAlertType(
         conditions: humanFn,
       };
       const actionContext = addMessages(options, baseContext, params);
-      const alertInstance = options.services.alertInstanceFactory(instanceId);
+      const alertInstance = options.services.alertInstanceFactory(instanceId, {
+        something: `foo-${instanceId}`,
+        this: `bar-${instanceId}`,
+      });
       alertInstance.scheduleActions(ActionGroupId, actionContext);
       logger.debug(`scheduled actionGroup: ${JSON.stringify(actionContext)}`);
     }

--- a/x-pack/plugins/triggers_actions_ui/public/application/lib/action_variables.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/lib/action_variables.ts
@@ -17,8 +17,9 @@ export function transformActionVariables(actionVariables: ActionVariables): Acti
     : [];
   const paramsVars = prefixKeys(actionVariables.params, 'params.');
   const stateVars = prefixKeys(actionVariables.state, 'state.');
+  const staticContextVars = prefixKeys(actionVariables.staticContext, 'staticContext.');
 
-  return alwaysProvidedVars.concat(contextVars, paramsVars, stateVars);
+  return alwaysProvidedVars.concat(contextVars, paramsVars, stateVars, staticContextVars);
 }
 
 export enum AlertProvidedActionVariables {

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -189,7 +189,7 @@ export type ActionConnectorTableItem = ActionConnector & {
 type AsActionVariables<Keys extends string> = {
   [Req in Keys]: ActionVariable[];
 };
-export const REQUIRED_ACTION_VARIABLES = ['state', 'params'] as const;
+export const REQUIRED_ACTION_VARIABLES = ['state', 'params', 'staticContext'] as const;
 export const OPTIONAL_ACTION_VARIABLES = ['context'] as const;
 export type ActionVariables = AsActionVariables<typeof REQUIRED_ACTION_VARIABLES[number]> &
   Partial<AsActionVariables<typeof OPTIONAL_ACTION_VARIABLES[number]>>;


### PR DESCRIPTION
With this POC, we are identifying a new group of context variables (`staticContext`) that are serialized in the alerting task manager document and remain with the rule as long as it stays enabled.

This static context is populated when an alert is created via the alert instance factory. If the alert already exists (for alerts active across rule executions), the existing static context is merged with the new static context, so these contexts can be updated with each rule execution, if desired. If an alert recovers during execution, its static context will be read from the serialized context from the previous execution and serialized again (this might not be necessary since an alert can only recover once??).