### PR TITLE
[build/docker] Replace CentOS base image with AlmaLinux

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -20,7 +20,7 @@ if [[ "${GITHUB_PR_LABELS:-}" == *"ci:deploy-cloud"* ]]; then
     --skip-archives \
     --docker-images \
     --skip-docker-ubi \
-    --skip-docker-centos \
+    --skip-docker-alma \
     --skip-docker-contexts
 fi
 

--- a/src/dev/build/args.test.ts
+++ b/src/dev/build/args.test.ts
@@ -28,7 +28,7 @@ it('build default and oss dist for current platform, without packages, by defaul
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": false,
-        "createDockerCentOS": false,
+        "createDockerAlmaLinux": false,
         "createDockerCloud": false,
         "createDockerContexts": true,
         "createDockerUBI": false,
@@ -56,7 +56,7 @@ it('builds packages if --all-platforms is passed', () => {
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": true,
-        "createDockerCentOS": true,
+        "createDockerAlmaLinux": true,
         "createDockerCloud": true,
         "createDockerContexts": true,
         "createDockerUBI": true,
@@ -84,7 +84,7 @@ it('limits packages if --rpm passed with --all-platforms', () => {
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": false,
-        "createDockerCentOS": false,
+        "createDockerAlmaLinux": false,
         "createDockerCloud": false,
         "createDockerContexts": true,
         "createDockerUBI": false,
@@ -112,7 +112,7 @@ it('limits packages if --deb passed with --all-platforms', () => {
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": true,
-        "createDockerCentOS": false,
+        "createDockerAlmaLinux": false,
         "createDockerCloud": false,
         "createDockerContexts": true,
         "createDockerUBI": false,
@@ -141,7 +141,7 @@ it('limits packages if --docker passed with --all-platforms', () => {
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": false,
-        "createDockerCentOS": true,
+        "createDockerAlmaLinux": true,
         "createDockerCloud": true,
         "createDockerContexts": true,
         "createDockerUBI": true,
@@ -177,7 +177,7 @@ it('limits packages if --docker passed with --skip-docker-ubi and --all-platform
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": false,
-        "createDockerCentOS": true,
+        "createDockerAlmaLinux": true,
         "createDockerCloud": true,
         "createDockerContexts": true,
         "createDockerUBI": false,
@@ -199,14 +199,14 @@ it('limits packages if --docker passed with --skip-docker-ubi and --all-platform
   `);
 });
 
-it('limits packages if --all-platforms passed with --skip-docker-centos', () => {
-  expect(readCliArgs(['node', 'scripts/build', '--all-platforms', '--skip-docker-centos']))
+it('limits packages if --all-platforms passed with --skip-docker-almalinux', () => {
+  expect(readCliArgs(['node', 'scripts/build', '--all-platforms', '--skip-docker-almalinux']))
     .toMatchInlineSnapshot(`
     Object {
       "buildOptions": Object {
         "createArchives": true,
         "createDebPackage": true,
-        "createDockerCentOS": false,
+        "createDockerAlmaLinux": false,
         "createDockerCloud": true,
         "createDockerContexts": true,
         "createDockerUBI": true,

--- a/src/dev/build/args.ts
+++ b/src/dev/build/args.ts
@@ -25,7 +25,7 @@ export function readCliArgs(argv: string[]) {
       'docker-images',
       'skip-docker-contexts',
       'skip-docker-ubi',
-      'skip-docker-centos',
+      'skip-docker-almalinux',
       'skip-docker-cloud',
       'release',
       'skip-node-download',
@@ -104,8 +104,8 @@ export function readCliArgs(argv: string[]) {
     createExamplePlugins: Boolean(flags['example-plugins']),
     createRpmPackage: isOsPackageDesired('rpm'),
     createDebPackage: isOsPackageDesired('deb'),
-    createDockerCentOS:
-      isOsPackageDesired('docker-images') && !Boolean(flags['skip-docker-centos']),
+    createDockerAlmaLinux:
+      isOsPackageDesired('docker-images') && !Boolean(flags['skip-docker-almalinux']),
     createDockerCloud: isOsPackageDesired('docker-images') && !Boolean(flags['skip-docker-cloud']),
     createDockerUBI: isOsPackageDesired('docker-images') && !Boolean(flags['skip-docker-ubi']),
     createDockerContexts: !Boolean(flags['skip-docker-contexts']),

--- a/src/dev/build/build_distributables.ts
+++ b/src/dev/build/build_distributables.ts
@@ -22,7 +22,7 @@ export interface BuildOptions {
   createRpmPackage: boolean;
   createDebPackage: boolean;
   createDockerUBI: boolean;
-  createDockerCentOS: boolean;
+  createDockerAlmaLinux: boolean;
   createDockerCloud: boolean;
   createDockerContexts: boolean;
   versionQualifier: string | undefined;
@@ -124,9 +124,9 @@ export async function buildDistributables(log: ToolingLog, options: BuildOptions
     await run(Tasks.CreateDockerUBI);
   }
 
-  if (options.createDockerCentOS) {
-    // control w/ --docker-images or --skip-docker-centos or --skip-os-packages
-    await run(Tasks.CreateDockerCentOS);
+  if (options.createDockerAlmaLinux) {
+    // control w/ --docker-images or --skip-docker-almalinux or --skip-os-packages
+    await run(Tasks.CreateDockerAlmaLinux);
   }
 
   if (options.createDockerCloud) {

--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -41,7 +41,7 @@ if (showHelp) {
         --docker-images         {dim Only build the Docker images}
         --docker-contexts       {dim Only build the Docker build contexts}
         --skip-docker-ubi       {dim Don't build the docker ubi image}
-        --skip-docker-centos    {dim Don't build the docker centos image}
+        --skip-docker-almalinux {dim Don't build the docker AlmaLinux image}
         --release               {dim Produce a release-ready distributable}
         --version-qualifier     {dim Suffix version with a qualifier}
         --skip-node-download    {dim Reuse existing downloads of node.js}

--- a/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
+++ b/src/dev/build/tasks/os_packages/create_os_package_tasks.ts
@@ -59,20 +59,22 @@ export const CreateRpmPackage: Task = {
 };
 
 const dockerBuildDate = new Date().toISOString();
-export const CreateDockerCentOS: Task = {
-  description: 'Creating Docker CentOS image',
+export const CreateDockerAlmaLinux: Task = {
+  description: 'Creating Docker AlmaLinux image',
 
   async run(config, log, build) {
     await runDockerGenerator(config, log, build, {
       architecture: 'x64',
       context: false,
       image: true,
+      almalinux: true,
       dockerBuildDate,
     });
     await runDockerGenerator(config, log, build, {
       architecture: 'aarch64',
       context: false,
       image: true,
+      almalinux: true,
       dockerBuildDate,
     });
   },
@@ -117,6 +119,7 @@ export const CreateDockerContexts: Task = {
     await runDockerGenerator(config, log, build, {
       context: true,
       image: false,
+      almalinux: true,
       dockerBuildDate,
     });
 

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -30,14 +30,17 @@ export async function runDockerGenerator(
     architecture?: string;
     context: boolean;
     image: boolean;
+    almalinux?: boolean;
     ubi?: boolean;
     ironbank?: boolean;
     cloud?: boolean;
     dockerBuildDate?: string;
   }
 ) {
-  // UBI var config
-  const baseOSImage = flags.ubi ? 'docker.elastic.co/ubi8/ubi-minimal:latest' : 'centos:8';
+  let baseOSImage = '';
+  if (flags.almalinux || flags.cloud) baseOSImage = 'almalinux:8.4-minimal';
+  if (flags.ubi) baseOSImage = 'docker.elastic.co/ubi8/ubi-minimal:latest';
+
   const ubiVersionTag = 'ubi8';
 
   let imageFlavor = '';
@@ -84,6 +87,7 @@ export async function runDockerGenerator(
     dockerTargetFilename,
     baseOSImage,
     dockerBuildDate,
+    almalinux: flags.almalinux,
     ubi: flags.ubi,
     cloud: flags.cloud,
     metricbeatTarball,

--- a/src/dev/build/tasks/os_packages/docker_generator/template_context.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/template_context.ts
@@ -20,6 +20,7 @@ export interface TemplateContext {
   baseOSImage: string;
   dockerBuildDate: string;
   usePublicArtifact?: boolean;
+  almalinux?: boolean;
   ubi?: boolean;
   cloud?: boolean;
   metricbeatTarball?: string;

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -11,9 +11,7 @@
 ################################################################################
 FROM {{{baseOSImage}}} AS builder
 
-{{#ubi}}
-RUN {{packageManager}} install -y findutils tar gzip
-{{/ubi}}
+RUN microdnf install -y findutils tar gzip
 
 {{#usePublicArtifact}}
 RUN cd /opt && \
@@ -54,16 +52,11 @@ RUN mkdir -p /opt/filebeat /opt/metricbeat && \
 FROM {{{baseOSImage}}}
 EXPOSE 5601
 
-{{#ubi}}
-  # https://github.com/rpm-software-management/microdnf/issues/50
-  RUN mkdir -p /run/user/$(id -u)
-{{/ubi}}
-
 RUN for iter in {1..10}; do \
-      {{packageManager}} update --setopt=tsflags=nodocs -y && \
-      {{packageManager}} install --setopt=tsflags=nodocs -y \
-        fontconfig freetype shadow-utils nss {{#ubi}}findutils{{/ubi}} && \
-      {{packageManager}} clean all && exit_code=0 && break || exit_code=$? && echo "{{packageManager}} error: retry $iter in 10s" && \
+      microdnf update --setopt=tsflags=nodocs -y && \
+      microdnf install --setopt=tsflags=nodocs -y \
+        fontconfig freetype shadow-utils nss findutils && \
+      microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && \
       sleep 10; \
     done; \
     (exit $exit_code)

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/dockerfile.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/dockerfile.template.ts
@@ -16,7 +16,6 @@ function generator(options: TemplateContext) {
   const dir = options.ironbank ? 'ironbank' : 'base';
   const template = readFileSync(resolve(__dirname, dir, './Dockerfile'));
   return Mustache.render(template.toString(), {
-    packageManager: options.ubi ? 'microdnf' : 'yum',
     ...options,
   });
 }


### PR DESCRIPTION
CentOS 8 maintenance will end at the end of the year.  This updates our
base docker image to use AlmaLinux.
