### PR TITLE
[Charts] Add rtl label support to elastic charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@elastic/apm-rum": "^5.9.1",
     "@elastic/apm-rum-react": "^1.3.1",
     "@elastic/apm-synthtrace": "link:bazel-bin/packages/elastic-apm-synthtrace",
-    "@elastic/charts": "39.0.0",
+    "@elastic/charts": "39.0.1",
     "@elastic/datemath": "link:bazel-bin/packages/elastic-datemath",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@^8.0.0-canary.35",
     "@elastic/ems-client": "8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,10 +2337,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@39.0.0":
-  version "39.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-39.0.0.tgz#85e615f550d03d8fb880bf44e891452b4341706b"
-  integrity sha512-EnmOXFAN5u9rkcwM4L2AksxoWpOpZRXbjX2HYAxgj8WcBb14zYoYeyENMQyG/qu2Rm6PnUni0dgy+mPOTEnGmw==
+"@elastic/charts@39.0.1":
+  version "39.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-39.0.1.tgz#7891d6efb3a12eb73fcb57d9a1f71565c22f4501"
+  integrity sha512-k64+vrfRkP7Gn8+T0Vtdev/DKpy6G+M9H6OFQcf1fgXAd7qOnTXVaN4Ru+BRTPylTFwxf9pqHraz8Ayi+3VpjA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"


### PR DESCRIPTION
## Summary

Adds support to elastic-charts to correctly render rtl language labels.

- There is no option to set, the canvas [`dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) is assigned based on the language direction of _most_ labels displayed on the chart.
- For mixed labels including some rtl and some ltr, we set the [`ctx.direction`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/direction) per label. This is not supported in firefox which will show mixed charts with poor alignment in _some_ cases. In the future we may switch to dom text labels to get around this.
- All values are treated as ltr.
- Applies to tick labels, partition link and partition fill labels.

https://user-images.githubusercontent.com/19007109/141839458-464dab9f-d864-408d-b333-996e4acfb4f5.mp4

Chart version contains only this fix, see [`39.0.1`](https://github.com/elastic/elastic-charts/releases/tag/v39.0.1).
