### PR TITLE
Raise emotion animation issue using hello world plugin as an example

### DIFF
--- a/examples/hello_world/public/components/EmotionAnimation/index.tsx
+++ b/examples/hello_world/public/components/EmotionAnimation/index.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { jsx, css, keyframes } from "@emotion/react";
+
+const xb = keyframes`
+  from, 20%, 53%, 80%, to {
+    transform: translate3d(0,0,0);
+  }
+
+  40%, 43% {
+    transform: translate3d(0, -30px, 0);
+  }
+
+  70% {
+    transform: translate3d(0, -15px, 0);
+  }
+
+  90% {
+    transform: translate3d(0,-4px,0);
+  }
+`;
+
+const styles = css({
+  fontSize: '20px',
+  color: 'red',
+  animation: `${xb} 250ms infinite`,
+});
+
+export const EmotionAnimation = () => {
+  return <div css={styles}>too</div>;
+};

--- a/examples/hello_world/public/plugin.tsx
+++ b/examples/hello_world/public/plugin.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppMountParameters, CoreSetup, CoreStart, Plugin } from '../../../src/core/public';
 import { DeveloperExamplesSetup } from '../../developer_examples/public';
+import { EmotionAnimation } from './components/EmotionAnimation';
 
 interface SetupDeps {
   developerExamples: DeveloperExamplesSetup;
@@ -21,7 +22,7 @@ export class HelloWorldPlugin implements Plugin<void, void, SetupDeps> {
       id: 'helloWorld',
       title: 'Hello World',
       async mount({ element }: AppMountParameters) {
-        ReactDOM.render(<div data-test-subj="helloWorldDiv">Hello World!</div>, element);
+        ReactDOM.render(<div data-test-subj="helloWorldDiv"><EmotionAnimation /></div>, element);
         return () => ReactDOM.unmountComponentAtNode(element);
       },
     });


### PR DESCRIPTION
emotion animation not working within changes in hello_world plugin (for testing).

![image](https://user-images.githubusercontent.com/16872649/141866913-4779bc28-1260-4382-88f6-fb105029fadb.png)

the rendered component has `animation` css property but the `animation-name` (animation-1x6uqa8) is not available in the DOM. The styled div class in the same component suggests that there might be some babel config conflicts between styled component and emotion