### PR TITLE
Fix cluster call responses that are missing source fields

### DIFF
--- a/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.test.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.test.ts
@@ -121,7 +121,7 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
       "calls": Array [
         Array [
           Object {
-            "_source": "true",
+            "_source": true,
             "index": "bar",
             "query": undefined,
             "rest_total_hits_as_int": true,
@@ -136,7 +136,7 @@ describe('esArchiver: createGenerateDocRecordsStream()', () => {
         ],
         Array [
           Object {
-            "_source": "true",
+            "_source": true,
             "index": "foo",
             "query": undefined,
             "rest_total_hits_as_int": true,

--- a/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/generate_doc_records_stream.ts
@@ -38,7 +38,7 @@ export function createGenerateDocRecordsStream({
             index,
             scroll: SCROLL_TIMEOUT,
             size: SCROLL_SIZE,
-            _source: 'true',
+            _source: true,
             query,
             rest_total_hits_as_int: true,
           },

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -1825,7 +1825,7 @@ export class SavedObjectsRepository {
       index: this.getIndexForType(type),
       refresh,
       require_alias: true,
-      _source: 'true',
+      _source: true,
       body: {
         script: {
           source: `


### PR DESCRIPTION
Resolves #118639.

Change usage from `_source: 'true'` to `_source: true`.

This is an unreleased regression that appears to have been caused by the recent upgrade of the `elasticsearch-js` client upgrade to the 8.0 version.

To test, you can:
* Use es-archiver to save an archive and verify that the documents contain source fields
* Add a console log message to the `incrementCounter` method of the saved objects repository and verify that the periodic calls to `incrementCounter` are getting a response that contains source fields