### PR TITLE
[8.0] [Observability] Fixes incorrect link from empty data message (#118450) (#118451)

### DIFF
--- a/x-pack/plugins/observability/public/utils/no_data_config.ts
+++ b/x-pack/plugins/observability/public/utils/no_data_config.ts
@@ -32,7 +32,7 @@ export function getNoDataConfig({
             defaultMessage:
               'Use Beats and APM agents to send observability data to Elasticsearch. We make it easy with support for many popular systems, apps, and languages.',
           }),
-          href: basePath.prepend(`/app/integrations`),
+          href: basePath.prepend(`/app/integrations/browse`),
         },
       },
       docsLink,


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Observability] Fixes incorrect link from empty data message (#118450) (#118451)