### PR TITLE
[7.16] [Reporting] Add log level to config (#118319)

### DIFF
--- a/x-pack/plugins/reporting/server/config/index.ts
+++ b/x-pack/plugins/reporting/server/config/index.ts
@@ -18,10 +18,10 @@ export const config: PluginConfigDescriptor<ReportingConfigType> = {
   exposeToBrowser: { poll: true, roles: true },
   schema: ConfigSchema,
   deprecations: ({ unused }) => [
-    unused('capture.browser.chromium.maxScreenshotDimension'), // unused since 7.8
-    unused('poll.jobCompletionNotifier.intervalErrorMultiplier'), // unused since 7.10
-    unused('poll.jobsRefresh.intervalErrorMultiplier'), // unused since 7.10
-    unused('capture.viewport'), // deprecated as unused since 7.16
+    unused('capture.browser.chromium.maxScreenshotDimension', { level: 'warning' }), // unused since 7.8
+    unused('poll.jobCompletionNotifier.intervalErrorMultiplier', { level: 'warning' }), // unused since 7.10
+    unused('poll.jobsRefresh.intervalErrorMultiplier', { level: 'warning' }), // unused since 7.10
+    unused('capture.viewport', { level: 'warning' }), // deprecated as unused since 7.16
     (settings, fromPath, addDeprecation) => {
       const reporting = get(settings, fromPath);
       if (reporting?.index) {


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Reporting] Add log level to config (#118319)