### PR TITLE
Fix flaky value suggestion tests

### DIFF
--- a/test/functional/services/query_bar.ts
+++ b/test/functional/services/query_bar.ts
@@ -76,8 +76,24 @@ export class QueryBarService extends FtrService {
     expect((await queryLanguageButton.getVisibleText()).toLowerCase()).to.eql(lang);
   }
 
-  public async getSuggestions() {
+  /**
+   * Returns the currently shown suggestions texts of the query bar. Since there is no loading
+   * indicator to wait for to validate if suggestion loading is done, this method is private
+   * and should not be used in tests. Instead {@link #expectSuggestions} should be used, which
+   * properly waits for the expected suggestions.
+   */
+  private async getSuggestions() {
     const suggestions = await this.testSubjects.findAll('autoCompleteSuggestionText');
     return Promise.all(suggestions.map((suggestion) => suggestion.getVisibleText()));
+  }
+
+  public async expectSuggestions({ count, contains }: { count: number; contains?: string }) {
+    await this.retry.try(async () => {
+      const suggestions = await this.getSuggestions();
+      expect(suggestions.length).to.be(count);
+      if (contains) {
+        expect(suggestions).to.contain(contains);
+      }
+    });
   }
 }

--- a/x-pack/test/functional/apps/discover/value_suggestions.ts
+++ b/x-pack/test/functional/apps/discover/value_suggestions.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { UI_SETTINGS } from '../../../../../src/plugins/data/common';
 
@@ -56,16 +55,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           );
 
           await queryBar.setQuery('extension.raw : ');
-          const suggestions = await queryBar.getSuggestions();
-          expect(suggestions.length).to.be(0);
+          await queryBar.expectSuggestions({ count: 0 });
         });
 
         it('show up if in range', async () => {
           await PageObjects.timePicker.setDefaultAbsoluteRange();
           await queryBar.setQuery('extension.raw : ');
-          const suggestions = await queryBar.getSuggestions();
-          expect(suggestions.length).to.be(5);
-          expect(suggestions).to.contain('"jpg"');
+          await queryBar.expectSuggestions({ count: 5, contains: '"jpg"' });
         });
       });
 
@@ -90,8 +86,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/116892
-    describe.skip('useTimeRange disabled', () => {
+    describe('useTimeRange disabled', () => {
       before(async () => {
         await setAutocompleteUseTimeRange(false);
       });
@@ -117,17 +112,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
 
         await queryBar.setQuery('extension.raw : ');
-        const suggestions = await queryBar.getSuggestions();
-        expect(suggestions.length).to.be(5);
-        expect(suggestions).to.contain('"jpg"');
+        await queryBar.expectSuggestions({ count: 5, contains: '"jpg"' });
       });
 
       it('show up', async () => {
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         await queryBar.setQuery('extension.raw : ');
-        const suggestions = await queryBar.getSuggestions();
-        expect(suggestions.length).to.be(5);
-        expect(suggestions).to.contain('"jpg"');
+        await queryBar.expectSuggestions({ count: 5, contains: '"jpg"' });
       });
     });
   });

--- a/x-pack/test/functional/apps/discover/value_suggestions_non_timebased.ts
+++ b/x-pack/test/functional/apps/discover/value_suggestions_non_timebased.ts
@@ -5,13 +5,11 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const queryBar = getService('queryBar');
-  const retry = getService('retry');
   const PageObjects = getPageObjects(['common', 'settings', 'context', 'header']);
 
   describe('value suggestions non time based', function describeIndexTests() {
@@ -30,12 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('shows all autosuggest options for a filter in discover context app', async () => {
       await PageObjects.common.navigateToApp('discover');
       await queryBar.setQuery('type.keyword : ');
-
-      await retry.try(async () => {
-        const suggestions = await queryBar.getSuggestions();
-        expect(suggestions.length).to.be(1);
-        expect(suggestions).to.contain('"apache"');
-      });
+      await queryBar.expectSuggestions({ count: 1, contains: '"apache"' });
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #117773 
Fixes #116892

Flaky Test Runs (150 times): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/221
↳ 3 out of 150 failed, all with different tests unrelated to this.

Loading the suggestions currently does have no loading indicator. Thus there is nothing to wait on for knowing when we can actually get the suggestions. This PR replaces the previous `getSuggestions` method by a `expectSuggestions` that will allow you to specify what you're looking for and retry till this is available. We've done the same fix previously inside one specific test, this PR now pulls it out into the service and makes the `getSuggestions` method private, so it won't be used inside tests anymore.

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- ~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~
