### PR TITLE
[Telemetry] revert to v2 endpoint

### DIFF
--- a/src/plugins/telemetry/common/constants.ts
+++ b/src/plugins/telemetry/common/constants.ts
@@ -35,7 +35,7 @@ export const PAYLOAD_CONTENT_ENCODING = 'aes256gcm';
 /**
  * The endpoint version when hitting the remote telemetry service
  */
-export const ENDPOINT_VERSION = 'v3';
+export const ENDPOINT_VERSION = 'v2';
 
 /**
  * The staging telemetry endpoint for the remote telemetry service.
@@ -53,6 +53,6 @@ export const ENDPOINT_PROD = 'https://telemetry.elastic.co/';
  * The telemetry channels for the remote telemetry service.
  */
 export const TELEMETRY_CHANNELS = {
-  SNAPSHOT_CHANNEL: 'kibana-snapshot',
-  OPT_IN_STATUS_CHANNEL: 'kibana-opt_in_status',
+  SNAPSHOT_CHANNEL: 'xpack',
+  OPT_IN_STATUS_CHANNEL: 'opt_in_status',
 };

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_channel_endpoint.test.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_channel_endpoint.test.ts
@@ -41,12 +41,12 @@ describe('getChannel', () => {
 
   it('returns correct snapshot channel name', () => {
     const channelName = getChannel('snapshot');
-    expect(channelName).toMatchInlineSnapshot(`"kibana-snapshot"`);
+    expect(channelName).toMatchInlineSnapshot(`"xpack"`);
   });
 
   it('returns correct optInStatus channel name', () => {
     const channelName = getChannel('optInStatus');
-    expect(channelName).toMatchInlineSnapshot(`"kibana-opt_in_status"`);
+    expect(channelName).toMatchInlineSnapshot(`"opt_in_status"`);
   });
 });
 
@@ -68,14 +68,12 @@ describe('getTelemetryChannelEndpoint', () => {
   describe('snapshot channel', () => {
     it('returns correct prod endpoint', () => {
       const endpoint = getTelemetryChannelEndpoint({ env: 'prod', channelName: 'snapshot' });
-      expect(endpoint).toMatchInlineSnapshot(
-        `"https://telemetry.elastic.co/v3/send/kibana-snapshot"`
-      );
+      expect(endpoint).toMatchInlineSnapshot(`"https://telemetry.elastic.co/xpack/v2/send"`);
     });
     it('returns correct staging endpoint', () => {
       const endpoint = getTelemetryChannelEndpoint({ env: 'staging', channelName: 'snapshot' });
       expect(endpoint).toMatchInlineSnapshot(
-        `"https://telemetry-staging.elastic.co/v3/send/kibana-snapshot"`
+        `"https://telemetry-staging.elastic.co/xpack/v2/send"`
       );
     });
   });
@@ -84,13 +82,13 @@ describe('getTelemetryChannelEndpoint', () => {
     it('returns correct prod endpoint', () => {
       const endpoint = getTelemetryChannelEndpoint({ env: 'prod', channelName: 'optInStatus' });
       expect(endpoint).toMatchInlineSnapshot(
-        `"https://telemetry.elastic.co/v3/send/kibana-opt_in_status"`
+        `"https://telemetry.elastic.co/opt_in_status/v2/send"`
       );
     });
     it('returns correct staging endpoint', () => {
       const endpoint = getTelemetryChannelEndpoint({ env: 'staging', channelName: 'optInStatus' });
       expect(endpoint).toMatchInlineSnapshot(
-        `"https://telemetry-staging.elastic.co/v3/send/kibana-opt_in_status"`
+        `"https://telemetry-staging.elastic.co/opt_in_status/v2/send"`
       );
     });
   });

--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_channel_endpoint.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_channel_endpoint.ts
@@ -49,5 +49,5 @@ export function getTelemetryChannelEndpoint({
   const baseUrl = getBaseUrl(env);
   const channelPath = getChannel(channelName);
 
-  return `${baseUrl}${ENDPOINT_VERSION}/send/${channelPath}`;
+  return `${baseUrl}${channelPath}/${ENDPOINT_VERSION}/send`;
 }

--- a/src/plugins/telemetry/public/services/telemetry_service.test.ts
+++ b/src/plugins/telemetry/public/services/telemetry_service.test.ts
@@ -143,7 +143,7 @@ describe('TelemetryService', () => {
       });
 
       expect(telemetryService.getTelemetryUrl()).toMatchInlineSnapshot(
-        `"https://telemetry-staging.elastic.co/v3/send/kibana-snapshot"`
+        `"https://telemetry-staging.elastic.co/xpack/v2/send"`
       );
     });
 
@@ -153,7 +153,7 @@ describe('TelemetryService', () => {
       });
 
       expect(telemetryService.getTelemetryUrl()).toMatchInlineSnapshot(
-        `"https://telemetry.elastic.co/v3/send/kibana-snapshot"`
+        `"https://telemetry.elastic.co/xpack/v2/send"`
       );
     });
   });
@@ -165,7 +165,7 @@ describe('TelemetryService', () => {
       });
 
       expect(telemetryService.getOptInStatusUrl()).toMatchInlineSnapshot(
-        `"https://telemetry-staging.elastic.co/v3/send/kibana-opt_in_status"`
+        `"https://telemetry-staging.elastic.co/opt_in_status/v2/send"`
       );
     });
 
@@ -175,7 +175,7 @@ describe('TelemetryService', () => {
       });
 
       expect(telemetryService.getOptInStatusUrl()).toMatchInlineSnapshot(
-        `"https://telemetry.elastic.co/v3/send/kibana-opt_in_status"`
+        `"https://telemetry.elastic.co/opt_in_status/v2/send"`
       );
     });
   });

--- a/src/plugins/telemetry/server/routes/telemetry_opt_in_stats.test.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_opt_in_stats.test.ts
@@ -40,7 +40,7 @@ describe('sendTelemetryOptInStatus', () => {
     expect(fetch).toBeCalledTimes(1);
     expect((fetch as jest.MockedFunction<typeof fetch>).mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "https://telemetry.elastic.co/v3/send/kibana-opt_in_status",
+        "https://telemetry.elastic.co/opt_in_status/v2/send",
         Object {
           "body": "mock_opt_in_hashed_value",
           "headers": Object {
@@ -71,7 +71,7 @@ describe('sendTelemetryOptInStatus', () => {
     expect(fetch).toBeCalledTimes(1);
     expect((fetch as jest.MockedFunction<typeof fetch>).mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "https://telemetry-staging.elastic.co/v3/send/kibana-opt_in_status",
+        "https://telemetry-staging.elastic.co/opt_in_status/v2/send",
         Object {
           "body": "mock_opt_in_hashed_value",
           "headers": Object {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/117923

7.16 PR: https://github.com/elastic/kibana/pull/118025


- [x] Tested locally to send to the staging v2 endpoint :+1: 