### PR TITLE
[8.0] Enforce "LogRecord.meta: LogMeta" type (#118334)

### DIFF
--- a/packages/kbn-logging/src/log_record.ts
+++ b/packages/kbn-logging/src/log_record.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { LogLevel } from './log_level';
+import type { LogLevel } from './log_level';
+import type { LogMeta } from './log_meta';
 
 /**
  * Essential parts of every log message.
@@ -18,7 +19,7 @@ export interface LogRecord {
   context: string;
   message: string;
   error?: Error;
-  meta?: { [name: string]: any };
+  meta?: LogMeta;
   pid: number;
   spanId?: string;
   traceId?: string;

--- a/src/core/server/logging/layouts/json_layout.test.ts
+++ b/src/core/server/logging/layouts/json_layout.test.ts
@@ -98,6 +98,7 @@ test('`format()` correctly formats record with meta-data', () => {
         timestamp,
         pid: 5355,
         meta: {
+          // @ts-expect-error ECS custom meta
           version: {
             from: 'v7',
             to: 'v8',
@@ -140,6 +141,7 @@ test('`format()` correctly formats error record with meta-data', () => {
         timestamp,
         pid: 5355,
         meta: {
+          // @ts-expect-error ECS custom meta
           version: {
             from: 'v7',
             to: 'v8',
@@ -182,6 +184,7 @@ test('format() meta can merge override logs', () => {
         pid: 3,
         meta: {
           log: {
+            // @ts-expect-error ECS custom meta
             kbn_custom_field: 'hello',
           },
         },
@@ -213,6 +216,7 @@ test('format() meta can not override message', () => {
         context: 'bar',
         pid: 3,
         meta: {
+          // @ts-expect-error cannot override message
           message: 'baz',
         },
       })
@@ -242,7 +246,8 @@ test('format() meta can not override ecs version', () => {
         context: 'bar',
         pid: 3,
         meta: {
-          message: 'baz',
+          // @ts-expect-error cannot override ecs version
+          ecs: 1,
         },
       })
     )
@@ -272,6 +277,7 @@ test('format() meta can not override logger or level', () => {
         pid: 3,
         meta: {
           log: {
+            // @ts-expect-error cannot override log.level
             level: 'IGNORE',
             logger: 'me',
           },
@@ -303,6 +309,7 @@ test('format() meta can not override timestamp', () => {
         context: 'bar',
         pid: 3,
         meta: {
+          // @ts-expect-error cannot override @timestamp
           '@timestamp': '2099-02-01T09:30:22.011-05:00',
         },
       })
@@ -332,9 +339,9 @@ test('format() meta can not override tracing properties', () => {
         context: 'bar',
         pid: 3,
         meta: {
-          span: 'span_override',
-          trace: 'trace_override',
-          transaction: 'transaction_override',
+          span: { id: 'span_override' },
+          trace: { id: 'trace_override' },
+          transaction: { id: 'transaction_override' },
         },
         spanId: 'spanId-1',
         traceId: 'traceId-1',

--- a/src/core/server/logging/layouts/pattern_layout.test.ts
+++ b/src/core/server/logging/layouts/pattern_layout.test.ts
@@ -118,6 +118,7 @@ test('`format()` correctly formats record with meta data.', () => {
       timestamp,
       pid: 5355,
       meta: {
+        // @ts-expect-error not valid ECS field
         from: 'v7',
         to: 'v8',
       },
@@ -177,6 +178,7 @@ test('`format()` allows specifying pattern with meta.', () => {
       to: 'v8',
     },
   };
+  // @ts-expect-error not valid ECS field
   expect(layout.format(record)).toBe('context-{"from":"v7","to":"v8"}-message');
 });
 


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Enforce "LogRecord.meta: LogMeta" type (#118334)