### PR TITLE
[Osquery] Fix RBAC

### DIFF
--- a/x-pack/plugins/osquery/server/plugin.ts
+++ b/x-pack/plugins/osquery/server/plugin.ts
@@ -134,7 +134,7 @@ const registerFeatures = (features: SetupPlugins['features']) => {
             groupType: 'mutually_exclusive',
             privileges: [
               {
-                api: [`${PLUGIN_ID}-writeSavedQueries`],
+                api: [`${PLUGIN_ID}-writeSavedQueries`, `${PLUGIN_ID}-readSavedQueries`],
                 id: 'saved_queries_all',
                 includeIn: 'all',
                 name: 'All',
@@ -168,7 +168,7 @@ const registerFeatures = (features: SetupPlugins['features']) => {
             groupType: 'mutually_exclusive',
             privileges: [
               {
-                api: [`${PLUGIN_ID}-writePacks`],
+                api: [`${PLUGIN_ID}-writePacks`, `${PLUGIN_ID}-readPacks`],
                 id: 'packs_all',
                 includeIn: 'all',
                 name: 'All',


### PR DESCRIPTION
**Describe the bug**
Forbidden red banner pop up for "Saved Queries"

**Build Details**
```
Version : v7.16.0-BC4
Commit : e50bc2eded568ff3ceaebdbe616f84b3987be975
Build : 45952
```

**Browser Details**
This issue is occurring on all browsers.

**Preconditions**
1. Kibana v7.16 must be available.
2. User must be created with below privileges.
 - OS Query - ```READ```
 - Customize sub-feature privileges toggle - ```Enabled```
 - Saved Queries - ```ALL```.
3. Login with pre requisite user profile.

**Steps to Reproduce**
1. Navigate to ```Management``` -> ```Osquery``` -> ```Saved Query```.
2. Observe that there will be a blank page opened and after few seconds red banner will appear as ```Forbidden```.

**Actual Result**
 Forbidden red banner pop up for "Saved Queries"

**Expected Result**
Forbidden red banner pop up should not appear for "Saved Queries" with pre requiste privileges and Saved Queries tab will must be fully accessible.

**What's Working**
 - N/A
 
**What's Not Working**
 - N/A

**Screenshot**
- Privileges
![2](https://user-images.githubusercontent.com/78947943/141980813-906f9cb2-b22b-414a-8efc-97d237557e0b.png)

- Error
![1](https://user-images.githubusercontent.com/78947943/141980831-48e4821e-5efa-4fb6-8af8-b35e4d500ba0.png)
