### PR TITLE
[Fleet] remove internal params when querying registry

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -61,7 +61,6 @@ const optionalArchivePackageProps: readonly OptionalPackageProp[] = [
   'readme',
   'assets',
   'data_streams',
-  'internal',
   'license',
   'type',
   'categories',

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -54,15 +54,11 @@ export async function getPackages(
   });
   // get the installed packages
   const packageSavedObjects = await getPackageSavedObjects(savedObjectsClient);
-  // filter out any internal packages
-  const savedObjectsVisible = packageSavedObjects.saved_objects.filter(
-    (o) => !o.attributes.internal
-  );
   const packageList = registryItems
     .map((item) =>
       createInstallableFrom(
         item,
-        savedObjectsVisible.find(({ id }) => id === item.name)
+        packageSavedObjects.saved_objects.find(({ id }) => id === item.name)
       )
     )
     .sort(sortByName);

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -530,7 +530,7 @@ export async function createInstallation(options: {
   installSource: InstallSource;
 }) {
   const { savedObjectsClient, packageInfo, installSource } = options;
-  const { internal = false, name: pkgName, version: pkgVersion } = packageInfo;
+  const { name: pkgName, version: pkgVersion } = packageInfo;
   const removable = !isUnremovablePackage(pkgName);
   const toSaveESIndexPatterns = generateESIndexPatterns(packageInfo.data_streams);
 
@@ -549,7 +549,6 @@ export async function createInstallation(options: {
       es_index_patterns: toSaveESIndexPatterns,
       name: pkgName,
       version: pkgVersion,
-      internal,
       removable,
       install_version: pkgVersion,
       install_status: 'installing',

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -96,9 +96,7 @@ export async function fetchList(params?: SearchParams): Promise<RegistrySearchRe
 
 export async function fetchFindLatestPackage(packageName: string): Promise<RegistrySearchResult> {
   const registryUrl = getRegistryUrl();
-  const url = new URL(
-    `${registryUrl}/search?package=${packageName}&internal=true&experimental=true`
-  );
+  const url = new URL(`${registryUrl}/search?package=${packageName}&experimental=true`);
 
   setKibanaVersion(url);
 

--- a/x-pack/test/fleet_api_integration/apis/epm/__snapshots__/install_by_upload.snap
+++ b/x-pack/test/fleet_api_integration/apis/epm/__snapshots__/install_by_upload.snap
@@ -446,7 +446,6 @@ Object {
           "type": "search",
         },
       ],
-      "internal": false,
       "keep_policies_up_to_date": false,
       "name": "apache",
       "package_assets": Array [

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -668,7 +668,6 @@ const expectAssetsInstalled = ({
       ],
       name: 'all_assets',
       version: '0.1.0',
-      internal: false,
       removable: true,
       install_version: '0.1.0',
       install_status: 'installed',

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -457,7 +457,6 @@ export default function (providerContext: FtrProviderContext) {
         ],
         name: 'all_assets',
         version: '0.2.0',
-        internal: false,
         removable: true,
         install_version: '0.2.0',
         install_status: 'installed',


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/117853

Removed the `internal` params  when querying the package registry

To test:
- open kibana integrations page, verify that integrations are loading successfully from registry without `internal` query param


