### PR TITLE
[7.16] [kbn/rule-data-utils] add submodules and require public use them (#117963)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -852,6 +852,10 @@ module.exports = {
                 name: 'semver',
                 message: 'Please use "semver/*/{function}" instead',
               },
+              {
+                name: '@kbn/rule-data-utils',
+                message: `Import directly from @kbn/rule-data-utils/* submodules in public/common code`,
+              },
             ],
           },
         ],

--- a/packages/kbn-rule-data-utils/BUILD.bazel
+++ b/packages/kbn-rule-data-utils/BUILD.bazel
@@ -20,6 +20,10 @@ filegroup(
 
 NPM_MODULE_EXTRA_FILES = [
   "package.json",
+  "alerts_as_data_rbac/package.json",
+  "alerts_as_data_severity/package.json",
+  "alerts_as_data_status/package.json",
+  "technical_field_names/package.json",
 ]
 
 RUNTIME_DEPS = [

--- a/packages/kbn-rule-data-utils/alerts_as_data_rbac/package.json
+++ b/packages/kbn-rule-data-utils/alerts_as_data_rbac/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../target_node/alerts_as_data_rbac",
+  "types": "../target_types/alerts_as_data_rbac"
+}

--- a/packages/kbn-rule-data-utils/alerts_as_data_severity/package.json
+++ b/packages/kbn-rule-data-utils/alerts_as_data_severity/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../target_node/alerts_as_data_severity",
+  "types": "../target_types/alerts_as_data_severity"
+}

--- a/packages/kbn-rule-data-utils/alerts_as_data_status/package.json
+++ b/packages/kbn-rule-data-utils/alerts_as_data_status/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../target_node/alerts_as_data_status",
+  "types": "../target_types/alerts_as_data_status"
+}

--- a/packages/kbn-rule-data-utils/technical_field_names/package.json
+++ b/packages/kbn-rule-data-utils/technical_field_names/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../target_node/technical_field_names",
+  "types": "../target_types/technical_field_names"
+}

--- a/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
+++ b/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
@@ -8,17 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import { lazy } from 'react';
 import { stringify } from 'querystring';
-import type {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_NON_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_NON_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_SEVERITY,
+} from '@kbn/rule-data-utils/technical_field_names';
 import type { ObservabilityRuleTypeRegistry } from '../../../../observability/public';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
 import {
@@ -33,12 +27,6 @@ import {
 const SERVICE_ENVIRONMENT = 'service.environment';
 const SERVICE_NAME = 'service.name';
 const TRANSACTION_TYPE = 'transaction.type';
-
-const ALERT_EVALUATION_THRESHOLD: typeof ALERT_EVALUATION_THRESHOLD_TYPED =
-  ALERT_EVALUATION_THRESHOLD_NON_TYPED;
-const ALERT_EVALUATION_VALUE: typeof ALERT_EVALUATION_VALUE_TYPED =
-  ALERT_EVALUATION_VALUE_NON_TYPED;
-const ALERT_SEVERITY: typeof ALERT_SEVERITY_TYPED = ALERT_SEVERITY_NON_TYPED;
 
 const format = ({
   pathname,

--- a/x-pack/plugins/apm/public/components/app/error_group_details/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_details/Distribution/index.tsx
@@ -16,9 +16,7 @@ import {
 } from '@elastic/charts';
 import { EuiTitle } from '@elastic/eui';
 import React, { Suspense, useState } from 'react';
-import type { ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_TYPED } from '@kbn/rule-data-utils';
-// @ts-expect-error
-import { ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_NON_TYPED } from '@kbn/rule-data-utils/target_node/technical_field_names';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils/technical_field_names';
 import { i18n } from '@kbn/i18n';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
@@ -31,9 +29,6 @@ import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plug
 import { LazyAlertsFlyout } from '../../../../../../observability/public';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { getTimeZone } from '../../../shared/charts/helper/timezone';
-
-const ALERT_RULE_TYPE_ID: typeof ALERT_RULE_TYPE_ID_TYPED =
-  ALERT_RULE_TYPE_ID_NON_TYPED;
 
 type ErrorDistributionAPIResponse =
   APIReturnType<'GET /internal/apm/services/{serviceName}/errors/distribution'>;

--- a/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.test.tsx
@@ -16,13 +16,13 @@ import {
   ALERT_SEVERITY,
   ALERT_START,
   ALERT_STATUS,
-  ALERT_STATUS_ACTIVE,
   ALERT_UUID,
   SPACE_IDS,
   ALERT_RULE_UUID,
   ALERT_RULE_NAME,
   ALERT_RULE_CATEGORY,
-} from '@kbn/rule-data-utils';
+} from '@kbn/rule-data-utils/technical_field_names';
+import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils/alerts_as_data_status';
 import { ValuesType } from 'utility-types';
 import { EuiTheme } from '../../../../../../../../src/plugins/kibana_react/common';
 import { ObservabilityRuleTypeRegistry } from '../../../../../../observability/public';

--- a/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/helper/get_alert_annotations.tsx
@@ -12,23 +12,14 @@ import {
 } from '@elastic/charts';
 import { EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type {
-  ALERT_DURATION as ALERT_DURATION_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_TYPED,
-  ALERT_START as ALERT_START_TYPED,
-  ALERT_UUID as ALERT_UUID_TYPED,
-  ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_TYPED,
-  ALERT_RULE_NAME as ALERT_RULE_NAME_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_DURATION as ALERT_DURATION_NON_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_NON_TYPED,
-  ALERT_START as ALERT_START_NON_TYPED,
-  ALERT_UUID as ALERT_UUID_NON_TYPED,
-  ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_NON_TYPED,
-  ALERT_RULE_NAME as ALERT_RULE_NAME_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+  ALERT_DURATION,
+  ALERT_SEVERITY,
+  ALERT_START,
+  ALERT_UUID,
+  ALERT_RULE_TYPE_ID,
+  ALERT_RULE_NAME,
+} from '@kbn/rule-data-utils/technical_field_names';
 import React, { Dispatch, SetStateAction } from 'react';
 import { EuiTheme } from 'src/plugins/kibana_react/common';
 import { ValuesType } from 'utility-types';
@@ -36,14 +27,6 @@ import type { ObservabilityRuleTypeRegistry } from '../../../../../../observabil
 import { parseTechnicalFields } from '../../../../../../rule_registry/common';
 import { asDuration, asPercent } from '../../../../../common/utils/formatters';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
-
-const ALERT_DURATION: typeof ALERT_DURATION_TYPED = ALERT_DURATION_NON_TYPED;
-const ALERT_SEVERITY: typeof ALERT_SEVERITY_TYPED = ALERT_SEVERITY_NON_TYPED;
-const ALERT_START: typeof ALERT_START_TYPED = ALERT_START_NON_TYPED;
-const ALERT_UUID: typeof ALERT_UUID_TYPED = ALERT_UUID_NON_TYPED;
-const ALERT_RULE_TYPE_ID: typeof ALERT_RULE_TYPE_ID_TYPED =
-  ALERT_RULE_TYPE_ID_NON_TYPED;
-const ALERT_RULE_NAME: typeof ALERT_RULE_NAME_TYPED = ALERT_RULE_NAME_NON_TYPED;
 
 type Alert = ValuesType<
   APIReturnType<'GET /internal/apm/services/{serviceName}/alerts'>['alerts']

--- a/x-pack/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
@@ -9,9 +9,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiSelect, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import type { ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_TYPED } from '@kbn/rule-data-utils';
-// @ts-expect-error
-import { ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_NON_TYPED } from '@kbn/rule-data-utils/target_node/technical_field_names';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils/technical_field_names';
 import { AlertType } from '../../../../../common/alert_types';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { LatencyAggregationType } from '../../../../../common/latency_aggregation_types';
@@ -28,9 +26,6 @@ import {
 import { MLHeader } from '../../../shared/charts/transaction_charts/ml_header';
 import * as urlHelpers from '../../../shared/Links/url_helpers';
 import { getComparisonChartTheme } from '../../time_comparison/get_time_range_comparison';
-
-const ALERT_RULE_TYPE_ID: typeof ALERT_RULE_TYPE_ID_TYPED =
-  ALERT_RULE_TYPE_ID_NON_TYPED;
 
 interface Props {
   height?: number;

--- a/x-pack/plugins/apm/public/components/shared/charts/latency_chart/latency_chart.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/latency_chart/latency_chart.stories.tsx
@@ -14,7 +14,6 @@ import {
   ALERT_SEVERITY,
   ALERT_START,
   ALERT_STATUS,
-  ALERT_STATUS_ACTIVE,
   ALERT_UUID,
   TIMESTAMP,
   ALERT_RULE_UUID,
@@ -23,7 +22,8 @@ import {
   ALERT_RULE_CONSUMER,
   ALERT_RULE_PRODUCER,
   SPACE_IDS,
-} from '@kbn/rule-data-utils';
+} from '@kbn/rule-data-utils/technical_field_names';
+import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils/alerts_as_data_status';
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';

--- a/x-pack/plugins/apm/server/lib/alerts/register_error_count_alert_type.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/register_error_count_alert_type.ts
@@ -7,17 +7,11 @@
 
 import { schema } from '@kbn/config-schema';
 import { take } from 'rxjs/operators';
-import type {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_TYPED,
-  ALERT_REASON as ALERT_REASON_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_NON_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_NON_TYPED,
-  ALERT_REASON as ALERT_REASON_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_REASON,
+} from '@kbn/rule-data-utils/technical_field_names';
 import { createLifecycleRuleTypeFactory } from '../../../../rule_registry/server';
 import {
   ENVIRONMENT_NOT_DEFINED,
@@ -41,12 +35,6 @@ import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
 import { apmActionVariables } from './action_variables';
 import { alertingEsClient } from './alerting_es_client';
 import { RegisterRuleDependencies } from './register_apm_alerts';
-
-const ALERT_EVALUATION_THRESHOLD: typeof ALERT_EVALUATION_THRESHOLD_TYPED =
-  ALERT_EVALUATION_THRESHOLD_NON_TYPED;
-const ALERT_EVALUATION_VALUE: typeof ALERT_EVALUATION_VALUE_TYPED =
-  ALERT_EVALUATION_VALUE_NON_TYPED;
-const ALERT_REASON: typeof ALERT_REASON_TYPED = ALERT_REASON_NON_TYPED;
 
 const paramsSchema = schema.object({
   windowSize: schema.number(),

--- a/x-pack/plugins/apm/server/lib/alerts/register_transaction_duration_alert_type.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/register_transaction_duration_alert_type.ts
@@ -7,17 +7,11 @@
 
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/api/types';
 import { schema } from '@kbn/config-schema';
-import type {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_TYPED,
-  ALERT_REASON as ALERT_REASON_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_NON_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_NON_TYPED,
-  ALERT_REASON as ALERT_REASON_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_REASON,
+} from '@kbn/rule-data-utils/technical_field_names';
 import { take } from 'rxjs/operators';
 import { asDuration } from '../../../../observability/common/utils/formatters';
 import { createLifecycleRuleTypeFactory } from '../../../../rule_registry/server';
@@ -48,12 +42,6 @@ import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
 import { apmActionVariables } from './action_variables';
 import { alertingEsClient } from './alerting_es_client';
 import { RegisterRuleDependencies } from './register_apm_alerts';
-
-const ALERT_EVALUATION_THRESHOLD: typeof ALERT_EVALUATION_THRESHOLD_TYPED =
-  ALERT_EVALUATION_THRESHOLD_NON_TYPED;
-const ALERT_EVALUATION_VALUE: typeof ALERT_EVALUATION_VALUE_TYPED =
-  ALERT_EVALUATION_VALUE_NON_TYPED;
-const ALERT_REASON: typeof ALERT_REASON_TYPED = ALERT_REASON_NON_TYPED;
 
 const paramsSchema = schema.object({
   serviceName: schema.string(),

--- a/x-pack/plugins/apm/server/lib/alerts/register_transaction_duration_anomaly_alert_type.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/register_transaction_duration_anomaly_alert_type.ts
@@ -9,19 +9,12 @@ import { schema } from '@kbn/config-schema';
 import { compact } from 'lodash';
 import { ESSearchResponse } from 'src/core/types/elasticsearch';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/api/types';
-import type {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_TYPED,
-  ALERT_REASON as ALERT_REASON_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_NON_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_NON_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_NON_TYPED,
-  ALERT_REASON as ALERT_REASON_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_SEVERITY,
+  ALERT_REASON,
+} from '@kbn/rule-data-utils/technical_field_names';
 import { createLifecycleRuleTypeFactory } from '../../../../rule_registry/server';
 import { ProcessorEvent } from '../../../common/processor_event';
 import { getSeverity } from '../../../common/anomaly_detection';
@@ -46,13 +39,6 @@ import {
   getEnvironmentEsField,
   getEnvironmentLabel,
 } from '../../../common/environment_filter_values';
-
-const ALERT_EVALUATION_THRESHOLD: typeof ALERT_EVALUATION_THRESHOLD_TYPED =
-  ALERT_EVALUATION_THRESHOLD_NON_TYPED;
-const ALERT_EVALUATION_VALUE: typeof ALERT_EVALUATION_VALUE_TYPED =
-  ALERT_EVALUATION_VALUE_NON_TYPED;
-const ALERT_SEVERITY: typeof ALERT_SEVERITY_TYPED = ALERT_SEVERITY_NON_TYPED;
-const ALERT_REASON: typeof ALERT_REASON_TYPED = ALERT_REASON_NON_TYPED;
 
 const paramsSchema = schema.object({
   serviceName: schema.maybe(schema.string()),

--- a/x-pack/plugins/apm/server/lib/alerts/register_transaction_error_rate_alert_type.ts
+++ b/x-pack/plugins/apm/server/lib/alerts/register_transaction_error_rate_alert_type.ts
@@ -7,17 +7,11 @@
 
 import { schema } from '@kbn/config-schema';
 import { take } from 'rxjs/operators';
-import type {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_TYPED,
-  ALERT_REASON as ALERT_REASON_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_NON_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_NON_TYPED,
-  ALERT_REASON as ALERT_REASON_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_REASON,
+} from '@kbn/rule-data-utils/technical_field_names';
 import {
   ENVIRONMENT_NOT_DEFINED,
   getEnvironmentEsField,
@@ -48,12 +42,6 @@ import { RegisterRuleDependencies } from './register_apm_alerts';
 import { SearchAggregatedTransactionSetting } from '../../../common/aggregated_transactions';
 import { getDocumentTypeFilterForAggregatedTransactions } from '../helpers/aggregated_transactions';
 import { asPercent } from '../../../../observability/common/utils/formatters';
-
-const ALERT_EVALUATION_THRESHOLD: typeof ALERT_EVALUATION_THRESHOLD_TYPED =
-  ALERT_EVALUATION_THRESHOLD_NON_TYPED;
-const ALERT_EVALUATION_VALUE: typeof ALERT_EVALUATION_VALUE_TYPED =
-  ALERT_EVALUATION_VALUE_NON_TYPED;
-const ALERT_REASON: typeof ALERT_REASON_TYPED = ALERT_REASON_NON_TYPED;
 
 const paramsSchema = schema.object({
   windowSize: schema.number(),

--- a/x-pack/plugins/apm/server/lib/services/get_service_alerts.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_alerts.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import type { EVENT_KIND as EVENT_KIND_TYPED } from '@kbn/rule-data-utils';
-// @ts-expect-error
-import { EVENT_KIND as EVENT_KIND_NON_TYPED } from '@kbn/rule-data-utils/target_node/technical_field_names';
+import { EVENT_KIND } from '@kbn/rule-data-utils/technical_field_names';
 import { IRuleDataClient } from '../../../../rule_registry/server';
 import {
   SERVICE_NAME,
@@ -15,8 +13,6 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { rangeQuery } from '../../../../observability/server';
 import { environmentQuery } from '../../../common/utils/environment_query';
-
-const EVENT_KIND: typeof EVENT_KIND_TYPED = EVENT_KIND_NON_TYPED;
 
 export async function getServiceAlerts({
   ruleDataClient,

--- a/x-pack/plugins/infra/public/alerting/inventory/rule_data_formatters.ts
+++ b/x-pack/plugins/infra/public/alerting/inventory/rule_data_formatters.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { ALERT_REASON, ALERT_RULE_PARAMS, TIMESTAMP } from '@kbn/rule-data-utils';
+import {
+  ALERT_REASON,
+  ALERT_RULE_PARAMS,
+  TIMESTAMP,
+} from '@kbn/rule-data-utils/technical_field_names';
 import { encode } from 'rison-node';
 import { stringify } from 'query-string';
 import { ObservabilityRuleTypeFormatter } from '../../../../observability/public';

--- a/x-pack/plugins/infra/public/alerting/log_threshold/rule_data_formatters.ts
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/rule_data_formatters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ALERT_REASON, ALERT_START } from '@kbn/rule-data-utils';
+import { ALERT_REASON, ALERT_START } from '@kbn/rule-data-utils/technical_field_names';
 import { modifyUrl } from '@kbn/std';
 import { ObservabilityRuleTypeFormatter } from '../../../../observability/public';
 

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/rule_data_formatters.ts
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/rule_data_formatters.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ALERT_REASON } from '@kbn/rule-data-utils';
+import { ALERT_REASON } from '@kbn/rule-data-utils/technical_field_names';
 import { ObservabilityRuleTypeFormatter } from '../../../../observability/public';
 
 export const formatReason: ObservabilityRuleTypeFormatter = ({ fields }) => {

--- a/x-pack/plugins/observability/public/components/shared/alert_status_indicator.tsx
+++ b/x-pack/plugins/observability/public/components/shared/alert_status_indicator.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiHealth, EuiText } from '@elastic/eui';
-import { ALERT_STATUS_ACTIVE, AlertStatus } from '@kbn/rule-data-utils';
+import { ALERT_STATUS_ACTIVE, AlertStatus } from '@kbn/rule-data-utils/alerts_as_data_status';
 import { useTheme } from '../../hooks/use_theme';
 
 interface AlertStatusIndicatorProps {

--- a/x-pack/plugins/observability/public/pages/alerts/alerts_flyout/alerts_flyout.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_flyout/alerts_flyout.stories.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ALERT_UUID } from '@kbn/rule-data-utils';
+import { ALERT_UUID } from '@kbn/rule-data-utils/technical_field_names';
 import React, { ComponentType } from 'react';
 import { KibanaContextProvider } from '../../../../../../../src/plugins/kibana_react/public';
 import { PluginContext, PluginContextValue } from '../../../context/plugin_context';

--- a/x-pack/plugins/observability/public/pages/alerts/alerts_flyout/index.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_flyout/index.tsx
@@ -20,24 +20,18 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type {
-  ALERT_DURATION as ALERT_DURATION_TYPED,
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_TYPED,
-  ALERT_UUID as ALERT_UUID_TYPED,
-  ALERT_RULE_CATEGORY as ALERT_RULE_CATEGORY_TYPED,
-  ALERT_RULE_NAME as ALERT_RULE_NAME_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_DURATION as ALERT_DURATION_NON_TYPED,
-  ALERT_EVALUATION_THRESHOLD as ALERT_EVALUATION_THRESHOLD_NON_TYPED,
-  ALERT_EVALUATION_VALUE as ALERT_EVALUATION_VALUE_NON_TYPED,
-  ALERT_UUID as ALERT_UUID_NON_TYPED,
-  ALERT_RULE_CATEGORY as ALERT_RULE_CATEGORY_NON_TYPED,
-  ALERT_RULE_NAME as ALERT_RULE_NAME_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
-import { ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
+  ALERT_DURATION,
+  ALERT_EVALUATION_THRESHOLD,
+  ALERT_EVALUATION_VALUE,
+  ALERT_UUID,
+  ALERT_RULE_CATEGORY,
+  ALERT_RULE_NAME,
+} from '@kbn/rule-data-utils/technical_field_names';
+import {
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+} from '@kbn/rule-data-utils/alerts_as_data_status';
 import moment from 'moment-timezone';
 import React, { useMemo } from 'react';
 import type { TopAlert } from '../';
@@ -55,15 +49,6 @@ type AlertsFlyoutProps = {
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
   selectedAlertId?: string;
 } & EuiFlyoutProps;
-
-const ALERT_DURATION: typeof ALERT_DURATION_TYPED = ALERT_DURATION_NON_TYPED;
-const ALERT_EVALUATION_THRESHOLD: typeof ALERT_EVALUATION_THRESHOLD_TYPED =
-  ALERT_EVALUATION_THRESHOLD_NON_TYPED;
-const ALERT_EVALUATION_VALUE: typeof ALERT_EVALUATION_VALUE_TYPED =
-  ALERT_EVALUATION_VALUE_NON_TYPED;
-const ALERT_UUID: typeof ALERT_UUID_TYPED = ALERT_UUID_NON_TYPED;
-const ALERT_RULE_CATEGORY: typeof ALERT_RULE_CATEGORY_TYPED = ALERT_RULE_CATEGORY_NON_TYPED;
-const ALERT_RULE_NAME: typeof ALERT_RULE_NAME_TYPED = ALERT_RULE_NAME_NON_TYPED;
 
 export function AlertsFlyout({
   alert,

--- a/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts_table_t_grid.tsx
@@ -11,23 +11,14 @@
  * This way plugins can do targeted imports to reduce the final code bundle
  */
 import {
-  ALERT_DURATION as ALERT_DURATION_TYPED,
-  ALERT_REASON as ALERT_REASON_TYPED,
+  ALERT_DURATION,
+  ALERT_REASON,
   ALERT_RULE_CONSUMER,
   ALERT_RULE_PRODUCER,
-  ALERT_STATUS as ALERT_STATUS_TYPED,
-  ALERT_WORKFLOW_STATUS as ALERT_WORKFLOW_STATUS_TYPED,
-} from '@kbn/rule-data-utils';
-// @ts-expect-error importing from a place other than root because we want to limit what we import from this package
-import { AlertConsumers as AlertConsumersNonTyped } from '@kbn/rule-data-utils/target_node/alerts_as_data_rbac';
-import {
-  ALERT_DURATION as ALERT_DURATION_NON_TYPED,
-  ALERT_REASON as ALERT_REASON_NON_TYPED,
-  ALERT_STATUS as ALERT_STATUS_NON_TYPED,
-  ALERT_WORKFLOW_STATUS as ALERT_WORKFLOW_STATUS_NON_TYPED,
+  ALERT_STATUS,
+  ALERT_WORKFLOW_STATUS,
   TIMESTAMP,
-  // @ts-expect-error importing from a place other than root because we want to limit what we import from this package
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
+} from '@kbn/rule-data-utils/technical_field_names';
 
 import {
   EuiButtonIcon,
@@ -66,11 +57,6 @@ import { getDefaultCellActions } from './default_cell_actions';
 import { LazyAlertsFlyout } from '../..';
 import { parseAlert } from './parse_alert';
 import { CoreStart } from '../../../../../../src/core/public';
-
-const ALERT_DURATION: typeof ALERT_DURATION_TYPED = ALERT_DURATION_NON_TYPED;
-const ALERT_REASON: typeof ALERT_REASON_TYPED = ALERT_REASON_NON_TYPED;
-const ALERT_STATUS: typeof ALERT_STATUS_TYPED = ALERT_STATUS_NON_TYPED;
-const ALERT_WORKFLOW_STATUS: typeof ALERT_WORKFLOW_STATUS_TYPED = ALERT_WORKFLOW_STATUS_NON_TYPED;
 
 interface AlertsTableTGridProps {
   indexNames: string[];

--- a/x-pack/plugins/observability/public/pages/alerts/example_data.ts
+++ b/x-pack/plugins/observability/public/pages/alerts/example_data.ts
@@ -13,14 +13,16 @@ import {
   ALERT_RULE_TYPE_ID,
   ALERT_START,
   ALERT_STATUS,
-  ALERT_STATUS_ACTIVE,
-  ALERT_STATUS_RECOVERED,
   ALERT_UUID,
   ALERT_RULE_UUID,
   ALERT_RULE_NAME,
   ALERT_RULE_CATEGORY,
   ALERT_RULE_PRODUCER,
-} from '@kbn/rule-data-utils';
+} from '@kbn/rule-data-utils/technical_field_names';
+import {
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+} from '@kbn/rule-data-utils/alerts_as_data_status';
 
 export const apmAlertResponseExample = [
   {

--- a/x-pack/plugins/observability/public/pages/alerts/parse_alert.ts
+++ b/x-pack/plugins/observability/public/pages/alerts/parse_alert.ts
@@ -5,29 +5,17 @@
  * 2.0.
  */
 
-import type {
-  ALERT_START as ALERT_START_TYPED,
-  ALERT_STATUS as ALERT_STATUS_TYPED,
-  ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_TYPED,
-  ALERT_RULE_NAME as ALERT_RULE_NAME_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_START as ALERT_START_NON_TYPED,
-  ALERT_STATUS as ALERT_STATUS_NON_TYPED,
-  ALERT_RULE_TYPE_ID as ALERT_RULE_TYPE_ID_NON_TYPED,
-  ALERT_RULE_NAME as ALERT_RULE_NAME_NON_TYPED,
-  // @ts-expect-error
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
-import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils';
+  ALERT_START,
+  ALERT_STATUS,
+  ALERT_RULE_TYPE_ID,
+  ALERT_RULE_NAME,
+} from '@kbn/rule-data-utils/technical_field_names';
+import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils/alerts_as_data_status';
 import type { TopAlert } from '.';
 import { parseTechnicalFields } from '../../../../rule_registry/common/parse_technical_fields';
 import { asDuration, asPercent } from '../../../common/utils/formatters';
 import { ObservabilityRuleTypeRegistry } from '../../rules/create_observability_rule_type_registry';
-
-const ALERT_START: typeof ALERT_START_TYPED = ALERT_START_NON_TYPED;
-const ALERT_STATUS: typeof ALERT_STATUS_TYPED = ALERT_STATUS_NON_TYPED;
-const ALERT_RULE_TYPE_ID: typeof ALERT_RULE_TYPE_ID_TYPED = ALERT_RULE_TYPE_ID_NON_TYPED;
-const ALERT_RULE_NAME: typeof ALERT_RULE_NAME_TYPED = ALERT_RULE_NAME_NON_TYPED;
 
 export const parseAlert =
   (observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry) =>

--- a/x-pack/plugins/observability/public/pages/alerts/render_cell_value.test.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/render_cell_value.test.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-// @ts-expect-error importing from a place other than root because we want to limit what we import from this package
-import { ALERT_STATUS } from '@kbn/rule-data-utils/target_node/technical_field_names';
-import { ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
+import {
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+} from '@kbn/rule-data-utils/alerts_as_data_status';
+import { ALERT_STATUS } from '@kbn/rule-data-utils/technical_field_names';
 import type { CellValueElementProps } from '../../../../timelines/common';
 import { createObservabilityRuleTypeRegistryMock } from '../../rules/observability_rule_type_registry_mock';
 import * as PluginHook from '../../hooks/use_plugin_context';

--- a/x-pack/plugins/observability/public/pages/alerts/render_cell_value.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/render_cell_value.tsx
@@ -6,26 +6,17 @@
  */
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
-/**
- * We need to produce types and code transpilation at different folders during the build of the package.
- * We have types and code at different imports because we don't want to import the whole package in the resulting webpack bundle for the plugin.
- * This way plugins can do targeted imports to reduce the final code bundle
- */
-import type {
-  ALERT_DURATION as ALERT_DURATION_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_TYPED,
-  ALERT_STATUS as ALERT_STATUS_TYPED,
-  ALERT_REASON as ALERT_REASON_TYPED,
-} from '@kbn/rule-data-utils';
 import {
-  ALERT_DURATION as ALERT_DURATION_NON_TYPED,
-  ALERT_SEVERITY as ALERT_SEVERITY_NON_TYPED,
-  ALERT_STATUS as ALERT_STATUS_NON_TYPED,
-  ALERT_REASON as ALERT_REASON_NON_TYPED,
+  ALERT_DURATION,
+  ALERT_SEVERITY,
+  ALERT_STATUS,
+  ALERT_REASON,
   TIMESTAMP,
-  // @ts-expect-error importing from a place other than root because we want to limit what we import from this package
-} from '@kbn/rule-data-utils/target_node/technical_field_names';
-import { ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
+} from '@kbn/rule-data-utils/technical_field_names';
+import {
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+} from '@kbn/rule-data-utils/alerts_as_data_status';
 import type { CellValueElementProps, TimelineNonEcsData } from '../../../../timelines/common';
 import { AlertStatusIndicator } from '../../components/shared/alert_status_indicator';
 import { TimestampTooltip } from '../../components/shared/timestamp_tooltip';
@@ -34,11 +25,6 @@ import { SeverityBadge } from './severity_badge';
 import { TopAlert } from '.';
 import { parseAlert } from './parse_alert';
 import { usePluginContext } from '../../hooks/use_plugin_context';
-
-const ALERT_DURATION: typeof ALERT_DURATION_TYPED = ALERT_DURATION_NON_TYPED;
-const ALERT_SEVERITY: typeof ALERT_SEVERITY_TYPED = ALERT_SEVERITY_NON_TYPED;
-const ALERT_STATUS: typeof ALERT_STATUS_TYPED = ALERT_STATUS_NON_TYPED;
-const ALERT_REASON: typeof ALERT_REASON_TYPED = ALERT_REASON_NON_TYPED;
 
 export const getMappedNonEcsValue = ({
   data,

--- a/x-pack/plugins/rule_registry/common/technical_rule_data_field_names.ts
+++ b/x-pack/plugins/rule_registry/common/technical_rule_data_field_names.ts
@@ -5,4 +5,6 @@
  * 2.0.
  */
 
-export * from '@kbn/rule-data-utils';
+export * from '@kbn/rule-data-utils/technical_field_names';
+export * from '@kbn/rule-data-utils/alerts_as_data_status';
+export * from '@kbn/rule-data-utils/alerts_as_data_rbac';

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/default_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/default_config.tsx
@@ -15,7 +15,7 @@ import {
   ALERT_RULE_UUID,
   ALERT_RULE_NAME,
   ALERT_RULE_CATEGORY,
-} from '@kbn/rule-data-utils';
+} from '@kbn/rule-data-utils/technical_field_names';
 
 import { defaultColumnHeaderType } from '../../../timelines/components/timeline/body/column_headers/default_headers';
 import { ColumnHeaderOptions, RowRendererId } from '../../../../common/types/timeline';

--- a/x-pack/plugins/security_solution/public/detections/configurations/examples/observablity_alerts/columns.ts
+++ b/x-pack/plugins/security_solution/public/detections/configurations/examples/observablity_alerts/columns.ts
@@ -6,7 +6,7 @@
  */
 
 import { EuiDataGridColumn } from '@elastic/eui';
-import { ALERT_DURATION, ALERT_STATUS } from '@kbn/rule-data-utils';
+import { ALERT_DURATION, ALERT_STATUS } from '@kbn/rule-data-utils/technical_field_names';
 
 import { ColumnHeaderOptions } from '../../../../../common';
 import { defaultColumnHeaderType } from '../../../../timelines/components/timeline/body/column_headers/default_headers';

--- a/x-pack/plugins/security_solution/public/detections/configurations/examples/observablity_alerts/render_cell_value.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/configurations/examples/observablity_alerts/render_cell_value.test.tsx
@@ -9,7 +9,7 @@ import { mount } from 'enzyme';
 import { cloneDeep } from 'lodash/fp';
 import React from 'react';
 
-import { ALERT_DURATION, ALERT_STATUS } from '@kbn/rule-data-utils';
+import { ALERT_DURATION, ALERT_STATUS } from '@kbn/rule-data-utils/technical_field_names';
 
 import { mockBrowserFields } from '../../../../common/containers/source/mock';
 import { DragDropContextWrapper } from '../../../../common/components/drag_and_drop/drag_drop_context_wrapper';

--- a/x-pack/plugins/security_solution/public/detections/configurations/examples/observablity_alerts/render_cell_value.tsx
+++ b/x-pack/plugins/security_solution/public/detections/configurations/examples/observablity_alerts/render_cell_value.tsx
@@ -9,7 +9,7 @@ import moment from 'moment';
 import React from 'react';
 
 import { EuiDataGridCellValueElementProps, EuiLink } from '@elastic/eui';
-import { ALERT_DURATION, ALERT_STATUS } from '@kbn/rule-data-utils';
+import { ALERT_DURATION, ALERT_STATUS } from '@kbn/rule-data-utils/technical_field_names';
 
 import { TruncatableText } from '../../../../common/components/truncatable_text';
 import { Severity } from '../../../components/severity';

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/field_maps/field_names.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/field_maps/field_names.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ALERT_NAMESPACE, ALERT_RULE_NAMESPACE } from '@kbn/rule-data-utils';
+import { ALERT_NAMESPACE, ALERT_RULE_NAMESPACE } from '@kbn/rule-data-utils/technical_field_names';
 
 export const ALERT_ANCESTORS = `${ALERT_NAMESPACE}.ancestors` as const;
 export const ALERT_BUILDING_BLOCK_TYPE = `${ALERT_NAMESPACE}.building_block_type` as const;

--- a/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.test.tsx
+++ b/x-pack/plugins/timelines/public/components/actions/timeline/cases/add_to_case_action.test.tsx
@@ -11,7 +11,7 @@ import { TestProviders, mockGetAllCasesSelectorModal } from '../../../../mock';
 import { AddToCaseAction } from './add_to_case_action';
 import { SECURITY_SOLUTION_OWNER } from '../../../../../../cases/common';
 import { AddToCaseActionButton } from './add_to_case_action_button';
-import { ALERT_RULE_UUID } from '@kbn/rule-data-utils';
+import { ALERT_RULE_UUID } from '@kbn/rule-data-utils/technical_field_names';
 
 jest.mock('react-router-dom', () => ({
   useLocation: () => ({

--- a/x-pack/plugins/timelines/public/components/t_grid/body/helpers.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/helpers.tsx
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { ALERT_RULE_CONSUMER, ALERT_RULE_PRODUCER } from '@kbn/rule-data-utils';
+import {
+  ALERT_RULE_CONSUMER,
+  ALERT_RULE_PRODUCER,
+} from '@kbn/rule-data-utils/technical_field_names';
 import { isEmpty } from 'lodash/fp';
 
 import { EuiDataGridCellValueElementProps } from '@elastic/eui';

--- a/x-pack/plugins/timelines/public/components/t_grid/body/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/body/index.tsx
@@ -32,7 +32,10 @@ import React, {
 import { connect, ConnectedProps, useDispatch } from 'react-redux';
 
 import styled, { ThemeContext } from 'styled-components';
-import { ALERT_RULE_CONSUMER, ALERT_RULE_PRODUCER } from '@kbn/rule-data-utils';
+import {
+  ALERT_RULE_CONSUMER,
+  ALERT_RULE_PRODUCER,
+} from '@kbn/rule-data-utils/technical_field_names';
 import {
   TGridCellAction,
   BulkActionsProp,

--- a/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/event_rendered_view/index.tsx
@@ -15,7 +15,7 @@ import {
   EuiHorizontalRule,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
+import { ALERT_RULE_NAME } from '@kbn/rule-data-utils/technical_field_names';
 import { get } from 'lodash';
 import moment from 'moment';
 import React, { ComponentType, useCallback, useMemo } from 'react';

--- a/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
+++ b/x-pack/plugins/timelines/public/components/t_grid/integrated/index.tsx
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import type { AlertConsumers as AlertConsumersTyped } from '@kbn/rule-data-utils';
-// @ts-expect-error
-import { AlertConsumers as AlertConsumersNonTyped } from '@kbn/rule-data-utils/target_node/alerts_as_data_rbac';
+import { AlertConsumers } from '@kbn/rule-data-utils/alerts_as_data_rbac';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { isEmpty } from 'lodash/fp';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -52,8 +50,6 @@ import { Sort } from '../body/sort';
 import { InspectButton, InspectButtonContainer } from '../../inspect';
 import { SummaryViewSelector, ViewSelection } from '../event_rendered_view/selector';
 import { TGridLoading, TGridEmpty, TimelineContext } from '../shared';
-
-const AlertConsumers: typeof AlertConsumersTyped = AlertConsumersNonTyped;
 
 const TitleText = styled.span`
   margin-right: 12px;

--- a/x-pack/plugins/timelines/public/container/index.tsx
+++ b/x-pack/plugins/timelines/public/container/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { AlertConsumers } from '@kbn/rule-data-utils';
+import type { AlertConsumers } from '@kbn/rule-data-utils/alerts_as_data_rbac';
 import deepEqual from 'fast-deep-equal';
 import { isEmpty, isString, noop } from 'lodash/fp';
 import { useCallback, useEffect, useRef, useState } from 'react';

--- a/x-pack/plugins/timelines/public/hooks/use_add_to_case.test.ts
+++ b/x-pack/plugins/timelines/public/hooks/use_add_to_case.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { normalizedEventFields } from './use_add_to_case';
-import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
+import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils/technical_field_names';
 import { merge } from 'lodash';
 
 const defaultArgs = {

--- a/x-pack/plugins/timelines/public/hooks/use_add_to_case.ts
+++ b/x-pack/plugins/timelines/public/hooks/use_add_to_case.ts
@@ -8,7 +8,7 @@ import { get, isEmpty } from 'lodash/fp';
 import { useState, useCallback, useMemo, SyntheticEvent } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
+import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils/technical_field_names';
 import { useKibana } from '../../../../../src/plugins/kibana_react/public';
 import { Case, SubCase } from '../../../cases/common';
 import { TimelinesStartServices } from '../types';

--- a/x-pack/plugins/timelines/public/mock/t_grid.tsx
+++ b/x-pack/plugins/timelines/public/mock/t_grid.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { ALERT_START, ALERT_STATUS } from '@kbn/rule-data-utils';
+import { ALERT_START, ALERT_STATUS } from '@kbn/rule-data-utils/technical_field_names';
 import { TGridIntegratedProps } from '../components/t_grid/integrated';
 import { mockBrowserFields, mockDocValueFields } from './browser_fields';
 import { mockDataProviders } from './mock_data_providers';

--- a/x-pack/plugins/uptime/public/lib/alert_types/duration_anomaly.tsx
+++ b/x-pack/plugins/uptime/public/lib/alert_types/duration_anomaly.tsx
@@ -8,7 +8,8 @@
 import React from 'react';
 import moment from 'moment';
 
-import { ALERT_END, ALERT_STATUS, ALERT_STATUS_ACTIVE, ALERT_REASON } from '@kbn/rule-data-utils';
+import { ALERT_END, ALERT_STATUS, ALERT_REASON } from '@kbn/rule-data-utils/technical_field_names';
+import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils/alerts_as_data_status';
 
 import { AlertTypeInitializer } from '.';
 import { getMonitorRouteFromMonitorId } from './common';

--- a/x-pack/plugins/uptime/public/lib/alert_types/monitor_status.tsx
+++ b/x-pack/plugins/uptime/public/lib/alert_types/monitor_status.tsx
@@ -12,9 +12,9 @@ import {
   ALERT_END,
   ALERT_START,
   ALERT_STATUS,
-  ALERT_STATUS_ACTIVE,
   ALERT_REASON,
-} from '@kbn/rule-data-utils';
+} from '@kbn/rule-data-utils/technical_field_names';
+import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils/alerts_as_data_status';
 
 import { AlertTypeInitializer } from '.';
 import { getMonitorRouteFromMonitorId } from './common';

--- a/x-pack/plugins/uptime/public/lib/alert_types/tls.tsx
+++ b/x-pack/plugins/uptime/public/lib/alert_types/tls.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { ALERT_REASON } from '@kbn/rule-data-utils';
+import { ALERT_REASON } from '@kbn/rule-data-utils/technical_field_names';
 import { ObservabilityRuleTypeModel } from '../../../../observability/public';
 import { CLIENT_ALERT_TYPES } from '../../../common/constants/alerts';
 import { TlsTranslations } from '../../../common/translations';


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [kbn/rule-data-utils] add submodules and require public use them (#117963)