### PR TITLE
[DOCS] Update Kibana install docs for security ON by default Beta

### DIFF
--- a/docs/setup/install/auto-enroll.asciidoc
+++ b/docs/setup/install/auto-enroll.asciidoc
@@ -1,0 +1,15 @@
+[role="exclude"]
+
+If this is the first time you're starting {kib}, this command generates a 
+unique link to enroll your {kib} instance with {es}.
+
+. In your terminal, click the generated link to open {kib} in your browser.
+
+. In your browser, paste the enrollment token for {kib} and click the
+button to connect your {kib} instance with {es}.
+
+. Log in to {kib} as the `elastic` user with the password that was 
+generated when you started {es}.
+
+NOTE: If you need to reset the password for the `elastic` user or other
+built-in users, run the {ref}/reset-password.html[`elasticsearch-reset-password`] tool.

--- a/docs/setup/install/auto-enroll.asciidoc
+++ b/docs/setup/install/auto-enroll.asciidoc
@@ -1,15 +1,21 @@
 [role="exclude"]
 
 If this is the first time you're starting {kib}, this command generates a 
-unique link to enroll your {kib} instance with {es}.
+unique link in your terminal to enroll your {kib} instance with {es}.
 
 . In your terminal, click the generated link to open {kib} in your browser.
 
-. In your browser, paste the enrollment token for {kib} and click the
-button to connect your {kib} instance with {es}.
+. In your browser, paste the enrollment token that was generated in the terminal 
+when you started {es}, and then click the button to connect your {kib} instance with {es}.
 
 . Log in to {kib} as the `elastic` user with the password that was 
 generated when you started {es}.
 
-NOTE: If you need to reset the password for the `elastic` user or other
-built-in users, run the {ref}/reset-password.html[`elasticsearch-reset-password`] tool.
+[NOTE]
+====
+If you need to reset the password for the `elastic` user or other
+built-in users, run the {ref}/reset-password.html[`elasticsearch-reset-password`] tool. To generate new enrollment tokens for 
+{kib} or {es} nodes, run the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool.
+These tools are available in the {es} `bin` directory.
+====

--- a/docs/setup/install/deb.asciidoc
+++ b/docs/setup/install/deb.asciidoc
@@ -123,7 +123,28 @@ sudo dpkg -i kibana-{version}-amd64.deb
 endif::[]
 
 [[deb-enroll]]
-include::start-es-and-enroll.asciidoc[]
+==== Start {es} and generate an enrollment token for {kib}
+++++
+<titleabbrev>Generate an enrollment token</titleabbrev>
+++++
+
+When you start {es} for the first time, the following security configuration
+occurs automatically:
+
+* Authentication and authorization are enabled, and a password is generated for the `elastic` built-in superuser.
+* Certificates and keys for TLS are generated for the transport and HTTP layer, and TLS is enabled and configured with these keys and certificates.
+
+The password and certificate and keys are output to your terminal.
+
+You can then generate an enrollment token for {kib} with the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool:
+
+[source,sh]
+----
+bin/elasticsearch-create-enrollment-token -s kibana
+----
+
+Start {kib} and enter the enrollment token to securely connect {kib} with {es}.
 
 [[deb-running-systemd]]
 include::systemd.asciidoc[]

--- a/docs/setup/install/deb.asciidoc
+++ b/docs/setup/install/deb.asciidoc
@@ -122,6 +122,9 @@ sudo dpkg -i kibana-{version}-amd64.deb
 
 endif::[]
 
+[[deb-enroll]]
+include::start-es-and-enroll.asciidoc[]
+
 [[deb-running-systemd]]
 include::systemd.asciidoc[]
 

--- a/docs/setup/install/rpm.asciidoc
+++ b/docs/setup/install/rpm.asciidoc
@@ -115,6 +115,9 @@ sudo rpm --install kibana-{version}-x86_64.rpm
 
 endif::[]
 
+[[rpm-enroll]]
+include::start-es-and-enroll.asciidoc[]
+
 [[rpm-running-systemd]]
 include::systemd.asciidoc[]
 

--- a/docs/setup/install/rpm.asciidoc
+++ b/docs/setup/install/rpm.asciidoc
@@ -116,7 +116,28 @@ sudo rpm --install kibana-{version}-x86_64.rpm
 endif::[]
 
 [[rpm-enroll]]
-include::start-es-and-enroll.asciidoc[]
+==== Start {es} and generate an enrollment token for {kib}
+++++
+<titleabbrev>Generate an enrollment token</titleabbrev>
+++++
+
+When you start {es} for the first time, the following security configuration
+occurs automatically:
+
+* Authentication and authorization are enabled, and a password is generated for the `elastic` built-in superuser.
+* Certificates and keys for TLS are generated for the transport and HTTP layer, and TLS is enabled and configured with these keys and certificates.
+
+The password and certificate and keys are output to your terminal.
+
+You can then generate an enrollment token for {kib} with the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool:
+
+[source,sh]
+----
+bin/elasticsearch-create-enrollment-token -s kibana
+----
+
+Start {kib} and enter the enrollment token to securely connect {kib} with {es}.
 
 [[rpm-running-systemd]]
 include::systemd.asciidoc[]

--- a/docs/setup/install/start-es-and-enroll.asciidoc
+++ b/docs/setup/install/start-es-and-enroll.asciidoc
@@ -1,0 +1,21 @@
+==== Start {es} and generate an enrollment token for {kib}
+++++
+<titleabbrev>Generate an enrollment token</titleabbrev>
+++++
+
+When you start {es} for the first time, the following security configuration
+occurs automatically:
+
+* {ref}/configuring-stack-security.html#stack-security-certificates[Certificates and keys] for TLS are
+generated for the transport and HTTP layers.
+* The TLS configuration settings are written to `elasticsearch.yml`.
+* A password is generated for the `elastic` user.
+* An enrollment token is generated for {kib}.
+
+You can then start {kib} and enter the enrollment token, which is valid for 30
+minutes. This token automatically applies the security settings from your {es} 
+cluster, authenticates to {es} with the built-in `kibana` service account, and
+writes the security configuration to `kibana.yml`.
+
+To generate a new enrollment token for {kib}, run the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool.

--- a/docs/setup/install/start-es-and-enroll.asciidoc
+++ b/docs/setup/install/start-es-and-enroll.asciidoc
@@ -12,10 +12,5 @@ generated for the transport and HTTP layers.
 * A password is generated for the `elastic` user.
 * An enrollment token is generated for {kib}.
 
-You can then start {kib} and enter the enrollment token, which is valid for 30
-minutes. This token automatically applies the security settings from your {es} 
-cluster, authenticates to {es} with the built-in `kibana` service account, and
-writes the security configuration to `kibana.yml`.
-
-To generate a new enrollment token for {kib}, run the
-{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool.
+You can then start {kib} and enter the enrollment token to securely connect 
+{kib} with {es}. The enrollment token is valid for 30 minutes.

--- a/docs/setup/install/systemd.asciidoc
+++ b/docs/setup/install/systemd.asciidoc
@@ -20,5 +20,3 @@ sudo systemctl stop kibana.service
 These commands provide no feedback as to whether {kib} was started
 successfully or not. Log information can be accessed via
 `journalctl -u kibana.service`.
-
-include::auto-enroll.asciidoc[]

--- a/docs/setup/install/systemd.asciidoc
+++ b/docs/setup/install/systemd.asciidoc
@@ -1,6 +1,6 @@
 ==== Run {kib} with `systemd`
 
-To configure Kibana to start automatically when the system boots up,
+To configure {kib} to start automatically when the system starts,
 run the following commands:
 
 [source,sh]
@@ -9,7 +9,7 @@ sudo /bin/systemctl daemon-reload
 sudo /bin/systemctl enable kibana.service
 --------------------------------------------------
 
-Kibana can be started and stopped as follows:
+{kib} can be started and stopped as follows:
 
 [source,sh]
 --------------------------------------------
@@ -17,6 +17,8 @@ sudo systemctl start kibana.service
 sudo systemctl stop kibana.service
 --------------------------------------------
 
-These commands provide no feedback as to whether Kibana was started
+These commands provide no feedback as to whether {kib} was started
 successfully or not. Log information can be accessed via
 `journalctl -u kibana.service`.
+
+include::auto-enroll.asciidoc[]

--- a/docs/setup/install/targz-running.asciidoc
+++ b/docs/setup/install/targz-running.asciidoc
@@ -9,3 +9,5 @@ Kibana can be started from the command line as follows:
 
 By default, Kibana runs in the foreground, prints its logs to the
 standard output (`stdout`), and can be stopped by pressing *Ctrl-C*.
+
+include::auto-enroll.asciidoc[]

--- a/docs/setup/install/targz.asciidoc
+++ b/docs/setup/install/targz.asciidoc
@@ -90,6 +90,8 @@ cd kibana-{version}/ <2>
 
 endif::[]
 
+[[targz-enroll]]
+include::start-es-and-enroll.asciidoc[]
 
 [[targz-running]]
 include::targz-running.asciidoc[]

--- a/docs/setup/install/windows-running.asciidoc
+++ b/docs/setup/install/windows-running.asciidoc
@@ -9,3 +9,5 @@ Kibana can be started from the command line as follows:
 
 By default, Kibana runs in the foreground, prints its logs to `STDOUT`,
 and can be stopped by pressing *Ctrl-C*.
+
+include::auto-enroll.asciidoc[]

--- a/docs/setup/install/windows.asciidoc
+++ b/docs/setup/install/windows.asciidoc
@@ -40,6 +40,9 @@ CD c:\kibana-{version}-windows-x86_64
 
 endif::[]
 
+[[windows-enroll]]
+include::start-es-and-enroll.asciidoc[]
+
 [[windows-running]]
 include::windows-running.asciidoc[]
 


### PR DESCRIPTION
## Summary

In 8.0, security is enabled and configured when users start Elasticsearch. An enrollment token is generated for Kibana, which users can copy and paste to enroll Kibana with Elasticsearch. This PR:

* Adds a new section for starting Elasticsearch and enrolling Kibana (`tar.gz`, Windows, Deb, RPM)
* Updates the section for *Running Kibana from the command line* to include steps for copying/pasting the enrollment token (`tar.gz`, Windows)

Preview links:

* [tar.gz](https://kibana_118770.docs-preview.app.elstc.co/guide/en/kibana/master/targz.html)
* [Windows](https://kibana_118770.docs-preview.app.elstc.co/guide/en/kibana/master/windows.html)
* [Deb](https://kibana_118770.docs-preview.app.elstc.co/guide/en/kibana/master/deb.html)
* [RPM](https://kibana_118770.docs-preview.app.elstc.co/guide/en/kibana/master/rpm.html)

**Note:** Security ON by default currently does not support Homebrew, but hopefully will for 8.0.
