### PR TITLE
[ci] validate bootstrap changes at beginning of checks

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -18,6 +18,10 @@ if ! yarn kbn bootstrap; then
   yarn kbn bootstrap
 fi
 
+if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
+  verify_no_git_changes 'yarn kbn bootstrap'
+fi
+
 ###
 ### upload ts-refs-cache artifacts as quickly as possible so they are available for download
 ###
@@ -26,8 +30,4 @@ if [[ "${BUILD_TS_REFS_CACHE_CAPTURE:-}" == "true" ]]; then
   cd "$KIBANA_DIR/target/ts_refs_cache"
   gsutil cp "*.zip" 'gs://kibana-ci-ts-refs-cache/'
   cd "$KIBANA_DIR"
-fi
-
-if [[ "$DISABLE_BOOTSTRAP_VALIDATION" != "true" ]]; then
-  verify_no_git_changes 'yarn kbn bootstrap'
 fi

--- a/.buildkite/scripts/steps/checks.sh
+++ b/.buildkite/scripts/steps/checks.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+export DISABLE_BOOTSTRAP_VALIDATION=false
 .buildkite/scripts/bootstrap.sh
 
 .buildkite/scripts/steps/checks/commit/commit.sh

--- a/package.json
+++ b/package.json
@@ -411,8 +411,8 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",
-    "@babel/eslint-parser": "^7.16.3",
     "@babel/core": "^7.16.0",
+    "@babel/eslint-parser": "^7.16.3",
     "@babel/eslint-plugin": "^7.14.5",
     "@babel/generator": "^7.16.0",
     "@babel/parser": "^7.16.3",

--- a/package.json
+++ b/package.json
@@ -411,8 +411,8 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",
-    "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.3",
+    "@babel/core": "^7.16.0",
     "@babel/eslint-plugin": "^7.14.5",
     "@babel/generator": "^7.16.0",
     "@babel/parser": "^7.16.3",


### PR DESCRIPTION
This is caused because the default env vars disable validation of changes after running `yarn kbn bootstrap` and we instead have to disable this disable by specifying `DISABLE_BOOTSTRAP_VALIDATION=false` in the env. This is now done at the top of `.buildkite/scripts/steps/checks.sh` so that if `package.json` is not correct (more likely to happen after #118805) the correct error will be logged and users will know to rebootstrap and commit the changes. 

Example of failure on main: https://buildkite.com/elastic/kibana-pull-request/builds/7264#1d2018d8-0e37-4658-a5b8-281deecc22e4
Example of failure with these changes: https://buildkite.com/elastic/kibana-pull-request/builds/7263#28b241ff-48ad-4f42-b905-4bfdc9c3f55a