### PR TITLE
Preemptive link fix for stack upgrade page

### DIFF
--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -72,7 +72,7 @@ For a comprehensive overview of the upgrade process, refer to
 {es} can read indices created in the previous major version. Before you upgrade
 to 7.0.0, you must reindex or delete any indices created in 5.x or earlier.
 For more information, refer to
-{stack-ref}/upgrading-elastic-stack[Upgrading the Elastic Stack].
+{stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack].
 
 When your reindex is complete, follow the <<upgrade-standard, Standard upgrade>>
 instructions.

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -72,7 +72,7 @@ For a comprehensive overview of the upgrade process, refer to
 {es} can read indices created in the previous major version. Before you upgrade
 to 7.0.0, you must reindex or delete any indices created in 5.x or earlier.
 For more information, refer to
-{stack-ref}/upgrading-elastic-stack-on-prem.html#oss-stack-upgrade[Upgrading the Elastic Stack].
+{stack-ref}/upgrading-elastic-stack[Upgrading the Elastic Stack].
 
 When your reindex is complete, follow the <<upgrade-standard, Standard upgrade>>
 instructions.

--- a/docs/setup/upgrade.asciidoc
+++ b/docs/setup/upgrade.asciidoc
@@ -72,7 +72,7 @@ For a comprehensive overview of the upgrade process, refer to
 {es} can read indices created in the previous major version. Before you upgrade
 to 7.0.0, you must reindex or delete any indices created in 5.x or earlier.
 For more information, refer to
-{stack-ref}/upgrading-elastic-stack.html#oss-stack-upgrade[Upgrading the Elastic Stack].
+{stack-ref}/upgrading-elastic-stack-on-prem.html#oss-stack-upgrade[Upgrading the Elastic Stack].
 
 When your reindex is complete, follow the <<upgrade-standard, Standard upgrade>>
 instructions.


### PR DESCRIPTION
I'm planning changes to the stack upgrade documentation via https://github.com/elastic/stack-docs/pull/1876, which will create a broken link from this Kibana [Upgrade from 5.x or earlier](https://www.elastic.co/guide/en/kibana/current/upgrade.html#upgrade-5x-earlier) section to a page that I am moving. 

This fix isn't ideal since I'm redirecting the original link to a parent topic, but:
i) I need to avoid the chicken and egg problem that if I try to point to the exact new location, neither PR can pass CI checks.
ii) 5.x is no longer supported anyway

@KOTungseth or Kibana writers, can you help me with this please? I would like to backport to 8.0 but I'm not sure about the labels/process for that.
