### PR TITLE
[Fleet] Split package policy Upgrade endpoint

### DIFF
--- a/x-pack/plugins/fleet/common/constants/routes.ts
+++ b/x-pack/plugins/fleet/common/constants/routes.ts
@@ -46,6 +46,7 @@ export const PACKAGE_POLICY_API_ROUTES = {
   UPDATE_PATTERN: `${PACKAGE_POLICY_API_ROOT}/{packagePolicyId}`,
   DELETE_PATTERN: `${PACKAGE_POLICY_API_ROOT}/delete`,
   UPGRADE_PATTERN: `${PACKAGE_POLICY_API_ROOT}/upgrade`,
+  DRYRUN_PATTERN: `${PACKAGE_POLICY_API_ROOT}/upgrade/dryrun`,
 };
 
 // Agent policy API routes

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1603,6 +1603,115 @@
         ]
       }
     },
+    "/package_policies/upgrade": {
+      "post": {
+        "summary": "Package policy - Upgrade",
+        "operationId": "upgrade-package-policy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "packagePolicyIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "packagePolicyIds"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "success": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "success"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package_policies/upgrade/dryrun": {
+      "post": {
+        "summary": "Package policy - Upgrade Dry run",
+        "operationId": "upgrade-package-policy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "packagePolicyIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "packageVersion": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "packagePolicyIds"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "hasErrors": {
+                      "type": "boolean"
+                    },
+                    "diff": {
+                      "schema": null,
+                      "$ref": "#/components/schemas/upgrade_diff"
+                    },
+                    "required": [
+                      "hasErrors"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/package_policies/{packagePolicyId}": {
       "get": {
         "summary": "Package policy - Info",
@@ -1716,6 +1825,74 @@
           }
         },
         "operationId": "get-outputs"
+      },
+      "post": {
+        "summary": "Outputs",
+        "description": "Create a new output",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "$ref": "#/components/schemas/output"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "elasticsearch"
+                    ]
+                  },
+                  "is_default": {
+                    "type": "boolean"
+                  },
+                  "is_default_monitoring": {
+                    "type": "boolean"
+                  },
+                  "hosts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "ca_sha256": {
+                    "type": "string"
+                  },
+                  "config_yaml": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ]
+              }
+            }
+          }
+        },
+        "operationId": "post-outputs"
       }
     },
     "/outputs/{outputId}": {
@@ -1754,6 +1931,35 @@
           "required": true
         }
       ],
+      "delete": {
+        "summary": "Output - Delete",
+        "operationId": "delete-output",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ]
+      },
       "put": {
         "summary": "Output - Update",
         "operationId": "update-output",
@@ -1763,19 +1969,38 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "hosts": {
+                  "name": {
                     "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "elasticsearch"
+                    ]
+                  },
+                  "is_default": {
+                    "type": "boolean"
+                  },
+                  "is_default_monitoring": {
+                    "type": "boolean"
+                  },
+                  "hosts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "ca_sha256": {
                     "type": "string"
                   },
-                  "config": {
-                    "type": "object"
-                  },
                   "config_yaml": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ]
               }
             }
           }
@@ -2626,6 +2851,11 @@
           "created_at"
         ]
       },
+      "upgrade_diff": {
+        "title": "Package policy Upgrade dryrun",
+        "type": "array",
+        "items": {}
+      },
       "update_package_policy": {
         "title": "Update package policy",
         "allOf": [
@@ -2650,6 +2880,9 @@
             "type": "string"
           },
           "is_default": {
+            "type": "boolean"
+          },
+          "is_default_monitoring": {
             "type": "boolean"
           },
           "name": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -8,9 +8,9 @@ info:
     name: Fleet Team
   license:
     name: Elastic License 2.0
-    url: 'https://www.elastic.co/licensing/elastic-license'
+    url: https://www.elastic.co/licensing/elastic-license
 servers:
-  - url: 'http://localhost:5601/api/fleet'
+  - url: http://localhost:5601/api/fleet
     description: local
 paths:
   /setup:
@@ -99,7 +99,7 @@ paths:
                   $ref: '#/components/schemas/search_result'
       operationId: list-all-packages
     parameters: []
-  '/epm/packages/{pkgkey}':
+  /epm/packages/{pkgkey}:
     get:
       summary: Packages - Info
       tags: []
@@ -361,7 +361,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bulk_upgrade_agents'
-  '/agents/{agentId}':
+  /agents/{agentId}:
     parameters:
       - schema:
           type: string
@@ -422,7 +422,7 @@ paths:
       operationId: delete-agent
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agents/{agentId}/reassign':
+  /agents/{agentId}/reassign:
     parameters:
       - schema:
           type: string
@@ -453,7 +453,7 @@ paths:
                   type: string
               required:
                 - policy_id
-  '/agents/{agentId}/unenroll':
+  /agents/{agentId}/unenroll:
     parameters:
       - schema:
           type: string
@@ -498,7 +498,7 @@ paths:
                   type: boolean
                 force:
                   type: boolean
-  '/agents/{agentId}/upgrade':
+  /agents/{agentId}/upgrade:
     parameters:
       - schema:
           type: string
@@ -666,7 +666,7 @@ paths:
       security: []
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agent_policies/{agentPolicyId}':
+  /agent_policies/{agentPolicyId}:
     parameters:
       - schema:
           type: string
@@ -714,7 +714,7 @@ paths:
               $ref: '#/components/schemas/new_agent_policy'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agent_policies/{agentPolicyId}/copy':
+  /agent_policies/{agentPolicyId}/copy:
     parameters:
       - schema:
           type: string
@@ -832,7 +832,7 @@ paths:
       operationId: create-enrollment-api-keys
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/enrollment-api-keys/{keyId}':
+  /enrollment-api-keys/{keyId}:
     parameters:
       - schema:
           type: string
@@ -973,7 +973,75 @@ paths:
                     - success
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/package_policies/{packagePolicyId}':
+  /package_policies/upgrade:
+    post:
+      summary: Package policy - Upgrade
+      operationId: upgrade-package-policy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                packagePolicyIds:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    success:
+                      type: boolean
+                  required:
+                    - id
+                    - success
+  /package_policies/upgrade/dryrun:
+    post:
+      summary: Package policy - Upgrade Dry run
+      operationId: upgrade-package-policy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                packagePolicyIds:
+                  type: array
+                  items:
+                    type: string
+                packageVersion:
+                  type: string
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hasErrors:
+                    type: boolean
+                  diff:
+                    schema: null
+                    $ref: '#/components/schemas/upgrade_diff'
+                  required:
+                    - hasErrors
+  /package_policies/{packagePolicyId}:
     get:
       summary: Package policy - Info
       tags: []
@@ -1044,7 +1112,51 @@ paths:
                   perPage:
                     type: integer
       operationId: get-outputs
-  '/outputs/{outputId}':
+    post:
+      summary: Outputs
+      description: Create a new output
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/output'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                name:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - elasticsearch
+                is_default:
+                  type: boolean
+                is_default_monitoring:
+                  type: boolean
+                hosts:
+                  type: array
+                  items:
+                    type: string
+                ca_sha256:
+                  type: string
+                config_yaml:
+                  type: string
+              required:
+                - name
+                - type
+      operationId: post-outputs
+  /outputs/{outputId}:
     get:
       summary: Output - Info
       tags: []
@@ -1067,6 +1179,23 @@ paths:
         name: outputId
         in: path
         required: true
+    delete:
+      summary: Output - Delete
+      operationId: delete-output
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
     put:
       summary: Output - Update
       operationId: update-output
@@ -1076,14 +1205,27 @@ paths:
             schema:
               type: object
               properties:
-                hosts:
+                name:
                   type: string
+                type:
+                  type: string
+                  enum:
+                    - elasticsearch
+                is_default:
+                  type: boolean
+                is_default_monitoring:
+                  type: boolean
+                hosts:
+                  type: array
+                  items:
+                    type: string
                 ca_sha256:
                   type: string
-                config:
-                  type: object
                 config_yaml:
                   type: string
+              required:
+                - name
+                - type
       responses:
         '200':
           description: OK
@@ -1098,7 +1240,7 @@ paths:
                   - item
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/epm/packages/{pkgName}/stats':
+  /epm/packages/{pkgName}/stats:
     get:
       summary: Get stats for a package
       tags: []
@@ -1653,6 +1795,10 @@ components:
         - api_key
         - active
         - created_at
+    upgrade_diff:
+      title: Package policy Upgrade dryrun
+      type: array
+      items: {}
     update_package_policy:
       title: Update package policy
       allOf:
@@ -1668,6 +1814,8 @@ components:
         id:
           type: string
         is_default:
+          type: boolean
+        is_default_monitoring:
           type: boolean
         name:
           type: string

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/upgrade_diff.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/upgrade_diff.yaml
@@ -1,0 +1,3 @@
+title: Package policy Upgrade dryrun
+type: array
+items: {}

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -62,6 +62,10 @@ paths:
     $ref: paths/package_policies.yaml
   /package_policies/delete:
     $ref: paths/package_policies@delete.yaml
+  /package_policies/upgrade:
+    $ref: paths/package_policies@upgrade.yaml
+  /package_policies/upgrade/dryrun:
+    $ref: paths/package_policies@upgrade_dryrun.yaml
   '/package_policies/{packagePolicyId}':
     $ref: 'paths/package_policies@{package_policy_id}.yaml'
   /outputs:

--- a/x-pack/plugins/fleet/common/openapi/paths/package_policies@upgrade.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/package_policies@upgrade.yaml
@@ -1,0 +1,34 @@
+post:
+  summary: Package policy - Upgrade
+  operationId: upgrade-package-policy
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            packagePolicyIds:
+              type: array
+              items:
+                type: string
+          required:
+            - packagePolicyIds
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                name:
+                  type: string
+                success:
+                  type: boolean
+              required:
+                - id
+                - success

--- a/x-pack/plugins/fleet/common/openapi/paths/package_policies@upgrade_dryrun.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/package_policies@upgrade_dryrun.yaml
@@ -1,0 +1,32 @@
+post:
+  summary: Package policy - Upgrade Dry run
+  operationId: upgrade-package-policy
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            packagePolicyIds:
+              type: array
+              items:
+                type: string
+            packageVersion:
+              type: string
+          required:
+            - packagePolicyIds
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              hasErrors:
+                type: boolean
+              diff:
+                schema:
+                $ref: ../components/schemas/upgrade_diff.yaml
+              required:
+                - hasErrors

--- a/x-pack/plugins/fleet/common/services/routes.ts
+++ b/x-pack/plugins/fleet/common/services/routes.ts
@@ -89,6 +89,10 @@ export const packagePolicyRouteService = {
   getUpgradePath: () => {
     return PACKAGE_POLICY_API_ROUTES.UPGRADE_PATTERN;
   },
+
+  getDryRunPath: () => {
+    return PACKAGE_POLICY_API_ROUTES.DRYRUN_PATTERN;
+  },
 };
 
 export const agentPolicyRouteService = {

--- a/x-pack/plugins/fleet/public/hooks/use_request/package_policy.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/package_policy.ts
@@ -77,9 +77,8 @@ export function sendUpgradePackagePolicyDryRun(
   packagePolicyIds: string[],
   packageVersion?: string
 ) {
-  const body: { packagePolicyIds: string[]; dryRun: boolean; packageVersion?: string } = {
+  const body: { packagePolicyIds: string[]; packageVersion?: string } = {
     packagePolicyIds,
-    dryRun: true,
   };
 
   if (packageVersion) {
@@ -87,7 +86,7 @@ export function sendUpgradePackagePolicyDryRun(
   }
 
   return sendRequest<UpgradePackagePolicyDryRunResponse>({
-    path: packagePolicyRouteService.getUpgradePath(),
+    path: packagePolicyRouteService.getDryRunPath(),
     method: 'post',
     body: JSON.stringify(body),
   });
@@ -99,7 +98,6 @@ export function sendUpgradePackagePolicy(packagePolicyIds: string[]) {
     method: 'post',
     body: JSON.stringify({
       packagePolicyIds,
-      dryRun: false,
     }),
   });
 }

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -18,6 +18,7 @@ import type {
   UpdatePackagePolicyRequestSchema,
   DeletePackagePoliciesRequestSchema,
   UpgradePackagePoliciesRequestSchema,
+  DryRunPackagePoliciesRequestSchema,
 } from '../../types';
 import type {
   CreatePackagePolicyResponse,
@@ -192,8 +193,6 @@ export const deletePackagePolicyHandler: RequestHandler<
   }
 };
 
-// TODO: Separate the upgrade and dry-run processes into separate endpoints, and address
-// duplicate logic in error handling as part of https://github.com/elastic/kibana/issues/63123
 export const upgradePackagePolicyHandler: RequestHandler<
   unknown,
   unknown,
@@ -203,50 +202,56 @@ export const upgradePackagePolicyHandler: RequestHandler<
   const esClient = context.core.elasticsearch.client.asCurrentUser;
   const user = appContextService.getSecurity()?.authc.getCurrentUser(request) || undefined;
   try {
-    if (request.body.dryRun) {
-      const body: UpgradePackagePolicyDryRunResponse = [];
+    const body: UpgradePackagePolicyResponse = await packagePolicyService.upgrade(
+      soClient,
+      esClient,
+      request.body.packagePolicyIds,
+      { user }
+    );
 
-      for (const id of request.body.packagePolicyIds) {
-        const result = await packagePolicyService.getUpgradeDryRunDiff(
-          soClient,
-          id,
-          request.body.packageVersion
-        );
-        body.push(result);
-      }
+    const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
 
-      const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
-
-      if (firstFatalError) {
-        return response.customError({
-          statusCode: firstFatalError.statusCode!,
-          body: { message: firstFatalError.body!.message },
-        });
-      }
-
-      return response.ok({
-        body,
-      });
-    } else {
-      const body: UpgradePackagePolicyResponse = await packagePolicyService.upgrade(
-        soClient,
-        esClient,
-        request.body.packagePolicyIds,
-        { user }
-      );
-
-      const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
-
-      if (firstFatalError) {
-        return response.customError({
-          statusCode: firstFatalError.statusCode!,
-          body: { message: firstFatalError.body!.message },
-        });
-      }
-      return response.ok({
-        body,
+    if (firstFatalError) {
+      return response.customError({
+        statusCode: firstFatalError.statusCode!,
+        body: { message: firstFatalError.body!.message },
       });
     }
+    return response.ok({
+      body,
+    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
+  }
+};
+
+export const dryRunUpgradePackagePolicyHandler: RequestHandler<
+  unknown,
+  unknown,
+  TypeOf<typeof DryRunPackagePoliciesRequestSchema.body>
+> = async (context, request, response) => {
+  const soClient = context.core.savedObjects.client;
+  try {
+    const body: UpgradePackagePolicyDryRunResponse = [];
+    const { packagePolicyIds, packageVersion } = request.body;
+
+    for (const id of packagePolicyIds) {
+      const result = await packagePolicyService.getUpgradeDryRunDiff(soClient, id, packageVersion);
+      body.push(result);
+    }
+
+    const firstFatalError = body.find((item) => item.statusCode && item.statusCode !== 200);
+
+    if (firstFatalError) {
+      return response.customError({
+        statusCode: firstFatalError.statusCode!,
+        body: { message: firstFatalError.body!.message },
+      });
+    }
+
+    return response.ok({
+      body,
+    });
   } catch (error) {
     return defaultIngestErrorHandler({ error, response });
   }

--- a/x-pack/plugins/fleet/server/routes/package_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/index.ts
@@ -15,6 +15,7 @@ import {
   UpdatePackagePolicyRequestSchema,
   DeletePackagePoliciesRequestSchema,
   UpgradePackagePoliciesRequestSchema,
+  DryRunPackagePoliciesRequestSchema,
 } from '../../types';
 
 import {
@@ -24,6 +25,7 @@ import {
   updatePackagePolicyHandler,
   deletePackagePolicyHandler,
   upgradePackagePolicyHandler,
+  dryRunUpgradePackagePolicyHandler,
 } from './handlers';
 
 export const registerRoutes = (router: IRouter) => {
@@ -85,5 +87,15 @@ export const registerRoutes = (router: IRouter) => {
       options: { tags: [`access:${PLUGIN_ID}-all`] },
     },
     upgradePackagePolicyHandler
+  );
+
+  // Upgrade - DryRun
+  router.post(
+    {
+      path: PACKAGE_POLICY_API_ROUTES.DRYRUN_PATTERN,
+      validate: DryRunPackagePoliciesRequestSchema,
+      options: { tags: [`access:${PLUGIN_ID}-all`] },
+    },
+    dryRunUpgradePackagePolicyHandler
   );
 };

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -428,7 +428,6 @@ class PackagePolicyService {
           currentVersion: currentVersion || 'unknown',
           newVersion: packagePolicy.package.version,
           status: 'success',
-          dryRun: false,
           eventType: 'package-policy-upgrade' as UpdateEventType,
         };
         sendTelemetryEvents(

--- a/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts
@@ -40,7 +40,12 @@ export const DeletePackagePoliciesRequestSchema = {
 export const UpgradePackagePoliciesRequestSchema = {
   body: schema.object({
     packagePolicyIds: schema.arrayOf(schema.string()),
-    dryRun: schema.maybe(schema.boolean()),
+  }),
+};
+
+export const DryRunPackagePoliciesRequestSchema = {
+  body: schema.object({
+    packagePolicyIds: schema.arrayOf(schema.string()),
     packageVersion: schema.maybe(schema.string()),
   }),
 };

--- a/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/upgrade.ts
@@ -124,11 +124,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
               packageVersion: '0.2.0-add-non-required-test-var',
             })
             .expect(200);
@@ -145,14 +144,12 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       describe('upgrade', function () {
-        it('should respond with an error when "dryRun: false" is provided', async function () {
+        it('should respond with an error', async function () {
           await supertest
             .post(`/api/fleet/package_policies/upgrade`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
-              packageVersion: '0.2.0-add-non-required-test-var',
             })
             .expect(400);
         });
@@ -234,11 +231,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -265,7 +261,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(200);
 
@@ -345,11 +340,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -371,7 +365,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(200);
 
@@ -455,11 +448,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -476,7 +468,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(200);
 
@@ -556,11 +547,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a diff with errors', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -575,7 +565,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(400);
         });
@@ -656,11 +645,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a diff with errors', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -675,7 +663,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(400);
         });
@@ -756,11 +743,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -775,7 +761,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(200);
 
@@ -884,11 +869,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -903,7 +887,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(200);
 
@@ -981,11 +964,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('returns a valid diff', async function () {
           const { body }: { body: UpgradePackagePolicyDryRunResponse } = await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
             })
             .expect(200);
 
@@ -1023,7 +1005,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
             })
             .expect(200);
 
@@ -1033,24 +1014,22 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('when package policy is not found', function () {
-      it('should return an 200 with errors when "dryRun:true" is provided', async function () {
+      it('should return an 200 with errors when performing a dryrun', async function () {
         await supertest
-          .post(`/api/fleet/package_policies/upgrade`)
+          .post(`/api/fleet/package_policies/upgrade/dryrun`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             packagePolicyIds: ['xxxx', 'yyyy'],
-            dryRun: true,
           })
           .expect(404);
       });
 
-      it('should return a 200 with errors and "success:false" when "dryRun:false" is provided', async function () {
+      it('should return a 200 with errors and "success:false" when trying to upgrade', async function () {
         await supertest
           .post(`/api/fleet/package_policies/upgrade`)
           .set('kbn-xsrf', 'xxxx')
           .send({
             packagePolicyIds: ['xxxx', 'yyyy'],
-            dryRun: false,
           })
           .expect(404);
       });
@@ -1126,11 +1105,10 @@ export default function (providerContext: FtrProviderContext) {
       describe('dry run', function () {
         it('should respond with a bad request', async function () {
           await supertest
-            .post(`/api/fleet/package_policies/upgrade`)
+            .post(`/api/fleet/package_policies/upgrade/dryrun`)
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: true,
               packageVersion: '0.1.0',
             })
             .expect(400);
@@ -1144,8 +1122,6 @@ export default function (providerContext: FtrProviderContext) {
             .set('kbn-xsrf', 'xxxx')
             .send({
               packagePolicyIds: [packagePolicyId],
-              dryRun: false,
-              packageVersion: '0.1.0',
             })
             .expect(400);
         });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/115570

**Breaking change in the package policies upgrade API**

The packagePolicy `upgrade` endpoint currently has this format. It supports a mutative upgrade operation (when `dryRun: false`) and a read-only dry run operation (when `dryRun: true`)  for package policy upgrades:

```
POST /package_policies/upgrade
{
  packagePolicyIds: [...],
  dryRun: false
}
```
As part of a general reordering of Fleet APIs, this endpoint will now be split in two separate endpoints:

```
POST /package_policies/upgrade
{
  packagePolicyIds: [...]
}

POST /package_policies/upgrade/dry_run
{
  packagePolicyIds: [...]
}
```

### Repro steps

- Navigate to `app/fleet/integrations/docker-1.0.0/add-integration` to install an older version of docker
- Go to the network tab and get the `packagePolicyId` of this integration

#### Test case 1: Dry run
- Using postman or curl, post to `/package_policies/upgrade/dryrun`. An example of `body` targeting docker version `1.1.1` is 
```
{
  "packagePolicyIds": ["23020b5e-39fa-4421-8c77-05b184b96fd0"],
  "packageVersion": "1.1.1"
}
- The upgrade should work properly

```
#### Test case 2: Upgrade
- Using postman or curl, post to `/package_policies/upgrade`. An example of `body`:
```
{
  "packagePolicyIds": ["23020b5e-39fa-4421-8c77-05b184b96fd0"],
}
```
- The dry run should work normally

#### Test case 3: Upgrade (in UI):

- Same as before, install an older version of a package 
- Go to Integrations settings, click on the "Upgrade to latest version", it will trigger the modal
- Click on "upgrade". In the network tab both the `dryrun` and the `upgrade` endpoint should work successfully

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
