### PR TITLE
Update Search UI field config route.

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_ui.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_ui.test.ts
@@ -33,7 +33,7 @@ describe('reference application routes', () => {
       });
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/as/engines/:engineName/reference_application/field_config',
+        path: '/as/engines/:engineName/search_experience/field_config',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/search_ui.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/search_ui.ts
@@ -23,7 +23,7 @@ export function registerSearchUIRoutes({
       },
     },
     enterpriseSearchRequestHandler.createRequest({
-      path: '/as/engines/:engineName/reference_application/field_config',
+      path: '/as/engines/:engineName/search_experience/field_config',
     })
   );
 }


### PR DESCRIPTION
## Summary

This PR updates routes in Kibana to use `search_experience` instead of `reference_application` to retrieve field config of the Search UI application.



### Checklist

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
