### PR TITLE
[7.16] Remove soft limit for snapshot repositories (#118634)

### DIFF
--- a/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_retention.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_retention.tsx
@@ -16,7 +16,6 @@ import {
   EuiButtonEmpty,
   EuiFieldNumber,
   EuiSelect,
-  EuiCode,
 } from '@elastic/eui';
 
 import { SlmPolicyPayload } from '../../../../../common/types';
@@ -139,10 +138,7 @@ export const PolicyStepRetention: React.FunctionComponent<StepProps> = ({
       description={
         <FormattedMessage
           id="xpack.snapshotRestore.policyForm.stepRetention.countDescription"
-          defaultMessage="The minimum and maximum number of snapshots to store in your cluster. It should not exceed {maxNumber}."
-          values={{
-            maxNumber: <EuiCode>200</EuiCode>,
-          }}
+          defaultMessage="The minimum and maximum number of snapshots to store for the policy."
         />
       }
       fullWidth
@@ -225,13 +221,13 @@ export const PolicyStepRetention: React.FunctionComponent<StepProps> = ({
           <EuiButtonEmpty
             size="s"
             flush="right"
-            href={docLinks.links.apis.putSnapshotLifecyclePolicy}
+            href={docLinks.links.snapshotRestore.createSnapshot}
             target="_blank"
             iconType="help"
           >
             <FormattedMessage
               id="xpack.snapshotRestore.policyForm.stepRetention.docsButtonLabel"
-              defaultMessage="Snapshot retention docs"
+              defaultMessage="Snapshot docs"
             />
           </EuiButtonEmpty>
         </EuiFlexItem>

--- a/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_settings/step_settings.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_settings/step_settings.tsx
@@ -191,7 +191,7 @@ export const PolicyStepSettings: React.FunctionComponent<StepProps> = ({
           >
             <FormattedMessage
               id="xpack.snapshotRestore.policyForm.stepSettings.docsButtonLabel"
-              defaultMessage="Snapshot settings docs"
+              defaultMessage="Snapshot docs"
             />
           </EuiButtonEmpty>
         </EuiFlexItem>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -23465,7 +23465,7 @@
     "xpack.snapshotRestore.policyForm.stepLogistics.snapshotNameDescription": "スナップショットの名前です。それぞれの名前に自動的に追加される固有の識別子です。",
     "xpack.snapshotRestore.policyForm.stepLogistics.snapshotNameDescriptionTitle": "スナップショット名",
     "xpack.snapshotRestore.policyForm.stepLogisticsTitle": "ロジスティクス",
-    "xpack.snapshotRestore.policyForm.stepRetention.countDescription": "クラスターに格納するスナップショットの最少数と最大数。{maxNumber} 以下でなければなりません。",
+    "xpack.snapshotRestore.policyForm.stepRetention.countDescription": "クラスターに格納するスナップショットの最少数と最大数。",
     "xpack.snapshotRestore.policyForm.stepRetention.countTitle": "保存するスナップショット",
     "xpack.snapshotRestore.policyForm.stepRetention.docsButtonLabel": "スナップショット保存ドキュメント",
     "xpack.snapshotRestore.policyForm.stepRetention.expirationDescription": "スナップショットの削除までに待つ時間です。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -23858,7 +23858,7 @@
     "xpack.snapshotRestore.policyForm.stepLogistics.snapshotNameDescription": "快照的名称。唯一标识符将自动添加到每个名称中。",
     "xpack.snapshotRestore.policyForm.stepLogistics.snapshotNameDescriptionTitle": "快照名称",
     "xpack.snapshotRestore.policyForm.stepLogisticsTitle": "运筹",
-    "xpack.snapshotRestore.policyForm.stepRetention.countDescription": "在您的集群中要存储的最小和最大快照数目。不应超过 {maxNumber}。",
+    "xpack.snapshotRestore.policyForm.stepRetention.countDescription": "在您的集群中要存储的最小和最大快照数目。",
     "xpack.snapshotRestore.policyForm.stepRetention.countTitle": "要保留的快照",
     "xpack.snapshotRestore.policyForm.stepRetention.docsButtonLabel": "快照保留文档",
     "xpack.snapshotRestore.policyForm.stepRetention.expirationDescription": "删除快照前要等候的时间。",


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Remove soft limit for snapshot repositories (#118634)