### PR TITLE
[8.0] Use documentation link service in index lifecycle management (#118623)

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/data_tier_allocation_field/components/no_custom_attributes_messages.tsx
+++ b/x-pack/plugins/index_lifecycle_management/public/application/sections/edit_policy/components/phases/shared_fields/data_tier_allocation_field/components/no_custom_attributes_messages.tsx
@@ -9,21 +9,26 @@ import React from 'react';
 import { EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { DocLinksStart } from 'src/core/public';
 
 import { getNodeAllocationMigrationLink } from '../../../../../../../services/documentation';
+
+export interface Props {
+  docLinks: DocLinksStart;
+}
 
 export const noCustomAttributesTitle = i18n.translate(
   'xpack.indexLifecycleMgmt.editPolicy.noCustomAttributesTitle',
   { defaultMessage: 'No custom attributes defined' }
 );
 
-export const nodeAllocationMigrationGuidance = (
+export const nodeAllocationMigrationGuidance = ({ docLinks }: Props) => (
   <FormattedMessage
     id="xpack.indexLifecycleMgmt.editPolicy.defaultToDataNodesDescription"
     defaultMessage="To allocate data to particular data nodes, {roleBasedGuidance} or configure custom node attributes in elasticsearch.yml."
     values={{
       roleBasedGuidance: (
-        <EuiLink href={getNodeAllocationMigrationLink()} target="_blank" external={true}>
+        <EuiLink href={getNodeAllocationMigrationLink(docLinks)} target="_blank" external={true}>
           {i18n.translate(
             'xpack.indexLifecycleMgmt.editPolicy.defaultToDataNodesDescription.migrationGuidanceMessage',
             {

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/documentation.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/documentation.ts
@@ -11,6 +11,8 @@
  * in future. The pattern in this file is legacy and should be updated to conform to the plugin lifecycle.
  */
 
+import { DocLinksStart } from 'src/core/public';
+
 export let skippingDisconnectedClustersUrl: string;
 export let remoteClustersUrl: string;
 export let transportPortUrl: string;
@@ -22,5 +24,5 @@ export function init(esDocBasePath: string): void {
 }
 
 export const createDocLink = (docPath: string): string => `${_esDocBasePath}${docPath}`;
-export const getNodeAllocationMigrationLink = () =>
-  `${_esDocBasePath}migrate-index-allocation-filters.html`;
+export const getNodeAllocationMigrationLink = ({ links }: DocLinksStart) =>
+  `${links.elasticsearch.migrateIndexAllocationFilters}`;


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Use documentation link service in index lifecycle management (#118623)