### PR TITLE
[DOCS] Fixes #100586 settings

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -451,7 +451,7 @@ Use the <<xpack-fleet-agents-elasticsearch-hosts,`xpack.fleet.agents.elasticsear
 The `kibana.autocompleteTerminateAfter` and `kibana.autocompleteTimeout` settings are deprecated. For more information, refer to {kibana-pull}100586[#100586].
 
 *Impact* +
-Use the `data.autocomplete.terminateAfter` and `data.autocomplete.timeout` settings.
+Use the `data.autocomplete.valueSuggestions.terminateAfter` and `data.autocomplete.valueSuggestions.timeout` settings.
 ====
       
 [discrete]


### PR DESCRIPTION
## Summary

Updates the following settings in the 7.14.0 release notes:

- `data.autocomplete.terminateAfter ` -> `data.autocomplete.valueSuggestions.terminateAfter`
- `data.autocomplete.timeout` -> `data.autocomplete.valueSuggestions.timeout`