### PR TITLE
[CI] Exclude TSVB chart tests from Firefox

### DIFF
--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -27,8 +27,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   ]);
 
   describe('visual builder', function describeIndexTests() {
-    this.tags('includeFirefox');
-
     before(async () => {
       await visualize.initTests();
     });


### PR DESCRIPTION
OSS Firefox tests are currently our longest-running suite of tests. Digging into it, it turns out that just the `visualize/_tsvb_chart.ts` tests are running for about 40 minutes. Excluding them brings the overall build time for this suite from 1h5m down to 25m. This should cut an additional 10 minutes off our overall CI time.

Given this, how critical is it that these tests run in Firefox? Can they be excluded like this?