### PR TITLE
[ftr/remote] delay chrome restarts, limit attempts

### DIFF
--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -10,7 +10,7 @@ import { resolve } from 'path';
 import Fs from 'fs';
 
 import * as Rx from 'rxjs';
-import { mergeMap, map, takeUntil, catchError } from 'rxjs/operators';
+import { mergeMap, map, takeUntil, catchError, ignoreElements } from 'rxjs/operators';
 import { Lifecycle } from '@kbn/test';
 import { ToolingLog } from '@kbn/dev-utils';
 import chromeDriver from 'chromedriver';
@@ -52,6 +52,8 @@ const chromiumUserPrefs = {
     },
   },
 };
+
+const sleep$ = (ms: number) => Rx.timer(ms).pipe(ignoreElements());
 
 /**
  * Best we can tell WebDriver locks up sometimes when we send too many
@@ -331,6 +333,7 @@ export async function initWebDriver(
     edgePaths = await installDriver();
   }
 
+  let attempt = 1;
   return await Rx.race(
     Rx.timer(2 * MINUTE).pipe(
       map(() => {
@@ -355,8 +358,14 @@ export async function initWebDriver(
       catchError((error, resubscribe) => {
         log.warning('Failure while creating webdriver instance');
         log.warning(error);
-        log.warning('...retrying...');
-        return resubscribe;
+
+        if (attempt > 5) {
+          throw new Error('out of retry attempts');
+        }
+
+        attempt += 1;
+        log.warning('...retrying in 15 seconds...');
+        return Rx.concat(sleep$(15000), resubscribe);
       })
     )
   ).toPromise();


### PR DESCRIPTION
When chromedriver fails to install for whatever reason we try to restart Chrome in a loop until the job is timed out. This leads to tons of logs being generated for no good reason, so this modifies the retry logic to wait for 15 seconds and only try to start Chrome 5 times before giving up.