### PR TITLE
[ftr] label global hooks which tie into lifecycle service

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/decorate_mocha_ui.js
@@ -57,7 +57,7 @@ export function decorateMochaUi(log, lifecycle, context, { isDockerGroup, rootTa
         }
 
         argumentsList[1] = function () {
-          before(async () => {
+          before('beforeTestSuite.trigger', async () => {
             await lifecycle.beforeTestSuite.trigger(this);
           });
 
@@ -87,7 +87,7 @@ export function decorateMochaUi(log, lifecycle, context, { isDockerGroup, rootTa
 
           provider.call(this);
 
-          after(async () => {
+          after('afterTestSuite.trigger', async () => {
             await lifecycle.afterTestSuite.trigger(this);
           });
         };


### PR DESCRIPTION
I'm trying to debug why we're getting weird timeouts in the lens rollup tests, I suspect that it's actually happening in the after() hook triggering the `afterTestSuite` lifecycle method but since it's anonymous it's tricky to know