### PR TITLE
[Security Solutions] Removes plugins/data/public deprecations from cases plugin

### DIFF
--- a/x-pack/plugins/cases/common/utils/markdown_plugins/utils.ts
+++ b/x-pack/plugins/cases/common/utils/markdown_plugins/utils.ts
@@ -11,8 +11,8 @@ import markdown from 'remark-parse';
 import remarkStringify from 'remark-stringify';
 import unified from 'unified';
 
-import { TimeRange } from 'src/plugins/data/server';
 import { SerializableRecord } from '@kbn/utility-types';
+import type { TimeRange } from 'src/plugins/data/common';
 import { LENS_ID, LensParser, LensSerializer } from './lens';
 import { TimelineSerializer, TimelineParser } from './timeline';
 

--- a/x-pack/plugins/cases/server/authorization/types.ts
+++ b/x-pack/plugins/cases/server/authorization/types.ts
@@ -6,7 +6,7 @@
  */
 
 import { EcsEventType, KibanaRequest } from 'kibana/server';
-import { KueryNode } from 'src/plugins/data/common';
+import type { KueryNode } from '@kbn/es-query';
 import { Space } from '../../../spaces/server';
 
 /**

--- a/x-pack/plugins/cases/server/authorization/utils.test.ts
+++ b/x-pack/plugins/cases/server/authorization/utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { nodeBuilder } from '../../../../../src/plugins/data/common';
+import { nodeBuilder } from '@kbn/es-query';
 import { OWNER_FIELD } from '../../common';
 import {
   combineFilterWithAuthorizationFilter,

--- a/x-pack/plugins/cases/server/authorization/utils.ts
+++ b/x-pack/plugins/cases/server/authorization/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { remove, uniq } from 'lodash';
-import { nodeBuilder, KueryNode } from '../../../../../src/plugins/data/common';
+import { nodeBuilder, KueryNode } from '@kbn/es-query';
 import { OWNER_FIELD } from '../../common';
 
 export const getOwnersFilter = (

--- a/x-pack/plugins/cases/server/client/attachments/add.ts
+++ b/x-pack/plugins/cases/server/client/attachments/add.ts
@@ -10,6 +10,7 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 
+import { nodeBuilder } from '@kbn/es-query';
 import {
   SavedObject,
   SavedObjectsClientContract,
@@ -17,7 +18,6 @@ import {
   SavedObjectsUtils,
 } from '../../../../../../src/core/server';
 import { LensServerPluginSetup } from '../../../../lens/server';
-import { nodeBuilder } from '../../../../../../src/plugins/data/common';
 
 import {
   AlertCommentRequestRt,

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -18,7 +18,7 @@ import {
   SavedObjectsFindResult,
 } from 'kibana/server';
 
-import { nodeBuilder } from '../../../../../../src/plugins/data/common';
+import { nodeBuilder } from '@kbn/es-query';
 
 import {
   AssociationType,

--- a/x-pack/plugins/cases/server/client/sub_cases/update.ts
+++ b/x-pack/plugins/cases/server/client/sub_cases/update.ts
@@ -16,7 +16,7 @@ import {
   Logger,
 } from 'kibana/server';
 
-import { nodeBuilder } from '../../../../../../src/plugins/data/common';
+import { nodeBuilder } from '@kbn/es-query';
 import { CasesService } from '../../services';
 import {
   CASE_COMMENT_SAVED_OBJECT,

--- a/x-pack/plugins/cases/server/client/utils.ts
+++ b/x-pack/plugins/cases/server/client/utils.ts
@@ -12,8 +12,7 @@ import { fold } from 'fp-ts/lib/Either';
 import { identity } from 'fp-ts/lib/function';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { nodeBuilder, KueryNode } from '../../../../../src/plugins/data/common';
-import { esKuery } from '../../../../../src/plugins/data/server';
+import { nodeBuilder, fromKueryExpression, KueryNode } from '@kbn/es-query';
 import {
   AlertCommentRequestRt,
   ActionsCommentRequestRt,
@@ -183,7 +182,7 @@ export function stringToKueryNode(expression?: string): KueryNode | undefined {
     return;
   }
 
-  return esKuery.fromKueryExpression(expression);
+  return fromKueryExpression(expression);
 }
 
 /**

--- a/x-pack/plugins/cases/server/common/types.ts
+++ b/x-pack/plugins/cases/server/common/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { KueryNode } from '../../../../../src/plugins/data/server';
+import type { KueryNode } from '@kbn/es-query';
 import { SavedObjectFindOptions } from '../../common';
 
 /**

--- a/x-pack/plugins/cases/server/services/attachments/index.ts
+++ b/x-pack/plugins/cases/server/services/attachments/index.ts
@@ -12,7 +12,7 @@ import {
   SavedObjectsUpdateOptions,
 } from 'kibana/server';
 
-import { KueryNode } from '../../../../../../src/plugins/data/common';
+import type { KueryNode } from '@kbn/es-query';
 import {
   AttributesTypeAlerts,
   CASE_COMMENT_SAVED_OBJECT,

--- a/x-pack/plugins/cases/server/services/cases/index.ts
+++ b/x-pack/plugins/cases/server/services/cases/index.ts
@@ -20,7 +20,7 @@ import {
 } from 'kibana/server';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { nodeBuilder, KueryNode } from '../../../../../../src/plugins/data/common';
+import { nodeBuilder, KueryNode } from '@kbn/es-query';
 
 import { SecurityPluginSetup } from '../../../../security/server';
 import {


### PR DESCRIPTION
## Summary

This removes all the areas marked as deprecated from `.../src/plugins/data/public` with their `@kbn/es-query` equivalent or it uses the directly exported version from `.../src/plugins/data/public`. Anywhere else this adds the `import type {` where it can to encourage the build system to do more type erasures.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
