### PR TITLE
[8.0] [APM] fixes missing legacy apm schema config translation (#117645) (#118908)

### DIFF
--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.test.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.test.ts
@@ -10,6 +10,7 @@ import { preprocessLegacyFields } from './get_apm_package_policy_definition';
 const apmServerSchema = {
   'apm-server.host': '0.0.0.0:8200',
   'apm-server.secret_token': 'asdfkjhasdf',
+  'apm-server.api_key.enabled': true,
   'apm-server.read_timeout': 3600,
   'apm-server.rum.event_rate.limit': 100,
   'apm-server.rum.event_rate.lru_size': 100,
@@ -29,6 +30,7 @@ describe('get_apm_package_policy_definition', () => {
           "apm-server.auth.anonymous.allow_service": "opbeans-test",
           "apm-server.auth.anonymous.rate_limit.event_limit": 100,
           "apm-server.auth.anonymous.rate_limit.ip_limit": 100,
+          "apm-server.auth.api_key.enabled": true,
           "apm-server.auth.secret_token": "asdfkjhasdf",
           "apm-server.host": "0.0.0.0:8200",
           "apm-server.read_timeout": 3600,

--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.test.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { preprocessLegacyFields } from './get_apm_package_policy_definition';
+
+const apmServerSchema = {
+  'apm-server.host': '0.0.0.0:8200',
+  'apm-server.secret_token': 'asdfkjhasdf',
+  'apm-server.read_timeout': 3600,
+  'apm-server.rum.event_rate.limit': 100,
+  'apm-server.rum.event_rate.lru_size': 100,
+  'apm-server.rum.allow_service_names': 'opbeans-test',
+  'logging.level': 'error',
+  'queue.mem.events': 2000,
+  'queue.mem.flush.timeout': '1s',
+  'setup.template.settings.index.number_of_jshards': 1,
+};
+
+describe('get_apm_package_policy_definition', () => {
+  describe('preprocessLegacyFields', () => {
+    it('should replace legacy fields with supported fields', () => {
+      const result = preprocessLegacyFields({ apmServerSchema });
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "apm-server.auth.anonymous.allow_service": "opbeans-test",
+          "apm-server.auth.anonymous.rate_limit.event_limit": 100,
+          "apm-server.auth.anonymous.rate_limit.ip_limit": 100,
+          "apm-server.auth.secret_token": "asdfkjhasdf",
+          "apm-server.host": "0.0.0.0:8200",
+          "apm-server.read_timeout": 3600,
+          "logging.level": "error",
+          "queue.mem.events": 2000,
+          "queue.mem.flush.timeout": "1s",
+          "setup.template.settings.index.number_of_jshards": 1,
+        }
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
@@ -68,6 +68,10 @@ export function preprocessLegacyFields({
       key: 'apm-server.auth.secret_token',
       legacyKey: 'apm-server.secret_token',
     },
+    {
+      key: 'apm-server.auth.api_key.enabled',
+      legacyKey: 'apm-server.api_key.enabled',
+    },
   ].forEach(({ key, legacyKey }) => {
     if (!copyOfApmServerSchema[key]) {
       copyOfApmServerSchema[key] = copyOfApmServerSchema[legacyKey];

--- a/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_apm_package_policy_definition.ts
@@ -45,7 +45,7 @@ export function getApmPackagePolicyDefinition(
   };
 }
 
-function preprocessLegacyFields({
+export function preprocessLegacyFields({
   apmServerSchema,
 }: {
   apmServerSchema: Record<string, any>;
@@ -63,6 +63,10 @@ function preprocessLegacyFields({
     {
       key: 'apm-server.auth.anonymous.allow_service',
       legacyKey: 'apm-server.rum.allow_service_names',
+    },
+    {
+      key: 'apm-server.auth.secret_token',
+      legacyKey: 'apm-server.secret_token',
     },
   ].forEach(({ key, legacyKey }) => {
     if (!copyOfApmServerSchema[key]) {

--- a/x-pack/plugins/apm/server/lib/fleet/get_unsupported_apm_server_schema.test.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_unsupported_apm_server_schema.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsClientContract } from 'kibana/server';
+import { getUnsupportedApmServerSchema } from './get_unsupported_apm_server_schema';
+
+const apmServerSchema = {
+  'apm-server.host': '0.0.0.0:8200',
+  'apm-server.secret_token': 'asdfkjhasdf',
+  'apm-server.read_timeout': 3600,
+  'apm-server.rum.event_rate.limit': 100,
+  'apm-server.rum.event_rate.lru_size': 100,
+  'apm-server.rum.allow_service_names': 'opbeans-test',
+  'logging.level': 'error',
+  'queue.mem.events': 2000,
+  'queue.mem.flush.timeout': '1s',
+  'setup.template.settings.index.number_of_jshards': 1,
+};
+
+const mockSavaedObectsClient = {
+  get: () => ({
+    attributes: { schemaJson: JSON.stringify(apmServerSchema) },
+  }),
+} as unknown as SavedObjectsClientContract;
+
+describe('get_unsupported_apm_server_schema', () => {
+  describe('getUnsupportedApmServerSchema', () => {
+    it('should return key-value pairs of unsupported configs', async () => {
+      const result = await getUnsupportedApmServerSchema({
+        savedObjectsClient: mockSavaedObectsClient,
+      });
+      expect(result).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "key": "logging.level",
+            "value": "error",
+          },
+          Object {
+            "key": "queue.mem.events",
+            "value": 2000,
+          },
+          Object {
+            "key": "queue.mem.flush.timeout",
+            "value": "1s",
+          },
+          Object {
+            "key": "setup.template.settings.index.number_of_jshards",
+            "value": 1,
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/x-pack/plugins/apm/server/lib/fleet/get_unsupported_apm_server_schema.ts
+++ b/x-pack/plugins/apm/server/lib/fleet/get_unsupported_apm_server_schema.ts
@@ -10,7 +10,10 @@ import {
   APM_SERVER_SCHEMA_SAVED_OBJECT_TYPE,
   APM_SERVER_SCHEMA_SAVED_OBJECT_ID,
 } from '../../../common/apm_saved_object_constants';
-import { apmConfigMapping } from './get_apm_package_policy_definition';
+import {
+  apmConfigMapping,
+  preprocessLegacyFields,
+} from './get_apm_package_policy_definition';
 
 export async function getUnsupportedApmServerSchema({
   savedObjectsClient,
@@ -24,7 +27,10 @@ export async function getUnsupportedApmServerSchema({
   const apmServerSchema: Record<string, any> = JSON.parse(
     (attributes as { schemaJson: string }).schemaJson
   );
-  return Object.entries(apmServerSchema)
+  const preprocessedApmServerSchema = preprocessLegacyFields({
+    apmServerSchema,
+  });
+  return Object.entries(preprocessedApmServerSchema)
     .filter(([name]) => !(name in apmConfigMapping))
     .map(([key, value]) => ({ key, value }));
 }


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [APM] fixes missing legacy apm schema config translation (#117645) (#118908)
 - [APM] Adds missing legacy key for apm-server.secret_token (#116385) (#116554)