### PR TITLE
Lens tests: increase window height to avoid scrolling

### DIFF
--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -17,7 +17,7 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
   describe('lens app', () => {
     before(async () => {
       log.debug('Starting lens before method');
-      await browser.setWindowSize(1280, 800);
+      await browser.setWindowSize(1280, 1000);
       await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
       // changing the timepicker default here saves us from having to set it in Discover (~8s)
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();

--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -17,7 +17,7 @@ export default function ({ getService, loadTestFile, getPageObjects }: FtrProvid
   describe('lens app', () => {
     before(async () => {
       log.debug('Starting lens before method');
-      await browser.setWindowSize(1280, 1000);
+      await browser.setWindowSize(1280, 1200);
       await esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
       // changing the timepicker default here saves us from having to set it in Discover (~8s)
       await PageObjects.timePicker.setDefaultAbsoluteRangeViaUiSettings();

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -20,8 +20,6 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
   const browser = getService('browser');
   const dashboardAddPanel = getService('dashboardAddPanel');
 
-  const FORMULA_TAB_HEIGHT = 40;
-
   const PageObjects = getPageObjects([
     'common',
     'header',
@@ -133,7 +131,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           : `lns-indexPatternDimension-${opts.operation}`;
         async function getAriaPressed() {
           const operationSelectorContainer = await testSubjects.find(operationSelector);
-          await testSubjects.click(operationSelector, undefined, FORMULA_TAB_HEIGHT);
+          await testSubjects.click(operationSelect);
           const ariaPressed = await operationSelectorContainer.getAttribute('aria-pressed');
           return ariaPressed;
         }

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -131,7 +131,7 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
           : `lns-indexPatternDimension-${opts.operation}`;
         async function getAriaPressed() {
           const operationSelectorContainer = await testSubjects.find(operationSelector);
-          await testSubjects.click(operationSelect);
+          await testSubjects.click(operationSelector);
           const ariaPressed = await operationSelectorContainer.getAttribute('aria-pressed');
           return ariaPressed;
         }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/117769#issuecomment-971824641

I didn't find a good way to improve the auto-scrolling behavior - this fix gets rid of the scrolling case for Lens completely by increasing the window height of the test a bit so the Lens UI fits.