### PR TITLE
Lens tests: heatmap fix

### DIFF
--- a/x-pack/plugins/lens/public/shared_components/coloring/palette_panel_container.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/palette_panel_container.tsx
@@ -56,6 +56,7 @@ export function PalettePanelContainer({
           <div
             role="dialog"
             aria-labelledby="lnsPalettePanelContainerTitle"
+            data-test-subj="lns-indexPattern-PalettePanelContainer"
             className="lnsPalettePanelContainer"
           >
             <EuiFlyoutHeader hasBorder className="lnsPalettePanelContainer__header">

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -874,6 +874,8 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     async openPalettePanel(chartType: string) {
       await retry.try(async () => {
         await testSubjects.click(`${chartType}_dynamicColoring_trigger`);
+        // wait for the UI to settle
+        await PageObjects.common.sleep(100);
         await testSubjects.existOrFail('lns-indexPattern-PalettePanelContainer', { timeout: 2500 });
       });
     },

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -872,7 +872,10 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     },
 
     async openPalettePanel(chartType: string) {
-      await testSubjects.click(`${chartType}_dynamicColoring_trigger`);
+      await retry.try(async () => {
+        await testSubjects.click(`${chartType}_dynamicColoring_trigger`);
+        await testSubjects.existOrFail('lns-indexPattern-PalettePanelContainer', { timeout: 2500 });
+      });
     },
 
     async closePalettePanel() {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/113043

There are two issues

Palette flyout doesn't open:
<img width="739" alt="Screenshot 2021-11-18 at 11 00 28" src="https://user-images.githubusercontent.com/1508364/142393855-93775fa5-cda9-4da0-ab3e-ec10ed0cba7b.png">

Typing in the wrong input:
<img width="812" alt="Screenshot 2021-11-18 at 11 00 36" src="https://user-images.githubusercontent.com/1508364/142393978-60346b0c-a827-4729-bd86-ad506aae1d7e.png">

I suspect the second one to be a race condition of some sort and selenium is trying to click the input before rendering the UI has settled which is causing weird behavior.

This fix adds a retry and explicitly waits for the container to show up before continuing which should help with both problems