### PR TITLE
[8.0] [Security Solution] Refactor Host isolation exceptions delete modal to use react query instead of redux (#117161)

### DIFF
--- a/x-pack/plugins/security_solution/public/app/app.tsx
+++ b/x-pack/plugins/security_solution/public/app/app.tsx
@@ -11,6 +11,7 @@ import { Store, Action } from 'redux';
 import { Provider as ReduxStoreProvider } from 'react-redux';
 
 import { EuiErrorBoundary } from '@elastic/eui';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { AppLeaveHandler, AppMountParameters } from '../../../../../src/core/public';
 
 import { ManageUserInfo } from '../detections/components/user_info';
@@ -34,6 +35,8 @@ interface StartAppComponent {
   store: Store<State, Action>;
 }
 
+const queryClient = new QueryClient();
+
 const StartAppComponent: FC<StartAppComponent> = ({
   children,
   history,
@@ -56,13 +59,15 @@ const StartAppComponent: FC<StartAppComponent> = ({
               <MlCapabilitiesProvider>
                 <UserPrivilegesProvider kibanaCapabilities={capabilities}>
                   <ManageUserInfo>
-                    <PageRouter
-                      history={history}
-                      onAppLeave={onAppLeave}
-                      setHeaderActionMenu={setHeaderActionMenu}
-                    >
-                      {children}
-                    </PageRouter>
+                    <QueryClientProvider client={queryClient}>
+                      <PageRouter
+                        history={history}
+                        onAppLeave={onAppLeave}
+                        setHeaderActionMenu={setHeaderActionMenu}
+                      >
+                        {children}
+                      </PageRouter>
+                    </QueryClientProvider>
                   </ManageUserInfo>
                 </UserPrivilegesProvider>
               </MlCapabilitiesProvider>

--- a/x-pack/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
@@ -10,6 +10,7 @@ import { createMemoryHistory, MemoryHistory } from 'history';
 import { render as reactRender, RenderOptions, RenderResult } from '@testing-library/react';
 import { Action, Reducer, Store } from 'redux';
 import { AppDeepLink } from 'kibana/public';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { coreMock } from '../../../../../../../src/core/public/mocks';
 import { StartPlugins, StartServices } from '../../../types';
 import { depsStartMock } from './dependencies_start_mock';
@@ -85,6 +86,14 @@ const experimentalFeaturesReducer: Reducer<State['app'], UpdateExperimentalFeatu
   }
   return state;
 };
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // turns retries off
+      retry: false,
+    },
+  },
+});
 
 /**
  * Creates a mocked endpoint app context custom renderer that can be used to render
@@ -115,7 +124,7 @@ export const createAppRootMockRenderer = (): AppContextTestRender => {
   const AppWrapper: React.FC<{ children: React.ReactElement }> = ({ children }) => (
     <KibanaContextProvider services={startServices}>
       <AppRootProvider store={store} history={history} coreStart={coreStart} depsStart={depsStart}>
-        {children}
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
       </AppRootProvider>
     </KibanaContextProvider>
   );

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/service.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/service.ts
@@ -81,7 +81,7 @@ export async function createHostIsolationExceptionItem({
   });
 }
 
-export async function deleteHostIsolationExceptionItems(http: HttpStart, id: string) {
+export async function deleteOneHostIsolationExceptionItem(http: HttpStart, id: string) {
   await ensureHostIsolationExceptionsListExists(http);
   return http.delete<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
     query: {

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/action.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/action.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import {
-  ExceptionListItemSchema,
-  UpdateExceptionListItemSchema,
-} from '@kbn/securitysolution-io-ts-list-types';
+import { UpdateExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { Action } from 'redux';
 import { HostIsolationExceptionsPageState } from '../types';
 
@@ -31,16 +28,7 @@ export type HostIsolationExceptionsCreateEntry = Action<'hostIsolationExceptions
   payload: HostIsolationExceptionsPageState['form']['entry'];
 };
 
-export type HostIsolationExceptionsDeleteItem = Action<'hostIsolationExceptionsMarkToDelete'> & {
-  payload?: ExceptionListItemSchema;
-};
-
-export type HostIsolationExceptionsSubmitDelete = Action<'hostIsolationExceptionsSubmitDelete'>;
-
-export type HostIsolationExceptionsDeleteStatusChanged =
-  Action<'hostIsolationExceptionsDeleteStatusChanged'> & {
-    payload: HostIsolationExceptionsPageState['deletion']['status'];
-  };
+export type HostIsolationExceptionsRefreshList = Action<'hostIsolationExceptionsRefreshList'>;
 
 export type HostIsolationExceptionsMarkToEdit = Action<'hostIsolationExceptionsMarkToEdit'> & {
   payload: {
@@ -56,9 +44,7 @@ export type HostIsolationExceptionsPageAction =
   | HostIsolationExceptionsPageDataChanged
   | HostIsolationExceptionsCreateEntry
   | HostIsolationExceptionsFormStateChanged
-  | HostIsolationExceptionsDeleteItem
-  | HostIsolationExceptionsSubmitDelete
-  | HostIsolationExceptionsDeleteStatusChanged
+  | HostIsolationExceptionsRefreshList
   | HostIsolationExceptionsFormEntryChanged
   | HostIsolationExceptionsMarkToEdit
   | HostIsolationExceptionsSubmitEdit;

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/middleware.test.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../state';
 import {
   createHostIsolationExceptionItem,
-  deleteHostIsolationExceptionItems,
   getHostIsolationExceptionItems,
   getOneHostIsolationExceptionItem,
   updateOneHostIsolationExceptionItem,
@@ -39,7 +38,6 @@ import { getListFetchError } from './selector';
 
 jest.mock('../service');
 const getHostIsolationExceptionItemsMock = getHostIsolationExceptionItems as jest.Mock;
-const deleteHostIsolationExceptionItemsMock = deleteHostIsolationExceptionItems as jest.Mock;
 const createHostIsolationExceptionItemMock = createHostIsolationExceptionItem as jest.Mock;
 const getOneHostIsolationExceptionItemMock = getOneHostIsolationExceptionItem as jest.Mock;
 const updateOneHostIsolationExceptionItemMock = updateOneHostIsolationExceptionItem as jest.Mock;
@@ -317,71 +315,6 @@ describe('Host isolation exceptions middleware', () => {
         payload: fakeException,
       });
       await waiter;
-    });
-  });
-
-  describe('When deleting an item from host isolation exceptions', () => {
-    beforeEach(() => {
-      deleteHostIsolationExceptionItemsMock.mockReset();
-      deleteHostIsolationExceptionItemsMock.mockReturnValue(undefined);
-      getHostIsolationExceptionItemsMock.mockReset();
-      getHostIsolationExceptionItemsMock.mockImplementation(getFoundExceptionListItemSchemaMock);
-      store.dispatch({
-        type: 'hostIsolationExceptionsMarkToDelete',
-        payload: {
-          id: '1',
-        },
-      });
-    });
-
-    it('should call the delete exception API when a delete is submitted and advertise a loading status', async () => {
-      const waiter = Promise.all([
-        // delete loading action
-        spyMiddleware.waitForAction('hostIsolationExceptionsDeleteStatusChanged', {
-          validate({ payload }) {
-            return isLoadingResourceState(payload);
-          },
-        }),
-        // delete finished action
-        spyMiddleware.waitForAction('hostIsolationExceptionsDeleteStatusChanged', {
-          validate({ payload }) {
-            return isLoadedResourceState(payload);
-          },
-        }),
-      ]);
-      store.dispatch({
-        type: 'hostIsolationExceptionsSubmitDelete',
-      });
-      await waiter;
-      expect(deleteHostIsolationExceptionItemsMock).toHaveBeenLastCalledWith(
-        fakeCoreStart.http,
-        '1'
-      );
-    });
-
-    it('should dispatch a failure if the API returns an error', async () => {
-      deleteHostIsolationExceptionItemsMock.mockRejectedValue({
-        body: { message: 'error message', statusCode: 500, error: 'Internal Server Error' },
-      });
-      store.dispatch({
-        type: 'hostIsolationExceptionsSubmitDelete',
-      });
-      await spyMiddleware.waitForAction('hostIsolationExceptionsDeleteStatusChanged', {
-        validate({ payload }) {
-          return isFailedResourceState(payload);
-        },
-      });
-    });
-
-    it('should reload the host isolation exception lists after delete', async () => {
-      store.dispatch({
-        type: 'hostIsolationExceptionsSubmitDelete',
-      });
-      await spyMiddleware.waitForAction('hostIsolationExceptionsPageDataChanged', {
-        validate({ payload }) {
-          return isLoadingResourceState(payload);
-        },
-      });
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/middleware.ts
@@ -26,14 +26,13 @@ import {
   asStaleResourceState,
 } from '../../../state/async_resource_builders';
 import {
-  deleteHostIsolationExceptionItems,
   getHostIsolationExceptionItems,
   createHostIsolationExceptionItem,
   getOneHostIsolationExceptionItem,
   updateOneHostIsolationExceptionItem,
 } from '../service';
 import { HostIsolationExceptionsPageState } from '../types';
-import { getCurrentListPageDataState, getCurrentLocation, getItemToDelete } from './selector';
+import { getCurrentListPageDataState, getCurrentLocation } from './selector';
 import { HostIsolationExceptionsPageAction } from './action';
 
 export const SEARCHABLE_FIELDS: Readonly<string[]> = [`name`, `description`, `entries.value`];
@@ -52,12 +51,12 @@ export const createHostIsolationExceptionsPageMiddleware = (
       loadHostIsolationExceptionsList(store, coreStart.http);
     }
 
-    if (action.type === 'hostIsolationExceptionsCreateEntry') {
-      createHostIsolationException(store, coreStart.http);
+    if (action.type === 'hostIsolationExceptionsRefreshList') {
+      loadHostIsolationExceptionsList(store, coreStart.http);
     }
 
-    if (action.type === 'hostIsolationExceptionsSubmitDelete') {
-      deleteHostIsolationExceptionsItem(store, coreStart.http);
+    if (action.type === 'hostIsolationExceptionsCreateEntry') {
+      createHostIsolationException(store, coreStart.http);
     }
 
     if (action.type === 'hostIsolationExceptionsMarkToEdit') {
@@ -154,42 +153,6 @@ function isHostIsolationExceptionsPage(location: Immutable<AppLocation>) {
       exact: true,
     }) !== null
   );
-}
-
-async function deleteHostIsolationExceptionsItem(
-  store: ImmutableMiddlewareAPI<
-    HostIsolationExceptionsPageState,
-    HostIsolationExceptionsPageAction
-  >,
-  http: HttpSetup
-) {
-  const { dispatch } = store;
-  const itemToDelete = getItemToDelete(store.getState());
-  if (itemToDelete === undefined) {
-    return;
-  }
-
-  try {
-    dispatch({
-      type: 'hostIsolationExceptionsDeleteStatusChanged',
-      payload: {
-        type: 'LoadingResourceState',
-      },
-    });
-
-    await deleteHostIsolationExceptionItems(http, itemToDelete.id);
-
-    dispatch({
-      type: 'hostIsolationExceptionsDeleteStatusChanged',
-      payload: createLoadedResourceState(itemToDelete),
-    });
-    loadHostIsolationExceptionsList(store, http);
-  } catch (error) {
-    dispatch({
-      type: 'hostIsolationExceptionsDeleteStatusChanged',
-      payload: createFailedResourceState<ExceptionListItemSchema>(error.body ?? error),
-    });
-  }
 }
 
 async function loadHostIsolationExceptionsItem(

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/reducer.ts
@@ -73,23 +73,6 @@ export const hostIsolationExceptionsPageReducer: StateReducer = (
     }
     case 'userChangedUrl':
       return userChangedUrl(state, action);
-    case 'hostIsolationExceptionsMarkToDelete': {
-      return {
-        ...state,
-        deletion: {
-          item: action.payload,
-          status: createUninitialisedResourceState(),
-        },
-      };
-    }
-    case 'hostIsolationExceptionsDeleteStatusChanged':
-      return {
-        ...state,
-        deletion: {
-          ...state.deletion,
-          status: action.payload,
-        },
-      };
   }
   return state;
 };

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/selector.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/store/selector.ts
@@ -93,9 +93,6 @@ export const showDeleteModal: HostIsolationExceptionsSelector<boolean> = createS
   }
 );
 
-export const getItemToDelete: HostIsolationExceptionsSelector<StoreState['deletion']['item']> =
-  createSelector(getDeletionState, ({ item }) => item);
-
 export const isDeletionInProgress: HostIsolationExceptionsSelector<boolean> = createSelector(
   getDeletionState,
   ({ status }) => {

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/delete_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/delete_modal.test.tsx
@@ -5,38 +5,34 @@
  * 2.0.
  */
 import React from 'react';
-import { act } from '@testing-library/react';
 import {
   AppContextTestRender,
   createAppRootMockRenderer,
 } from '../../../../../common/mock/endpoint';
 import { HostIsolationExceptionDeleteModal } from './delete_modal';
-import { isFailedResourceState, isLoadedResourceState } from '../../../../state';
-import { getHostIsolationExceptionItems, deleteHostIsolationExceptionItems } from '../../service';
+import { deleteOneHostIsolationExceptionItem } from '../../service';
 import { getExceptionListItemSchemaMock } from '../../../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
-import { fireEvent } from '@testing-library/dom';
+import { waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../../service');
-const getHostIsolationExceptionItemsMock = getHostIsolationExceptionItems as jest.Mock;
-const deleteHostIsolationExceptionItemsMock = deleteHostIsolationExceptionItems as jest.Mock;
+const deleteOneHostIsolationExceptionItemMock = deleteOneHostIsolationExceptionItem as jest.Mock;
 
 describe('When on the host isolation exceptions delete modal', () => {
   let render: () => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<typeof render>;
-  let waitForAction: AppContextTestRender['middlewareSpy']['waitForAction'];
   let coreStart: AppContextTestRender['coreStart'];
+  let onCancel: (forceRefresh?: boolean) => void;
 
   beforeEach(() => {
-    const itemToDelete = getExceptionListItemSchemaMock();
-    getHostIsolationExceptionItemsMock.mockReset();
-    deleteHostIsolationExceptionItemsMock.mockReset();
     const mockedContext = createAppRootMockRenderer();
-    mockedContext.store.dispatch({
-      type: 'hostIsolationExceptionsMarkToDelete',
-      payload: itemToDelete,
-    });
-    render = () => (renderResult = mockedContext.render(<HostIsolationExceptionDeleteModal />));
-    waitForAction = mockedContext.middlewareSpy.waitForAction;
+    const itemToDelete = getExceptionListItemSchemaMock();
+    deleteOneHostIsolationExceptionItemMock.mockReset();
+    onCancel = jest.fn();
+    render = () =>
+      (renderResult = mockedContext.render(
+        <HostIsolationExceptionDeleteModal item={itemToDelete} onCancel={onCancel} />
+      ));
     ({ coreStart } = mockedContext);
   });
 
@@ -51,6 +47,13 @@ describe('When on the host isolation exceptions delete modal', () => {
   it('should disable the buttons when confirm is pressed and show loading', async () => {
     render();
 
+    // fake a delay on a response
+    deleteOneHostIsolationExceptionItemMock.mockImplementationOnce(() => {
+      return new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+    });
+
     const submitButton = renderResult.baseElement.querySelector(
       '[data-test-subj="hostIsolationExceptionsDeleteModalConfirmButton"]'
     ) as HTMLButtonElement;
@@ -59,77 +62,65 @@ describe('When on the host isolation exceptions delete modal', () => {
       '[data-test-subj="hostIsolationExceptionsDeleteModalConfirmButton"]'
     ) as HTMLButtonElement;
 
-    act(() => {
-      fireEvent.click(submitButton);
-    });
+    userEvent.click(submitButton);
+
+    // wait for the mock API to be called
+    await waitFor(expect(deleteOneHostIsolationExceptionItemMock).toHaveBeenCalled);
 
     expect(submitButton.disabled).toBe(true);
     expect(cancelButton.disabled).toBe(true);
     expect(submitButton.querySelector('.euiLoadingSpinner')).not.toBeNull();
   });
 
-  it('should clear the item marked to delete when cancel is pressed', async () => {
+  it('should call the onCancel callback when cancel is pressed', async () => {
     render();
     const cancelButton = renderResult.baseElement.querySelector(
       '[data-test-subj="hostIsolationExceptionsDeleteModalConfirmButton"]'
     ) as HTMLButtonElement;
 
-    const waiter = waitForAction('hostIsolationExceptionsMarkToDelete', {
-      validate: ({ payload }) => {
-        return payload === undefined;
-      },
+    userEvent.click(cancelButton);
+    await waitFor(() => {
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
-
-    act(() => {
-      fireEvent.click(cancelButton);
-    });
-    expect(await waiter).toBeTruthy();
   });
 
-  it('should show success toast after the delete is completed', async () => {
+  it('should show success toast after the delete is completed and call onCancel with forceRefresh', async () => {
+    deleteOneHostIsolationExceptionItemMock.mockResolvedValue({});
     render();
-    const updateCompleted = waitForAction('hostIsolationExceptionsDeleteStatusChanged', {
-      validate(action) {
-        return isLoadedResourceState(action.payload);
-      },
-    });
 
     const submitButton = renderResult.baseElement.querySelector(
       '[data-test-subj="hostIsolationExceptionsDeleteModalConfirmButton"]'
     ) as HTMLButtonElement;
 
-    await act(async () => {
-      fireEvent.click(submitButton);
-      await updateCompleted;
-    });
+    userEvent.click(submitButton);
+
+    // wait for the mock API to be called
+    await waitFor(expect(deleteOneHostIsolationExceptionItemMock).toHaveBeenCalled);
 
     expect(coreStart.notifications.toasts.addSuccess).toHaveBeenCalledWith(
       '"some name" has been removed from the Host isolation exceptions list.'
     );
+    expect(onCancel).toHaveBeenCalledWith(true);
   });
 
-  it('should show error toast if error is encountered', async () => {
-    deleteHostIsolationExceptionItemsMock.mockRejectedValue(
+  it('should show error toast if error is encountered and call onCancel with forceRefresh', async () => {
+    deleteOneHostIsolationExceptionItemMock.mockRejectedValue(
       new Error("That's not true. That's impossible")
     );
     render();
-    const updateFailure = waitForAction('hostIsolationExceptionsDeleteStatusChanged', {
-      validate(action) {
-        return isFailedResourceState(action.payload);
-      },
-    });
 
     const submitButton = renderResult.baseElement.querySelector(
       '[data-test-subj="hostIsolationExceptionsDeleteModalConfirmButton"]'
     ) as HTMLButtonElement;
 
-    await act(async () => {
-      fireEvent.click(submitButton);
-      await updateFailure;
-    });
+    userEvent.click(submitButton);
+
+    // wait for the mock API to be called
+    await waitFor(expect(deleteOneHostIsolationExceptionItemMock).toHaveBeenCalled);
 
     expect(coreStart.notifications.toasts.addDanger).toHaveBeenCalledWith(
       'Unable to remove "some name" from the Host isolation exceptions list. Reason: That\'s not true. That\'s impossible'
     );
+    expect(onCancel).toHaveBeenCalledWith(true);
   });
 });

--- a/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/host_isolation_exceptions_list.tsx
@@ -7,15 +7,14 @@
 
 import { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { i18n } from '@kbn/i18n';
-import React, { Dispatch, useCallback, useEffect } from 'react';
+import React, { Dispatch, useCallback, useEffect, useState } from 'react';
 import { EuiButton, EuiText, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { ExceptionItem } from '../../../../common/components/exceptions/viewer/exception_item';
 import {
   getCurrentLocation,
-  getItemToDelete,
   getListFetchError,
   getListIsLoading,
   getListItems,
@@ -32,7 +31,6 @@ import { AdministrationListPage } from '../../../components/administration_list_
 import { SearchExceptions } from '../../../components/search_exceptions';
 import { ArtifactEntryCard, ArtifactEntryCardProps } from '../../../components/artifact_entry_card';
 import { HostIsolationExceptionsEmptyState } from './components/empty';
-import { HostIsolationExceptionsPageAction } from '../store/action';
 import { HostIsolationExceptionDeleteModal } from './components/delete_modal';
 import { HostIsolationExceptionsFormFlyout } from './components/form_flyout';
 import {
@@ -41,6 +39,7 @@ import {
 } from './components/translations';
 import { getEndpointListPath } from '../../../common/routing';
 import { useEndpointPrivileges } from '../../../../common/components/user_privileges/endpoint';
+import { HostIsolationExceptionsPageAction } from '../store/action';
 
 type HostIsolationExceptionPaginatedContent = PaginatedContentProps<
   Immutable<ExceptionListItemSchema>,
@@ -55,8 +54,10 @@ export const HostIsolationExceptionsList = () => {
   const fetchError = useHostIsolationExceptionsSelector(getListFetchError);
   const location = useHostIsolationExceptionsSelector(getCurrentLocation);
   const dispatch = useDispatch<Dispatch<HostIsolationExceptionsPageAction>>();
-  const itemToDelete = useHostIsolationExceptionsSelector(getItemToDelete);
   const navigateCallback = useHostIsolationExceptionsNavigateCallback();
+
+  const [itemToDelete, setItemToDelete] = useState<ExceptionListItemSchema | null>(null);
+
   const history = useHistory();
   const privileges = useEndpointPrivileges();
   const showFlyout = privileges.canIsolateHost && !!location.show;
@@ -90,10 +91,7 @@ export const HostIsolationExceptionsList = () => {
     const deleteAction = {
       icon: 'trash',
       onClick: () => {
-        dispatch({
-          type: 'hostIsolationExceptionsMarkToDelete',
-          payload: element,
-        });
+        setItemToDelete(element);
       },
       'data-test-subj': 'deleteHostIsolationException',
       children: DELETE_HOST_ISOLATION_EXCEPTION_LABEL,
@@ -124,6 +122,15 @@ export const HostIsolationExceptionsList = () => {
       }),
     [navigateCallback]
   );
+
+  const handleCloseDeleteDialog = (forceRefresh: boolean = false) => {
+    if (forceRefresh) {
+      dispatch({
+        type: 'hostIsolationExceptionsRefreshList',
+      });
+    }
+    setItemToDelete(null);
+  };
 
   return (
     <AdministrationListPage
@@ -161,7 +168,9 @@ export const HostIsolationExceptionsList = () => {
     >
       {showFlyout && <HostIsolationExceptionsFormFlyout />}
 
-      {itemToDelete ? <HostIsolationExceptionDeleteModal /> : null}
+      {itemToDelete ? (
+        <HostIsolationExceptionDeleteModal item={itemToDelete} onCancel={handleCloseDeleteDialog} />
+      ) : null}
 
       {hasDataToShow ? (
         <>


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [Security Solution] Refactor Host isolation exceptions delete modal to use react query instead of redux (#117161)