### PR TITLE
[DOCS] Change Docker quick start to bind to localhost

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -32,7 +32,7 @@ To start an {es} container for development or testing, run:
 ----
 docker network create elastic
 docker pull {es-docker-image}
-docker run --name es01-test --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {es-docker-image}
+docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {es-docker-image}
 ----
 
 To start {kib} and connect it to your {es} container, run the following commands
@@ -41,7 +41,7 @@ in a new terminal session:
 [source,sh,subs="attributes"]
 ----
 docker pull {docker-image}
-docker run --name kib01-test --net elastic -p 5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" {docker-image}
+docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" {docker-image}
 ----
 
 To access {kib}, go to http://localhost:5601[http://localhost:5601].


### PR DESCRIPTION
The current Docker run instructions can expose Kibana and Elasticsearch
publicly to the internet. This updates the instructions to bind to
localhost to avoid this.

Relates to https://github.com/elastic/elasticsearch/pull/80812

~Note: These instructions will likely change in 8.0+ with https://github.com/elastic/elasticsearch/pull/80735. @lockewritesdocs will be handling those updates as a separate effort.~ To avoid conflicts with  #118809, this PR no longer targets 8.0+ branches.

CC @xeraa 