### PR TITLE
[Infra UI] Select the palette option in test using clicks

### DIFF
--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -121,8 +121,12 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
     },
 
     async changePalette(paletteId: string) {
-      await testSubjects.find('legendControlsPalette');
-      await testSubjects.selectValue('legendControlsPalette', paletteId);
+      const paletteSelector = await testSubjects.find('legendControlsPalette');
+      await paletteSelector.click();
+      const paletteSelectorEntry = await paletteSelector.findByCssSelector(
+        `option[value=${paletteId}]`
+      );
+      await paletteSelectorEntry.click();
     },
 
     async applyLegendControls() {


### PR DESCRIPTION
## :memo: Summary

This changes the way the test attempts to select a color palette to use clicks instead of the keyboard. The intention is to remove the flakiness observed when running in Firefox on CI.

closes #118481