### PR TITLE
Fix upgrade tests for maps and dashboards

### DIFF
--- a/x-pack/test/upgrade/apps/dashboard/dashboard_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/dashboard/dashboard_smoke_tests.ts
@@ -12,7 +12,6 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const find = getService('find');
   const log = getService('log');
-  const pieChart = getService('pieChart');
   const renderable = getService('renderable');
   const dashboardExpect = getService('dashboardExpect');
   const PageObjects = getPageObjects(['common', 'header', 'home', 'dashboard', 'timePicker']);
@@ -63,10 +62,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           await PageObjects.home.launchSampleDashboard('flights');
           await PageObjects.header.waitUntilLoadingHasFinished();
           await renderable.waitForRender();
-          log.debug('Checking pie charts rendered');
-          await pieChart.expectPieSliceCount(4);
-          log.debug('Checking area, bar and heatmap charts rendered');
-          await dashboardExpect.seriesElementCount(15);
           log.debug('Checking saved searches rendered');
           await dashboardExpect.savedSearchRowCount(49);
           log.debug('Checking input controls rendered');

--- a/x-pack/test/upgrade/apps/maps/maps_smoke_tests.ts
+++ b/x-pack/test/upgrade/apps/maps/maps_smoke_tests.ts
@@ -168,7 +168,7 @@ export default function ({
           await PageObjects.header.waitUntilLoadingHasFinished();
           await PageObjects.maps.waitForLayersToLoad();
           await PageObjects.maps.toggleLayerVisibility('Road map - desaturated');
-          await PageObjects.maps.toggleLayerVisibility('Total Requests by Destination');
+          await PageObjects.maps.toggleLayerVisibility('Total Requests by Country');
           await PageObjects.timePicker.setCommonlyUsedTime('sample_data range');
           await PageObjects.maps.enterFullScreen();
           await PageObjects.maps.closeLegend();


### PR DESCRIPTION
Removes checks for legacy visualizations and changes layer title for maps test 