### PR TITLE
[Security Solution] migrate to new GET metadata list API

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/schema/metadata.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/metadata.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { HostStatus } from '../types';
+import { GetMetadataListRequestSchemaV2 } from './metadata';
+
+describe('endpoint metadata schema', () => {
+  describe('GetMetadataListRequestSchemaV2', () => {
+    const query = GetMetadataListRequestSchemaV2.query;
+
+    it('should return correct query params when valid', () => {
+      const queryParams = {
+        page: 1,
+        pageSize: 20,
+        kuery: 'some kuery',
+        hostStatuses: [HostStatus.HEALTHY.toString()],
+      };
+      expect(query.validate(queryParams)).toEqual(queryParams);
+    });
+
+    it('should correctly use default values', () => {
+      const expected = { page: 0, pageSize: 10 };
+      expect(query.validate(undefined)).toEqual(expected);
+      expect(query.validate({ page: undefined })).toEqual(expected);
+      expect(query.validate({ pageSize: undefined })).toEqual(expected);
+      expect(query.validate({ page: undefined, pageSize: undefined })).toEqual(expected);
+    });
+
+    it('should throw if page param is not a number', () => {
+      expect(() => query.validate({ page: 'notanumber' })).toThrowError();
+    });
+
+    it('should throw if page param is less than 0', () => {
+      expect(() => query.validate({ page: -1 })).toThrowError();
+    });
+
+    it('should throw if pageSize param is not a number', () => {
+      expect(() => query.validate({ pageSize: 'notanumber' })).toThrowError();
+    });
+
+    it('should throw if pageSize param is less than 1', () => {
+      expect(() => query.validate({ pageSize: 0 })).toThrowError();
+    });
+
+    it('should throw if pageSize param is greater than 10000', () => {
+      expect(() => query.validate({ pageSize: 10001 })).toThrowError();
+    });
+
+    it('should throw if kuery is not string', () => {
+      expect(() => query.validate({ kuery: 123 })).toThrowError();
+    });
+
+    it('should work with valid hostStatus', () => {
+      const queryParams = { hostStatuses: [HostStatus.HEALTHY, HostStatus.UPDATING] };
+      const expected = { page: 0, pageSize: 10, ...queryParams };
+      expect(query.validate(queryParams)).toEqual(expected);
+    });
+
+    it('should throw if invalid hostStatus', () => {
+      expect(() =>
+        query.validate({ hostStatuses: [HostStatus.UNHEALTHY, 'invalidstatus'] })
+      ).toThrowError();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/common/endpoint/schema/metadata.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/metadata.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, TypeOf } from '@kbn/config-schema';
+import { HostStatus } from '../types';
+
+export const GetMetadataListRequestSchemaV2 = {
+  query: schema.object(
+    {
+      page: schema.number({ defaultValue: 0, min: 0 }),
+      pageSize: schema.number({ defaultValue: 10, min: 1, max: 10000 }),
+      kuery: schema.maybe(schema.string()),
+      hostStatuses: schema.maybe(
+        schema.arrayOf(
+          schema.oneOf([
+            schema.literal(HostStatus.HEALTHY.toString()),
+            schema.literal(HostStatus.OFFLINE.toString()),
+            schema.literal(HostStatus.UPDATING.toString()),
+            schema.literal(HostStatus.UNHEALTHY.toString()),
+            schema.literal(HostStatus.INACTIVE.toString()),
+          ])
+        )
+      ),
+    },
+    { defaultValue: { page: 0, pageSize: 10 } }
+  ),
+};
+
+export type GetMetadataListRequestQuery = TypeOf<typeof GetMetadataListRequestSchemaV2.query>;

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -1235,18 +1235,14 @@ export interface ListPageRouteState {
 /**
  * REST API standard base response for list types
  */
-export interface BaseListResponse {
-  data: unknown[];
+interface BaseListResponse<D = unknown> {
+  data: D[];
   page: number;
   pageSize: number;
   total: number;
-  sort?: string;
-  sortOrder?: 'asc' | 'desc';
 }
 
 /**
  * Returned by the server via GET /api/endpoint/metadata
  */
-export interface MetadataListResponse extends BaseListResponse {
-  data: HostInfo[];
-}
+export type MetadataListResponse = BaseListResponse<HostInfo>;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/mocks.ts
@@ -14,8 +14,8 @@ import {
   ActivityLog,
   HostInfo,
   HostPolicyResponse,
-  HostResultList,
   HostStatus,
+  MetadataListResponse,
 } from '../../../../common/endpoint/types';
 import { EndpointDocGenerator } from '../../../../common/endpoint/generate_data';
 import { FleetActionGenerator } from '../../../../common/endpoint/data_generators/fleet_action_generator';
@@ -43,7 +43,7 @@ import {
 } from '../mocks';
 
 type EndpointMetadataHttpMocksInterface = ResponseProvidersInterface<{
-  metadataList: () => HostResultList;
+  metadataList: () => MetadataListResponse;
   metadataDetails: () => HostInfo;
 }>;
 export const endpointMetadataHttpMocks = httpHandlerMockFactory<EndpointMetadataHttpMocksInterface>(
@@ -69,6 +69,30 @@ export const endpointMetadataHttpMocks = httpHandlerMockFactory<EndpointMetadata
           total: 10,
           request_page_size: 10,
           request_page_index: 0,
+        };
+      },
+    },
+    {
+      id: 'metadataList',
+      path: HOST_METADATA_LIST_ROUTE,
+      method: 'get',
+      handler: () => {
+        const generator = new EndpointDocGenerator('seed');
+
+        return {
+          data: Array.from({ length: 10 }, () => {
+            const endpoint = {
+              metadata: generator.generateHostMetadata(),
+              host_status: HostStatus.UNHEALTHY,
+            };
+
+            generator.updateCommonInfo();
+
+            return endpoint;
+          }),
+          total: 10,
+          page: 0,
+          pageSize: 10,
         };
       },
     },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/action.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/action.ts
@@ -9,11 +9,11 @@ import { Action } from 'redux';
 import { EuiSuperDatePickerRecentRange } from '@elastic/eui';
 import type { DataViewBase } from '@kbn/es-query';
 import {
-  HostResultList,
   HostInfo,
   GetHostPolicyResponse,
   HostIsolationRequestBody,
   ISOLATION_ACTIONS,
+  MetadataListResponse,
 } from '../../../../../common/endpoint/types';
 import { ServerApiError } from '../../../../common/types';
 import { GetPolicyListResponse } from '../../policy/types';
@@ -21,7 +21,7 @@ import { EndpointState } from '../types';
 
 export interface ServerReturnedEndpointList {
   type: 'serverReturnedEndpointList';
-  payload: HostResultList;
+  payload: MetadataListResponse;
 }
 
 export interface ServerFailedToReturnEndpointList {

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/endpoint_pagination.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/endpoint_pagination.test.ts
@@ -11,7 +11,7 @@ import { applyMiddleware, Store, createStore } from 'redux';
 
 import { coreMock } from '../../../../../../../../src/core/public/mocks';
 
-import { HostResultList, AppLocation } from '../../../../../common/endpoint/types';
+import { AppLocation, MetadataListResponse } from '../../../../../common/endpoint/types';
 import { DepsStartMock, depsStartMock } from '../../../../common/mock/endpoint';
 
 import { endpointMiddlewareFactory } from './middleware';
@@ -19,13 +19,17 @@ import { endpointMiddlewareFactory } from './middleware';
 import { endpointListReducer } from './reducer';
 
 import { uiQueryParams } from './selectors';
-import { mockEndpointResultList } from './mock_endpoint_result_list';
+import {
+  mockEndpointResultList,
+  setEndpointListApiMockImplementation,
+} from './mock_endpoint_result_list';
 import { EndpointState, EndpointIndexUIQueryParams } from '../types';
 import {
   MiddlewareActionSpyHelper,
   createSpyMiddleware,
 } from '../../../../common/store/test_utils';
 import { getEndpointListPath } from '../../../common/routing';
+import { HOST_METADATA_LIST_ROUTE } from '../../../../../common/endpoint/constants';
 
 jest.mock('../../policy/store/services/ingest', () => ({
   sendGetAgentPolicyList: () => Promise.resolve({ items: [] }),
@@ -40,8 +44,8 @@ describe('endpoint list pagination: ', () => {
   let queryParams: () => EndpointIndexUIQueryParams;
   let waitForAction: MiddlewareActionSpyHelper['waitForAction'];
   let actionSpyMiddleware;
-  const getEndpointListApiResponse = (): HostResultList => {
-    return mockEndpointResultList({ request_page_size: 1, request_page_index: 1, total: 10 });
+  const getEndpointListApiResponse = (): MetadataListResponse => {
+    return mockEndpointResultList({ pageSize: 1, page: 0, total: 10 });
   };
 
   let historyPush: (params: EndpointIndexUIQueryParams) => void;
@@ -63,13 +67,15 @@ describe('endpoint list pagination: ', () => {
     historyPush = (nextQueryParams: EndpointIndexUIQueryParams): void => {
       return history.push(getEndpointListPath({ name: 'endpointList', ...nextQueryParams }));
     };
+
+    setEndpointListApiMockImplementation(fakeHttpServices);
   });
 
   describe('when the user enteres the endpoint list for the first time', () => {
     it('the api is called with page_index and page_size defaulting to 0 and 10 respectively', async () => {
       const apiResponse = getEndpointListApiResponse();
-      fakeHttpServices.post.mockResolvedValue(apiResponse);
-      expect(fakeHttpServices.post).not.toHaveBeenCalled();
+      fakeHttpServices.get.mockResolvedValue(apiResponse);
+      expect(fakeHttpServices.get).not.toHaveBeenCalled();
 
       store.dispatch({
         type: 'userChangedUrl',
@@ -79,11 +85,12 @@ describe('endpoint list pagination: ', () => {
         },
       });
       await waitForAction('serverReturnedEndpointList');
-      expect(fakeHttpServices.post).toHaveBeenCalledWith('/api/endpoint/metadata', {
-        body: JSON.stringify({
-          paging_properties: [{ page_index: '0' }, { page_size: '10' }],
-          filters: { kql: '' },
-        }),
+      expect(fakeHttpServices.get).toHaveBeenCalledWith(HOST_METADATA_LIST_ROUTE, {
+        query: {
+          page: '0',
+          pageSize: '10',
+          kuery: '',
+        },
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
@@ -25,7 +25,7 @@ describe('EndpointList store concerns', () => {
   const loadDataToStore = () => {
     dispatch({
       type: 'serverReturnedEndpointList',
-      payload: mockEndpointResultList({ request_page_size: 1, request_page_index: 1, total: 10 }),
+      payload: mockEndpointResultList({ pageSize: 1, page: 0, total: 10 }),
     });
   };
 
@@ -101,8 +101,8 @@ describe('EndpointList store concerns', () => {
 
     test('it handles `serverReturnedEndpointList', () => {
       const payload = mockEndpointResultList({
-        request_page_size: 1,
-        request_page_index: 1,
+        page: 0,
+        pageSize: 1,
         total: 10,
       });
       dispatch({
@@ -111,9 +111,9 @@ describe('EndpointList store concerns', () => {
       });
 
       const currentState = store.getState();
-      expect(currentState.hosts).toEqual(payload.hosts);
-      expect(currentState.pageSize).toEqual(payload.request_page_size);
-      expect(currentState.pageIndex).toEqual(payload.request_page_index);
+      expect(currentState.hosts).toEqual(payload.data);
+      expect(currentState.pageSize).toEqual(payload.pageSize);
+      expect(currentState.pageIndex).toEqual(payload.page);
       expect(currentState.total).toEqual(payload.total);
     });
   });

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/middleware.test.ts
@@ -16,10 +16,10 @@ import {
 } from '../../../../common/store/test_utils';
 import {
   Immutable,
-  HostResultList,
   HostIsolationResponse,
   ISOLATION_ACTIONS,
   ActivityLog,
+  MetadataListResponse,
 } from '../../../../../common/endpoint/types';
 import { AppAction } from '../../../../common/store/actions';
 import { mockEndpointResultList } from './mock_endpoint_result_list';
@@ -72,8 +72,8 @@ describe('endpoint list middleware', () => {
   let actionSpyMiddleware;
   let history: History<never>;
 
-  const getEndpointListApiResponse = (): HostResultList => {
-    return mockEndpointResultList({ request_page_size: 1, request_page_index: 1, total: 10 });
+  const getEndpointListApiResponse = (): MetadataListResponse => {
+    return mockEndpointResultList({ pageSize: 1, page: 0, total: 10 });
   };
 
   const dispatchUserChangedUrlToEndpointList = (locationOverrides: Partial<Location> = {}) => {
@@ -105,25 +105,26 @@ describe('endpoint list middleware', () => {
   it('handles `userChangedUrl`', async () => {
     endpointPageHttpMock(fakeHttpServices);
     const apiResponse = getEndpointListApiResponse();
-    fakeHttpServices.post.mockResolvedValue(apiResponse);
-    expect(fakeHttpServices.post).not.toHaveBeenCalled();
+    fakeHttpServices.get.mockResolvedValue(apiResponse);
+    expect(fakeHttpServices.get).not.toHaveBeenCalled();
 
     dispatchUserChangedUrlToEndpointList();
     await waitForAction('serverReturnedEndpointList');
-    expect(fakeHttpServices.post).toHaveBeenCalledWith('/api/endpoint/metadata', {
-      body: JSON.stringify({
-        paging_properties: [{ page_index: '0' }, { page_size: '10' }],
-        filters: { kql: '' },
-      }),
+    expect(fakeHttpServices.get).toHaveBeenNthCalledWith(1, HOST_METADATA_LIST_ROUTE, {
+      query: {
+        page: '0',
+        pageSize: '10',
+        kuery: '',
+      },
     });
-    expect(listData(getState())).toEqual(apiResponse.hosts);
+    expect(listData(getState())).toEqual(apiResponse.data);
   });
 
   it('handles `appRequestedEndpointList`', async () => {
     endpointPageHttpMock(fakeHttpServices);
     const apiResponse = getEndpointListApiResponse();
-    fakeHttpServices.post.mockResolvedValue(apiResponse);
-    expect(fakeHttpServices.post).not.toHaveBeenCalled();
+    fakeHttpServices.get.mockResolvedValue(apiResponse);
+    expect(fakeHttpServices.get).not.toHaveBeenCalled();
 
     // First change the URL
     dispatchUserChangedUrlToEndpointList();
@@ -144,13 +145,14 @@ describe('endpoint list middleware', () => {
       waitForAction('serverReturnedAgenstWithEndpointsTotal'),
     ]);
 
-    expect(fakeHttpServices.post).toHaveBeenCalledWith(HOST_METADATA_LIST_ROUTE, {
-      body: JSON.stringify({
-        paging_properties: [{ page_index: '0' }, { page_size: '10' }],
-        filters: { kql: '' },
-      }),
+    expect(fakeHttpServices.get).toHaveBeenNthCalledWith(1, HOST_METADATA_LIST_ROUTE, {
+      query: {
+        page: '0',
+        pageSize: '10',
+        kuery: '',
+      },
     });
-    expect(listData(getState())).toEqual(apiResponse.hosts);
+    expect(listData(getState())).toEqual(apiResponse.data);
   });
 
   describe('handling of IsolateEndpointHost action', () => {
@@ -242,7 +244,7 @@ describe('endpoint list middleware', () => {
     });
 
     const endpointList = getEndpointListApiResponse();
-    const agentId = endpointList.hosts[0].metadata.agent.id;
+    const agentId = endpointList.data[0].metadata.agent.id;
     const search = getEndpointDetailsPath({
       name: 'endpointActivityLog',
       selected_endpoint: agentId,
@@ -514,7 +516,7 @@ describe('endpoint list middleware', () => {
     });
 
     const endpointList = getEndpointListApiResponse();
-    const agentId = endpointList.hosts[0].metadata.agent.id;
+    const agentId = endpointList.data[0].metadata.agent.id;
     const search = getEndpointDetailsPath({
       name: 'endpointDetails',
       selected_endpoint: agentId,

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
@@ -95,20 +95,13 @@ const handleMetadataTransformStatsChanged: CaseReducer<MetadataTransformStatsCha
 /* eslint-disable-next-line complexity */
 export const endpointListReducer: StateReducer = (state = initialEndpointPageState(), action) => {
   if (action.type === 'serverReturnedEndpointList') {
-    const {
-      hosts,
-      total,
-      request_page_size: pageSize,
-      request_page_index: pageIndex,
-      policy_info: policyVersionInfo,
-    } = action.payload;
+    const { data, total, page, pageSize } = action.payload;
     return {
       ...state,
-      hosts,
+      hosts: data,
       total,
+      pageIndex: page,
       pageSize,
-      pageIndex,
-      policyVersionInfo,
       loading: false,
       error: undefined,
     };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/endpoint_agent_status.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/endpoint_agent_status.test.tsx
@@ -34,7 +34,7 @@ describe('When using the EndpointAgentStatus component', () => {
     (KibanaServices.get as jest.Mock).mockReturnValue(mockedContext.startServices);
     httpMocks = endpointPageHttpMock(mockedContext.coreStart.http);
     waitForAction = mockedContext.middlewareSpy.waitForAction;
-    endpointMeta = httpMocks.responseProvider.metadataList().hosts[0].metadata;
+    endpointMeta = httpMocks.responseProvider.metadataList().data[0].metadata;
     render = async (props: EndpointAgentStatusProps) => {
       renderResult = mockedContext.render(<EndpointAgentStatus {...props} />);
       return renderResult;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
@@ -52,6 +52,7 @@ import {
 } from '../../../../../common/constants';
 import { TransformStats } from '../types';
 import {
+  HOST_METADATA_LIST_ROUTE,
   metadataTransformPrefix,
   METADATA_UNITED_TRANSFORM,
 } from '../../../../../common/endpoint/constants';
@@ -170,6 +171,10 @@ describe('when on the endpoint list page', () => {
   });
 
   it('should NOT display timeline', async () => {
+    setEndpointListApiMockImplementation(coreStart.http, {
+      endpointsResults: [],
+    });
+
     const renderResult = render();
     const timelineFlyout = renderResult.queryByTestId('flyoutOverlay');
     expect(timelineFlyout).toBeNull();
@@ -243,7 +248,7 @@ describe('when on the endpoint list page', () => {
           total: 4,
         });
         setEndpointListApiMockImplementation(coreStart.http, {
-          endpointsResults: mockedEndpointListData.hosts,
+          endpointsResults: mockedEndpointListData.data,
           totalAgentsUsingEndpoint: 5,
         });
       });
@@ -260,7 +265,7 @@ describe('when on the endpoint list page', () => {
           total: 5,
         });
         setEndpointListApiMockImplementation(coreStart.http, {
-          endpointsResults: mockedEndpointListData.hosts,
+          endpointsResults: mockedEndpointListData.data,
           totalAgentsUsingEndpoint: 5,
         });
       });
@@ -277,7 +282,7 @@ describe('when on the endpoint list page', () => {
           total: 6,
         });
         setEndpointListApiMockImplementation(coreStart.http, {
-          endpointsResults: mockedEndpointListData.hosts,
+          endpointsResults: mockedEndpointListData.data,
           totalAgentsUsingEndpoint: 5,
         });
       });
@@ -291,6 +296,10 @@ describe('when on the endpoint list page', () => {
 
   describe('when there is no selected host in the url', () => {
     it('should not show the flyout', () => {
+      setEndpointListApiMockImplementation(coreStart.http, {
+        endpointsResults: [],
+      });
+
       const renderResult = render();
       expect.assertions(1);
       return renderResult.findByTestId('endpointDetailsFlyout').catch((e) => {
@@ -307,7 +316,7 @@ describe('when on the endpoint list page', () => {
       beforeEach(() => {
         reactTestingLibrary.act(() => {
           const mockedEndpointData = mockEndpointResultList({ total: 5 });
-          const hostListData = mockedEndpointData.hosts;
+          const hostListData = mockedEndpointData.data;
 
           firstPolicyID = hostListData[0].metadata.Endpoint.policy.applied.id;
           firstPolicyRev = hostListData[0].metadata.Endpoint.policy.applied.endpoint_policy_version;
@@ -518,7 +527,7 @@ describe('when on the endpoint list page', () => {
   describe.skip('when polling on Endpoint List', () => {
     beforeEach(() => {
       reactTestingLibrary.act(() => {
-        const hostListData = mockEndpointResultList({ total: 4 }).hosts;
+        const hostListData = mockEndpointResultList({ total: 4 }).data;
 
         setEndpointListApiMockImplementation(coreStart.http, {
           endpointsResults: hostListData,
@@ -546,7 +555,7 @@ describe('when on the endpoint list page', () => {
       expect(total[0].textContent).toEqual('4 Hosts');
 
       setEndpointListApiMockImplementation(coreStart.http, {
-        endpointsResults: mockEndpointResultList({ total: 1 }).hosts,
+        endpointsResults: mockEndpointResultList({ total: 1 }).data,
       });
 
       await reactTestingLibrary.act(async () => {
@@ -1090,7 +1099,7 @@ describe('when on the endpoint list page', () => {
       let renderResult: ReturnType<typeof render>;
       beforeEach(async () => {
         coreStart.http.post.mockImplementation(async (requestOptions) => {
-          if (requestOptions.path === '/api/endpoint/metadata') {
+          if (requestOptions.path === HOST_METADATA_LIST_ROUTE) {
             return mockEndpointResultList({ total: 0 });
           }
           throw new Error(`POST to '${requestOptions.path}' does not have a mock response!`);
@@ -1377,7 +1386,7 @@ describe('when on the endpoint list page', () => {
     let renderResult: ReturnType<AppContextTestRender['render']>;
 
     const mockEndpointListApi = () => {
-      const { hosts } = mockEndpointResultList();
+      const { data: hosts } = mockEndpointResultList();
       hostInfo = {
         host_status: hosts[0].host_status,
         metadata: {

--- a/x-pack/plugins/security_solution/public/management/pages/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/index.test.tsx
@@ -11,6 +11,7 @@ import { ManagementContainer } from './index';
 import '../../common/mock/match_media.ts';
 import { AppContextTestRender, createAppRootMockRenderer } from '../../common/mock/endpoint';
 import { useUserPrivileges } from '../../common/components/user_privileges';
+import { endpointPageHttpMock } from './endpoint_hosts/mocks';
 
 jest.mock('../../common/components/user_privileges');
 
@@ -19,6 +20,7 @@ describe('when in the Administration tab', () => {
 
   beforeEach(() => {
     const mockedContext = createAppRootMockRenderer();
+    endpointPageHttpMock(mockedContext.coreStart.http);
     render = () => mockedContext.render(<ManagementContainer />);
     mockedContext.history.push('/administration/endpoints');
   });

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -20,6 +20,7 @@ import {
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
 } from '../../../../common/endpoint/constants';
+import { GetMetadataListRequestSchemaV2 } from '../../../../common/endpoint/schema/metadata';
 
 /* Filters that can be applied to the endpoint fetch route */
 export const endpointFilters = schema.object({
@@ -63,24 +64,6 @@ export const GetMetadataListRequestSchema = {
       filters: endpointFilters,
     })
   ),
-};
-
-export const GetMetadataListRequestSchemaV2 = {
-  query: schema.object({
-    page: schema.number({ defaultValue: 0 }),
-    pageSize: schema.number({ defaultValue: 10, min: 1, max: 10000 }),
-    kuery: schema.maybe(schema.string()),
-    hostStatuses: schema.arrayOf(
-      schema.oneOf([
-        schema.literal(HostStatus.HEALTHY.toString()),
-        schema.literal(HostStatus.OFFLINE.toString()),
-        schema.literal(HostStatus.UPDATING.toString()),
-        schema.literal(HostStatus.UNHEALTHY.toString()),
-        schema.literal(HostStatus.INACTIVE.toString()),
-      ]),
-      { defaultValue: [] }
-    ),
-  }),
 };
 
 export function registerEndpointRoutes(

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.ts
@@ -6,7 +6,6 @@
  */
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { TypeOf } from '@kbn/config-schema';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import {
   metadataCurrentIndexPattern,
@@ -15,7 +14,7 @@ import {
 import { KibanaRequest } from '../../../../../../../src/core/server';
 import { EndpointAppContext } from '../../types';
 import { buildStatusesKuery } from './support/agent_status';
-import { GetMetadataListRequestSchemaV2 } from '.';
+import { GetMetadataListRequestQuery } from '../../../../common/endpoint/schema/metadata';
 
 /**
  * 00000000-0000-0000-0000-000000000000 is initial Elastic Agent id sent by Endpoint before policy is configured
@@ -234,14 +233,11 @@ interface BuildUnitedIndexQueryResponse {
 }
 
 export async function buildUnitedIndexQuery(
-  {
-    page = 0,
-    pageSize = 10,
-    hostStatuses = [],
-    kuery = '',
-  }: TypeOf<typeof GetMetadataListRequestSchemaV2.query>,
+  queryOptions: GetMetadataListRequestQuery,
   endpointPolicyIds: string[] = []
 ): Promise<BuildUnitedIndexQueryResponse> {
+  const { page = 0, pageSize = 10, hostStatuses = [], kuery = '' } = queryOptions || {};
+
   const statusesKuery = buildStatusesKuery(hostStatuses);
 
   const filterIgnoredAgents = {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.ts
@@ -36,7 +36,7 @@ export function buildStatusesKuery(statusesToFilter: string[]): string | undefin
 export async function findAgentIdsByStatus(
   agentService: AgentService,
   esClient: ElasticsearchClient,
-  statuses: string[] = [],
+  statuses: string[],
   pageSize: number = 1000
 ): Promise<string[]> {
   if (!statuses.length) {

--- a/x-pack/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/metadata/endpoint_metadata_service.ts
@@ -12,7 +12,6 @@ import {
   SavedObjectsServiceStart,
 } from 'kibana/server';
 
-import { TypeOf } from '@kbn/config-schema';
 import { TransportResult } from '@elastic/elasticsearch';
 import { SearchTotalHits, SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 import {
@@ -57,7 +56,7 @@ import { createInternalReadonlySoClient } from '../../utils/create_internal_read
 import { METADATA_UNITED_INDEX } from '../../../../common/endpoint/constants';
 import { getAllEndpointPackagePolicies } from '../../routes/metadata/support/endpoint_package_policies';
 import { getAgentStatus } from '../../../../../fleet/common/services/agent_status';
-import { GetMetadataListRequestSchemaV2 } from '../../routes/metadata';
+import { GetMetadataListRequestQuery } from '../../../../common/endpoint/schema/metadata';
 
 type AgentPolicyWithPackagePolicies = Omit<AgentPolicy, 'package_policies'> & {
   package_policies: PackagePolicy[];
@@ -403,7 +402,7 @@ export class EndpointMetadataService {
    */
   async getHostMetadataList(
     esClient: ElasticsearchClient,
-    queryOptions: TypeOf<typeof GetMetadataListRequestSchemaV2.query>
+    queryOptions: GetMetadataListRequestQuery
   ): Promise<Pick<MetadataListResponse, 'data' | 'total'>> {
     const endpointPolicies = await getAllEndpointPackagePolicies(
       this.packagePolicyService,


### PR DESCRIPTION
## Summary

Migrate frontend to use new GET metadata list API introduced in https://github.com/elastic/kibana/pull/118968. No functional differences.
Also addressing some comments on the GET API from https://github.com/elastic/kibana/pull/118968.

Behavior is unchanged:
![get-endpoints-list](https://user-images.githubusercontent.com/11009772/142513203-890668d7-239c-49ec-aada-4a6990fbcbf8.gif)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
