### PR TITLE
[Lens] Add max steps limit to coloring

### DIFF
--- a/x-pack/plugins/lens/common/types.ts
+++ b/x-pack/plugins/lens/common/types.ts
@@ -58,8 +58,13 @@ export interface CustomPaletteParams {
   colorStops?: ColorStop[];
   steps?: number;
 }
+export type CustomPaletteParamsConfig = CustomPaletteParams & {
+  maxSteps?: number;
+};
 
-export type RequiredPaletteParamTypes = Required<CustomPaletteParams>;
+export type RequiredPaletteParamTypes = Required<CustomPaletteParams> & {
+  maxSteps?: number;
+};
 
 export type LayerType = 'data' | 'referenceLine';
 

--- a/x-pack/plugins/lens/public/metric_visualization/palette_config.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/palette_config.tsx
@@ -12,6 +12,7 @@ export const DEFAULT_PALETTE_NAME = 'status';
 export const DEFAULT_COLOR_STEPS = 3;
 export const defaultPaletteParams: RequiredPaletteParamTypes = {
   ...sharedDefaultParams,
+  maxSteps: 5,
   name: DEFAULT_PALETTE_NAME,
   rangeType: 'number',
   steps: DEFAULT_COLOR_STEPS,

--- a/x-pack/plugins/lens/public/shared_components/coloring/color_stops.test.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_stops.test.tsx
@@ -58,6 +58,33 @@ describe('Color Stops component', () => {
     ).toBe(true);
   });
 
+  it('should disable "add new" button if there is maxStops configured', () => {
+    props.colorStops = [
+      { color: '#aaa', stop: 20 },
+      { color: '#bbb', stop: 40 },
+      { color: '#ccc', stop: 60 },
+      { color: '#ccc', stop: 80 },
+      { color: '#ccc', stop: 90 },
+    ];
+    const component = mount(<CustomStops {...props} />);
+    const componentWithMaxSteps = mount(
+      <CustomStops {...props} paletteConfiguration={{ maxSteps: 5 }} />
+    );
+    expect(
+      component
+        .find('[data-test-subj="my-test_dynamicColoring_addStop"]')
+        .first()
+        .prop('isDisabled')
+    ).toBe(false);
+
+    expect(
+      componentWithMaxSteps
+        .find('[data-test-subj="my-test_dynamicColoring_addStop"]')
+        .first()
+        .prop('isDisabled')
+    ).toBe(true);
+  });
+
   it('should add a new stop with default color and reasonable distance from last one', () => {
     let component = mount(<CustomStops {...props} />);
     const addStopButton = component

--- a/x-pack/plugins/lens/public/shared_components/coloring/color_stops.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_stops.tsx
@@ -17,7 +17,6 @@ import {
   EuiSpacer,
   EuiScreenReaderOnly,
   htmlIdGenerator,
-  EuiToolTip,
 } from '@elastic/eui';
 import useUnmount from 'react-use/lib/useUnmount';
 import { DEFAULT_COLOR } from './constants';
@@ -102,42 +101,6 @@ export const CustomStops = ({
   });
 
   const rangeType = paletteConfiguration?.rangeType || 'percent';
-
-  const addNewButton = (
-    <EuiButtonEmpty
-      data-test-subj={`${dataTestPrefix}_dynamicColoring_addStop`}
-      iconType="plusInCircle"
-      color="primary"
-      aria-label={i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
-        defaultMessage: 'Add color stop',
-      })}
-      size="xs"
-      isDisabled={shouldDisableAdd}
-      flush="left"
-      onClick={() => {
-        const newColorStops = [...localColorStops];
-        const length = newColorStops.length;
-        const { max } = getDataMinMax(rangeType, dataBounds);
-        const step = getStepValue(
-          colorStops,
-          newColorStops.map(({ color, stop }) => ({ color, stop: Number(stop) })),
-          max
-        );
-        const prevColor = localColorStops[length - 1].color || DEFAULT_COLOR;
-        const newStop = step + Number(localColorStops[length - 1].stop);
-        newColorStops.push({
-          color: prevColor,
-          stop: String(newStop),
-          id: idGeneratorFn(),
-        });
-        setLocalColorStops(newColorStops);
-      }}
-    >
-      {i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
-        defaultMessage: 'Add color stop',
-      })}
-    </EuiButtonEmpty>
-  );
 
   return (
     <>
@@ -297,18 +260,51 @@ export const CustomStops = ({
 
       <EuiSpacer size="s" />
 
-      {shouldDisableAdd ? (
-        <EuiToolTip
-          position="top"
-          content={i18n.translate('xpack.lens.dynamicColoring.customPalette.maximumStepsApplied', {
+      <TooltipWrapper
+        tooltipContent={i18n.translate(
+          'xpack.lens.dynamicColoring.customPalette.maximumStepsApplied',
+          {
             defaultMessage: `You've applied the maximum number of steps`,
+          }
+        )}
+        condition={shouldDisableAdd}
+        position="top"
+        delay="regular"
+      >
+        <EuiButtonEmpty
+          data-test-subj={`${dataTestPrefix}_dynamicColoring_addStop`}
+          iconType="plusInCircle"
+          color="primary"
+          aria-label={i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
+            defaultMessage: 'Add color stop',
           })}
+          size="xs"
+          isDisabled={shouldDisableAdd}
+          flush="left"
+          onClick={() => {
+            const newColorStops = [...localColorStops];
+            const length = newColorStops.length;
+            const { max } = getDataMinMax(rangeType, dataBounds);
+            const step = getStepValue(
+              colorStops,
+              newColorStops.map(({ color, stop }) => ({ color, stop: Number(stop) })),
+              max
+            );
+            const prevColor = localColorStops[length - 1].color || DEFAULT_COLOR;
+            const newStop = step + Number(localColorStops[length - 1].stop);
+            newColorStops.push({
+              color: prevColor,
+              stop: String(newStop),
+              id: idGeneratorFn(),
+            });
+            setLocalColorStops(newColorStops);
+          }}
         >
-          {addNewButton}
-        </EuiToolTip>
-      ) : (
-        addNewButton
-      )}
+          {i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
+            defaultMessage: 'Add color stop',
+          })}
+        </EuiButtonEmpty>
+      </TooltipWrapper>
     </>
   );
 };

--- a/x-pack/plugins/lens/public/shared_components/coloring/color_stops.tsx
+++ b/x-pack/plugins/lens/public/shared_components/coloring/color_stops.tsx
@@ -17,12 +17,13 @@ import {
   EuiSpacer,
   EuiScreenReaderOnly,
   htmlIdGenerator,
+  EuiToolTip,
 } from '@elastic/eui';
 import useUnmount from 'react-use/lib/useUnmount';
 import { DEFAULT_COLOR } from './constants';
 import { getDataMinMax, getStepValue, isValidColor } from './utils';
 import { TooltipWrapper, useDebouncedValue } from '../index';
-import type { ColorStop, CustomPaletteParams } from '../../../common';
+import type { ColorStop, CustomPaletteParamsConfig } from '../../../common';
 
 const idGeneratorFn = htmlIdGenerator();
 
@@ -44,7 +45,7 @@ export interface CustomStopsProps {
   colorStops: ColorStop[];
   onChange: (colorStops: ColorStop[]) => void;
   dataBounds: { min: number; max: number };
-  paletteConfiguration: CustomPaletteParams | undefined;
+  paletteConfiguration: CustomPaletteParamsConfig | undefined;
   'data-test-prefix': string;
 }
 export const CustomStops = ({
@@ -80,6 +81,9 @@ export const CustomStops = ({
   });
   const [sortedReason, setSortReason] = useState<string>('');
   const shouldEnableDelete = localColorStops.length > 2;
+  const shouldDisableAdd = Boolean(
+    paletteConfiguration?.maxSteps && localColorStops.length >= paletteConfiguration?.maxSteps
+  );
 
   const [popoverInFocus, setPopoverInFocus] = useState<boolean>(false);
 
@@ -98,6 +102,42 @@ export const CustomStops = ({
   });
 
   const rangeType = paletteConfiguration?.rangeType || 'percent';
+
+  const addNewButton = (
+    <EuiButtonEmpty
+      data-test-subj={`${dataTestPrefix}_dynamicColoring_addStop`}
+      iconType="plusInCircle"
+      color="primary"
+      aria-label={i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
+        defaultMessage: 'Add color stop',
+      })}
+      size="xs"
+      isDisabled={shouldDisableAdd}
+      flush="left"
+      onClick={() => {
+        const newColorStops = [...localColorStops];
+        const length = newColorStops.length;
+        const { max } = getDataMinMax(rangeType, dataBounds);
+        const step = getStepValue(
+          colorStops,
+          newColorStops.map(({ color, stop }) => ({ color, stop: Number(stop) })),
+          max
+        );
+        const prevColor = localColorStops[length - 1].color || DEFAULT_COLOR;
+        const newStop = step + Number(localColorStops[length - 1].stop);
+        newColorStops.push({
+          color: prevColor,
+          stop: String(newStop),
+          id: idGeneratorFn(),
+        });
+        setLocalColorStops(newColorStops);
+      }}
+    >
+      {i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
+        defaultMessage: 'Add color stop',
+      })}
+    </EuiButtonEmpty>
+  );
 
   return (
     <>
@@ -257,38 +297,18 @@ export const CustomStops = ({
 
       <EuiSpacer size="s" />
 
-      <EuiButtonEmpty
-        data-test-subj={`${dataTestPrefix}_dynamicColoring_addStop`}
-        iconType="plusInCircle"
-        color="primary"
-        aria-label={i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
-          defaultMessage: 'Add color stop',
-        })}
-        size="xs"
-        flush="left"
-        onClick={() => {
-          const newColorStops = [...localColorStops];
-          const length = newColorStops.length;
-          const { max } = getDataMinMax(rangeType, dataBounds);
-          const step = getStepValue(
-            colorStops,
-            newColorStops.map(({ color, stop }) => ({ color, stop: Number(stop) })),
-            max
-          );
-          const prevColor = localColorStops[length - 1].color || DEFAULT_COLOR;
-          const newStop = step + Number(localColorStops[length - 1].stop);
-          newColorStops.push({
-            color: prevColor,
-            stop: String(newStop),
-            id: idGeneratorFn(),
-          });
-          setLocalColorStops(newColorStops);
-        }}
-      >
-        {i18n.translate('xpack.lens.dynamicColoring.customPalette.addColorStop', {
-          defaultMessage: 'Add color stop',
-        })}
-      </EuiButtonEmpty>
+      {shouldDisableAdd ? (
+        <EuiToolTip
+          position="top"
+          content={i18n.translate('xpack.lens.dynamicColoring.customPalette.maximumStepsApplied', {
+            defaultMessage: `You've applied the maximum number of steps`,
+          })}
+        >
+          {addNewButton}
+        </EuiToolTip>
+      ) : (
+        addNewButton
+      )}
     </>
   );
 };

--- a/x-pack/plugins/lens/public/shared_components/coloring/constants.ts
+++ b/x-pack/plugins/lens/public/shared_components/coloring/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_MAX_STOP = 100;
 export const DEFAULT_COLOR_STEPS = 5;
 export const DEFAULT_COLOR = '#6092C0'; // Same as EUI ColorStops default for new stops
 export const defaultPaletteParams: RequiredPaletteParamTypes = {
+  maxSteps: undefined,
   name: DEFAULT_PALETTE_NAME,
   reverse: false,
   rangeType: 'percent',

--- a/x-pack/plugins/lens/public/shared_components/empty_placeholder.tsx
+++ b/x-pack/plugins/lens/public/shared_components/empty_placeholder.tsx
@@ -9,17 +9,22 @@ import React from 'react';
 import { EuiIcon, EuiText, IconType, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-export const EmptyPlaceholder = (props: { icon: IconType }) => (
+const noResultsMessage = (
+  <FormattedMessage id="xpack.lens.xyVisualization.noDataLabel" defaultMessage="No results found" />
+);
+
+export const EmptyPlaceholder = ({
+  icon,
+  message = noResultsMessage,
+}: {
+  icon: IconType;
+  message?: JSX.Element;
+}) => (
   <>
     <EuiText className="lnsChart__empty" textAlign="center" color="subdued" size="xs">
-      <EuiIcon type={props.icon} color="subdued" size="l" />
+      <EuiIcon type={icon} color="subdued" size="l" />
       <EuiSpacer size="s" />
-      <p>
-        <FormattedMessage
-          id="xpack.lens.xyVisualization.noDataLabel"
-          defaultMessage="No results found"
-        />
-      </p>
+      <p>{message}</p>
     </EuiText>
   </>
 );


### PR DESCRIPTION
## Summary

Adds ability to add limit for number of colors in a palette. Sets 5 for metric.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
