### PR TITLE
[Fleet] fix for bottom bar hiding content

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -60,6 +60,11 @@ const StepsWithLessPadding = styled(EuiSteps)`
   .euiStep__content {
     padding-bottom: ${(props) => props.theme.eui.paddingSizes.m};
   }
+
+  // compensating for EuiBottomBar hiding the content
+  @media (max-width: 767px) {
+    margin-bottom: 100px;
+  }
 `;
 
 const CustomEuiBottomBar = styled(EuiBottomBar)`

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/index.tsx
@@ -62,7 +62,7 @@ const StepsWithLessPadding = styled(EuiSteps)`
   }
 
   // compensating for EuiBottomBar hiding the content
-  @media (max-width: 767px) {
+  @media (max-width: ${(props) => props.theme.eui.euiBreakpoints.m}) {
     margin-bottom: 100px;
   }
 `;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/119004

EuiBottomBar was hiding policy selector dropdown on smaller resolutions. Added some margin to compensate that.

Steps to reproduce:

1. Change your browser's viewport to match mobile resolutions (width 767px or below)
2. Access "Add integration" > Synthetics > Add integration
3. Scroll to the bottom of the page and confirm you can choose another policy

![image](https://user-images.githubusercontent.com/90178898/142598079-846ade04-2050-45ee-80ac-fe5e88627b56.png)

![image](https://user-images.githubusercontent.com/90178898/142598146-73941976-fc74-4dd3-9116-8acdfb871a08.png)

Added this to `v7.16.0` as seemed to be critical, note: BC5 is already built, so there is only one more build until release of 7.16.
