### PR TITLE
Revert "migrations: handle 200 response code from _cluster/health API…

### DIFF
--- a/src/core/server/saved_objects/migrations/actions/wait_for_index_status_yellow.ts
+++ b/src/core/server/saved_objects/migrations/actions/wait_for_index_status_yellow.ts
@@ -40,11 +40,16 @@ export const waitForIndexStatusYellow =
   }: WaitForIndexStatusYellowParams): TaskEither.TaskEither<RetryableEsClientError, {}> =>
   () => {
     return client.cluster
-      .health({
-        index,
-        wait_for_status: 'yellow',
-        timeout,
-      })
+      .health(
+        {
+          index,
+          wait_for_status: 'yellow',
+          timeout,
+        },
+        // Don't reject on status code 408 so that we can handle the timeout
+        // explicitly and provide more context in the error message
+        { ignore: [408] }
+      )
       .then((res) => {
         if (res.body.timed_out === true) {
           return Either.left({


### PR DESCRIPTION
## Summary

853a0126fc38a7012d4307db9ef7bb56183cd17a handled a breaking upstream change from the health API, but the upstream change has been reverted in https://github.com/elastic/elasticsearch/pull/80821 so we need to handle the health API returning 408 status code on timeout again.

I started by just reverting 853a0126fc38a7012d4307db9ef7bb56183cd17a but decided to just not reject on 408 status code instead. This way we can handle 200 or 408 status codes which avoids problems with CI failing until https://github.com/elastic/elasticsearch/pull/80821 lands up in the next snapshot build (ca 4 hours until next build). Explicitly handling this error also means we can log a more useful message to users and also sets us up for fixing https://github.com/elastic/kibana/issues/118934

Fixes #119135


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
