### PR TITLE
Delete `kibana_index_template:.kibana` template at startup

### DIFF
--- a/src/core/server/saved_objects/saved_objects_service.test.mocks.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.mocks.ts
@@ -30,3 +30,8 @@ export const registerRoutesMock = jest.fn();
 jest.doMock('./routes', () => ({
   registerRoutes: registerRoutesMock,
 }));
+
+export const deleteIndexTemplatesMock = jest.fn();
+jest.doMock('./service/lib/delete_index_templates', () => ({
+  deleteIndexTemplates: deleteIndexTemplatesMock,
+}));

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -15,6 +15,7 @@ import {
   migratorInstanceMock,
   registerRoutesMock,
   typeRegistryInstanceMock,
+  deleteIndexTemplatesMock,
 } from './saved_objects_service.test.mocks';
 import { BehaviorSubject } from 'rxjs';
 import { RawPackageInfo } from '@kbn/config';
@@ -260,6 +261,29 @@ describe('SavedObjectsService', () => {
       await soService.setup(createSetupDeps());
       await soService.start(createStartDeps());
       expect(migratorInstanceMock.runMigrations).not.toHaveBeenCalled();
+    });
+
+    it('calls `deleteIndexTemplates` with the correct parameters', async () => {
+      const coreContext = createCoreContext({ skipMigration: false });
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+      const startDeps = createStartDeps();
+      await soService.start(startDeps);
+
+      expect(deleteIndexTemplatesMock).toHaveBeenCalledTimes(1);
+      expect(deleteIndexTemplatesMock).toHaveBeenCalledWith({
+        client: startDeps.elasticsearch.client.asInternalUser,
+        log: expect.any(Object),
+      });
+    });
+
+    it('does not call `deleteIndexTemplates` when `skipMigration` is true', async () => {
+      const coreContext = createCoreContext({ skipMigration: true });
+      const soService = new SavedObjectsService(coreContext);
+      await soService.setup(createSetupDeps());
+      await soService.start(createStartDeps());
+
+      expect(deleteIndexTemplatesMock).not.toHaveBeenCalled();
     });
 
     it('calls KibanaMigrator with correct version', async () => {

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -36,6 +36,7 @@ import {
   SavedObjectsClientFactoryProvider,
   SavedObjectsClientWrapperFactory,
 } from './service/lib/scoped_client_provider';
+import { deleteIndexTemplates } from './service/lib/delete_index_templates';
 import { Logger } from '../logging';
 import { SavedObjectTypeRegistry, ISavedObjectTypeRegistry } from './saved_objects_type_registry';
 import { SavedObjectsSerializer } from './serialization';
@@ -435,6 +436,7 @@ export class SavedObjectsService
       // and the promise above fulfils as undefined. We shouldn't trigger migrations at that point.
       if (compatibleNodes) {
         this.logger.info('Starting saved objects migrations');
+        await deleteIndexTemplates({ client: client.asInternalUser, log: this.logger });
         await migrator.runMigrations();
       }
     }

--- a/src/core/server/saved_objects/service/lib/delete_index_templates.test.ts
+++ b/src/core/server/saved_objects/service/lib/delete_index_templates.test.ts
@@ -24,9 +24,12 @@ describe('deleteIndexTemplates', () => {
     await deleteIndexTemplates({ client, log });
 
     expect(client.indices.getTemplate).toHaveBeenCalledTimes(1);
-    expect(client.indices.getTemplate).toHaveBeenCalledWith({
-      name: 'kibana_index_template*',
-    });
+    expect(client.indices.getTemplate).toHaveBeenCalledWith(
+      {
+        name: 'kibana_index_template*',
+      },
+      { ignore: [404] }
+    );
   });
 
   it('calls `client.indices.deleteTemplate` for each template', async () => {

--- a/src/core/server/saved_objects/service/lib/delete_index_templates.test.ts
+++ b/src/core/server/saved_objects/service/lib/delete_index_templates.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { elasticsearchClientMock } from '../../../elasticsearch/client/mocks';
+import { loggerMock } from '../../../logging/logger.mock';
+import { deleteIndexTemplates } from './delete_index_templates';
+
+describe('deleteIndexTemplates', () => {
+  let log: ReturnType<typeof loggerMock.create>;
+  let client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>;
+
+  beforeEach(() => {
+    log = loggerMock.create();
+    client = elasticsearchClientMock.createElasticsearchClient();
+  });
+
+  it('calls `client.cat.templates` with the correct parameters', async () => {
+    await deleteIndexTemplates({ client, log });
+
+    expect(client.cat.templates).toHaveBeenCalledTimes(1);
+    expect(client.cat.templates).toHaveBeenCalledWith({
+      format: 'json',
+      name: 'kibana_index_template*',
+    });
+  });
+
+  it('calls `client.indices.deleteTemplate` for each template', async () => {
+    client.cat.templates.mockReturnValue(
+      elasticsearchClientMock.createSuccessTransportRequestPromise([
+        { name: 'kibana_index_template:.kibana' },
+        { name: 'kibana_index_template:.another-template' },
+      ])
+    );
+
+    await deleteIndexTemplates({ client, log });
+
+    expect(client.indices.deleteTemplate).toHaveBeenCalledTimes(2);
+    expect(client.indices.deleteTemplate).toHaveBeenCalledWith({
+      name: 'kibana_index_template:.kibana',
+    });
+    expect(client.indices.deleteTemplate).toHaveBeenCalledWith({
+      name: 'kibana_index_template:.another-template',
+    });
+  });
+
+  it('logs a debug message with the name of the templates', async () => {
+    client.cat.templates.mockReturnValue(
+      elasticsearchClientMock.createSuccessTransportRequestPromise([
+        { name: 'template1' },
+        { name: 'template2' },
+      ])
+    );
+
+    await deleteIndexTemplates({ client, log });
+
+    expect(loggerMock.collect(log).debug).toEqual([
+      ['Deleting index templates: template1, template2'],
+    ]);
+  });
+});

--- a/src/core/server/saved_objects/service/lib/delete_index_templates.ts
+++ b/src/core/server/saved_objects/service/lib/delete_index_templates.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { ElasticsearchClient } from '../../../elasticsearch';
+import type { Logger } from '../../../logging';
+
+interface DeleteIndexTemplatesOptions {
+  client: ElasticsearchClient;
+  log: Logger;
+}
+
+/**
+ * Deletes old index templates that were used in 6.x as those will no longer be supported in ES 8.
+ */
+export const deleteIndexTemplates = async ({ client, log }: DeleteIndexTemplatesOptions) => {
+  const { body: templates } = await client.cat.templates({
+    format: 'json',
+    name: 'kibana_index_template*',
+  });
+
+  if (!templates.length) {
+    return;
+  }
+  const templateNames = templates
+    .filter((template) => template.name)
+    .map((template) => template.name!);
+
+  log.debug(`Deleting index templates: ${templateNames.join(', ')}`);
+
+  return await Promise.all(
+    templateNames.map((templateName) => {
+      return client.indices.deleteTemplate({
+        name: templateName,
+      });
+    })
+  );
+};

--- a/src/core/server/saved_objects/service/lib/integration_tests/delete_index_templates.test.ts
+++ b/src/core/server/saved_objects/service/lib/integration_tests/delete_index_templates.test.ts
@@ -38,11 +38,11 @@ describe('deleteIndexTemplates', () => {
     await root.shutdown();
   });
 
-  it('does not fail when no templates are present', async () => {
+  it('does not fail when no templates match', async () => {
     const log = root.logger.get('');
     const client = start.elasticsearch.client.asInternalUser;
 
-    await expect(deleteIndexTemplates({ log, client })).resolves.toBeUndefined();
+    await expect(deleteIndexTemplates({ log, client })).resolves.toBeDefined();
   });
 
   it('only deletes the `kibana_index_template*` templates', async () => {
@@ -62,11 +62,9 @@ describe('deleteIndexTemplates', () => {
 
     await deleteIndexTemplates({ log, client });
 
-    const { body: templates } = await client.cat.templates({
-      format: 'json',
-    });
+    const { body: templates } = await client.indices.getTemplate({});
 
-    const templateNames = templates.map((template) => template.name);
+    const templateNames = Object.keys(templates);
 
     expect(templateNames.includes('kibana_index_template:.kibana')).toBe(false);
     expect(templateNames.includes('another_template')).toBe(true);

--- a/src/core/server/saved_objects/service/lib/integration_tests/delete_index_templates.test.ts
+++ b/src/core/server/saved_objects/service/lib/integration_tests/delete_index_templates.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import * as kbnTestServer from '../../../../../test_helpers/kbn_server';
+import { deleteIndexTemplates } from '../delete_index_templates';
+import type { InternalCoreStart } from '../../../../internal_types';
+import type { Root } from '../../../../root';
+
+const { startES } = kbnTestServer.createTestServers({
+  adjustTimeout: (t: number) => jest.setTimeout(t),
+});
+
+describe('deleteIndexTemplates', () => {
+  let esServer: kbnTestServer.TestElasticsearchUtils;
+  let root: Root;
+  let start: InternalCoreStart;
+
+  beforeAll(async () => {
+    esServer = await startES();
+    root = kbnTestServer.createRootWithCorePlugins({
+      server: {
+        basePath: '/hello',
+      },
+    });
+
+    await root.preboot();
+    await root.setup();
+    start = await root.start();
+  });
+
+  afterAll(async () => {
+    await esServer.stop();
+    await root.shutdown();
+  });
+
+  it('does not fail when no templates are present', async () => {
+    const log = root.logger.get('');
+    const client = start.elasticsearch.client.asInternalUser;
+
+    await expect(deleteIndexTemplates({ log, client })).resolves.toBeUndefined();
+  });
+
+  it('only deletes the `kibana_index_template*` templates', async () => {
+    const log = root.logger.get('');
+    const client = start.elasticsearch.client.asInternalUser;
+
+    await client.indices.putTemplate({
+      name: 'kibana_index_template:.kibana',
+      create: true,
+      body: { index_patterns: ['foo*'] },
+    });
+    await client.indices.putTemplate({
+      name: 'another_template',
+      create: true,
+      body: { index_patterns: ['bar*'] },
+    });
+
+    await deleteIndexTemplates({ log, client });
+
+    const { body: templates } = await client.cat.templates({
+      format: 'json',
+    });
+
+    const templateNames = templates.map((template) => template.name);
+
+    expect(templateNames.includes('kibana_index_template:.kibana')).toBe(false);
+    expect(templateNames.includes('another_template')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/119117
Inspired from https://github.com/elastic/kibana/pull/28252

Delete the `kibana_index_template*` template during SO startup


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
