### PR TITLE
[Onweek] Model property-based search session state container

### DIFF
--- a/package.json
+++ b/package.json
@@ -708,6 +708,7 @@
     "eslint-plugin-react-perf": "^3.3.0",
     "eslint-traverse": "^1.0.0",
     "expose-loader": "^0.7.5",
+    "fast-check": "^2.19.0",
     "faker": "^5.1.0",
     "fancy-log": "^1.3.2",
     "fast-glob": "2.2.7",

--- a/src/plugins/data/public/search/session/search_session_state.pb.test.ts
+++ b/src/plugins/data/public/search/session/search_session_state.pb.test.ts
@@ -246,7 +246,7 @@ const SearchStateContainerCommands = fc.commands(
 describe('Search session state', () => {
   it('should function as expected', () => {
     fc.assert(
-      fc.property(SearchStateContainerCommands, fc.anything(), (commands, anything) => {
+      fc.property(SearchStateContainerCommands, (commands) => {
         const { stateContainer: real } = createSessionStateContainer();
         const model = new SearchSessionStateContainerModel();
         fc.modelRun(() => ({ real, model }), commands);

--- a/src/plugins/data/public/search/session/search_session_state.pb.test.ts
+++ b/src/plugins/data/public/search/session/search_session_state.pb.test.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/* eslint-disable max-classes-per-file */
+
+import { isColumnActionEnabled } from '@elastic/eui/src/components/datagrid/body/header/column_actions';
+import { SerializableRecord } from '@kbn/utility-types';
+import fc from 'fast-check';
+
+import { SearchSessionSavedObjectAttributes, SearchSessionStatus } from 'src/plugins/data/common';
+import { SessionStateContainer, createSessionStateContainer } from './search_session_state';
+import { SearchSessionSavedObject } from './sessions_client';
+
+const option = <T>(arb: fc.Arbitrary<T>) => fc.option(arb, { nil: undefined });
+
+function arbitrarySearchSessionSavedObjectAttributes(): fc.Arbitrary<SearchSessionSavedObjectAttributes> {
+  return fc.record<SearchSessionSavedObjectAttributes>({
+    idMapping: fc.object({
+      values: [
+        fc.record({
+          id: fc.string({ minLength: 1 }),
+          strategy: fc.string(),
+          status: fc.string(),
+          error: option(fc.string()),
+        }),
+      ],
+    }) as fc.Arbitrary<SearchSessionSavedObjectAttributes['idMapping']>,
+    created: fc.date().map((date) => date.toISOString()),
+    expires: fc.date().map((date) => date.toISOString()),
+    persisted: fc.boolean(),
+    sessionId: fc.string({ minLength: 1 }),
+    status: fc.constantFrom(
+      SearchSessionStatus.CANCELLED,
+      SearchSessionStatus.COMPLETE,
+      SearchSessionStatus.ERROR,
+      SearchSessionStatus.EXPIRED,
+      SearchSessionStatus.IN_PROGRESS
+    ),
+    touched: fc.date().map((date) => date.toISOString()),
+    version: fc.string(),
+    appId: option(fc.string()),
+    completed: option(fc.date().map((date) => date.toISOString())),
+    name: option(fc.string()),
+    initialState: option(fc.object() as fc.Arbitrary<SerializableRecord>),
+    locatorId: option(fc.string()),
+    realmName: option(fc.string()),
+    realmType: option(fc.string()),
+    restoreState: option(fc.object() as fc.Arbitrary<SerializableRecord>),
+    username: option(fc.string()),
+  });
+}
+
+function arbitrarySearchSessionSavedObject(): fc.Arbitrary<SearchSessionSavedObject> {
+  return fc.record<SearchSessionSavedObject>({
+    attributes: arbitrarySearchSessionSavedObjectAttributes(),
+    id: fc.string({ minLength: 1 }),
+    references: fc.array(fc.record({ id: fc.string(), name: fc.string(), type: fc.string() })),
+    type: fc.constant('search-session'),
+    coreMigrationVersion: option(fc.string()),
+  });
+}
+
+class SearchSessionStateContainerModel {
+  appName?: string;
+  isRestore?: boolean;
+  isStored?: boolean;
+  sessionId?: string;
+  isCanceled?: boolean;
+  isStarted?: boolean;
+  completedTime?: string;
+  pendingSearches?: unknown[];
+  searchSessionSavedObject?: SearchSessionSavedObject;
+}
+
+type SearchSessionStateCommand = fc.Command<
+  SearchSessionStateContainerModel,
+  SessionStateContainer
+>;
+
+class StartCommand implements SearchSessionStateCommand {
+  constructor(private readonly appName: string) {}
+  check(model: SearchSessionStateContainerModel): boolean {
+    return true;
+  }
+  public run(model: SearchSessionStateContainerModel, real: SessionStateContainer): void {
+    model.appName = this.appName;
+    model.sessionId = undefined;
+    model.isStored = false;
+    model.isRestore = false;
+    model.isCanceled = false;
+    model.isStarted = false;
+    model.pendingSearches = [];
+
+    real.transitions.start({ appName: this.appName });
+    const state = real.get();
+
+    expect(state.sessionId).toBeTruthy();
+    model.sessionId = state.sessionId;
+
+    expect(model.appName).toBe(state.appName);
+    expect(model.isCanceled).toBe(state.isCanceled);
+    expect(model.isStored).toBe(state.isStored);
+    expect(model.isRestore).toBe(state.isRestore);
+    expect(model.isStarted).toBe(state.isStarted);
+    expect(model.pendingSearches).toEqual(state.pendingSearches);
+  }
+  toString(): string {
+    return `StartCommand(${this.appName})`;
+  }
+}
+
+class RestoreCommand implements SearchSessionStateCommand {
+  constructor(private readonly sessionId: string) {}
+  check(model: SearchSessionStateContainerModel): boolean {
+    return true;
+  }
+  public run(model: SearchSessionStateContainerModel, real: SessionStateContainer): void {
+    model.sessionId = this.sessionId;
+    model.isRestore = true;
+    model.isStored = true;
+    model.appName = undefined;
+    model.isCanceled = false;
+    model.isStarted = false;
+    model.pendingSearches = [];
+
+    real.transitions.restore(this.sessionId);
+
+    const state = real.get();
+
+    expect(model.sessionId).toBe(state.sessionId);
+    expect(model.isRestore).toBe(state.isRestore);
+    expect(model.isStored).toBe(state.isStored);
+    expect(model.appName).toBe(state.appName);
+    expect(model.isCanceled).toBe(state.isCanceled);
+    expect(model.isStarted).toBe(state.isStarted);
+    expect(model.pendingSearches).toEqual(state.pendingSearches);
+  }
+  toString(): string {
+    return `RestoreCommand(${this.sessionId})`;
+  }
+}
+
+class StoreCommand implements SearchSessionStateCommand {
+  constructor(private readonly value: SearchSessionSavedObject) {}
+  check(model: SearchSessionStateContainerModel): boolean {
+    return Boolean(model.sessionId && !(model.isStored || model.isRestore));
+  }
+  public run(model: SearchSessionStateContainerModel, real: SessionStateContainer): void {
+    model.isStored = true;
+    model.searchSessionSavedObject = this.value;
+
+    real.transitions.store(this.value);
+    const state = real.get();
+
+    expect(model.isStored).toBe(state.isStored);
+    expect(model.searchSessionSavedObject).toEqual(state.searchSessionSavedObject);
+  }
+  toString(): string {
+    return `StoreCommand(${JSON.stringify(this.value)})`;
+  }
+}
+
+class TrackSearchCommand implements SearchSessionStateCommand {
+  constructor(private readonly value: unknown) {}
+  check(model: SearchSessionStateContainerModel): boolean {
+    return Boolean(model.sessionId);
+  }
+  public run(model: SearchSessionStateContainerModel, real: SessionStateContainer): void {
+    model.pendingSearches = (model.pendingSearches ?? []).concat(this.value);
+    model.isStarted = true;
+    model.completedTime = undefined;
+
+    real.transitions.trackSearch(this.value);
+    const state = real.get();
+
+    expect(model.isStarted).toBe(state.isStarted);
+    expect(model.pendingSearches).toEqual(state.pendingSearches);
+  }
+  toString(): string {
+    return `TrackSearchCommand(${JSON.stringify(this.value)})`;
+  }
+}
+
+class UntrackSearchCommand implements SearchSessionStateCommand {
+  constructor(private readonly value: unknown) {}
+  check(model: SearchSessionStateContainerModel): boolean {
+    return model.pendingSearches?.some((v) => v === this.value) ?? false;
+  }
+  public run(model: SearchSessionStateContainerModel, real: SessionStateContainer): void {
+    model.pendingSearches = (model.pendingSearches ?? []).filter((search) => search !== this.value);
+
+    real.transitions.unTrackSearch(this.value);
+    const state = real.get();
+
+    expect(model.pendingSearches).toEqual(state.pendingSearches);
+  }
+  toString(): string {
+    return `TrackSearchCommand(${JSON.stringify(this.value)})`;
+  }
+}
+
+class CancelCommand implements SearchSessionStateCommand {
+  constructor() {}
+  check(model: SearchSessionStateContainerModel): boolean {
+    return Boolean(model.sessionId && !model.isRestore);
+  }
+  public run(model: SearchSessionStateContainerModel, real: SessionStateContainer): void {
+    model.pendingSearches = [];
+    model.isCanceled = true;
+    model.isStored = false;
+    model.searchSessionSavedObject = undefined;
+
+    real.transitions.cancel();
+    const state = real.get();
+
+    expect(model.pendingSearches).toEqual(state.pendingSearches);
+    expect(model.isCanceled).toBe(state.isCanceled);
+    expect(model.isStored).toBe(state.isStored);
+    expect(model.searchSessionSavedObject).toBe(state.searchSessionSavedObject);
+  }
+  toString(): string {
+    return `CancelCommand()`;
+  }
+}
+
+const SearchStateContainerCommands = fc.commands(
+  [
+    fc.string().map((value) => new StartCommand(value)),
+    fc.string().map((sessionId) => new RestoreCommand(sessionId)),
+    arbitrarySearchSessionSavedObject().map((so) => new StoreCommand(so)),
+    fc.constant(new CancelCommand()),
+    // Generate random numbers between 1 and 10 so that we will test
+    // untracking
+    fc.nat({ max: 10 }).map((nr) => new TrackSearchCommand(nr)),
+    fc.nat({ max: 10 }).map((nr) => new UntrackSearchCommand(nr)),
+  ],
+  {
+    maxCommands: 1000,
+  }
+);
+
+describe('Search session state', () => {
+  it('should function as expected', () => {
+    fc.assert(
+      fc.property(SearchStateContainerCommands, fc.anything(), (commands, anything) => {
+        const { stateContainer: real } = createSessionStateContainer();
+        const model = new SearchSessionStateContainerModel();
+        fc.modelRun(() => ({ real, model }), commands);
+      })
+    );
+  });
+});

--- a/src/plugins/data/public/search/session/search_session_state.pb.test.ts
+++ b/src/plugins/data/public/search/session/search_session_state.pb.test.ts
@@ -199,7 +199,7 @@ class UntrackSearchCommand implements SearchSessionStateCommand {
     expect(model.pendingSearches).toEqual(state.pendingSearches);
   }
   toString(): string {
-    return `TrackSearchCommand(${JSON.stringify(this.value)})`;
+    return `UntrackSearchCommand(${JSON.stringify(this.value)})`;
   }
 }
 

--- a/src/plugins/data/public/search/session/search_session_state.pb.test.ts
+++ b/src/plugins/data/public/search/session/search_session_state.pb.test.ts
@@ -15,6 +15,18 @@ import { SearchSessionSavedObjectAttributes, SearchSessionStatus } from 'src/plu
 import { SessionStateContainer, createSessionStateContainer } from './search_session_state';
 import { SearchSessionSavedObject } from './sessions_client';
 
+describe('Search session state', () => {
+  it('should function as expected', () => {
+    fc.assert(
+      fc.property(SearchStateContainerCommands, (commands) => {
+        const { stateContainer: real } = createSessionStateContainer();
+        const model = new SearchSessionStateContainerModel();
+        fc.modelRun(() => ({ real, model }), commands);
+      })
+    );
+  });
+});
+
 const option = <T>(arb: fc.Arbitrary<T>) => fc.option(arb, { nil: undefined });
 
 function arbitrarySearchSessionSavedObjectAttributes(): fc.Arbitrary<SearchSessionSavedObjectAttributes> {
@@ -242,15 +254,3 @@ const SearchStateContainerCommands = fc.commands(
     maxCommands: 1000,
   }
 );
-
-describe('Search session state', () => {
-  it('should function as expected', () => {
-    fc.assert(
-      fc.property(SearchStateContainerCommands, (commands) => {
-        const { stateContainer: real } = createSessionStateContainer();
-        const model = new SearchSessionStateContainerModel();
-        fc.modelRun(() => ({ real, model }), commands);
-      })
-    );
-  });
-});

--- a/src/plugins/data/public/search/session/search_session_state.pb.test.ts
+++ b/src/plugins/data/public/search/session/search_session_state.pb.test.ts
@@ -45,13 +45,7 @@ function arbitrarySearchSessionSavedObjectAttributes(): fc.Arbitrary<SearchSessi
     expires: fc.date().map((date) => date.toISOString()),
     persisted: fc.boolean(),
     sessionId: fc.string({ minLength: 1 }),
-    status: fc.constantFrom(
-      SearchSessionStatus.CANCELLED,
-      SearchSessionStatus.COMPLETE,
-      SearchSessionStatus.ERROR,
-      SearchSessionStatus.EXPIRED,
-      SearchSessionStatus.IN_PROGRESS
-    ),
+    status: fc.constantFrom(...Object.values(SearchSessionStatus)),
     touched: fc.date().map((date) => date.toISOString()),
     version: fc.string(),
     appId: option(fc.string()),

--- a/src/plugins/data/public/search/session/search_session_state.pb.test.ts
+++ b/src/plugins/data/public/search/session/search_session_state.pb.test.ts
@@ -8,7 +8,6 @@
 
 /* eslint-disable max-classes-per-file */
 
-import { isColumnActionEnabled } from '@elastic/eui/src/components/datagrid/body/header/column_actions';
 import { SerializableRecord } from '@kbn/utility-types';
 import fc from 'fast-check';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14498,6 +14498,13 @@ fancy-log@^1.3.2:
     color-support "^1.1.3"
     time-stamp "^1.0.0"
 
+fast-check@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.19.0.tgz#e87666450e417cd163a564bd546ee763d27c0f19"
+  integrity sha512-qY4Rc0Nljl2aJx2qgbK3o6wPBjL9QvhKdD/VqJgaKd5ewn8l4ViqgDpUHJq/JkHTBnFKomYYvkFkOYGDVTT8bw==
+  dependencies:
+    pure-rand "^5.0.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -23557,6 +23564,11 @@ puppeteer@^5.3.1:
     tar-fs "^2.0.0"
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
+
+pure-rand@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.0.tgz#87f5bdabeadbd8904e316913a5c0b8caac517b37"
+  integrity sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
## Summary

Part of OnWeek experimentation and research with PBTs, this test shows how we could use PBTs to hard logic for testing long sequences of generated actions against a stateful class and make assertions against a model.

## Notes

Currently all implementation for the test lives in one file for convenience. There is clearly a use case for making arbitraries re-usable across tests but this was not done for brevity.

## Example failure detection

When a counter-example is discovered using this approach the output looks like the following:

```
    Property failed after 1 tests
    { seed: 1929090238, path: "0:2:1:1:3:4:3:4", endOnFailure: true }
    Counterexample: [RestoreCommand( ),TrackSearchCommand(1),UntrackSearchCommand(1) /*replayPath="ABABAAABBDACBAADAAABAGBDABBAACBCAABAahCP:qqqqqqK"*/]
    Shrunk 7 time(s)
```

The failure reports that doing:

```
RestoreCommand( )
TrackSearchCommand(1)
UntrackSearchCommand(1)
```

Results in an unacceptable state based on our model. Even though these commands are dynamically created and sequenced, subsequent runs of the test will discover the same issue until it is fixed.