### PR TITLE
[Onweek] PBT for tabify docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -708,6 +708,7 @@
     "eslint-plugin-react-perf": "^3.3.0",
     "eslint-traverse": "^1.0.0",
     "expose-loader": "^0.7.5",
+    "fast-check": "^2.19.0",
     "faker": "^5.1.0",
     "fancy-log": "^1.3.2",
     "fast-glob": "2.2.7",

--- a/src/plugins/data/common/search/tabify/tabify_docs.pb.test.ts
+++ b/src/plugins/data/common/search/tabify/tabify_docs.pb.test.ts
@@ -28,7 +28,7 @@ function arbitraryDataViewInputs() {
 function arbitraryHits(): fc.Arbitrary<estypes.SearchResponse['hits']['hits']> {
   return fc.array(
     fc.record<estypes.SearchHit>({
-      _id: fc.string(),
+      _id: fc.uuid(),
       _index: fc.string(),
       fields: fc.object({
         key: fc.string({ minLength: 1, maxLength: 10 }),
@@ -38,7 +38,7 @@ function arbitraryHits(): fc.Arbitrary<estypes.SearchResponse['hits']['hits']> {
       _type: fc.string(),
       _seq_no: fc.integer(),
     }),
-    { maxLength: 500 }
+    { maxLength: 250 }
   );
 }
 
@@ -87,7 +87,8 @@ describe('Tabify docs', () => {
           const indexPattern = new DataView({ ...dataViewInputs, fieldFormats: fieldFormatsMock });
           expect(() => tabifyDocs(esResponse, indexPattern, options)).not.toThrow();
         }
-      )
+      ),
+      { numRuns: 50 }
     );
   });
 
@@ -104,7 +105,7 @@ describe('Tabify docs', () => {
           );
         }
       ),
-      { numRuns: 10 }
+      { numRuns: 50 }
     );
   });
 });

--- a/src/plugins/data/common/search/tabify/tabify_docs.pb.test.ts
+++ b/src/plugins/data/common/search/tabify/tabify_docs.pb.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import fc from 'fast-check';
+import { tabifyDocs } from './tabify_docs';
+
+function arbitraryHits(): fc.Arbitrary<estypes.SearchResponse['hits']['hits']> {
+  return fc.array(
+    fc.record<estypes.SearchHit>({
+      _id: fc.string(),
+      _index: fc.string(),
+      fields: fc.object(),
+      _type: fc.string(),
+      _seq_no: fc.integer(),
+    }),
+    { minLength: 1000 }
+  );
+}
+
+function arbitraryEsResponse(
+  hits: estypes.SearchHit[]
+): fc.Arbitrary<estypes.SearchResponse<unknown>> {
+  return fc.record<estypes.SearchResponse<unknown>>({
+    _shards: fc.record({
+      failed: fc.integer(0, 10),
+      skipped: fc.integer(0, 10),
+      successful: fc.integer(0, 10),
+      total: fc.integer(0, 10),
+      failures: fc.array(
+        fc.record({
+          shard: fc.integer(),
+          reason: fc.record({ type: fc.string(), reason: fc.string() }),
+        })
+      ),
+    }),
+    timed_out: fc.boolean(),
+    took: fc.integer(0, 1000),
+    hits: fc.record({
+      total: fc.constant(hits.length),
+      hits: fc.constant(hits),
+      max_score: fc.float(),
+    }),
+  });
+}
+
+describe('Tabify docs', () => {
+  it('does not throw for expected inputs', () => {
+    fc.assert(
+      fc.property(
+        arbitraryHits().chain((hits) => arbitraryEsResponse(hits)),
+        (esResponse) => {
+          expect(() => tabifyDocs(esResponse)).not.toThrow();
+        }
+      )
+    );
+  });
+});

--- a/src/plugins/data/common/search/tabify/tabify_docs.ts
+++ b/src/plugins/data/common/search/tabify/tabify_docs.ts
@@ -26,7 +26,9 @@ type ValidMetaFieldNames = keyof Pick<
   | '_type'
   | '_version'
 >;
-const VALID_META_FIELD_NAMES: ValidMetaFieldNames[] = [
+
+/** @internal */
+export const VALID_META_FIELD_NAMES: ValidMetaFieldNames[] = [
   '_id',
   '_ignored',
   '_index',

--- a/yarn.lock
+++ b/yarn.lock
@@ -14498,6 +14498,13 @@ fancy-log@^1.3.2:
     color-support "^1.1.3"
     time-stamp "^1.0.0"
 
+fast-check@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.19.0.tgz#e87666450e417cd163a564bd546ee763d27c0f19"
+  integrity sha512-qY4Rc0Nljl2aJx2qgbK3o6wPBjL9QvhKdD/VqJgaKd5ewn8l4ViqgDpUHJq/JkHTBnFKomYYvkFkOYGDVTT8bw==
+  dependencies:
+    pure-rand "^5.0.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -23557,6 +23564,11 @@ puppeteer@^5.3.1:
     tar-fs "^2.0.0"
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
+
+pure-rand@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.0.tgz#87f5bdabeadbd8904e316913a5c0b8caac517b37"
+  integrity sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
## Summary

This functionality processes potentially large amounts of data into a tabular JSON format. These data are contained inside unknown/dynamic documents stored in Elasticsearch

## Notes

* Discovered a bottleneck with this logic due to its potential n2 (squared) algorithm under the hood given high cardinality on field names in documents. This revealed an underlying assumption that tabifyDocs will not be run on high cardinality documents in ES. This needs to be assessed a bit closer since generating the data is also intensive given potential nesting of documents in documents
* The number of runs and size of the arbitrary ES documents needs to be tweaked for optimal testing