### PR TITLE
[Fleet] improve instructions

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_requirements_page/components/fleet_server_on_prem_instructions.tsx
@@ -751,8 +751,8 @@ export const OnPremInstructions: React.FC = () => {
       <EuiSteps
         className="eui-textLeft"
         steps={[
-          DownloadStep(),
           AgentPolicySelectionStep({ policyId, setPolicyId }),
+          DownloadStep(true),
           deploymentModeStep({ deploymentMode, setDeploymentMode }),
           addFleetServerHostStep({ addFleetServerHost }),
           ServiceTokenStep({

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -95,7 +95,6 @@ export const ManagedInstructions = React.memo<Props>(
     const steps = useMemo(() => {
       const fleetServerHosts = settings?.fleet_server_hosts || [];
       const baseSteps: EuiContainedStepProps[] = [
-        DownloadStep(),
         !agentPolicy
           ? AgentPolicySelectionStep({
               agentPolicies,
@@ -104,6 +103,7 @@ export const ManagedInstructions = React.memo<Props>(
               setSelectedPolicyId,
             })
           : AgentEnrollmentKeySelectionStep({ agentPolicy, selectedApiKeyId, setSelectedAPIKeyId }),
+        DownloadStep(isFleetServerPolicySelected || false),
       ];
       if (isFleetServerPolicySelected) {
         baseSteps.push(...fleetServerSteps);

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -186,10 +186,10 @@ export const StandaloneInstructions = React.memo<Props>(({ agentPolicy, agentPol
     );
 
   const steps = [
-    DownloadStep(),
     !agentPolicy
       ? AgentPolicySelectionStep({ agentPolicies, setSelectedPolicyId, excludeFleetServer: true })
       : undefined,
+    DownloadStep(false),
     {
       title: i18n.translate('xpack.fleet.agentEnrollment.stepConfigureAgentTitle', {
         defaultMessage: 'Configure the agent',

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -19,25 +19,36 @@ import { useKibanaVersion } from '../../hooks';
 import { EnrollmentStepAgentPolicy } from './agent_policy_selection';
 import { AdvancedAgentAuthenticationSettings } from './advanced_agent_authentication_settings';
 
-export const DownloadStep = () => {
+export const DownloadStep = (hasFleetServer: boolean) => {
   const kibanaVersion = useKibanaVersion();
   const kibanaVersionURLString = useMemo(
     () =>
       `${semverMajor(kibanaVersion)}-${semverMinor(kibanaVersion)}-${semverPatch(kibanaVersion)}`,
     [kibanaVersion]
   );
+  const title = hasFleetServer
+    ? i18n.translate('xpack.fleet.agentEnrollment.stepDownloadAgentForFleetServerTitle', {
+        defaultMessage: 'Download the Fleet Server to a centralized host',
+      })
+    : i18n.translate('xpack.fleet.agentEnrollment.stepDownloadAgentTitle', {
+        defaultMessage: 'Download the Elastic Agent to your host',
+      });
+  const downloadDescription = hasFleetServer ? (
+    <FormattedMessage
+      id="xpack.fleet.agentEnrollment.downloadDescriptionForFleetServer"
+      defaultMessage="Fleet Server runs on an Elastic Agent. Install this agent on a centralized host so that other hosts you wish to monitor can connect to it. In production, we recommend using one or more dedicated hosts. You can download the Elastic Agent binaries and verification signatures from Elastic’s download page."
+    />
+  ) : (
+    <FormattedMessage
+      id="xpack.fleet.agentEnrollment.downloadDescription"
+      defaultMessage="Install the Elastic Agent on the hosts you wish to monitor. Do not install this agent policy on a host containing Fleet Server. You can download the Elastic Agent binaries and verification signatures from Elastic’s download page."
+    />
+  );
   return {
-    title: i18n.translate('xpack.fleet.agentEnrollment.stepDownloadAgentTitle', {
-      defaultMessage: 'Download the Elastic Agent to your host',
-    }),
+    title,
     children: (
       <>
-        <EuiText>
-          <FormattedMessage
-            id="xpack.fleet.agentEnrollment.downloadDescription"
-            defaultMessage="Fleet Server runs on an Elastic Agent. You can download the Elastic Agent binaries and verification signatures from Elastic’s download page."
-          />
-        </EuiText>
+        <EuiText>{downloadDescription}</EuiText>
         <EuiSpacer size="s" />
         <EuiText size="s">
           <FormattedMessage


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/118112

Improve instructions on Add Agent flyout and Fleet Server on prem instructions.

- Switched the order of Policy selection and download instructions
- Updated text for download instructions, to be different for Fleet Server and Agent

To test:

1. Check Fleet Server on prem instructions:
![image](https://user-images.githubusercontent.com/90178898/142635916-819a1a69-4879-4aa7-bf23-f88a3f3c860a.png)
2. Check Add Agent flyout
 Select `Default policy`
![image](https://user-images.githubusercontent.com/90178898/142636072-c6563ca8-02c5-4b86-a2e6-b64a3a5355b2.png)
Select `Default Fleet Server policy`
![image](https://user-images.githubusercontent.com/90178898/142636308-10762cf0-910a-4538-b8ff-d3c667c2e409.png)

3. Go to `Default policy` details and click on `Add Agent`, `Run standalone` tab
![image](https://user-images.githubusercontent.com/90178898/142636517-c0a8157d-d399-4e23-9430-9a5e95fc06ed.png)



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

