### PR TITLE
update APM agents with renovate bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "deep-freeze-strict": "^1.1.1",
     "deepmerge": "^4.2.2",
     "del": "^5.1.0",
-    "elastic-apm-node": "3.24.0",
+    "elastic-apm-node": "^3.24.0",
     "execa": "^4.0.2",
     "exit-hook": "^2.2.0",
     "expiry-js": "0.1.7",

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,14 @@
       "enabled": true
     },
     {
+      "groupName": "APM",
+      "matchPackageNames": ["elastic-apm-node", "@elastic/apm-rum", "@elastic/apm-rum-react"],
+      "reviewers": ["team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "enabled": true
+    },
+    {
       "groupName": "babel",
       "matchPackageNames": ["@types/babel__core"],
       "matchPackagePatterns": ["^@babel", "^babel-plugin"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12592,7 +12592,7 @@ elastic-apm-http-client@^10.3.0:
     readable-stream "^3.4.0"
     stream-chopper "^3.0.1"
 
-elastic-apm-node@3.24.0:
+elastic-apm-node@^3.24.0:
   version "3.24.0"
   resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-3.24.0.tgz#d7acb3352f928a23c28ebabab2bd30098562814e"
   integrity sha512-Fmj/W2chWQa2zb1FfMYK2ypLB4TcnKNX+1klaJFbytRYDLgeSfo0EC7egvI3a+bLPZSRL5053PXOp7slVTPO6Q==


### PR DESCRIPTION
## Summary
`elasticsearch-js` client is going to implement integration tests with the latest APM agent version to ensure their compatibility with the latest APM agent version. 
The APM agent release process is not aligned with the Stack release schedule. To make sure that both Kibana and `elasticsearch-js` use the same APM agent version, this PR automates `APM agents` upgrade to the latest available release.