### PR TITLE
[7.16] [Dashboard][Saved Object Tagging] Fix Duplicating Tags (#119079)

### DIFF
--- a/src/plugins/dashboard/common/embeddable/dashboard_container_persistable_state.ts
+++ b/src/plugins/dashboard/common/embeddable/dashboard_container_persistable_state.ts
@@ -108,10 +108,12 @@ export const createExtract = (
         });
 
         // We're going to prefix the names of the references so that we don't end up with dupes (from visualizations for instance)
-        const prefixedReferences = panelReferences.map((reference) => ({
-          ...reference,
-          name: `${prefix}${reference.name}`,
-        }));
+        const prefixedReferences = panelReferences
+          .filter((reference) => reference.type !== 'tag') // panel references should never contain tags. If they do, they must be removed
+          .map((reference) => ({
+            ...reference,
+            name: `${prefix}${reference.name}`,
+          }));
 
         references.push(...prefixedReferences);
 

--- a/src/plugins/saved_objects_tagging_oss/public/decorator/extract_tag_references.test.ts
+++ b/src/plugins/saved_objects_tagging_oss/public/decorator/extract_tag_references.test.ts
@@ -81,4 +81,20 @@ describe('extractTagReferences', () => {
     expect(resultRefs).toEqual([refA, refB]);
     expect(resultAttrs).toEqual({ someString: 'foo', someNumber: 42 });
   });
+
+  it('removes duplicated tags', () => {
+    const attributes = {
+      __tags: ['tag-id-1', 'tag-id-1', 'tag-id-1', 'tag-id-1', 'tag-id-2'],
+    };
+
+    const { references: resultRefs } = extractTagReferences({
+      attributes,
+      references: [] as SavedObjectReference[],
+    });
+
+    expect(resultRefs).toEqual([
+      { id: 'tag-id-1', name: 'tag-tag-id-1', type: 'tag' },
+      { id: 'tag-id-2', name: 'tag-tag-id-2', type: 'tag' },
+    ]);
+  });
 });

--- a/src/plugins/saved_objects_tagging_oss/public/decorator/extract_tag_references.ts
+++ b/src/plugins/saved_objects_tagging_oss/public/decorator/extract_tag_references.ts
@@ -18,7 +18,7 @@ export const extractTagReferences: Required<SavedObjectConfig>['extractReference
   references,
 }) => {
   const { __tags, ...otherAttributes } = attributes;
-  const tags = (__tags as string[]) ?? [];
+  const tags = [...new Set(__tags as string[])] ?? [];
   return {
     attributes: otherAttributes,
     references: [

--- a/x-pack/plugins/lens/common/embeddable_factory/index.ts
+++ b/x-pack/plugins/lens/common/embeddable_factory/index.ts
@@ -18,7 +18,20 @@ export const inject: EmbeddableRegistryDefinition['inject'] = (state, references
   const typedState = state as LensEmbeddablePersistableState;
 
   if ('attributes' in typedState && typedState.attributes !== undefined) {
-    typedState.attributes.references = references as unknown as Serializable[];
+    // match references based on name, so only references associated with this lens panel are injected.
+    const matchedReferences: SavedObjectReference[] = [];
+
+    if (Array.isArray(typedState.attributes.references)) {
+      typedState.attributes.references.forEach((serializableRef) => {
+        const internalReference = serializableRef as unknown as SavedObjectReference;
+        const matchedReference = references.find(
+          (reference) => reference.name === internalReference.name
+        );
+        if (matchedReference) matchedReferences.push(matchedReference);
+      });
+    }
+
+    typedState.attributes.references = matchedReferences as unknown as Serializable[];
   }
 
   return typedState;


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Dashboard][Saved Object Tagging] Fix Duplicating Tags (#119079)