### PR TITLE
Remove duplicate Spaces functional test

### DIFF
--- a/x-pack/test/functional/apps/spaces/spaces_selection.ts
+++ b/x-pack/test/functional/apps/spaces/spaces_selection.ts
@@ -63,36 +63,6 @@ export default function spaceSelectorFunctionalTests({
       });
     });
 
-    describe('Space Selector', () => {
-      before(async () => {
-        await PageObjects.security.forceLogout();
-      });
-
-      afterEach(async () => {
-        await PageObjects.security.forceLogout();
-      });
-
-      it('allows user to navigate to different spaces', async () => {
-        const spaceId = 'another-space';
-
-        await PageObjects.security.login(undefined, undefined, {
-          expectSpaceSelector: true,
-        });
-
-        await PageObjects.spaceSelector.clickSpaceCard(spaceId);
-
-        await PageObjects.spaceSelector.expectHomePage(spaceId);
-
-        await PageObjects.spaceSelector.openSpacesNav();
-
-        // change spaces
-
-        await PageObjects.spaceSelector.clickSpaceAvatar('default');
-
-        await PageObjects.spaceSelector.expectHomePage('default');
-      });
-    });
-
     // FLAKY: https://github.com/elastic/kibana/issues/118356
     // FLAKY: https://github.com/elastic/kibana/issues/118474
     describe.skip('Search spaces in popover', () => {


### PR DESCRIPTION
Through a bad merge in #117888, we had two copies of the same "allows user to navigate to different spaces" test.

It turns out this test is flaky, so it's supposed to be skipped for now.
So we need to remove the not-skipped one.