### PR TITLE
[App Search] Crawl Details Flyout with Raw JSON

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
@@ -16,20 +16,14 @@ import { EuiCodeBlock, EuiFlyout } from '@elastic/eui';
 import { Loading } from '../../../../shared/loading';
 
 import { CrawlDetailValues } from '../crawl_detail_logic';
-import { CrawlerStatus } from '../types';
+import { CrawlerStatus, CrawlRequestFromServer } from '../types';
 
 import { CrawlDetailsFlyout } from './crawl_details_flyout';
 
-const MOCK_VALUES: CrawlDetailValues = {
+const MOCK_VALUES: Partial<CrawlDetailValues> = {
   dataLoading: false,
-  flyoutHidden: false,
-  request: {
-    id: '654364aed23623456',
-    status: CrawlerStatus.Pending,
-    createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
-    beganAt: null,
-    completedAt: null,
-  },
+  flyoutClosed: false,
+  crawlRequestFromServer: {} as CrawlRequestFromServer,
 };
 
 describe('CrawlDetailsFlyout', () => {
@@ -53,7 +47,7 @@ describe('CrawlDetailsFlyout', () => {
 
   it('is empty when the flyout is hidden', () => {
     setMockValues({
-      flyoutHidden: true,
+      flyoutClosed: true,
     });
 
     const wrapper = shallow(<CrawlDetailsFlyout />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
@@ -16,7 +16,7 @@ import { EuiCodeBlock, EuiFlyout } from '@elastic/eui';
 import { Loading } from '../../../../shared/loading';
 
 import { CrawlDetailValues } from '../crawl_detail_logic';
-import { CrawlerStatus, CrawlRequestFromServer } from '../types';
+import { CrawlRequestFromServer } from '../types';
 
 import { CrawlDetailsFlyout } from './crawl_details_flyout';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { setMockValues } from '../../../../__mocks__/kea_logic';
+import '../../../__mocks__/engine_logic.mock';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiCodeBlock, EuiFlyout } from '@elastic/eui';
+
+import { Loading } from '../../../../shared/loading';
+
+import { CrawlDetailValues } from '../crawl_detail_logic';
+import { CrawlerStatus } from '../types';
+
+import { CrawlDetailsFlyout } from './crawl_details_flyout';
+
+const MOCK_VALUES: CrawlDetailValues = {
+  dataLoading: false,
+  flyoutHidden: false,
+  request: {
+    id: '654364aed23623456',
+    status: CrawlerStatus.Pending,
+    createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+    beganAt: null,
+    completedAt: null,
+  },
+};
+
+describe('CrawlDetailsFlyout', () => {
+  it('renders a flyout containing the raw json of the crawl details', () => {
+    setMockValues(MOCK_VALUES);
+
+    const wrapper = shallow(<CrawlDetailsFlyout />);
+
+    expect(wrapper.is(EuiFlyout)).toBe(true);
+    expect(wrapper.find(EuiCodeBlock)).toHaveLength(1);
+  });
+
+  it('renders a loading screen when loading', () => {
+    setMockValues({ ...MOCK_VALUES, dataLoading: true });
+
+    const wrapper = shallow(<CrawlDetailsFlyout />);
+
+    expect(wrapper.is(EuiFlyout)).toBe(true);
+    expect(wrapper.find(Loading)).toHaveLength(1);
+  });
+
+  it('is empty when the flyout is hidden', () => {
+    setMockValues({
+      flyoutHidden: true,
+    });
+
+    const wrapper = shallow(<CrawlDetailsFlyout />);
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
@@ -16,15 +16,15 @@ import { Loading } from '../../../../shared/loading';
 import { CrawlDetailLogic } from '../crawl_detail_logic';
 
 export const CrawlDetailsFlyout: React.FC = () => {
-  const { hideFlyout } = useActions(CrawlDetailLogic);
-  const { dataLoading, flyoutHidden, request } = useValues(CrawlDetailLogic);
+  const { closeFlyout } = useActions(CrawlDetailLogic);
+  const { dataLoading, flyoutClosed, crawlRequestFromServer } = useValues(CrawlDetailLogic);
 
-  if (flyoutHidden) {
+  if (flyoutClosed) {
     return null;
   }
 
   return (
-    <EuiFlyout ownFocus onClose={hideFlyout} aria-labelledby="CrawlDetailsFlyoutTitle">
+    <EuiFlyout ownFocus onClose={closeFlyout} aria-labelledby="CrawlDetailsFlyoutTitle">
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
           <h2 id="CrawlDetailsFlyoutTitle">
@@ -35,7 +35,13 @@ export const CrawlDetailsFlyout: React.FC = () => {
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        {dataLoading ? <Loading /> : <EuiCodeBlock language="json">{request}</EuiCodeBlock>}
+        {dataLoading ? (
+          <Loading />
+        ) : (
+          <EuiCodeBlock language="json">
+            {JSON.stringify(crawlRequestFromServer, null, 2)}
+          </EuiCodeBlock>
+        )}
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody, EuiCodeBlock } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import { Loading } from '../../../../shared/loading';
+import { CrawlDetailLogic } from '../crawl_detail_logic';
+
+export const CrawlDetailsFlyout: React.FC = () => {
+  const { hideFlyout } = useActions(CrawlDetailLogic);
+  const { dataLoading, flyoutHidden, request } = useValues(CrawlDetailLogic);
+
+  if (flyoutHidden) {
+    return null;
+  }
+
+  return (
+    <EuiFlyout ownFocus onClose={hideFlyout} aria-labelledby="CrawlDetailsFlyoutTitle">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id="CrawlDetailsFlyoutTitle">
+            {i18n.translate('xpack.enterpriseSearch.appSearch.crawler.crawlDetailsFlyout.title', {
+              defaultMessage: 'Crawl request details',
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {dataLoading ? <Loading /> : <EuiCodeBlock language="json">{request}</EuiCodeBlock>}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -74,18 +74,18 @@ describe('CrawlRequestsTable', () => {
 
     it('renders a id column ', () => {
       expect(tableContent).toContain('Request ID');
-      expect(tableContent).toContain('618d0e66abe97bc688328900');
-      expect(tableContent).toContain('54325423aef7890543');
 
-      // TODO Use data-test-subj instead, currently not able to find inside the table
-      // expect(wrapper.find('[data-test-subj="CrawlRequestsTableId"]').children()).toContain(
-      //   '54325423aef7890543'
-      // );
-      // expect(wrapper.find('[data-test-subj="CrawlRequestsTableIdLink"]').children()).toContain(
-      //   '618d0e66abe97bc688328900'
-      // );
-      // wrapper.find('[data-test-subj="CrawlRequestsTableIdLink"]').simulate('click');
-      // expect(actions.fetchCrawlRequest).toHaveBeenCalledWith('618d0e66abe97bc688328900');
+      const table = wrapper.find(EuiBasicTable);
+      const columns = table.prop('columns');
+
+      const crawlID = shallow(columns[0].render('618d0e66abe97bc688328900', { stage: 'crawl' }));
+      expect(crawlID.text()).toContain('618d0e66abe97bc688328900');
+
+      crawlID.simulate('click');
+      expect(actions.fetchCrawlRequest).toHaveBeenCalledWith('618d0e66abe97bc688328900');
+
+      const processCrawlID = shallow(columns[0].render('54325423aef7890543', { stage: 'process' }));
+      expect(processCrawlID.text()).toContain('54325423aef7890543');
     });
 
     it('renders a created at column', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { setMockValues } from '../../../../__mocks__/kea_logic';
+import { setMockActions, setMockValues } from '../../../../__mocks__/kea_logic';
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
@@ -35,7 +35,23 @@ const values: { events: CrawlEvent[] } = {
         domainAllowlist: ['https://www.elastic.co'],
       },
     },
+    {
+      id: '54325423aef7890543',
+      status: CrawlerStatus.Success,
+      stage: 'process',
+      createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      beganAt: null,
+      completedAt: null,
+      type: CrawlType.Full,
+      crawlConfig: {
+        domainAllowlist: ['https://www.elastic.co'],
+      },
+    },
   ],
+};
+
+const actions = {
+  fetchCrawlRequest: jest.fn(),
 };
 
 describe('CrawlRequestsTable', () => {
@@ -48,6 +64,7 @@ describe('CrawlRequestsTable', () => {
 
   describe('columns', () => {
     beforeAll(() => {
+      setMockActions(actions);
       setMockValues(values);
       wrapper = shallow(<CrawlRequestsTable />);
       tableContent = mountWithIntl(<CrawlRequestsTable />)
@@ -55,8 +72,20 @@ describe('CrawlRequestsTable', () => {
         .text();
     });
 
-    it('renders an id column', () => {
+    it('renders a id column ', () => {
+      expect(tableContent).toContain('Request ID');
       expect(tableContent).toContain('618d0e66abe97bc688328900');
+      expect(tableContent).toContain('54325423aef7890543');
+
+      // TODO Use data-test-subj instead, currently not able to find inside the table
+      // expect(wrapper.find('[data-test-subj="CrawlRequestsTableId"]').children()).toContain(
+      //   '54325423aef7890543'
+      // );
+      // expect(wrapper.find('[data-test-subj="CrawlRequestsTableIdLink"]').children()).toContain(
+      //   '618d0e66abe97bc688328900'
+      // );
+      // wrapper.find('[data-test-subj="CrawlRequestsTableIdLink"]').simulate('click');
+      // expect(actions.fetchCrawlRequest).toHaveBeenCalledWith('618d0e66abe97bc688328900');
     });
 
     it('renders a created at column', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -7,73 +7,96 @@
 
 import React from 'react';
 
-import { useValues } from 'kea';
+import { useActions, useValues } from 'kea';
 
-import { EuiBadge, EuiBasicTable, EuiBasicTableColumn, EuiEmptyPrompt } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiEmptyPrompt,
+  EuiLink,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
+import { CrawlDetailLogic } from '../crawl_detail_logic';
 import { CrawlerLogic } from '../crawler_logic';
 import { CrawlEvent, readableCrawlerStatuses } from '../types';
 
 import { CrawlEventTypeBadge } from './crawl_event_type_badge';
 import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
 
-const columns: Array<EuiBasicTableColumn<CrawlEvent>> = [
-  {
-    field: 'id',
-    name: i18n.translate(
-      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.domainURL',
-      {
-        defaultMessage: 'Request ID',
-      }
-    ),
-  },
-  {
-    field: 'createdAt',
-    name: i18n.translate(
-      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.created',
-      {
-        defaultMessage: 'Created',
-      }
-    ),
-    render: (createdAt: CrawlEvent['createdAt']) => (
-      <CustomFormattedTimestamp timestamp={createdAt} />
-    ),
-  },
-  {
-    field: 'type',
-    name: i18n.translate(
-      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.crawlType',
-      {
-        defaultMessage: 'Crawl type',
-      }
-    ),
-    render: (_, event: CrawlEvent) => <CrawlEventTypeBadge event={event} />,
-  },
-  {
-    name: i18n.translate(
-      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.domains',
-      {
-        defaultMessage: 'Domains',
-      }
-    ),
-    render: (event: CrawlEvent) => <EuiBadge>{event.crawlConfig.domainAllowlist.length}</EuiBadge>,
-  },
-  {
-    field: 'status',
-    name: i18n.translate(
-      'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.status',
-      {
-        defaultMessage: 'Status',
-      }
-    ),
-    render: (status: CrawlEvent['status']) => readableCrawlerStatuses[status],
-  },
-];
-
 export const CrawlRequestsTable: React.FC = () => {
   const { events } = useValues(CrawlerLogic);
+  const { fetchCrawlRequest } = useActions(CrawlDetailLogic);
+
+  const columns: Array<EuiBasicTableColumn<CrawlEvent>> = [
+    {
+      field: 'id',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.domainURL',
+        {
+          defaultMessage: 'Request ID',
+        }
+      ),
+      render: (id: string, event: CrawlEvent) => {
+        if (event.stage === 'crawl') {
+          return (
+            <EuiLink
+              data-test-subj="CrawlRequestsTableIdLink"
+              onClick={() => fetchCrawlRequest(id)}
+            >
+              {id}
+            </EuiLink>
+          );
+        }
+        return <span data-test-subj="CrawlRequestsTableId">{id}</span>;
+      },
+    },
+    {
+      field: 'createdAt',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.created',
+        {
+          defaultMessage: 'Created',
+        }
+      ),
+      render: (createdAt: CrawlEvent['createdAt']) => (
+        <CustomFormattedTimestamp timestamp={createdAt} />
+      ),
+    },
+    {
+      field: 'type',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.crawlType',
+        {
+          defaultMessage: 'Crawl type',
+        }
+      ),
+      render: (_, event: CrawlEvent) => <CrawlEventTypeBadge event={event} />,
+    },
+    {
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.domains',
+        {
+          defaultMessage: 'Domains',
+        }
+      ),
+      render: (event: CrawlEvent) => (
+        <EuiBadge>{event.crawlConfig.domainAllowlist.length}</EuiBadge>
+      ),
+    },
+    {
+      field: 'status',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.column.status',
+        {
+          defaultMessage: 'Status',
+        }
+      ),
+      render: (status: CrawlEvent['status']) => readableCrawlerStatuses[status],
+    },
+  ];
 
   return (
     <EuiBasicTable

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -41,16 +41,9 @@ export const CrawlRequestsTable: React.FC = () => {
       ),
       render: (id: string, event: CrawlEvent) => {
         if (event.stage === 'crawl') {
-          return (
-            <EuiLink
-              data-test-subj="CrawlRequestsTableIdLink"
-              onClick={() => fetchCrawlRequest(id)}
-            >
-              {id}
-            </EuiLink>
-          );
+          return <EuiLink onClick={() => fetchCrawlRequest(id)}>{id}</EuiLink>;
         }
-        return <span data-test-subj="CrawlRequestsTableId">{id}</span>;
+        return <span>{id}</span>;
       },
     },
     {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -20,8 +20,9 @@ import { crawlRequestServerToClient } from './utils';
 
 const DEFAULT_VALUES: CrawlDetailValues = {
   dataLoading: true,
-  flyoutHidden: true,
-  request: null,
+  flyoutClosed: true,
+  crawlRequest: null,
+  crawlRequestFromServer: null,
 };
 
 const crawlRequestResponse: CrawlRequestFromServer = {
@@ -49,15 +50,15 @@ describe('CrawlDetailLogic', () => {
   });
 
   describe('reducers', () => {
-    describe('hideFlyout', () => {
+    describe('closeFlyout', () => {
       it('closes the flyout', () => {
-        mount({ flyoutHidden: false });
+        mount({ flyoutClosed: false });
 
-        CrawlDetailLogic.actions.hideFlyout();
+        CrawlDetailLogic.actions.closeFlyout();
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
-          flyoutHidden: true,
+          flyoutClosed: true,
         });
       });
     });
@@ -66,7 +67,7 @@ describe('CrawlDetailLogic', () => {
       it('opens the flyout and sets loading to true', () => {
         mount({
           dataLoading: false,
-          flyoutHidden: true,
+          flyoutClosed: true,
         });
 
         CrawlDetailLogic.actions.fetchCrawlRequest('12345');
@@ -74,7 +75,7 @@ describe('CrawlDetailLogic', () => {
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
           dataLoading: true,
-          flyoutHidden: false,
+          flyoutClosed: false,
         });
       });
     });
@@ -86,12 +87,13 @@ describe('CrawlDetailLogic', () => {
           request: null,
         });
 
-        CrawlDetailLogic.actions.onRecieveCrawlRequest(clientCrawlRequest);
+        CrawlDetailLogic.actions.onRecieveCrawlRequest(crawlRequestResponse);
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
           dataLoading: false,
-          request: clientCrawlRequest,
+          crawlRequestFromServer: crawlRequestResponse,
+          crawlRequest: clientCrawlRequest,
         });
       });
     });
@@ -112,7 +114,7 @@ describe('CrawlDetailLogic', () => {
           '/internal/app_search/engines/some-engine/crawler/crawl_requests/12345'
         );
         expect(CrawlDetailLogic.actions.onRecieveCrawlRequest).toHaveBeenCalledWith(
-          clientCrawlRequest
+          crawlRequestResponse
         );
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -20,7 +20,7 @@ import { crawlRequestServerToClient } from './utils';
 
 const DEFAULT_VALUES: CrawlDetailValues = {
   dataLoading: true,
-  isFlyoutOpen: false,
+  flyoutHidden: true,
   request: null,
 };
 
@@ -49,15 +49,15 @@ describe('CrawlDetailLogic', () => {
   });
 
   describe('reducers', () => {
-    describe('closeFlyout', () => {
+    describe('hideFlyout', () => {
       it('closes the flyout', () => {
-        mount({ isFlyoutOpen: true });
+        mount({ flyoutHidden: false });
 
-        CrawlDetailLogic.actions.closeFlyout();
+        CrawlDetailLogic.actions.hideFlyout();
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
-          isFlyoutOpen: false,
+          flyoutHidden: true,
         });
       });
     });
@@ -65,8 +65,8 @@ describe('CrawlDetailLogic', () => {
     describe('fetchCrawlRequest', () => {
       it('opens the flyout and sets loading to true', () => {
         mount({
-          isFlyoutOpen: false,
           dataLoading: false,
+          flyoutHidden: true,
         });
 
         CrawlDetailLogic.actions.fetchCrawlRequest('12345');
@@ -74,7 +74,7 @@ describe('CrawlDetailLogic', () => {
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
           dataLoading: true,
-          isFlyoutOpen: true,
+          flyoutHidden: false,
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  LogicMounter,
+  mockHttpValues,
+  mockFlashMessageHelpers,
+} from '../../../__mocks__/kea_logic';
+import '../../__mocks__/engine_logic.mock';
+
+import { nextTick } from '@kbn/test/jest';
+
+import { CrawlDetailLogic, CrawlDetailValues } from './crawl_detail_logic';
+import { CrawlerStatus, CrawlRequestFromServer } from './types';
+import { crawlRequestServerToClient } from './utils';
+
+const DEFAULT_VALUES: CrawlDetailValues = {
+  dataLoading: true,
+  isFlyoutOpen: false,
+  request: null,
+};
+
+const crawlRequestResponse: CrawlRequestFromServer = {
+  id: '12345',
+  status: CrawlerStatus.Pending,
+  created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+  began_at: null,
+  completed_at: null,
+};
+
+const clientCrawlRequest = crawlRequestServerToClient(crawlRequestResponse);
+
+describe('CrawlDetailLogic', () => {
+  const { mount } = new LogicMounter(CrawlDetailLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has expected default values', () => {
+    mount();
+    expect(CrawlDetailLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('reducers', () => {
+    describe('closeFlyout', () => {
+      it('closes the flyout', () => {
+        mount({ isFlyoutOpen: true });
+
+        CrawlDetailLogic.actions.closeFlyout();
+
+        expect(CrawlDetailLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          isFlyoutOpen: false,
+        });
+      });
+    });
+
+    describe('fetchCrawlRequest', () => {
+      it('opens the flyout and sets loading to true', () => {
+        mount({
+          isFlyoutOpen: false,
+          dataLoading: false,
+        });
+
+        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
+
+        expect(CrawlDetailLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: true,
+          isFlyoutOpen: true,
+        });
+      });
+    });
+
+    describe('onRecieveCrawlRequest', () => {
+      it('saves the crawl request and sets data loading to false', () => {
+        mount({
+          dataLoading: true,
+          request: null,
+        });
+
+        CrawlDetailLogic.actions.onRecieveCrawlRequest(clientCrawlRequest);
+
+        expect(CrawlDetailLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: false,
+          request: clientCrawlRequest,
+        });
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('fetchCrawlRequest', () => {
+      it('updates logic with data that has been converted from server to client', async () => {
+        mount();
+        jest.spyOn(CrawlDetailLogic.actions, 'onRecieveCrawlRequest');
+
+        http.get.mockReturnValueOnce(Promise.resolve(crawlRequestResponse));
+
+        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
+        await nextTick();
+
+        expect(http.get).toHaveBeenCalledWith(
+          '/internal/app_search/engines/some-engine/crawler/crawl_requests/12345'
+        );
+        expect(CrawlDetailLogic.actions.onRecieveCrawlRequest).toHaveBeenCalledWith(
+          clientCrawlRequest
+        );
+      });
+
+      it('displays any errors to the user', async () => {
+        mount();
+        http.get.mockReturnValueOnce(Promise.reject('error'));
+
+        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -16,10 +16,10 @@ import { CrawlRequest, CrawlRequestFromServer } from './types';
 import { crawlRequestServerToClient } from './utils';
 
 export interface CrawlDetailValues {
+  crawlRequest: CrawlRequest | null;
+  crawlRequestFromServer: CrawlRequestFromServer | null;
   dataLoading: boolean;
   flyoutClosed: boolean;
-  crawlRequestFromServer: CrawlRequestFromServer | null;
-  crawlRequest: CrawlRequest | null;
 }
 
 interface CrawlDetailActions {
@@ -38,11 +38,11 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
     onRecieveCrawlRequest: (crawlRequestFromServer) => ({ crawlRequestFromServer }),
   },
   reducers: {
-    dataLoading: [
-      true,
+    crawlRequest: [
+      null,
       {
-        fetchCrawlRequest: () => true,
-        onRecieveCrawlRequest: () => false,
+        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) =>
+          crawlRequestServerToClient(crawlRequestFromServer),
       },
     ],
     crawlRequestFromServer: [
@@ -51,11 +51,11 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
         onRecieveCrawlRequest: (_, { crawlRequestFromServer }) => crawlRequestFromServer,
       },
     ],
-    crawlRequest: [
-      null,
+    dataLoading: [
+      true,
       {
-        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) =>
-          crawlRequestServerToClient(crawlRequestFromServer),
+        fetchCrawlRequest: () => true,
+        onRecieveCrawlRequest: () => false,
       },
     ],
     flyoutClosed: [

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -31,7 +31,7 @@ interface CrawlDetailActions {
 }
 
 export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetailActions>>({
-  path: ['enterprise_search', 'app_search', 'crawl_detail_logic'],
+  path: ['enterprise_search', 'app_search', 'crawler', 'crawl_detail_logic'],
   actions: {
     closeFlyout: true,
     fetchCrawlRequest: (requestId) => ({ requestId }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -17,12 +17,12 @@ import { crawlRequestServerToClient } from './utils';
 
 export interface CrawlDetailValues {
   dataLoading: boolean;
-  isFlyoutOpen: boolean;
+  flyoutHidden: boolean;
   request: CrawlRequest | null;
 }
 
 interface CrawlDetailActions {
-  closeFlyout(): void;
+  hideFlyout(): void;
   fetchCrawlRequest(requestId: string): { requestId: string };
   onRecieveCrawlRequest(request: CrawlRequest): { request: CrawlRequest };
 }
@@ -30,7 +30,7 @@ interface CrawlDetailActions {
 export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetailActions>>({
   path: ['enterprise_search', 'app_search', 'crawl_detail_logic'],
   actions: {
-    closeFlyout: true,
+    hideFlyout: true,
     fetchCrawlRequest: (requestId) => ({ requestId }),
     onRecieveCrawlRequest: (request) => ({ request }),
   },
@@ -48,11 +48,11 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
         onRecieveCrawlRequest: (_, { request }) => request,
       },
     ],
-    isFlyoutOpen: [
-      false,
+    flyoutHidden: [
+      true,
       {
-        fetchCrawlRequest: () => true,
-        closeFlyout: () => false,
+        fetchCrawlRequest: () => false,
+        hideFlyout: () => true,
       },
     ],
   },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -17,22 +17,25 @@ import { crawlRequestServerToClient } from './utils';
 
 export interface CrawlDetailValues {
   dataLoading: boolean;
-  flyoutHidden: boolean;
-  request: CrawlRequest | null;
+  flyoutClosed: boolean;
+  crawlRequestFromServer: CrawlRequestFromServer | null;
+  crawlRequest: CrawlRequest | null;
 }
 
 interface CrawlDetailActions {
-  hideFlyout(): void;
+  closeFlyout(): void;
   fetchCrawlRequest(requestId: string): { requestId: string };
-  onRecieveCrawlRequest(request: CrawlRequest): { request: CrawlRequest };
+  onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {
+    crawlRequestFromServer: CrawlRequestFromServer;
+  };
 }
 
 export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetailActions>>({
   path: ['enterprise_search', 'app_search', 'crawl_detail_logic'],
   actions: {
-    hideFlyout: true,
+    closeFlyout: true,
     fetchCrawlRequest: (requestId) => ({ requestId }),
-    onRecieveCrawlRequest: (request) => ({ request }),
+    onRecieveCrawlRequest: (crawlRequestFromServer) => ({ crawlRequestFromServer }),
   },
   reducers: {
     dataLoading: [
@@ -42,17 +45,24 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
         onRecieveCrawlRequest: () => false,
       },
     ],
-    request: [
+    crawlRequestFromServer: [
       null,
       {
-        onRecieveCrawlRequest: (_, { request }) => request,
+        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) => crawlRequestFromServer,
       },
     ],
-    flyoutHidden: [
+    crawlRequest: [
+      null,
+      {
+        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) =>
+          crawlRequestServerToClient(crawlRequestFromServer),
+      },
+    ],
+    flyoutClosed: [
       true,
       {
         fetchCrawlRequest: () => false,
-        hideFlyout: () => true,
+        closeFlyout: () => true,
       },
     ],
   },
@@ -66,8 +76,7 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
           `/internal/app_search/engines/${engineName}/crawler/crawl_requests/${requestId}`
         );
 
-        const crawlRequest = crawlRequestServerToClient(response);
-        actions.onRecieveCrawlRequest(crawlRequest);
+        actions.onRecieveCrawlRequest(response);
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { flashAPIErrors } from '../../../shared/flash_messages';
+
+import { HttpLogic } from '../../../shared/http';
+import { EngineLogic } from '../engine';
+
+import { CrawlRequest, CrawlRequestFromServer } from './types';
+import { crawlRequestServerToClient } from './utils';
+
+export interface CrawlDetailValues {
+  dataLoading: boolean;
+  isFlyoutOpen: boolean;
+  request: CrawlRequest | null;
+}
+
+interface CrawlDetailActions {
+  closeFlyout(): void;
+  fetchCrawlRequest(requestId: string): { requestId: string };
+  onRecieveCrawlRequest(request: CrawlRequest): { request: CrawlRequest };
+}
+
+export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetailActions>>({
+  path: ['enterprise_search', 'app_search', 'crawl_detail_logic'],
+  actions: {
+    closeFlyout: true,
+    fetchCrawlRequest: (requestId) => ({ requestId }),
+    onRecieveCrawlRequest: (request) => ({ request }),
+  },
+  reducers: {
+    dataLoading: [
+      true,
+      {
+        fetchCrawlRequest: () => true,
+        onRecieveCrawlRequest: () => false,
+      },
+    ],
+    request: [
+      null,
+      {
+        onRecieveCrawlRequest: (_, { request }) => request,
+      },
+    ],
+    isFlyoutOpen: [
+      false,
+      {
+        fetchCrawlRequest: () => true,
+        closeFlyout: () => false,
+      },
+    ],
+  },
+  listeners: ({ actions }) => ({
+    fetchCrawlRequest: async ({ requestId }) => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const response = await http.get<CrawlRequestFromServer>(
+          `/internal/app_search/engines/${engineName}/crawler/crawl_requests/${requestId}`
+        );
+
+        const crawlRequest = crawlRequestServerToClient(response);
+        actions.onRecieveCrawlRequest(crawlRequest);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.test.tsx
@@ -17,6 +17,7 @@ import { getPageHeaderActions } from '../../../test_helpers';
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { AddDomainForm } from './components/add_domain/add_domain_form';
 import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
+import { CrawlDetailsFlyout } from './components/crawl_details_flyout';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { CrawlerStatusBanner } from './components/crawler_status_banner';
 import { CrawlerStatusIndicator } from './components/crawler_status_indicator/crawler_status_indicator';
@@ -175,5 +176,13 @@ describe('CrawlerOverview', () => {
     expect(wrapper.find(AddDomainFlyout)).toHaveLength(1);
     expect(wrapper.find(DomainsTable)).toHaveLength(1);
     expect(wrapper.find(CrawlRequestsTable)).toHaveLength(1);
+  });
+
+  it('contains a crawl details flyout', () => {
+    setMockValues(mockValues);
+
+    const wrapper = shallow(<CrawlerOverview />);
+
+    expect(wrapper.find(CrawlDetailsFlyout)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawler_overview.tsx
@@ -20,6 +20,7 @@ import { AppSearchPageTemplate } from '../layout';
 import { AddDomainFlyout } from './components/add_domain/add_domain_flyout';
 import { AddDomainForm } from './components/add_domain/add_domain_form';
 import { AddDomainFormSubmitButton } from './components/add_domain/add_domain_form_submit_button';
+import { CrawlDetailsFlyout } from './components/crawl_details_flyout';
 import { CrawlRequestsTable } from './components/crawl_requests_table';
 import { CrawlerStatusBanner } from './components/crawler_status_banner';
 import { CrawlerStatusIndicator } from './components/crawler_status_indicator/crawler_status_indicator';
@@ -131,6 +132,7 @@ export const CrawlerOverview: React.FC = () => {
           <CrawlRequestsTable />
         </>
       )}
+      <CrawlDetailsFlyout />
     </AppSearchPageTemplate>
   );
 };

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.test.ts
@@ -76,6 +76,44 @@ describe('crawler routes', () => {
     });
   });
 
+  describe('GET /internal/app_search/engines/{name}/crawler/crawl_requests/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/internal/app_search/engines/{name}/crawler/crawl_requests/{id}',
+      });
+
+      registerCrawlerRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/api/as/v0/engines/:name/crawler/crawl_requests/:id',
+      });
+    });
+
+    it('validates correctly with name and id', () => {
+      const request = { params: { name: 'some-engine', id: '12345' } };
+      mockRouter.shouldValidate(request);
+    });
+
+    it('fails validation without name', () => {
+      const request = { params: { id: '12345' } };
+      mockRouter.shouldThrow(request);
+    });
+
+    it('fails validation without id', () => {
+      const request = { params: { name: 'some-engine' } };
+      mockRouter.shouldThrow(request);
+    });
+  });
+
   describe('POST /internal/app_search/engines/{name}/crawler/crawl_requests', () => {
     let mockRouter: MockRouter;
 

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/crawler.ts
@@ -41,6 +41,21 @@ export function registerCrawlerRoutes({
     })
   );
 
+  router.get(
+    {
+      path: '/internal/app_search/engines/{name}/crawler/crawl_requests/{id}',
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+          id: schema.string(),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/api/as/v0/engines/:name/crawler/crawl_requests/:id',
+    })
+  );
+
   router.post(
     {
       path: '/internal/app_search/engines/{name}/crawler/crawl_requests',


### PR DESCRIPTION
## Summary

Adds a flyout to the Crawler Overview page to display the details of non-process crawls.  Right now this only contains the JSON output of the API response, but in a future PR will display the data in a more human readable format. 

### Screenshots

![Screen Shot 2021-11-22 at 10 40 26 AM](https://user-images.githubusercontent.com/2479295/142891469-27666f54-4ced-4bcc-a08b-6974464165af.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
