### PR TITLE
[7.16] [Fleet] Fix formatNonFatal error typings and avoid type error (#119203)

### DIFF
--- a/x-pack/plugins/fleet/server/routes/setup/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.test.ts
@@ -18,6 +18,7 @@ import { fleetSetupHandler } from './handlers';
 
 jest.mock('../../services/setup', () => {
   return {
+    ...jest.requireActual('../../services/setup'),
     setupFleet: jest.fn(),
   };
 });

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -7,7 +7,7 @@
 
 import { appContextService } from '../../services';
 import type { GetFleetStatusResponse, PostFleetSetupResponse } from '../../../common';
-import { setupFleet } from '../../services/setup';
+import { formatNonFatalErrors, setupFleet } from '../../services/setup';
 import { hasFleetServers } from '../../services/fleet_server';
 import { defaultIngestErrorHandler } from '../../errors';
 import type { FleetRequestHandler } from '../../types';
@@ -50,22 +50,7 @@ export const fleetSetupHandler: FleetRequestHandler = async (context, request, r
     const setupStatus = await setupFleet(soClient, esClient);
     const body: PostFleetSetupResponse = {
       ...setupStatus,
-      nonFatalErrors: setupStatus.nonFatalErrors.flatMap((e) => {
-        // JSONify the error object so it can be displayed properly in the UI
-        if ('error' in e) {
-          return {
-            name: e.error.name,
-            message: e.error.message,
-          };
-        } else {
-          return e.errors.map((upgradePackagePolicyError: any) => {
-            return {
-              name: upgradePackagePolicyError.key,
-              message: upgradePackagePolicyError.message,
-            };
-          });
-        }
-      }),
+      nonFatalErrors: formatNonFatalErrors(setupStatus.nonFatalErrors),
     };
 
     return response.ok({ body });

--- a/x-pack/plugins/fleet/server/services/managed_package_policies.ts
+++ b/x-pack/plugins/fleet/server/services/managed_package_policies.ts
@@ -74,7 +74,7 @@ export const upgradeManagedPackagePolicies = async (
       if (dryRunResults.hasErrors) {
         const errors = dryRunResults.diff
           ? dryRunResults.diff?.[1].errors
-          : dryRunResults.body?.message;
+          : [dryRunResults.body?.message];
 
         appContextService
           .getLogger()

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -189,3 +189,34 @@ export async function ensureDefaultEnrollmentAPIKeysExists(
     })
   );
 }
+
+/**
+ * Maps the `nonFatalErrors` object returned by the setup process to a more readable
+ * and predictable format suitable for logging output or UI presentation.
+ */
+export function formatNonFatalErrors(
+  nonFatalErrors: SetupStatus['nonFatalErrors']
+): Array<{ name: string; message: string }> {
+  return nonFatalErrors.flatMap((e) => {
+    if ('error' in e) {
+      return {
+        name: e.error.name,
+        message: e.error.message,
+      };
+    } else if ('errors' in e) {
+      return e.errors.map((upgradePackagePolicyError: any) => {
+        if (typeof upgradePackagePolicyError === 'string') {
+          return {
+            name: 'SetupNonFatalError',
+            message: upgradePackagePolicyError,
+          };
+        }
+
+        return {
+          name: upgradePackagePolicyError.key,
+          message: upgradePackagePolicyError.message,
+        };
+      });
+    }
+  });
+}


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [Fleet] Fix formatNonFatal error typings and avoid type error (#119203)