### PR TITLE
[7.16] waitForIndexStatusYellow: Don't reject on 408 status from health api (#119136)

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/actions/wait_for_index_status_yellow.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/wait_for_index_status_yellow.ts
@@ -40,13 +40,16 @@ export const waitForIndexStatusYellow =
   }: WaitForIndexStatusYellowParams): TaskEither.TaskEither<RetryableEsClientError, {}> =>
   () => {
     return client.cluster
-      .health({
-        index,
-        wait_for_status: 'yellow',
-        timeout,
-        // @ts-expect-error
-        return_200_for_cluster_health_timeout: true, // opt-in to the 8.0 breaking behaviour to prevent a deprecation log
-      })
+      .health(
+        {
+          index,
+          wait_for_status: 'yellow',
+          timeout,
+        },
+        // Don't reject on status code 408 so that we can handle the timeout
+        // explicitly and provide more context in the error message
+        { ignore: [408] }
+      )
       .then((res) => {
         if (res.body.timed_out === true) {
           return Either.left({


### PR DESCRIPTION
Backports the following commits to 7.16:
 - waitForIndexStatusYellow: Don't reject on 408 status from health api (#119136)