### PR TITLE
[ML] Re-enable transform Jest tests

### DIFF
--- a/x-pack/plugins/transform/public/app/hooks/use_index_data.test.tsx
+++ b/x-pack/plugins/transform/public/app/hooks/use_index_data.test.tsx
@@ -78,8 +78,7 @@ describe('Transform: useIndexData()', () => {
   });
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/109943
-describe.skip('Transform: <DataGrid /> with useIndexData()', () => {
+describe('Transform: <DataGrid /> with useIndexData()', () => {
   test('Minimal initialization, no cross cluster search warning.', async () => {
     // Arrange
     const indexPattern = {

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.test.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/expanded_row.test.tsx
@@ -20,8 +20,7 @@ jest.mock('../../../../../app/app_dependencies');
 import { MlSharedContext } from '../../../../../app/__mocks__/shared_context';
 import { getMlSharedImports } from '../../../../../shared_imports';
 
-// FLAKY https://github.com/elastic/kibana/issues/112922
-describe.skip('Transform: Transform List <ExpandedRow />', () => {
+describe('Transform: Transform List <ExpandedRow />', () => {
   const onAlertEdit = jest.fn();
   // Set timezone to US/Eastern for consistent test results.
   beforeEach(() => {


### PR DESCRIPTION
## Summary

This PR re-enables the temporarily skipped transform Jest tests.

Jest test execution has been stabilized, see #117188.

Closes #109943
Closes #112922
