### PR TITLE
[Security Solution][Endpoint] Fix link in Trusted Apps tab under policy details

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.tsx
@@ -32,7 +32,7 @@ import { PolicyTrustedAppsFlyout } from '../flyout';
 import { PolicyTrustedAppsList } from '../list/policy_trusted_apps_list';
 import { useEndpointPrivileges } from '../../../../../../common/components/user_privileges/endpoint/use_endpoint_privileges';
 import { useAppUrl } from '../../../../../../common/lib/kibana';
-import { APP_ID, APP_UI_ID } from '../../../../../../../common/constants';
+import { APP_UI_ID } from '../../../../../../../common/constants';
 import { getTrustedAppsListPath } from '../../../../../common/routing';
 
 export const PolicyTrustedAppsLayout = React.memo(() => {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/trusted_apps/layout/policy_trusted_apps_layout.tsx
@@ -32,7 +32,7 @@ import { PolicyTrustedAppsFlyout } from '../flyout';
 import { PolicyTrustedAppsList } from '../list/policy_trusted_apps_list';
 import { useEndpointPrivileges } from '../../../../../../common/components/user_privileges/endpoint/use_endpoint_privileges';
 import { useAppUrl } from '../../../../../../common/lib/kibana';
-import { APP_ID } from '../../../../../../../common/constants';
+import { APP_ID, APP_UI_ID } from '../../../../../../../common/constants';
 import { getTrustedAppsListPath } from '../../../../../common/routing';
 
 export const PolicyTrustedAppsLayout = React.memo(() => {
@@ -92,7 +92,10 @@ export const PolicyTrustedAppsLayout = React.memo(() => {
 
   const aboutInfo = useMemo(() => {
     const link = (
-      <EuiLink href={getAppUrl({ appId: APP_ID, path: getTrustedAppsListPath() })} target="_blank">
+      <EuiLink
+        href={getAppUrl({ appId: APP_UI_ID, path: getTrustedAppsListPath() })}
+        target="_blank"
+      >
         <FormattedMessage
           id="xpack.securitySolution.endpoint.policy.trustedApps.layout.about.viewAllLinkLabel"
           defaultMessage="view all trusted applications"


### PR DESCRIPTION
## Summary

- Fixes the link for taking the user to the Trusted Apps list that is displayed when viewing the Trusted Apps tab under the Policy Details

![olm-fix-trusted-apps-link-under-policy-details](https://user-images.githubusercontent.com/56442535/142896579-4e6aad7a-619c-4511-8e56-a59063a49319.gif)
