### PR TITLE
[Kibana-react] Fix exit fullscreen behaviour for embedded UI

### DIFF
--- a/src/plugins/kibana_react/public/exit_full_screen_button/__snapshots__/exit_full_screen_button.test.tsx.snap
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/__snapshots__/exit_full_screen_button.test.tsx.snap
@@ -1,13 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`is rendered 1`] = `
+exports[`<ExitFullScreenButton /> is rendered 1`] = `
 <ExitFullScreenButtonUi
   chrome={
     Object {
-      "setIsVisible": [Function],
+      "setIsVisible": [MockFunction] {
+        "calls": Array [
+          Array [
+            false,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
     }
   }
-  onExitFullScreenMode={[Function]}
+  onExitFullScreenMode={[MockFunction]}
+  toggleChrome={true}
 >
   <div>
     <EuiScreenReaderOnly>
@@ -23,7 +36,7 @@ exports[`is rendered 1`] = `
         aria-label="Exit full screen mode"
         className="dshExitFullScreenButton"
         data-test-subj="exitFullScreenModeLogo"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <EuiFlexGroup
           alignItems="center"

--- a/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.test.tsx
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.test.tsx
@@ -7,45 +7,70 @@
  */
 
 import React from 'react';
-import sinon from 'sinon';
+import { mount, ReactWrapper } from 'enzyme';
 import { ExitFullScreenButton } from './exit_full_screen_button';
 import { keys } from '@elastic/eui';
-import { mount } from 'enzyme';
 import type { ChromeStart } from '../../../../core/public';
 
 const MockChrome = {
-  setIsVisible: () => {},
+  setIsVisible: jest.fn(),
 } as unknown as ChromeStart;
 
-test('is rendered', () => {
-  const component = mount(
-    <ExitFullScreenButton onExitFullScreenMode={() => {}} chrome={MockChrome} />
-  );
-
-  expect(component).toMatchSnapshot();
-});
-
-describe('onExitFullScreenMode', () => {
-  test('is called when the button is pressed', () => {
-    const onExitHandler = sinon.stub();
-
-    const component = mount(
-      <ExitFullScreenButton onExitFullScreenMode={onExitHandler} chrome={MockChrome} />
-    );
-
-    component.find('button').simulate('click');
-
-    sinon.assert.calledOnce(onExitHandler);
+describe('<ExitFullScreenButton />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
-  test('is called when the ESC key is pressed', () => {
-    const onExitHandler = sinon.stub();
+  test('is rendered', () => {
+    const component = mount(
+      <ExitFullScreenButton onExitFullScreenMode={jest.fn()} chrome={MockChrome} />
+    );
 
-    mount(<ExitFullScreenButton onExitFullScreenMode={onExitHandler} chrome={MockChrome} />);
+    expect(component).toMatchSnapshot();
+  });
 
-    const escapeKeyEvent = new KeyboardEvent('keydown', { key: keys.ESCAPE } as any);
-    document.dispatchEvent(escapeKeyEvent);
+  test('passing `false` to toggleChrome does not toggle chrome', () => {
+    const component = mount(
+      <ExitFullScreenButton
+        onExitFullScreenMode={jest.fn()}
+        chrome={MockChrome}
+        toggleChrome={false}
+      />
+    );
+    expect(MockChrome.setIsVisible).toHaveBeenCalledTimes(0);
+    component.unmount();
+    expect(MockChrome.setIsVisible).toHaveBeenCalledTimes(0);
+  });
 
-    sinon.assert.calledOnce(onExitHandler);
+  describe('onExitFullScreenMode', () => {
+    const onExitHandler = jest.fn();
+    let component: ReactWrapper;
+
+    beforeEach(() => {
+      component = mount(
+        <ExitFullScreenButton onExitFullScreenMode={onExitHandler} chrome={MockChrome} />
+      );
+    });
+
+    test('is called when the button is pressed', () => {
+      expect(MockChrome.setIsVisible).toHaveBeenLastCalledWith(false);
+
+      component.find('button').simulate('click');
+
+      expect(onExitHandler).toHaveBeenCalledTimes(1);
+      component.unmount();
+      expect(MockChrome.setIsVisible).toHaveBeenLastCalledWith(true);
+    });
+
+    test('is called when the ESC key is pressed', () => {
+      expect(MockChrome.setIsVisible).toHaveBeenLastCalledWith(false);
+
+      const escapeKeyEvent = new KeyboardEvent('keydown', { key: keys.ESCAPE } as any);
+      document.dispatchEvent(escapeKeyEvent);
+
+      expect(onExitHandler).toHaveBeenCalledTimes(1);
+      component.unmount();
+      expect(MockChrome.setIsVisible).toHaveBeenLastCalledWith(true);
+    });
   });
 });

--- a/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
@@ -15,11 +15,24 @@ import type { ChromeStart } from '../../../../core/public';
 export interface ExitFullScreenButtonProps {
   onExitFullScreenMode: () => void;
   chrome: ChromeStart;
+  /**
+   * Optional argument that determines whether we toggle the chrome bar
+   * the button unmounts.
+   *
+   * @note The intended use for this prop is that it is either `true` or `false`
+   * for the lifetime of the button.
+   *
+   * @default true
+   */
+  toggleChrome?: boolean;
 }
 
 import './index.scss';
 
 class ExitFullScreenButtonUi extends PureComponent<ExitFullScreenButtonProps> {
+  constructor({ toggleChrome = true, ...restProps }: ExitFullScreenButtonProps) {
+    super({ toggleChrome, ...restProps });
+  }
   public onKeyDown = (e: KeyboardEvent) => {
     if (e.key === keys.ESCAPE) {
       this.props.onExitFullScreenMode();
@@ -27,12 +40,12 @@ class ExitFullScreenButtonUi extends PureComponent<ExitFullScreenButtonProps> {
   };
 
   public componentDidMount() {
-    this.props.chrome.setIsVisible(false);
+    if (this.props.toggleChrome) this.props.chrome.setIsVisible(false);
     document.addEventListener('keydown', this.onKeyDown, false);
   }
 
   public componentWillUnmount() {
-    this.props.chrome.setIsVisible(true);
+    if (this.props.toggleChrome) this.props.chrome.setIsVisible(true);
     document.removeEventListener('keydown', this.onKeyDown, false);
   }
 

--- a/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
+++ b/src/plugins/kibana_react/public/exit_full_screen_button/exit_full_screen_button.tsx
@@ -30,9 +30,10 @@ export interface ExitFullScreenButtonProps {
 import './index.scss';
 
 class ExitFullScreenButtonUi extends PureComponent<ExitFullScreenButtonProps> {
-  constructor({ toggleChrome = true, ...restProps }: ExitFullScreenButtonProps) {
-    super({ toggleChrome, ...restProps });
-  }
+  static defaultProps = {
+    toggleChrome: true,
+  };
+
   public onKeyDown = (e: KeyboardEvent) => {
     if (e.key === keys.ESCAPE) {
       this.props.onExitFullScreenMode();


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/119208

Tested locally by:

1. Starting Kibana and ES and activating trial license, load test data and copy embed code
2. Created a dummy HTML file `iframe-dashboard.html` (contents below). Just replace the iframe code
3. Serve the HTML file over HTTP by running `python -m SimpleHTTPServer` in the directory where the HTML file is
4. Navigate to `http://localhost:8000/iframe-dashboard.html`
5. Enter and then exit full screen dashboard

<details>

<summary>HTML file</summary>


```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=titl, initial-scale=1.0" />
    <title>Dashboard iFrame</title>
  </head>
  <body>
    <iframe
      src="http://localhost:5601/<dev-server-path>/goto/<my-dashboard-id>"
      height="600"
      width="800"
    ></iframe>
  </body>
</html>
```

</details>


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios