### PR TITLE
Undeprecate Spaces plugin setup APIs

### DIFF
--- a/x-pack/plugins/spaces/server/plugin.ts
+++ b/x-pack/plugins/spaces/server/plugin.ts
@@ -57,9 +57,6 @@ export interface PluginsStart {
 export interface SpacesPluginSetup {
   /**
    * Service for interacting with spaces.
-   *
-   * @deprecated Please use the `spacesService` available on this plugin's start contract.
-   * @removeBy 7.16
    */
   spacesService: SpacesServiceSetup;
 

--- a/x-pack/plugins/spaces/server/spaces_service/spaces_service.ts
+++ b/x-pack/plugins/spaces/server/spaces_service/spaces_service.ts
@@ -20,27 +20,18 @@ export interface SpacesServiceSetup {
   /**
    * Retrieves the space id associated with the provided request.
    * @param request the request.
-   *
-   * @deprecated Use `getSpaceId` from the `SpacesServiceStart` contract instead.
-   * @removeBy 7.16
    */
   getSpaceId(request: KibanaRequest): string;
 
   /**
    * Converts the provided space id into the corresponding Saved Objects `namespace` id.
    * @param spaceId the space id to convert.
-   *
-   * @deprecated use `spaceIdToNamespace` from the `SpacesServiceStart` contract instead.
-   * @removeBy 7.16
    */
   spaceIdToNamespace(spaceId: string): string | undefined;
 
   /**
    * Converts the provided namespace into the corresponding space id.
    * @param namespace the namespace to convert.
-   *
-   * @deprecated use `namespaceToSpaceId` from the `SpacesServiceStart` contract instead.
-   * @removeBy 7.16
    */
   namespaceToSpaceId(namespace: string | undefined): string;
 }


### PR DESCRIPTION
In #98966, we deprecated the Spaces plugin's setup contract. All of the APIs this provides are available on the start contract, and I believe our thinking at the time was that we'd like to reduce our API surface "before it's too late". We believed that our last chance for the foreseeable future was to do that in the 8.0 release.

Since then, Elastic has changed its stance on breaking changes, we now have a greater focus on backwards compatibility and we are doing away with the concept of big breaking major releases.

As such, I think we have less motivation to remove these APIs, and until we get a clearer picture on future releases, we should just undeprecate these.