### PR TITLE
[7.16] Revert "[Uptime] redirect Uptime tutorials to the Elastic Synthetics Integration (#115229) (#115470)" (#118986)

### DIFF
--- a/x-pack/plugins/observability/public/components/shared/add_data_buttons/synthetics_add_data.tsx
+++ b/x-pack/plugins/observability/public/components/shared/add_data_buttons/synthetics_add_data.tsx
@@ -16,9 +16,9 @@ export function SyntheticsAddData() {
   return (
     <EuiHeaderLink
       aria-label={i18n.translate('xpack.observability.page_header.addUptimeDataLink.label', {
-        defaultMessage: 'Navigate to the Elastic Synthetics integration to add Uptime data',
+        defaultMessage: 'Navigate to a tutorial about adding Uptime data',
       })}
-      href={kibana.services?.application?.getUrlForApp('/integrations/detail/synthetics/overview')}
+      href={kibana.services?.application?.getUrlForApp('/home#/tutorial/uptimeMonitors')}
       color="primary"
       iconType="indexOpen"
     >

--- a/x-pack/plugins/observability/public/pages/overview/empty_section.ts
+++ b/x-pack/plugins/observability/public/pages/overview/empty_section.ts
@@ -69,7 +69,7 @@ export const getEmptySections = ({ core }: { core: CoreStart }): ISection[] => {
       linkTitle: i18n.translate('xpack.observability.emptySection.apps.uptime.link', {
         defaultMessage: 'Install Heartbeat',
       }),
-      href: core.http.basePath.prepend('/app/integrations/detail/synthetics/overview'),
+      href: core.http.basePath.prepend('/app/home#/tutorial/uptimeMonitors'),
     },
     {
       id: 'ux',

--- a/x-pack/plugins/uptime/public/apps/use_no_data_config.ts
+++ b/x-pack/plugins/uptime/public/apps/use_no_data_config.ts
@@ -31,13 +31,13 @@ export function useNoDataConfig(): KibanaPageTemplateProps['noDataConfig'] {
       actions: {
         beats: {
           title: i18n.translate('xpack.uptime.noDataConfig.beatsCard.title', {
-            defaultMessage: 'Add monitors with the Elastic Synthetics integration',
+            defaultMessage: 'Add monitors with Heartbeat',
           }),
           description: i18n.translate('xpack.uptime.noDataConfig.beatsCard.description', {
             defaultMessage:
               'Proactively monitor the availability of your sites and services. Receive alerts and resolve issues faster to optimize your users experience.',
           }),
-          href: basePath + `/app/integrations/detail/synthetics/overview`,
+          href: basePath + `/app/home#/tutorial/uptimeMonitors`,
         },
       },
       docsLink: docLinks!.links.observability.guide,

--- a/x-pack/plugins/uptime/public/components/common/header/action_menu_content.test.tsx
+++ b/x-pack/plugins/uptime/public/components/common/header/action_menu_content.test.tsx
@@ -45,13 +45,11 @@ describe('ActionMenuContent', () => {
   it('renders Add Data link', () => {
     const { getByLabelText, getByText } = render(<ActionMenuContent />);
 
-    const addDataAnchor = getByLabelText(
-      'Navigate to the Elastic Synthetics integration to add Uptime data'
-    );
+    const addDataAnchor = getByLabelText('Navigate to a tutorial about adding Uptime data');
 
     // this href value is mocked, so it doesn't correspond to the real link
     // that Kibana core services will provide
-    expect(addDataAnchor.getAttribute('href')).toBe('/integrations/detail/synthetics/overview');
+    expect(addDataAnchor.getAttribute('href')).toBe('/home#/tutorial/uptimeMonitors');
     expect(getByText('Add data'));
   });
 });

--- a/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
+++ b/x-pack/plugins/uptime/public/components/common/header/action_menu_content.tsx
@@ -99,11 +99,9 @@ export function ActionMenuContent(): React.ReactElement {
 
       <EuiHeaderLink
         aria-label={i18n.translate('xpack.uptime.page_header.addDataLink.label', {
-          defaultMessage: 'Navigate to the Elastic Synthetics integration to add Uptime data',
+          defaultMessage: 'Navigate to a tutorial about adding Uptime data',
         })}
-        href={kibana.services?.application?.getUrlForApp(
-          '/integrations/detail/synthetics/overview'
-        )}
+        href={kibana.services?.application?.getUrlForApp('/home#/tutorial/uptimeMonitors')}
         color="primary"
         iconType="indexOpen"
       >

--- a/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
+++ b/x-pack/plugins/uptime/public/lib/helper/rtl_helpers.tsx
@@ -83,7 +83,7 @@ const createMockStore = () => {
 const mockAppUrls: Record<string, string> = {
   uptime: '/app/uptime',
   observability: '/app/observability',
-  '/integrations/detail/synthetics/overview': '/integrations/detail/synthetics/overview',
+  '/home#/tutorial/uptimeMonitors': '/home#/tutorial/uptimeMonitors',
 };
 
 /* default mock core */


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Revert "[Uptime] redirect Uptime tutorials to the Elastic Synthetics Integration (#115229) (#115470)" (#118986)