### PR TITLE
Change order of default promoted integrations

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -314,7 +314,7 @@ export const AvailablePackages: React.FC = memo(() => {
         <EuiFlexItem>
           <TrackApplicationView viewId="integration-card:epr:app_search_web_crawler:featured">
             <EuiCard
-              data-test-sub="integration-card:epr:app_search_web_crawler:featured"
+              data-test-subj="integration-card:epr:app_search_web_crawler:featured"
               icon={<EuiIcon type="logoAppSearch" size="xxl" />}
               href={addBasePath('/app/enterprise_search/app_search/engines/new?method=crawler')}
               title={i18n.translate('xpack.fleet.featuredSearchTitle', {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx
@@ -312,17 +312,16 @@ export const AvailablePackages: React.FC = memo(() => {
     <>
       <EuiFlexGrid columns={3}>
         <EuiFlexItem>
-          <TrackApplicationView viewId="integration-card:epr:endpoint:featured">
+          <TrackApplicationView viewId="integration-card:epr:app_search_web_crawler:featured">
             <EuiCard
-              data-test-subj="integration-card:epr:endpoint:featured"
-              icon={<EuiIcon type="logoSecurity" size="xxl" />}
-              href={addBasePath('/app/integrations/detail/endpoint/')}
-              title={i18n.translate('xpack.fleet.featuredSecurityTitle', {
-                defaultMessage: 'Endpoint Security',
+              data-test-sub="integration-card:epr:app_search_web_crawler:featured"
+              icon={<EuiIcon type="logoAppSearch" size="xxl" />}
+              href={addBasePath('/app/enterprise_search/app_search/engines/new?method=crawler')}
+              title={i18n.translate('xpack.fleet.featuredSearchTitle', {
+                defaultMessage: 'Web site crawler',
               })}
-              description={i18n.translate('xpack.fleet.featuredSecurityDesc', {
-                defaultMessage:
-                  'Protect your hosts with threat prevention, detection, and deep security data visibility.',
+              description={i18n.translate('xpack.fleet.featuredSearchDesc', {
+                defaultMessage: 'Add search to your website with the App Search web crawler.',
               })}
             />
           </TrackApplicationView>
@@ -344,16 +343,17 @@ export const AvailablePackages: React.FC = memo(() => {
           </TrackApplicationView>
         </EuiFlexItem>
         <EuiFlexItem>
-          <TrackApplicationView viewId="integration-card:epr:app_search_web_crawler:featured">
+          <TrackApplicationView viewId="integration-card:epr:endpoint:featured">
             <EuiCard
-              data-test-sub="integration-card:epr:app_search_web_crawler:featured"
-              icon={<EuiIcon type="logoAppSearch" size="xxl" />}
-              href={addBasePath('/app/enterprise_search/app_search/engines/new?method=crawler')}
-              title={i18n.translate('xpack.fleet.featuredSearchTitle', {
-                defaultMessage: 'Web site crawler',
+              data-test-subj="integration-card:epr:endpoint:featured"
+              icon={<EuiIcon type="logoSecurity" size="xxl" />}
+              href={addBasePath('/app/integrations/detail/endpoint/')}
+              title={i18n.translate('xpack.fleet.featuredSecurityTitle', {
+                defaultMessage: 'Endpoint Security',
               })}
-              description={i18n.translate('xpack.fleet.featuredSearchDesc', {
-                defaultMessage: 'Add search to your website with the App Search web crawler.',
+              description={i18n.translate('xpack.fleet.featuredSecurityDesc', {
+                defaultMessage:
+                  'Protect your hosts with threat prevention, detection, and deep security data visibility.',
               })}
             />
           </TrackApplicationView>


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/119361

Changes the order of the default pomoted integrations to match our marketing. Also fixes a small typo in one of props for data-test-subj.

![image](https://user-images.githubusercontent.com/324519/142918481-fe833d48-8352-4b8d-99a7-e16a17d4ed63.png)
