### PR TITLE
[Uptime] Show all recorded Layout Shifts

### DIFF
--- a/x-pack/plugins/uptime/public/components/monitor/synthetics/waterfall/components/waterfall_markers.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/synthetics/waterfall/components/waterfall_markers.tsx
@@ -14,11 +14,10 @@ import { euiStyled } from '../../../../../../../../../src/plugins/kibana_react/c
 import { MarkerItems } from '../context/waterfall_chart';
 import { WaterfallMarkerIcon } from './waterfall_marker_icon';
 
-export const SYNTHETICS_CLS = 'browser.experience.cls';
-export const SYNTHETICS_LCP = 'browser.experience.lcp.us';
-export const SYNTHETICS_FCP = 'browser.experience.fcp.us';
-export const SYNTHETICS_DOCUMENT_ONLOAD = 'browser.experience.load.us';
-export const SYNTHETICS_DCL = 'browser.experience.dcl.us';
+export const FIELD_SYNTHETICS_LCP = 'browser.experience.lcp.us';
+export const FIELD_SYNTHETICS_FCP = 'browser.experience.fcp.us';
+export const FIELD_SYNTHETICS_DOCUMENT_ONLOAD = 'browser.experience.load.us';
+export const FIELD_SYNTHETICS_DCL = 'browser.experience.dcl.us';
 export const LAYOUT_SHIFT = 'layoutShift';
 
 export function WaterfallChartMarkers() {
@@ -106,35 +105,35 @@ function getMarkersInfo(id: string, theme: ReturnType<typeof useTheme>) {
       return {
         label: DOCUMENT_CONTENT_LOADED_LABEL,
         color: theme.eui.euiColorVis0,
-        field: SYNTHETICS_DCL,
+        field: FIELD_SYNTHETICS_DCL,
         strokeWidth: 2,
       };
     case 'firstContentfulPaint':
       return {
         label: FCP_LABEL,
         color: theme.eui.euiColorVis1,
-        field: SYNTHETICS_FCP,
+        field: FIELD_SYNTHETICS_FCP,
         strokeWidth: 2,
       };
     case 'largestContentfulPaint':
       return {
         label: LCP_LABEL,
         color: theme.eui.euiColorVis2,
-        field: SYNTHETICS_LCP,
+        field: FIELD_SYNTHETICS_LCP,
         strokeWidth: 2,
       };
     case 'layoutShift':
       return {
         label: LAYOUT_SHIFT_LABEL,
         color: theme.eui.euiColorVis6,
-        field: SYNTHETICS_CLS,
+        field: '',
         strokeWidth: 1,
       };
     case 'loadEvent':
       return {
         label: LOAD_EVENT_LABEL,
         color: theme.eui.euiColorVis9,
-        field: SYNTHETICS_DOCUMENT_ONLOAD,
+        field: FIELD_SYNTHETICS_DOCUMENT_ONLOAD,
         strokeWidth: 2,
       };
   }

--- a/x-pack/plugins/uptime/public/components/monitor/synthetics/waterfall/components/waterfall_markers.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/synthetics/waterfall/components/waterfall_markers.tsx
@@ -46,7 +46,7 @@ export function WaterfallChartMarkers() {
         uniqueIds = uniqueIds.filter((id) => id !== LAYOUT_SHIFT);
       }
 
-      const label = uniqueIds.map((id) => getMarkersInfo(id, theme).label ?? id).join(' / ');
+      const label = uniqueIds.map((id) => getMarkersInfo(id, theme)?.label ?? id).join(' / ');
       const id = uniqueIds[0];
       const markersInfo = getMarkersInfo(id, theme);
 
@@ -54,7 +54,7 @@ export function WaterfallChartMarkers() {
         id,
         offset,
         label,
-        field: markersInfo?.field,
+        field: markersInfo?.field ?? '',
         color: markersInfo?.color ?? theme.eui.euiColorMediumShade,
         strokeWidth: markersInfo?.strokeWidth ?? 1,
       };
@@ -101,43 +101,45 @@ export function WaterfallChartMarkers() {
 }
 
 function getMarkersInfo(id: string, theme: ReturnType<typeof useTheme>) {
-  const markersInfo: Record<
-    string,
-    { label: string; color: string; field: string; strokeWidth: number }
-  > = {
-    domContentLoaded: {
-      label: DOCUMENT_CONTENT_LOADED_LABEL,
-      color: theme.eui.euiColorVis0,
-      field: SYNTHETICS_DCL,
-      strokeWidth: 2,
-    },
-    firstContentfulPaint: {
-      label: FCP_LABEL,
-      color: theme.eui.euiColorVis1,
-      field: SYNTHETICS_FCP,
-      strokeWidth: 2,
-    },
-    largestContentfulPaint: {
-      label: LCP_LABEL,
-      color: theme.eui.euiColorVis2,
-      field: SYNTHETICS_LCP,
-      strokeWidth: 2,
-    },
-    layoutShift: {
-      label: LAYOUT_SHIFT_LABEL,
-      color: theme.eui.euiColorVis6,
-      field: SYNTHETICS_CLS,
-      strokeWidth: 1,
-    },
-    loadEvent: {
-      label: LOAD_EVENT_LABEL,
-      color: theme.eui.euiColorVis9,
-      field: SYNTHETICS_DOCUMENT_ONLOAD,
-      strokeWidth: 2,
-    },
-  };
+  switch (id) {
+    case 'domContentLoaded':
+      return {
+        label: DOCUMENT_CONTENT_LOADED_LABEL,
+        color: theme.eui.euiColorVis0,
+        field: SYNTHETICS_DCL,
+        strokeWidth: 2,
+      };
+    case 'firstContentfulPaint':
+      return {
+        label: FCP_LABEL,
+        color: theme.eui.euiColorVis1,
+        field: SYNTHETICS_FCP,
+        strokeWidth: 2,
+      };
+    case 'largestContentfulPaint':
+      return {
+        label: LCP_LABEL,
+        color: theme.eui.euiColorVis2,
+        field: SYNTHETICS_LCP,
+        strokeWidth: 2,
+      };
+    case 'layoutShift':
+      return {
+        label: LAYOUT_SHIFT_LABEL,
+        color: theme.eui.euiColorVis6,
+        field: SYNTHETICS_CLS,
+        strokeWidth: 1,
+      };
+    case 'loadEvent':
+      return {
+        label: LOAD_EVENT_LABEL,
+        color: theme.eui.euiColorVis9,
+        field: SYNTHETICS_DOCUMENT_ONLOAD,
+        strokeWidth: 2,
+      };
+  }
 
-  return markersInfo[id];
+  return undefined;
 }
 
 const Wrapper = euiStyled.span`

--- a/x-pack/plugins/uptime/public/components/monitor/synthetics/waterfall/components/waterfall_markers.tsx
+++ b/x-pack/plugins/uptime/public/components/monitor/synthetics/waterfall/components/waterfall_markers.tsx
@@ -5,13 +5,148 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { AnnotationDomainType, LineAnnotation } from '@elastic/charts';
 import { i18n } from '@kbn/i18n';
 import { useWaterfallContext } from '..';
 import { useTheme } from '../../../../../../../observability/public';
 import { euiStyled } from '../../../../../../../../../src/plugins/kibana_react/common';
+import { MarkerItems } from '../context/waterfall_chart';
 import { WaterfallMarkerIcon } from './waterfall_marker_icon';
+
+export const SYNTHETICS_CLS = 'browser.experience.cls';
+export const SYNTHETICS_LCP = 'browser.experience.lcp.us';
+export const SYNTHETICS_FCP = 'browser.experience.fcp.us';
+export const SYNTHETICS_DOCUMENT_ONLOAD = 'browser.experience.load.us';
+export const SYNTHETICS_DCL = 'browser.experience.dcl.us';
+export const LAYOUT_SHIFT = 'layoutShift';
+
+export function WaterfallChartMarkers() {
+  const { markerItems } = useWaterfallContext();
+
+  const theme = useTheme();
+
+  const markerItemsByOffset = useMemo(
+    () =>
+      (markerItems ?? []).reduce((acc, cur) => {
+        acc.set(cur.offset, [...(acc.get(cur.offset) ?? []), cur]);
+        return acc;
+      }, new Map<number, MarkerItems>()),
+    [markerItems]
+  );
+
+  const annotations = useMemo(() => {
+    return Array.from(markerItemsByOffset.entries()).map(([offset, items]) => {
+      let uniqueIds = (items ?? [])
+        .map(({ id }) => id)
+        .filter((id, index, arr) => arr.indexOf(id) === index);
+
+      // Omit coinciding layoutShift's with other vital marks
+      if (uniqueIds.length > 1) {
+        uniqueIds = uniqueIds.filter((id) => id !== LAYOUT_SHIFT);
+      }
+
+      const label = uniqueIds.map((id) => getMarkersInfo(id, theme).label ?? id).join(' / ');
+      const id = uniqueIds[0];
+      const markersInfo = getMarkersInfo(id, theme);
+
+      return {
+        id,
+        offset,
+        label,
+        field: markersInfo?.field,
+        color: markersInfo?.color ?? theme.eui.euiColorMediumShade,
+        strokeWidth: markersInfo?.strokeWidth ?? 1,
+      };
+    });
+  }, [markerItemsByOffset, theme]);
+
+  if (!markerItems) {
+    return null;
+  }
+
+  return (
+    <Wrapper>
+      {annotations.map(({ id, offset, label, field, color, strokeWidth }) => {
+        const key = `${id}-${offset}`;
+
+        return (
+          <LineAnnotation
+            key={key}
+            id={key}
+            domainType={AnnotationDomainType.YDomain}
+            dataValues={[
+              {
+                dataValue: offset,
+                details: label,
+                header: i18n.translate('xpack.uptime.synthetics.waterfall.offsetUnit', {
+                  defaultMessage: '{offset} ms',
+                  values: { offset },
+                }),
+              },
+            ]}
+            marker={<WaterfallMarkerIcon field={field} label={label} />}
+            style={{
+              line: {
+                strokeWidth,
+                stroke: color,
+                opacity: 1,
+              },
+            }}
+          />
+        );
+      })}
+    </Wrapper>
+  );
+}
+
+function getMarkersInfo(id: string, theme: ReturnType<typeof useTheme>) {
+  const markersInfo: Record<
+    string,
+    { label: string; color: string; field: string; strokeWidth: number }
+  > = {
+    domContentLoaded: {
+      label: DOCUMENT_CONTENT_LOADED_LABEL,
+      color: theme.eui.euiColorVis0,
+      field: SYNTHETICS_DCL,
+      strokeWidth: 2,
+    },
+    firstContentfulPaint: {
+      label: FCP_LABEL,
+      color: theme.eui.euiColorVis1,
+      field: SYNTHETICS_FCP,
+      strokeWidth: 2,
+    },
+    largestContentfulPaint: {
+      label: LCP_LABEL,
+      color: theme.eui.euiColorVis2,
+      field: SYNTHETICS_LCP,
+      strokeWidth: 2,
+    },
+    layoutShift: {
+      label: LAYOUT_SHIFT_LABEL,
+      color: theme.eui.euiColorVis6,
+      field: SYNTHETICS_CLS,
+      strokeWidth: 1,
+    },
+    loadEvent: {
+      label: LOAD_EVENT_LABEL,
+      color: theme.eui.euiColorVis9,
+      field: SYNTHETICS_DOCUMENT_ONLOAD,
+      strokeWidth: 2,
+    },
+  };
+
+  return markersInfo[id];
+}
+
+const Wrapper = euiStyled.span`
+  &&& {
+    > .echAnnotation__icon {
+      top: 8px;
+    }
+  }
+`;
 
 export const FCP_LABEL = i18n.translate('xpack.uptime.synthetics.waterfall.fcpLabel', {
   defaultMessage: 'First contentful paint',
@@ -38,87 +173,3 @@ export const DOCUMENT_CONTENT_LOADED_LABEL = i18n.translate(
     defaultMessage: 'DOM Content Loaded',
   }
 );
-
-export const SYNTHETICS_CLS = 'browser.experience.cls';
-export const SYNTHETICS_LCP = 'browser.experience.lcp.us';
-export const SYNTHETICS_FCP = 'browser.experience.fcp.us';
-export const SYNTHETICS_DOCUMENT_ONLOAD = 'browser.experience.load.us';
-export const SYNTHETICS_DCL = 'browser.experience.dcl.us';
-
-export function WaterfallChartMarkers() {
-  const { markerItems } = useWaterfallContext();
-
-  const theme = useTheme();
-
-  if (!markerItems) {
-    return null;
-  }
-
-  const markersInfo: Record<string, { label: string; color: string; field: string }> = {
-    domContentLoaded: {
-      label: DOCUMENT_CONTENT_LOADED_LABEL,
-      color: theme.eui.euiColorVis0,
-      field: SYNTHETICS_DCL,
-    },
-    firstContentfulPaint: {
-      label: FCP_LABEL,
-      color: theme.eui.euiColorVis1,
-      field: SYNTHETICS_FCP,
-    },
-    largestContentfulPaint: {
-      label: LCP_LABEL,
-      color: theme.eui.euiColorVis2,
-      field: SYNTHETICS_LCP,
-    },
-    layoutShift: {
-      label: LAYOUT_SHIFT_LABEL,
-      color: theme.eui.euiColorVis3,
-      field: SYNTHETICS_CLS,
-    },
-    loadEvent: {
-      label: LOAD_EVENT_LABEL,
-      color: theme.eui.euiColorVis9,
-      field: SYNTHETICS_DOCUMENT_ONLOAD,
-    },
-  };
-
-  return (
-    <Wrapper>
-      {markerItems.map(({ id, offset }) => (
-        <LineAnnotation
-          key={id}
-          id={id}
-          domainType={AnnotationDomainType.YDomain}
-          dataValues={[
-            {
-              dataValue: offset,
-              details: markersInfo[id]?.label ?? id,
-              header: i18n.translate('xpack.uptime.synthetics.waterfall.offsetUnit', {
-                defaultMessage: '{offset} ms',
-                values: { offset },
-              }),
-            },
-          ]}
-          marker={
-            <WaterfallMarkerIcon field={markersInfo[id]?.field} label={markersInfo[id]?.label} />
-          }
-          style={{
-            line: {
-              strokeWidth: 2,
-              stroke: markersInfo[id]?.color ?? theme.eui.euiColorMediumShade,
-              opacity: 1,
-            },
-          }}
-        />
-      ))}
-    </Wrapper>
-  );
-}
-
-const Wrapper = euiStyled.span`
-  &&& {
-    > .echAnnotation__icon {
-      top: 8px;
-    }
-  }
-`;


### PR DESCRIPTION
Fixes #118569

## Summary

On Kibana -> Uptime -> _any browser monitor_ -> _any first step_ -> Performance Breakdown, LayoutShift was being displayed as a single metric on waterfall chart alongside FCP, LCP, DOMContentLoaded, whereas there were multiple values available over the initial lifecycle of a webpage.

This PR
- Removes considering CLS (`browser.experience.cls`) as a field to represent LayoutShift
- Only displays one annotation for a given time value
- Ignores LayoutShifts if they coincide with other metrics e.g. FCP, LCP
- Combines labels for multiple coinciding metrics on annotation tooltip (if any, coinciding LayoutShifts with other metrics are ignored)
- Displays all other LayoutShifts with thin stroke and comparatively dim color

### Visuals
**Before:**
|Light|Dark|
|:---:|:---:|
![Screenshot 2021-11-22 at 20 28 01](https://user-images.githubusercontent.com/2748376/142931013-348bfe2a-6079-4816-9e28-6c752f4087c7.png)|![Screenshot 2021-11-22 at 21 34 42](https://user-images.githubusercontent.com/2748376/142931576-2c7275c6-a229-4a8f-b6cc-6e703e428632.png)|

**After:**
|Light|Dark|
|:---:|:---:|
|![Screenshot 2021-11-22 at 20 24 59](https://user-images.githubusercontent.com/2748376/142931179-1dbcd950-786d-4048-be84-dcf157a73d52.png)|![Screenshot 2021-11-22 at 21 03 36](https://user-images.githubusercontent.com/2748376/142931136-af07f802-a1b6-49e7-b9e0-67cfc1a44cbe.png)|

https://user-images.githubusercontent.com/2748376/142932007-98efc488-0aa3-408d-8d95-3b0f7987b4ba.mov

### Checklist


- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
