### PR TITLE
[Fleet] Add consistent `_meta` property to all Fleet ES assets

### DIFF
--- a/x-pack/plugins/fleet/server/constants/fleet_es_assets.ts
+++ b/x-pack/plugins/fleet/server/constants/fleet_es_assets.ts
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
+import { getESAssetMetadata } from '../services/epm/elasticsearch/meta';
+
+const meta = getESAssetMetadata();
+
 export const FLEET_FINAL_PIPELINE_ID = '.fleet_final_pipeline-1';
 
 export const FLEET_GLOBAL_COMPONENT_TEMPLATE_NAME = '.fleet_component_template-1';
 
 export const FLEET_GLOBAL_COMPONENT_TEMPLATE_CONTENT = {
-  _meta: {},
+  _meta: meta,
   template: {
     settings: {
       index: {
@@ -36,10 +40,14 @@ export const FLEET_GLOBAL_COMPONENT_TEMPLATE_CONTENT = {
   },
 };
 
-export const FLEET_FINAL_PIPELINE_VERSION = 1;
+export const FLEET_FINAL_PIPELINE_VERSION = 2;
+
 // If the content is updated you probably need to update the FLEET_FINAL_PIPELINE_VERSION too to allow upgrade of the pipeline
 export const FLEET_FINAL_PIPELINE_CONTENT = `---
 version: ${FLEET_FINAL_PIPELINE_VERSION}
+_meta:
+  managed_by: ${meta.managed_by}
+  managed: ${meta.managed}
 description: >
   Final pipeline for processing all incoming Fleet Agent documents.
 processors:

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/datastream_ilm/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/datastream_ilm/install.ts
@@ -80,11 +80,11 @@ export const installIlmForDataStream = async (
     const ilmInstallations: IlmInstallation[] = ilmPathDatasets.map(
       (ilmPathDataset: IlmPathDataset) => {
         const content = JSON.parse(getAsset(ilmPathDataset.path).toString('utf-8'));
-        content._meta = getESAssetMetadata({ packageName: installation?.name });
+        content.policy._meta = getESAssetMetadata({ packageName: installation?.name });
 
         return {
           installationName: getIlmNameForInstallation(ilmPathDataset),
-          content: getAsset(ilmPathDataset.path).toString('utf-8'),
+          content,
         };
       }
     );

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/datastream_ilm/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/datastream_ilm/install.ts
@@ -17,6 +17,8 @@ import { getInstallation } from '../../packages';
 import { saveInstalledEsRefs } from '../../packages/install';
 import { getAsset } from '../transform/common';
 
+import { getESAssetMetadata } from '../meta';
+
 import { deleteIlmRefs, deleteIlms } from './remove';
 
 interface IlmInstallation {
@@ -77,6 +79,9 @@ export const installIlmForDataStream = async (
 
     const ilmInstallations: IlmInstallation[] = ilmPathDatasets.map(
       (ilmPathDataset: IlmPathDataset) => {
+        const content = JSON.parse(getAsset(ilmPathDataset.path).toString('utf-8'));
+        content._meta = getESAssetMetadata({ packageName: installation?.name });
+
         return {
           installationName: getIlmNameForInstallation(ilmPathDataset),
           content: getAsset(ilmPathDataset.path).toString('utf-8'),

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ilm/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ilm/install.ts
@@ -24,7 +24,7 @@ export async function installILMPolicy(
     ilmPaths.map(async (path) => {
       const body = JSON.parse(getAsset(path).toString('utf-8'));
 
-      body._meta = getESAssetMetadata({ packageName: packageInfo.name });
+      body.policy._meta = getESAssetMetadata({ packageName: packageInfo.name });
 
       const { file } = getPathParts(path);
       const name = file.substr(0, file.lastIndexOf('.'));

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/ilm/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/ilm/install.ts
@@ -7,15 +7,25 @@
 
 import type { ElasticsearchClient } from 'kibana/server';
 
+import type { InstallablePackage } from '../../../../types';
+
 import { ElasticsearchAssetType } from '../../../../types';
 import { getAsset, getPathParts } from '../../archive';
+import { getESAssetMetadata } from '../meta';
 
-export async function installILMPolicy(paths: string[], esClient: ElasticsearchClient) {
+export async function installILMPolicy(
+  packageInfo: InstallablePackage,
+  paths: string[],
+  esClient: ElasticsearchClient
+) {
   const ilmPaths = paths.filter((path) => isILMPolicy(path));
   if (!ilmPaths.length) return;
   await Promise.all(
     ilmPaths.map(async (path) => {
-      const body = getAsset(path).toString('utf-8');
+      const body = JSON.parse(getAsset(path).toString('utf-8'));
+
+      body._meta = getESAssetMetadata({ packageName: packageInfo.name });
+
       const { file } = getPathParts(path);
       const name = file.substr(0, file.lastIndexOf('.'));
       try {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getESAssetMetadata } from './meta';
+
+describe('getESAssetMetadata', () => {
+  describe('with package name', () => {
+    it('generates expected JSON', () => {
+      const packageName = 'foo';
+
+      const meta = getESAssetMetadata({ packageName });
+
+      expect(meta).toEqual({ managed_by: 'fleet', managed: true, package: { name: packageName } });
+    });
+  });
+
+  describe('without package name', () => {
+    it('generates expected JSON', () => {
+      const meta = getESAssetMetadata();
+
+      expect(meta).toEqual({ managed_by: 'fleet', managed: true });
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { safeLoad, safeDump } from 'js-yaml';
+
+const MANAGED_BY_DEFAULT = 'fleet';
+
+export interface ESAssetMetadata {
+  package?: {
+    name: string;
+  };
+  managed_by: string;
+  managed: boolean;
+}
+
+/**
+ * Build common metadata object for Elasticsearch assets installed by Fleet. Result should be
+ * stored on a `_meta` field on the generated assets.
+ */
+export function getESAssetMetadata({
+  packageName,
+}: { packageName?: string } = {}): ESAssetMetadata {
+  const meta: ESAssetMetadata = {
+    managed_by: MANAGED_BY_DEFAULT,
+    managed: true,
+  };
+
+  if (packageName) {
+    meta.package = {
+      name: packageName,
+    };
+  }
+
+  return meta;
+}
+
+export function appendMetadataToIngestPipeline({
+  pipeline,
+  packageName,
+}: {
+  pipeline: any;
+  packageName?: string;
+}): any {
+  const meta = getESAssetMetadata({ packageName });
+
+  if (pipeline.extension === 'yml') {
+    // Convert the YML content to JSON, append the `_meta` value, then convert it back to
+    // YML and return the resulting YML
+    const parsedPipelineContent = safeLoad(pipeline.contentForInstallation);
+    parsedPipelineContent._meta = meta;
+
+    return {
+      ...pipeline,
+      contentForInstallation: `---\n${safeDump(parsedPipelineContent)}`,
+    };
+  }
+
+  // For JSON content, we have a much easier time here :)
+  pipeline.contentForInstallation._meta = meta;
+
+  return pipeline;
+}

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/meta.ts
@@ -59,8 +59,11 @@ export function appendMetadataToIngestPipeline({
     };
   }
 
-  // For JSON content, we have a much easier time here :)
-  pipeline.contentForInstallation._meta = meta;
+  const parsedPipelineContent = JSON.parse(pipeline.contentForInstallation);
+  parsedPipelineContent._meta = meta;
 
-  return pipeline;
+  return {
+    ...pipeline,
+    contentForInstallation: parsedPipelineContent,
+  };
 }

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
@@ -75,11 +75,11 @@ exports[`EPM template tests loading base.yml: base.yml 1`] = `
         }
       },
       "_meta": {
+        "managed_by": "fleet",
+        "managed": true,
         "package": {
           "name": "nginx"
-        },
-        "managed_by": "ingest-manager",
-        "managed": true
+        }
       }
     }
   },
@@ -88,11 +88,11 @@ exports[`EPM template tests loading base.yml: base.yml 1`] = `
     ".fleet_component_template-1"
   ],
   "_meta": {
+    "managed_by": "fleet",
+    "managed": true,
     "package": {
       "name": "nginx"
-    },
-    "managed_by": "ingest-manager",
-    "managed": true
+    }
   }
 }
 `;
@@ -168,11 +168,11 @@ exports[`EPM template tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
         }
       },
       "_meta": {
+        "managed_by": "fleet",
+        "managed": true,
         "package": {
           "name": "coredns"
-        },
-        "managed_by": "ingest-manager",
-        "managed": true
+        }
       }
     }
   },
@@ -181,11 +181,11 @@ exports[`EPM template tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
     ".fleet_component_template-1"
   ],
   "_meta": {
+    "managed_by": "fleet",
+    "managed": true,
     "package": {
       "name": "coredns"
-    },
-    "managed_by": "ingest-manager",
-    "managed": true
+    }
   }
 }
 `;
@@ -1645,11 +1645,11 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
         }
       },
       "_meta": {
+        "managed_by": "fleet",
+        "managed": true,
         "package": {
           "name": "system"
-        },
-        "managed_by": "ingest-manager",
-        "managed": true
+        }
       }
     }
   },
@@ -1658,11 +1658,11 @@ exports[`EPM template tests loading system.yml: system.yml 1`] = `
     ".fleet_component_template-1"
   ],
   "_meta": {
+    "managed_by": "fleet",
+    "managed": true,
     "package": {
       "name": "system"
-    },
-    "managed_by": "ingest-manager",
-    "managed": true
+    }
   }
 }
 `;

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -27,6 +27,9 @@ import {
   FLEET_GLOBAL_COMPONENT_TEMPLATE_CONTENT,
 } from '../../../../constants';
 
+import type { ESAssetMetadata } from '../meta';
+import { getESAssetMetadata } from '../meta';
+
 import {
   generateMappings,
   generateTemplateName,
@@ -171,7 +174,7 @@ export async function installTemplateForDataStream({
 }
 
 interface TemplateMapEntry {
-  _meta: { package?: { name: string } };
+  _meta: ESAssetMetadata;
   template:
     | {
         mappings: NonNullable<RegistryElasticsearch['index_template.mappings']>;
@@ -220,7 +223,7 @@ function buildComponentTemplates(params: {
   const userSettingsTemplateName = `${templateName}${userSettingsSuffix}`;
 
   const templatesMap: TemplateMap = {};
-  const _meta = { package: { name: packageName } };
+  const _meta = getESAssetMetadata({ packageName });
 
   if (registryElasticsearch && registryElasticsearch['index_template.mappings']) {
     templatesMap[mappingsTemplateName] = {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -17,6 +17,7 @@ import type {
 import { appContextService } from '../../../';
 import { getRegistryDataStreamAssetBaseName } from '../index';
 import { FLEET_GLOBAL_COMPONENT_TEMPLATE_NAME } from '../../../../constants';
+import { getESAssetMetadata } from '../meta';
 
 interface Properties {
   [key: string]: any;
@@ -367,13 +368,7 @@ function getBaseTemplate(
   hidden?: boolean
 ): IndexTemplate {
   // Meta information to identify Ingest Manager's managed templates and indices
-  const _meta = {
-    package: {
-      name: packageName,
-    },
-    managed_by: 'ingest-manager',
-    managed: true,
-  };
+  const _meta = getESAssetMetadata({ packageName });
 
   return {
     priority: templatePriority,

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -22,7 +22,7 @@ import { getAsset } from './common';
 
 interface TransformInstallation {
   installationName: string;
-  content: string;
+  content: any;
 }
 
 export const installTransform = async (
@@ -128,7 +128,6 @@ async function handleTransformInstall({
     await esClient.transform.putTransform({
       transform_id: transform.installationName,
       defer_validation: true,
-      // @ts-expect-error expect object, but given a string
       body: transform.content,
     });
   } catch (err) {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -74,7 +74,7 @@ export const installTransform = async (
 
     const transforms: TransformInstallation[] = transformPaths.map((path: string) => {
       const content = JSON.parse(getAsset(path).toString('utf-8'));
-      content.meta = getESAssetMetadata({ packageName: installablePackage.name });
+      content._meta = getESAssetMetadata({ packageName: installablePackage.name });
 
       return {
         installationName: getTransformNameForInstallation(

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/install.ts
@@ -15,6 +15,8 @@ import type { EsAssetReference, InstallablePackage } from '../../../../../common
 import { getInstallation } from '../../packages';
 import { appContextService } from '../../../app_context';
 
+import { getESAssetMetadata } from '../meta';
+
 import { deleteTransforms, deleteTransformRefs } from './remove';
 import { getAsset } from './common';
 
@@ -71,13 +73,16 @@ export const installTransform = async (
     await saveInstalledEsRefs(savedObjectsClient, installablePackage.name, transformRefs);
 
     const transforms: TransformInstallation[] = transformPaths.map((path: string) => {
+      const content = JSON.parse(getAsset(path).toString('utf-8'));
+      content.meta = getESAssetMetadata({ packageName: installablePackage.name });
+
       return {
         installationName: getTransformNameForInstallation(
           installablePackage,
           path,
           installNameSuffix
         ),
-        content: getAsset(path).toString('utf-8'),
+        content,
       };
     });
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -31,8 +31,10 @@ import { savedObjectsClientMock } from '../../../../../../../../src/core/server/
 import { elasticsearchClientMock } from '../../../../../../../../src/core/server/elasticsearch/client/mocks';
 import { appContextService } from '../../../app_context';
 
-import { getAsset } from './common';
+import { getESAssetMetadata } from '../meta';
+
 import { installTransform } from './install';
+import { getAsset } from './common';
 
 describe('test transform install', () => {
   let esClient: DeeplyMockedKeys<ElasticsearchClient>;
@@ -195,19 +197,21 @@ describe('test transform install', () => {
       ],
     ]);
 
+    const meta = getESAssetMetadata({ packageName: 'endpoint' });
+
     expect(esClient.transform.putTransform.mock.calls).toEqual([
       [
         {
           transform_id: 'endpoint.metadata-default-0.16.0-dev.0',
           defer_validation: true,
-          body: '{"content": "data"}',
+          body: { content: 'data', _meta: meta },
         },
       ],
       [
         {
           transform_id: 'endpoint.metadata_current-default-0.16.0-dev.0',
           defer_validation: true,
-          body: '{"content": "data"}',
+          body: { content: 'data', _meta: meta },
         },
       ],
     ]);
@@ -328,12 +332,14 @@ describe('test transform install', () => {
       savedObjectsClient
     );
 
+    const meta = getESAssetMetadata({ packageName: 'endpoint' });
+
     expect(esClient.transform.putTransform.mock.calls).toEqual([
       [
         {
           transform_id: 'endpoint.metadata_current-default-0.16.0-dev.0',
           defer_validation: true,
-          body: '{"content": "data"}',
+          body: { content: 'data', _meta: meta },
         },
       ],
     ]);
@@ -553,12 +559,14 @@ describe('test transform install', () => {
       savedObjectsClient
     );
 
+    const meta = getESAssetMetadata({ packageName: 'endpoint' });
+
     expect(esClient.transform.putTransform.mock.calls).toEqual([
       [
         {
           transform_id: 'endpoint.metadata_current-default-0.16.0-dev.0',
           defer_validation: true,
-          body: '{"content": "data"}',
+          body: { content: 'data', _meta: meta },
         },
       ],
     ]);

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
@@ -131,7 +131,7 @@ export async function _installPackage({
     // currently only the base package has an ILM policy
     // at some point ILM policies can be installed/modified
     // per data stream and we should then save them
-    await installILMPolicy(paths, esClient);
+    await installILMPolicy(packageInfo, paths, esClient);
 
     const installedDataStreamIlm = await installIlmForDataStream(
       packageInfo,

--- a/x-pack/test/fleet_api_integration/apis/epm/final_pipeline.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/final_pipeline.ts
@@ -101,7 +101,7 @@ export default function (providerContext: FtrProviderContext) {
       await supertest.post(`/api/fleet/setup`).set('kbn-xsrf', 'xxxx');
       const pipelineRes = await es.ingest.getPipeline({ id: FINAL_PIPELINE_ID });
       expect(pipelineRes).to.have.property(FINAL_PIPELINE_ID);
-      expect(pipelineRes[FINAL_PIPELINE_ID].version).to.be(1);
+      expect(pipelineRes[FINAL_PIPELINE_ID].version).to.be(2);
     });
 
     it('should correctly setup the final pipeline and apply to fleet managed index template', async () => {

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -52,7 +52,15 @@ export default function (providerContext: FtrProviderContext) {
         },
         { meta: true }
       );
+
       expect(resPolicy.body.all_assets.policy).eql({
+        _meta: {
+          managed: true,
+          managed_by: 'fleet',
+          package: {
+            name: 'all_assets',
+          },
+        },
         phases: {
           hot: {
             min_age: '1ms',
@@ -265,6 +273,8 @@ export default function (providerContext: FtrProviderContext) {
             name: 'logs-all_assets.test_logs@custom',
             component_template: {
               _meta: {
+                managed: true,
+                managed_by: 'fleet',
                 package: {
                   name: 'all_assets',
                 },


### PR DESCRIPTION
## Summary

Resolves #111737

Adds/alters the `_meta` property on Elasticsearch assets generated by Fleet to consistently indicate that the assets come from Fleet, and when possible tie them back to an integration.

## To Test

1. Run Fleet setup
2. Install any integrations
3. Verify the assets generated included a `_meta` field of the format

```
{
  managed: true,
  managed_by: "fleet",
  package: {
    name: "foo"
  }
}
```

In cases like the `.fleet-final-pipeline` ingest pipeline and others, the `package` value will be omitted. 

To verify assets, use these Kibana dev tools queries:

```
GET /_index_template
GET /_component_template
GET /_ingest/pipeline
GET /_ilm/policy
GET /_transform/_all
```

## Examples

|Asset Type|Screenshot|
|-----------|-----------|
|Index template|![image](https://user-images.githubusercontent.com/6766512/142924297-f58c265b-c1c9-47eb-a987-75f6b28d3d8b.png)|
|Component template|![image](https://user-images.githubusercontent.com/6766512/142924670-9c8d4e8b-53db-4abe-929f-1d9b7265f8e7.png)|
|Ingest pipeline|![image](https://user-images.githubusercontent.com/6766512/142924831-30c574a5-aeaf-49a2-9908-c56be5cb63db.png)|
|ILM policy|![image](https://user-images.githubusercontent.com/6766512/142931881-71df9bed-98fa-4bc9-a8a8-6bd3733cb601.png)|
|Transform|![image](https://user-images.githubusercontent.com/6766512/142929271-ce99fa9c-b5a3-44c3-a061-a3fd3ace7ab7.png)|
