### PR TITLE
[Maps] fix heatmap layer intial style

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/heatmap_layer/heatmap_layer.ts
+++ b/x-pack/plugins/maps/public/classes/layers/heatmap_layer/heatmap_layer.ts
@@ -153,7 +153,8 @@ export class HeatmapLayer extends AbstractLayer {
     }
     const metricField = metricFields[0];
 
-    const tileMetaFeatures = this._getMetaFromTiles();
+    // do not use tile meta features from previous urlTemplate to avoid styling new tiles from previous tile meta features
+    const tileMetaFeatures = this._requiresPrevSourceCleanup(mbMap) ? [] : this._getMetaFromTiles();
     let max = 0;
     for (let i = 0; i < tileMetaFeatures.length; i++) {
       const range = metricField.pluckRangeFromTileMetaFeature(tileMetaFeatures[i]);

--- a/x-pack/plugins/maps/public/classes/styles/heatmap/heatmap_style.tsx
+++ b/x-pack/plugins/maps/public/classes/styles/heatmap/heatmap_style.tsx
@@ -87,8 +87,11 @@ export class HeatmapStyle implements IStyle {
       radius = 8;
     }
     mbMap.setPaintProperty(layerId, 'heatmap-radius', radius);
-    const safeMax = max <= 0 ? 1 : max;
-    mbMap.setPaintProperty(layerId, 'heatmap-weight', ['/', ['get', propertyName], safeMax]);
+    if (max <= 0) {
+      mbMap.setPaintProperty(layerId, 'heatmap-weight', 0);
+    } else {
+      mbMap.setPaintProperty(layerId, 'heatmap-weight', ['/', ['get', propertyName], max]);
+    }
 
     const colorStops = getOrdinalMbColorRampStops(
       this._descriptor.colorRampName,


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/119070 converted HeatmapLayer to use vector tiles. The PR added a check to protect against dividing by zero by setting max to 1 when the value is zero. This resulted in maps that flash with high densities before all tile meta is loaded and counts are provided.

This PR changes the check to default to zero instead of one to avoid this initial view of all data at high intensity.