### PR TITLE
[optimizer] pretty-print jest snapshots to help reviews

### DIFF
--- a/packages/kbn-optimizer/src/integration_tests/__snapshots__/basic_optimization.test.ts.snap
+++ b/packages/kbn-optimizer/src/integration_tests/__snapshots__/basic_optimization.test.ts.snap
@@ -156,16 +156,627 @@ OptimizerConfig {
 }
 `;
 
-exports[`prepares assets for distribution: bar bundle 1`] = `"!function(e){var n={};function t(r){if(n[r])return n[r].exports;var o=n[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,t),o.l=!0,o.exports}t.m=e,t.c=n,t.d=function(e,n,r){t.o(e,n)||Object.defineProperty(e,n,{enumerable:!0,get:r})},t.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},t.t=function(e,n){if(1&n&&(e=t(e)),8&n)return e;if(4&n&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(t.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&n&&\\"string\\"!=typeof e)for(var o in e)t.d(r,o,function(n){return e[n]}.bind(null,o));return r},t.n=function(e){var n=e&&e.__esModule?function(){return e.default}:function(){return e};return t.d(n,\\"a\\",n),n},t.o=function(e,n){return Object.prototype.hasOwnProperty.call(e,n)},t.p=\\"\\",t(t.s=3)}([function(e,n,t){\\"use strict\\";var r,o=function(){return void 0===r&&(r=Boolean(window&&document&&document.all&&!window.atob)),r},i=function(){var e={};return function(n){if(void 0===e[n]){var t=document.querySelector(n);if(window.HTMLIFrameElement&&t instanceof window.HTMLIFrameElement)try{t=t.contentDocument.head}catch(e){t=null}e[n]=t}return e[n]}}(),a=[];function c(e){for(var n=-1,t=0;t<a.length;t++)if(a[t].identifier===e){n=t;break}return n}function u(e,n){for(var t={},r=[],o=0;o<e.length;o++){var i=e[o],u=n.base?i[0]+n.base:i[0],s=t[u]||0,f=\\"\\".concat(u,\\" \\").concat(s);t[u]=s+1;var l=c(f),d={css:i[1],media:i[2],sourceMap:i[3]};-1!==l?(a[l].references++,a[l].updater(d)):a.push({identifier:f,updater:h(d,n),references:1}),r.push(f)}return r}function s(e){var n=document.createElement(\\"style\\"),r=e.attributes||{};if(void 0===r.nonce){var o=t.nc;o&&(r.nonce=o)}if(Object.keys(r).forEach((function(e){n.setAttribute(e,r[e])})),\\"function\\"==typeof e.insert)e.insert(n);else{var a=i(e.insert||\\"head\\");if(!a)throw new Error(\\"Couldn't find a style target. This probably means that the value for the 'insert' parameter is invalid.\\");a.appendChild(n)}return n}var f,l=(f=[],function(e,n){return f[e]=n,f.filter(Boolean).join(\\"\\\\n\\")});function d(e,n,t,r){var o=t?\\"\\":r.media?\\"@media \\".concat(r.media,\\" {\\").concat(r.css,\\"}\\"):r.css;if(e.styleSheet)e.styleSheet.cssText=l(n,o);else{var i=document.createTextNode(o),a=e.childNodes;a[n]&&e.removeChild(a[n]),a.length?e.insertBefore(i,a[n]):e.appendChild(i)}}function p(e,n,t){var r=t.css,o=t.media,i=t.sourceMap;if(o?e.setAttribute(\\"media\\",o):e.removeAttribute(\\"media\\"),i&&btoa&&(r+=\\"\\\\n/*# sourceMappingURL=data:application/json;base64,\\".concat(btoa(unescape(encodeURIComponent(JSON.stringify(i)))),\\" */\\")),e.styleSheet)e.styleSheet.cssText=r;else{for(;e.firstChild;)e.removeChild(e.firstChild);e.appendChild(document.createTextNode(r))}}var v=null,b=0;function h(e,n){var t,r,o;if(n.singleton){var i=b++;t=v||(v=s(n)),r=d.bind(null,t,i,!1),o=d.bind(null,t,i,!0)}else t=s(n),r=p.bind(null,t,n),o=function(){!function(e){if(null===e.parentNode)return!1;e.parentNode.removeChild(e)}(t)};return r(e),function(n){if(n){if(n.css===e.css&&n.media===e.media&&n.sourceMap===e.sourceMap)return;r(e=n)}else o()}}e.exports=function(e,n){(n=n||{}).singleton||\\"boolean\\"==typeof n.singleton||(n.singleton=o());var t=u(e=e||[],n);return function(e){if(e=e||[],\\"[object Array]\\"===Object.prototype.toString.call(e)){for(var r=0;r<t.length;r++){var o=c(t[r]);a[o].references--}for(var i=u(e,n),s=0;s<t.length;s++){var f=c(t[s]);0===a[f].references&&(a[f].updater(),a.splice(f,1))}t=i}}}},function(e,n,t){\\"use strict\\";e.exports=function(e){var n=[];return n.toString=function(){return this.map((function(n){var t=function(e,n){var t=e[1]||\\"\\",r=e[3];if(!r)return t;if(n&&\\"function\\"==typeof btoa){var o=(a=r,c=btoa(unescape(encodeURIComponent(JSON.stringify(a)))),u=\\"sourceMappingURL=data:application/json;charset=utf-8;base64,\\".concat(c),\\"/*# \\".concat(u,\\" */\\")),i=r.sources.map((function(e){return\\"/*# sourceURL=\\".concat(r.sourceRoot||\\"\\").concat(e,\\" */\\")}));return[t].concat(i).concat([o]).join(\\"\\\\n\\")}var a,c,u;return[t].join(\\"\\\\n\\")}(n,e);return n[2]?\\"@media \\".concat(n[2],\\" {\\").concat(t,\\"}\\"):t})).join(\\"\\")},n.i=function(e,t,r){\\"string\\"==typeof e&&(e=[[null,e,\\"\\"]]);var o={};if(r)for(var i=0;i<this.length;i++){var a=this[i][0];null!=a&&(o[a]=!0)}for(var c=0;c<e.length;c++){var u=[].concat(e[c]);r&&o[u[0]]||(t&&(u[2]?u[2]=\\"\\".concat(t,\\" and \\").concat(u[2]):u[2]=t),n.push(u))}},n}},function(e,n,t){t.r(n);var r=__kbnBundles__.get(\\"plugin/foo/public\\");Object.defineProperties(n,Object.getOwnPropertyDescriptors(r))},function(e,n,t){t(4),__kbnBundles__.define(\\"plugin/bar/public\\",t,15)},function(e,n,t){t.p=window.__kbnPublicPath__.bar},function(e,n,t){switch(window.__kbnThemeTag__){case\\"v8dark\\":return t(6);case\\"v8light\\":return t(8)}},function(e,n,t){var r=t(0),o=t(7);\\"string\\"==typeof(o=o.__esModule?o.default:o)&&(o=[[e.i,o,\\"\\"]]);var i={insert:\\"head\\",singleton:!1};r(o,i);e.exports=o.locals||{}},function(e,n,t){(n=t(1)(!1)).push([e.i,\\"p{background-color:rebeccapurple}body{width:12}\\\\n\\",\\"\\"]),e.exports=n},function(e,n,t){var r=t(0),o=t(9);\\"string\\"==typeof(o=o.__esModule?o.default:o)&&(o=[[e.i,o,\\"\\"]]);var i={insert:\\"head\\",singleton:!1};r(o,i);e.exports=o.locals||{}},function(e,n,t){(n=t(1)(!1)).push([e.i,\\"p{background-color:rebeccapurple}body{width:13}\\\\n\\",\\"\\"]),e.exports=n},function(e,n,t){switch(window.__kbnThemeTag__){case\\"v8dark\\":return t(11);case\\"v8light\\":return t(13)}},function(e,n,t){var r=t(0),o=t(12);\\"string\\"==typeof(o=o.__esModule?o.default:o)&&(o=[[e.i,o,\\"\\"]]);var i={insert:\\"head\\",singleton:!1};r(o,i);e.exports=o.locals||{}},function(e,n,t){(n=t(1)(!1)).push([e.i,\\"body{color:green}\\\\n\\",\\"\\"]),e.exports=n},function(e,n,t){var r=t(0),o=t(14);\\"string\\"==typeof(o=o.__esModule?o.default:o)&&(o=[[e.i,o,\\"\\"]]);var i={insert:\\"head\\",singleton:!1};r(o,i);e.exports=o.locals||{}},function(e,n,t){(n=t(1)(!1)).push([e.i,\\"body{color:green}\\\\n\\",\\"\\"]),e.exports=n},function(e,n,t){\\"use strict\\";t.r(n),t.d(n,\\"barLibFn\\",(function(){return o})),t.d(n,\\"fooLibFn\\",(function(){return r.fooLibFn}));t(5),t(10);var r=t(2);function o(){return\\"bar\\"}}]);"`;
-
-exports[`prepares assets for distribution: baz bundle 1`] = `
-"/*! Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one or more contributor license agreements. 
- * Licensed under the Elastic License 2.0; you may not use this file except in compliance with the Elastic License 2.0. */!function(e){var n={};function t(r){if(n[r])return n[r].exports;var o=n[r]={i:r,l:!1,exports:{}};return e[r].call(o.exports,o,o.exports,t),o.l=!0,o.exports}t.m=e,t.c=n,t.d=function(e,n,r){t.o(e,n)||Object.defineProperty(e,n,{enumerable:!0,get:r})},t.r=function(e){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(e,\\"__esModule\\",{value:!0})},t.t=function(e,n){if(1&n&&(e=t(e)),8&n)return e;if(4&n&&\\"object\\"==typeof e&&e&&e.__esModule)return e;var r=Object.create(null);if(t.r(r),Object.defineProperty(r,\\"default\\",{enumerable:!0,value:e}),2&n&&\\"string\\"!=typeof e)for(var o in e)t.d(r,o,function(n){return e[n]}.bind(null,o));return r},t.n=function(e){var n=e&&e.__esModule?function(){return e.default}:function(){return e};return t.d(n,\\"a\\",n),n},t.o=function(e,n){return Object.prototype.hasOwnProperty.call(e,n)},t.p=\\"\\",t(t.s=0)}([function(e,n,t){t(1),__kbnBundles__.define(\\"plugin/baz/public\\",t,2)},function(e,n,t){t.p=window.__kbnPublicPath__.baz},function(e,n){console.log(\\"plugin in an x-pack dir\\")}]);"
+exports[`prepares assets for distribution: bar bundle 1`] = `
+"!(function (e) {
+  var n = {};
+  function t(r) {
+    if (n[r]) return n[r].exports;
+    var o = (n[r] = { i: r, l: !1, exports: {} });
+    return e[r].call(o.exports, o, o.exports, t), (o.l = !0), o.exports;
+  }
+  (t.m = e),
+    (t.c = n),
+    (t.d = function (e, n, r) {
+      t.o(e, n) || Object.defineProperty(e, n, { enumerable: !0, get: r });
+    }),
+    (t.r = function (e) {
+      \\"undefined\\" != typeof Symbol &&
+        Symbol.toStringTag &&
+        Object.defineProperty(e, Symbol.toStringTag, { value: \\"Module\\" }),
+        Object.defineProperty(e, \\"__esModule\\", { value: !0 });
+    }),
+    (t.t = function (e, n) {
+      if ((1 & n && (e = t(e)), 8 & n)) return e;
+      if (4 & n && \\"object\\" == typeof e && e && e.__esModule) return e;
+      var r = Object.create(null);
+      if (
+        (t.r(r),
+        Object.defineProperty(r, \\"default\\", { enumerable: !0, value: e }),
+        2 & n && \\"string\\" != typeof e)
+      )
+        for (var o in e)
+          t.d(
+            r,
+            o,
+            function (n) {
+              return e[n];
+            }.bind(null, o)
+          );
+      return r;
+    }),
+    (t.n = function (e) {
+      var n =
+        e && e.__esModule
+          ? function () {
+              return e.default;
+            }
+          : function () {
+              return e;
+            };
+      return t.d(n, \\"a\\", n), n;
+    }),
+    (t.o = function (e, n) {
+      return Object.prototype.hasOwnProperty.call(e, n);
+    }),
+    (t.p = \\"\\"),
+    t((t.s = 3));
+})([
+  function (e, n, t) {
+    \\"use strict\\";
+    var r,
+      o = function () {
+        return (
+          void 0 === r &&
+            (r = Boolean(window && document && document.all && !window.atob)),
+          r
+        );
+      },
+      i = (function () {
+        var e = {};
+        return function (n) {
+          if (void 0 === e[n]) {
+            var t = document.querySelector(n);
+            if (
+              window.HTMLIFrameElement &&
+              t instanceof window.HTMLIFrameElement
+            )
+              try {
+                t = t.contentDocument.head;
+              } catch (e) {
+                t = null;
+              }
+            e[n] = t;
+          }
+          return e[n];
+        };
+      })(),
+      a = [];
+    function c(e) {
+      for (var n = -1, t = 0; t < a.length; t++)
+        if (a[t].identifier === e) {
+          n = t;
+          break;
+        }
+      return n;
+    }
+    function u(e, n) {
+      for (var t = {}, r = [], o = 0; o < e.length; o++) {
+        var i = e[o],
+          u = n.base ? i[0] + n.base : i[0],
+          s = t[u] || 0,
+          f = \\"\\".concat(u, \\" \\").concat(s);
+        t[u] = s + 1;
+        var l = c(f),
+          d = { css: i[1], media: i[2], sourceMap: i[3] };
+        -1 !== l
+          ? (a[l].references++, a[l].updater(d))
+          : a.push({ identifier: f, updater: h(d, n), references: 1 }),
+          r.push(f);
+      }
+      return r;
+    }
+    function s(e) {
+      var n = document.createElement(\\"style\\"),
+        r = e.attributes || {};
+      if (void 0 === r.nonce) {
+        var o = t.nc;
+        o && (r.nonce = o);
+      }
+      if (
+        (Object.keys(r).forEach(function (e) {
+          n.setAttribute(e, r[e]);
+        }),
+        \\"function\\" == typeof e.insert)
+      )
+        e.insert(n);
+      else {
+        var a = i(e.insert || \\"head\\");
+        if (!a)
+          throw new Error(
+            \\"Couldn't find a style target. This probably means that the value for the 'insert' parameter is invalid.\\"
+          );
+        a.appendChild(n);
+      }
+      return n;
+    }
+    var f,
+      l =
+        ((f = []),
+        function (e, n) {
+          return (f[e] = n), f.filter(Boolean).join(\\"\\\\n\\");
+        });
+    function d(e, n, t, r) {
+      var o = t
+        ? \\"\\"
+        : r.media
+        ? \\"@media \\".concat(r.media, \\" {\\").concat(r.css, \\"}\\")
+        : r.css;
+      if (e.styleSheet) e.styleSheet.cssText = l(n, o);
+      else {
+        var i = document.createTextNode(o),
+          a = e.childNodes;
+        a[n] && e.removeChild(a[n]),
+          a.length ? e.insertBefore(i, a[n]) : e.appendChild(i);
+      }
+    }
+    function p(e, n, t) {
+      var r = t.css,
+        o = t.media,
+        i = t.sourceMap;
+      if (
+        (o ? e.setAttribute(\\"media\\", o) : e.removeAttribute(\\"media\\"),
+        i &&
+          btoa &&
+          (r += \\"\\\\n/*# sourceMappingURL=data:application/json;base64,\\".concat(
+            btoa(unescape(encodeURIComponent(JSON.stringify(i)))),
+            \\" */\\"
+          )),
+        e.styleSheet)
+      )
+        e.styleSheet.cssText = r;
+      else {
+        for (; e.firstChild; ) e.removeChild(e.firstChild);
+        e.appendChild(document.createTextNode(r));
+      }
+    }
+    var v = null,
+      b = 0;
+    function h(e, n) {
+      var t, r, o;
+      if (n.singleton) {
+        var i = b++;
+        (t = v || (v = s(n))),
+          (r = d.bind(null, t, i, !1)),
+          (o = d.bind(null, t, i, !0));
+      } else
+        (t = s(n)),
+          (r = p.bind(null, t, n)),
+          (o = function () {
+            !(function (e) {
+              if (null === e.parentNode) return !1;
+              e.parentNode.removeChild(e);
+            })(t);
+          });
+      return (
+        r(e),
+        function (n) {
+          if (n) {
+            if (
+              n.css === e.css &&
+              n.media === e.media &&
+              n.sourceMap === e.sourceMap
+            )
+              return;
+            r((e = n));
+          } else o();
+        }
+      );
+    }
+    e.exports = function (e, n) {
+      (n = n || {}).singleton ||
+        \\"boolean\\" == typeof n.singleton ||
+        (n.singleton = o());
+      var t = u((e = e || []), n);
+      return function (e) {
+        if (
+          ((e = e || []),
+          \\"[object Array]\\" === Object.prototype.toString.call(e))
+        ) {
+          for (var r = 0; r < t.length; r++) {
+            var o = c(t[r]);
+            a[o].references--;
+          }
+          for (var i = u(e, n), s = 0; s < t.length; s++) {
+            var f = c(t[s]);
+            0 === a[f].references && (a[f].updater(), a.splice(f, 1));
+          }
+          t = i;
+        }
+      };
+    };
+  },
+  function (e, n, t) {
+    \\"use strict\\";
+    e.exports = function (e) {
+      var n = [];
+      return (
+        (n.toString = function () {
+          return this.map(function (n) {
+            var t = (function (e, n) {
+              var t = e[1] || \\"\\",
+                r = e[3];
+              if (!r) return t;
+              if (n && \\"function\\" == typeof btoa) {
+                var o =
+                    ((a = r),
+                    (c = btoa(unescape(encodeURIComponent(JSON.stringify(a))))),
+                    (u =
+                      \\"sourceMappingURL=data:application/json;charset=utf-8;base64,\\".concat(
+                        c
+                      )),
+                    \\"/*# \\".concat(u, \\" */\\")),
+                  i = r.sources.map(function (e) {
+                    return \\"/*# sourceURL=\\"
+                      .concat(r.sourceRoot || \\"\\")
+                      .concat(e, \\" */\\");
+                  });
+                return [t].concat(i).concat([o]).join(\\"\\\\n\\");
+              }
+              var a, c, u;
+              return [t].join(\\"\\\\n\\");
+            })(n, e);
+            return n[2] ? \\"@media \\".concat(n[2], \\" {\\").concat(t, \\"}\\") : t;
+          }).join(\\"\\");
+        }),
+        (n.i = function (e, t, r) {
+          \\"string\\" == typeof e && (e = [[null, e, \\"\\"]]);
+          var o = {};
+          if (r)
+            for (var i = 0; i < this.length; i++) {
+              var a = this[i][0];
+              null != a && (o[a] = !0);
+            }
+          for (var c = 0; c < e.length; c++) {
+            var u = [].concat(e[c]);
+            (r && o[u[0]]) ||
+              (t &&
+                (u[2]
+                  ? (u[2] = \\"\\".concat(t, \\" and \\").concat(u[2]))
+                  : (u[2] = t)),
+              n.push(u));
+          }
+        }),
+        n
+      );
+    };
+  },
+  function (e, n, t) {
+    t.r(n);
+    var r = __kbnBundles__.get(\\"plugin/foo/public\\");
+    Object.defineProperties(n, Object.getOwnPropertyDescriptors(r));
+  },
+  function (e, n, t) {
+    t(4), __kbnBundles__.define(\\"plugin/bar/public\\", t, 15);
+  },
+  function (e, n, t) {
+    t.p = window.__kbnPublicPath__.bar;
+  },
+  function (e, n, t) {
+    switch (window.__kbnThemeTag__) {
+      case \\"v8dark\\":
+        return t(6);
+      case \\"v8light\\":
+        return t(8);
+    }
+  },
+  function (e, n, t) {
+    var r = t(0),
+      o = t(7);
+    \\"string\\" == typeof (o = o.__esModule ? o.default : o) &&
+      (o = [[e.i, o, \\"\\"]]);
+    var i = { insert: \\"head\\", singleton: !1 };
+    r(o, i);
+    e.exports = o.locals || {};
+  },
+  function (e, n, t) {
+    (n = t(1)(!1)).push([
+      e.i,
+      \\"p{background-color:rebeccapurple}body{width:12}\\\\n\\",
+      \\"\\",
+    ]),
+      (e.exports = n);
+  },
+  function (e, n, t) {
+    var r = t(0),
+      o = t(9);
+    \\"string\\" == typeof (o = o.__esModule ? o.default : o) &&
+      (o = [[e.i, o, \\"\\"]]);
+    var i = { insert: \\"head\\", singleton: !1 };
+    r(o, i);
+    e.exports = o.locals || {};
+  },
+  function (e, n, t) {
+    (n = t(1)(!1)).push([
+      e.i,
+      \\"p{background-color:rebeccapurple}body{width:13}\\\\n\\",
+      \\"\\",
+    ]),
+      (e.exports = n);
+  },
+  function (e, n, t) {
+    switch (window.__kbnThemeTag__) {
+      case \\"v8dark\\":
+        return t(11);
+      case \\"v8light\\":
+        return t(13);
+    }
+  },
+  function (e, n, t) {
+    var r = t(0),
+      o = t(12);
+    \\"string\\" == typeof (o = o.__esModule ? o.default : o) &&
+      (o = [[e.i, o, \\"\\"]]);
+    var i = { insert: \\"head\\", singleton: !1 };
+    r(o, i);
+    e.exports = o.locals || {};
+  },
+  function (e, n, t) {
+    (n = t(1)(!1)).push([e.i, \\"body{color:green}\\\\n\\", \\"\\"]), (e.exports = n);
+  },
+  function (e, n, t) {
+    var r = t(0),
+      o = t(14);
+    \\"string\\" == typeof (o = o.__esModule ? o.default : o) &&
+      (o = [[e.i, o, \\"\\"]]);
+    var i = { insert: \\"head\\", singleton: !1 };
+    r(o, i);
+    e.exports = o.locals || {};
+  },
+  function (e, n, t) {
+    (n = t(1)(!1)).push([e.i, \\"body{color:green}\\\\n\\", \\"\\"]), (e.exports = n);
+  },
+  function (e, n, t) {
+    \\"use strict\\";
+    t.r(n),
+      t.d(n, \\"barLibFn\\", function () {
+        return o;
+      }),
+      t.d(n, \\"fooLibFn\\", function () {
+        return r.fooLibFn;
+      });
+    t(5), t(10);
+    var r = t(2);
+    function o() {
+      return \\"bar\\";
+    }
+  },
+]);
+"
 `;
 
-exports[`prepares assets for distribution: foo async bundle 1`] = `"(window.foo_bundle_jsonpfunction=window.foo_bundle_jsonpfunction||[]).push([[1],{3:function(n,o,u){\\"use strict\\";function f(){}u.r(o),u.d(o,\\"foo\\",(function(){return f}))}}]);"`;
+exports[`prepares assets for distribution: baz bundle 1`] = `
+"/*! Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one or more contributor license agreements.
+ * Licensed under the Elastic License 2.0; you may not use this file except in compliance with the Elastic License 2.0. */ !(function (
+  e
+) {
+  var n = {};
+  function t(r) {
+    if (n[r]) return n[r].exports;
+    var o = (n[r] = { i: r, l: !1, exports: {} });
+    return e[r].call(o.exports, o, o.exports, t), (o.l = !0), o.exports;
+  }
+  (t.m = e),
+    (t.c = n),
+    (t.d = function (e, n, r) {
+      t.o(e, n) || Object.defineProperty(e, n, { enumerable: !0, get: r });
+    }),
+    (t.r = function (e) {
+      \\"undefined\\" != typeof Symbol &&
+        Symbol.toStringTag &&
+        Object.defineProperty(e, Symbol.toStringTag, { value: \\"Module\\" }),
+        Object.defineProperty(e, \\"__esModule\\", { value: !0 });
+    }),
+    (t.t = function (e, n) {
+      if ((1 & n && (e = t(e)), 8 & n)) return e;
+      if (4 & n && \\"object\\" == typeof e && e && e.__esModule) return e;
+      var r = Object.create(null);
+      if (
+        (t.r(r),
+        Object.defineProperty(r, \\"default\\", { enumerable: !0, value: e }),
+        2 & n && \\"string\\" != typeof e)
+      )
+        for (var o in e)
+          t.d(
+            r,
+            o,
+            function (n) {
+              return e[n];
+            }.bind(null, o)
+          );
+      return r;
+    }),
+    (t.n = function (e) {
+      var n =
+        e && e.__esModule
+          ? function () {
+              return e.default;
+            }
+          : function () {
+              return e;
+            };
+      return t.d(n, \\"a\\", n), n;
+    }),
+    (t.o = function (e, n) {
+      return Object.prototype.hasOwnProperty.call(e, n);
+    }),
+    (t.p = \\"\\"),
+    t((t.s = 0));
+})([
+  function (e, n, t) {
+    t(1), __kbnBundles__.define(\\"plugin/baz/public\\", t, 2);
+  },
+  function (e, n, t) {
+    t.p = window.__kbnPublicPath__.baz;
+  },
+  function (e, n) {
+    console.log(\\"plugin in an x-pack dir\\");
+  },
+]);
+"
+`;
 
-exports[`prepares assets for distribution: foo bundle 1`] = `"!function(n){function e(e){for(var t,o,u=e[0],i=e[1],c=0,a=[];c<u.length;c++)o=u[c],Object.prototype.hasOwnProperty.call(r,o)&&r[o]&&a.push(r[o][0]),r[o]=0;for(t in i)Object.prototype.hasOwnProperty.call(i,t)&&(n[t]=i[t]);for(f&&f(e);a.length;)a.shift()()}var t={},r={0:0};function o(e){if(t[e])return t[e].exports;var r=t[e]={i:e,l:!1,exports:{}};return n[e].call(r.exports,r,r.exports,o),r.l=!0,r.exports}o.e=function(n){var e=[],t=r[n];if(0!==t)if(t)e.push(t[2]);else{var u=new Promise((function(e,o){t=r[n]=[e,o]}));e.push(t[2]=u);var i,c=document.createElement(\\"script\\");c.charset=\\"utf-8\\",c.timeout=120,o.nc&&c.setAttribute(\\"nonce\\",o.nc),c.src=function(n){return o.p+\\"foo.chunk.\\"+n+\\".js\\"}(n);var f=new Error;i=function(e){c.onerror=c.onload=null,clearTimeout(a);var t=r[n];if(0!==t){if(t){var o=e&&(\\"load\\"===e.type?\\"missing\\":e.type),u=e&&e.target&&e.target.src;f.message=\\"Loading chunk \\"+n+\\" failed.\\\\n(\\"+o+\\": \\"+u+\\")\\",f.name=\\"ChunkLoadError\\",f.type=o,f.request=u,t[1](f)}r[n]=void 0}};var a=setTimeout((function(){i({type:\\"timeout\\",target:c})}),12e4);c.onerror=c.onload=i,document.head.appendChild(c)}return Promise.all(e)},o.m=n,o.c=t,o.d=function(n,e,t){o.o(n,e)||Object.defineProperty(n,e,{enumerable:!0,get:t})},o.r=function(n){\\"undefined\\"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(n,Symbol.toStringTag,{value:\\"Module\\"}),Object.defineProperty(n,\\"__esModule\\",{value:!0})},o.t=function(n,e){if(1&e&&(n=o(n)),8&e)return n;if(4&e&&\\"object\\"==typeof n&&n&&n.__esModule)return n;var t=Object.create(null);if(o.r(t),Object.defineProperty(t,\\"default\\",{enumerable:!0,value:n}),2&e&&\\"string\\"!=typeof n)for(var r in n)o.d(t,r,function(e){return n[e]}.bind(null,r));return t},o.n=function(n){var e=n&&n.__esModule?function(){return n.default}:function(){return n};return o.d(e,\\"a\\",e),e},o.o=function(n,e){return Object.prototype.hasOwnProperty.call(n,e)},o.p=\\"\\",o.oe=function(n){throw console.error(n),n};var u=window.foo_bundle_jsonpfunction=window.foo_bundle_jsonpfunction||[],i=u.push.bind(u);u.push=e,u=u.slice();for(var c=0;c<u.length;c++)e(u[c]);var f=i;o(o.s=0)}([function(n,e,t){t(1),__kbnBundles__.define(\\"plugin/foo/public\\",t,2)},function(n,e,t){t.p=window.__kbnPublicPath__.foo},function(n,e,t){\\"use strict\\";function r(){return\\"foo\\"}t.r(e),t.d(e,\\"fooLibFn\\",(function(){return r})),t.d(e,\\"ext\\",(function(){return o})),t.d(e,\\"getFoo\\",(function(){return u}));const o=\\"TRUE\\";async function u(){return await t.e(1).then(t.bind(null,3))}}]);"`;
+exports[`prepares assets for distribution: foo async bundle 1`] = `
+"(window.foo_bundle_jsonpfunction = window.foo_bundle_jsonpfunction || []).push([
+  [1],
+  {
+    3: function (n, o, u) {
+      \\"use strict\\";
+      function f() {}
+      u.r(o),
+        u.d(o, \\"foo\\", function () {
+          return f;
+        });
+    },
+  },
+]);
+"
+`;
+
+exports[`prepares assets for distribution: foo bundle 1`] = `
+"!(function (n) {
+  function e(e) {
+    for (var t, o, u = e[0], i = e[1], c = 0, a = []; c < u.length; c++)
+      (o = u[c]),
+        Object.prototype.hasOwnProperty.call(r, o) && r[o] && a.push(r[o][0]),
+        (r[o] = 0);
+    for (t in i) Object.prototype.hasOwnProperty.call(i, t) && (n[t] = i[t]);
+    for (f && f(e); a.length; ) a.shift()();
+  }
+  var t = {},
+    r = { 0: 0 };
+  function o(e) {
+    if (t[e]) return t[e].exports;
+    var r = (t[e] = { i: e, l: !1, exports: {} });
+    return n[e].call(r.exports, r, r.exports, o), (r.l = !0), r.exports;
+  }
+  (o.e = function (n) {
+    var e = [],
+      t = r[n];
+    if (0 !== t)
+      if (t) e.push(t[2]);
+      else {
+        var u = new Promise(function (e, o) {
+          t = r[n] = [e, o];
+        });
+        e.push((t[2] = u));
+        var i,
+          c = document.createElement(\\"script\\");
+        (c.charset = \\"utf-8\\"),
+          (c.timeout = 120),
+          o.nc && c.setAttribute(\\"nonce\\", o.nc),
+          (c.src = (function (n) {
+            return o.p + \\"foo.chunk.\\" + n + \\".js\\";
+          })(n));
+        var f = new Error();
+        i = function (e) {
+          (c.onerror = c.onload = null), clearTimeout(a);
+          var t = r[n];
+          if (0 !== t) {
+            if (t) {
+              var o = e && (\\"load\\" === e.type ? \\"missing\\" : e.type),
+                u = e && e.target && e.target.src;
+              (f.message =
+                \\"Loading chunk \\" + n + \\" failed.\\\\n(\\" + o + \\": \\" + u + \\")\\"),
+                (f.name = \\"ChunkLoadError\\"),
+                (f.type = o),
+                (f.request = u),
+                t[1](f);
+            }
+            r[n] = void 0;
+          }
+        };
+        var a = setTimeout(function () {
+          i({ type: \\"timeout\\", target: c });
+        }, 12e4);
+        (c.onerror = c.onload = i), document.head.appendChild(c);
+      }
+    return Promise.all(e);
+  }),
+    (o.m = n),
+    (o.c = t),
+    (o.d = function (n, e, t) {
+      o.o(n, e) || Object.defineProperty(n, e, { enumerable: !0, get: t });
+    }),
+    (o.r = function (n) {
+      \\"undefined\\" != typeof Symbol &&
+        Symbol.toStringTag &&
+        Object.defineProperty(n, Symbol.toStringTag, { value: \\"Module\\" }),
+        Object.defineProperty(n, \\"__esModule\\", { value: !0 });
+    }),
+    (o.t = function (n, e) {
+      if ((1 & e && (n = o(n)), 8 & e)) return n;
+      if (4 & e && \\"object\\" == typeof n && n && n.__esModule) return n;
+      var t = Object.create(null);
+      if (
+        (o.r(t),
+        Object.defineProperty(t, \\"default\\", { enumerable: !0, value: n }),
+        2 & e && \\"string\\" != typeof n)
+      )
+        for (var r in n)
+          o.d(
+            t,
+            r,
+            function (e) {
+              return n[e];
+            }.bind(null, r)
+          );
+      return t;
+    }),
+    (o.n = function (n) {
+      var e =
+        n && n.__esModule
+          ? function () {
+              return n.default;
+            }
+          : function () {
+              return n;
+            };
+      return o.d(e, \\"a\\", e), e;
+    }),
+    (o.o = function (n, e) {
+      return Object.prototype.hasOwnProperty.call(n, e);
+    }),
+    (o.p = \\"\\"),
+    (o.oe = function (n) {
+      throw (console.error(n), n);
+    });
+  var u = (window.foo_bundle_jsonpfunction =
+      window.foo_bundle_jsonpfunction || []),
+    i = u.push.bind(u);
+  (u.push = e), (u = u.slice());
+  for (var c = 0; c < u.length; c++) e(u[c]);
+  var f = i;
+  o((o.s = 0));
+})([
+  function (n, e, t) {
+    t(1), __kbnBundles__.define(\\"plugin/foo/public\\", t, 2);
+  },
+  function (n, e, t) {
+    t.p = window.__kbnPublicPath__.foo;
+  },
+  function (n, e, t) {
+    \\"use strict\\";
+    function r() {
+      return \\"foo\\";
+    }
+    t.r(e),
+      t.d(e, \\"fooLibFn\\", function () {
+        return r;
+      }),
+      t.d(e, \\"ext\\", function () {
+        return o;
+      }),
+      t.d(e, \\"getFoo\\", function () {
+        return u;
+      });
+    const o = \\"TRUE\\";
+    async function u() {
+      return await t.e(1).then(t.bind(null, 3));
+    }
+  },
+]);
+"
+`;
 
 exports[`prepares assets for distribution: metrics.json 1`] = `
 "[

--- a/packages/kbn-optimizer/src/integration_tests/basic_optimization.test.ts
+++ b/packages/kbn-optimizer/src/integration_tests/basic_optimization.test.ts
@@ -10,6 +10,7 @@ import Path from 'path';
 import Fs from 'fs';
 import Zlib from 'zlib';
 import { inspect } from 'util';
+import prettier from 'prettier';
 
 import cpy from 'cpy';
 import del from 'del';
@@ -245,9 +246,13 @@ it('prepares assets for distribution', async () => {
  * Verifies that the file matches the expected output and has matching compressed variants.
  */
 const expectFileMatchesSnapshotWithCompression = (filePath: string, snapshotLabel: string) => {
-  const raw = Fs.readFileSync(Path.resolve(MOCK_REPO_DIR, filePath), 'utf8');
+  const path = Path.resolve(MOCK_REPO_DIR, filePath);
+  const raw = Fs.readFileSync(path, 'utf8');
+  const pretty = prettier.format(raw, {
+    filepath: path,
+  });
 
-  expect(raw).toMatchSnapshot(snapshotLabel);
+  expect(pretty).toMatchSnapshot(snapshotLabel);
 
   // Verify the brotli variant matches
   expect(


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/119107 ended up triggering an update to the bundle saved in a Jest snapshot. This snapshot isn't massive, but it's too large to spot a little change so I'd like to format the code with prettier before snapshotting it so that we can spot changes more easily.