### PR TITLE
[DOCS] Fix elasticsearch-reset-password typo

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -64,7 +64,7 @@ For example:
 
 [source,sh]
 ----
-docker exec -it es-node01 /usr/share/elasticsearch/bin/reset-elastic-password
+docker exec -it es-node01 /usr/share/elasticsearch/bin/elasticsearch-reset-password
 ----
 ====
 


### PR DESCRIPTION
Changes `reset-elastic-password` to `elasticsearch-reset-password`.