### PR TITLE
[HTTP] Improve message for 500 error response

### DIFF
--- a/src/core/server/http/integration_tests/lifecycle.test.ts
+++ b/src/core/server/http/integration_tests/lifecycle.test.ts
@@ -259,7 +259,9 @@ describe('OnPreRouting', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -284,7 +286,9 @@ describe('OnPreRouting', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -403,7 +407,9 @@ describe('OnPreAuth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -424,7 +430,9 @@ describe('OnPreAuth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -570,7 +578,9 @@ describe('OnPostAuth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -590,7 +600,9 @@ describe('OnPostAuth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -808,7 +820,9 @@ describe('Auth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -1100,7 +1114,9 @@ describe('Auth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -1120,7 +1136,9 @@ describe('Auth', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -1296,7 +1314,9 @@ describe('OnPreResponse', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -1320,7 +1340,9 @@ describe('OnPreResponse', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [

--- a/src/core/server/http/integration_tests/router.test.ts
+++ b/src/core/server/http/integration_tests/router.test.ts
@@ -569,7 +569,9 @@ describe('Handler', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
@@ -590,7 +592,9 @@ describe('Handler', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -609,7 +613,9 @@ describe('Handler', () => {
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
 
-    expect(result.body.message).toBe('An internal server error occurred.');
+    expect(result.body.message).toBe(
+      'An internal server error occurred. Check Kibana server logs for details.'
+    );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -737,7 +743,7 @@ describe('handleLegacyErrors', () => {
 
     expect(result.body).toEqual({
       error: 'Internal Server Error',
-      message: 'An internal server error occurred.',
+      message: 'An internal server error occurred. Check Kibana server logs for details.',
       statusCode: 500,
     });
   });
@@ -1113,7 +1119,9 @@ describe('Response factory', () => {
 
       const result = await supertest(innerServer.listener).get('/').expect(500);
 
-      expect(result.body.message).toBe('An internal server error occurred.');
+      expect(result.body.message).toBe(
+        'An internal server error occurred. Check Kibana server logs for details.'
+      );
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
@@ -1517,7 +1525,7 @@ describe('Response factory', () => {
 
       expect(result.body).toEqual({
         error: 'Internal Server Error',
-        message: 'An internal server error occurred.',
+        message: 'An internal server error occurred. Check Kibana server logs for details.',
         statusCode: 500,
       });
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
@@ -1726,7 +1734,9 @@ describe('Response factory', () => {
 
       const result = await supertest(innerServer.listener).get('/').expect(500);
 
-      expect(result.body.message).toBe('An internal server error occurred.');
+      expect(result.body.message).toBe(
+        'An internal server error occurred. Check Kibana server logs for details.'
+      );
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
@@ -1750,7 +1760,9 @@ describe('Response factory', () => {
 
       const result = await supertest(innerServer.listener).get('/').expect(500);
 
-      expect(result.body.message).toBe('An internal server error occurred.');
+      expect(result.body.message).toBe(
+        'An internal server error occurred. Check Kibana server logs for details.'
+      );
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
@@ -1773,7 +1785,9 @@ describe('Response factory', () => {
 
       const result = await supertest(innerServer.listener).get('/').expect(500);
 
-      expect(result.body.message).toBe('An internal server error occurred.');
+      expect(result.body.message).toBe(
+        'An internal server error occurred. Check Kibana server logs for details.'
+      );
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
@@ -1796,7 +1810,9 @@ describe('Response factory', () => {
 
       const result = await supertest(innerServer.listener).get('/').expect(500);
 
-      expect(result.body.message).toBe('An internal server error occurred.');
+      expect(result.body.message).toBe(
+        'An internal server error occurred. Check Kibana server logs for details.'
+      );
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [

--- a/src/core/server/http/router/response_adapter.ts
+++ b/src/core/server/http/router/response_adapter.ts
@@ -55,7 +55,8 @@ export class HapiResponseAdapter {
       statusCode: 500,
     });
 
-    error.output.payload.message = 'An internal server error occurred.';
+    error.output.payload.message =
+      'An internal server error occurred. Check Kibana server logs for details.';
 
     return error;
   }

--- a/x-pack/plugins/global_search/server/routes/integration_tests/find.test.ts
+++ b/x-pack/plugins/global_search/server/routes/integration_tests/find.test.ts
@@ -136,7 +136,7 @@ describe('POST /internal/global_search/find', () => {
 
     expect(response.body).toEqual(
       expect.objectContaining({
-        message: 'An internal server error occurred.',
+        message: 'An internal server error occurred. Check Kibana server logs for details.',
         statusCode: 500,
       })
     );

--- a/x-pack/plugins/global_search/server/routes/integration_tests/get_searchable_types.test.ts
+++ b/x-pack/plugins/global_search/server/routes/integration_tests/get_searchable_types.test.ts
@@ -73,7 +73,7 @@ describe('GET /internal/global_search/searchable_types', () => {
 
     expect(response.body).toEqual(
       expect.objectContaining({
-        message: 'An internal server error occurred.',
+        message: 'An internal server error occurred. Check Kibana server logs for details.',
         statusCode: 500,
       })
     );


### PR DESCRIPTION
## Summary
Kibana returns the 500 error response and logs the error details whenever an exception is raised during an incoming request handling. From the issues in the Kibana repo, it seems unclear for the Kibana user that error details can be found in the Kibana logs. This PR improves the error message to hint that error details are available in the KIbana logs for further investigation.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix
| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Kibana users might rely on a returned error message shape. | Low | Low | Relying on a particular error message in response is flaky, use the response status code instead. In any case, this PR doesn't change the wording completely, but added another sentence. |