### PR TITLE
[ML] Fix error handling for missing data view in data frame analytics wizard

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/source_selection/source_selection.test.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/source_selection/source_selection.test.tsx
@@ -76,6 +76,11 @@ jest.mock('../../../../../contexts/kibana', () => ({
     },
   }),
   useNavigateToPath: () => mockNavigateToPath,
+  useNotifications: () => {
+    return {
+      toasts: { addSuccess: jest.fn(), addDanger: jest.fn(), addError: jest.fn() },
+    };
+  },
 }));
 
 jest.mock('../../../../../util/index_utils', () => {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/source_selection/source_selection.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/source_selection/source_selection.tsx
@@ -23,6 +23,8 @@ import type { SimpleSavedObject } from 'src/core/public';
 import { SavedObjectFinderUi } from '../../../../../../../../../../src/plugins/saved_objects/public';
 import { useMlKibana, useNavigateToPath } from '../../../../../contexts/kibana';
 
+import { useToastNotificationService } from '../../../../../services/toast_notification_service';
+
 import { getNestedProperty } from '../../../../../util/object_utils';
 
 import { getDataViewAndSavedSearch, isCcsIndexPattern } from '../../../../../util/index_utils';
@@ -41,6 +43,7 @@ export const SourceSelection: FC<Props> = ({ onClose }) => {
 
   const [isCcsCallOut, setIsCcsCallOut] = useState(false);
   const [ccsCallOutBodyText, setCcsCallOutBodyText] = useState<string>();
+  const toastNotificationService = useToastNotificationService();
 
   const onSearchSelected = async (
     id: string,
@@ -57,8 +60,22 @@ export const SourceSelection: FC<Props> = ({ onClose }) => {
     if (type === 'index-pattern') {
       dataViewName = getNestedProperty(savedObject, 'attributes.title');
     } else if (type === 'search') {
-      const dataViewAndSavedSearch = await getDataViewAndSavedSearch(id);
-      dataViewName = dataViewAndSavedSearch.dataView?.title ?? '';
+      try {
+        const dataViewAndSavedSearch = await getDataViewAndSavedSearch(id);
+        dataViewName = dataViewAndSavedSearch.dataView?.title ?? '';
+      } catch (error) {
+        // an unexpected error has occurred. This could be caused by a saved search for which the data view no longer exists.
+        toastNotificationService.displayErrorToast(
+          error,
+          i18n.translate(
+            'xpack.ml.dataFrame.analytics.create.searchSelection.errorGettingDataViewTitle',
+            {
+              defaultMessage: 'Error loading data view used by the saved search',
+            }
+          )
+        );
+        return;
+      }
     }
 
     if (isCcsIndexPattern(dataViewName)) {


### PR DESCRIPTION
## Summary

Fixes the error handling when selecting a saved search in the first step of the 'create data frame analytics job' wizard, for which the data view used by the saved search has been deleted. A toast notification is now displayed where previously none was shown.

![image](https://user-images.githubusercontent.com/7405507/143021787-ff74aeb9-4a33-4fe1-95f9-c5d54d094d55.png)

Note that the error message text is that received in the error from the `DataViewsContract` and still refers to 'index-pattern' and the link cannot be clicked. This behavior is consistent with the anomaly detection wizard, and is something that could be improved in a follow-up

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

Fixes #118517 