### PR TITLE
[ML] Catching error for syntax error in job wizard editor

### DIFF
--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/ml_job_editor/ml_job_editor.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/ml_job_editor/ml_job_editor.tsx
@@ -37,7 +37,12 @@ export const MLJobEditor: FC<MlJobEditorProps> = ({
   onChange = () => {},
 }) => {
   if (mode === ML_EDITOR_MODE.XJSON) {
-    value = expandLiteralStrings(value);
+    try {
+      value = expandLiteralStrings(value);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
   }
 
   return (


### PR DESCRIPTION
Errors when parsing XJSON cause the page to crash.
This change catches the error and sends it to the browser's console.

Fixes https://github.com/elastic/kibana/issues/118671

