### PR TITLE
[ML] Functional tests - stabilize clear job messages test

### DIFF
--- a/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
+++ b/x-pack/test/api_integration/apis/ml/job_audit_messages/get_job_audit_messages.ts
@@ -16,6 +16,7 @@ export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertestWithoutAuth');
   const ml = getService('ml');
+  const retry = getService('retry');
 
   describe('get_job_audit_messages', function () {
     before(async () => {
@@ -32,63 +33,81 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     it('should fetch all audit messages', async () => {
-      const { body } = await supertest
-        .get(`/api/ml/job_audit_messages/messages`)
-        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+      await retry.tryForTime(5000, async () => {
+        const { body } = await supertest
+          .get(`/api/ml/job_audit_messages/messages`)
+          .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+          .set(COMMON_REQUEST_HEADERS)
+          .expect(200);
 
-      expect(body.messages.length).to.eql(2);
+        expect(body.messages.length).to.eql(
+          2,
+          `Expected 2 job audit messages, got ${JSON.stringify(body.messages, null, 2)}`
+        );
+        const messagesDict = keyBy(body.messages, 'job_id');
 
-      const messagesDict = keyBy(body.messages, 'job_id');
-
-      expect(omit(messagesDict.test_get_job_audit_messages_2, ['timestamp', 'node_name'])).to.eql({
-        job_id: 'test_get_job_audit_messages_2',
-        message: 'Job created',
-        level: 'info',
-        job_type: 'anomaly_detector',
+        expect(omit(messagesDict.test_get_job_audit_messages_2, ['timestamp', 'node_name'])).to.eql(
+          {
+            job_id: 'test_get_job_audit_messages_2',
+            message: 'Job created',
+            level: 'info',
+            job_type: 'anomaly_detector',
+          }
+        );
+        expect(omit(messagesDict.test_get_job_audit_messages_1, ['timestamp', 'node_name'])).to.eql(
+          {
+            job_id: 'test_get_job_audit_messages_1',
+            message: 'Job created',
+            level: 'info',
+            job_type: 'anomaly_detector',
+          }
+        );
+        expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
       });
-      expect(omit(messagesDict.test_get_job_audit_messages_1, ['timestamp', 'node_name'])).to.eql({
-        job_id: 'test_get_job_audit_messages_1',
-        message: 'Job created',
-        level: 'info',
-        job_type: 'anomaly_detector',
-      });
-      expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
     });
 
     it('should fetch audit messages for specified job', async () => {
-      const { body } = await supertest
-        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
-        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+      await retry.tryForTime(5000, async () => {
+        const { body } = await supertest
+          .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+          .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+          .set(COMMON_REQUEST_HEADERS)
+          .expect(200);
 
-      expect(body.messages.length).to.eql(1);
-      expect(omit(body.messages[0], ['timestamp', 'node_name'])).to.eql({
-        job_id: 'test_get_job_audit_messages_1',
-        message: 'Job created',
-        level: 'info',
-        job_type: 'anomaly_detector',
+        expect(body.messages.length).to.eql(
+          1,
+          `Expected 1 job audit message, got ${JSON.stringify(body.messages, null, 2)}`
+        );
+        expect(omit(body.messages[0], ['timestamp', 'node_name'])).to.eql({
+          job_id: 'test_get_job_audit_messages_1',
+          message: 'Job created',
+          level: 'info',
+          job_type: 'anomaly_detector',
+        });
+        expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
       });
-      expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
     });
 
     it('should fetch audit messages for user with ML read permissions', async () => {
-      const { body } = await supertest
-        .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
-        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
-        .set(COMMON_REQUEST_HEADERS)
-        .expect(200);
+      await retry.tryForTime(5000, async () => {
+        const { body } = await supertest
+          .get(`/api/ml/job_audit_messages/messages/test_get_job_audit_messages_1`)
+          .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+          .set(COMMON_REQUEST_HEADERS)
+          .expect(200);
 
-      expect(body.messages.length).to.eql(1);
-      expect(omit(body.messages[0], ['timestamp', 'node_name'])).to.eql({
-        job_id: 'test_get_job_audit_messages_1',
-        message: 'Job created',
-        level: 'info',
-        job_type: 'anomaly_detector',
+        expect(body.messages.length).to.eql(
+          1,
+          `Expected 1 job audit message, got ${JSON.stringify(body.messages, null, 2)}`
+        );
+        expect(omit(body.messages[0], ['timestamp', 'node_name'])).to.eql({
+          job_id: 'test_get_job_audit_messages_1',
+          message: 'Job created',
+          level: 'info',
+          job_type: 'anomaly_detector',
+        });
+        expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
       });
-      expect(body.notificationIndices).to.eql(['.ml-notifications-000002']);
     });
 
     it('should not allow to fetch audit messages for unauthorized user', async () => {


### PR DESCRIPTION
## Summary

This PR stabilizes the get and clear job messages API tests by adding a retry. In some cases when fetching the job messages too quickly after a change, the updated data was not available for search yet.

Closes #118503
