### PR TITLE
[Maps] fix dark map style

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/vector_tile_layer/vector_tile_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_tile_layer/vector_tile_layer.tsx
@@ -241,10 +241,11 @@ export class VectorTileLayer extends TileLayer {
         }
         const newLayerObject = {
           ...layer,
-          source:
+          source: this._generateMbSourceId(
             typeof (layer as MbLayer).source === 'string'
-              ? this._generateMbSourceId((layer as MbLayer).source as string)
-              : undefined,
+              ? ((layer as MbLayer).source as string)
+              : undefined
+          ),
           id: mbLayerId,
         };
 

--- a/x-pack/plugins/maps/public/classes/layers/vector_tile_layer/vector_tile_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_tile_layer/vector_tile_layer.tsx
@@ -116,7 +116,7 @@ export class VectorTileLayer extends TileLayer {
     return `${this.getId()}${DELIMITTER}${this.getSource().getTileLayerId()}${DELIMITTER}`;
   }
 
-  _generateMbSourceId(name: string) {
+  _generateMbSourceId(name: string | undefined) {
     return `${this._generateMbSourceIdPrefix()}${name}`;
   }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/119412

Regression caused by https://github.com/elastic/kibana/pull/117745

Original code was `source: this._generateMbSourceId(layer.source),`. This fix keeps the original code's behavior of always setting source to _generateMbSourceId.