### PR TITLE
[ML] APM Correlations: Fix tooltip values for 0 workaround.

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
@@ -267,6 +267,13 @@ export function TransactionDistributionChart({
               yAccessors={['doc_count']}
               color={areaSeriesColors[i]}
               fit="lookahead"
+              // To make the area appear without the orphaned points technique,
+              // we changed the original data to replace values of 0 with 0.0001.
+              // To show the correct values again in tooltips, we use a custom tickFormat to round values.
+              // We can safely do this because all transaction values above 0 are without decimal points anyway.
+              // An update for Elastic Charts is in the works to be able to customize the above "fit"
+              // attribute. Once that is available we can get rid of the full workaround.
+              tickFormat={(p) => `${Math.round(p)}`}
             />
           ))}
         </Chart>

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
@@ -273,6 +273,7 @@ export function TransactionDistributionChart({
               // We can safely do this because all transaction values above 0 are without decimal points anyway.
               // An update for Elastic Charts is in the works to be able to customize the above "fit"
               // attribute. Once that is available we can get rid of the full workaround.
+              // Elastic Charts issue: https://github.com/elastic/elastic-charts/issues/1489
               tickFormat={(p) => `${Math.round(p)}`}
             />
           ))}


### PR DESCRIPTION
## Summary

The workaround for Elastic Charts we are using to show a continuous area chart instead of the default approach with dots for orphaned data points caused values of `0` to show up as `0.0001` in tooltips. This PR fixes it by using a custom `tickFormatter` to again round the value back to `0`. Elastic Charts is working on an update that will allow us to use this customization without this workaround, we'll follow up with another PR once that is available.

Before:

![image](https://user-images.githubusercontent.com/230104/143039512-8e666882-8b76-41e3-a681-6488046e4fc3.png)

After:

![image](https://user-images.githubusercontent.com/230104/143039009-f5b6b7ec-bd8d-44ca-98dc-951884855b0e.png)

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
