### PR TITLE
[CI] Bump size of agent running Checks step in hourly pipeline

### DIFF
--- a/.buildkite/pipelines/hourly.yml
+++ b/.buildkite/pipelines/hourly.yml
@@ -158,7 +158,7 @@ steps:
   - command: .buildkite/scripts/steps/checks.sh
     label: 'Checks'
     agents:
-      queue: c2-4
+      queue: c2-8
     key: checks
     timeout_in_minutes: 120
 


### PR DESCRIPTION
This was bumped in the PR pipeline, but not the hourly pipeline.