### PR TITLE
[Fleet] Override branch in doc links

### DIFF
--- a/src/plugins/custom_integrations/server/language_clients/index.ts
+++ b/src/plugins/custom_integrations/server/language_clients/index.ts
@@ -152,7 +152,10 @@ export function registerLanguageClients(
       type: 'ui_link',
       shipper: 'language_clients',
       // Documentation for `main` branches is still published at a `master` URL.
-      uiInternalPath: integration.docUrlTemplate.replace('{branch}', branch === 'main' ? 'master' : branch),
+      uiInternalPath: integration.docUrlTemplate.replace(
+        '{branch}',
+        branch === 'main' ? 'master' : branch
+      ),
       isBeta: false,
       icons,
       categories: ['elastic_stack', 'custom', 'language_client'],

--- a/src/plugins/custom_integrations/server/language_clients/index.ts
+++ b/src/plugins/custom_integrations/server/language_clients/index.ts
@@ -152,7 +152,7 @@ export function registerLanguageClients(
       type: 'ui_link',
       shipper: 'language_clients',
       // Documentation for `main` branches is still published at a `master` URL.
-      uiInternalPath: integration.docUrlTemplate.replace('{branch}', 'master'),
+      uiInternalPath: integration.docUrlTemplate.replace('{branch}', branch === 'main' ? 'master' : branch),
       isBeta: false,
       icons,
       categories: ['elastic_stack', 'custom', 'language_client'],

--- a/src/plugins/custom_integrations/server/language_clients/index.ts
+++ b/src/plugins/custom_integrations/server/language_clients/index.ts
@@ -151,7 +151,8 @@ export function registerLanguageClients(
       description: integration.description,
       type: 'ui_link',
       shipper: 'language_clients',
-      uiInternalPath: integration.docUrlTemplate.replace('{branch}', branch),
+      // Documentation for `main` branches is still published at a `master` URL.
+      uiInternalPath: integration.docUrlTemplate.replace('{branch}', 'master'),
       isBeta: false,
       icons,
       categories: ['elastic_stack', 'custom', 'language_client'],

--- a/src/plugins/custom_integrations/server/plugin.test.ts
+++ b/src/plugins/custom_integrations/server/plugin.test.ts
@@ -38,7 +38,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master/introduction.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/branch/introduction.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -50,7 +50,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/master/ruby_client.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/branch/ruby_client.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -62,7 +62,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/go-api/master/overview.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/go-api/branch/overview.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -74,7 +74,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/net-api/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/net-api/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -86,7 +86,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/php-api/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/php-api/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -98,7 +98,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/perl-api/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/perl-api/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -110,7 +110,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/python-api/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/python-api/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -122,7 +122,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/rust-api/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/rust-api/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -134,7 +134,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/master/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/branch/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],

--- a/src/plugins/custom_integrations/server/plugin.test.ts
+++ b/src/plugins/custom_integrations/server/plugin.test.ts
@@ -38,7 +38,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/branch/introduction.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master/introduction.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -50,7 +50,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/branch/ruby_client.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/master/ruby_client.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -62,7 +62,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/go-api/branch/overview.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/go-api/master/overview.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -74,7 +74,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/net-api/branch/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/net-api/master/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -86,7 +86,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/php-api/branch/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/php-api/master/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -98,7 +98,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/perl-api/branch/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/perl-api/master/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -110,7 +110,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/python-api/branch/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/python-api/master/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -122,7 +122,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/rust-api/branch/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/rust-api/master/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],
@@ -134,7 +134,7 @@ describe('CustomIntegrationsPlugin', () => {
           type: 'ui_link',
           shipper: 'language_clients',
           uiInternalPath:
-            'https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/branch/index.html',
+            'https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/master/index.html',
           isBeta: false,
           icons: [{ type: 'svg' }],
           categories: ['elastic_stack', 'custom', 'language_client'],


### PR DESCRIPTION
## Summary

The documentation links in the language client integrations get a 404 (e.g. when you click any of the clients here):

![image](https://user-images.githubusercontent.com/26471269/143070318-b1bee25b-eae3-4516-ad87-44a13bb64a45.png)

This is occurring because those links do not use the Kibana doc link service (per 
https://github.com/elastic/kibana/pull/113666#issuecomment-934615202 and https://github.com/elastic/kibana/issues/95389) and therefore don't have our current [work-around](https://github.com/elastic/kibana/blob/e5b279f318eac64660a5f4b157e891339f05ea61/src/core/public/doc_links/doc_links_service.ts#L23) for the lack of "main" branch documentation.

This PR therefore just overrides the branch in https://github.com/elastic/kibana/blob/main/src/plugins/custom_integrations/server/language_clients/index.ts until we replace the "master" documentation with "main".
