### PR TITLE
[ML] Fixing update datafeed endpoint

### DIFF
--- a/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
@@ -480,7 +480,7 @@ export function getMlClient(
       }
       const { datafeed_id: id, body } = p[0];
 
-      return client.asCurrentUser.transport.request({
+      return client.asInternalUser.transport.request({
         method: 'POST',
         path: `/_ml/datafeeds/${id}/_update`,
         body,

--- a/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
@@ -472,6 +472,7 @@ export function getMlClient(
     async updateDatafeed(...p: Parameters<MlClient['updateDatafeed']>) {
       await datafeedIdsCheck(p);
 
+      // Temporary workaround for the incorrect updateDatafeed function in the esclient
       if (p.length === 0 || p[0] === undefined) {
         // Temporary generic error message. This should never be triggered
         // but is added for type correctness below
@@ -484,6 +485,9 @@ export function getMlClient(
         path: `/_ml/datafeeds/${id}/_update`,
         body,
       });
+
+      // this should be reinstated once https://github.com/elastic/kibana/issues/118427
+      // is fixed
       // return mlClient.updateDatafeed(...p);
     },
     async updateFilter(...p: Parameters<MlClient['updateFilter']>) {

--- a/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
@@ -486,7 +486,7 @@ export function getMlClient(
         body,
       });
 
-      // this should be reinstated once https://github.com/elastic/kibana/issues/118427
+      // this should be reinstated once https://github.com/elastic/elasticsearch-js/issues/1601
       // is fixed
       // return mlClient.updateDatafeed(...p);
     },

--- a/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
@@ -471,7 +471,20 @@ export function getMlClient(
     },
     async updateDatafeed(...p: Parameters<MlClient['updateDatafeed']>) {
       await datafeedIdsCheck(p);
-      return mlClient.updateDatafeed(...p);
+
+      if (p.length === 0 || p[0] === undefined) {
+        // Temporary generic error message. This should never be triggered
+        // but is added for type correctness below
+        throw new Error('Incorrect arguments supplied');
+      }
+      const { datafeed_id: id, body } = p[0];
+
+      return client.asCurrentUser.transport.request({
+        method: 'POST',
+        path: `/_ml/datafeeds/${id}/_update`,
+        body,
+      });
+      // return mlClient.updateDatafeed(...p);
     },
     async updateFilter(...p: Parameters<MlClient['updateFilter']>) {
       return mlClient.updateFilter(...p);


### PR DESCRIPTION
Temporary work around for the incorrect esclient function `updateDatafeed`
The `updateDatafeed` function in the client currently ignores the body which is passed to it

Rather than using `updateDatafeed` we are now using `transport.request` to call the es endpoint directly.

Fixes https://github.com/elastic/kibana/issues/118427
Related to https://github.com/elastic/elasticsearch-js/issues/1601

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
