### PR TITLE
[App Search] Add empty preview tab to Crawl Detail Flyout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
@@ -35,13 +35,12 @@ describe('CrawlDetailsFlyout', () => {
     jest.clearAllMocks();
   });
 
-  it('renders a flyout containing the raw json of the crawl details', () => {
+  it('renders a flyout ', () => {
     setMockValues(MOCK_VALUES);
 
     const wrapper = shallow(<CrawlDetailsFlyout />);
 
     expect(wrapper.is(EuiFlyout)).toBe(true);
-    expect(wrapper.find(EuiCodeBlock)).toHaveLength(1);
   });
 
   it('contains a tab group to control displayed content inside the flyout', () => {
@@ -77,6 +76,12 @@ describe('CrawlDetailsFlyout', () => {
       expect(tabs.at(0).prop('isSelected')).toBe(true);
       expect(tabs.at(1).prop('isSelected')).toBe(false);
     });
+
+    it('hides the raw json of the crawl details', () => {
+      const wrapper = shallow(<CrawlDetailsFlyout />);
+
+      expect(wrapper.find(EuiCodeBlock)).toHaveLength(0);
+    });
   });
 
   describe('when the json tab is selected', () => {
@@ -93,6 +98,12 @@ describe('CrawlDetailsFlyout', () => {
 
       expect(tabs.at(0).prop('isSelected')).toBe(false);
       expect(tabs.at(1).prop('isSelected')).toBe(true);
+    });
+
+    it('shows the raw json of the crawl details', () => {
+      const wrapper = shallow(<CrawlDetailsFlyout />);
+
+      expect(wrapper.find(EuiCodeBlock)).toHaveLength(1);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.test.tsx
@@ -4,18 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { setMockValues } from '../../../../__mocks__/kea_logic';
+import { setMockActions, setMockValues } from '../../../../__mocks__/kea_logic';
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiCodeBlock, EuiFlyout } from '@elastic/eui';
+import { EuiCodeBlock, EuiFlyout, EuiTab, EuiTabs } from '@elastic/eui';
 
 import { Loading } from '../../../../shared/loading';
 
-import { CrawlDetailValues } from '../crawl_detail_logic';
+import { CrawlDetailActions, CrawlDetailValues } from '../crawl_detail_logic';
 import { CrawlRequestFromServer } from '../types';
 
 import { CrawlDetailsFlyout } from './crawl_details_flyout';
@@ -26,7 +26,15 @@ const MOCK_VALUES: Partial<CrawlDetailValues> = {
   crawlRequestFromServer: {} as CrawlRequestFromServer,
 };
 
+const MOCK_ACTIONS: Partial<CrawlDetailActions> = {
+  setSelectedTab: jest.fn(),
+};
+
 describe('CrawlDetailsFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders a flyout containing the raw json of the crawl details', () => {
     setMockValues(MOCK_VALUES);
 
@@ -34,6 +42,58 @@ describe('CrawlDetailsFlyout', () => {
 
     expect(wrapper.is(EuiFlyout)).toBe(true);
     expect(wrapper.find(EuiCodeBlock)).toHaveLength(1);
+  });
+
+  it('contains a tab group to control displayed content inside the flyout', () => {
+    setMockActions(MOCK_ACTIONS);
+    setMockValues(MOCK_VALUES);
+
+    const wrapper = shallow(<CrawlDetailsFlyout />);
+    const tabs = wrapper.find(EuiTabs).find(EuiTab);
+
+    expect(tabs).toHaveLength(2);
+
+    tabs.at(0).simulate('click');
+
+    expect(MOCK_ACTIONS.setSelectedTab).toHaveBeenCalledWith('preview');
+
+    tabs.at(1).simulate('click');
+
+    expect(MOCK_ACTIONS.setSelectedTab).toHaveBeenCalledWith('json');
+  });
+
+  describe('when the preview tab is selected', () => {
+    beforeEach(() => {
+      setMockValues({
+        ...MOCK_VALUES,
+        selectedTab: 'preview',
+      });
+    });
+
+    it('shows the correct tab is selected in the UX', () => {
+      const wrapper = shallow(<CrawlDetailsFlyout />);
+      const tabs = wrapper.find(EuiTabs).find(EuiTab);
+
+      expect(tabs.at(0).prop('isSelected')).toBe(true);
+      expect(tabs.at(1).prop('isSelected')).toBe(false);
+    });
+  });
+
+  describe('when the json tab is selected', () => {
+    beforeEach(() => {
+      setMockValues({
+        ...MOCK_VALUES,
+        selectedTab: 'json',
+      });
+    });
+
+    it('shows the correct tab is selected in the UX', () => {
+      const wrapper = shallow(<CrawlDetailsFlyout />);
+      const tabs = wrapper.find(EuiTabs).find(EuiTab);
+
+      expect(tabs.at(0).prop('isSelected')).toBe(false);
+      expect(tabs.at(1).prop('isSelected')).toBe(true);
+    });
   });
 
   it('renders a loading screen when loading', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
@@ -8,7 +8,15 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiFlyout, EuiFlyoutHeader, EuiTitle, EuiFlyoutBody, EuiCodeBlock } from '@elastic/eui';
+import {
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiCodeBlock,
+  EuiTab,
+  EuiTabs,
+} from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -16,8 +24,9 @@ import { Loading } from '../../../../shared/loading';
 import { CrawlDetailLogic } from '../crawl_detail_logic';
 
 export const CrawlDetailsFlyout: React.FC = () => {
-  const { closeFlyout } = useActions(CrawlDetailLogic);
-  const { dataLoading, flyoutClosed, crawlRequestFromServer } = useValues(CrawlDetailLogic);
+  const { closeFlyout, setSelectedTab } = useActions(CrawlDetailLogic);
+  const { crawlRequestFromServer, dataLoading, flyoutClosed, selectedTab } =
+    useValues(CrawlDetailLogic);
 
   if (flyoutClosed) {
     return null;
@@ -33,14 +42,24 @@ export const CrawlDetailsFlyout: React.FC = () => {
             })}
           </h2>
         </EuiTitle>
+        <EuiTabs style={{ marginBottom: '-25px' }}>
+          <EuiTab isSelected={selectedTab === 'preview'} onClick={() => setSelectedTab('preview')}>
+            Preview
+          </EuiTab>
+          <EuiTab isSelected={selectedTab === 'json'} onClick={() => setSelectedTab('json')}>
+            Raw JSON
+          </EuiTab>
+        </EuiTabs>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {dataLoading ? (
           <Loading />
         ) : (
-          <EuiCodeBlock language="json">
-            {JSON.stringify(crawlRequestFromServer, null, 2)}
-          </EuiCodeBlock>
+          <>
+            <EuiCodeBlock language="json">
+              {JSON.stringify(crawlRequestFromServer, null, 2)}
+            </EuiCodeBlock>
+          </>
         )}
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout.tsx
@@ -56,9 +56,12 @@ export const CrawlDetailsFlyout: React.FC = () => {
           <Loading />
         ) : (
           <>
-            <EuiCodeBlock language="json">
-              {JSON.stringify(crawlRequestFromServer, null, 2)}
-            </EuiCodeBlock>
+            {selectedTab === 'preview' && <></>}
+            {selectedTab === 'json' && (
+              <EuiCodeBlock language="json">
+                {JSON.stringify(crawlRequestFromServer, null, 2)}
+              </EuiCodeBlock>
+            )}
           </>
         )}
       </EuiFlyoutBody>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { setMockActions, setMockValues } from '../../../../__mocks__/kea_logic';
-import '../../../__mocks__/engine_logic.mock';
+import { setMockActions, setMockValues } from '../../../../../__mocks__/kea_logic';
+import '../../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
@@ -13,12 +13,14 @@ import { shallow } from 'enzyme';
 
 import { EuiCodeBlock, EuiFlyout, EuiTab, EuiTabs } from '@elastic/eui';
 
-import { Loading } from '../../../../shared/loading';
+import { Loading } from '../../../../../shared/loading';
 
-import { CrawlDetailActions, CrawlDetailValues } from '../crawl_detail_logic';
-import { CrawlRequestFromServer } from '../types';
+import { CrawlDetailActions, CrawlDetailValues } from '../../crawl_detail_logic';
+import { CrawlRequestFromServer } from '../../types';
 
-import { CrawlDetailsFlyout } from './crawl_details_flyout';
+import { CrawlDetailsPreview } from './crawl_details_preview';
+
+import { CrawlDetailsFlyout } from '.';
 
 const MOCK_VALUES: Partial<CrawlDetailValues> = {
   dataLoading: false,
@@ -77,10 +79,10 @@ describe('CrawlDetailsFlyout', () => {
       expect(tabs.at(1).prop('isSelected')).toBe(false);
     });
 
-    it('hides the raw json of the crawl details', () => {
+    it('shows the human readable version of the crawl details', () => {
       const wrapper = shallow(<CrawlDetailsFlyout />);
 
-      expect(wrapper.find(EuiCodeBlock)).toHaveLength(0);
+      expect(wrapper.find(CrawlDetailsPreview)).toHaveLength(1);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
@@ -46,10 +46,20 @@ export const CrawlDetailsFlyout: React.FC = () => {
         </EuiTitle>
         <EuiTabs style={{ marginBottom: '-25px' }}>
           <EuiTab isSelected={selectedTab === 'preview'} onClick={() => setSelectedTab('preview')}>
-            Preview
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.crawlDetailsFlyout.previewTabLabel',
+              {
+                defaultMessage: 'Preview',
+              }
+            )}
           </EuiTab>
           <EuiTab isSelected={selectedTab === 'json'} onClick={() => setSelectedTab('json')}>
-            Raw JSON
+            {i18n.translate(
+              'xpack.enterpriseSearch.appSearch.crawler.crawlDetailsFlyout.rawJSONTabLabel',
+              {
+                defaultMessage: 'Raw JSON',
+              }
+            )}
           </EuiTab>
         </EuiTabs>
       </EuiFlyoutHeader>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
@@ -20,8 +20,10 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { Loading } from '../../../../shared/loading';
-import { CrawlDetailLogic } from '../crawl_detail_logic';
+import { Loading } from '../../../../../shared/loading';
+import { CrawlDetailLogic } from '../../crawl_detail_logic';
+
+import { CrawlDetailsPreview } from './crawl_details_preview';
 
 export const CrawlDetailsFlyout: React.FC = () => {
   const { closeFlyout, setSelectedTab } = useActions(CrawlDetailLogic);
@@ -56,7 +58,7 @@ export const CrawlDetailsFlyout: React.FC = () => {
           <Loading />
         ) : (
           <>
-            {selectedTab === 'preview' && <></>}
+            {selectedTab === 'preview' && <CrawlDetailsPreview />}
             {selectedTab === 'json' && (
               <EuiCodeBlock language="json">
                 {JSON.stringify(crawlRequestFromServer, null, 2)}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_preview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_preview.test.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { CrawlDetailsPreview } from './crawl_details_preview';
+
+describe('CrawlDetailsPreview', () => {
+  it('is empty', () => {
+    const wrapper = shallow(<CrawlDetailsPreview />);
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_preview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_preview.tsx
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+export const CrawlDetailsPreview: React.FC = () => null;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { CrawlDetailsFlyout } from './crawl_details_flyout';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -52,6 +52,7 @@ const values: { events: CrawlEvent[] } = {
 
 const actions = {
   fetchCrawlRequest: jest.fn(),
+  openFlyout: jest.fn(),
 };
 
 describe('CrawlRequestsTable', () => {
@@ -83,6 +84,7 @@ describe('CrawlRequestsTable', () => {
 
       crawlID.simulate('click');
       expect(actions.fetchCrawlRequest).toHaveBeenCalledWith('618d0e66abe97bc688328900');
+      expect(actions.openFlyout).toHaveBeenCalled();
 
       const processCrawlID = shallow(columns[0].render('54325423aef7890543', { stage: 'process' }));
       expect(processCrawlID.text()).toContain('54325423aef7890543');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -28,7 +28,7 @@ import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
 
 export const CrawlRequestsTable: React.FC = () => {
   const { events } = useValues(CrawlerLogic);
-  const { fetchCrawlRequest } = useActions(CrawlDetailLogic);
+  const { fetchCrawlRequest, openFlyout } = useActions(CrawlDetailLogic);
 
   const columns: Array<EuiBasicTableColumn<CrawlEvent>> = [
     {
@@ -41,7 +41,16 @@ export const CrawlRequestsTable: React.FC = () => {
       ),
       render: (id: string, event: CrawlEvent) => {
         if (event.stage === 'crawl') {
-          return <EuiLink onClick={() => fetchCrawlRequest(id)}>{id}</EuiLink>;
+          return (
+            <EuiLink
+              onClick={() => {
+                fetchCrawlRequest(id);
+                openFlyout();
+              }}
+            >
+              {id}
+            </EuiLink>
+          );
         }
         return <span>{id}</span>;
       },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -94,12 +94,27 @@ describe('CrawlDetailLogic', () => {
       });
     });
 
-    describe('fetchCrawlRequest', () => {
-      it('opens the flyout, resets the selected tab, and sets loading to true', () => {
+    describe('openFlyout', () => {
+      it('opens the flyout and resets the selected tab', () => {
         mount({
-          dataLoading: false,
           flyoutClosed: true,
           selectedTab: 'json',
+        });
+
+        CrawlDetailLogic.actions.openFlyout();
+
+        expect(CrawlDetailLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          flyoutClosed: false,
+          selectedTab: 'preview',
+        });
+      });
+    });
+
+    describe('fetchCrawlRequest', () => {
+      it('sets loading to true', () => {
+        mount({
+          dataLoading: false,
         });
 
         CrawlDetailLogic.actions.fetchCrawlRequest('12345');
@@ -107,8 +122,6 @@ describe('CrawlDetailLogic', () => {
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
           dataLoading: true,
-          flyoutClosed: false,
-          selectedTab: 'preview',
         });
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -21,6 +21,7 @@ const DEFAULT_VALUES: CrawlDetailValues = {
   flyoutClosed: true,
   crawlRequest: null,
   crawlRequestFromServer: null,
+  selectedTab: 'preview',
 };
 
 const crawlRequestResponse: CrawlRequestFromServer = {
@@ -46,7 +47,7 @@ describe('CrawlDetailLogic', () => {
     expect(CrawlDetailLogic.values).toEqual(DEFAULT_VALUES);
   });
 
-  describe('reducers', () => {
+  describe('actions', () => {
     describe('closeFlyout', () => {
       it('closes the flyout', () => {
         mount({ flyoutClosed: false });
@@ -77,14 +78,28 @@ describe('CrawlDetailLogic', () => {
         });
       });
     });
-  });
 
-  describe('listeners', () => {
+    describe('setSelectedTab', () => {
+      it('sets the select tab', () => {
+        mount({
+          selectedTab: 'preview',
+        });
+
+        CrawlDetailLogic.actions.setSelectedTab('json');
+
+        expect(CrawlDetailLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          selectedTab: 'json',
+        });
+      });
+    });
+
     describe('fetchCrawlRequest', () => {
-      it('opens the flyout and sets loading to true', () => {
+      it('opens the flyout, resets the selected tab, and sets loading to true', () => {
         mount({
           dataLoading: false,
           flyoutClosed: true,
+          selectedTab: 'json',
         });
 
         CrawlDetailLogic.actions.fetchCrawlRequest('12345');
@@ -93,6 +108,7 @@ describe('CrawlDetailLogic', () => {
           ...DEFAULT_VALUES,
           dataLoading: true,
           flyoutClosed: false,
+          selectedTab: 'preview',
         });
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -31,6 +31,7 @@ interface CrawlDetailActions {
   onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {
     crawlRequestFromServer: CrawlRequestFromServer;
   };
+  openFlyout(): void;
   setSelectedTab(selectedTab: CrawlDetailFlyoutTabs): { selectedTab: CrawlDetailFlyoutTabs };
 }
 
@@ -40,6 +41,7 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
     closeFlyout: true,
     fetchCrawlRequest: (requestId) => ({ requestId }),
     onRecieveCrawlRequest: (crawlRequestFromServer) => ({ crawlRequestFromServer }),
+    openFlyout: true,
     setSelectedTab: (selectedTab) => ({ selectedTab }),
   },
   reducers: {
@@ -66,14 +68,14 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
     flyoutClosed: [
       true,
       {
-        fetchCrawlRequest: () => false,
+        openFlyout: () => false,
         closeFlyout: () => true,
       },
     ],
     selectedTab: [
       'preview',
       {
-        fetchCrawlRequest: () => 'preview',
+        openFlyout: () => 'preview',
         setSelectedTab: (_, { selectedTab }) => selectedTab,
       },
     ],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -15,11 +15,14 @@ import { EngineLogic } from '../engine';
 import { CrawlRequest, CrawlRequestFromServer } from './types';
 import { crawlRequestServerToClient } from './utils';
 
+type CrawlDetailFlyoutTabs = 'preview' | 'json';
+
 export interface CrawlDetailValues {
   crawlRequest: CrawlRequest | null;
   crawlRequestFromServer: CrawlRequestFromServer | null;
   dataLoading: boolean;
   flyoutClosed: boolean;
+  selectedTab: CrawlDetailFlyoutTabs;
 }
 
 interface CrawlDetailActions {
@@ -28,6 +31,7 @@ interface CrawlDetailActions {
   onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {
     crawlRequestFromServer: CrawlRequestFromServer;
   };
+  setSelectedTab(selectedTab: CrawlDetailFlyoutTabs): { selectedTab: CrawlDetailFlyoutTabs };
 }
 
 export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetailActions>>({
@@ -36,6 +40,7 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
     closeFlyout: true,
     fetchCrawlRequest: (requestId) => ({ requestId }),
     onRecieveCrawlRequest: (crawlRequestFromServer) => ({ crawlRequestFromServer }),
+    setSelectedTab: (selectedTab) => ({ selectedTab }),
   },
   reducers: {
     crawlRequest: [
@@ -63,6 +68,13 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
       {
         fetchCrawlRequest: () => false,
         closeFlyout: () => true,
+      },
+    ],
+    selectedTab: [
+      'preview',
+      {
+        fetchCrawlRequest: () => 'preview',
+        setSelectedTab: (_, { selectedTab }) => selectedTab,
       },
     ],
   },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -25,7 +25,7 @@ export interface CrawlDetailValues {
   selectedTab: CrawlDetailFlyoutTabs;
 }
 
-interface CrawlDetailActions {
+export interface CrawlDetailActions {
   closeFlyout(): void;
   fetchCrawlRequest(requestId: string): { requestId: string };
   onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {


### PR DESCRIPTION
## Summary

Adds tabs to the existing crawl detail flyout, including a json preview tab to show the existing `EuiCodeBlock`, and a new preview tab, which is currently empty.

### Screenshots

![Screen Shot 2021-11-23 at 1 51 21 PM](https://user-images.githubusercontent.com/2479295/143085993-cf81df43-1a98-4be9-9a53-a99c3d368683.png)

![Screen Shot 2021-11-23 at 1 51 27 PM](https://user-images.githubusercontent.com/2479295/143086001-c69a2e96-d2cc-4ad9-bbf3-47cbcecdf91e.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
