### PR TITLE
[App Search] Update types for Crawl Detail Flyout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
@@ -16,7 +16,7 @@ import { EuiCodeBlock, EuiFlyout, EuiTab, EuiTabs } from '@elastic/eui';
 import { Loading } from '../../../../../shared/loading';
 
 import { CrawlDetailActions, CrawlDetailValues } from '../../crawl_detail_logic';
-import { CrawlRequestFromServer } from '../../types';
+import { CrawlEventFromServer } from '../../types';
 
 import { CrawlDetailsPreview } from './crawl_details_preview';
 
@@ -25,7 +25,7 @@ import { CrawlDetailsFlyout } from '.';
 const MOCK_VALUES: Partial<CrawlDetailValues> = {
   dataLoading: false,
   flyoutClosed: false,
-  crawlRequestFromServer: {} as CrawlRequestFromServer,
+  crawlEventFromServer: {} as CrawlEventFromServer,
 };
 
 const MOCK_ACTIONS: Partial<CrawlDetailActions> = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
@@ -27,7 +27,7 @@ import { CrawlDetailsPreview } from './crawl_details_preview';
 
 export const CrawlDetailsFlyout: React.FC = () => {
   const { closeFlyout, setSelectedTab } = useActions(CrawlDetailLogic);
-  const { crawlRequestFromServer, dataLoading, flyoutClosed, selectedTab } =
+  const { crawlEventFromServer, dataLoading, flyoutClosed, selectedTab } =
     useValues(CrawlDetailLogic);
 
   if (flyoutClosed) {
@@ -71,7 +71,7 @@ export const CrawlDetailsFlyout: React.FC = () => {
             {selectedTab === 'preview' && <CrawlDetailsPreview />}
             {selectedTab === 'json' && (
               <EuiCodeBlock language="json">
-                {JSON.stringify(crawlRequestFromServer, null, 2)}
+                {JSON.stringify(crawlEventFromServer, null, 2)}
               </EuiCodeBlock>
             )}
           </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -51,7 +51,7 @@ const values: { events: CrawlEvent[] } = {
 };
 
 const actions = {
-  fetchCrawlRequest: jest.fn(),
+  fetchCrawlEvent: jest.fn(),
   openFlyout: jest.fn(),
 };
 
@@ -83,7 +83,7 @@ describe('CrawlRequestsTable', () => {
       expect(crawlID.text()).toContain('618d0e66abe97bc688328900');
 
       crawlID.simulate('click');
-      expect(actions.fetchCrawlRequest).toHaveBeenCalledWith('618d0e66abe97bc688328900');
+      expect(actions.fetchCrawlEvent).toHaveBeenCalledWith('618d0e66abe97bc688328900');
       expect(actions.openFlyout).toHaveBeenCalled();
 
       const processCrawlID = shallow(columns[0].render('54325423aef7890543', { stage: 'process' }));

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -28,7 +28,7 @@ import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
 
 export const CrawlRequestsTable: React.FC = () => {
   const { events } = useValues(CrawlerLogic);
-  const { fetchCrawlRequest, openFlyout } = useActions(CrawlDetailLogic);
+  const { fetchCrawlEvent, openFlyout } = useActions(CrawlDetailLogic);
 
   const columns: Array<EuiBasicTableColumn<CrawlEvent>> = [
     {
@@ -44,7 +44,7 @@ export const CrawlRequestsTable: React.FC = () => {
           return (
             <EuiLink
               onClick={() => {
-                fetchCrawlRequest(id);
+                fetchCrawlEvent(id);
                 openFlyout();
               }}
             >

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -13,26 +13,31 @@ import { nextTick } from '@kbn/test/jest';
 import { itShowsServerErrorAsFlashMessage } from '../../../test_helpers';
 
 import { CrawlDetailLogic, CrawlDetailValues } from './crawl_detail_logic';
-import { CrawlerStatus, CrawlRequestFromServer } from './types';
-import { crawlRequestServerToClient } from './utils';
+import { CrawlerStatus, CrawlEventFromServer, CrawlType } from './types';
+import { crawlEventServerToClient } from './utils';
 
 const DEFAULT_VALUES: CrawlDetailValues = {
   dataLoading: true,
   flyoutClosed: true,
-  crawlRequest: null,
-  crawlRequestFromServer: null,
+  crawlEvent: null,
+  crawlEventFromServer: null,
   selectedTab: 'preview',
 };
 
-const crawlRequestResponse: CrawlRequestFromServer = {
+const crawlEventResponse: CrawlEventFromServer = {
   id: '12345',
   status: CrawlerStatus.Pending,
   created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
   began_at: null,
   completed_at: null,
+  stage: 'crawl',
+  type: CrawlType.Full,
+  crawl_config: {
+    domain_allowlist: [],
+  },
 };
 
-const clientCrawlRequest = crawlRequestServerToClient(crawlRequestResponse);
+const clientCrawlEvent = crawlEventServerToClient(crawlEventResponse);
 
 describe('CrawlDetailLogic', () => {
   const { mount } = new LogicMounter(CrawlDetailLogic);
@@ -61,20 +66,20 @@ describe('CrawlDetailLogic', () => {
       });
     });
 
-    describe('onRecieveCrawlRequest', () => {
+    describe('onRecieveCrawlEvent', () => {
       it('saves the crawl request and sets data loading to false', () => {
         mount({
           dataLoading: true,
           request: null,
         });
 
-        CrawlDetailLogic.actions.onRecieveCrawlRequest(crawlRequestResponse);
+        CrawlDetailLogic.actions.onRecieveCrawlEvent(crawlEventResponse);
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
           dataLoading: false,
-          crawlRequestFromServer: crawlRequestResponse,
-          crawlRequest: clientCrawlRequest,
+          crawlEventFromServer: crawlEventResponse,
+          crawlEvent: clientCrawlEvent,
         });
       });
     });
@@ -111,13 +116,13 @@ describe('CrawlDetailLogic', () => {
       });
     });
 
-    describe('fetchCrawlRequest', () => {
+    describe('fetchCrawlEvent', () => {
       it('sets loading to true', () => {
         mount({
           dataLoading: false,
         });
 
-        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
+        CrawlDetailLogic.actions.fetchCrawlEvent('12345');
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
@@ -127,24 +132,24 @@ describe('CrawlDetailLogic', () => {
 
       it('updates logic with data that has been converted from server to client', async () => {
         mount();
-        jest.spyOn(CrawlDetailLogic.actions, 'onRecieveCrawlRequest');
+        jest.spyOn(CrawlDetailLogic.actions, 'onRecieveCrawlEvent');
 
-        http.get.mockReturnValueOnce(Promise.resolve(crawlRequestResponse));
+        http.get.mockReturnValueOnce(Promise.resolve(crawlEventResponse));
 
-        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
+        CrawlDetailLogic.actions.fetchCrawlEvent('12345');
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith(
           '/internal/app_search/engines/some-engine/crawler/crawl_requests/12345'
         );
-        expect(CrawlDetailLogic.actions.onRecieveCrawlRequest).toHaveBeenCalledWith(
-          crawlRequestResponse
+        expect(CrawlDetailLogic.actions.onRecieveCrawlEvent).toHaveBeenCalledWith(
+          crawlEventResponse
         );
       });
 
       itShowsServerErrorAsFlashMessage(http.get, () => {
         mount();
-        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
+        CrawlDetailLogic.actions.fetchCrawlEvent('12345');
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -12,14 +12,14 @@ import { flashAPIErrors } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlRequest, CrawlRequestFromServer } from './types';
-import { crawlRequestServerToClient } from './utils';
+import { CrawlEvent, CrawlEventFromServer } from './types';
+import { crawlEventServerToClient } from './utils';
 
 type CrawlDetailFlyoutTabs = 'preview' | 'json';
 
 export interface CrawlDetailValues {
-  crawlRequest: CrawlRequest | null;
-  crawlRequestFromServer: CrawlRequestFromServer | null;
+  crawlEvent: CrawlEvent | null;
+  crawlEventFromServer: CrawlEventFromServer | null;
   dataLoading: boolean;
   flyoutClosed: boolean;
   selectedTab: CrawlDetailFlyoutTabs;
@@ -27,9 +27,9 @@ export interface CrawlDetailValues {
 
 export interface CrawlDetailActions {
   closeFlyout(): void;
-  fetchCrawlRequest(requestId: string): { requestId: string };
-  onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {
-    crawlRequestFromServer: CrawlRequestFromServer;
+  fetchCrawlEvent(requestId: string): { requestId: string };
+  onRecieveCrawlEvent(crawlEventFromServer: CrawlEventFromServer): {
+    crawlEventFromServer: CrawlEventFromServer;
   };
   openFlyout(): void;
   setSelectedTab(selectedTab: CrawlDetailFlyoutTabs): { selectedTab: CrawlDetailFlyoutTabs };
@@ -39,30 +39,30 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
   path: ['enterprise_search', 'app_search', 'crawler', 'crawl_detail_logic'],
   actions: {
     closeFlyout: true,
-    fetchCrawlRequest: (requestId) => ({ requestId }),
-    onRecieveCrawlRequest: (crawlRequestFromServer) => ({ crawlRequestFromServer }),
+    fetchCrawlEvent: (requestId) => ({ requestId }),
+    onRecieveCrawlEvent: (crawlEventFromServer) => ({ crawlEventFromServer }),
     openFlyout: true,
     setSelectedTab: (selectedTab) => ({ selectedTab }),
   },
   reducers: {
-    crawlRequest: [
+    crawlEvent: [
       null,
       {
-        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) =>
-          crawlRequestServerToClient(crawlRequestFromServer),
+        onRecieveCrawlEvent: (_, { crawlEventFromServer }) =>
+          crawlEventServerToClient(crawlEventFromServer),
       },
     ],
-    crawlRequestFromServer: [
+    crawlEventFromServer: [
       null,
       {
-        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) => crawlRequestFromServer,
+        onRecieveCrawlEvent: (_, { crawlEventFromServer }) => crawlEventFromServer,
       },
     ],
     dataLoading: [
       true,
       {
-        fetchCrawlRequest: () => true,
-        onRecieveCrawlRequest: () => false,
+        fetchCrawlEvent: () => true,
+        onRecieveCrawlEvent: () => false,
       },
     ],
     flyoutClosed: [
@@ -81,16 +81,16 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
     ],
   },
   listeners: ({ actions }) => ({
-    fetchCrawlRequest: async ({ requestId }) => {
+    fetchCrawlEvent: async ({ requestId }) => {
       const { http } = HttpLogic.values;
       const { engineName } = EngineLogic.values;
 
       try {
-        const response = await http.get<CrawlRequestFromServer>(
+        const response = await http.get<CrawlEventFromServer>(
           `/internal/app_search/engines/${engineName}/crawler/crawl_requests/${requestId}`
         );
 
-        actions.onRecieveCrawlRequest(response);
+        actions.onRecieveCrawlEvent(response);
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import typeDetect from 'type-detect';
-
 import { i18n } from '@kbn/i18n';
 
 export enum CrawlerPolicies {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import typeDetect from 'type-detect';
+
 import { i18n } from '@kbn/i18n';
 
 export enum CrawlerPolicies {
@@ -208,27 +210,17 @@ export interface CrawlConfig {
 export interface CrawlConfigFromServer {
   domain_allowlist: string[];
 }
-export interface CrawlEventFromServer {
-  id: string;
+export type CrawlEventFromServer = CrawlRequestFromServer & {
   stage: CrawlEventStage;
-  status: CrawlerStatus;
-  created_at: string;
-  began_at: string | null;
-  completed_at: string | null;
   type: CrawlType;
   crawl_config: CrawlConfigFromServer;
-}
+};
 
-export interface CrawlEvent {
-  id: string;
+export type CrawlEvent = CrawlRequest & {
   stage: CrawlEventStage;
-  status: CrawlerStatus;
-  createdAt: string;
-  beganAt: string | null;
-  completedAt: string | null;
   type: CrawlType;
   crawlConfig: CrawlConfig;
-}
+};
 
 export const readableCrawlerStatuses: { [key in CrawlerStatus]: string } = {
   [CrawlerStatus.Pending]: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -90,25 +90,14 @@ export function crawlConfigServerToClient(crawlConfig: CrawlConfigFromServer): C
   };
 }
 
-export function crawlerEventServerToClient(event: CrawlEventFromServer): CrawlEvent {
-  const {
-    id,
-    stage,
-    status,
-    created_at: createdAt,
-    began_at: beganAt,
-    completed_at: completedAt,
-    type,
-    crawl_config: crawlConfig,
-  } = event;
+export function crawlEventServerToClient(event: CrawlEventFromServer): CrawlEvent {
+  const clientCrawlRequest = crawlRequestServerToClient(event as CrawlRequestFromServer);
+
+  const { stage, type, crawl_config: crawlConfig } = event;
 
   return {
-    id,
+    ...clientCrawlRequest,
     stage,
-    status,
-    createdAt,
-    beganAt,
-    completedAt,
     type,
     crawlConfig: crawlConfigServerToClient(crawlConfig),
   };
@@ -119,7 +108,7 @@ export function crawlerDataServerToClient(payload: CrawlerDataFromServer): Crawl
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
-    events: events.map((event) => crawlerEventServerToClient(event)),
+    events: events.map((event) => crawlEventServerToClient(event)),
     mostRecentCrawlRequest:
       mostRecentCrawlRequest && crawlRequestServerToClient(mostRecentCrawlRequest),
   };


### PR DESCRIPTION
## Summary

The crawl detail flyout needs all the props available in `CrawlEvent` not just `CrawlRequest`. UX as currently implemented is unchanged, this is prep for a future PR adding more content to the `CrawlDetailsFlyout` Preview tab

## QA

Requires running the latest `main` branch of the Enterprise Search standalone application, 