### PR TITLE
[7.16] [APM] Check kibana advanced settings to set comparison enabled (#119484)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/MaybeViewTraceLink.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/MaybeViewTraceLink.tsx
@@ -25,7 +25,7 @@ export function MaybeViewTraceLink({
   environment: Environment;
 }) {
   const {
-    urlParams: { latencyAggregationType },
+    urlParams: { latencyAggregationType, comparisonEnabled, comparisonType },
   } = useUrlParams();
 
   const viewFullTraceButtonLabel = i18n.translate(
@@ -94,6 +94,8 @@ export function MaybeViewTraceLink({
           transactionType={rootTransaction.transaction.type}
           environment={nextEnvironment}
           latencyAggregationType={latencyAggregationType}
+          comparisonEnabled={comparisonEnabled}
+          comparisonType={comparisonType}
         >
           <EuiButton fill iconType="apmTrace">
             {viewFullTraceButtonLabel}

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/FlyoutTopLevelProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/FlyoutTopLevelProperties.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 export function FlyoutTopLevelProperties({ transaction }: Props) {
   const {
-    urlParams: { latencyAggregationType },
+    urlParams: { latencyAggregationType, comparisonEnabled, comparisonType },
   } = useUrlParams();
   const { query } = useApmParams('/services/{serviceName}/transactions/view');
 
@@ -67,6 +67,8 @@ export function FlyoutTopLevelProperties({ transaction }: Props) {
           transactionType={transaction.transaction.type}
           environment={nextEnvironment}
           latencyAggregationType={latencyAggregationType}
+          comparisonEnabled={comparisonEnabled}
+          comparisonType={comparisonType}
         >
           {transaction.transaction.name}
         </TransactionDetailLink>

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/span_flyout/sticky_span_properties.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/Waterfall/span_flyout/sticky_span_properties.tsx
@@ -34,7 +34,12 @@ interface Props {
 
 export function StickySpanProperties({ span, transaction }: Props) {
   const { query } = useApmParams('/services/{serviceName}/transactions/view');
-  const { environment, latencyAggregationType } = query;
+  const {
+    environment,
+    latencyAggregationType,
+    comparisonEnabled,
+    comparisonType,
+  } = query;
 
   const trackEvent = useUiTracker();
 
@@ -82,6 +87,8 @@ export function StickySpanProperties({ span, transaction }: Props) {
               transactionType={transaction.transaction.type}
               environment={nextEnvironment}
               latencyAggregationType={latencyAggregationType}
+              comparisonEnabled={comparisonEnabled}
+              comparisonType={comparisonType}
             >
               {transaction.transaction.name}
             </TransactionDetailLink>

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/transaction_detail_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/transaction_detail_link.tsx
@@ -18,6 +18,7 @@ import {
   TimeRangeComparisonEnum,
   TimeRangeComparisonType,
 } from '../../../../../common/runtime_types/comparison_type_rt';
+import { getComparisonEnabled } from '../../time_comparison/get_comparison_enabled';
 
 interface Props extends APMLinkExtendProps {
   serviceName: string;
@@ -44,12 +45,16 @@ export function TransactionDetailLink({
   transactionType,
   latencyAggregationType,
   environment,
-  comparisonEnabled = true,
+  comparisonEnabled,
   comparisonType = TimeRangeComparisonEnum.DayBefore,
   ...rest
 }: Props) {
   const { urlParams } = useUrlParams();
   const { core } = useApmPluginContext();
+  const defaultComparisonEnabled = getComparisonEnabled({
+    core,
+    urlComparisonEnabled: comparisonEnabled,
+  });
   const location = useLocation();
   const href = getAPMHref({
     basePath: core.http.basePath,
@@ -59,7 +64,7 @@ export function TransactionDetailLink({
       transactionId,
       transactionName,
       transactionType,
-      comparisonEnabled,
+      comparisonEnabled: defaultComparisonEnabled,
       comparisonType,
       ...pickKeys(urlParams as APMQueryParams, ...persistedFilters),
       ...pickBy({ latencyAggregationType, environment }, identity),


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [APM] Check kibana advanced settings to set comparison enabled (#119484)