### PR TITLE
[Maps] fix creating filter from array fields

### DIFF
--- a/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.test.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.test.ts
@@ -110,11 +110,10 @@ describe('getESFilters', () => {
 
   test('Should return phrase filters when field value is an array', async () => {
     const esTooltipProperty = new ESTooltipProperty(
-      new TooltipProperty(
-        featurePropertyField.getName(),
-        await featurePropertyField.getLabel(),
-        ['my value', 'my other value']
-      ),
+      new TooltipProperty(featurePropertyField.getName(), await featurePropertyField.getLabel(), [
+        'my value',
+        'my other value',
+      ]),
       indexPattern,
       featurePropertyField,
       APPLY_GLOBAL_QUERY

--- a/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.test.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.test.ts
@@ -108,6 +108,41 @@ describe('getESFilters', () => {
     ]);
   });
 
+  test('Should return phrase filters when field value is an array', async () => {
+    const esTooltipProperty = new ESTooltipProperty(
+      new TooltipProperty(
+        featurePropertyField.getName(),
+        await featurePropertyField.getLabel(),
+        ['my value', 'my other value']
+      ),
+      indexPattern,
+      featurePropertyField,
+      APPLY_GLOBAL_QUERY
+    );
+    expect(await esTooltipProperty.getESFilters()).toEqual([
+      {
+        meta: {
+          index: 'indexPatternId',
+        },
+        query: {
+          match_phrase: {
+            ['machine.os']: 'my value',
+          },
+        },
+      },
+      {
+        meta: {
+          index: 'indexPatternId',
+        },
+        query: {
+          match_phrase: {
+            ['machine.os']: 'my other value',
+          },
+        },
+      },
+    ]);
+  });
+
   test('Should return NOT exists filter for null values', async () => {
     const esTooltipProperty = new ESTooltipProperty(
       new TooltipProperty(

--- a/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
@@ -96,13 +96,16 @@ export class ESTooltipProperty implements ITooltipProperty {
       return [];
     }
 
-    const value = this.getRawValue();
-    if (value == null) {
+    const rawValue = this.getRawValue();
+    if (rawValue == null) {
       const existsFilter = esFilters.buildExistsFilter(indexPatternField, this._indexPattern);
       existsFilter.meta.negate = true;
       return [existsFilter];
     } else {
-      return [esFilters.buildPhraseFilter(indexPatternField, value as string, this._indexPattern)];
+      const values = Array.isArray(rawValue) ? rawValue as string[] : [rawValue as string];
+      return values.map(value => {
+        return esFilters.buildPhraseFilter(indexPatternField, value as string, this._indexPattern);
+      });
     }
   }
 }

--- a/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
@@ -102,8 +102,8 @@ export class ESTooltipProperty implements ITooltipProperty {
       existsFilter.meta.negate = true;
       return [existsFilter];
     } else {
-      const values = Array.isArray(rawValue) ? rawValue as string[] : [rawValue as string];
-      return values.map(value => {
+      const values = Array.isArray(rawValue) ? (rawValue as string[]) : [rawValue as string];
+      return values.map((value) => {
         return esFilters.buildPhraseFilter(indexPatternField, value as string, this._indexPattern);
       });
     }

--- a/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
+++ b/x-pack/plugins/maps/public/classes/tooltips/es_tooltip_property.ts
@@ -104,7 +104,7 @@ export class ESTooltipProperty implements ITooltipProperty {
     } else {
       const values = Array.isArray(rawValue) ? (rawValue as string[]) : [rawValue as string];
       return values.map((value) => {
-        return esFilters.buildPhraseFilter(indexPatternField, value as string, this._indexPattern);
+        return esFilters.buildPhraseFilter(indexPatternField, value, this._indexPattern);
       });
     }
   }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/94736 and https://github.com/elastic/kibana/issues/87864

Create multiple match_phrase filter when value is an array. This mirrors the filtering experience of Discover.