### PR TITLE
[Security Solution] remove page defaults from security solution plugin config

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -354,8 +354,6 @@ kibana_vars=(
     xpack.security.showInsecureClusterWarning
     xpack.securitySolution.alertMergeStrategy
     xpack.securitySolution.alertIgnoreFields
-    xpack.securitySolution.endpointResultListDefaultFirstPageIndex
-    xpack.securitySolution.endpointResultListDefaultPageSize
     xpack.securitySolution.maxRuleImportExportSize
     xpack.securitySolution.maxRuleImportPayloadBytes
     xpack.securitySolution.maxTimelineImportExportSize

--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -65,3 +65,6 @@ export const ENDPOINT_ACTION_LOG_ROUTE = `/api/endpoint/action_log/{agent_id}`;
 export const ACTION_STATUS_ROUTE = `/api/endpoint/action_status`;
 
 export const failedFleetActionErrorCode = '424';
+
+export const ENDPOINT_DEFAULT_PAGE = 0;
+export const ENDPOINT_DEFAULT_PAGE_SIZE = 10;

--- a/x-pack/plugins/security_solution/common/endpoint/schema/metadata.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/metadata.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { ENDPOINT_DEFAULT_PAGE, ENDPOINT_DEFAULT_PAGE_SIZE } from '../constants';
 import { HostStatus } from '../types';
 import { GetMetadataListRequestSchemaV2 } from './metadata';
 
@@ -23,7 +24,7 @@ describe('endpoint metadata schema', () => {
     });
 
     it('should correctly use default values', () => {
-      const expected = { page: 0, pageSize: 10 };
+      const expected = { page: ENDPOINT_DEFAULT_PAGE, pageSize: ENDPOINT_DEFAULT_PAGE_SIZE };
       expect(query.validate(undefined)).toEqual(expected);
       expect(query.validate({ page: undefined })).toEqual(expected);
       expect(query.validate({ pageSize: undefined })).toEqual(expected);
@@ -56,7 +57,11 @@ describe('endpoint metadata schema', () => {
 
     it('should work with valid hostStatus', () => {
       const queryParams = { hostStatuses: [HostStatus.HEALTHY, HostStatus.UPDATING] };
-      const expected = { page: 0, pageSize: 10, ...queryParams };
+      const expected = {
+        page: ENDPOINT_DEFAULT_PAGE,
+        pageSize: ENDPOINT_DEFAULT_PAGE_SIZE,
+        ...queryParams,
+      };
       expect(query.validate(queryParams)).toEqual(expected);
     });
 

--- a/x-pack/plugins/security_solution/common/endpoint/schema/metadata.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/metadata.ts
@@ -6,13 +6,14 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
+import { ENDPOINT_DEFAULT_PAGE, ENDPOINT_DEFAULT_PAGE_SIZE } from '../constants';
 import { HostStatus } from '../types';
 
 export const GetMetadataListRequestSchemaV2 = {
   query: schema.object(
     {
-      page: schema.number({ defaultValue: 0, min: 0 }),
-      pageSize: schema.number({ defaultValue: 10, min: 1, max: 10000 }),
+      page: schema.number({ defaultValue: ENDPOINT_DEFAULT_PAGE, min: 0 }),
+      pageSize: schema.number({ defaultValue: ENDPOINT_DEFAULT_PAGE_SIZE, min: 1, max: 10000 }),
       kuery: schema.maybe(schema.string()),
       hostStatuses: schema.maybe(
         schema.arrayOf(
@@ -26,7 +27,7 @@ export const GetMetadataListRequestSchemaV2 = {
         )
       ),
     },
-    { defaultValue: { page: 0, pageSize: 10 } }
+    { defaultValue: { page: ENDPOINT_DEFAULT_PAGE, pageSize: ENDPOINT_DEFAULT_PAGE_SIZE } }
   ),
 };
 

--- a/x-pack/plugins/security_solution/server/config.mock.ts
+++ b/x-pack/plugins/security_solution/server/config.mock.ts
@@ -23,8 +23,6 @@ export const createMockConfig = (): ConfigType => {
     maxTimelineImportExportSize: 10000,
     maxTimelineImportPayloadBytes: 10485760,
     enableExperimental,
-    endpointResultListDefaultFirstPageIndex: 0,
-    endpointResultListDefaultPageSize: 10,
     packagerTaskInterval: '60s',
     alertMergeStrategy: 'missingFields',
     alertIgnoreFields: [],

--- a/x-pack/plugins/security_solution/server/config.ts
+++ b/x-pack/plugins/security_solution/server/config.ts
@@ -119,12 +119,6 @@ export const configSchema = schema.object({
   }),
 
   /**
-   * Host Endpoint Configuration
-   */
-  endpointResultListDefaultFirstPageIndex: schema.number({ defaultValue: 0 }),
-  endpointResultListDefaultPageSize: schema.number({ defaultValue: 10 }),
-
-  /**
    * Artifacts Configuration
    */
   packagerTaskInterval: schema.string({ defaultValue: '60s' }),

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -38,6 +38,10 @@ import { EndpointError, NotFoundError } from '../../errors';
 import { EndpointHostUnEnrolledError } from '../../services/metadata';
 import { CustomHttpRequestError } from '../../../utils/custom_http_request_error';
 import { GetMetadataListRequestQuery } from '../../../../common/endpoint/schema/metadata';
+import {
+  ENDPOINT_DEFAULT_PAGE,
+  ENDPOINT_DEFAULT_PAGE_SIZE,
+} from '../../../../common/endpoint/constants';
 
 export interface MetadataRequestContext {
   esClient?: IScopedClusterClient;
@@ -185,9 +189,6 @@ export function getMetadataListRequestHandlerV2(
       didUnitedIndexError = true;
     }
 
-    const { endpointResultListDefaultPageSize, endpointResultListDefaultFirstPageIndex } =
-      await endpointAppContext.config();
-
     // If no unified Index present, then perform a search using the legacy approach
     if (!doesUnitedIndexExist || didUnitedIndexError) {
       const endpointPolicies = await getAllEndpointPackagePolicies(
@@ -205,8 +206,8 @@ export function getMetadataListRequestHandlerV2(
       body = {
         data: legacyResponse.hosts,
         total: legacyResponse.total,
-        page: request.query.page || endpointResultListDefaultFirstPageIndex,
-        pageSize: request.query.pageSize || endpointResultListDefaultPageSize,
+        page: request.query.page || ENDPOINT_DEFAULT_PAGE,
+        pageSize: request.query.pageSize || ENDPOINT_DEFAULT_PAGE_SIZE,
       };
       return response.ok({ body });
     }
@@ -221,8 +222,8 @@ export function getMetadataListRequestHandlerV2(
       body = {
         data,
         total,
-        page: request.query.page || endpointResultListDefaultFirstPageIndex,
-        pageSize: request.query.pageSize || endpointResultListDefaultPageSize,
+        page: request.query.page || ENDPOINT_DEFAULT_PAGE,
+        pageSize: request.query.pageSize || ENDPOINT_DEFAULT_PAGE_SIZE,
       };
     } catch (error) {
       return errorHandler(logger, response, error);
@@ -422,11 +423,9 @@ async function legacyListMetadataQuery(
     queryOptions?.hostStatuses || []
   );
 
-  const { endpointResultListDefaultPageSize, endpointResultListDefaultFirstPageIndex } =
-    await endpointAppContext.config();
   const queryParams = await kibanaRequestToMetadataListESQuery({
-    page: queryOptions?.page || endpointResultListDefaultFirstPageIndex,
-    pageSize: queryOptions?.pageSize || endpointResultListDefaultPageSize,
+    page: queryOptions?.page || ENDPOINT_DEFAULT_PAGE,
+    pageSize: queryOptions?.pageSize || ENDPOINT_DEFAULT_PAGE_SIZE,
     kuery: queryOptions?.kuery || '',
     unenrolledAgentIds,
     statusAgentIds,

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -17,6 +17,8 @@ import {
 } from './handlers';
 import type { SecuritySolutionPluginRouter } from '../../../types';
 import {
+  ENDPOINT_DEFAULT_PAGE,
+  ENDPOINT_DEFAULT_PAGE_SIZE,
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
 } from '../../../../common/endpoint/constants';
@@ -52,12 +54,18 @@ export const GetMetadataListRequestSchema = {
              * the number of results to return for this request per page
              */
             schema.object({
-              page_size: schema.number({ defaultValue: 10, min: 1, max: 10000 }),
+              page_size: schema.number({
+                defaultValue: ENDPOINT_DEFAULT_PAGE_SIZE,
+                min: 1,
+                max: 10000,
+              }),
             }),
             /**
              * the zero based page index of the the total number of pages of page size
              */
-            schema.object({ page_index: schema.number({ defaultValue: 0, min: 0 }) }),
+            schema.object({
+              page_index: schema.number({ defaultValue: ENDPOINT_DEFAULT_PAGE, min: 0 }),
+            }),
           ])
         )
       ),

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/query_builders.ts
@@ -8,6 +8,8 @@
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import {
+  ENDPOINT_DEFAULT_PAGE,
+  ENDPOINT_DEFAULT_PAGE_SIZE,
   metadataCurrentIndexPattern,
   METADATA_UNITED_INDEX,
 } from '../../../../common/endpoint/constants';
@@ -78,7 +80,6 @@ export async function getPagingProperties(
   request: KibanaRequest<any, any, any>,
   endpointAppContext: EndpointAppContext
 ) {
-  const config = await endpointAppContext.config();
   const pagingProperties: { page_size?: number; page_index?: number } = {};
   if (request?.body?.paging_properties) {
     for (const property of request.body.paging_properties) {
@@ -89,8 +90,8 @@ export async function getPagingProperties(
     }
   }
   return {
-    pageSize: pagingProperties.page_size || config.endpointResultListDefaultPageSize,
-    pageIndex: pagingProperties.page_index ?? config.endpointResultListDefaultFirstPageIndex,
+    pageSize: pagingProperties.page_size || ENDPOINT_DEFAULT_PAGE_SIZE,
+    pageIndex: pagingProperties.page_index || ENDPOINT_DEFAULT_PAGE,
   };
 }
 
@@ -236,7 +237,12 @@ export async function buildUnitedIndexQuery(
   queryOptions: GetMetadataListRequestQuery,
   endpointPolicyIds: string[] = []
 ): Promise<BuildUnitedIndexQueryResponse> {
-  const { page = 0, pageSize = 10, hostStatuses = [], kuery = '' } = queryOptions || {};
+  const {
+    page = ENDPOINT_DEFAULT_PAGE,
+    pageSize = ENDPOINT_DEFAULT_PAGE_SIZE,
+    hostStatuses = [],
+    kuery = '',
+  } = queryOptions || {};
 
   const statusesKuery = buildStatusesKuery(hostStatuses);
 


### PR DESCRIPTION
## Summary

Removing unnecessary security solution plugin configs. Discussed here: https://github.com/elastic/kibana/pull/119123#discussion_r755283119.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] (removed from allowlist) If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)


### Risk Matrix


Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
