### PR TITLE
[8.0] [UA] Remove index_mapper_dynamic setting when reindexing and remove duped copy from header

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecations.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecations.tsx
@@ -46,7 +46,7 @@ const i18nTexts = {
   }),
   pageDescription: i18n.translate('xpack.upgradeAssistant.esDeprecations.pageDescription', {
     defaultMessage:
-      'Resolve all critical issues before upgrading. Before making changes, ensure you have a current snapshot of your cluster. Indices created before 7.0 must be reindexed or removed. To start multiple reindexing tasks in a single request, use the Kibana batch reindexing API.',
+      'Resolve all critical issues before upgrading. Before making changes, ensure you have a current snapshot of your cluster. Indices created before 7.0 must be reindexed or removed.',
   }),
   isLoading: i18n.translate('xpack.upgradeAssistant.esDeprecations.loadingText', {
     defaultMessage: 'Loading deprecation issues…',
@@ -136,8 +136,7 @@ export const EsDeprecations = withRouter(({ history }: RouteComponentProps) => {
         pageTitle={i18nTexts.pageTitle}
         description={
           <>
-            {i18nTexts.pageDescription}
-            {getBatchReindexLink(docLinks)}
+            {i18nTexts.pageDescription} {getBatchReindexLink(docLinks)}
           </>
         }
       >

--- a/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.test.ts
@@ -64,6 +64,7 @@ describe('transformFlatSettings', () => {
           'index.verified_before_close': 'true',
           'index.version.created': '123123',
           'index.version.upgraded': '123123',
+          'index.mapper.dynamic': 'true',
 
           // Deprecated settings
           'index.force_memory_term_dictionary': '1024',

--- a/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts
@@ -178,6 +178,9 @@ const removeUnsettableSettings = (settings: FlatSettings['settings']) =>
     'index.verified_before_close',
     'index.version.created',
 
+    // Ignored since 6.x and forbidden in 7.x
+    'index.mapper.dynamic',
+
     // Deprecated in 9.0
     'index.version.upgraded',
   ]);


### PR DESCRIPTION
Backports the following commits to main:

* https://github.com/elastic/kibana/pull/119441
* https://github.com/elastic/kibana/pull/119476