### PR TITLE
[8.0] [ML] APM Correlations: Fix tooltip values for 0 workaround. (#119479)

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_distribution_chart/index.tsx
@@ -267,6 +267,14 @@ export function TransactionDistributionChart({
               yAccessors={['doc_count']}
               color={areaSeriesColors[i]}
               fit="lookahead"
+              // To make the area appear without the orphaned points technique,
+              // we changed the original data to replace values of 0 with 0.0001.
+              // To show the correct values again in tooltips, we use a custom tickFormat to round values.
+              // We can safely do this because all transaction values above 0 are without decimal points anyway.
+              // An update for Elastic Charts is in the works to be able to customize the above "fit"
+              // attribute. Once that is available we can get rid of the full workaround.
+              // Elastic Charts issue: https://github.com/elastic/elastic-charts/issues/1489
+              tickFormat={(p) => `${Math.round(p)}`}
             />
           ))}
         </Chart>


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [ML] APM Correlations: Fix tooltip values for 0 workaround. (#119479)