### PR TITLE
[ML] Functional tests - stabilize Discover custom URL test

### DIFF
--- a/x-pack/test/functional/services/ml/custom_urls.ts
+++ b/x-pack/test/functional/services/ml/custom_urls.ts
@@ -16,6 +16,7 @@ export function MachineLearningCustomUrlsProvider({
   getService,
   getPageObjects,
 }: FtrProviderContext) {
+  const browser = getService('browser');
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
   const comboBox = getService('comboBox');
@@ -169,6 +170,9 @@ export function MachineLearningCustomUrlsProvider({
 
     async assertDiscoverCustomUrlAction(expectedHitCountFormatted: string) {
       await PageObjects.discover.waitForDiscoverAppOnScreen();
+      // Make sure all existing popovers are closed
+      await browser.pressKeys(browser.keys.ESCAPE);
+
       // During cloud tests, the small browser width might cause hit count to be invisible
       // so temporarily collapsing the sidebar ensures the count shows
       await PageObjects.discover.closeSidebar();


### PR DESCRIPTION
## Summary

This PR stabilizes the Discover custom URL test by making sure all popover are closed before clicking the Discover hide side bar button.

Closes #119273
