### PR TITLE
Functional tests - adjust userMenu timeout

### DIFF
--- a/x-pack/test/functional/services/user_menu.js
+++ b/x-pack/test/functional/services/user_menu.js
@@ -45,7 +45,7 @@ export function UserMenuProvider({ getService }) {
 
       await retry.try(async () => {
         await testSubjects.click('userMenuButton');
-        await testSubjects.existOrFail('userMenu');
+        await testSubjects.existOrFail('userMenu', { timeout: 2500 });
       });
     }
   })();


### PR DESCRIPTION
## Summary

This PR stabilizes the login during functional tests by adjusting the timeout for the opened user menu.

### Details

The `existOrFail` default timeout changed some time ago from 2.5 seconds to 120 seconds. The wrapping `retry.try` also has a default timeout of 120 seconds, so in case the button click didn't come through / was sent too early after page load, it just times out on the user menu wait and doesn't try to click the button again. With this PR, the old timeout of 2.5 seconds is explicitly provided, so it can actually retry the button click.

Closes #113079
Closes #116877
Closes #116552
Closes #109460
Closes #111600
Closes #112317
Closes #112318
Closes #112323
Closes #110418
Closes #112517