### PR TITLE
[Fleet] Update naming in duplicate integration policy error message

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -105,7 +105,7 @@ class PackagePolicyService {
 
     // Check that the name does not exist already
     if (existingPoliciesWithName.items.length > 0) {
-      throw new IngestManagerError('There is already a package with the same name');
+      throw new IngestManagerError('There is already an integration policy with the same name');
     }
     let elasticsearch: PackagePolicy['elasticsearch'];
     // Add ids to stream
@@ -366,7 +366,7 @@ class PackagePolicyService {
     const filtered = (existingPoliciesWithName?.items || []).filter((p) => p.id !== id);
 
     if (filtered.length > 0) {
-      throw new IngestManagerError('There is already a package with the same name');
+      throw new IngestManagerError('There is already an integration policy with the same name');
     }
 
     let inputs = restOfPackagePolicy.inputs.map((input) =>


### PR DESCRIPTION
## Summary

Update error message on duplicate policy to be consistent with naming elsewhere.

Fixes https://github.com/elastic/kibana/issues/119428

![image](https://user-images.githubusercontent.com/6766512/143260677-80f330dc-fe5e-4071-b91e-909e4cc698a4.png)

