### PR TITLE
chore(NA): bump chromedriver to v96.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -664,7 +664,7 @@
     "callsites": "^3.1.0",
     "chai": "3.5.0",
     "chance": "1.0.18",
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^96.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "cmd-shim": "^2.1.0",
     "compression-webpack-plugin": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9760,10 +9760,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^95.0.0:
-  version "95.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-95.0.0.tgz#ecf854cac6df5137a651dcc132edf55612d3db7f"
-  integrity sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==
+chromedriver@^96.0.0:
+  version "96.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
+  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.2"


### PR DESCRIPTION
This PR simply bumps the. chromedriver version to `v96.0.0` has it recently got an update.