### PR TITLE
fix uptime config key

### DIFF
--- a/x-pack/plugins/uptime/server/lib/saved_objects/saved_objects.ts
+++ b/x-pack/plugins/uptime/server/lib/saved_objects/saved_objects.ts
@@ -28,7 +28,7 @@ export const registerUptimeSavedObjects = (
 ) => {
   savedObjectsService.registerType(umDynamicSettings);
 
-  if (config?.unsafe.service.enabled) {
+  if (config?.unsafe?.service.enabled) {
     savedObjectsService.registerType(syntheticsMonitor);
   }
 };


### PR DESCRIPTION
Fixes: https://github.com/elastic/uptime/issues/419

## Summary

Fixes a condition where if 

`xpack.uptime.index: remote_cluster:heartbeat-*` was used

and service config key wasn't, it was throwing error on kibana server