### PR TITLE
[build] automatically retry all downloads

### DIFF
--- a/src/dev/build/lib/download.ts
+++ b/src/dev/build/lib/download.ts
@@ -8,11 +8,12 @@
 
 import { openSync, writeSync, unlinkSync, closeSync } from 'fs';
 import { dirname } from 'path';
+import { setTimeout } from 'timers/promises';
 
 import chalk from 'chalk';
 import { createHash } from 'crypto';
 import Axios from 'axios';
-import { ToolingLog } from '@kbn/dev-utils';
+import { ToolingLog, isAxiosResponseError } from '@kbn/dev-utils';
 
 // https://github.com/axios/axios/tree/ffea03453f77a8176c51554d5f6c3c6829294649/lib/adapters
 // @ts-expect-error untyped internal module used to prevent axios from using xhr adapter in tests
@@ -30,81 +31,151 @@ function tryUnlink(path: string) {
   }
 }
 
-interface DownloadOptions {
+interface DownloadToDiskOptions {
   log: ToolingLog;
   url: string;
   destination: string;
   shaChecksum: string;
   shaAlgorithm: string;
-  retries?: number;
+  maxAttempts?: number;
+  retryDelaySecMultiplier?: number;
 }
-export async function download(options: DownloadOptions): Promise<void> {
-  const { log, url, destination, shaChecksum, shaAlgorithm, retries = 0 } = options;
-
+export async function downloadToDisk({
+  log,
+  url,
+  destination,
+  shaChecksum,
+  shaAlgorithm,
+  maxAttempts = 1,
+  retryDelaySecMultiplier = 5,
+}: DownloadToDiskOptions) {
   if (!shaChecksum) {
     throw new Error(`${shaAlgorithm} checksum of ${url} not provided, refusing to download.`);
   }
 
-  // mkdirp and open file outside of try/catch, we don't retry for those errors
-  await mkdirp(dirname(destination));
-  const fileHandle = openSync(destination, 'w');
+  if (maxAttempts < 1) {
+    throw new Error(`[maxAttempts=${maxAttempts}] must be >= 1`);
+  }
 
-  let error;
-  try {
-    log.debug(`Attempting download of ${url}`, chalk.dim(shaAlgorithm));
+  let attempt = 0;
+  while (true) {
+    attempt += 1;
 
-    const response = await Axios.request({
-      url,
-      responseType: 'stream',
-      adapter: AxiosHttpAdapter,
-    });
+    // mkdirp and open file outside of try/catch, we don't retry for those errors
+    await mkdirp(dirname(destination));
+    const fileHandle = openSync(destination, 'w');
 
-    if (response.status !== 200) {
-      throw new Error(`Unexpected status code ${response.status} when downloading ${url}`);
-    }
+    let error;
+    try {
+      log.debug(
+        `[${attempt}/${maxAttempts}] Attempting download of ${url}`,
+        chalk.dim(shaAlgorithm)
+      );
 
-    const hash = createHash(shaAlgorithm);
-    await new Promise((resolve, reject) => {
-      response.data.on('data', (chunk: Buffer) => {
-        hash.update(chunk);
-        writeSync(fileHandle, chunk);
+      const response = await Axios.request({
+        url,
+        responseType: 'stream',
+        adapter: AxiosHttpAdapter,
       });
 
-      response.data.on('error', reject);
-      response.data.on('end', resolve);
-    });
+      if (response.status !== 200) {
+        throw new Error(`Unexpected status code ${response.status} when downloading ${url}`);
+      }
 
-    const downloadedSha = hash.digest('hex');
-    if (downloadedSha !== shaChecksum) {
-      throw new Error(
-        `Downloaded checksum ${downloadedSha} does not match the expected ${shaAlgorithm} checksum.`
-      );
+      const hash = createHash(shaAlgorithm);
+      await new Promise((resolve, reject) => {
+        response.data.on('data', (chunk: Buffer) => {
+          hash.update(chunk);
+          writeSync(fileHandle, chunk);
+        });
+
+        response.data.on('error', reject);
+        response.data.on('end', resolve);
+      });
+
+      const downloadedSha = hash.digest('hex');
+      if (downloadedSha !== shaChecksum) {
+        throw new Error(
+          `Downloaded checksum ${downloadedSha} does not match the expected ${shaAlgorithm} checksum.`
+        );
+      }
+    } catch (_error) {
+      error = _error;
+    } finally {
+      closeSync(fileHandle);
     }
-  } catch (_error) {
-    error = _error;
-  } finally {
-    closeSync(fileHandle);
+
+    if (!error) {
+      log.debug(`Downloaded ${url} and verified checksum`);
+      return;
+    }
+
+    log.debug(`Download failed: ${error.message}`);
+
+    // cleanup downloaded data and log error
+    log.debug(`Deleting downloaded data at ${destination}`);
+    tryUnlink(destination);
+
+    // retry if we have retries left
+    if (attempt < maxAttempts) {
+      const sec = attempt * retryDelaySecMultiplier;
+      log.info(`Retrying in ${sec} seconds`);
+      await setTimeout(sec * 1000);
+      continue;
+    }
+
+    throw error;
   }
+}
 
-  if (!error) {
-    log.debug(`Downloaded ${url} and verified checksum`);
-    return;
+interface DownloadToStringOptions {
+  log: ToolingLog;
+  url: string;
+  expectStatus?: number;
+  maxAttempts?: number;
+  retryDelaySecMultiplier?: number;
+}
+export async function downloadToString({
+  log,
+  url,
+  expectStatus,
+  maxAttempts = 3,
+  retryDelaySecMultiplier = 5,
+}: DownloadToStringOptions) {
+  let attempt = 0;
+  while (true) {
+    try {
+      attempt += 1;
+      log.debug(`[${attempt}/${maxAttempts}] Attempting download to string of [${url}]`);
+
+      const resp = await Axios.request<string>({
+        url,
+        method: 'GET',
+        adapter: AxiosHttpAdapter,
+        responseType: 'text',
+        validateStatus: !expectStatus ? undefined : (status) => status === expectStatus,
+      });
+
+      log.success(`Downloaded [${url}]`);
+      return resp.data;
+    } catch (error) {
+      log.warning(`Download failed: ${error.message}`);
+      if (isAxiosResponseError(error)) {
+        log.debug(
+          `[${error.response.status}/${error.response.statusText}] response: ${error.response.data}`
+        );
+      } else {
+        log.debug('received no response');
+      }
+
+      if ((maxAttempts ?? 3) > attempt) {
+        const sec = (retryDelaySecMultiplier ?? 5) * attempt;
+        log.info(`Retrying in ${sec} seconds`);
+        await setTimeout(sec * 1000);
+        continue;
+      }
+
+      throw error;
+    }
   }
-
-  log.debug(`Download failed: ${error.message}`);
-
-  // cleanup downloaded data and log error
-  log.debug(`Deleting downloaded data at ${destination}`);
-  tryUnlink(destination);
-
-  // retry if we have retries left
-  if (retries > 0) {
-    log.debug(`Retrying - ${retries} attempt remaining`);
-    return await download({
-      ...options,
-      retries: retries - 1,
-    });
-  }
-
-  throw error;
 }

--- a/src/dev/build/lib/integration_tests/download.test.ts
+++ b/src/dev/build/lib/integration_tests/download.test.ts
@@ -13,13 +13,24 @@ import { readFileSync } from 'fs';
 
 import del from 'del';
 import { CI_PARALLEL_PROCESS_PREFIX } from '@kbn/test';
-import { ToolingLog } from '@kbn/dev-utils';
+import {
+  ToolingLog,
+  ToolingLogCollectingWriter,
+  createStripAnsiSerializer,
+  createReplaceSerializer,
+} from '@kbn/dev-utils';
 
 import { mkdirp } from '../fs';
-import { download } from '../download';
+import { downloadToDisk, downloadToString } from '../download';
 
 const TMP_DIR = join(tmpdir(), CI_PARALLEL_PROCESS_PREFIX, 'download-js-test-tmp-dir');
 const TMP_DESTINATION = join(TMP_DIR, '__tmp_download_js_test_file__');
+
+expect.addSnapshotSerializer(createStripAnsiSerializer());
+expect.addSnapshotSerializer(createReplaceSerializer(TMP_DIR, 'TMP_DIR'));
+expect.addSnapshotSerializer(
+  createReplaceSerializer(/http:\/\/localhost:\d+\//g, 'TEST_SERVER_URL')
+);
 
 beforeEach(async () => {
   await del(TMP_DIR, { force: true });
@@ -31,12 +42,11 @@ afterEach(async () => {
   await del(TMP_DIR, { force: true });
 });
 
-const onLogLine = jest.fn();
-const log = new ToolingLog({
-  level: 'verbose',
-  writeTo: {
-    write: onLogLine,
-  },
+const logWritter = new ToolingLogCollectingWriter('verbose');
+const log = new ToolingLog();
+log.setWriters([logWritter]);
+afterEach(() => {
+  logWritter.messages.length = 0;
 });
 
 type Handler = (req: IncomingMessage, res: ServerResponse) => void;
@@ -54,18 +64,14 @@ const sendErrorHandler: Handler = (req, res) => {
 };
 
 let serverUrl: string;
-let nextHandler: Handler | null = null;
+const handlers: Handler[] = [];
 const server = createServer((req, res) => {
-  if (!nextHandler) {
-    nextHandler = sendErrorHandler;
-  }
-
-  const handler = nextHandler;
-  nextHandler = null;
-  handler(req, res);
+  (handlers.shift() ?? sendErrorHandler)(req, res);
 });
 
-afterEach(() => (nextHandler = null));
+afterEach(() => {
+  handlers.length = 0;
+});
 
 beforeAll(async () => {
   await Promise.race([
@@ -87,136 +93,224 @@ afterAll(async () => {
   server.close();
 });
 
-it('downloads from URL and checks that content matches sha256', async () => {
-  nextHandler = createSendHandler('foo');
-  await download({
-    log,
-    url: serverUrl,
-    destination: TMP_DESTINATION,
-    shaChecksum: FOO_SHA256,
-    shaAlgorithm: 'sha256',
+describe('downloadToDisk', () => {
+  it('downloads from URL and checks that content matches sha256', async () => {
+    handlers.push(createSendHandler('foo'));
+    await downloadToDisk({
+      log,
+      url: serverUrl,
+      destination: TMP_DESTINATION,
+      shaChecksum: FOO_SHA256,
+      shaAlgorithm: 'sha256',
+    });
+    expect(readFileSync(TMP_DESTINATION, 'utf8')).toBe('foo');
   });
-  expect(readFileSync(TMP_DESTINATION, 'utf8')).toBe('foo');
-});
 
-it('rejects and deletes destination if sha256 does not match', async () => {
-  nextHandler = createSendHandler('foo');
+  it('rejects and deletes destination if sha256 does not match', async () => {
+    handlers.push(createSendHandler('foo'));
 
-  try {
-    await download({
+    const promise = downloadToDisk({
       log,
       url: serverUrl,
       destination: TMP_DESTINATION,
       shaChecksum: 'bar',
       shaAlgorithm: 'sha256',
     });
-    throw new Error('Expected download() to reject');
-  } catch (error) {
-    expect(error).toHaveProperty(
-      'message',
-      expect.stringContaining('does not match the expected sha256 checksum')
+    await expect(promise).rejects.toMatchInlineSnapshot(
+      `[Error: Downloaded checksum 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae does not match the expected sha256 checksum.]`
     );
-  }
-
-  try {
-    readFileSync(TMP_DESTINATION);
-    throw new Error('Expected download to be deleted');
-  } catch (error) {
-    expect(error).toHaveProperty('code', 'ENOENT');
-  }
-});
-
-describe('reties download retries: number of times', () => {
-  it('resolves if retries = 1 and first attempt fails', async () => {
-    let reqCount = 0;
-    nextHandler = function sequenceHandler(req, res) {
-      switch (++reqCount) {
-        case 1:
-          nextHandler = sequenceHandler;
-          return sendErrorHandler(req, res);
-        default:
-          return createSendHandler('foo')(req, res);
-      }
-    };
-
-    await download({
-      log,
-      url: serverUrl,
-      destination: TMP_DESTINATION,
-      shaChecksum: FOO_SHA256,
-      shaAlgorithm: 'sha256',
-      retries: 2,
-    });
-
-    expect(readFileSync(TMP_DESTINATION, 'utf8')).toBe('foo');
-  });
-
-  it('resolves if first fails, second is bad shasum, but third succeeds', async () => {
-    let reqCount = 0;
-    nextHandler = function sequenceHandler(req, res) {
-      switch (++reqCount) {
-        case 1:
-          nextHandler = sequenceHandler;
-          return sendErrorHandler(req, res);
-        case 2:
-          nextHandler = sequenceHandler;
-          return createSendHandler('bar')(req, res);
-        default:
-          return createSendHandler('foo')(req, res);
-      }
-    };
-
-    await download({
-      log,
-      url: serverUrl,
-      destination: TMP_DESTINATION,
-      shaChecksum: FOO_SHA256,
-      shaAlgorithm: 'sha256',
-      retries: 2,
-    });
-  });
-
-  it('makes 6 requests if `retries: 5` and all failed', async () => {
-    let reqCount = 0;
-    nextHandler = function sequenceHandler(req, res) {
-      reqCount += 1;
-      nextHandler = sequenceHandler;
-      sendErrorHandler(req, res);
-    };
 
     try {
-      await download({
+      readFileSync(TMP_DESTINATION);
+      throw new Error('Expected download to be deleted');
+    } catch (error) {
+      expect(error).toHaveProperty('code', 'ENOENT');
+    }
+  });
+
+  describe('reties download retries: number of times', () => {
+    it('resolves if retries = 1 and first attempt fails', async () => {
+      handlers.push(sendErrorHandler, createSendHandler('foo'));
+
+      await downloadToDisk({
         log,
         url: serverUrl,
         destination: TMP_DESTINATION,
         shaChecksum: FOO_SHA256,
         shaAlgorithm: 'sha256',
-        retries: 5,
+        maxAttempts: 2,
+        retryDelaySecMultiplier: 0.1,
       });
-      throw new Error('Expected download() to reject');
-    } catch (error) {
-      expect(error).toHaveProperty(
-        'message',
-        expect.stringContaining('Request failed with status code 500')
-      );
-      expect(reqCount).toBe(6);
-    }
-  });
-});
 
-describe('sha256 option not supplied', () => {
-  it('refuses to download', async () => {
-    try {
+      expect(readFileSync(TMP_DESTINATION, 'utf8')).toBe('foo');
+      expect(logWritter.messages).toMatchInlineSnapshot(`
+        Array [
+          " debg [1/2] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.1 seconds",
+          " debg [2/2] Attempting download of TEST_SERVER_URL sha256",
+          " debg Downloaded TEST_SERVER_URL and verified checksum",
+        ]
+      `);
+    });
+
+    it('resolves if first fails, second is bad shasum, but third succeeds', async () => {
+      handlers.push(sendErrorHandler, createSendHandler('bar'), createSendHandler('foo'));
+
+      await downloadToDisk({
+        log,
+        url: serverUrl,
+        destination: TMP_DESTINATION,
+        shaChecksum: FOO_SHA256,
+        shaAlgorithm: 'sha256',
+        maxAttempts: 3,
+        retryDelaySecMultiplier: 0.1,
+      });
+
+      expect(logWritter.messages).toMatchInlineSnapshot(`
+        Array [
+          " debg [1/3] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.1 seconds",
+          " debg [2/3] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Downloaded checksum fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9 does not match the expected sha256 checksum.",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.2 seconds",
+          " debg [3/3] Attempting download of TEST_SERVER_URL sha256",
+          " debg Downloaded TEST_SERVER_URL and verified checksum",
+        ]
+      `);
+    });
+
+    it('makes 5 requests if `maxAttempts: 5` and all failed', async () => {
+      const promise = downloadToDisk({
+        log,
+        url: serverUrl,
+        destination: TMP_DESTINATION,
+        shaChecksum: FOO_SHA256,
+        shaAlgorithm: 'sha256',
+        maxAttempts: 5,
+        retryDelaySecMultiplier: 0.1,
+      });
+      await expect(promise).rejects.toMatchInlineSnapshot(
+        `[Error: Request failed with status code 500]`
+      );
+      expect(logWritter.messages).toMatchInlineSnapshot(`
+        Array [
+          " debg [1/5] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.1 seconds",
+          " debg [2/5] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.2 seconds",
+          " debg [3/5] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.30000000000000004 seconds",
+          " debg [4/5] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+          " info Retrying in 0.4 seconds",
+          " debg [5/5] Attempting download of TEST_SERVER_URL sha256",
+          " debg Download failed: Request failed with status code 500",
+          " debg Deleting downloaded data at TMP_DIR/__tmp_download_js_test_file__",
+        ]
+      `);
+    });
+  });
+
+  describe('sha256 option not supplied', () => {
+    it('refuses to download', async () => {
       // @ts-expect-error missing sha256 param is intentional
-      await download({
+      const promise = downloadToDisk({
         log,
         url: 'http://google.com',
         destination: TMP_DESTINATION,
       });
 
-      throw new Error('expected download() to reject');
-    } catch (error) {
-      expect(error).toHaveProperty('message', expect.stringContaining('refusing to download'));
-    }
+      await expect(promise).rejects.toMatchInlineSnapshot(
+        `[Error: undefined checksum of http://google.com not provided, refusing to download.]`
+      );
+    });
+  });
+});
+
+describe('downloadToString', () => {
+  it('returns a string from the server', async () => {
+    handlers.push(createSendHandler('foo bar'));
+
+    const result = await downloadToString({ log, url: serverUrl });
+    expect(result).toBe('foo bar');
+    expect(logWritter.messages).toMatchInlineSnapshot(`
+      Array [
+        " debg [1/3] Attempting download to string of [TEST_SERVER_URL]",
+        " succ Downloaded [TEST_SERVER_URL]",
+      ]
+    `);
+  });
+
+  it(`throws when expectStatus doesn't match`, async () => {
+    handlers.push(createSendHandler('foo'));
+
+    const promise = downloadToString({
+      log,
+      url: serverUrl,
+      expectStatus: 201,
+      maxAttempts: 1,
+    });
+    await expect(promise).rejects.toMatchInlineSnapshot(
+      `[Error: Request failed with status code 200]`
+    );
+    expect(logWritter.messages).toMatchInlineSnapshot(`
+      Array [
+        " debg [1/1] Attempting download to string of [TEST_SERVER_URL]",
+        " warn Download failed: Request failed with status code 200",
+        " debg [200/OK] response: foo",
+      ]
+    `);
+  });
+
+  it(`retries when expectStatus doesn't match`, async () => {
+    handlers.push(
+      (_, res) => {
+        res.statusCode = 500;
+        res.end('something went wrong');
+      },
+      (_, res) => {
+        res.statusCode = 404;
+        res.end('not found');
+      },
+      (_, res) => {
+        res.statusCode = 201;
+        res.end('bar');
+      }
+    );
+
+    const result = await downloadToString({
+      log,
+      url: serverUrl,
+      expectStatus: 201,
+      retryDelaySecMultiplier: 0.1,
+    });
+
+    expect(result).toBe('bar');
+    expect(logWritter.messages).toMatchInlineSnapshot(`
+      Array [
+        " debg [1/3] Attempting download to string of [TEST_SERVER_URL]",
+        " warn Download failed: Request failed with status code 500",
+        " debg [500/Internal Server Error] response: something went wrong",
+        " info Retrying in 0.1 seconds",
+        " debg [2/3] Attempting download to string of [TEST_SERVER_URL]",
+        " warn Download failed: Request failed with status code 404",
+        " debg [404/Not Found] response: not found",
+        " info Retrying in 0.2 seconds",
+        " debg [3/3] Attempting download to string of [TEST_SERVER_URL]",
+        " succ Downloaded [TEST_SERVER_URL]",
+      ]
+    `);
   });
 });

--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -27,7 +27,7 @@ export const DownloadCloudDependencies: Task = {
         destination,
         shaChecksum: checksum.split(' ')[0],
         shaAlgorithm: 'sha512',
-        retries: 3,
+        maxAttempts: 3,
       });
     };
 

--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -6,10 +6,9 @@
  * Side Public License, v 1.
  */
 
-import axios from 'axios';
 import Path from 'path';
 import del from 'del';
-import { Task, download } from '../lib';
+import { Task, downloadToDisk, downloadToString } from '../lib';
 
 export const DownloadCloudDependencies: Task = {
   description: 'Downloading cloud dependencies',
@@ -20,16 +19,13 @@ export const DownloadCloudDependencies: Task = {
       const version = config.getBuildVersion();
       const architecture = process.arch === 'arm64' ? 'arm64' : 'x86_64';
       const url = `https://${subdomain}-no-kpi.elastic.co/downloads/beats/${beat}/${beat}-${version}-linux-${architecture}.tar.gz`;
-      const checksumRes = await axios.get(url + '.sha512');
-      if (checksumRes.status !== 200) {
-        throw new Error(`Unexpected status code ${checksumRes.status} when downloading ${url}`);
-      }
+      const checksum = await downloadToString({ log, url: url + '.sha512', expectStatus: 200 });
       const destination = config.resolveFromRepo('.beats', Path.basename(url));
-      return download({
+      return downloadToDisk({
         log,
         url,
         destination,
-        shaChecksum: checksumRes.data.split(' ')[0],
+        shaChecksum: checksum.split(' ')[0],
         shaAlgorithm: 'sha512',
         retries: 3,
       });

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.test.ts
@@ -24,7 +24,7 @@ expect.addSnapshotSerializer(createAnyInstanceSerializer(ToolingLog));
 
 const { getNodeDownloadInfo } = jest.requireMock('./node_download_info');
 const { getNodeShasums } = jest.requireMock('./node_shasums');
-const { download } = jest.requireMock('../../lib/download');
+const { downloadToDisk } = jest.requireMock('../../lib/download');
 
 const log = new ToolingLog();
 const testWriter = new ToolingLogCollectingWriter();
@@ -55,7 +55,7 @@ async function setup({ failOnUrl }: { failOnUrl?: string } = {}) {
     'win32:downloadName': 'win32:sha256',
   });
 
-  download.mockImplementation(({ url }: any) => {
+  downloadToDisk.mockImplementation(({ url }: any) => {
     if (url === failOnUrl) {
       throw new Error('Download failed for reasons');
     }
@@ -69,13 +69,13 @@ it('downloads node builds for each platform', async () => {
 
   await DownloadNodeBuilds.run(config, log, []);
 
-  expect(download.mock.calls).toMatchInlineSnapshot(`
+  expect(downloadToDisk.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
         Object {
           "destination": "linux:downloadPath",
           "log": <ToolingLog>,
-          "retries": 3,
+          "maxAttempts": 3,
           "shaAlgorithm": "sha256",
           "shaChecksum": "linux:sha256",
           "url": "linux:url",
@@ -85,7 +85,7 @@ it('downloads node builds for each platform', async () => {
         Object {
           "destination": "linux:downloadPath",
           "log": <ToolingLog>,
-          "retries": 3,
+          "maxAttempts": 3,
           "shaAlgorithm": "sha256",
           "shaChecksum": "linux:sha256",
           "url": "linux:url",
@@ -95,7 +95,7 @@ it('downloads node builds for each platform', async () => {
         Object {
           "destination": "darwin:downloadPath",
           "log": <ToolingLog>,
-          "retries": 3,
+          "maxAttempts": 3,
           "shaAlgorithm": "sha256",
           "shaChecksum": "darwin:sha256",
           "url": "darwin:url",
@@ -105,7 +105,7 @@ it('downloads node builds for each platform', async () => {
         Object {
           "destination": "darwin:downloadPath",
           "log": <ToolingLog>,
-          "retries": 3,
+          "maxAttempts": 3,
           "shaAlgorithm": "sha256",
           "shaChecksum": "darwin:sha256",
           "url": "darwin:url",
@@ -115,7 +115,7 @@ it('downloads node builds for each platform', async () => {
         Object {
           "destination": "win32:downloadPath",
           "log": <ToolingLog>,
-          "retries": 3,
+          "maxAttempts": 3,
           "shaAlgorithm": "sha256",
           "shaChecksum": "win32:sha256",
           "url": "win32:url",

--- a/src/dev/build/tasks/nodejs/download_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/download_node_builds_task.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { download, GlobalTask } from '../../lib';
+import { downloadToDisk, GlobalTask } from '../../lib';
 import { getNodeShasums } from './node_shasums';
 import { getNodeDownloadInfo } from './node_download_info';
 
@@ -18,13 +18,13 @@ export const DownloadNodeBuilds: GlobalTask = {
     await Promise.all(
       config.getNodePlatforms().map(async (platform) => {
         const { url, downloadPath, downloadName } = getNodeDownloadInfo(config, platform);
-        await download({
+        await downloadToDisk({
           log,
           url,
           shaChecksum: shasums[downloadName],
           shaAlgorithm: 'sha256',
           destination: downloadPath,
-          retries: 3,
+          maxAttempts: 3,
         });
       })
     );

--- a/src/dev/build/tasks/nodejs/node_shasums.test.ts
+++ b/src/dev/build/tasks/nodejs/node_shasums.test.ts
@@ -47,15 +47,12 @@ c4edece2c0aa68e816c4e067f397eb12e9d0c81bb37b3d349dbaf47cf246b0b7  win-x86/node.l
 6a2ee7a0b0074ece27d171418d82ce25a60b87750ec30c5c9fbeaaca8c206fa5  win-x86/node_pdb.7z
 1b44176d888c1bc6a6b05fcc6234031b3b8a58da9de8b99661088f998ac5e269  win-x86/node_pdb.zip`;
 
-jest.mock('axios', () => ({
-  async get(url: string) {
+jest.mock('../../lib/download', () => ({
+  async downloadToString({ url }: { url: string }) {
     expect(url).toBe(
       'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/dist/v8.9.4/SHASUMS256.txt'
     );
-    return {
-      status: 200,
-      data: mockResponse,
-    };
+    return mockResponse;
   },
 }));
 

--- a/src/dev/build/tasks/patch_native_modules_task.ts
+++ b/src/dev/build/tasks/patch_native_modules_task.ts
@@ -10,7 +10,17 @@ import path from 'path';
 
 import { ToolingLog } from '@kbn/dev-utils';
 
-import { deleteAll, download, gunzip, untar, Task, Config, Build, Platform, read } from '../lib';
+import {
+  deleteAll,
+  downloadToDisk,
+  gunzip,
+  untar,
+  Task,
+  Config,
+  Build,
+  Platform,
+  read,
+} from '../lib';
 
 const DOWNLOAD_DIRECTORY = '.native_modules';
 
@@ -100,13 +110,13 @@ async function patchModule(
   log.debug(`Patching ${pkg.name} binaries from ${archive.url} to ${extractPath}`);
 
   await deleteAll([extractPath], log);
-  await download({
+  await downloadToDisk({
     log,
     url: archive.url,
     destination: downloadPath,
     shaChecksum: archive.sha256,
     shaAlgorithm: 'sha256',
-    retries: 3,
+    maxAttempts: 3,
   });
   switch (pkg.extractMethod) {
     case 'gunzip':


### PR DESCRIPTION
We had a failure on CI recently because we weren't able to download the shasums for nodejs. This HTTP request was being done with axios directly because we're not trying to download to the filesystem and validate the shasums of the shasums, so we couldn't use the existing `download()` helper. This renames that helper to `downloadToDisk()` and adds a `downloadToString()` helper which wraps axios, adds retries and logging about the requests, and is now in use in all locations where Axios was used in the build scripts. 