### PR TITLE
[App Search] Add new type CrawlRequestWithDetails, and use that for CrawlDetailsLogic.values.crawlRequest

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
@@ -16,7 +16,7 @@ import { EuiCodeBlock, EuiFlyout, EuiTab, EuiTabs } from '@elastic/eui';
 import { Loading } from '../../../../../shared/loading';
 
 import { CrawlDetailActions, CrawlDetailValues } from '../../crawl_detail_logic';
-import { CrawlRequestFromServer } from '../../types';
+import { CrawlRequestWithDetailsFromServer } from '../../types';
 
 import { CrawlDetailsPreview } from './crawl_details_preview';
 
@@ -25,7 +25,7 @@ import { CrawlDetailsFlyout } from '.';
 const MOCK_VALUES: Partial<CrawlDetailValues> = {
   dataLoading: false,
   flyoutClosed: false,
-  crawlRequestFromServer: {} as CrawlRequestFromServer,
+  crawlRequestFromServer: {} as CrawlRequestWithDetailsFromServer,
 };
 
 const MOCK_ACTIONS: Partial<CrawlDetailActions> = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.test.tsx
@@ -16,7 +16,7 @@ import { EuiCodeBlock, EuiFlyout, EuiTab, EuiTabs } from '@elastic/eui';
 import { Loading } from '../../../../../shared/loading';
 
 import { CrawlDetailActions, CrawlDetailValues } from '../../crawl_detail_logic';
-import { CrawlEventFromServer } from '../../types';
+import { CrawlRequestFromServer } from '../../types';
 
 import { CrawlDetailsPreview } from './crawl_details_preview';
 
@@ -25,7 +25,7 @@ import { CrawlDetailsFlyout } from '.';
 const MOCK_VALUES: Partial<CrawlDetailValues> = {
   dataLoading: false,
   flyoutClosed: false,
-  crawlEventFromServer: {} as CrawlEventFromServer,
+  crawlRequestFromServer: {} as CrawlRequestFromServer,
 };
 
 const MOCK_ACTIONS: Partial<CrawlDetailActions> = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_details_flyout/crawl_details_flyout.tsx
@@ -27,7 +27,7 @@ import { CrawlDetailsPreview } from './crawl_details_preview';
 
 export const CrawlDetailsFlyout: React.FC = () => {
   const { closeFlyout, setSelectedTab } = useActions(CrawlDetailLogic);
-  const { crawlEventFromServer, dataLoading, flyoutClosed, selectedTab } =
+  const { crawlRequestFromServer, dataLoading, flyoutClosed, selectedTab } =
     useValues(CrawlDetailLogic);
 
   if (flyoutClosed) {
@@ -71,7 +71,7 @@ export const CrawlDetailsFlyout: React.FC = () => {
             {selectedTab === 'preview' && <CrawlDetailsPreview />}
             {selectedTab === 'json' && (
               <EuiCodeBlock language="json">
-                {JSON.stringify(crawlEventFromServer, null, 2)}
+                {JSON.stringify(crawlRequestFromServer, null, 2)}
               </EuiCodeBlock>
             )}
           </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.test.tsx
@@ -51,7 +51,7 @@ const values: { events: CrawlEvent[] } = {
 };
 
 const actions = {
-  fetchCrawlEvent: jest.fn(),
+  fetchCrawlRequest: jest.fn(),
   openFlyout: jest.fn(),
 };
 
@@ -83,7 +83,7 @@ describe('CrawlRequestsTable', () => {
       expect(crawlID.text()).toContain('618d0e66abe97bc688328900');
 
       crawlID.simulate('click');
-      expect(actions.fetchCrawlEvent).toHaveBeenCalledWith('618d0e66abe97bc688328900');
+      expect(actions.fetchCrawlRequest).toHaveBeenCalledWith('618d0e66abe97bc688328900');
       expect(actions.openFlyout).toHaveBeenCalled();
 
       const processCrawlID = shallow(columns[0].render('54325423aef7890543', { stage: 'process' }));

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -28,7 +28,7 @@ import { CustomFormattedTimestamp } from './custom_formatted_timestamp';
 
 export const CrawlRequestsTable: React.FC = () => {
   const { events } = useValues(CrawlerLogic);
-  const { fetchCrawlEvent, openFlyout } = useActions(CrawlDetailLogic);
+  const { fetchCrawlRequest, openFlyout } = useActions(CrawlDetailLogic);
 
   const columns: Array<EuiBasicTableColumn<CrawlEvent>> = [
     {
@@ -44,7 +44,7 @@ export const CrawlRequestsTable: React.FC = () => {
           return (
             <EuiLink
               onClick={() => {
-                fetchCrawlEvent(id);
+                fetchCrawlRequest(id);
                 openFlyout();
               }}
             >

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -13,8 +13,8 @@ import { nextTick } from '@kbn/test/jest';
 import { itShowsServerErrorAsFlashMessage } from '../../../test_helpers';
 
 import { CrawlDetailLogic, CrawlDetailValues } from './crawl_detail_logic';
-import { CrawlerStatus, CrawlRequestFromServer } from './types';
-import { crawlRequestServerToClient } from './utils';
+import { CrawlType, CrawlerStatus, CrawlRequestWithDetailsFromServer } from './types';
+import { crawlRequestWithDetailsServerToClient } from './utils';
 
 const DEFAULT_VALUES: CrawlDetailValues = {
   dataLoading: true,
@@ -24,15 +24,19 @@ const DEFAULT_VALUES: CrawlDetailValues = {
   selectedTab: 'preview',
 };
 
-const crawlRequestResponse: CrawlRequestFromServer = {
+const crawlRequestResponse: CrawlRequestWithDetailsFromServer = {
   id: '12345',
   status: CrawlerStatus.Pending,
   created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
   began_at: null,
   completed_at: null,
+  type: CrawlType.Full,
+  crawl_config: {
+    domain_allowlist: [],
+  },
 };
 
-const clientCrawlRequest = crawlRequestServerToClient(crawlRequestResponse);
+const clientCrawlRequest = crawlRequestWithDetailsServerToClient(crawlRequestResponse);
 
 describe('CrawlDetailLogic', () => {
   const { mount } = new LogicMounter(CrawlDetailLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.test.ts
@@ -13,31 +13,26 @@ import { nextTick } from '@kbn/test/jest';
 import { itShowsServerErrorAsFlashMessage } from '../../../test_helpers';
 
 import { CrawlDetailLogic, CrawlDetailValues } from './crawl_detail_logic';
-import { CrawlerStatus, CrawlEventFromServer, CrawlType } from './types';
-import { crawlEventServerToClient } from './utils';
+import { CrawlerStatus, CrawlRequestFromServer } from './types';
+import { crawlRequestServerToClient } from './utils';
 
 const DEFAULT_VALUES: CrawlDetailValues = {
   dataLoading: true,
   flyoutClosed: true,
-  crawlEvent: null,
-  crawlEventFromServer: null,
+  crawlRequest: null,
+  crawlRequestFromServer: null,
   selectedTab: 'preview',
 };
 
-const crawlEventResponse: CrawlEventFromServer = {
+const crawlRequestResponse: CrawlRequestFromServer = {
   id: '12345',
   status: CrawlerStatus.Pending,
   created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
   began_at: null,
   completed_at: null,
-  stage: 'crawl',
-  type: CrawlType.Full,
-  crawl_config: {
-    domain_allowlist: [],
-  },
 };
 
-const clientCrawlEvent = crawlEventServerToClient(crawlEventResponse);
+const clientCrawlRequest = crawlRequestServerToClient(crawlRequestResponse);
 
 describe('CrawlDetailLogic', () => {
   const { mount } = new LogicMounter(CrawlDetailLogic);
@@ -66,20 +61,20 @@ describe('CrawlDetailLogic', () => {
       });
     });
 
-    describe('onRecieveCrawlEvent', () => {
+    describe('onRecieveCrawlRequest', () => {
       it('saves the crawl request and sets data loading to false', () => {
         mount({
           dataLoading: true,
           request: null,
         });
 
-        CrawlDetailLogic.actions.onRecieveCrawlEvent(crawlEventResponse);
+        CrawlDetailLogic.actions.onRecieveCrawlRequest(crawlRequestResponse);
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
           dataLoading: false,
-          crawlEventFromServer: crawlEventResponse,
-          crawlEvent: clientCrawlEvent,
+          crawlRequestFromServer: crawlRequestResponse,
+          crawlRequest: clientCrawlRequest,
         });
       });
     });
@@ -116,13 +111,13 @@ describe('CrawlDetailLogic', () => {
       });
     });
 
-    describe('fetchCrawlEvent', () => {
+    describe('fetchCrawlRequest', () => {
       it('sets loading to true', () => {
         mount({
           dataLoading: false,
         });
 
-        CrawlDetailLogic.actions.fetchCrawlEvent('12345');
+        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
 
         expect(CrawlDetailLogic.values).toEqual({
           ...DEFAULT_VALUES,
@@ -132,24 +127,24 @@ describe('CrawlDetailLogic', () => {
 
       it('updates logic with data that has been converted from server to client', async () => {
         mount();
-        jest.spyOn(CrawlDetailLogic.actions, 'onRecieveCrawlEvent');
+        jest.spyOn(CrawlDetailLogic.actions, 'onRecieveCrawlRequest');
 
-        http.get.mockReturnValueOnce(Promise.resolve(crawlEventResponse));
+        http.get.mockReturnValueOnce(Promise.resolve(crawlRequestResponse));
 
-        CrawlDetailLogic.actions.fetchCrawlEvent('12345');
+        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith(
           '/internal/app_search/engines/some-engine/crawler/crawl_requests/12345'
         );
-        expect(CrawlDetailLogic.actions.onRecieveCrawlEvent).toHaveBeenCalledWith(
-          crawlEventResponse
+        expect(CrawlDetailLogic.actions.onRecieveCrawlRequest).toHaveBeenCalledWith(
+          crawlRequestResponse
         );
       });
 
       itShowsServerErrorAsFlashMessage(http.get, () => {
         mount();
-        CrawlDetailLogic.actions.fetchCrawlEvent('12345');
+        CrawlDetailLogic.actions.fetchCrawlRequest('12345');
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -12,14 +12,14 @@ import { flashAPIErrors } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlEvent, CrawlEventFromServer } from './types';
-import { crawlEventServerToClient } from './utils';
+import { CrawlRequest, CrawlRequestFromServer } from './types';
+import { crawlRequestServerToClient } from './utils';
 
 type CrawlDetailFlyoutTabs = 'preview' | 'json';
 
 export interface CrawlDetailValues {
-  crawlEvent: CrawlEvent | null;
-  crawlEventFromServer: CrawlEventFromServer | null;
+  crawlRequest: CrawlRequest | null;
+  crawlRequestFromServer: CrawlRequestFromServer | null;
   dataLoading: boolean;
   flyoutClosed: boolean;
   selectedTab: CrawlDetailFlyoutTabs;
@@ -27,9 +27,9 @@ export interface CrawlDetailValues {
 
 export interface CrawlDetailActions {
   closeFlyout(): void;
-  fetchCrawlEvent(requestId: string): { requestId: string };
-  onRecieveCrawlEvent(crawlEventFromServer: CrawlEventFromServer): {
-    crawlEventFromServer: CrawlEventFromServer;
+  fetchCrawlRequest(requestId: string): { requestId: string };
+  onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {
+    crawlRequestFromServer: CrawlRequestFromServer;
   };
   openFlyout(): void;
   setSelectedTab(selectedTab: CrawlDetailFlyoutTabs): { selectedTab: CrawlDetailFlyoutTabs };
@@ -39,30 +39,30 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
   path: ['enterprise_search', 'app_search', 'crawler', 'crawl_detail_logic'],
   actions: {
     closeFlyout: true,
-    fetchCrawlEvent: (requestId) => ({ requestId }),
-    onRecieveCrawlEvent: (crawlEventFromServer) => ({ crawlEventFromServer }),
+    fetchCrawlRequest: (requestId) => ({ requestId }),
+    onRecieveCrawlRequest: (crawlRequestFromServer) => ({ crawlRequestFromServer }),
     openFlyout: true,
     setSelectedTab: (selectedTab) => ({ selectedTab }),
   },
   reducers: {
-    crawlEvent: [
+    crawlRequest: [
       null,
       {
-        onRecieveCrawlEvent: (_, { crawlEventFromServer }) =>
-          crawlEventServerToClient(crawlEventFromServer),
+        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) =>
+          crawlRequestServerToClient(crawlRequestFromServer),
       },
     ],
-    crawlEventFromServer: [
+    crawlRequestFromServer: [
       null,
       {
-        onRecieveCrawlEvent: (_, { crawlEventFromServer }) => crawlEventFromServer,
+        onRecieveCrawlRequest: (_, { crawlRequestFromServer }) => crawlRequestFromServer,
       },
     ],
     dataLoading: [
       true,
       {
-        fetchCrawlEvent: () => true,
-        onRecieveCrawlEvent: () => false,
+        fetchCrawlRequest: () => true,
+        onRecieveCrawlRequest: () => false,
       },
     ],
     flyoutClosed: [
@@ -81,16 +81,16 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
     ],
   },
   listeners: ({ actions }) => ({
-    fetchCrawlEvent: async ({ requestId }) => {
+    fetchCrawlRequest: async ({ requestId }) => {
       const { http } = HttpLogic.values;
       const { engineName } = EngineLogic.values;
 
       try {
-        const response = await http.get<CrawlEventFromServer>(
+        const response = await http.get<CrawlRequestFromServer>(
           `/internal/app_search/engines/${engineName}/crawler/crawl_requests/${requestId}`
         );
 
-        actions.onRecieveCrawlEvent(response);
+        actions.onRecieveCrawlRequest(response);
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/crawl_detail_logic.ts
@@ -12,14 +12,14 @@ import { flashAPIErrors } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { EngineLogic } from '../engine';
 
-import { CrawlRequest, CrawlRequestFromServer } from './types';
-import { crawlRequestServerToClient } from './utils';
+import { CrawlRequestWithDetails, CrawlRequestWithDetailsFromServer } from './types';
+import { crawlRequestWithDetailsServerToClient } from './utils';
 
 type CrawlDetailFlyoutTabs = 'preview' | 'json';
 
 export interface CrawlDetailValues {
-  crawlRequest: CrawlRequest | null;
-  crawlRequestFromServer: CrawlRequestFromServer | null;
+  crawlRequest: CrawlRequestWithDetails | null;
+  crawlRequestFromServer: CrawlRequestWithDetailsFromServer | null;
   dataLoading: boolean;
   flyoutClosed: boolean;
   selectedTab: CrawlDetailFlyoutTabs;
@@ -28,8 +28,8 @@ export interface CrawlDetailValues {
 export interface CrawlDetailActions {
   closeFlyout(): void;
   fetchCrawlRequest(requestId: string): { requestId: string };
-  onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestFromServer): {
-    crawlRequestFromServer: CrawlRequestFromServer;
+  onRecieveCrawlRequest(crawlRequestFromServer: CrawlRequestWithDetailsFromServer): {
+    crawlRequestFromServer: CrawlRequestWithDetailsFromServer;
   };
   openFlyout(): void;
   setSelectedTab(selectedTab: CrawlDetailFlyoutTabs): { selectedTab: CrawlDetailFlyoutTabs };
@@ -49,7 +49,7 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
       null,
       {
         onRecieveCrawlRequest: (_, { crawlRequestFromServer }) =>
-          crawlRequestServerToClient(crawlRequestFromServer),
+          crawlRequestWithDetailsServerToClient(crawlRequestFromServer),
       },
     ],
     crawlRequestFromServer: [
@@ -86,7 +86,7 @@ export const CrawlDetailLogic = kea<MakeLogicType<CrawlDetailValues, CrawlDetail
       const { engineName } = EngineLogic.values;
 
       try {
-        const response = await http.get<CrawlRequestFromServer>(
+        const response = await http.get<CrawlRequestWithDetailsFromServer>(
           `/internal/app_search/engines/${engineName}/crawler/crawl_requests/${requestId}`
         );
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -208,17 +208,27 @@ export interface CrawlConfig {
 export interface CrawlConfigFromServer {
   domain_allowlist: string[];
 }
-export type CrawlEventFromServer = CrawlRequestFromServer & {
+export interface CrawlEventFromServer {
+  id: string;
   stage: CrawlEventStage;
+  status: CrawlerStatus;
+  created_at: string;
+  began_at: string | null;
+  completed_at: string | null;
   type: CrawlType;
   crawl_config: CrawlConfigFromServer;
-};
+}
 
-export type CrawlEvent = CrawlRequest & {
+export interface CrawlEvent {
+  id: string;
   stage: CrawlEventStage;
+  status: CrawlerStatus;
+  createdAt: string;
+  beganAt: string | null;
+  completedAt: string | null;
   type: CrawlType;
   crawlConfig: CrawlConfig;
-};
+}
 
 export const readableCrawlerStatuses: { [key in CrawlerStatus]: string } = {
   [CrawlerStatus.Pending]: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/types.ts
@@ -199,8 +199,6 @@ export interface CrawlRequest {
   completedAt: string | null;
 }
 
-export type CrawlEventStage = 'crawl' | 'process';
-
 export interface CrawlConfig {
   domainAllowlist: string[];
 }
@@ -208,27 +206,32 @@ export interface CrawlConfig {
 export interface CrawlConfigFromServer {
   domain_allowlist: string[];
 }
-export interface CrawlEventFromServer {
-  id: string;
-  stage: CrawlEventStage;
-  status: CrawlerStatus;
-  created_at: string;
-  began_at: string | null;
-  completed_at: string | null;
+
+export type CrawlRequestWithDetailsFromServer = CrawlRequestFromServer & {
   type: CrawlType;
   crawl_config: CrawlConfigFromServer;
-}
+  // TODO add other properties like stats
+};
 
-export interface CrawlEvent {
-  id: string;
-  stage: CrawlEventStage;
-  status: CrawlerStatus;
-  createdAt: string;
-  beganAt: string | null;
-  completedAt: string | null;
+export type CrawlRequestWithDetails = CrawlRequest & {
   type: CrawlType;
   crawlConfig: CrawlConfig;
-}
+  // TODO add other properties like stats
+};
+
+export type CrawlEventStage = 'crawl' | 'process';
+
+export type CrawlEventFromServer = CrawlRequestFromServer & {
+  stage: CrawlEventStage;
+  type: CrawlType;
+  crawl_config: CrawlConfigFromServer;
+};
+
+export type CrawlEvent = CrawlRequest & {
+  stage: CrawlEventStage;
+  type: CrawlType;
+  crawlConfig: CrawlConfig;
+};
 
 export const readableCrawlerStatuses: { [key in CrawlerStatus]: string } = {
   [CrawlerStatus.Pending]: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.test.ts
@@ -18,13 +18,19 @@ import {
   CrawlRequest,
   CrawlerDomain,
   CrawlType,
+  CrawlRequestWithDetailsFromServer,
+  CrawlRequestWithDetails,
+  CrawlEvent,
+  CrawlEventFromServer,
 } from './types';
 
 import {
   crawlerDomainServerToClient,
   crawlerDataServerToClient,
   crawlDomainValidationToResult,
+  crawlEventServerToClient,
   crawlRequestServerToClient,
+  crawlRequestWithDetailsServerToClient,
   getDeleteDomainConfirmationMessage,
   getDeleteDomainSuccessMessage,
   getCrawlRulePathPatternTooltip,
@@ -113,6 +119,98 @@ describe('crawlRequestServerToClient', () => {
     ).toStrictEqual({ ...defaultClientPayload, beganAt: 'Mon, 31 Aug 2020 17:00:00 +0000' });
     expect(
       crawlRequestServerToClient({
+        ...defaultServerPayload,
+        completed_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      })
+    ).toStrictEqual({ ...defaultClientPayload, completedAt: 'Mon, 31 Aug 2020 17:00:00 +0000' });
+  });
+});
+
+describe('crawlRequestWithDetailsServerToClient', () => {
+  it('converts the API payload into properties matching our code style', () => {
+    const id = '507f1f77bcf86cd799439011';
+
+    const defaultServerPayload: CrawlRequestWithDetailsFromServer = {
+      id,
+      status: CrawlerStatus.Pending,
+      created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      began_at: null,
+      completed_at: null,
+      type: CrawlType.Full,
+      crawl_config: {
+        domain_allowlist: [],
+      },
+    };
+
+    const defaultClientPayload: CrawlRequestWithDetails = {
+      id,
+      status: CrawlerStatus.Pending,
+      createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      beganAt: null,
+      completedAt: null,
+      type: CrawlType.Full,
+      crawlConfig: {
+        domainAllowlist: [],
+      },
+    };
+
+    expect(crawlRequestWithDetailsServerToClient(defaultServerPayload)).toStrictEqual(
+      defaultClientPayload
+    );
+    expect(
+      crawlRequestWithDetailsServerToClient({
+        ...defaultServerPayload,
+        began_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      })
+    ).toStrictEqual({ ...defaultClientPayload, beganAt: 'Mon, 31 Aug 2020 17:00:00 +0000' });
+    expect(
+      crawlRequestWithDetailsServerToClient({
+        ...defaultServerPayload,
+        completed_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      })
+    ).toStrictEqual({ ...defaultClientPayload, completedAt: 'Mon, 31 Aug 2020 17:00:00 +0000' });
+  });
+});
+
+describe('crawlEventServerToClient', () => {
+  it('converts the API payload into properties matching our code style', () => {
+    const id = '507f1f77bcf86cd799439011';
+
+    const defaultServerPayload: CrawlEventFromServer = {
+      id,
+      status: CrawlerStatus.Pending,
+      created_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      began_at: null,
+      completed_at: null,
+      type: CrawlType.Full,
+      crawl_config: {
+        domain_allowlist: [],
+      },
+      stage: 'crawl',
+    };
+
+    const defaultClientPayload: CrawlEvent = {
+      id,
+      status: CrawlerStatus.Pending,
+      createdAt: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      beganAt: null,
+      completedAt: null,
+      type: CrawlType.Full,
+      crawlConfig: {
+        domainAllowlist: [],
+      },
+      stage: 'crawl',
+    };
+
+    expect(crawlEventServerToClient(defaultServerPayload)).toStrictEqual(defaultClientPayload);
+    expect(
+      crawlEventServerToClient({
+        ...defaultServerPayload,
+        began_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
+      })
+    ).toStrictEqual({ ...defaultClientPayload, beganAt: 'Mon, 31 Aug 2020 17:00:00 +0000' });
+    expect(
+      crawlEventServerToClient({
         ...defaultServerPayload,
         completed_at: 'Mon, 31 Aug 2020 17:00:00 +0000',
       })

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -90,14 +90,25 @@ export function crawlConfigServerToClient(crawlConfig: CrawlConfigFromServer): C
   };
 }
 
-export function crawlEventServerToClient(event: CrawlEventFromServer): CrawlEvent {
-  const clientCrawlRequest = crawlRequestServerToClient(event as CrawlRequestFromServer);
-
-  const { stage, type, crawl_config: crawlConfig } = event;
+export function crawlerEventServerToClient(event: CrawlEventFromServer): CrawlEvent {
+  const {
+    id,
+    stage,
+    status,
+    created_at: createdAt,
+    began_at: beganAt,
+    completed_at: completedAt,
+    type,
+    crawl_config: crawlConfig,
+  } = event;
 
   return {
-    ...clientCrawlRequest,
+    id,
     stage,
+    status,
+    createdAt,
+    beganAt,
+    completedAt,
     type,
     crawlConfig: crawlConfigServerToClient(crawlConfig),
   };
@@ -108,7 +119,7 @@ export function crawlerDataServerToClient(payload: CrawlerDataFromServer): Crawl
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
-    events: events.map((event) => crawlEventServerToClient(event)),
+    events: events.map((event) => crawlerEventServerToClient(event)),
     mostRecentCrawlRequest:
       mostRecentCrawlRequest && crawlRequestServerToClient(mostRecentCrawlRequest),
   };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/utils.ts
@@ -22,6 +22,8 @@ import {
   CrawlEvent,
   CrawlConfigFromServer,
   CrawlConfig,
+  CrawlRequestWithDetailsFromServer,
+  CrawlRequestWithDetails,
 } from './types';
 
 export function crawlerDomainServerToClient(payload: CrawlerDomainFromServer): CrawlerDomain {
@@ -90,7 +92,7 @@ export function crawlConfigServerToClient(crawlConfig: CrawlConfigFromServer): C
   };
 }
 
-export function crawlerEventServerToClient(event: CrawlEventFromServer): CrawlEvent {
+export function crawlEventServerToClient(event: CrawlEventFromServer): CrawlEvent {
   const {
     id,
     stage,
@@ -114,12 +116,37 @@ export function crawlerEventServerToClient(event: CrawlEventFromServer): CrawlEv
   };
 }
 
+export function crawlRequestWithDetailsServerToClient(
+  event: CrawlRequestWithDetailsFromServer
+): CrawlRequestWithDetails {
+  const {
+    id,
+    status,
+    created_at: createdAt,
+    began_at: beganAt,
+    completed_at: completedAt,
+    type,
+    crawl_config: crawlConfig,
+  } = event;
+
+  return {
+    id,
+    status,
+    createdAt,
+    beganAt,
+    completedAt,
+    type,
+    crawlConfig: crawlConfigServerToClient(crawlConfig),
+    // TODO add fields like stats
+  };
+}
+
 export function crawlerDataServerToClient(payload: CrawlerDataFromServer): CrawlerData {
   const { domains, events, most_recent_crawl_request: mostRecentCrawlRequest } = payload;
 
   return {
     domains: domains.map((domain) => crawlerDomainServerToClient(domain)),
-    events: events.map((event) => crawlerEventServerToClient(event)),
+    events: events.map((event) => crawlEventServerToClient(event)),
     mostRecentCrawlRequest:
       mostRecentCrawlRequest && crawlRequestServerToClient(mostRecentCrawlRequest),
   };


### PR DESCRIPTION
## Summary

This reverts #119541 and then attempts to solve the same problem by adding a new type, instead of converting `CrawlDetailsLogic.values.crawlRequest` into `CrawlDetailsLogic.values.crawlEvent`.  `CrawlEvents` are a distinct type from the type returned by the `/crawl_requests/<request_id>` API endpoint, which include props like `stats` but are missing props like `stage`.  

The new changes are constrained to commit ea61a32d3501


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios