### PR TITLE
add a new plugin for registering task types on behalf of reporting

### DIFF
--- a/x-pack/plugins/reporting/common/constants.ts
+++ b/x-pack/plugins/reporting/common/constants.ts
@@ -25,6 +25,10 @@ export const ALLOWED_JOB_CONTENT_TYPES = [
   'text/plain',
 ];
 
+// Task IDs registered with Task Manager
+export const REPORTING_EXECUTE_TYPE = 'report:execute';
+export const REPORTING_MONITOR_TYPE = 'reports:monitor';
+
 // See:
 // https://github.com/chromium/chromium/blob/3611052c055897e5ebbc5b73ea295092e0c20141/services/network/public/cpp/header_util_unittest.cc#L50
 // For a list of headers that chromium doesn't like

--- a/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
@@ -11,6 +11,7 @@ import * as Rx from 'rxjs';
 import { timeout } from 'rxjs/operators';
 import { finished, Writable } from 'stream';
 import { promisify } from 'util';
+import { REPORTING_EXECUTE_TYPE } from '../../../common/constants';
 import { getContentStream, LevelLogger } from '../';
 import { ReportingCore } from '../../';
 import {
@@ -25,13 +26,7 @@ import { ReportingConfigType } from '../../config';
 import { BasePayload, ExportTypeDefinition, RunTaskFn } from '../../types';
 import { Report, ReportDocument, ReportingStore, SavedReport } from '../store';
 import { ReportFailedFields, ReportProcessingFields } from '../store/store';
-import {
-  ReportingTask,
-  ReportingTaskStatus,
-  REPORTING_EXECUTE_TYPE,
-  ReportTaskParams,
-  TaskRunResult,
-} from './';
+import { ReportingTask, ReportingTaskStatus, ReportTaskParams, TaskRunResult } from './';
 import { errorLogger } from './error_logger';
 
 type CompletedReportOutput = Omit<ReportOutput, 'content'>;

--- a/x-pack/plugins/reporting/server/lib/tasks/index.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/index.ts
@@ -9,11 +9,9 @@ import { TaskRunCreatorFunction } from '../../../../task_manager/server';
 import { ReportSource, TaskRunResult } from '../../../common/types';
 import { BasePayload } from '../../types';
 
-export const REPORTING_EXECUTE_TYPE = 'report:execute';
-export const REPORTING_MONITOR_TYPE = 'reports:monitor';
-
 export { ExecuteReportTask } from './execute_report';
 export { MonitorReportsTask } from './monitor_reports';
+
 export type { TaskRunResult };
 
 export interface ReportTaskParams<JobPayloadType = BasePayload> {

--- a/x-pack/plugins/reporting/server/lib/tasks/monitor_reports.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/monitor_reports.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import { REPORTING_MONITOR_TYPE } from '../../../common/constants';
 import { LevelLogger, ReportingStore } from '../';
 import { ReportingCore } from '../../';
 import { TaskManagerStartContract, TaskRunCreatorFunction } from '../../../../task_manager/server';
@@ -13,7 +14,7 @@ import { numberToDuration } from '../../../common/schema_utils';
 import { ReportingConfigType } from '../../config';
 import { statuses } from '../statuses';
 import { SavedReport } from '../store';
-import { ReportingTask, ReportingTaskStatus, REPORTING_MONITOR_TYPE, ReportTaskParams } from './';
+import { ReportingTask, ReportingTaskStatus, ReportTaskParams } from './';
 
 /*
  * Task for finding the ReportingRecords left in the ReportingStore (.reporting index) and stuck in

--- a/x-pack/plugins/reporting_tasks/README.md
+++ b/x-pack/plugins/reporting_tasks/README.md
@@ -1,0 +1,5 @@
+# Kibana Reporting Tasks
+
+A plugin to register the Reporting task types with Task Manager plugin. This
+must be done even if Reporting is disabled, to have the Kibana instance safely
+ignore the Reporting tasks types.

--- a/x-pack/plugins/reporting_tasks/kibana.json
+++ b/x-pack/plugins/reporting_tasks/kibana.json
@@ -1,0 +1,14 @@
+{
+  "id": "reportingTasks",
+  "version": "8.0.0",
+  "kibanaVersion": "kibana",
+  "owner": {
+    "name": "Kibana Reporting Services",
+    "githubTeam": "kibana-reporting-services"
+  },
+  "description": "Registers Reporting's task types when Reporting is disabled",
+  "optionalPlugins": ["reporting"],
+  "requiredPlugins": ["taskManager"],
+  "server": true,
+  "ui": false
+}

--- a/x-pack/plugins/reporting_tasks/server/index.ts
+++ b/x-pack/plugins/reporting_tasks/server/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginInitializerContext } from 'kibana/server';
+import { ReportingTasksPlugin } from './plugin';
+
+export function plugin(initContext: PluginInitializerContext) {
+  return new ReportingTasksPlugin(initContext);
+}

--- a/x-pack/plugins/reporting_tasks/server/plugin.ts
+++ b/x-pack/plugins/reporting_tasks/server/plugin.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoreSetup, Logger, Plugin, PluginInitializerContext } from 'src/core/server';
+import { constants } from '../../reporting/common';
+import { ReportingSetup as ReportingPlugin } from '../../reporting/server';
+import {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+  TaskRegisterDefinition,
+} from '../../task_manager/server';
+
+type ReportingTasksPluginSetup = void;
+type ReportingTasksPluginStart = void;
+
+interface ReportingTasksPluginSetupDeps {
+  taskManager: TaskManagerSetupContract;
+  reporting?: ReportingPlugin;
+}
+interface ReportingTasksPluginsStartDeps {
+  taskManager: TaskManagerStartContract;
+  reporting?: ReportingPlugin;
+}
+
+export class ReportingTasksPlugin
+  implements
+    Plugin<
+      ReportingTasksPluginSetup,
+      ReportingTasksPluginStart,
+      ReportingTasksPluginSetupDeps,
+      ReportingTasksPluginsStartDeps
+    >
+{
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+  setup(_core: CoreSetup, plugins: ReportingTasksPluginSetupDeps) {
+    const { reporting, taskManager } = plugins;
+
+    if (reporting) {
+      this.logger.debug(`Reporting is enabled.`);
+      // Reporting registers the full task types
+      return;
+    }
+
+    // Register "dummy" task types on behalf of Reporting
+    this.logger.info(`Reporting is disabled: registering minimal task types.`);
+
+    const stubTask: TaskRegisterDefinition = {
+      createTaskRunner: () => ({
+        async run() {},
+      }),
+      maxConcurrency: 0,
+    };
+
+    taskManager.registerTaskDefinitions({
+      [constants.REPORTING_EXECUTE_TYPE]: stubTask,
+      [constants.REPORTING_MONITOR_TYPE]: stubTask,
+    });
+  }
+  start() {}
+}

--- a/x-pack/plugins/reporting_tasks/tsconfig.json
+++ b/x-pack/plugins/reporting_tasks/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./target/types",
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": [
+    "common/**/*",
+    "public/**/*",
+    "server/**/*"
+  ],
+  "references": [
+    { "path": "../../../src/core/tsconfig.json" },
+    { "path": "../task_manager/tsconfig.json" },
+    { "path": "../reporting/tsconfig.json" }
+  ]
+}


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/118477
Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
