### PR TITLE
[7.16] Fix saved visualization time range error (#116347)

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.test.ts
@@ -57,4 +57,15 @@ describe('savedVisualization', () => {
     const expression = fn(null, { ...args, title: '' }, {} as any);
     expect(expression.input.title).toEqual('');
   });
+
+  it('accepts time range', () => {
+    const expression = fn(
+      null,
+      { ...args, timerange: { type: 'timerange', from: '15m-now', to: 'now' } },
+      {} as any
+    );
+    expect(expression.input.timeRange).toHaveProperty('from', '15m-now');
+    expect(expression.input.timeRange).toHaveProperty('to', 'now');
+    expect(expression.input.timeRange).not.toHaveProperty('type');
+  });
 });

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { omit } from 'lodash';
 import { ExpressionFunctionDefinition } from 'src/plugins/expressions';
 import { VisualizeInput } from 'src/plugins/visualizations/public';
 import {
@@ -96,7 +97,7 @@ export function savedVisualization(): ExpressionFunctionDefinition<
         input: {
           id,
           disableTriggers: true,
-          timeRange: timerange || defaultTimeRange,
+          timeRange: timerange ? omit(timerange, 'type') : defaultTimeRange,
           filters: getQueryFilters(filters),
           vis: visOptions,
           title: title === null ? undefined : title,


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Fix saved visualization time range error (#116347)