### PR TITLE
Add delay between kibana and ES shutdown in xpack IT tests

### DIFF
--- a/src/core/server/saved_objects/migrations/integration_tests/7.7.2_xpack_100k.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/7.7.2_xpack_100k.test.ts
@@ -89,12 +89,12 @@ describe('migration from 7.7.2-xpack with 100k objects', () => {
   const stopServers = async () => {
     if (root) {
       await root.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
     if (esServer) {
       await esServer.stop();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
   };
 
   const migratedIndex = `.kibana_${kibanaVersion}_001`;

--- a/src/core/server/saved_objects/migrations/integration_tests/7_13_0_failed_action_tasks.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/7_13_0_failed_action_tasks.test.ts
@@ -43,12 +43,12 @@ describe('migration from 7.13 to 7.14+ with many failed action_tasks', () => {
   afterEach(async () => {
     if (root) {
       await root.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
     if (esServer) {
       await esServer.stop();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
   });
 
   const getCounts = async (

--- a/src/core/server/saved_objects/migrations/integration_tests/batch_size_bytes.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/batch_size_bytes.test.ts
@@ -26,6 +26,7 @@ async function removeLogFile() {
   // ignore errors if it doesn't exist
   await fs.unlink(logFilePath).catch(() => void 0);
 }
+
 function sortByTypeAndId(a: { type: string; id: string }, b: { type: string; id: string }) {
   return a.type.localeCompare(b.type) || a.id.localeCompare(b.id);
 }
@@ -76,12 +77,12 @@ describe('migration v2', () => {
   afterEach(async () => {
     if (root) {
       await root.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
     if (esServer) {
       await esServer.stop();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
   });
 
   it('completes the migration even when a full batch would exceed ES http.max_content_length', async () => {

--- a/src/core/server/saved_objects/migrations/integration_tests/collects_corrupt_docs.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/collects_corrupt_docs.test.ts
@@ -32,12 +32,12 @@ describe('migration v2 with corrupt saved object documents', () => {
   afterAll(async () => {
     if (root) {
       await root.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
     if (esServer) {
       await esServer.stop();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
   });
 
   it('collects corrupt saved object documents across batches', async () => {

--- a/src/core/server/saved_objects/migrations/integration_tests/migration_from_older_v1.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/migration_from_older_v1.test.ts
@@ -24,10 +24,12 @@ const kibanaVersion = Env.createDefault(REPO_ROOT, getEnvOptions()).packageInfo.
 const logFilePath = Path.join(__dirname, 'migration_from_older_v1.log');
 
 const asyncUnlink = Util.promisify(Fs.unlink);
+
 async function removeLogFile() {
   // ignore errors if it doesn't exist
   await asyncUnlink(logFilePath).catch(() => void 0);
 }
+
 const assertMigratedDocuments = (arr: any[], target: any[]) => target.every((v) => arr.includes(v));
 
 function sortByTypeAndId(a: { type: string; id: string }, b: { type: string; id: string }) {
@@ -153,12 +155,12 @@ describe('migrating from 7.3.0-xpack which used v1 migrations', () => {
   const stopServers = async () => {
     if (root) {
       await root.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
     if (esServer) {
       await esServer.stop();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
   };
 
   beforeAll(async () => {

--- a/src/core/server/saved_objects/migrations/integration_tests/migration_from_same_v1.test.ts
+++ b/src/core/server/saved_objects/migrations/integration_tests/migration_from_same_v1.test.ts
@@ -24,10 +24,12 @@ const kibanaVersion = Env.createDefault(REPO_ROOT, getEnvOptions()).packageInfo.
 const logFilePath = Path.join(__dirname, 'migration_from_same_v1.log');
 
 const asyncUnlink = Util.promisify(Fs.unlink);
+
 async function removeLogFile() {
   // ignore errors if it doesn't exist
   await asyncUnlink(logFilePath).catch(() => void 0);
 }
+
 const assertMigratedDocuments = (arr: any[], target: any[]) => target.every((v) => arr.includes(v));
 
 function sortByTypeAndId(a: { type: string; id: string }, b: { type: string; id: string }) {
@@ -153,12 +155,12 @@ describe('migrating from the same Kibana version that used v1 migrations', () =>
   const stopServers = async () => {
     if (root) {
       await root.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
     if (esServer) {
       await esServer.stop();
+      await new Promise((resolve) => setTimeout(resolve, 10000));
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 10000));
   };
 
   beforeAll(async () => {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/119236

Add delay between `root.shutdown()` and `es.stop()` in core's integration tests that are starting root with `oss: false`, as an attempt to reduce flakiness by allowing some time to complete pending tasks and/or requests before terminating the ES server.

See https://github.com/elastic/kibana/issues/119236#issuecomment-974794872 for more context

