### PR TITLE
[7.16] [ML] Functional tests - stabilize Discover custom URL test (#119578)

### DIFF
--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -314,6 +314,13 @@ export class DiscoverPageObject extends FtrService {
     return await this.testSubjects.click('collapseSideBarButton');
   }
 
+  public async closeSidebar() {
+    await this.retry.tryForTime(2 * 1000, async () => {
+      await this.toggleSidebarCollapse();
+      await this.testSubjects.missingOrFail('discover-sidebar');
+    });
+  }
+
   public async getAllFieldNames() {
     const sidebar = await this.testSubjects.find('discover-sidebar');
     const $ = await sidebar.parseDomContent();

--- a/x-pack/test/functional/services/ml/custom_urls.ts
+++ b/x-pack/test/functional/services/ml/custom_urls.ts
@@ -16,6 +16,7 @@ export function MachineLearningCustomUrlsProvider({
   getService,
   getPageObjects,
 }: FtrProviderContext) {
+  const browser = getService('browser');
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
   const comboBox = getService('comboBox');
@@ -169,7 +170,13 @@ export function MachineLearningCustomUrlsProvider({
 
     async assertDiscoverCustomUrlAction(expectedHitCountFormatted: string) {
       await PageObjects.discover.waitForDiscoverAppOnScreen();
-      await retry.tryForTime(5000, async () => {
+      // Make sure all existing popovers are closed
+      await browser.pressKeys(browser.keys.ESCAPE);
+
+      // During cloud tests, the small browser width might cause hit count to be invisible
+      // so temporarily collapsing the sidebar ensures the count shows
+      await PageObjects.discover.closeSidebar();
+      await retry.tryForTime(10 * 1000, async () => {
         const hitCount = await PageObjects.discover.getHitCount();
         expect(hitCount).to.eql(
           expectedHitCountFormatted,


### PR DESCRIPTION
Backports the following commits to 7.16:
 - [ML] Functional tests - stabilize Discover custom URL test (#119578)

Also backports a few parts of #107184 (the ones relevant for Discover test stability).