### PR TITLE
[ML] Fix data view service permissions

### DIFF
--- a/x-pack/plugins/ml/server/lib/data_views_utils.ts
+++ b/x-pack/plugins/ml/server/lib/data_views_utils.ts
@@ -22,5 +22,5 @@ export function getDataViewsServiceFactory(
     throw Error('data views service has not been initialized');
   }
 
-  return () => dataViews.dataViewsServiceFactory(savedObjectClient, scopedClient.asInternalUser);
+  return () => dataViews.dataViewsServiceFactory(savedObjectClient, scopedClient.asCurrentUser);
 }


### PR DESCRIPTION
Calls to the data view service should use current user.

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
