### PR TITLE
[Fleet] fix flaky test

### DIFF
--- a/x-pack/plugins/fleet/server/telemetry/sender.test.ts
+++ b/x-pack/plugins/fleet/server/telemetry/sender.test.ts
@@ -32,6 +32,15 @@ describe('TelemetryEventsSender', () => {
   beforeEach(() => {
     logger = loggingSystemMock.createLogger();
     sender = new TelemetryEventsSender(logger);
+    sender['fetchClusterInfo'] = jest.fn(async () => {
+      return {
+        cluster_uuid: '1',
+        cluster_name: 'name',
+        version: {
+          number: '8.0.0',
+        },
+      } as InfoResponse;
+    });
     sender.start(undefined, {
       elasticsearch: { client: { asInternalUser: { info: jest.fn(async () => ({})) } } },
     } as any);
@@ -76,7 +85,7 @@ describe('TelemetryEventsSender', () => {
 
       expect(sender['sendEvents']).toHaveBeenCalledWith(
         'https://telemetry-staging.elastic.co/v3/send/fleet-upgrades',
-        undefined,
+        { cluster_name: 'name', cluster_uuid: '1', version: { number: '8.0.0' } },
         expect.anything()
       );
     });
@@ -112,16 +121,6 @@ describe('TelemetryEventsSender', () => {
           async () => new URL('https://telemetry.elastic.co/v3/send/snapshot')
         ),
       };
-
-      sender['fetchClusterInfo'] = jest.fn(async () => {
-        return {
-          cluster_uuid: '1',
-          cluster_name: 'name',
-          version: {
-            number: '8.0.0',
-          },
-        } as InfoResponse;
-      });
 
       const myChannelEvents = [{ 'event.kind': '1' }, { 'event.kind': '2' }];
       // @ts-ignore


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/119236

In `TelemetryEventsSender`, moved `fetchClusterInfo` to be called once on `start` rather than for each call of `sendIfDue`. 
This was causing flaky tests in jest integration tests, see linked issue.
It seems like that `sendIfDue` was called after plugins were stopped and this caused an error.

Verification:

- check that telemetry events are still send with correct `cluster uuid` and `version` (by doing package policy upgrades to trigger events in debug log)
  - verified locally by logging out request headers: 
  - `[2021-11-25T11:39:49.240+01:00][DEBUG][plugins.fleet.telemetry_events] {"Content-Type":"application/x-ndjson","X-Elastic-Cluster-ID":"pp7mNbzjSqu0ruizsXw8DA","X-Elastic-Stack-Version":"8.1.0-SNAPSHOT"}`
- jest integration tests are running successfully on multiple runs

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
